### PR TITLE
perf: hoist the packed Berlekamp pivot-row read out of the row addition

### DIFF
--- a/HexBerlekamp/PackedKernel.lean
+++ b/HexBerlekamp/PackedKernel.lean
@@ -285,14 +285,25 @@ def rowScale (q : UInt32) (A : Matrix UInt32 n m) (i : Fin n) (c : UInt32) :
     Matrix UInt32 n m :=
   A.modifyEntries i.val fun _ x => mulMod q c x
 
+/-- Replace row `dst` of a packed matrix by `row dst + c * rsrc`, with the source
+row supplied by the caller instead of read out of the matrix.
+
+`rsrc` must be a freshly materialized row, as {name}`Hex.Matrix.getRow` produces.
+A borrow of `A`'s own backing buffer would leave that buffer multiply
+referenced, and the {name}`Hex.Matrix.modifyEntries` below would copy the whole
+matrix per row addition instead of writing in place. -/
+@[inline, expose]
+def rowAddFrom (q : UInt32) (A : Matrix UInt32 n m) (rsrc : Vector UInt32 m)
+    (dst : Fin n) (c : UInt32) : Matrix UInt32 n m :=
+  A.modifyEntries dst.val fun k x => addMod q x (mulMod q c rsrc[k])
+
 /-- Replace row `dst` of a packed matrix by `row dst + c * row src`. Mirrors
 {name}`Hex.Matrix.rowAdd`: the source row is read once, then the destination
 row's entries are updated in place. -/
 @[expose]
 def rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst : Fin n) (c : UInt32) :
     Matrix UInt32 n m :=
-  let rsrc := Matrix.getRow A src
-  A.modifyEntries dst.val fun k x => addMod q x (mulMod q c rsrc[k])
+  rowAddFrom q A (Matrix.getRow A src) dst c
 
 theorem getElem_rowScale (q : UInt32) (A : Matrix UInt32 n m) (i r : Fin n)
     (c : UInt32) (k : Fin m) :
@@ -302,15 +313,21 @@ theorem getElem_rowScale (q : UInt32) (A : Matrix UInt32 n m) (i r : Fin n)
   · rw [if_pos (congrArg Fin.val h), if_pos h, h]
   · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
 
+theorem getElem_rowAddFrom (q : UInt32) (A : Matrix UInt32 n m)
+    (rsrc : Vector UInt32 m) (dst r : Fin n) (c : UInt32) (k : Fin m) :
+    (rowAddFrom q A rsrc dst c)[r][k] =
+      if r = dst then addMod q A[dst][k] (mulMod q c rsrc[k]) else A[r][k] := by
+  rw [rowAddFrom, Matrix.getElem_modifyEntries]
+  by_cases h : r = dst
+  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
+  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+
 theorem getElem_rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst r : Fin n)
     (c : UInt32) (k : Fin m) :
     (rowAdd q A src dst c)[r][k] =
       if r = dst then addMod q A[dst][k] (mulMod q c A[src][k]) else A[r][k] := by
-  rw [rowAdd, Matrix.getElem_modifyEntries]
-  by_cases h : r = dst
-  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
-    rw [show (Matrix.getRow A src)[k] = A[src][k] from rfl]
-  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+  rw [rowAdd]
+  exact getElem_rowAddFrom q A (Matrix.getRow A src) dst r c k
 
 /-! ## The packed elementary operations interpret to the generic ones -/
 
@@ -337,19 +354,29 @@ theorem Rep.rowScale {q : UInt32} (hq : q.toNat = p)
     rw [ZMod64.toNat_mul, hc, h i k]
   · rw [if_neg hri, if_neg hri]; exact h r k
 
-theorem Rep.rowAdd {q : UInt32} (hq : q.toNat = p)
+/-- A caller-supplied source row that agrees entrywise with row `src` of the
+packed matrix interprets the reference row addition, just as reading the row out
+of the matrix does. -/
+theorem Rep.rowAddFrom {q : UInt32} (hq : q.toNat = p)
     {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
-    (src dst : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
-    Rep (rowAdd q A src dst c) (Matrix.rowAdd E src dst γ) := by
-  have hγ : γ.toNat < p := γ.isLt
+    {rsrc : Vector UInt32 m} (src dst : Fin n)
+    (hsrc : ∀ k : Fin m, rsrc[k] = A[src][k])
+    {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
+    Rep (rowAddFrom q A rsrc dst c) (Matrix.rowAdd E src dst γ) := by
   intro r k
-  rw [getElem_rowAdd, Matrix.getElem_rowAdd]
+  rw [getElem_rowAddFrom, Matrix.getElem_rowAdd]
   by_cases hrd : r = dst
-  · rw [if_pos hrd, if_pos hrd]
+  · rw [if_pos hrd, if_pos hrd, hsrc k]
     rw [toNat_addMod hq (h.lt dst k) (mulMod_lt hq), toNat_mulMod hq]
     show _ = (ZMod64.add E[dst][k] (ZMod64.mul γ E[src][k])).toNat
     rw [ZMod64.toNat_add, ZMod64.toNat_mul, h dst k, hc, h src k]
   · rw [if_neg hrd, if_neg hrd]; exact h r k
+
+theorem Rep.rowAdd {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
+    (src dst : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
+    Rep (rowAdd q A src dst c) (Matrix.rowAdd E src dst γ) :=
+  h.rowAddFrom hq src dst (fun _ => rfl) hc
 
 /-! # Packed Gauss-Jordan
 
@@ -384,16 +411,22 @@ def findPivot? (A : Matrix UInt32 n m) (col : Fin m) (start : Nat) : Option (Fin
   findPivotAux A col start (n - start)
 
 /-- Eliminate every non-pivot entry of a packed pivot column. Mirrors
-`Hex.Matrix.eliminateColumn` with the transform component dropped. -/
+`Hex.Matrix.eliminateColumn` with the transform component dropped.
+
+The pivot row is read once for the whole column rather than once per row
+addition: the fold skips `j = pivotRow`, so nothing it writes can change what
+the next row addition reads. That removes `n - 1` of every `n` source-row
+copies. -/
 def eliminateColumn (q : UInt32) (A : Matrix UInt32 n m) (pivotRow : Fin n)
     (col : Fin m) : Matrix UInt32 n m :=
+  let rsrc := Matrix.getRow A pivotRow
   (List.finRange n).foldl
     (fun A j =>
       if j = pivotRow then
         A
       else
         let c := negMod q A[(j, col)]
-        if c == 0 then A else rowAdd q A pivotRow j c)
+        if c == 0 then A else rowAddFrom q A rsrc j c)
     A
 
 /-- Running state of the packed Gauss-Jordan loop. Mirrors
@@ -481,12 +514,13 @@ omit [ZMod64.PrimeModulus p] in
 the reference fold. -/
 private theorem rep_elim_step {q : UInt32} (hq : q.toNat = p)
     {A : Matrix UInt32 n m} {st : Matrix (ZMod64 p) n m × Matrix (ZMod64 p) n n}
-    (h : Rep A st.1) (pivotRow : Fin n) (col : Fin m) (j : Fin n) :
+    (h : Rep A st.1) (pivotRow : Fin n) (col : Fin m) (j : Fin n)
+    {rsrc : Vector UInt32 m} (hsrc : ∀ k : Fin m, rsrc[k] = A[pivotRow][k]) :
     Rep
       (if j = pivotRow then A
         else
           let c := negMod q A[(j, col)]
-          if c == 0 then A else rowAdd q A pivotRow j c)
+          if c == 0 then A else rowAddFrom q A rsrc j c)
       (if _hj : j = pivotRow then st
         else
           have coeff := -st.1[(j, col)]
@@ -515,22 +549,44 @@ private theorem rep_elim_step {q : UInt32} (hq : q.toNat = p)
       exact h
     · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)),
         if_neg (fun hE => hA (hiff.mpr hE))]
-      exact h.rowAdd hq pivotRow j hcoeff
+      exact h.rowAddFrom hq pivotRow j hsrc hcoeff
+
+/-- One elimination step leaves the pivot row alone: the step either does
+nothing or adds into a row `j ≠ pivotRow`. This is what makes the hoisted source
+row still the accumulated buffer's pivot row at the next step. -/
+private theorem elim_step_pivotRow {q : UInt32} (A : Matrix UInt32 n m)
+    (pivotRow : Fin n) (col : Fin m) (j : Fin n) (rsrc : Vector UInt32 m)
+    (k : Fin m) :
+    (if j = pivotRow then A
+      else
+        let c := negMod q A[(j, col)]
+        if c == 0 then A else rowAddFrom q A rsrc j c)[pivotRow][k]
+      = A[pivotRow][k] := by
+  by_cases hj : j = pivotRow
+  · rw [if_pos hj]
+  · rw [if_neg hj]
+    by_cases hA : negMod q A[(j, col)] = 0
+    · rw [if_pos (beq_iff_eq.mpr hA)]
+    · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)), getElem_rowAddFrom,
+        if_neg (fun hp => hj hp.symm)]
 
 omit [ZMod64.PrimeModulus p] in
-/-- The packed column elimination represents the reference column elimination. -/
+/-- The packed column elimination represents the reference column elimination.
+The source row `rsrc` is hoisted out of the fold, so the fold carries the
+invariant that it still agrees with the accumulated buffer's pivot row. -/
 theorem rep_eliminateColumn_foldl {q : UInt32} (hq : q.toNat = p) (pivotRow : Fin n)
-    (col : Fin m) :
+    (col : Fin m) (rsrc : Vector UInt32 m) :
     ∀ (xs : List (Fin n)) (A : Matrix UInt32 n m)
       (st : Matrix (ZMod64 p) n m × Matrix (ZMod64 p) n n),
       Rep A st.1 →
+      (∀ k : Fin m, rsrc[k] = A[pivotRow][k]) →
       Rep
         (xs.foldl
           (fun A j =>
             if j = pivotRow then A
             else
               let c := negMod q A[(j, col)]
-              if c == 0 then A else rowAdd q A pivotRow j c) A)
+              if c == 0 then A else rowAddFrom q A rsrc j c) A)
         (xs.foldl
           (fun st j =>
             if _hj : j = pivotRow then st
@@ -541,11 +597,12 @@ theorem rep_eliminateColumn_foldl {q : UInt32} (hq : q.toNat = p) (pivotRow : Fi
           st).1 := by
   intro xs
   induction xs with
-  | nil => intro A st h; exact h
+  | nil => intro A st h _; exact h
   | cons x xs ih =>
-      intro A st h
+      intro A st h hsrc
       simp only [List.foldl_cons]
-      exact ih _ _ (rep_elim_step hq h pivotRow col x)
+      exact ih _ _ (rep_elim_step hq h pivotRow col x hsrc)
+        (fun k => (hsrc k).trans (elim_step_pivotRow A pivotRow col x rsrc k).symm)
 
 /-- The packed column elimination represents the reference column elimination. -/
 private theorem rep_eliminateColumn {q : UInt32} (hq : q.toNat = p)
@@ -554,7 +611,8 @@ private theorem rep_eliminateColumn {q : UInt32} (hq : q.toNat = p)
     Rep (eliminateColumn q A pivotRow col)
       (Hex.Matrix.eliminateColumn E T pivotRow col).1 := by
   unfold eliminateColumn Hex.Matrix.eliminateColumn
-  exact rep_eliminateColumn_foldl hq pivotRow col (List.finRange n) A (E, T) h
+  exact rep_eliminateColumn_foldl hq pivotRow col (Matrix.getRow A pivotRow)
+    (List.finRange n) A (E, T) h (fun _ => rfl)
 
 
 omit [ZMod64.PrimeModulus p] in

--- a/HexBerlekamp/PackedKernel.lean
+++ b/HexBerlekamp/PackedKernel.lean
@@ -415,8 +415,8 @@ def findPivot? (A : Matrix UInt32 n m) (col : Fin m) (start : Nat) : Option (Fin
 
 The pivot row is read once for the whole column rather than once per row
 addition: the fold skips `j = pivotRow`, so nothing it writes can change what
-the next row addition reads. That removes `n - 1` of every `n` source-row
-copies. -/
+the next row addition reads. A dense column's `n - 1` source-row copies become
+one. -/
 def eliminateColumn (q : UInt32) (A : Matrix UInt32 n m) (pivotRow : Fin n)
     (col : Fin m) : Matrix UInt32 n m :=
   let rsrc := Matrix.getRow A pivotRow

--- a/bench/HexBench/BerlekampKernel.lean
+++ b/bench/HexBench/BerlekampKernel.lean
@@ -64,9 +64,15 @@ scaffolding rather than arithmetic. Two measurements separate it.
   `Fin.foldl`, then the outer column scan as a `Nat` range rather than
   `List.finRange`, and finally the prototype loop above run on the packed
   buffer. **These form a comparison graph, not a chain**: each rung names its
-  own baseline, and only `mirrored - hoistedPivotRow` decomposes the whole gap.
-  The prototype rung changes six things at once and is a residual comparison
-  rather than an attribution.
+  own baseline. The prototype rung changes six things at once and is a residual
+  comparison rather than an attribution.
+
+  Since issue #9166 landed the hoist in `Packed.eliminateColumn` itself,
+  `mirrored - hoistedPivotRow` no longer decomposes the gap it was built to
+  measure: both rungs now read the pivot row once per column, and their
+  difference is a null control on the ladder's own scaffolding. The rung is kept
+  because a regression that reintroduces the per-row-addition read would show up
+  as that difference going positive again.
 
 The inner modular multiply is priced by `eliminateFlatDoubleMul` and
 `rowAddFromDoubled`, which perform a second, salted modular multiply per

--- a/progress/20260805T003000Z_issue-9166.md
+++ b/progress/20260805T003000Z_issue-9166.md
@@ -40,8 +40,8 @@ from the old record.
 
 The change is landed and measured. The rows that do not improve are the ones
 with nothing to save: the three Wilkinson rows find no pivot column at all, so
-`eliminateColumn` never executes and their 1.02x bounds the cross-run noise
-floor; `xpow24_minus1` has 11 pivots and 11 row additions, so the hoist replaces
+`eliminateColumn` never executes and their 1.02x is cross-run drift on a no-work
+row; `xpow24_minus1` has 11 pivots and 11 row additions, so the hoist replaces
 11 reads with 11 reads.
 
 ## Next step

--- a/progress/20260805T003000Z_issue-9166.md
+++ b/progress/20260805T003000Z_issue-9166.md
@@ -1,0 +1,57 @@
+# Hoist the packed Berlekamp pivot-row read (issue #9166)
+
+## Accomplished
+
+`Hex.Berlekamp.Packed.eliminateColumn` now reads the pivot row once per pivot
+column and threads it into the new `Packed.rowAddFrom`, instead of reading it out
+of the matrix once per row addition. `Packed.rowAdd` is kept, defined as
+`rowAddFrom` on `Matrix.getRow A src`, so its correspondence lemma is a one-line
+consequence of the new `Rep.rowAddFrom`.
+
+The correspondence proof carries one extra invariant through
+`rep_eliminateColumn_foldl`: `∀ k, rsrc[k] = A[pivotRow][k]` on the accumulated
+buffer at every step. `elim_step_pivotRow` establishes preservation from the fold
+step either doing nothing or writing a row `j ≠ pivotRow`; the invariant holds at
+entry by `rfl`. No `axiom`, `sorry`, `native_decide` or unchecked oracle.
+
+Measured on `chungus2` in three runs ordered after, before, after, with the
+before run taken by reverting only `HexBerlekamp/PackedKernel.lean` and
+`bench/HexBench/BerlekampKernel.lean` to `a5a55cbf`:
+
+- `cyclo_phi385` packed reduction 45.095 ms to 13.260 ms, **0.29x**; whole
+  `factor` call 143.566 ms to 115.069 ms, **0.80x**.
+- `cyclo_phi128_x_phi165` 19.529 ms to 5.739 ms, 0.29x; `factor` 0.82x.
+- Against the benchmark prototype the reduction goes from 2.80x to **0.83x** on
+  `cyclo_phi385` and 2.76x to 0.82x on `cyclo_phi128_x_phi165`, which is what
+  #9160 projected.
+- The within-run paired `mirrored - hoistedPivotRow` collapses from 31.606 ms to
+  16.841 us on `cyclo_phi385`, 0.1% of the rung, so the hoist is in production
+  and not only in the ladder.
+- The multiply's incremental share rises from ~5% to ~17% of the reduction, at
+  unchanged absolute cost. That is the condition #9166 set for re-opening the
+  Barrett reciprocal.
+
+Report: `reports/hexbz-hoisted-pivot-row.md`, reading three new records under
+`reports/bench-results/`. Table generation lives in the new
+`scripts/bench/packed_ladder_diff.py`, which reproduces #9160's paired medians
+from the old record.
+
+## Current frontier
+
+The change is landed and measured. The rows that do not improve are the ones
+with nothing to save: the three Wilkinson rows find no pivot column at all, so
+`eliminateColumn` never executes and their 1.02x bounds the cross-run noise
+floor; `xpow24_minus1` has 11 pivots and 11 row additions, so the hoist replaces
+11 reads with 11 reads.
+
+## Next step
+
+Re-open the Barrett reciprocal, per #9166's own instruction. The two findings
+#9166 held out of scope are untouched: `Packed.nullspaceArray`'s per-entry
+pivot-column search, and the `List.finRange n` column scan in `eliminateColumn`,
+which is what the sparse rows' remaining 1.5x to 1.6x against the prototype is.
+
+## Blockers
+
+None. `coordination` was not on PATH in this session, so the issue was claimed
+and the PR opened with `gh` directly.

--- a/progress/20260805T003000Z_issue-9166.md
+++ b/progress/20260805T003000Z_issue-9166.md
@@ -46,8 +46,8 @@ row; `xpow24_minus1` has 11 pivots and 11 row additions, so the hoist replaces
 
 ## Next step
 
-Re-open the Barrett reciprocal, per #9166's own instruction. The two findings
-#9166 held out of scope are untouched: `Packed.nullspaceArray`'s per-entry
+Re-open the Barrett reciprocal, per #9166's own instruction. The two findings it
+held out of scope are untouched: `Packed.nullspaceArray`'s per-entry
 pivot-column search, and the `List.finRange n` column scan in `eliminateColumn`,
 which is what the sparse rows' remaining 1.5x to 1.6x against the prototype is.
 

--- a/progress/20260805T003000Z_issue-9166.md
+++ b/progress/20260805T003000Z_issue-9166.md
@@ -55,3 +55,17 @@ which is what the sparse rows' remaining 1.5x to 1.6x against the prototype is.
 
 None. `coordination` was not on PATH in this session, so the issue was claimed
 and the PR opened with `gh` directly.
+
+## Addendum: corpus sweep refresh
+
+CI's `check_factor_sweep_freshness.py` rejects any change to executable
+factorization code until the committed cross-system sweep is re-recorded, so
+`hexbz-factor-sweep-8ed3c378-hex-chungus2.json` was taken on a clean tree and
+the 25 figures under `reports/figures/` regenerated from it. Same 377 of 392
+solved as the `48bdfb8e` baseline, clean cross-check, 64 instances better than
+0.90x and eight worse than 1.05x (all sub-millisecond, 22 to 255 us, where the
+sweep's own per-call overhead is 18.7 us).
+
+Regenerating the figures needs
+`uv run --with matplotlib==3.11.1 python3 scripts/plots/hexbz-cactus.py`;
+this host has no system matplotlib and no `pip`.

--- a/progress/20260805T003720Z_pr-9176-review.md
+++ b/progress/20260805T003720Z_pr-9176-review.md
@@ -1,0 +1,52 @@
+# PR #9176 review
+
+## Accomplished
+
+Reviewed `HexBerlekamp/PackedKernel.lean` in full, the generic matrix backing
+representation and reference elimination fold, the generated C ownership path,
+the benchmark report and table script, and all three before/after JSON records.
+The new snapshot invariant and `elim_step_pivotRow` preservation argument are
+sound, the final packed/reference correspondence statement is unchanged, and
+the generated code releases the temporary closure over the original matrix
+before entering the fold so the accumulator remains uniquely referenced.
+
+Reproduced the integrated, paired-difference, prototype, and multiply tables.
+Found report-only inaccuracies: the claimed prior-run agreement is not within
+about 1% on every arithmetic row, 22 rather than 12 after-run paired ranges
+straddle zero, and `fixedSpaceKernelVectors` is medianed across eight kernel
+profile calls. Also noted that the Wilkinson rows show drift on those tiny
+controls but cannot bound a general cross-process noise floor. The helper script
+silently truncates unequal paired sample arrays via `zip`, though all committed
+records have matching eight-sample arrays and the expected alternating order.
+
+Verified `lake build HexBerlekamp.PackedKernel` and `git diff --check` are green.
+
+## Current frontier
+
+Review complete. No Lean soundness, semantic-equivalence, aliasing, attribute,
+or retained-API blocker was found. The remaining findings are report wording or
+benchmark-script robustness issues and do not undermine the large measured
+speedup.
+
+## Next step
+
+Correct the report statements and optionally make `packed_ladder_diff.py`
+validate equal sample lengths and the recorded direction schedule before
+labeling a comparison paired.
+
+## Blockers
+
+None.
+
+## Resolution
+
+All five report and script findings were applied on the PR branch: the
+prior-run agreement claim now names the rows that agree and the rows that do
+not (and why: two of the four intervening commits change the factorization
+path), `12 of 24` is corrected to `22 of 24`, `fixedSpaceKernelVectors` is
+described as the median of eight one-call observations with no retained range,
+the Wilkinson rows are described as showing about 2% of drift rather than
+bounding a floor, and `packed_ladder_diff.py` now refuses to call a difference
+paired when the sample arrays differ in length or are odd. The
+`eliminateColumn` docstring's "removes `n - 1` of every `n` copies" is now "a
+dense column's `n - 1` source-row copies become one".

--- a/reports/bench-results/hexbz-factor-sweep-8ed3c378-hex-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-8ed3c378-hex-chungus2.json
@@ -1,0 +1,6028 @@
+{
+  "env": {
+    "lean_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "platform_target": null,
+    "os": "linux",
+    "arch": "x86_64",
+    "cpu_model": null,
+    "cpu_cores": 96,
+    "hostname": "chungus2",
+    "exe_name": "factor_sweep",
+    "lean_bench_version": null,
+    "git_commit": "8ed3c378f2d8d07257bb7bb0ccb1c8bb538d1d33",
+    "git_dirty": false,
+    "timestamp_unix_ms": 1785890826913,
+    "timestamp_iso": "2026-08-05T00:47:06Z"
+  },
+  "config": {
+    "cutoff_seconds": 10.0,
+    "repeats_policy": "median-of-5 when first call < 1s, else single call",
+    "overhead_repeats": 21,
+    "corpus_path": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "early_terminate_run": 3,
+    "early_terminate_families": [
+      "conway",
+      "hoeij-zimmermann",
+      "sd-products",
+      "swinnerton-dyer"
+    ],
+    "systems": [
+      "hex-factor"
+    ],
+    "system_versions": {
+      "hex-factor": "leanprover/lean4:v4.33.0-rc1"
+    },
+    "per_system_overhead_nanos": {
+      "hex-factor": 18688
+    }
+  },
+  "results": [
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi5",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33730,
+      "min_nanos": 32949,
+      "max_nanos": 49323,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi7",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43104,
+      "min_nanos": 41251,
+      "max_nanos": 46900,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi15",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 97755,
+      "min_nanos": 96393,
+      "max_nanos": 129141,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi11",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 95532,
+      "min_nanos": 94240,
+      "max_nanos": 108340,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi13",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 213907,
+      "min_nanos": 205334,
+      "max_nanos": 243792,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi17",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 99127,
+      "min_nanos": 98035,
+      "max_nanos": 109513,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi19",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 114710,
+      "min_nanos": 113158,
+      "max_nanos": 118686,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi25",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 129161,
+      "min_nanos": 127880,
+      "max_nanos": 136673,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi23",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 252685,
+      "min_nanos": 243521,
+      "max_nanos": 280716,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi35",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 354506,
+      "min_nanos": 351692,
+      "max_nanos": 390048,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi29",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 211073,
+      "min_nanos": 204332,
+      "max_nanos": 213627,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi64",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 329258,
+      "min_nanos": 325553,
+      "max_nanos": 344180,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi37",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 652978,
+      "min_nanos": 632909,
+      "max_nanos": 698265,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi41",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1969019,
+      "min_nanos": 1963602,
+      "max_nanos": 1994057,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi49",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 382437,
+      "min_nanos": 379282,
+      "max_nanos": 388216,
+      "factor_count": 1,
+      "factor_degrees": [
+        42
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi105",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 5226470,
+      "min_nanos": 5210776,
+      "max_nanos": 5264967,
+      "factor_count": 1,
+      "factor_degrees": [
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi53",
+      "degree": 52,
+      "status": "ok",
+      "median_nanos": 551578,
+      "min_nanos": 544958,
+      "max_nanos": 561142,
+      "factor_count": 1,
+      "factor_degrees": [
+        52
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi81",
+      "degree": 54,
+      "status": "ok",
+      "median_nanos": 674390,
+      "min_nanos": 666328,
+      "max_nanos": 678276,
+      "factor_count": 1,
+      "factor_degrees": [
+        54
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi61",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 6353300,
+      "min_nanos": 6348854,
+      "max_nanos": 6387471,
+      "factor_count": 1,
+      "factor_degrees": [
+        60
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi128",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 992271,
+      "min_nanos": 984039,
+      "max_nanos": 1027253,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi165",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 7983708,
+      "min_nanos": 7970207,
+      "max_nanos": 8063056,
+      "factor_count": 1,
+      "factor_degrees": [
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi89",
+      "degree": 88,
+      "status": "ok",
+      "median_nanos": 1368449,
+      "min_nanos": 1356021,
+      "max_nanos": 1374117,
+      "factor_count": 1,
+      "factor_degrees": [
+        88
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi121",
+      "degree": 110,
+      "status": "ok",
+      "median_nanos": 44512190,
+      "min_nanos": 43539418,
+      "max_nanos": 44660391,
+      "factor_count": 1,
+      "factor_degrees": [
+        110
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi256",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 3882217,
+      "min_nanos": 3846333,
+      "max_nanos": 3949426,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi151",
+      "degree": 150,
+      "status": "ok",
+      "median_nanos": 30531090,
+      "min_nanos": 30351203,
+      "max_nanos": 30557619,
+      "factor_count": 1,
+      "factor_degrees": [
+        150
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi243",
+      "degree": 162,
+      "status": "ok",
+      "median_nanos": 5206530,
+      "min_nanos": 5197807,
+      "max_nanos": 5219369,
+      "factor_count": 1,
+      "factor_degrees": [
+        162
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi179",
+      "degree": 178,
+      "status": "ok",
+      "median_nanos": 33691756,
+      "min_nanos": 33661722,
+      "max_nanos": 33787238,
+      "factor_count": 1,
+      "factor_degrees": [
+        178
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi275",
+      "degree": 200,
+      "status": "ok",
+      "median_nanos": 635632095,
+      "min_nanos": 629032299,
+      "max_nanos": 637029577,
+      "factor_count": 1,
+      "factor_degrees": [
+        200
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi385",
+      "degree": 240,
+      "status": "ok",
+      "median_nanos": 114088796,
+      "min_nanos": 113469406,
+      "max_nanos": 114707593,
+      "factor_count": 1,
+      "factor_degrees": [
+        240
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi257",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 10093946,
+      "min_nanos": 10081458,
+      "max_nanos": 10195918,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi331",
+      "degree": 330,
+      "status": "ok",
+      "median_nanos": 16809014,
+      "min_nanos": 16760392,
+      "max_nanos": 17102929,
+      "factor_count": 1,
+      "factor_degrees": [
+        330
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi625",
+      "degree": 500,
+      "status": "ok",
+      "median_nanos": 41545362,
+      "min_nanos": 41231035,
+      "max_nanos": 42238579,
+      "factor_count": 1,
+      "factor_degrees": [
+        500
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi509",
+      "degree": 508,
+      "status": "ok",
+      "median_nanos": 38893919,
+      "min_nanos": 38616419,
+      "max_nanos": 39086295,
+      "factor_count": 1,
+      "factor_degrees": [
+        508
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi1031",
+      "degree": 1030,
+      "status": "ok",
+      "median_nanos": 2582970633,
+      "min_nanos": 2582970633,
+      "max_nanos": 2582970633,
+      "factor_count": 1,
+      "factor_degrees": [
+        1030
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow6_minus1",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 99707,
+      "min_nanos": 92277,
+      "max_nanos": 226966,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow12_minus1",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 255279,
+      "min_nanos": 251162,
+      "max_nanos": 374946,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow15_minus1",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 286284,
+      "min_nanos": 272615,
+      "max_nanos": 313755,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi12_x_phi13",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 375037,
+      "min_nanos": 362567,
+      "max_nanos": 405551,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi7_x_phi11",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 242770,
+      "min_nanos": 240557,
+      "max_nanos": 262619,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow20_minus1",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 464379,
+      "min_nanos": 439462,
+      "max_nanos": 501914,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi15_x_phi17",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 615783,
+      "min_nanos": 602563,
+      "max_nanos": 646008,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow24_minus1",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 2318097,
+      "min_nanos": 2299810,
+      "max_nanos": 2376253,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow30_minus1",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1715083,
+      "min_nanos": 1696505,
+      "max_nanos": 1747751,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi24_x_phi35",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6461401,
+      "min_nanos": 6458807,
+      "max_nanos": 6524044,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow36_minus1",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 2641897,
+      "min_nanos": 2635168,
+      "max_nanos": 2684310,
+      "factor_count": 9,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi32_x_phi45",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2432997,
+      "min_nanos": 2417244,
+      "max_nanos": 2443163,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow48_minus1",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 10508041,
+      "min_nanos": 10491726,
+      "max_nanos": 10550533,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow60_minus1",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 5650688,
+      "min_nanos": 5601405,
+      "max_nanos": 5690457,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi64_x_phi105",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 16601726,
+      "min_nanos": 16554717,
+      "max_nanos": 16644239,
+      "factor_count": 2,
+      "factor_degrees": [
+        32,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow105_minus1",
+      "degree": 105,
+      "status": "ok",
+      "median_nanos": 45802633,
+      "min_nanos": 45575087,
+      "max_nanos": 45978855,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi105_x_phi128",
+      "degree": 112,
+      "status": "ok",
+      "median_nanos": 29116642,
+      "min_nanos": 29079668,
+      "max_nanos": 29218263,
+      "factor_count": 2,
+      "factor_degrees": [
+        48,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow120_minus1",
+      "degree": 120,
+      "status": "ok",
+      "median_nanos": 148218050,
+      "min_nanos": 147825228,
+      "max_nanos": 148966170,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi128_x_phi165",
+      "degree": 144,
+      "status": "ok",
+      "median_nanos": 62682963,
+      "min_nanos": 62558238,
+      "max_nanos": 63358816,
+      "factor_count": 2,
+      "factor_degrees": [
+        64,
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 61271,
+      "min_nanos": 46288,
+      "max_nanos": 87190,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2_shift1",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 51446,
+      "min_nanos": 48942,
+      "max_nanos": 1011790,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 165545,
+      "min_nanos": 161930,
+      "max_nanos": 185866,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 160428,
+      "min_nanos": 159116,
+      "max_nanos": 169242,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift2",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 157794,
+      "min_nanos": 153798,
+      "max_nanos": 173147,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 850301,
+      "min_nanos": 845734,
+      "max_nanos": 891101,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 784333,
+      "min_nanos": 778975,
+      "max_nanos": 804783,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift3",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 858533,
+      "min_nanos": 855248,
+      "max_nanos": 882960,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 71444715,
+      "min_nanos": 71061016,
+      "max_nanos": 72798101,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 66253057,
+      "min_nanos": 64964146,
+      "max_nanos": 67881802,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift2",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 67093874,
+      "min_nanos": 67015968,
+      "max_nanos": 67426587,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 8152349123,
+      "min_nanos": 8152349123,
+      "max_nanos": 8152349123,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift5",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_phi12",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 143072,
+      "min_nanos": 123783,
+      "max_nanos": 22857041,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_sd2shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 132807,
+      "min_nanos": 126097,
+      "max_nanos": 146327,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi15",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 490508,
+      "min_nanos": 473923,
+      "max_nanos": 549825,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi24",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 559189,
+      "min_nanos": 553241,
+      "max_nanos": 592619,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_sd3shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 850831,
+      "min_nanos": 842669,
+      "max_nanos": 896429,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi17",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 2733544,
+      "min_nanos": 2725641,
+      "max_nanos": 2780713,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_sd4shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 17508140,
+      "min_nanos": 17388112,
+      "max_nanos": 17517844,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi35",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 17167975,
+      "min_nanos": 17092494,
+      "max_nanos": 17262826,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi11",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 139326615,
+      "min_nanos": 138714168,
+      "max_nanos": 139610526,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi45",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 323267733,
+      "min_nanos": 322403692,
+      "max_nanos": 324619387,
+      "factor_count": 2,
+      "factor_degrees": [
+        24,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_sd5shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi13",
+      "degree": 76,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi105",
+      "degree": 112,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_sd6shift1",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 39318,
+      "min_nanos": 28362,
+      "max_nanos": 22566741,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28552,
+      "min_nanos": 27210,
+      "max_nanos": 91436,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33941,
+      "min_nanos": 32678,
+      "max_nanos": 47571,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 50415,
+      "min_nanos": 49123,
+      "max_nanos": 78666,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 33480,
+      "min_nanos": 33039,
+      "max_nanos": 36504,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 61952,
+      "min_nanos": 59949,
+      "max_nanos": 70234,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 87169,
+      "min_nanos": 85937,
+      "max_nanos": 101750,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 67159,
+      "min_nanos": 64576,
+      "max_nanos": 71916,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 64195,
+      "min_nanos": 63153,
+      "max_nanos": 69363,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 60510,
+      "min_nanos": 59118,
+      "max_nanos": 65557,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 55843,
+      "min_nanos": 54531,
+      "max_nanos": 61772,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 138185,
+      "min_nanos": 130704,
+      "max_nanos": 149902,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 87800,
+      "min_nanos": 83353,
+      "max_nanos": 95762,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 101591,
+      "min_nanos": 101080,
+      "max_nanos": 111736,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 141450,
+      "min_nanos": 137684,
+      "max_nanos": 169861,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 112526,
+      "min_nanos": 108611,
+      "max_nanos": 120900,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 160027,
+      "min_nanos": 153538,
+      "max_nanos": 173267,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 180468,
+      "min_nanos": 174819,
+      "max_nanos": 191454,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 279745,
+      "min_nanos": 269469,
+      "max_nanos": 309208,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 199225,
+      "min_nanos": 192385,
+      "max_nanos": 207367,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 128851,
+      "min_nanos": 126968,
+      "max_nanos": 140658,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 221078,
+      "min_nanos": 213828,
+      "max_nanos": 244923,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 478860,
+      "min_nanos": 454904,
+      "max_nanos": 522736,
+      "factor_count": 3,
+      "factor_degrees": [
+        2,
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 260827,
+      "min_nanos": 254748,
+      "max_nanos": 301777,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 522866,
+      "min_nanos": 497958,
+      "max_nanos": 554983,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 691205,
+      "min_nanos": 673609,
+      "max_nanos": 745465,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3,
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 410760,
+      "min_nanos": 402998,
+      "max_nanos": 433563,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 577265,
+      "min_nanos": 546901,
+      "max_nanos": 604586,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 36014,
+      "min_nanos": 35423,
+      "max_nanos": 44026,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 36253,
+      "min_nanos": 35623,
+      "max_nanos": 43985,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 64466,
+      "min_nanos": 63154,
+      "max_nanos": 69153,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 92547,
+      "min_nanos": 89863,
+      "max_nanos": 103393,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 74932,
+      "min_nanos": 73849,
+      "max_nanos": 79488,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 161419,
+      "min_nanos": 159977,
+      "max_nanos": 175921,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 174438,
+      "min_nanos": 169892,
+      "max_nanos": 191665,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 282949,
+      "min_nanos": 279765,
+      "max_nanos": 304541,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 226466,
+      "min_nanos": 221488,
+      "max_nanos": 236240,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 625708,
+      "min_nanos": 608472,
+      "max_nanos": 654680,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 532109,
+      "min_nanos": 527252,
+      "max_nanos": 557918,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1281840,
+      "min_nanos": 1264405,
+      "max_nanos": 1336501,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1888310,
+      "min_nanos": 1872426,
+      "max_nanos": 1916922,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 954976,
+      "min_nanos": 951741,
+      "max_nanos": 1003417,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1687832,
+      "min_nanos": 1674874,
+      "max_nanos": 1750265,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 6992338,
+      "min_nanos": 6963394,
+      "max_nanos": 7045778,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 1813419,
+      "min_nanos": 1798427,
+      "max_nanos": 1847880,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 8410460,
+      "min_nanos": 8363271,
+      "max_nanos": 8424351,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 2990554,
+      "min_nanos": 2952127,
+      "max_nanos": 2996193,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 3689330,
+      "min_nanos": 3685485,
+      "max_nanos": 3733846,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 32999,
+      "min_nanos": 32187,
+      "max_nanos": 49894,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 55782,
+      "min_nanos": 55232,
+      "max_nanos": 68521,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 85637,
+      "min_nanos": 83374,
+      "max_nanos": 95081,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 100389,
+      "min_nanos": 96834,
+      "max_nanos": 113488,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 147429,
+      "min_nanos": 141781,
+      "max_nanos": 158515,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 117915,
+      "min_nanos": 116103,
+      "max_nanos": 133949,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 118626,
+      "min_nanos": 117594,
+      "max_nanos": 124515,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 226806,
+      "min_nanos": 221588,
+      "max_nanos": 245224,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 169431,
+      "min_nanos": 168380,
+      "max_nanos": 179466,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 364851,
+      "min_nanos": 352453,
+      "max_nanos": 387725,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 384651,
+      "min_nanos": 381857,
+      "max_nanos": 409467,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 545078,
+      "min_nanos": 542354,
+      "max_nanos": 577276,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 697724,
+      "min_nanos": 679237,
+      "max_nanos": 723502,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 917341,
+      "min_nanos": 907976,
+      "max_nanos": 960695,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1035615,
+      "min_nanos": 1021515,
+      "max_nanos": 1059751,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1695464,
+      "min_nanos": 1673591,
+      "max_nanos": 1725928,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 956248,
+      "min_nanos": 955356,
+      "max_nanos": 967414,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1673421,
+      "min_nanos": 1665850,
+      "max_nanos": 1711388,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 2689418,
+      "min_nanos": 2638653,
+      "max_nanos": 2696488,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 5076297,
+      "min_nanos": 5048786,
+      "max_nanos": 5103557,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 79298,
+      "min_nanos": 78866,
+      "max_nanos": 101321,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 132707,
+      "min_nanos": 129302,
+      "max_nanos": 143443,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 200077,
+      "min_nanos": 195240,
+      "max_nanos": 210512,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 446192,
+      "min_nanos": 439712,
+      "max_nanos": 473772,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 603344,
+      "min_nanos": 591957,
+      "max_nanos": 624175,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 852083,
+      "min_nanos": 844552,
+      "max_nanos": 890741,
+      "factor_count": 14,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1175763,
+      "min_nanos": 1142264,
+      "max_nanos": 1179769,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1670106,
+      "min_nanos": 1648945,
+      "max_nanos": 1727331,
+      "factor_count": 18,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2209686,
+      "min_nanos": 2197278,
+      "max_nanos": 2235264,
+      "factor_count": 20,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 3467512,
+      "min_nanos": 3448373,
+      "max_nanos": 3500430,
+      "factor_count": 24,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 5293760,
+      "min_nanos": 5277505,
+      "max_nanos": 5316413,
+      "factor_count": 28,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6718192,
+      "min_nanos": 6687426,
+      "max_nanos": 6746664,
+      "factor_count": 32,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 9297426,
+      "min_nanos": 9276104,
+      "max_nanos": 9310145,
+      "factor_count": 40,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_48",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 16333688,
+      "min_nanos": 16296884,
+      "max_nanos": 16353838,
+      "factor_count": 48,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_56",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 21248296,
+      "min_nanos": 21207155,
+      "max_nanos": 21267314,
+      "factor_count": 56,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_26",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 107329,
+      "min_nanos": 99157,
+      "max_nanos": 146918,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_22",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 207558,
+      "min_nanos": 201248,
+      "max_nanos": 225404,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_23",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 175020,
+      "min_nanos": 169322,
+      "max_nanos": 185065,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_25",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 170994,
+      "min_nanos": 168530,
+      "max_nanos": 186136,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_07",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 151375,
+      "min_nanos": 149612,
+      "max_nanos": 172045,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_13",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 209130,
+      "min_nanos": 204123,
+      "max_nanos": 233266,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_09",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 299745,
+      "min_nanos": 292424,
+      "max_nanos": 332363,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_14",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 208399,
+      "min_nanos": 199616,
+      "max_nanos": 227037,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_04",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 333184,
+      "min_nanos": 330070,
+      "max_nanos": 352673,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_08",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 353845,
+      "min_nanos": 345242,
+      "max_nanos": 368907,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_16",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 218704,
+      "min_nanos": 217332,
+      "max_nanos": 241047,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_20",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 315198,
+      "min_nanos": 311131,
+      "max_nanos": 325272,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_28",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 570436,
+      "min_nanos": 549494,
+      "max_nanos": 652337,
+      "factor_count": 5,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_29",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 316760,
+      "min_nanos": 312043,
+      "max_nanos": 340064,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_06",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 356058,
+      "min_nanos": 354485,
+      "max_nanos": 382087,
+      "factor_count": 3,
+      "factor_degrees": [
+        4,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_17",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 247547,
+      "min_nanos": 239034,
+      "max_nanos": 268027,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_01",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 266845,
+      "min_nanos": 260816,
+      "max_nanos": 301978,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_05",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 322608,
+      "min_nanos": 312493,
+      "max_nanos": 365983,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_19",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 243932,
+      "min_nanos": 237973,
+      "max_nanos": 271603,
+      "factor_count": 2,
+      "factor_degrees": [
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_27",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 431830,
+      "min_nanos": 421074,
+      "max_nanos": 464468,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_11",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 387795,
+      "min_nanos": 374255,
+      "max_nanos": 412352,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        7,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_00",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 834368,
+      "min_nanos": 797182,
+      "max_nanos": 893214,
+      "factor_count": 3,
+      "factor_degrees": [
+        5,
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_03",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 738595,
+      "min_nanos": 723072,
+      "max_nanos": 766476,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_12",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 430909,
+      "min_nanos": 416437,
+      "max_nanos": 452311,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        3,
+        7,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_24",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 472181,
+      "min_nanos": 455906,
+      "max_nanos": 505219,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_02",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 748580,
+      "min_nanos": 747839,
+      "max_nanos": 789090,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_10",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 586079,
+      "min_nanos": 580661,
+      "max_nanos": 627400,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_15",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 663824,
+      "min_nanos": 639629,
+      "max_nanos": 701130,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_18",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 976007,
+      "min_nanos": 962918,
+      "max_nanos": 1018360,
+      "factor_count": 3,
+      "factor_degrees": [
+        6,
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_21",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1345125,
+      "min_nanos": 1322651,
+      "max_nanos": 1381209,
+      "factor_count": 3,
+      "factor_degrees": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_M12_f132",
+      "degree": 132,
+      "status": "ok",
+      "median_nanos": 958696092,
+      "min_nanos": 955859425,
+      "max_nanos": 979176680,
+      "factor_count": 1,
+      "factor_degrees": [
+        132
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F190",
+      "degree": 190,
+      "status": "ok",
+      "median_nanos": 3271906616,
+      "min_nanos": 3271906616,
+      "max_nanos": 3271906616,
+      "factor_count": 3,
+      "factor_degrees": [
+        10,
+        90,
+        90
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F192",
+      "degree": 192,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F256",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S8",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F351",
+      "degree": 351,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_P7",
+      "degree": 384,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S9",
+      "degree": 512,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F630",
+      "degree": 630,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 27601,
+      "min_nanos": 21623,
+      "max_nanos": 22389478,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21272,
+      "min_nanos": 20661,
+      "max_nanos": 24766,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 23535,
+      "min_nanos": 21622,
+      "max_nanos": 31016,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20030,
+      "min_nanos": 19850,
+      "max_nanos": 20250,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21061,
+      "min_nanos": 20721,
+      "max_nanos": 23575,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19238,
+      "min_nanos": 18908,
+      "max_nanos": 19950,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20671,
+      "min_nanos": 20280,
+      "max_nanos": 22253,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20311,
+      "min_nanos": 19859,
+      "max_nanos": 21702,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20381,
+      "min_nanos": 20270,
+      "max_nanos": 20721,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 33159,
+      "min_nanos": 27060,
+      "max_nanos": 38046,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 35142,
+      "min_nanos": 33619,
+      "max_nanos": 58887,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 27031,
+      "min_nanos": 26289,
+      "max_nanos": 29143,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 26319,
+      "min_nanos": 25968,
+      "max_nanos": 26849,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34992,
+      "min_nanos": 34682,
+      "max_nanos": 38066,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 26489,
+      "min_nanos": 25839,
+      "max_nanos": 30745,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 37525,
+      "min_nanos": 37255,
+      "max_nanos": 44856,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34321,
+      "min_nanos": 34281,
+      "max_nanos": 35682,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 35763,
+      "min_nanos": 34912,
+      "max_nanos": 35914,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 45067,
+      "min_nanos": 43695,
+      "max_nanos": 56304,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31026,
+      "min_nanos": 29143,
+      "max_nanos": 33459,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 38968,
+      "min_nanos": 38177,
+      "max_nanos": 43474,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28032,
+      "min_nanos": 27731,
+      "max_nanos": 28803,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 41121,
+      "min_nanos": 39969,
+      "max_nanos": 42383,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 30295,
+      "min_nanos": 29925,
+      "max_nanos": 31868,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31347,
+      "min_nanos": 31066,
+      "max_nanos": 34661,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 41582,
+      "min_nanos": 40840,
+      "max_nanos": 46028,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 30606,
+      "min_nanos": 30104,
+      "max_nanos": 33679,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 57836,
+      "min_nanos": 56484,
+      "max_nanos": 67881,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 62823,
+      "min_nanos": 60380,
+      "max_nanos": 73829,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 44936,
+      "min_nanos": 44026,
+      "max_nanos": 48001,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 35412,
+      "min_nanos": 34972,
+      "max_nanos": 37155,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 37286,
+      "min_nanos": 36935,
+      "max_nanos": 39128,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 51286,
+      "min_nanos": 49503,
+      "max_nanos": 58476,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 69673,
+      "min_nanos": 66959,
+      "max_nanos": 75532,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 48762,
+      "min_nanos": 47800,
+      "max_nanos": 52618,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 35102,
+      "min_nanos": 34391,
+      "max_nanos": 39979,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 45648,
+      "min_nanos": 44896,
+      "max_nanos": 50615,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 38067,
+      "min_nanos": 37716,
+      "max_nanos": 39578,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 51617,
+      "min_nanos": 51045,
+      "max_nanos": 57005,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 38277,
+      "min_nanos": 37936,
+      "max_nanos": 41161,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 57064,
+      "min_nanos": 55873,
+      "max_nanos": 67781,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 68070,
+      "min_nanos": 66679,
+      "max_nanos": 74440,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 66188,
+      "min_nanos": 64335,
+      "max_nanos": 73689,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 53690,
+      "min_nanos": 52638,
+      "max_nanos": 56784,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 46068,
+      "min_nanos": 44516,
+      "max_nanos": 54841,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 64926,
+      "min_nanos": 63664,
+      "max_nanos": 71346,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 45698,
+      "min_nanos": 45116,
+      "max_nanos": 58216,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 44967,
+      "min_nanos": 44386,
+      "max_nanos": 45528,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 82413,
+      "min_nanos": 80859,
+      "max_nanos": 91626,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 56423,
+      "min_nanos": 55823,
+      "max_nanos": 65297,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 72397,
+      "min_nanos": 70675,
+      "max_nanos": 76413,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 45057,
+      "min_nanos": 44916,
+      "max_nanos": 46739,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 81130,
+      "min_nanos": 78967,
+      "max_nanos": 100038,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 64606,
+      "min_nanos": 62974,
+      "max_nanos": 72107,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 67860,
+      "min_nanos": 64946,
+      "max_nanos": 70454,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 48722,
+      "min_nanos": 47410,
+      "max_nanos": 51016,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 69333,
+      "min_nanos": 68151,
+      "max_nanos": 74280,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 55983,
+      "min_nanos": 54731,
+      "max_nanos": 60850,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 64155,
+      "min_nanos": 62904,
+      "max_nanos": 68802,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 70565,
+      "min_nanos": 68432,
+      "max_nanos": 75412,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 101871,
+      "min_nanos": 100259,
+      "max_nanos": 112777,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 70975,
+      "min_nanos": 69132,
+      "max_nanos": 73989,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 103484,
+      "min_nanos": 102141,
+      "max_nanos": 111195,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 60950,
+      "min_nanos": 57986,
+      "max_nanos": 64565,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 102762,
+      "min_nanos": 100480,
+      "max_nanos": 110123,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 81531,
+      "min_nanos": 79788,
+      "max_nanos": 87911,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 77195,
+      "min_nanos": 73670,
+      "max_nanos": 80640,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 86128,
+      "min_nanos": 84766,
+      "max_nanos": 91105,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 83353,
+      "min_nanos": 82463,
+      "max_nanos": 92978,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 64285,
+      "min_nanos": 63504,
+      "max_nanos": 89853,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 96343,
+      "min_nanos": 92677,
+      "max_nanos": 106738,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 104485,
+      "min_nanos": 101050,
+      "max_nanos": 110814,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 109642,
+      "min_nanos": 106819,
+      "max_nanos": 118176,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 76153,
+      "min_nanos": 74230,
+      "max_nanos": 80329,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 70965,
+      "min_nanos": 70445,
+      "max_nanos": 73529,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 159336,
+      "min_nanos": 158475,
+      "max_nanos": 181239,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 124465,
+      "min_nanos": 118055,
+      "max_nanos": 140188,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 68582,
+      "min_nanos": 66990,
+      "max_nanos": 70985,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 78907,
+      "min_nanos": 77645,
+      "max_nanos": 104245,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 153187,
+      "min_nanos": 148790,
+      "max_nanos": 162512,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 129502,
+      "min_nanos": 127119,
+      "max_nanos": 151054,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 89252,
+      "min_nanos": 87159,
+      "max_nanos": 98316,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 206626,
+      "min_nanos": 200418,
+      "max_nanos": 227477,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 175199,
+      "min_nanos": 166677,
+      "max_nanos": 186456,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 93078,
+      "min_nanos": 92948,
+      "max_nanos": 102091,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 80039,
+      "min_nanos": 78417,
+      "max_nanos": 83784,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 105426,
+      "min_nanos": 104655,
+      "max_nanos": 107960,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 225825,
+      "min_nanos": 215850,
+      "max_nanos": 251453,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 157754,
+      "min_nanos": 152846,
+      "max_nanos": 181830,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 116192,
+      "min_nanos": 114630,
+      "max_nanos": 124915,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 138826,
+      "min_nanos": 137694,
+      "max_nanos": 148310,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 164504,
+      "min_nanos": 162961,
+      "max_nanos": 166578,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 219275,
+      "min_nanos": 213937,
+      "max_nanos": 254638,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 115661,
+      "min_nanos": 113749,
+      "max_nanos": 120028,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 146067,
+      "min_nanos": 145575,
+      "max_nanos": 160177,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 191764,
+      "min_nanos": 187649,
+      "max_nanos": 200307,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 121550,
+      "min_nanos": 119337,
+      "max_nanos": 148200,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 129652,
+      "min_nanos": 128780,
+      "max_nanos": 131825,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 299283,
+      "min_nanos": 286835,
+      "max_nanos": 322248,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 281988,
+      "min_nanos": 263351,
+      "max_nanos": 304561,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 261738,
+      "min_nanos": 255719,
+      "max_nanos": 295749,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 111355,
+      "min_nanos": 110173,
+      "max_nanos": 114480,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 436657,
+      "min_nanos": 416417,
+      "max_nanos": 468125,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 305633,
+      "min_nanos": 293565,
+      "max_nanos": 336068,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 333995,
+      "min_nanos": 329758,
+      "max_nanos": 360164,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 156051,
+      "min_nanos": 154359,
+      "max_nanos": 162972,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 233736,
+      "min_nanos": 228429,
+      "max_nanos": 254887,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 295578,
+      "min_nanos": 281087,
+      "max_nanos": 315307,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 265503,
+      "min_nanos": 263802,
+      "max_nanos": 296179,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 128100,
+      "min_nanos": 127399,
+      "max_nanos": 129922,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 363859,
+      "min_nanos": 341867,
+      "max_nanos": 403529,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 128571,
+      "min_nanos": 127389,
+      "max_nanos": 137825,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 332943,
+      "min_nanos": 327226,
+      "max_nanos": 367785,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 192185,
+      "min_nanos": 191383,
+      "max_nanos": 199897,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 267717,
+      "min_nanos": 260165,
+      "max_nanos": 283901,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 243051,
+      "min_nanos": 238924,
+      "max_nanos": 264692,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 283030,
+      "min_nanos": 273776,
+      "max_nanos": 306765,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 189281,
+      "min_nanos": 187698,
+      "max_nanos": 194438,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 296059,
+      "min_nanos": 280286,
+      "max_nanos": 315638,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 269039,
+      "min_nanos": 264021,
+      "max_nanos": 299754,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 475215,
+      "min_nanos": 460042,
+      "max_nanos": 515554,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 209551,
+      "min_nanos": 207478,
+      "max_nanos": 221728,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 391761,
+      "min_nanos": 372172,
+      "max_nanos": 434535,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 432071,
+      "min_nanos": 417039,
+      "max_nanos": 466872,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 477057,
+      "min_nanos": 454624,
+      "max_nanos": 509776,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 178795,
+      "min_nanos": 175770,
+      "max_nanos": 188970,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 202480,
+      "min_nanos": 202060,
+      "max_nanos": 210522,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 292974,
+      "min_nanos": 287166,
+      "max_nanos": 316178,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 382717,
+      "min_nanos": 369928,
+      "max_nanos": 405651,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 238253,
+      "min_nanos": 234678,
+      "max_nanos": 242930,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 469166,
+      "min_nanos": 451239,
+      "max_nanos": 515895,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 448195,
+      "min_nanos": 434394,
+      "max_nanos": 473101,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 581112,
+      "min_nanos": 564437,
+      "max_nanos": 623985,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 219996,
+      "min_nanos": 218273,
+      "max_nanos": 230171,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 503247,
+      "min_nanos": 484738,
+      "max_nanos": 541373,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 442977,
+      "min_nanos": 430088,
+      "max_nanos": 470608,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 490527,
+      "min_nanos": 476587,
+      "max_nanos": 540131,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 273235,
+      "min_nanos": 271132,
+      "max_nanos": 280395,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 498079,
+      "min_nanos": 483677,
+      "max_nanos": 530677,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 534753,
+      "min_nanos": 513842,
+      "max_nanos": 570887,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 540992,
+      "min_nanos": 531629,
+      "max_nanos": 582744,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 216521,
+      "min_nanos": 209771,
+      "max_nanos": 240947,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 357009,
+      "min_nanos": 353123,
+      "max_nanos": 362267,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 592949,
+      "min_nanos": 571988,
+      "max_nanos": 650945,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 290350,
+      "min_nanos": 284282,
+      "max_nanos": 299264,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 307455,
+      "min_nanos": 304101,
+      "max_nanos": 309409,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 842299,
+      "min_nanos": 827688,
+      "max_nanos": 880675,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 670915,
+      "min_nanos": 642333,
+      "max_nanos": 699226,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 389878,
+      "min_nanos": 378441,
+      "max_nanos": 416478,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 232655,
+      "min_nanos": 229340,
+      "max_nanos": 242219,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 319683,
+      "min_nanos": 317951,
+      "max_nanos": 322458,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 343029,
+      "min_nanos": 330981,
+      "max_nanos": 392001,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 681711,
+      "min_nanos": 661922,
+      "max_nanos": 733538,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 366323,
+      "min_nanos": 362918,
+      "max_nanos": 374124,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 906744,
+      "min_nanos": 895628,
+      "max_nanos": 918081,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 963088,
+      "min_nanos": 943439,
+      "max_nanos": 992772,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 746978,
+      "min_nanos": 731906,
+      "max_nanos": 771474,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 276410,
+      "min_nanos": 274317,
+      "max_nanos": 282469,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 299804,
+      "min_nanos": 295588,
+      "max_nanos": 346594,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 688671,
+      "min_nanos": 662151,
+      "max_nanos": 712607,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 604546,
+      "min_nanos": 571577,
+      "max_nanos": 639629,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 364480,
+      "min_nanos": 361056,
+      "max_nanos": 382337,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 1155363,
+      "min_nanos": 1137176,
+      "max_nanos": 1173350,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 385622,
+      "min_nanos": 378651,
+      "max_nanos": 387775,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 521543,
+      "min_nanos": 517227,
+      "max_nanos": 523907,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 888087,
+      "min_nanos": 876771,
+      "max_nanos": 908147,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 442306,
+      "min_nanos": 438630,
+      "max_nanos": 445441,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 956688,
+      "min_nanos": 945893,
+      "max_nanos": 978741,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 398581,
+      "min_nanos": 395707,
+      "max_nanos": 418420,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 545569,
+      "min_nanos": 542775,
+      "max_nanos": 549314,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1463040,
+      "min_nanos": 1457871,
+      "max_nanos": 1507155,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 974044,
+      "min_nanos": 955567,
+      "max_nanos": 1005962,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 507582,
+      "min_nanos": 504418,
+      "max_nanos": 522615,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 992201,
+      "min_nanos": 979713,
+      "max_nanos": 1008716,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1365495,
+      "min_nanos": 1355659,
+      "max_nanos": 1385274,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 1267319,
+      "min_nanos": 1260960,
+      "max_nanos": 1277554,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 382918,
+      "min_nanos": 381115,
+      "max_nanos": 396788,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 441935,
+      "min_nanos": 437618,
+      "max_nanos": 446743,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 924501,
+      "min_nanos": 913745,
+      "max_nanos": 947715,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 1602736,
+      "min_nanos": 1583979,
+      "max_nanos": 1615626,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 556144,
+      "min_nanos": 544958,
+      "max_nanos": 583445,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 517377,
+      "min_nanos": 512480,
+      "max_nanos": 522414,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 489326,
+      "min_nanos": 488494,
+      "max_nanos": 495535,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 1247139,
+      "min_nanos": 1239839,
+      "max_nanos": 1287990,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1354208,
+      "min_nanos": 1337633,
+      "max_nanos": 1362430,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 588353,
+      "min_nanos": 583315,
+      "max_nanos": 604015,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "certificate-boundary",
+      "name": "quartic_a4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 56103,
+      "min_nanos": 50805,
+      "max_nanos": 63464,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    }
+  ],
+  "cross_check": {
+    "mismatches": [],
+    "ok": true
+  }
+}

--- a/reports/bench-results/hexbz-phase-profile-a5a55cbf-chungus2.json
+++ b/reports/bench-results/hexbz-phase-profile-a5a55cbf-chungus2.json
@@ -1,0 +1,17771 @@
+{
+  "config": {
+    "controls": [
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "corpus": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "cpu": 1,
+    "cutoff_seconds": 120.0,
+    "hex_exe_sha256": "f2865db27f012eaad5f03488e6d796a35de3f16dddba834dcb4321247165edda",
+    "kernel_repeats": 8,
+    "names": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56",
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "plan_repeats": 3,
+    "repeat_ceiling_nanos": 1000000000,
+    "repeats": 5,
+    "representative": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56"
+    ],
+    "sampling_profiles": [
+      "sd5",
+      "sd5_x_phi11",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi385",
+      "wilkinson_56"
+    ],
+    "validate_cutoff_seconds": 2.0,
+    "warmup": 1
+  },
+  "counterfactuals": [],
+  "env": {
+    "arch": "x86_64",
+    "cpu_cores": 96,
+    "cpu_model": null,
+    "exe_name": "hexbz_factor_service",
+    "git_commit": "55fc3beef0f7dada6774c861cd1e71a2ba4beb18",
+    "git_dirty": true,
+    "hostname": "chungus2",
+    "lean_bench_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "lean_version": null,
+    "os": "linux",
+    "platform_target": null,
+    "timestamp_iso": "2026-08-05T00:19:41Z",
+    "timestamp_unix_ms": 1785889181305
+  },
+  "kernels": [
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4457,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1231906,
+            "smallAllocs": 120747
+          },
+          "berlekampSplit": {
+            "nanos": 3376576,
+            "smallAllocs": 279386
+          },
+          "columnPolys": {
+            "nanos": 1186524,
+            "smallAllocs": 116346
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 791,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 277558,
+              "smallAllocs": 15527
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 27485,
+              "smallAllocs": 1625
+            },
+            "stagedNanos": 305822,
+            "wall": {
+              "nanos": 323234,
+              "smallAllocs": 17591
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 808,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 505810,
+              "smallAllocs": 29287
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 37370,
+              "smallAllocs": 2137
+            },
+            "stagedNanos": 543952,
+            "wall": {
+              "nanos": 560581,
+              "smallAllocs": 31866
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 18042,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1357392,
+            "smallAllocs": 121100
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1258651,
+            "smallAllocs": 121804
+          },
+          "frobeniusPower": {
+            "nanos": 25693,
+            "smallAllocs": 2354
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 19308,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1269352,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 37615,
+          "nullspaceBasisNanos": 37615,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2183,
+            "packNanos": 41837,
+            "rank": 16,
+            "reduceNanos": 35473,
+            "reduceNanosSamples": [
+              47891,
+              37014,
+              35603,
+              33930,
+              35923,
+              33990,
+              35343,
+              34531
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 79984
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1918,
+            "packNanos": 41141,
+            "rank": 16,
+            "reduceNanos": 34892,
+            "reduceNanosSamples": [
+              34591,
+              34661,
+              34862,
+              34922,
+              35332,
+              35012,
+              34091,
+              35022
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 78011
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2328,
+            "packNanos": 41877,
+            "rank": 16,
+            "reduceNanos": 26339,
+            "reduceNanosSamples": [
+              25758,
+              27120,
+              25448,
+              26910,
+              25678,
+              27211,
+              25769,
+              27100
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 70529
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248160,
+              "rank": 16,
+              "readbackNanos": 33209,
+              "reduceNanos": 36244,
+              "reduceNanosSamples": [
+                36144,
+                36514,
+                35723,
+                36364,
+                35643,
+                36344,
+                35622,
+                36423
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1317648
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1247544,
+              "rank": 16,
+              "readbackNanos": 33229,
+              "reduceNanos": 39393,
+              "reduceNanosSamples": [
+                39148,
+                39888,
+                38918,
+                39639,
+                38778,
+                41462,
+                38698,
+                39649
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1325084
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1245937,
+              "rank": 16,
+              "readbackNanos": 33199,
+              "reduceNanos": 34486,
+              "reduceNanosSamples": [
+                35042,
+                34452,
+                34441,
+                34581,
+                34461,
+                33560,
+                34511,
+                34632
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1316196
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1247845,
+              "rank": 16,
+              "readbackNanos": 1948,
+              "reduceNanos": 34085,
+              "reduceNanosSamples": [
+                34742,
+                34021,
+                33970,
+                34150,
+                35573,
+                33990,
+                33900,
+                34551
+              ],
+              "smallAllocs": 120097,
+              "totalNanos": 1284209
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246007,
+              "rank": 16,
+              "readbackNanos": 33039,
+              "reduceNanos": 38887,
+              "reduceNanosSamples": [
+                39649,
+                39138,
+                41321,
+                38778,
+                38127,
+                38707,
+                38997,
+                38697
+              ],
+              "smallAllocs": 122378,
+              "totalNanos": 1317683
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246152,
+              "rank": 16,
+              "readbackNanos": 32899,
+              "reduceNanos": 40660,
+              "reduceNanosSamples": [
+                41261,
+                40930,
+                40540,
+                40860,
+                40670,
+                40650,
+                40369,
+                40600
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1319852
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248361,
+              "rank": 16,
+              "readbackNanos": 33144,
+              "reduceNanos": 36033,
+              "reduceNanosSamples": [
+                37435,
+                35573,
+                36234,
+                35253,
+                36153,
+                35402,
+                35913,
+                39007
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1318595
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1250899,
+              "rank": 16,
+              "readbackNanos": 33024,
+              "reduceNanos": 36809,
+              "reduceNanosSamples": [
+                37786,
+                36804,
+                36804,
+                36725,
+                36785,
+                36915,
+                36965,
+                36814
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1320743
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1249532,
+              "rank": 16,
+              "readbackNanos": 33064,
+              "reduceNanos": 87845,
+              "reduceNanosSamples": [
+                86918,
+                89022,
+                88281,
+                87530,
+                86699,
+                87579,
+                88111,
+                88562
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1370717
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248936,
+              "rank": 16,
+              "readbackNanos": 33169,
+              "reduceNanos": 88231,
+              "reduceNanosSamples": [
+                87640,
+                89243,
+                89042,
+                87560,
+                87720,
+                87931,
+                88531,
+                88882
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1371098
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1251595,
+              "rank": 16,
+              "readbackNanos": 33154,
+              "reduceNanos": 36379,
+              "reduceNanosSamples": [
+                36855,
+                36053,
+                36985,
+                36874,
+                36414,
+                36344,
+                36094,
+                36074
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1321224
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1244590,
+              "rank": 16,
+              "readbackNanos": 33048,
+              "reduceNanos": 34060,
+              "reduceNanosSamples": [
+                34882,
+                34381,
+                34371,
+                33540,
+                33500,
+                34221,
+                33279,
+                33900
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1311770
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1243368,
+              "smallAllocs": 119722
+            },
+            "columnCount": {
+              "nanos": 7718,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 84506,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 6880,
+            "pivotSearch": {
+              "nanos": 847,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 32924,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 4873,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 90062,
+            "wall": {
+              "nanos": 100709,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5303,
+            "packNanos": 39584,
+            "rank": 16,
+            "reduceNanos": 60455,
+            "reduceNanosSamples": [
+              63594,
+              60570,
+              60359,
+              60470,
+              60440,
+              60370,
+              60390,
+              60620
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 8858,
+            "totalNanos": 105636
+          },
+          "peakResidentBytes": 63473664,
+          "productionMatrixRebuild": {
+            "nanos": 1289472,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 586539,
+            "smallAllocs": 31823
+          },
+          "productionRowReduce": {
+            "nanos": 550421,
+            "smallAllocs": 30631
+          },
+          "rank": 16,
+          "residentBytesAfter": 63164416,
+          "residentBytesBefore": 62935040,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1285766,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4582,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1609120,
+            "smallAllocs": 149530
+          },
+          "berlekampSplit": {
+            "nanos": 3221857,
+            "smallAllocs": 258979
+          },
+          "columnPolys": {
+            "nanos": 1559622,
+            "smallAllocs": 145131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 761,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 559043,
+              "smallAllocs": 30737
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 26986,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 586637,
+            "wall": {
+              "nanos": 604831,
+              "smallAllocs": 32793
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 801,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1042829,
+              "smallAllocs": 59473
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 37061,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1080706,
+            "wall": {
+              "nanos": 1098398,
+              "smallAllocs": 62044
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 24921,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1809012,
+            "smallAllocs": 149883
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1633051,
+            "smallAllocs": 150587
+          },
+          "frobeniusPower": {
+            "nanos": 25869,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 21788,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1643526,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 47099,
+          "nullspaceBasisNanos": 47099,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2143,
+            "packNanos": 41662,
+            "rank": 16,
+            "reduceNanos": 61105,
+            "reduceNanosSamples": [
+              62242,
+              60550,
+              61601,
+              60610,
+              65286,
+              60059,
+              63814,
+              60099
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 106037
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1963,
+            "packNanos": 41476,
+            "rank": 16,
+            "reduceNanos": 61612,
+            "reduceNanosSamples": [
+              61642,
+              61952,
+              60610,
+              61541,
+              61702,
+              60460,
+              61852,
+              61582
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 105020
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2233,
+            "packNanos": 41957,
+            "rank": 16,
+            "reduceNanos": 53118,
+            "reduceNanosSamples": [
+              52238,
+              53369,
+              52678,
+              56964,
+              52688,
+              53609,
+              52868,
+              53829
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 97324
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619445,
+              "rank": 16,
+              "readbackNanos": 34265,
+              "reduceNanos": 58246,
+              "reduceNanosSamples": [
+                58117,
+                58647,
+                57946,
+                58677,
+                57656,
+                58376,
+                57676,
+                59017
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1711312
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619060,
+              "rank": 16,
+              "readbackNanos": 34005,
+              "reduceNanos": 69518,
+              "reduceNanosSamples": [
+                69513,
+                69643,
+                69413,
+                70084,
+                69523,
+                69383,
+                68972,
+                70184
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1722418
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1616301,
+              "rank": 16,
+              "readbackNanos": 33845,
+              "reduceNanos": 59433,
+              "reduceNanosSamples": [
+                59509,
+                59448,
+                57926,
+                57886,
+                59418,
+                61691,
+                57735,
+                59979
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1709705
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1618660,
+              "rank": 16,
+              "readbackNanos": 2008,
+              "reduceNanos": 61095,
+              "reduceNanosSamples": [
+                63764,
+                64375,
+                60580,
+                60179,
+                61611,
+                60079,
+                62172,
+                60329
+              ],
+              "smallAllocs": 148646,
+              "totalNanos": 1683290
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619195,
+              "rank": 16,
+              "readbackNanos": 33660,
+              "reduceNanos": 64185,
+              "reduceNanosSamples": [
+                64045,
+                64346,
+                62633,
+                64355,
+                63053,
+                64055,
+                64316,
+                64806
+              ],
+              "smallAllocs": 151395,
+              "totalNanos": 1717151
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1622055,
+              "rank": 16,
+              "readbackNanos": 33780,
+              "reduceNanos": 68090,
+              "reduceNanosSamples": [
+                68070,
+                67610,
+                68222,
+                68252,
+                68111,
+                67941,
+                67620,
+                68331
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1723570
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1618579,
+              "rank": 16,
+              "readbackNanos": 34170,
+              "reduceNanos": 57751,
+              "reduceNanosSamples": [
+                58337,
+                57716,
+                58177,
+                57666,
+                57686,
+                57435,
+                57986,
+                57786
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1710461
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1615414,
+              "rank": 16,
+              "readbackNanos": 34160,
+              "reduceNanos": 60139,
+              "reduceNanosSamples": [
+                60139,
+                62743,
+                60349,
+                60079,
+                60070,
+                60139,
+                59958,
+                60470
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1710060
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1617864,
+              "rank": 16,
+              "readbackNanos": 34316,
+              "reduceNanos": 174423,
+              "reduceNanosSamples": [
+                178905,
+                174388,
+                189241,
+                174459,
+                171634,
+                171414,
+                172996,
+                177273
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1830894
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1617708,
+              "rank": 16,
+              "readbackNanos": 33990,
+              "reduceNanos": 173928,
+              "reduceNanosSamples": [
+                171233,
+                174479,
+                175780,
+                174980,
+                171805,
+                171534,
+                173377,
+                182050
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1829071
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1614784,
+              "rank": 16,
+              "readbackNanos": 33930,
+              "reduceNanos": 64070,
+              "reduceNanosSamples": [
+                62503,
+                64175,
+                64045,
+                64095,
+                63064,
+                62273,
+                68532,
+                67099
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1714987
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1616767,
+              "rank": 16,
+              "readbackNanos": 33735,
+              "reduceNanos": 59608,
+              "reduceNanosSamples": [
+                59748,
+                59618,
+                59608,
+                57915,
+                59478,
+                57846,
+                59609,
+                59839
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1709379
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1622100,
+              "smallAllocs": 148505
+            },
+            "columnCount": {
+              "nanos": 7651,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 169036,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14368,
+            "pivotSearch": {
+              "nanos": 841,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 33875,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 4822,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 174855,
+            "wall": {
+              "nanos": 185275,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5363,
+            "packNanos": 40084,
+            "rank": 16,
+            "reduceNanos": 111110,
+            "reduceNanosSamples": [
+              122741,
+              110854,
+              111164,
+              111045,
+              110865,
+              111705,
+              111115,
+              111105
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 16080,
+            "totalNanos": 156602
+          },
+          "peakResidentBytes": 63563776,
+          "productionMatrixRebuild": {
+            "nanos": 1659760,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1138257,
+            "smallAllocs": 62101
+          },
+          "productionRowReduce": {
+            "nanos": 1093311,
+            "smallAllocs": 60809
+          },
+          "rank": 16,
+          "residentBytesAfter": 63438848,
+          "residentBytesBefore": 63389696,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1661678,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4516,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1602981,
+            "smallAllocs": 149061
+          },
+          "berlekampSplit": {
+            "nanos": 4788359,
+            "smallAllocs": 381697
+          },
+          "columnPolys": {
+            "nanos": 1551801,
+            "smallAllocs": 144662
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 759,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 570392,
+              "smallAllocs": 31127
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 27044,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 598337,
+            "wall": {
+              "nanos": 616514,
+              "smallAllocs": 33183
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 796,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1058297,
+              "smallAllocs": 60247
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 37481,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1098203,
+            "wall": {
+              "nanos": 1115258,
+              "smallAllocs": 62818
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 17336,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1801891,
+            "smallAllocs": 149414
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1623832,
+            "smallAllocs": 150118
+          },
+          "frobeniusPower": {
+            "nanos": 26068,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 22257,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1633146,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 47796,
+          "nullspaceBasisNanos": 47796,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2008,
+            "packNanos": 41732,
+            "rank": 16,
+            "reduceNanos": 61706,
+            "reduceNanosSamples": [
+              63154,
+              60500,
+              62332,
+              60560,
+              65798,
+              61080,
+              62793,
+              60951
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 105611
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1883,
+            "packNanos": 41426,
+            "rank": 16,
+            "reduceNanos": 62508,
+            "reduceNanosSamples": [
+              62513,
+              62793,
+              62503,
+              62663,
+              61081,
+              62342,
+              62653,
+              62493
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 105717
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2148,
+            "packNanos": 42493,
+            "rank": 16,
+            "reduceNanos": 53619,
+            "reduceNanosSamples": [
+              53039,
+              54200,
+              52648,
+              54420,
+              52628,
+              54370,
+              52789,
+              54310
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 99352
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1611194,
+              "rank": 16,
+              "readbackNanos": 33644,
+              "reduceNanos": 58461,
+              "reduceNanosSamples": [
+                58387,
+                58616,
+                58066,
+                58877,
+                58287,
+                58536,
+                57945,
+                58797
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1703455
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1608795,
+              "rank": 16,
+              "readbackNanos": 33670,
+              "reduceNanos": 69969,
+              "reduceNanosSamples": [
+                70184,
+                70655,
+                69754,
+                70835,
+                69714,
+                70264,
+                69452,
+                69724
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1712529
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1605770,
+              "rank": 16,
+              "readbackNanos": 33439,
+              "reduceNanos": 59829,
+              "reduceNanosSamples": [
+                60069,
+                59849,
+                58357,
+                60109,
+                59809,
+                59889,
+                59669,
+                59798
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1699239
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609071,
+              "rank": 16,
+              "readbackNanos": 1822,
+              "reduceNanos": 61040,
+              "reduceNanosSamples": [
+                60860,
+                60820,
+                61220,
+                60830,
+                62272,
+                60720,
+                63204,
+                79158
+              ],
+              "smallAllocs": 148171,
+              "totalNanos": 1677106
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1613622,
+              "rank": 16,
+              "readbackNanos": 33464,
+              "reduceNanos": 64751,
+              "reduceNanosSamples": [
+                63173,
+                66098,
+                64726,
+                63003,
+                64566,
+                64776,
+                65727,
+                65126
+              ],
+              "smallAllocs": 150932,
+              "totalNanos": 1711948
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610744,
+              "rank": 16,
+              "readbackNanos": 33404,
+              "reduceNanos": 68842,
+              "reduceNanosSamples": [
+                68923,
+                68852,
+                68832,
+                69243,
+                71677,
+                68762,
+                68562,
+                68361
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1712464
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1605505,
+              "rank": 16,
+              "readbackNanos": 33449,
+              "reduceNanos": 58387,
+              "reduceNanosSamples": [
+                58506,
+                61801,
+                58277,
+                57835,
+                58397,
+                60169,
+                58377,
+                57866
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1699525
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1604859,
+              "rank": 16,
+              "readbackNanos": 33530,
+              "reduceNanos": 60575,
+              "reduceNanosSamples": [
+                60870,
+                60760,
+                60289,
+                60500,
+                60650,
+                60310,
+                60319,
+                63694
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1702068
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610933,
+              "rank": 16,
+              "readbackNanos": 33545,
+              "reduceNanos": 173642,
+              "reduceNanosSamples": [
+                174869,
+                172686,
+                176862,
+                171555,
+                170042,
+                172786,
+                177994,
+                174498
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1818331
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610057,
+              "rank": 16,
+              "readbackNanos": 33519,
+              "reduceNanos": 173692,
+              "reduceNanosSamples": [
+                178104,
+                175140,
+                170754,
+                174799,
+                174128,
+                173107,
+                173257,
+                170913
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1817223
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1608970,
+              "rank": 16,
+              "readbackNanos": 33479,
+              "reduceNanos": 64476,
+              "reduceNanosSamples": [
+                63425,
+                63554,
+                63294,
+                64766,
+                65277,
+                67530,
+                65207,
+                64186
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1707241
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607923,
+              "rank": 16,
+              "readbackNanos": 33624,
+              "reduceNanos": 60058,
+              "reduceNanosSamples": [
+                60230,
+                60269,
+                59879,
+                69603,
+                60149,
+                59839,
+                59968,
+                59739
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1701707
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1614328,
+              "smallAllocs": 148036
+            },
+            "columnCount": {
+              "nanos": 7586,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 168415,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14560,
+            "pivotSearch": {
+              "nanos": 832,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 33860,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 4859,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 174121,
+            "wall": {
+              "nanos": 185630,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5347,
+            "packNanos": 39178,
+            "rank": 16,
+            "reduceNanos": 110057,
+            "reduceNanosSamples": [
+              112216,
+              112567,
+              111216,
+              109543,
+              110463,
+              109652,
+              109152,
+              108641
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 16266,
+            "totalNanos": 154905
+          },
+          "peakResidentBytes": 63586304,
+          "productionMatrixRebuild": {
+            "nanos": 1646836,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1154306,
+            "smallAllocs": 62874
+          },
+          "productionRowReduce": {
+            "nanos": 1107667,
+            "smallAllocs": 61583
+          },
+          "rank": 16,
+          "residentBytesAfter": 63664128,
+          "residentBytesBefore": 63664128,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1646431,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift2",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4562,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1607994,
+            "smallAllocs": 149683
+          },
+          "berlekampSplit": {
+            "nanos": 3998252,
+            "smallAllocs": 320808
+          },
+          "columnPolys": {
+            "nanos": 1557193,
+            "smallAllocs": 145284
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 766,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 556516,
+              "smallAllocs": 30412
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 27069,
+              "smallAllocs": 1618
+            },
+            "stagedNanos": 584322,
+            "wall": {
+              "nanos": 603053,
+              "smallAllocs": 32469
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 804,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1025094,
+              "smallAllocs": 58828
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 37374,
+              "smallAllocs": 2130
+            },
+            "stagedNanos": 1063311,
+            "wall": {
+              "nanos": 1080722,
+              "smallAllocs": 61400
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 18797,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1805692,
+            "smallAllocs": 150036
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1621564,
+            "smallAllocs": 150740
+          },
+          "frobeniusPower": {
+            "nanos": 26088,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 16265,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1640076,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 47140,
+          "nullspaceBasisNanos": 47140,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1933,
+            "packNanos": 41656,
+            "rank": 16,
+            "reduceNanos": 60710,
+            "reduceNanosSamples": [
+              62353,
+              59799,
+              61522,
+              60160,
+              61261,
+              60160,
+              61611,
+              59748
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 104304
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1698,
+            "packNanos": 41381,
+            "rank": 16,
+            "reduceNanos": 61271,
+            "reduceNanosSamples": [
+              61572,
+              60249,
+              60549,
+              61581,
+              61271,
+              61732,
+              61271,
+              61220
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 104320
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2048,
+            "packNanos": 42112,
+            "rank": 16,
+            "reduceNanos": 53404,
+            "reduceNanosSamples": [
+              52407,
+              54530,
+              52478,
+              54411,
+              52478,
+              53930,
+              52969,
+              53840
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 97449
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1618599,
+              "rank": 16,
+              "readbackNanos": 33810,
+              "reduceNanos": 57505,
+              "reduceNanosSamples": [
+                57535,
+                57976,
+                57084,
+                57876,
+                57015,
+                57996,
+                56965,
+                57475
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1709995
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619150,
+              "rank": 16,
+              "readbackNanos": 33690,
+              "reduceNanos": 68827,
+              "reduceNanosSamples": [
+                68832,
+                68972,
+                68782,
+                69312,
+                68731,
+                69412,
+                68562,
+                68822
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1722048
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619971,
+              "rank": 16,
+              "readbackNanos": 33579,
+              "reduceNanos": 58812,
+              "reduceNanosSamples": [
+                58777,
+                59338,
+                58877,
+                59278,
+                57305,
+                58848,
+                57024,
+                58777
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1711627
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619401,
+              "rank": 16,
+              "readbackNanos": 1823,
+              "reduceNanos": 60394,
+              "reduceNanosSamples": [
+                60810,
+                59979,
+                60440,
+                60240,
+                60349,
+                61501,
+                61752,
+                59839
+              ],
+              "smallAllocs": 148804,
+              "totalNanos": 1682143
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1617147,
+              "rank": 16,
+              "readbackNanos": 33480,
+              "reduceNanos": 64515,
+              "reduceNanosSamples": [
+                63845,
+                79388,
+                65186,
+                63374,
+                63144,
+                63254,
+                66669,
+                68071
+              ],
+              "smallAllocs": 151543,
+              "totalNanos": 1716750
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1616702,
+              "rank": 16,
+              "readbackNanos": 33479,
+              "reduceNanos": 67349,
+              "reduceNanosSamples": [
+                67150,
+                67650,
+                67470,
+                67621,
+                66869,
+                67900,
+                67169,
+                67229
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1717626
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1615870,
+              "rank": 16,
+              "readbackNanos": 33444,
+              "reduceNanos": 57170,
+              "reduceNanosSamples": [
+                57586,
+                57155,
+                57495,
+                56864,
+                57275,
+                56915,
+                57185,
+                56734
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1706505
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619326,
+              "rank": 16,
+              "readbackNanos": 33630,
+              "reduceNanos": 59518,
+              "reduceNanosSamples": [
+                63074,
+                59619,
+                64115,
+                59418,
+                59378,
+                59628,
+                59368,
+                59398
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1713716
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1620352,
+              "rank": 16,
+              "readbackNanos": 33710,
+              "reduceNanos": 169366,
+              "reduceNanosSamples": [
+                171605,
+                169361,
+                183592,
+                168250,
+                171865,
+                166697,
+                169371,
+                164454
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1823388
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619230,
+              "rank": 16,
+              "readbackNanos": 33695,
+              "reduceNanos": 168965,
+              "reduceNanosSamples": [
+                169001,
+                170513,
+                173677,
+                168620,
+                168930,
+                167388,
+                171524,
+                164434
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1822957
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1617899,
+              "rank": 16,
+              "readbackNanos": 33560,
+              "reduceNanos": 62412,
+              "reduceNanosSamples": [
+                62002,
+                63354,
+                63073,
+                63414,
+                62272,
+                62372,
+                62142,
+                62453
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1713795
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1618619,
+              "rank": 16,
+              "readbackNanos": 33579,
+              "reduceNanos": 58196,
+              "reduceNanosSamples": [
+                60459,
+                57395,
+                56974,
+                57506,
+                59068,
+                58988,
+                58887,
+                57275
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1710490
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1620878,
+              "smallAllocs": 148658
+            },
+            "columnCount": {
+              "nanos": 7586,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 164958,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14208,
+            "pivotSearch": {
+              "nanos": 847,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 33574,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 4938,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 170590,
+            "wall": {
+              "nanos": 181329,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5398,
+            "packNanos": 39498,
+            "rank": 16,
+            "reduceNanos": 107384,
+            "reduceNanosSamples": [
+              116583,
+              108260,
+              107229,
+              107439,
+              107329,
+              107680,
+              107118,
+              107049
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 15925,
+            "totalNanos": 152541
+          },
+          "peakResidentBytes": 63520768,
+          "productionMatrixRebuild": {
+            "nanos": 1656786,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1123836,
+            "smallAllocs": 61452
+          },
+          "productionRowReduce": {
+            "nanos": 1074182,
+            "smallAllocs": 60165
+          },
+          "rank": 16,
+          "residentBytesAfter": 63545344,
+          "residentBytesBefore": 63512576,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1659986,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd4_x_sd4shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 42,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 42,
+          "basisToPolynomials": {
+            "nanos": 5147,
+            "smallAllocs": 444
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2818223,
+            "smallAllocs": 263817
+          },
+          "berlekampSplit": {
+            "nanos": 7763209,
+            "smallAllocs": 625572
+          },
+          "columnPolys": {
+            "nanos": 2762375,
+            "smallAllocs": 258009
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1002,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 1445186,
+              "smallAllocs": 82650
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 53766,
+              "smallAllocs": 3279
+            },
+            "stagedNanos": 1499814,
+            "wall": {
+              "nanos": 1531575,
+              "smallAllocs": 86460
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1058,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 2747412,
+              "smallAllocs": 161190
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 74124,
+              "smallAllocs": 4329
+            },
+            "stagedNanos": 2823275,
+            "wall": {
+              "nanos": 2850891,
+              "smallAllocs": 166053
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 34922,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3305150,
+            "smallAllocs": 264369
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2859769,
+            "smallAllocs": 265624
+          },
+          "frobeniusPower": {
+            "nanos": 25277,
+            "smallAllocs": 2281
+          },
+          "kernelDimension": 17,
+          "matrixConversionNanos": 36439,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2902488,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 78206,
+          "nullspaceBasisNanos": 78206,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2979,
+            "packNanos": 73759,
+            "rank": 25,
+            "reduceNanos": 157478,
+            "reduceNanosSamples": [
+              158124,
+              156712,
+              158125,
+              156421,
+              159146,
+              156612,
+              162821,
+              156833
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 234102
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2639,
+            "packNanos": 73689,
+            "rank": 25,
+            "reduceNanos": 160272,
+            "reduceNanosSamples": [
+              159877,
+              157143,
+              160377,
+              160168,
+              161329,
+              160067,
+              164594,
+              160437
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 236500
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3059,
+            "packNanos": 74946,
+            "rank": 25,
+            "reduceNanos": 140353,
+            "reduceNanosSamples": [
+              142321,
+              140328,
+              138816,
+              140378,
+              139607,
+              140879,
+              139297,
+              143183
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 218939
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2822580,
+              "rank": 25,
+              "readbackNanos": 53283,
+              "reduceNanos": 143598,
+              "reduceNanosSamples": [
+                144254,
+                145445,
+                144765,
+                143673,
+                143212,
+                143363,
+                142842,
+                143523
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3019657
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2829419,
+              "rank": 25,
+              "readbackNanos": 52883,
+              "reduceNanos": 180678,
+              "reduceNanosSamples": [
+                178705,
+                182421,
+                184484,
+                181920,
+                178585,
+                182061,
+                178926,
+                179436
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3064493
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2823771,
+              "rank": 25,
+              "readbackNanos": 52557,
+              "reduceNanos": 153523,
+              "reduceNanosSamples": [
+                154499,
+                153408,
+                153347,
+                156372,
+                153638,
+                151294,
+                151165,
+                156332
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3028990
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2826476,
+              "rank": 25,
+              "readbackNanos": 2794,
+              "reduceNanos": 157748,
+              "reduceNanosSamples": [
+                157263,
+                157022,
+                158234,
+                156963,
+                158274,
+                156972,
+                160338,
+                160147
+              ],
+              "smallAllocs": 262265,
+              "totalNanos": 2986818
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2821037,
+              "rank": 25,
+              "readbackNanos": 52467,
+              "reduceNanos": 162376,
+              "reduceNanosSamples": [
+                161860,
+                160218,
+                161309,
+                170833,
+                165335,
+                161790,
+                162892,
+                168630
+              ],
+              "smallAllocs": 266773,
+              "totalNanos": 3037939
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2825889,
+              "rank": 25,
+              "readbackNanos": 52763,
+              "reduceNanos": 171724,
+              "reduceNanosSamples": [
+                170102,
+                170733,
+                172726,
+                173728,
+                171023,
+                171724,
+                171724,
+                173978
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3050332
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2824672,
+              "rank": 25,
+              "readbackNanos": 52568,
+              "reduceNanos": 144594,
+              "reduceNanosSamples": [
+                145806,
+                146157,
+                146337,
+                143162,
+                143382,
+                142712,
+                146447,
+                142482
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3022716
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2823185,
+              "rank": 25,
+              "readbackNanos": 52533,
+              "reduceNanos": 150027,
+              "reduceNanosSamples": [
+                149020,
+                153047,
+                151484,
+                149612,
+                150583,
+                149221,
+                150443,
+                149522
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3027238
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2828228,
+              "rank": 25,
+              "readbackNanos": 52773,
+              "reduceNanos": 448610,
+              "reduceNanosSamples": [
+                455415,
+                442707,
+                449266,
+                443208,
+                447954,
+                452851,
+                457508,
+                447343
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3329956
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2826475,
+              "rank": 25,
+              "readbackNanos": 52583,
+              "reduceNanos": 448835,
+              "reduceNanosSamples": [
+                449597,
+                445661,
+                451019,
+                444008,
+                448074,
+                455656,
+                457358,
+                447373
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3328219
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2829885,
+              "rank": 25,
+              "readbackNanos": 52613,
+              "reduceNanos": 164128,
+              "reduceNanosSamples": [
+                161490,
+                163513,
+                164634,
+                169041,
+                169090,
+                163412,
+                165876,
+                163622
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3045144
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2828899,
+              "rank": 25,
+              "readbackNanos": 52673,
+              "reduceNanos": 151244,
+              "reduceNanosSamples": [
+                147859,
+                147198,
+                148010,
+                153507,
+                157533,
+                149471,
+                154099,
+                153017
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3034574
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2823260,
+              "smallAllocs": 262052
+            },
+            "columnCount": {
+              "nanos": 14888,
+              "smallAllocs": 1125
+            },
+            "eliminate": {
+              "nanos": 445699,
+              "smallAllocs": 1125
+            },
+            "freeColumns": 17,
+            "innerMultiplies": 39270,
+            "pivotSearch": {
+              "nanos": 1106,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "readback": {
+              "nanos": 52678,
+              "smallAllocs": 2680
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 8643,
+              "smallAllocs": 100
+            },
+            "scaleMultiplies": 1050,
+            "stagedNanos": 455268,
+            "wall": {
+              "nanos": 473727,
+              "smallAllocs": 2549
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8402,
+            "packNanos": 69984,
+            "rank": 25,
+            "reduceNanos": 286930,
+            "reduceNanosSamples": [
+              296711,
+              284802,
+              286645,
+              286465,
+              286014,
+              287216,
+              287306,
+              288808
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 42384,
+            "totalNanos": 365767
+          },
+          "peakResidentBytes": 63840256,
+          "productionMatrixRebuild": {
+            "nanos": 2872618,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2938166,
+            "smallAllocs": 166027
+          },
+          "productionRowReduce": {
+            "nanos": 2859824,
+            "smallAllocs": 163665
+          },
+          "rank": 25,
+          "residentBytesAfter": 63729664,
+          "residentBytesBefore": 63520768,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2880064,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 17
+        },
+        "modularDegree": 42,
+        "modularFactorCount": 17,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_x_phi11",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 6760,
+            "smallAllocs": 686
+          },
+          "berlekampMatrixWall": {
+            "nanos": 539574,
+            "smallAllocs": 51263
+          },
+          "berlekampSplit": {
+            "nanos": 1959515,
+            "smallAllocs": 163103
+          },
+          "columnPolys": {
+            "nanos": 475980,
+            "smallAllocs": 46071
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1171,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 122063,
+              "smallAllocs": 7891
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 71065,
+              "smallAllocs": 4425
+            },
+            "stagedNanos": 194533,
+            "wall": {
+              "nanos": 230156,
+              "smallAllocs": 13028
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1268,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 181601,
+              "smallAllocs": 11539
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 95834,
+              "smallAllocs": 5817
+            },
+            "stagedNanos": 279705,
+            "wall": {
+              "nanos": 312578,
+              "smallAllocs": 18071
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 31816,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 625602,
+            "smallAllocs": 51959
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 572418,
+            "smallAllocs": 53616
+          },
+          "frobeniusPower": {
+            "nanos": 7706,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 19,
+          "matrixConversionNanos": 58592,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 588908,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 63108,
+          "nullspaceBasisNanos": 63108,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3385,
+            "packNanos": 97534,
+            "rank": 29,
+            "reduceNanos": 27566,
+            "reduceNanosSamples": [
+              30535,
+              26980,
+              28272,
+              26880,
+              27891,
+              27241,
+              28192,
+              26930
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 128840
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3235,
+            "packNanos": 97539,
+            "rank": 29,
+            "reduceNanos": 27180,
+            "reduceNanosSamples": [
+              27160,
+              31446,
+              27311,
+              26980,
+              26900,
+              27270,
+              27201,
+              27040
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 128400
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3570,
+            "packNanos": 98466,
+            "rank": 29,
+            "reduceNanos": 25342,
+            "reduceNanosSamples": [
+              24757,
+              27590,
+              24606,
+              25718,
+              24416,
+              26149,
+              24967,
+              26028
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 127423
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 533912,
+              "rank": 29,
+              "readbackNanos": 71902,
+              "reduceNanos": 42422,
+              "reduceNanosSamples": [
+                40790,
+                42342,
+                41581,
+                42533,
+                45307,
+                42503,
+                41742,
+                42523
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 650224
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 539109,
+              "rank": 29,
+              "readbackNanos": 71461,
+              "reduceNanos": 33494,
+              "reduceNanosSamples": [
+                33340,
+                34191,
+                32799,
+                33620,
+                33369,
+                33760,
+                32688,
+                33880
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 644320
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 536370,
+              "rank": 29,
+              "readbackNanos": 71631,
+              "reduceNanos": 31902,
+              "reduceNanosSamples": [
+                32358,
+                31997,
+                31807,
+                31997,
+                31527,
+                31727,
+                31787,
+                32088
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 639613
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 535759,
+              "rank": 29,
+              "readbackNanos": 3305,
+              "reduceNanos": 27035,
+              "reduceNanosSamples": [
+                27080,
+                26740,
+                26991,
+                26829,
+                27140,
+                27220,
+                27170,
+                26900
+              ],
+              "smallAllocs": 50422,
+              "totalNanos": 566094
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 536074,
+              "rank": 29,
+              "readbackNanos": 71756,
+              "reduceNanos": 43189,
+              "reduceNanosSamples": [
+                43004,
+                43435,
+                43174,
+                43094,
+                42994,
+                46740,
+                43535,
+                43204
+              ],
+              "smallAllocs": 53866,
+              "totalNanos": 653218
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 536665,
+              "rank": 29,
+              "readbackNanos": 71611,
+              "reduceNanos": 43539,
+              "reduceNanosSamples": [
+                43324,
+                44015,
+                43414,
+                43485,
+                43745,
+                43765,
+                43465,
+                43594
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 652141
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537061,
+              "rank": 29,
+              "readbackNanos": 71331,
+              "reduceNanos": 42462,
+              "reduceNanosSamples": [
+                42633,
+                41652,
+                42844,
+                42083,
+                42634,
+                42292,
+                42773,
+                41932
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 651085
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 536770,
+              "rank": 29,
+              "readbackNanos": 71526,
+              "reduceNanos": 42498,
+              "reduceNanosSamples": [
+                42713,
+                42083,
+                42473,
+                42523,
+                42473,
+                42713,
+                42783,
+                42463
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 650198
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 533701,
+              "rank": 29,
+              "readbackNanos": 71926,
+              "reduceNanos": 44476,
+              "reduceNanosSamples": [
+                43184,
+                44696,
+                44276,
+                44416,
+                47961,
+                44546,
+                44536,
+                44165
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 654300
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 539164,
+              "rank": 29,
+              "readbackNanos": 71416,
+              "reduceNanos": 45132,
+              "reduceNanosSamples": [
+                44756,
+                45137,
+                45437,
+                45127,
+                45267,
+                45017,
+                45357,
+                44916
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 655937
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 538788,
+              "rank": 29,
+              "readbackNanos": 71566,
+              "reduceNanos": 32143,
+              "reduceNanosSamples": [
+                32728,
+                36865,
+                32168,
+                32027,
+                32118,
+                32087,
+                32038,
+                32578
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 644074
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 535669,
+              "rank": 29,
+              "readbackNanos": 71631,
+              "reduceNanos": 31717,
+              "reduceNanosSamples": [
+                31917,
+                31857,
+                31547,
+                31817,
+                31537,
+                31476,
+                31617,
+                32318
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 638892
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 539144,
+              "smallAllocs": 48958
+            },
+            "columnCount": {
+              "nanos": 17807,
+              "smallAllocs": 1479
+            },
+            "eliminate": {
+              "nanos": 36032,
+              "smallAllocs": 1479
+            },
+            "freeColumns": 19,
+            "innerMultiplies": 1824,
+            "pivotSearch": {
+              "nanos": 1242,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "readback": {
+              "nanos": 70915,
+              "smallAllocs": 3414
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 10734,
+              "smallAllocs": 116
+            },
+            "scaleMultiplies": 1392,
+            "stagedNanos": 47981,
+            "wall": {
+              "nanos": 70004,
+              "smallAllocs": 3301
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10110,
+            "packNanos": 92236,
+            "rank": 29,
+            "reduceNanos": 41005,
+            "reduceNanosSamples": [
+              43265,
+              41171,
+              40309,
+              39889,
+              40860,
+              41151,
+              40831,
+              41441
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 7083,
+            "totalNanos": 144043
+          },
+          "peakResidentBytes": 64024576,
+          "productionMatrixRebuild": {
+            "nanos": 576404,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 341015,
+            "smallAllocs": 17567
+          },
+          "productionRowReduce": {
+            "nanos": 276775,
+            "smallAllocs": 14957
+          },
+          "rank": 29,
+          "residentBytesAfter": 63959040,
+          "residentBytesBefore": 63758336,
+          "rowReduceMatrixRebuild": {
+            "nanos": 586469,
+            "smallAllocs": 0
+          },
+          "sink": 104,
+          "splitFactors": 19
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 19,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow48_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 105,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 105,
+          "basisToPolynomials": {
+            "nanos": 7156,
+            "smallAllocs": 657
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3549126,
+            "smallAllocs": 337638
+          },
+          "berlekampSplit": {
+            "nanos": 8920936,
+            "smallAllocs": 750003
+          },
+          "columnPolys": {
+            "nanos": 3269883,
+            "smallAllocs": 314148
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2607,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1003654,
+              "smallAllocs": 65681
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 458053,
+              "smallAllocs": 29307
+            },
+            "stagedNanos": 1463531,
+            "wall": {
+              "nanos": 1601860,
+              "smallAllocs": 95903
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2666,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1598033,
+              "smallAllocs": 102431
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 620243,
+              "smallAllocs": 38862
+            },
+            "stagedNanos": 2221509,
+            "wall": {
+              "nanos": 2348827,
+              "smallAllocs": 142211
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 174088,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4014326,
+            "smallAllocs": 339228
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3723821,
+            "smallAllocs": 348769
+          },
+          "frobeniusPower": {
+            "nanos": 16930,
+            "smallAllocs": 1441
+          },
+          "kernelDimension": 14,
+          "matrixConversionNanos": 254702,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3774756,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 227793,
+          "nullspaceBasisNanos": 227793,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9489,
+            "packNanos": 511238,
+            "rank": 91,
+            "reduceNanos": 184363,
+            "reduceNanosSamples": [
+              186446,
+              186947,
+              184554,
+              183663,
+              187788,
+              181609,
+              184173,
+              182410
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 704029
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9068,
+            "packNanos": 507352,
+            "rank": 91,
+            "reduceNanos": 184208,
+            "reduceNanosSamples": [
+              190483,
+              192575,
+              184434,
+              184854,
+              182971,
+              183983,
+              182450,
+              181749
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 703353
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9469,
+            "packNanos": 510586,
+            "rank": 91,
+            "reduceNanos": 154173,
+            "reduceNanosSamples": [
+              154749,
+              157403,
+              153598,
+              155030,
+              152226,
+              152907,
+              151494,
+              156702
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 674605
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3525692,
+              "rank": 91,
+              "readbackNanos": 204808,
+              "reduceNanos": 272063,
+              "reduceNanosSamples": [
+                270011,
+                274537,
+                272755,
+                272383,
+                269560,
+                271743,
+                272895,
+                270251
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4003130
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3528356,
+              "rank": 91,
+              "readbackNanos": 207867,
+              "reduceNanos": 223581,
+              "reduceNanosSamples": [
+                228769,
+                222109,
+                224322,
+                222911,
+                221068,
+                224252,
+                221909,
+                225435
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3957542
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3528025,
+              "rank": 91,
+              "readbackNanos": 206010,
+              "reduceNanos": 208268,
+              "reduceNanosSamples": [
+                207678,
+                214507,
+                207077,
+                208859,
+                207027,
+                210673,
+                206987,
+                214318
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3944507
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3534330,
+              "rank": 91,
+              "readbackNanos": 9349,
+              "reduceNanos": 183732,
+              "reduceNanosSamples": [
+                188229,
+                186526,
+                184674,
+                187498,
+                181830,
+                182531,
+                181439,
+                182791
+              ],
+              "smallAllocs": 336216,
+              "totalNanos": 3730931
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3529938,
+              "rank": 91,
+              "readbackNanos": 205324,
+              "reduceNanos": 287716,
+              "reduceNanosSamples": [
+                279965,
+                290160,
+                287406,
+                290541,
+                285694,
+                296891,
+                286785,
+                288027
+              ],
+              "smallAllocs": 342378,
+              "totalNanos": 4020786
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3524400,
+              "rank": 91,
+              "readbackNanos": 205469,
+              "reduceNanos": 291918,
+              "reduceNanosSamples": [
+                286244,
+                296780,
+                291773,
+                293295,
+                290700,
+                294807,
+                292063,
+                289650
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4025338
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3526122,
+              "rank": 91,
+              "readbackNanos": 205294,
+              "reduceNanos": 278573,
+              "reduceNanosSamples": [
+                278053,
+                279094,
+                281137,
+                279284,
+                278042,
+                276790,
+                294847,
+                274146
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4010911
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3525912,
+              "rank": 91,
+              "readbackNanos": 205248,
+              "reduceNanos": 280380,
+              "reduceNanosSamples": [
+                278133,
+                281307,
+                283340,
+                283270,
+                279063,
+                279454,
+                285293,
+                279445
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4016820
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3528200,
+              "rank": 91,
+              "readbackNanos": 204773,
+              "reduceNanos": 340324,
+              "reduceNanosSamples": [
+                338753,
+                342418,
+                342708,
+                340275,
+                340374,
+                338401,
+                343098,
+                337340
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4073734
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3529823,
+              "rank": 91,
+              "readbackNanos": 204583,
+              "reduceNanos": 341050,
+              "reduceNanosSamples": [
+                339733,
+                342278,
+                342888,
+                344221,
+                339874,
+                340174,
+                341927,
+                339684
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4075061
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3527224,
+              "rank": 91,
+              "readbackNanos": 205810,
+              "reduceNanos": 214007,
+              "reduceNanosSamples": [
+                212916,
+                215369,
+                211924,
+                217993,
+                213928,
+                226376,
+                213786,
+                214087
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3949094
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3530073,
+              "rank": 91,
+              "readbackNanos": 206386,
+              "reduceNanos": 209135,
+              "reduceNanosSamples": [
+                208779,
+                208549,
+                207808,
+                210101,
+                209491,
+                210843,
+                206226,
+                210372
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3943827
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3528516,
+              "smallAllocs": 326612
+            },
+            "columnCount": {
+              "nanos": 110389,
+              "smallAllocs": 9828
+            },
+            "eliminate": {
+              "nanos": 288369,
+              "smallAllocs": 9828
+            },
+            "freeColumns": 14,
+            "innerMultiplies": 18375,
+            "pivotSearch": {
+              "nanos": 2689,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "readback": {
+              "nanos": 203001,
+              "smallAllocs": 5848
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 56376,
+              "smallAllocs": 364
+            },
+            "scaleMultiplies": 9555,
+            "stagedNanos": 348309,
+            "wall": {
+              "nanos": 474052,
+              "smallAllocs": 20537
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 46649,
+            "packNanos": 474473,
+            "rank": 91,
+            "reduceNanos": 297671,
+            "reduceNanosSamples": [
+              305363,
+              302449,
+              297822,
+              298012,
+              292814,
+              296339,
+              296429,
+              297521
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 48772,
+            "totalNanos": 818323
+          },
+          "peakResidentBytes": 65056768,
+          "productionMatrixRebuild": {
+            "nanos": 3766469,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2361446,
+            "smallAllocs": 134628
+          },
+          "productionRowReduce": {
+            "nanos": 2133097,
+            "smallAllocs": 122300
+          },
+          "rank": 91,
+          "residentBytesAfter": 64905216,
+          "residentBytesBefore": 63946752,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3777165,
+            "smallAllocs": 0
+          },
+          "sink": 136,
+          "splitFactors": 14
+        },
+        "modularDegree": 105,
+        "modularFactorCount": 14,
+        "prime": 17,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow105_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 120,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 120,
+          "basisToPolynomials": {
+            "nanos": 27961,
+            "smallAllocs": 2778
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2287666,
+            "smallAllocs": 214939
+          },
+          "berlekampSplit": {
+            "nanos": 16199766,
+            "smallAllocs": 1312571
+          },
+          "columnPolys": {
+            "nanos": 1926075,
+            "smallAllocs": 185863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 2984,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 836948,
+              "smallAllocs": 57197
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 466497,
+              "smallAllocs": 30075
+            },
+            "stagedNanos": 1305573,
+            "wall": {
+              "nanos": 1507750,
+              "smallAllocs": 89910
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3071,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 1290885,
+              "smallAllocs": 85037
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 629606,
+              "smallAllocs": 39795
+            },
+            "stagedNanos": 1923538,
+            "wall": {
+              "nanos": 2115967,
+              "smallAllocs": 127473
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 200236,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2956543,
+            "smallAllocs": 218459
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2488985,
+            "smallAllocs": 229460
+          },
+          "frobeniusPower": {
+            "nanos": 4261,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 39,
+          "matrixConversionNanos": 349233,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2564637,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 499475,
+          "nullspaceBasisNanos": 499475,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16664,
+            "packNanos": 673684,
+            "rank": 81,
+            "reduceNanos": 171759,
+            "reduceNanosSamples": [
+              172275,
+              171344,
+              171955,
+              170983,
+              172907,
+              171564,
+              172906,
+              171104
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 862158
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16534,
+            "packNanos": 669502,
+            "rank": 81,
+            "reduceNanos": 172986,
+            "reduceNanosSamples": [
+              172255,
+              172075,
+              172786,
+              175390,
+              173187,
+              174689,
+              171784,
+              174929
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 861236
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 17195,
+            "packNanos": 675627,
+            "rank": 81,
+            "reduceNanos": 148655,
+            "reduceNanosSamples": [
+              148299,
+              149011,
+              147969,
+              149351,
+              147518,
+              149231,
+              147658,
+              150323
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 840225
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2240111,
+              "rank": 81,
+              "readbackNanos": 565939,
+              "reduceNanos": 267076,
+              "reduceNanosSamples": [
+                268027,
+                262189,
+                267126,
+                272294,
+                267026,
+                269459,
+                262029,
+                264001
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3072735
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2240642,
+              "rank": 81,
+              "readbackNanos": 569124,
+              "reduceNanos": 210392,
+              "reduceNanosSamples": [
+                209340,
+                206967,
+                214308,
+                209751,
+                208819,
+                211033,
+                216802,
+                211213
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3018084
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2236000,
+              "rank": 81,
+              "readbackNanos": 568277,
+              "reduceNanos": 200292,
+              "reduceNanosSamples": [
+                200206,
+                199596,
+                202480,
+                200288,
+                198545,
+                204813,
+                200998,
+                200297
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3005205
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2235544,
+              "rank": 81,
+              "readbackNanos": 16394,
+              "reduceNanos": 170798,
+              "reduceNanosSamples": [
+                170343,
+                170352,
+                173868,
+                173718,
+                170613,
+                172385,
+                170433,
+                170984
+              ],
+              "smallAllocs": 210396,
+              "totalNanos": 2423478
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2248688,
+              "rank": 81,
+              "readbackNanos": 566449,
+              "reduceNanos": 279981,
+              "reduceNanosSamples": [
+                278674,
+                278633,
+                283320,
+                281627,
+                286344,
+                281288,
+                274367,
+                275719
+              ],
+              "smallAllocs": 228020,
+              "totalNanos": 3099094
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2245158,
+              "rank": 81,
+              "readbackNanos": 566534,
+              "reduceNanos": 282153,
+              "reduceNanosSamples": [
+                280526,
+                279945,
+                285053,
+                282830,
+                282609,
+                286084,
+                275599,
+                281698
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3101994
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2251748,
+              "rank": 81,
+              "readbackNanos": 565378,
+              "reduceNanos": 271792,
+              "reduceNanosSamples": [
+                275178,
+                265394,
+                272594,
+                276060,
+                270991,
+                273686,
+                269740,
+                269249
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3093862
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2250877,
+              "rank": 81,
+              "readbackNanos": 564501,
+              "reduceNanos": 273471,
+              "reduceNanosSamples": [
+                272354,
+                267286,
+                275148,
+                277852,
+                274588,
+                278433,
+                270531,
+                271874
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3090637
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2238333,
+              "rank": 81,
+              "readbackNanos": 567606,
+              "reduceNanos": 301046,
+              "reduceNanosSamples": [
+                300235,
+                295478,
+                301858,
+                303420,
+                298132,
+                302668,
+                302589,
+                297801
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3111398
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2233070,
+              "rank": 81,
+              "readbackNanos": 568733,
+              "reduceNanos": 304126,
+              "reduceNanosSamples": [
+                305503,
+                296229,
+                304341,
+                304411,
+                299644,
+                303911,
+                304862,
+                299373
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3106991
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2248974,
+              "rank": 81,
+              "readbackNanos": 567045,
+              "reduceNanos": 203806,
+              "reduceNanosSamples": [
+                202080,
+                203261,
+                206046,
+                204573,
+                203711,
+                203292,
+                208039,
+                203902
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3026271
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2236941,
+              "rank": 81,
+              "readbackNanos": 567822,
+              "reduceNanos": 199471,
+              "reduceNanosSamples": [
+                199065,
+                197653,
+                201248,
+                199135,
+                199807,
+                198715,
+                202019,
+                200867
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3011695
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2244302,
+              "smallAllocs": 200538
+            },
+            "columnCount": {
+              "nanos": 110467,
+              "smallAllocs": 9963
+            },
+            "eliminate": {
+              "nanos": 245719,
+              "smallAllocs": 9963
+            },
+            "freeColumns": 39,
+            "innerMultiplies": 13920,
+            "pivotSearch": {
+              "nanos": 3123,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "readback": {
+              "nanos": 563140,
+              "smallAllocs": 17478
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 56233,
+              "smallAllocs": 324
+            },
+            "scaleMultiplies": 9720,
+            "stagedNanos": 307456,
+            "wall": {
+              "nanos": 434233,
+              "smallAllocs": 20817
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 62507,
+            "packNanos": 629468,
+            "rank": 81,
+            "reduceNanos": 263671,
+            "reduceNanosSamples": [
+              264592,
+              267197,
+              262579,
+              262750,
+              264993,
+              262349,
+              262600,
+              266395
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 48141,
+            "totalNanos": 955506
+          },
+          "peakResidentBytes": 65767424,
+          "productionMatrixRebuild": {
+            "nanos": 2510467,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2424464,
+            "smallAllocs": 123505
+          },
+          "productionRowReduce": {
+            "nanos": 1921573,
+            "smallAllocs": 107187
+          },
+          "rank": 81,
+          "residentBytesAfter": 65503232,
+          "residentBytesBefore": 63807488,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2545934,
+            "smallAllocs": 0
+          },
+          "sink": 152,
+          "splitFactors": 39
+        },
+        "modularDegree": 120,
+        "modularFactorCount": 39,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "xpow120_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 178,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 178,
+          "basisToPolynomials": {
+            "nanos": 3655,
+            "smallAllocs": 371
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3108534,
+            "smallAllocs": 274190
+          },
+          "berlekampSplit": {
+            "nanos": 6457759,
+            "smallAllocs": 339370
+          },
+          "columnPolys": {
+            "nanos": 2367079,
+            "smallAllocs": 210706
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4474,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 7875702,
+              "smallAllocs": 491858
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1493105,
+              "smallAllocs": 95034
+            },
+            "stagedNanos": 9390162,
+            "wall": {
+              "nanos": 9820439,
+              "smallAllocs": 587969
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4473,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 14520792,
+              "smallAllocs": 888442
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 2043355,
+              "smallAllocs": 126362
+            },
+            "stagedNanos": 16592142,
+            "wall": {
+              "nanos": 16988146,
+              "smallAllocs": 1015884
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 494407,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 5741131,
+            "smallAllocs": 275077
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3607147,
+            "smallAllocs": 306053
+          },
+          "frobeniusPower": {
+            "nanos": 2674,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 2,
+          "matrixConversionNanos": 730363,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3648124,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 331351,
+          "nullspaceBasisNanos": 331351,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14511,
+            "packNanos": 1514745,
+            "rank": 176,
+            "reduceNanos": 1075955,
+            "reduceNanosSamples": [
+              1078149,
+              1073321,
+              1079060,
+              1076165,
+              1075745,
+              1068043,
+              1076556,
+              1074283
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2603960
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14436,
+            "packNanos": 1522937,
+            "rank": 176,
+            "reduceNanos": 1078194,
+            "reduceNanosSamples": [
+              1075935,
+              1074443,
+              1076106,
+              1080282,
+              1086611,
+              1069896,
+              1087132,
+              1083216
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2618417
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 15128,
+            "packNanos": 1523057,
+            "rank": 176,
+            "reduceNanos": 718334,
+            "reduceNanosSamples": [
+              718946,
+              717984,
+              720188,
+              709512,
+              718685,
+              714880,
+              711815,
+              727529
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2256395
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3019216,
+              "rank": 176,
+              "readbackNanos": 180798,
+              "reduceNanos": 1270949,
+              "reduceNanosSamples": [
+                1260759,
+                1268490,
+                1267069,
+                1280638,
+                1276362,
+                1281090,
+                1273408,
+                1266288
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4466897
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3004639,
+              "rank": 176,
+              "readbackNanos": 183066,
+              "reduceNanos": 1251275,
+              "reduceNanosSamples": [
+                1259408,
+                1247069,
+                1247890,
+                1253048,
+                1273748,
+                1249503,
+                1247960,
+                1261891
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4448805
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3000423,
+              "rank": 176,
+              "readbackNanos": 186086,
+              "reduceNanos": 1118018,
+              "reduceNanosSamples": [
+                1101783,
+                1118869,
+                1120662,
+                1122414,
+                1116475,
+                1119890,
+                1117167,
+                1103516
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4304461
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2997970,
+              "rank": 176,
+              "readbackNanos": 14552,
+              "reduceNanos": 1073747,
+              "reduceNanosSamples": [
+                1074613,
+                1071248,
+                1074863,
+                1072881,
+                1076977,
+                1070787,
+                1087142,
+                1070918
+              ],
+              "smallAllocs": 273089,
+              "totalNanos": 4086544
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3004704,
+              "rank": 176,
+              "readbackNanos": 181850,
+              "reduceNanos": 1376651,
+              "reduceNanosSamples": [
+                1369110,
+                1375329,
+                1360377,
+                1399615,
+                1391292,
+                1390091,
+                1377973,
+                1355700
+              ],
+              "smallAllocs": 276914,
+              "totalNanos": 4562664
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3017193,
+              "rank": 176,
+              "readbackNanos": 180041,
+              "reduceNanos": 1441522,
+              "reduceNanosSamples": [
+                1437862,
+                1443280,
+                1436710,
+                1459714,
+                1446324,
+                1458251,
+                1438352,
+                1439764
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4649568
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3008045,
+              "rank": 176,
+              "readbackNanos": 186766,
+              "reduceNanos": 1306977,
+              "reduceNanosSamples": [
+                1302461,
+                1297684,
+                1300258,
+                1320158,
+                1313297,
+                1314538,
+                1303232,
+                1310723
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4507723
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3000693,
+              "rank": 176,
+              "readbackNanos": 180723,
+              "reduceNanos": 1336776,
+              "reduceNanosSamples": [
+                1336391,
+                1331193,
+                1332415,
+                1345685,
+                1348740,
+                1345866,
+                1330523,
+                1337162
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4528573
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3015070,
+              "rank": 176,
+              "readbackNanos": 186391,
+              "reduceNanos": 2539555,
+              "reduceNanosSamples": [
+                2527117,
+                2539755,
+                2529229,
+                2555679,
+                2560556,
+                2555038,
+                2536972,
+                2539355
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 5740741
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2999707,
+              "rank": 176,
+              "readbackNanos": 187002,
+              "reduceNanos": 2549709,
+              "reduceNanosSamples": [
+                2534618,
+                2540947,
+                2551372,
+                2564301,
+                2560976,
+                2573566,
+                2538423,
+                2548047
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 5743445
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3009276,
+              "rank": 176,
+              "readbackNanos": 186596,
+              "reduceNanos": 1178377,
+              "reduceNanosSamples": [
+                1212478,
+                1173890,
+                1181281,
+                1165769,
+                1201761,
+                1175473,
+                1191126,
+                1174912
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4387089
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3008340,
+              "rank": 176,
+              "readbackNanos": 180803,
+              "reduceNanos": 1108518,
+              "reduceNanosSamples": [
+                1119109,
+                1115774,
+                1093662,
+                1100913,
+                1116736,
+                1102354,
+                1108423,
+                1108613
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4300100
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3013763,
+              "smallAllocs": 242505
+            },
+            "columnCount": {
+              "nanos": 368572,
+              "smallAllocs": 31856
+            },
+            "eliminate": {
+              "nanos": 2366388,
+              "smallAllocs": 31856
+            },
+            "freeColumns": 2,
+            "innerMultiplies": 198292,
+            "pivotSearch": {
+              "nanos": 4535,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "readback": {
+              "nanos": 174994,
+              "smallAllocs": 1609
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 168395,
+              "smallAllocs": 704
+            },
+            "scaleMultiplies": 31328,
+            "stagedNanos": 2541914,
+            "wall": {
+              "nanos": 2964635,
+              "smallAllocs": 65310
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 109433,
+            "packNanos": 1413981,
+            "rank": 176,
+            "reduceNanos": 1847570,
+            "reduceNanosSamples": [
+              1849032,
+              1846108,
+              1840519,
+              1855752,
+              1856041,
+              1853037,
+              1844674,
+              1845446
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 291357,
+            "totalNanos": 3379931
+          },
+          "peakResidentBytes": 67887104,
+          "productionMatrixRebuild": {
+            "nanos": 3647688,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 16977985,
+            "smallAllocs": 984110
+          },
+          "productionRowReduce": {
+            "nanos": 16689142,
+            "smallAllocs": 951807
+          },
+          "rank": 176,
+          "residentBytesAfter": 67506176,
+          "residentBytesBefore": 65843200,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3691158,
+            "smallAllocs": 0
+          },
+          "sink": 180,
+          "splitFactors": 2
+        },
+        "modularDegree": 178,
+        "modularFactorCount": 2,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi179",
+      "status": "ok"
+    },
+    {
+      "degree": 80,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 80,
+          "basisToPolynomials": {
+            "nanos": 3976,
+            "smallAllocs": 307
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3727226,
+            "smallAllocs": 346439
+          },
+          "berlekampSplit": {
+            "nanos": 10294316,
+            "smallAllocs": 586770
+          },
+          "columnPolys": {
+            "nanos": 3558741,
+            "smallAllocs": 333055
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2003,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 11867594,
+              "smallAllocs": 705467
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 277045,
+              "smallAllocs": 17180
+            },
+            "stagedNanos": 12147203,
+            "wall": {
+              "nanos": 12234824,
+              "smallAllocs": 723226
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2075,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 22891825,
+              "smallAllocs": 1389787
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 377615,
+              "smallAllocs": 22780
+            },
+            "stagedNanos": 23272604,
+            "wall": {
+              "nanos": 23353768,
+              "smallAllocs": 1413149
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 94058,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 7450611,
+            "smallAllocs": 347380
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3805952,
+            "smallAllocs": 352920
+          },
+          "frobeniusPower": {
+            "nanos": 8322,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 10,
+          "matrixConversionNanos": 157853,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3852526,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 197277,
+          "nullspaceBasisNanos": 197277,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5903,
+            "packNanos": 282259,
+            "rank": 70,
+            "reduceNanos": 1301284,
+            "reduceNanosSamples": [
+              1310523,
+              1303913,
+              1310263,
+              1291245,
+              1300337,
+              1294430,
+              1297344,
+              1302231
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1588555
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5743,
+            "packNanos": 283004,
+            "rank": 70,
+            "reduceNanos": 1317558,
+            "reduceNanosSamples": [
+              1297443,
+              1320407,
+              1313097,
+              1328089,
+              1320668,
+              1323933,
+              1314709,
+              1312786
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1605791
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6134,
+            "packNanos": 282583,
+            "rank": 70,
+            "reduceNanos": 1015746,
+            "reduceNanosSamples": [
+              1017418,
+              1012852,
+              1012601,
+              1043086,
+              1014074,
+              1018450,
+              1011310,
+              1028555
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1304904
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3717461,
+              "rank": 70,
+              "readbackNanos": 104039,
+              "reduceNanos": 1105268,
+              "reduceNanosSamples": [
+                1111959,
+                1103286,
+                1106510,
+                1116866,
+                1100391,
+                1104968,
+                1104297,
+                1105569
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4932553
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3717501,
+              "rank": 70,
+              "readbackNanos": 105932,
+              "reduceNanos": 1428798,
+              "reduceNanosSamples": [
+                1427607,
+                1431272,
+                1424693,
+                1422328,
+                1429990,
+                1424692,
+                1431793,
+                1430851
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5250844
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3717751,
+              "rank": 70,
+              "readbackNanos": 103709,
+              "reduceNanos": 1199193,
+              "reduceNanosSamples": [
+                1158097,
+                1204726,
+                1157536,
+                1208151,
+                1203114,
+                1199929,
+                1198457,
+                1172198
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5029782
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3714311,
+              "rank": 70,
+              "readbackNanos": 5944,
+              "reduceNanos": 1313958,
+              "reduceNanosSamples": [
+                1328399,
+                1297884,
+                1315551,
+                1312365,
+                1328800,
+                1296632,
+                1324223,
+                1299777
+              ],
+              "smallAllocs": 341535,
+              "totalNanos": 5037112
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3737616,
+              "rank": 70,
+              "readbackNanos": 105617,
+              "reduceNanos": 1251705,
+              "reduceNanosSamples": [
+                1249212,
+                1356321,
+                1212888,
+                1255832,
+                1250093,
+                1253318,
+                1236223,
+                1253909
+              ],
+              "smallAllocs": 353284,
+              "totalNanos": 5082390
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3739343,
+              "rank": 70,
+              "readbackNanos": 104339,
+              "reduceNanos": 1354338,
+              "reduceNanosSamples": [
+                1357482,
+                1355750,
+                1358805,
+                1363131,
+                1347297,
+                1351784,
+                1352075,
+                1352926
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 5197395
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3726385,
+              "rank": 70,
+              "readbackNanos": 103574,
+              "reduceNanos": 1113911,
+              "reduceNanosSamples": [
+                1113741,
+                1108864,
+                1114081,
+                1107232,
+                1111458,
+                1121713,
+                1123426,
+                1127261
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4947825
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3740650,
+              "rank": 70,
+              "readbackNanos": 104014,
+              "reduceNanos": 1170705,
+              "reduceNanosSamples": [
+                1173550,
+                1164647,
+                1170986,
+                1165298,
+                1171877,
+                1171096,
+                1168662,
+                1170425
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 5013402
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3709555,
+              "rank": 70,
+              "readbackNanos": 103980,
+              "reduceNanos": 3641819,
+              "reduceNanosSamples": [
+                3645935,
+                3657363,
+                3674037,
+                3626786,
+                3627708,
+                3637703,
+                3616451,
+                3650271
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 7439239
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3715088,
+              "rank": 70,
+              "readbackNanos": 103519,
+              "reduceNanos": 3642390,
+              "reduceNanosSamples": [
+                3645475,
+                3667678,
+                3681958,
+                3625615,
+                3637232,
+                3639305,
+                3615680,
+                3665454
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 7463935
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3727216,
+              "rank": 70,
+              "readbackNanos": 104886,
+              "reduceNanos": 1306397,
+              "reduceNanosSamples": [
+                1302260,
+                1305716,
+                1322711,
+                1307078,
+                1314419,
+                1292776,
+                1302321,
+                1326326
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5141673
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3723655,
+              "rank": 70,
+              "readbackNanos": 103834,
+              "reduceNanos": 1203654,
+              "reduceNanosSamples": [
+                1170947,
+                1201852,
+                1212938,
+                1213699,
+                1185688,
+                1172018,
+                1205457,
+                1211806
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5029196
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3739223,
+              "smallAllocs": 340038
+            },
+            "columnCount": {
+              "nanos": 75601,
+              "smallAllocs": 5810
+            },
+            "eliminate": {
+              "nanos": 3599549,
+              "smallAllocs": 5810
+            },
+            "freeColumns": 10,
+            "innerMultiplies": 342160,
+            "pivotSearch": {
+              "nanos": 2081,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "readback": {
+              "nanos": 103208,
+              "smallAllocs": 3223
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 35528,
+              "smallAllocs": 280
+            },
+            "scaleMultiplies": 5600,
+            "stagedNanos": 3635851,
+            "wall": {
+              "nanos": 3725683,
+              "smallAllocs": 12296
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 25187,
+            "packNanos": 267602,
+            "rank": 70,
+            "reduceNanos": 2372126,
+            "reduceNanosSamples": [
+              2421811,
+              2364575,
+              2371776,
+              2372477,
+              2372728,
+              2366248,
+              2366920,
+              2373468
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 355100,
+            "totalNanos": 2663333
+          },
+          "peakResidentBytes": 67366912,
+          "productionMatrixRebuild": {
+            "nanos": 3861810,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 23732529,
+            "smallAllocs": 1408888
+          },
+          "productionRowReduce": {
+            "nanos": 23444342,
+            "smallAllocs": 1401336
+          },
+          "rank": 70,
+          "residentBytesAfter": 64712704,
+          "residentBytesBefore": 68030464,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3864469,
+            "smallAllocs": 0
+          },
+          "sink": 74,
+          "splitFactors": 10
+        },
+        "modularDegree": 80,
+        "modularFactorCount": 10,
+        "prime": 11,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi64_x_phi105",
+      "status": "ok"
+    },
+    {
+      "degree": 144,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 144,
+          "basisToPolynomials": {
+            "nanos": 7436,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7765332,
+            "smallAllocs": 722207
+          },
+          "berlekampSplit": {
+            "nanos": 33516424,
+            "smallAllocs": 1239327
+          },
+          "columnPolys": {
+            "nanos": 7272757,
+            "smallAllocs": 680459
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3666,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 64740655,
+              "smallAllocs": 3858949
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 950922,
+              "smallAllocs": 59552
+            },
+            "stagedNanos": 65694749,
+            "wall": {
+              "nanos": 66004209,
+              "smallAllocs": 3919428
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3924,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 127646431,
+              "smallAllocs": 7645861
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 1347775,
+              "smallAllocs": 79136
+            },
+            "stagedNanos": 128991302,
+            "wall": {
+              "nanos": 129288150,
+              "smallAllocs": 7725927
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 308508,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 27580224,
+            "smallAllocs": 723728
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8089963,
+            "smallAllocs": 743088
+          },
+          "frobeniusPower": {
+            "nanos": 5643,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 8,
+          "matrixConversionNanos": 467382,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8315457,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 1249412,
+          "nullspaceBasisNanos": 1249412,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 13109,
+            "packNanos": 981119,
+            "rank": 136,
+            "reduceNanos": 6983238,
+            "reduceNanosSamples": [
+              6978155,
+              6971416,
+              6981100,
+              7002271,
+              6966739,
+              7017654,
+              6986708,
+              6985376
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7983005
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 12698,
+            "packNanos": 975040,
+            "rank": 136,
+            "reduceNanos": 7066952,
+            "reduceNanosSamples": [
+              7019016,
+              7112896,
+              7074639,
+              7121257,
+              7010393,
+              6980279,
+              7124032,
+              7059265
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 8052638
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14211,
+            "packNanos": 983127,
+            "rank": 136,
+            "reduceNanos": 5107427,
+            "reduceNanosSamples": [
+              5124407,
+              5154101,
+              5162854,
+              5096827,
+              5106220,
+              5097287,
+              5108634,
+              5081954
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 6110729
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7827530,
+              "rank": 136,
+              "readbackNanos": 239179,
+              "reduceNanos": 5713976,
+              "reduceNanosSamples": [
+                5702914,
+                5724667,
+                5695824,
+                5710145,
+                5720370,
+                5707432,
+                5729524,
+                5717807
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13785573
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7809147,
+              "rank": 136,
+              "readbackNanos": 241203,
+              "reduceNanos": 7514996,
+              "reduceNanosSamples": [
+                7518346,
+                7518857,
+                7511647,
+                7559217,
+                7542222,
+                7507801,
+                7487841,
+                7490715
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 15572201
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7817349,
+              "rank": 136,
+              "readbackNanos": 240917,
+              "reduceNanos": 6237568,
+              "reduceNanosSamples": [
+                6233572,
+                6067666,
+                6065042,
+                6257818,
+                6087224,
+                6241564,
+                6255134,
+                6300400
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14196632
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7893778,
+              "rank": 136,
+              "readbackNanos": 13945,
+              "reduceNanos": 7065089,
+              "reduceNanosSamples": [
+                7099976,
+                7119825,
+                7059486,
+                7070693,
+                7073778,
+                7013448,
+                6996773,
+                6988681
+              ],
+              "smallAllocs": 708207,
+              "totalNanos": 14965592
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7835711,
+              "rank": 136,
+              "readbackNanos": 240356,
+              "reduceNanos": 6404950,
+              "reduceNanosSamples": [
+                6224358,
+                6380910,
+                6438635,
+                6428991,
+                6452856,
+                6358036,
+                6247532,
+                6436272
+              ],
+              "smallAllocs": 739204,
+              "totalNanos": 14448941
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7849206,
+              "rank": 136,
+              "readbackNanos": 240812,
+              "reduceNanos": 7035245,
+              "reduceNanosSamples": [
+                7029682,
+                7040838,
+                7044123,
+                7085675,
+                7037444,
+                7031975,
+                7028159,
+                7033047
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 15123186
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7847995,
+              "rank": 136,
+              "readbackNanos": 239625,
+              "reduceNanos": 5737196,
+              "reduceNanosSamples": [
+                5722795,
+                5741913,
+                5747430,
+                5727211,
+                5751748,
+                5725899,
+                5732479,
+                5750375
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13820494
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7854485,
+              "rank": 136,
+              "readbackNanos": 240987,
+              "reduceNanos": 6056229,
+              "reduceNanosSamples": [
+                6153373,
+                6055928,
+                6052022,
+                6045253,
+                6056530,
+                6044622,
+                6056810,
+                6088677
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 14140113
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7827990,
+              "rank": 136,
+              "readbackNanos": 241483,
+              "reduceNanos": 19528747,
+              "reduceNanosSamples": [
+                19540530,
+                19836399,
+                19995654,
+                19485368,
+                19973332,
+                19516965,
+                18760083,
+                19503505
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 27684178
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7835712,
+              "rank": 136,
+              "readbackNanos": 240146,
+              "reduceNanos": 19560569,
+              "reduceNanosSamples": [
+                19539989,
+                19821205,
+                19944279,
+                19518558,
+                20044657,
+                19581150,
+                18843016,
+                19538246
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 27717513
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7844465,
+              "rank": 136,
+              "readbackNanos": 242520,
+              "reduceNanos": 6869279,
+              "reduceNanosSamples": [
+                6867551,
+                6862224,
+                6872419,
+                6871007,
+                6878818,
+                6838078,
+                6844267,
+                6893089
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14933600
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7827845,
+              "rank": 136,
+              "readbackNanos": 240412,
+              "reduceNanos": 6069648,
+              "reduceNanosSamples": [
+                6295853,
+                6071662,
+                6174974,
+                6033515,
+                6067635,
+                6220732,
+                6046514,
+                6055217
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14175626
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7902876,
+              "smallAllocs": 701470
+            },
+            "columnCount": {
+              "nanos": 242492,
+              "smallAllocs": 19992
+            },
+            "eliminate": {
+              "nanos": 19464243,
+              "smallAllocs": 19992
+            },
+            "freeColumns": 8,
+            "innerMultiplies": 1893456,
+            "pivotSearch": {
+              "nanos": 3749,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "readback": {
+              "nanos": 239725,
+              "smallAllocs": 4723
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 108960,
+              "smallAllocs": 544
+            },
+            "scaleMultiplies": 19584,
+            "stagedNanos": 19576970,
+            "wall": {
+              "nanos": 19860569,
+              "smallAllocs": 41246
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 77495,
+            "packNanos": 919037,
+            "rank": 136,
+            "reduceNanos": 12927380,
+            "reduceNanosSamples": [
+              12934816,
+              12919945,
+              12866745,
+              12991420,
+              13008366,
+              12876801,
+              12870561,
+              12939203
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 1938068,
+            "totalNanos": 13943296
+          },
+          "peakResidentBytes": 67366912,
+          "productionMatrixRebuild": {
+            "nanos": 8285393,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 133914970,
+            "smallAllocs": 7708346
+          },
+          "productionRowReduce": {
+            "nanos": 131997707,
+            "smallAllocs": 7685628
+          },
+          "rank": 136,
+          "residentBytesAfter": 65597440,
+          "residentBytesBefore": 64757760,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8385897,
+            "smallAllocs": 0
+          },
+          "sink": 138,
+          "splitFactors": 8
+        },
+        "modularDegree": 144,
+        "modularFactorCount": 8,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi128_x_phi165",
+      "status": "ok"
+    },
+    {
+      "degree": 240,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 240,
+          "basisToPolynomials": {
+            "nanos": 6995,
+            "smallAllocs": 523
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7593883,
+            "smallAllocs": 660179
+          },
+          "berlekampSplit": {
+            "nanos": 56383065,
+            "smallAllocs": 1030964
+          },
+          "columnPolys": {
+            "nanos": 6213702,
+            "smallAllocs": 544863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6207,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 150536647,
+              "smallAllocs": 8803144
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 2865404,
+              "smallAllocs": 171267
+            },
+            "stagedNanos": 153418797,
+            "wall": {
+              "nanos": 154375648,
+              "smallAllocs": 8975874
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6428,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 299036273,
+              "smallAllocs": 17418184
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 3982433,
+              "smallAllocs": 227907
+            },
+            "stagedNanos": 303026172,
+            "wall": {
+              "nanos": 303870887,
+              "smallAllocs": 17647557
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 783411,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 52251906,
+            "smallAllocs": 661844
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8328057,
+            "smallAllocs": 718020
+          },
+          "frobeniusPower": {
+            "nanos": 3520,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 1346171,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8589264,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 4516295,
+          "nullspaceBasisNanos": 4516295,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 27070,
+            "packNanos": 2805929,
+            "rank": 236,
+            "reduceNanos": 15976406,
+            "reduceNanosSamples": [
+              15928435,
+              15979701,
+              15973111,
+              16018308,
+              16080571,
+              16333094,
+              15963607,
+              15955495
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18828114
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 26494,
+            "packNanos": 2832539,
+            "rank": 236,
+            "reduceNanos": 16127885,
+            "reduceNanosSamples": [
+              16030756,
+              16262170,
+              16242290,
+              16176302,
+              15998468,
+              16228931,
+              15986541,
+              16079469
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18991791
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 27475,
+            "packNanos": 2845062,
+            "rank": 236,
+            "reduceNanos": 9242397,
+            "reduceNanosSamples": [
+              9153601,
+              9357193,
+              9266769,
+              9216454,
+              9270124,
+              9218026,
+              9191046,
+              9379235
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 12096819
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7297298,
+              "rank": 236,
+              "readbackNanos": 419256,
+              "reduceNanos": 13159479,
+              "reduceNanosSamples": [
+                13185729,
+                13163475,
+                13159169,
+                13159790,
+                13134933,
+                13126781,
+                13178327,
+                13157667
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 20887912
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7219433,
+              "rank": 236,
+              "readbackNanos": 418755,
+              "reduceNanos": 17069636,
+              "reduceNanosSamples": [
+                17064950,
+                17068525,
+                17118098,
+                17037769,
+                17139219,
+                17181552,
+                17049597,
+                17070748
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 24718947
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7227745,
+              "rank": 236,
+              "readbackNanos": 412306,
+              "reduceNanos": 13933512,
+              "reduceNanosSamples": [
+                13847049,
+                14224709,
+                14021217,
+                13918134,
+                13997452,
+                13872166,
+                13948890,
+                13773350
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21580954
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7331909,
+              "rank": 236,
+              "readbackNanos": 27946,
+              "reduceNanos": 16103804,
+              "reduceNanosSamples": [
+                15935175,
+                16112968,
+                16262961,
+                16024968,
+                16043756,
+                16330020,
+                16094641,
+                16167469
+              ],
+              "smallAllocs": 641764,
+              "totalNanos": 23481672
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7267398,
+              "rank": 236,
+              "readbackNanos": 413218,
+              "reduceNanos": 14677154,
+              "reduceNanosSamples": [
+                14693164,
+                14753953,
+                14663679,
+                14690630,
+                14193823,
+                14157158,
+                14623851,
+                14725041
+              ],
+              "smallAllocs": 681727,
+              "totalNanos": 22362993
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7239027,
+              "rank": 236,
+              "readbackNanos": 415155,
+              "reduceNanos": 16163122,
+              "reduceNanosSamples": [
+                16148281,
+                16167558,
+                16158686,
+                16211815,
+                16484539,
+                16095613,
+                16190963,
+                16158416
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 23817585
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7376411,
+              "rank": 236,
+              "readbackNanos": 416072,
+              "reduceNanos": 13224721,
+              "reduceNanosSamples": [
+                13265396,
+                13222282,
+                13236654,
+                13221311,
+                13244926,
+                13181212,
+                13227160,
+                13208092
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21020153
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7249212,
+              "rank": 236,
+              "readbackNanos": 409482,
+              "reduceNanos": 13985313,
+              "reduceNanosSamples": [
+                13926988,
+                13975489,
+                13980707,
+                13989920,
+                14198250,
+                13902071,
+                14006174,
+                13997853
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21671179
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7410706,
+              "rank": 236,
+              "readbackNanos": 462556,
+              "reduceNanos": 45094509,
+              "reduceNanosSamples": [
+                44281058,
+                45310084,
+                45252248,
+                45405806,
+                44965203,
+                44090436,
+                45223816,
+                44120280
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 52963686
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7367448,
+              "rank": 236,
+              "readbackNanos": 462942,
+              "reduceNanos": 44856657,
+              "reduceNanosSamples": [
+                44501245,
+                45228053,
+                45212069,
+                45359678,
+                44010777,
+                44171336,
+                45230837,
+                44304213
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 52692003
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7275136,
+              "rank": 236,
+              "readbackNanos": 421815,
+              "reduceNanos": 15641904,
+              "reduceNanosSamples": [
+                15625906,
+                15603322,
+                15724262,
+                15632295,
+                15905851,
+                15899251,
+                15651514,
+                15530244
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 23411713
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7277279,
+              "rank": 236,
+              "readbackNanos": 428475,
+              "reduceNanos": 14046114,
+              "reduceNanosSamples": [
+                14030982,
+                14061247,
+                13824595,
+                14132312,
+                14099734,
+                14151891,
+                14026134,
+                13764016
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21779474
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7278050,
+              "smallAllocs": 602578
+            },
+            "columnCount": {
+              "nanos": 692939,
+              "smallAllocs": 57348
+            },
+            "eliminate": {
+              "nanos": 43901410,
+              "smallAllocs": 57348
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4307520,
+            "pivotSearch": {
+              "nanos": 6427,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "readback": {
+              "nanos": 411084,
+              "smallAllocs": 4083
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 297344,
+              "smallAllocs": 944
+            },
+            "scaleMultiplies": 56640,
+            "stagedNanos": 44208015,
+            "wall": {
+              "nanos": 45002333,
+              "smallAllocs": 116842
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 265328,
+            "packNanos": 2607641,
+            "rank": 236,
+            "reduceNanos": 31398654,
+            "reduceNanosSamples": [
+              31579848,
+              31932131,
+              31203290,
+              31533730,
+              31553029,
+              31157963,
+              31263579,
+              31132946
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 4446309,
+            "totalNanos": 34277703
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 8464273,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 312268411,
+            "smallAllocs": 17591476
+          },
+          "productionRowReduce": {
+            "nanos": 306783835,
+            "smallAllocs": 17532366
+          },
+          "rank": 236,
+          "residentBytesAfter": 71016448,
+          "residentBytesBefore": 66322432,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8699708,
+            "smallAllocs": 0
+          },
+          "sink": 238,
+          "splitFactors": 4
+        },
+        "modularDegree": 240,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi385",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 18121,
+            "smallAllocs": 1843
+          },
+          "berlekampMatrixWall": {
+            "nanos": 189346,
+            "smallAllocs": 17281
+          },
+          "berlekampSplit": {
+            "nanos": 103463,
+            "smallAllocs": 8327
+          },
+          "columnPolys": {
+            "nanos": 73463,
+            "smallAllocs": 6155
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 966,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 966,
+            "wall": {
+              "nanos": 41421,
+              "smallAllocs": 1807
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 975,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 975,
+            "wall": {
+              "nanos": 40635,
+              "smallAllocs": 1810
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26269,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 218554,
+            "smallAllocs": 17402
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 215404,
+            "smallAllocs": 18922
+          },
+          "frobeniusPower": {
+            "nanos": 82427,
+            "smallAllocs": 7927
+          },
+          "kernelDimension": 40,
+          "matrixConversionNanos": 33114,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 218799,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 47,
+          "nullspaceBasisMagnitudeNanos": 40109,
+          "nullspaceBasisNanos": 40109,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1487,
+            "packNanos": 66654,
+            "rank": 0,
+            "reduceNanos": 4767,
+            "reduceNanosSamples": [
+              6720,
+              4737,
+              4928,
+              4266,
+              4967,
+              4687,
+              4797,
+              4246
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72783
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1287,
+            "packNanos": 66553,
+            "rank": 0,
+            "reduceNanos": 4356,
+            "reduceNanosSamples": [
+              4376,
+              4747,
+              4727,
+              4336,
+              4266,
+              4738,
+              4337,
+              4296
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72232
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1547,
+            "packNanos": 66773,
+            "rank": 0,
+            "reduceNanos": 4872,
+            "reduceNanosSamples": [
+              4276,
+              4927,
+              4827,
+              4938,
+              4257,
+              5327,
+              4246,
+              4917
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 73739
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 185535,
+              "rank": 0,
+              "readbackNanos": 81370,
+              "reduceNanos": 3755,
+              "reduceNanosSamples": [
+                4046,
+                3766,
+                3756,
+                3706,
+                3755,
+                3715,
+                3765,
+                3746
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 271017
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 184964,
+              "rank": 0,
+              "readbackNanos": 81520,
+              "reduceNanos": 3600,
+              "reduceNanosSamples": [
+                3505,
+                3795,
+                3475,
+                3726,
+                3475,
+                3716,
+                3495,
+                3696
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270321
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 186115,
+              "rank": 0,
+              "readbackNanos": 81280,
+              "reduceNanos": 3506,
+              "reduceNanosSamples": [
+                3666,
+                3506,
+                3586,
+                3505,
+                3506,
+                3475,
+                3485,
+                3515
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 271002
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 186160,
+              "rank": 0,
+              "readbackNanos": 1381,
+              "reduceNanos": 4642,
+              "reduceNanosSamples": [
+                4927,
+                4407,
+                4477,
+                4827,
+                4527,
+                4757,
+                8383,
+                4386
+              ],
+              "smallAllocs": 15774,
+              "totalNanos": 193071
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 184543,
+              "rank": 0,
+              "readbackNanos": 81235,
+              "reduceNanos": 3485,
+              "reduceNanosSamples": [
+                3495,
+                3485,
+                3505,
+                3485,
+                3485,
+                3485,
+                3485,
+                3515
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 269940
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 185395,
+              "rank": 0,
+              "readbackNanos": 80989,
+              "reduceNanos": 3505,
+              "reduceNanosSamples": [
+                3496,
+                3515,
+                3505,
+                3486,
+                3516,
+                3505,
+                3505,
+                3506
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270361
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 186321,
+              "rank": 0,
+              "readbackNanos": 81295,
+              "reduceNanos": 3515,
+              "reduceNanosSamples": [
+                3525,
+                3525,
+                3525,
+                3495,
+                3515,
+                3505,
+                3495,
+                3515
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270746
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 186486,
+              "rank": 0,
+              "readbackNanos": 81096,
+              "reduceNanos": 3495,
+              "reduceNanosSamples": [
+                3495,
+                3485,
+                3485,
+                3495,
+                3495,
+                3495,
+                3495,
+                3566
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270717
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 185695,
+              "rank": 0,
+              "readbackNanos": 81450,
+              "reduceNanos": 3605,
+              "reduceNanosSamples": [
+                3616,
+                3605,
+                3576,
+                3605,
+                3595,
+                3605,
+                3575,
+                3605
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 271056
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 184979,
+              "rank": 0,
+              "readbackNanos": 81381,
+              "reduceNanos": 3610,
+              "reduceNanosSamples": [
+                4146,
+                3496,
+                3725,
+                3505,
+                3726,
+                3506,
+                3706,
+                3515
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270210
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 185359,
+              "rank": 0,
+              "readbackNanos": 81616,
+              "reduceNanos": 3510,
+              "reduceNanosSamples": [
+                3665,
+                3666,
+                3576,
+                3495,
+                3505,
+                3515,
+                3485,
+                3495
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 270616
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 186301,
+              "rank": 0,
+              "readbackNanos": 81611,
+              "reduceNanos": 3490,
+              "reduceNanosSamples": [
+                3515,
+                3545,
+                3485,
+                3515,
+                3495,
+                3485,
+                3485,
+                3485
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 272989
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 186301,
+              "smallAllocs": 15680
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 40,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1027,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 80479,
+              "smallAllocs": 5003
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1027,
+            "wall": {
+              "nanos": 6264,
+              "smallAllocs": 166
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5317,
+            "packNanos": 63044,
+            "rank": 0,
+            "reduceNanos": 4807,
+            "reduceNanosSamples": [
+              6539,
+              4837,
+              4867,
+              4797,
+              4817,
+              4727,
+              4787,
+              4747
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 73534
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 215389,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 83058,
+            "smallAllocs": 1728
+          },
+          "productionRowReduce": {
+            "nanos": 43199,
+            "smallAllocs": 1607
+          },
+          "rank": 0,
+          "residentBytesAfter": 69939200,
+          "residentBytesBefore": 69935104,
+          "rowReduceMatrixRebuild": {
+            "nanos": 217938,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 40
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 40,
+        "prime": 47,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_40",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 25398,
+            "smallAllocs": 2595
+          },
+          "berlekampMatrixWall": {
+            "nanos": 270425,
+            "smallAllocs": 24749
+          },
+          "berlekampSplit": {
+            "nanos": 162095,
+            "smallAllocs": 12707
+          },
+          "columnPolys": {
+            "nanos": 102507,
+            "smallAllocs": 8727
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1125,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1125,
+            "wall": {
+              "nanos": 60074,
+              "smallAllocs": 2551
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1174,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1174,
+            "wall": {
+              "nanos": 58767,
+              "smallAllocs": 2554
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 42068,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 313055,
+            "smallAllocs": 24894
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 310836,
+            "smallAllocs": 27102
+          },
+          "frobeniusPower": {
+            "nanos": 118570,
+            "smallAllocs": 11415
+          },
+          "kernelDimension": 48,
+          "matrixConversionNanos": 49297,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 310435,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 61,
+          "nullspaceBasisMagnitudeNanos": 57289,
+          "nullspaceBasisNanos": 57289,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1853,
+            "packNanos": 99722,
+            "rank": 0,
+            "reduceNanos": 6254,
+            "reduceNanosSamples": [
+              6619,
+              5989,
+              6530,
+              5879,
+              7150,
+              5868,
+              6520,
+              5829
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 107254
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1682,
+            "packNanos": 99061,
+            "rank": 0,
+            "reduceNanos": 5979,
+            "reduceNanosSamples": [
+              6009,
+              5858,
+              6430,
+              6009,
+              6530,
+              5949,
+              5879,
+              5869
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106993
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1832,
+            "packNanos": 98571,
+            "rank": 0,
+            "reduceNanos": 6480,
+            "reduceNanosSamples": [
+              5829,
+              6500,
+              6470,
+              6490,
+              6450,
+              6580,
+              5849,
+              6530
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106858
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 264708,
+              "rank": 0,
+              "readbackNanos": 118996,
+              "reduceNanos": 5158,
+              "reduceNanosSamples": [
+                5148,
+                5168,
+                5147,
+                5118,
+                5097,
+                5178,
+                5168,
+                5178
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 389072
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 265192,
+              "rank": 0,
+              "readbackNanos": 119052,
+              "reduceNanos": 5098,
+              "reduceNanosSamples": [
+                5058,
+                5157,
+                5088,
+                5168,
+                4907,
+                5128,
+                4957,
+                5108
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 389742
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 268823,
+              "rank": 0,
+              "readbackNanos": 119086,
+              "reduceNanos": 4927,
+              "reduceNanosSamples": [
+                4917,
+                4927,
+                4887,
+                4927,
+                4908,
+                4957,
+                5128,
+                4937
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 393813
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 265714,
+              "rank": 0,
+              "readbackNanos": 2113,
+              "reduceNanos": 6099,
+              "reduceNanosSamples": [
+                6130,
+                6570,
+                6049,
+                6069,
+                6649,
+                5998,
+                6139,
+                6039
+              ],
+              "smallAllocs": 22554,
+              "totalNanos": 273926
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 265834,
+              "rank": 0,
+              "readbackNanos": 119156,
+              "reduceNanos": 4937,
+              "reduceNanosSamples": [
+                4917,
+                4938,
+                4907,
+                5028,
+                5097,
+                4927,
+                4938,
+                4937
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 389582
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 264116,
+              "rank": 0,
+              "readbackNanos": 118771,
+              "reduceNanos": 4927,
+              "reduceNanosSamples": [
+                4927,
+                4908,
+                4918,
+                4927,
+                4937,
+                4927,
+                4927,
+                4928
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 387684
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 267612,
+              "rank": 0,
+              "readbackNanos": 119121,
+              "reduceNanos": 4942,
+              "reduceNanosSamples": [
+                5108,
+                4917,
+                4917,
+                4928,
+                4947,
+                4938,
+                5027,
+                5027
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 391450
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 267571,
+              "rank": 0,
+              "readbackNanos": 119993,
+              "reduceNanos": 4917,
+              "reduceNanosSamples": [
+                4917,
+                4917,
+                4917,
+                4917,
+                4957,
+                4917,
+                4947,
+                4998
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 393077
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 264638,
+              "rank": 0,
+              "readbackNanos": 119277,
+              "reduceNanos": 5012,
+              "reduceNanosSamples": [
+                5017,
+                5038,
+                5008,
+                5028,
+                4987,
+                4988,
+                5047,
+                5008
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 388826
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 266150,
+              "rank": 0,
+              "readbackNanos": 119017,
+              "reduceNanos": 5027,
+              "reduceNanosSamples": [
+                5198,
+                4948,
+                5107,
+                4917,
+                5248,
+                4937,
+                5178,
+                4917
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 390809
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 264787,
+              "rank": 0,
+              "readbackNanos": 119642,
+              "reduceNanos": 5022,
+              "reduceNanosSamples": [
+                4918,
+                4947,
+                5098,
+                4927,
+                5098,
+                4928,
+                5098,
+                5108
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 390834
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 264783,
+              "rank": 0,
+              "readbackNanos": 119447,
+              "reduceNanos": 4918,
+              "reduceNanosSamples": [
+                4917,
+                4897,
+                4918,
+                4918,
+                4927,
+                4937,
+                4907,
+                4928
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 389337
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 266916,
+              "smallAllocs": 22444
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 48,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1236,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 117549,
+              "smallAllocs": 7155
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1236,
+            "wall": {
+              "nanos": 8217,
+              "smallAllocs": 198
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 7311,
+            "packNanos": 92998,
+            "rank": 0,
+            "reduceNanos": 6494,
+            "reduceNanosSamples": [
+              6560,
+              6479,
+              6509,
+              6399,
+              6380,
+              6620,
+              6460,
+              6510
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106853
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 312002,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 120989,
+            "smallAllocs": 2456
+          },
+          "productionRowReduce": {
+            "nanos": 63730,
+            "smallAllocs": 2311
+          },
+          "rank": 0,
+          "residentBytesAfter": 69943296,
+          "residentBytesBefore": 69943296,
+          "rowReduceMatrixRebuild": {
+            "nanos": 310170,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 48
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 48,
+        "prime": 61,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_48",
+      "status": "ok"
+    },
+    {
+      "degree": 56,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 56,
+          "basisToPolynomials": {
+            "nanos": 32543,
+            "smallAllocs": 3475
+          },
+          "berlekampMatrixWall": {
+            "nanos": 442406,
+            "smallAllocs": 40562
+          },
+          "berlekampSplit": {
+            "nanos": 213266,
+            "smallAllocs": 16143
+          },
+          "columnPolys": {
+            "nanos": 141059,
+            "smallAllocs": 11747
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1308,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1308,
+            "wall": {
+              "nanos": 81546,
+              "smallAllocs": 3423
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1353,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1353,
+            "wall": {
+              "nanos": 77806,
+              "smallAllocs": 3426
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 53779,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 498213,
+            "smallAllocs": 40731
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 497748,
+            "smallAllocs": 43755
+          },
+          "frobeniusPower": {
+            "nanos": 235880,
+            "smallAllocs": 22544
+          },
+          "kernelDimension": 56,
+          "matrixConversionNanos": 66428,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 494678,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 76218,
+          "nullspaceBasisNanos": 76218,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2088,
+            "packNanos": 135776,
+            "rank": 0,
+            "reduceNanos": 8498,
+            "reduceNanosSamples": [
+              14492,
+              8583,
+              8463,
+              7992,
+              8663,
+              8363,
+              8533,
+              7991
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 146262
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1953,
+            "packNanos": 135325,
+            "rank": 0,
+            "reduceNanos": 8097,
+            "reduceNanosSamples": [
+              8122,
+              8152,
+              7942,
+              7972,
+              8072,
+              8483,
+              8473,
+              8022
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145521
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2147,
+            "packNanos": 135366,
+            "rank": 0,
+            "reduceNanos": 8232,
+            "reduceNanosSamples": [
+              8032,
+              8663,
+              7822,
+              8643,
+              7971,
+              8432,
+              7982,
+              8603
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145675
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 437849,
+              "rank": 0,
+              "readbackNanos": 165470,
+              "reduceNanos": 6814,
+              "reduceNanosSamples": [
+                6850,
+                6800,
+                6790,
+                6890,
+                6820,
+                6800,
+                6819,
+                6810
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 610240
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 434028,
+              "rank": 0,
+              "readbackNanos": 165585,
+              "reduceNanos": 6695,
+              "reduceNanosSamples": [
+                6570,
+                6830,
+                6550,
+                6871,
+                6580,
+                6850,
+                6610,
+                6780
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 605828
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 434159,
+              "rank": 0,
+              "readbackNanos": 167488,
+              "reduceNanos": 6570,
+              "reduceNanosSamples": [
+                6590,
+                6610,
+                6570,
+                6580,
+                6560,
+                6569,
+                6570,
+                6570
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 609329
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 435655,
+              "rank": 0,
+              "readbackNanos": 2478,
+              "reduceNanos": 8207,
+              "reduceNanosSamples": [
+                8172,
+                8653,
+                8103,
+                8192,
+                8222,
+                8533,
+                8222,
+                8152
+              ],
+              "smallAllocs": 37551,
+              "totalNanos": 446546
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 435981,
+              "rank": 0,
+              "readbackNanos": 165190,
+              "reduceNanos": 6570,
+              "reduceNanosSamples": [
+                6559,
+                6600,
+                6599,
+                6570,
+                6580,
+                6570,
+                6560,
+                6549
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 607340
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 434604,
+              "rank": 0,
+              "readbackNanos": 165085,
+              "reduceNanos": 6590,
+              "reduceNanosSamples": [
+                6590,
+                6590,
+                6590,
+                6590,
+                6590,
+                6589,
+                6579,
+                6579
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 606033
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 433983,
+              "rank": 0,
+              "readbackNanos": 165275,
+              "reduceNanos": 6590,
+              "reduceNanosSamples": [
+                6599,
+                6590,
+                6590,
+                6580,
+                6610,
+                6589,
+                6600,
+                6569
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 605883
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 434629,
+              "rank": 0,
+              "readbackNanos": 165365,
+              "reduceNanos": 6584,
+              "reduceNanosSamples": [
+                6590,
+                6589,
+                6600,
+                6560,
+                6580,
+                6569,
+                6600,
+                6560
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 606554
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 436797,
+              "rank": 0,
+              "readbackNanos": 164298,
+              "reduceNanos": 6685,
+              "reduceNanosSamples": [
+                6680,
+                6710,
+                6670,
+                6659,
+                6690,
+                6690,
+                6640,
+                6700
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 608371
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 434704,
+              "rank": 0,
+              "readbackNanos": 164384,
+              "reduceNanos": 6685,
+              "reduceNanosSamples": [
+                6870,
+                6580,
+                6780,
+                6579,
+                6850,
+                6590,
+                6810,
+                6590
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 606424
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 435270,
+              "rank": 0,
+              "readbackNanos": 164809,
+              "reduceNanos": 6590,
+              "reduceNanosSamples": [
+                6600,
+                6590,
+                6590,
+                6590,
+                6590,
+                6630,
+                6589,
+                6599
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 607050
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 436877,
+              "rank": 0,
+              "readbackNanos": 164529,
+              "reduceNanos": 6584,
+              "reduceNanosSamples": [
+                6570,
+                6580,
+                6560,
+                6580,
+                6589,
+                6600,
+                6600,
+                6589
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 609919
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 432266,
+              "smallAllocs": 37425
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 56,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1401,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 166351,
+              "smallAllocs": 9691
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1401,
+            "wall": {
+              "nanos": 10571,
+              "smallAllocs": 230
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10680,
+            "packNanos": 126227,
+            "rank": 0,
+            "reduceNanos": 8522,
+            "reduceNanosSamples": [
+              8612,
+              8452,
+              8974,
+              8412,
+              8443,
+              8443,
+              8593,
+              8593
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145425
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 492139,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 163667,
+            "smallAllocs": 3312
+          },
+          "productionRowReduce": {
+            "nanos": 87329,
+            "smallAllocs": 3143
+          },
+          "rank": 0,
+          "residentBytesAfter": 70086656,
+          "residentBytesBefore": 69951488,
+          "rowReduceMatrixRebuild": {
+            "nanos": 497913,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 56
+        },
+        "modularDegree": 56,
+        "modularFactorCount": 56,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_56",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1176,
+            "smallAllocs": 90
+          },
+          "berlekampMatrixWall": {
+            "nanos": 120563,
+            "smallAllocs": 10805
+          },
+          "berlekampSplit": {
+            "nanos": 198409,
+            "smallAllocs": 13395
+          },
+          "columnPolys": {
+            "nanos": 103539,
+            "smallAllocs": 9437
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 575,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 126629,
+              "smallAllocs": 7021
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 28106,
+              "smallAllocs": 1639
+            },
+            "stagedNanos": 155351,
+            "wall": {
+              "nanos": 165075,
+              "smallAllocs": 8826
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 611,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 218580,
+              "smallAllocs": 12397
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 38149,
+              "smallAllocs": 2143
+            },
+            "stagedNanos": 257417,
+            "wall": {
+              "nanos": 266915,
+              "smallAllocs": 14709
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9619,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 167128,
+            "smallAllocs": 10941
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 130113,
+            "smallAllocs": 11406
+          },
+          "frobeniusPower": {
+            "nanos": 3355,
+            "smallAllocs": 217
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 13515,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 130739,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 5,
+          "nullspaceBasisMagnitudeNanos": 11211,
+          "nullspaceBasisNanos": 11211,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 891,
+            "packNanos": 21932,
+            "rank": 21,
+            "reduceNanos": 18893,
+            "reduceNanosSamples": [
+              21182,
+              18457,
+              19789,
+              18448,
+              19980,
+              18357,
+              19279,
+              18508
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 41792
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 796,
+            "packNanos": 21822,
+            "rank": 21,
+            "reduceNanos": 18813,
+            "reduceNanosSamples": [
+              18788,
+              18998,
+              18628,
+              18838,
+              19008,
+              18497,
+              18868,
+              18507
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 41426
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1061,
+            "packNanos": 22203,
+            "rank": 21,
+            "reduceNanos": 15713,
+            "reduceNanosSamples": [
+              15273,
+              16865,
+              15463,
+              16154,
+              14852,
+              15983,
+              14502,
+              15964
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 38872
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119867,
+              "rank": 21,
+              "readbackNanos": 7601,
+              "reduceNanos": 24336,
+              "reduceNanosSamples": [
+                24055,
+                24807,
+                24036,
+                24457,
+                23916,
+                24256,
+                26991,
+                24416
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 152290
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119081,
+              "rank": 21,
+              "readbackNanos": 7561,
+              "reduceNanos": 22724,
+              "reduceNanosSamples": [
+                23255,
+                23505,
+                22584,
+                23165,
+                22243,
+                22774,
+                22403,
+                22674
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 149571
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118721,
+              "rank": 21,
+              "readbackNanos": 7396,
+              "reduceNanos": 20806,
+              "reduceNanosSamples": [
+                22083,
+                21032,
+                20621,
+                21122,
+                20380,
+                20571,
+                20741,
+                20871
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 146862
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118736,
+              "rank": 21,
+              "readbackNanos": 836,
+              "reduceNanos": 18557,
+              "reduceNanosSamples": [
+                18648,
+                18627,
+                18437,
+                18557,
+                18848,
+                18337,
+                18558,
+                18477
+              ],
+              "smallAllocs": 10682,
+              "totalNanos": 138074
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119191,
+              "rank": 21,
+              "readbackNanos": 7406,
+              "reduceNanos": 25117,
+              "reduceNanosSamples": [
+                27030,
+                25087,
+                25138,
+                25217,
+                24977,
+                25097,
+                25027,
+                25368
+              ],
+              "smallAllocs": 11210,
+              "totalNanos": 151830
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118826,
+              "rank": 21,
+              "readbackNanos": 7416,
+              "reduceNanos": 25813,
+              "reduceNanosSamples": [
+                26750,
+                25818,
+                25869,
+                25818,
+                25518,
+                25638,
+                25679,
+                25809
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 152030
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119321,
+              "rank": 21,
+              "readbackNanos": 7431,
+              "reduceNanos": 23950,
+              "reduceNanosSamples": [
+                25638,
+                23665,
+                24517,
+                23805,
+                24346,
+                23655,
+                24096,
+                23796
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 150808
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118691,
+              "rank": 21,
+              "readbackNanos": 7481,
+              "reduceNanos": 24501,
+              "reduceNanosSamples": [
+                25358,
+                24466,
+                24857,
+                24536,
+                24356,
+                24106,
+                24406,
+                26840
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 150723
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118991,
+              "rank": 21,
+              "readbackNanos": 7546,
+              "reduceNanos": 41892,
+              "reduceNanosSamples": [
+                46509,
+                42263,
+                42503,
+                42663,
+                41522,
+                41281,
+                41282,
+                41451
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 168160
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118976,
+              "rank": 21,
+              "readbackNanos": 7486,
+              "reduceNanos": 42222,
+              "reduceNanosSamples": [
+                42443,
+                42483,
+                42784,
+                45798,
+                42002,
+                41452,
+                41862,
+                41652
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 169035
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 118961,
+              "rank": 21,
+              "readbackNanos": 7431,
+              "reduceNanos": 21527,
+              "reduceNanosSamples": [
+                22593,
+                21682,
+                21502,
+                21572,
+                21451,
+                21532,
+                21402,
+                21522
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 147945
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119091,
+              "rank": 21,
+              "readbackNanos": 7396,
+              "reduceNanos": 20741,
+              "reduceNanosSamples": [
+                21492,
+                21111,
+                23995,
+                20601,
+                20280,
+                20510,
+                20380,
+                20881
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 147934
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 119462,
+              "smallAllocs": 10228
+            },
+            "columnCount": {
+              "nanos": 8043,
+              "smallAllocs": 567
+            },
+            "eliminate": {
+              "nanos": 39070,
+              "smallAllocs": 567
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 2688,
+            "pivotSearch": {
+              "nanos": 645,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "readback": {
+              "nanos": 7261,
+              "smallAllocs": 318
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 4934,
+              "smallAllocs": 84
+            },
+            "scaleMultiplies": 504,
+            "stagedNanos": 44899,
+            "wall": {
+              "nanos": 55832,
+              "smallAllocs": 1341
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2499,
+            "packNanos": 20921,
+            "rank": 21,
+            "reduceNanos": 31672,
+            "reduceNanosSamples": [
+              31016,
+              33059,
+              29483,
+              32598,
+              29243,
+              32328,
+              28863,
+              33089
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 4129,
+            "totalNanos": 55643
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 129953,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 258528,
+            "smallAllocs": 14185
+          },
+          "productionRowReduce": {
+            "nanos": 246861,
+            "smallAllocs": 13515
+          },
+          "rank": 21,
+          "residentBytesAfter": 70172672,
+          "residentBytesBefore": 70172672,
+          "rowReduceMatrixRebuild": {
+            "nanos": 130243,
+            "smallAllocs": 0
+          },
+          "sink": 92,
+          "splitFactors": 3
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 3,
+        "prime": 5,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_T24",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1297,
+            "smallAllocs": 99
+          },
+          "berlekampMatrixWall": {
+            "nanos": 84655,
+            "smallAllocs": 7348
+          },
+          "berlekampSplit": {
+            "nanos": 191834,
+            "smallAllocs": 12764
+          },
+          "columnPolys": {
+            "nanos": 70344,
+            "smallAllocs": 6080
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 585,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 112819,
+              "smallAllocs": 6262
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 26705,
+              "smallAllocs": 1560
+            },
+            "stagedNanos": 139980,
+            "wall": {
+              "nanos": 149687,
+              "smallAllocs": 7993
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 646,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 191589,
+              "smallAllocs": 10966
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 36399,
+              "smallAllocs": 2040
+            },
+            "stagedNanos": 228652,
+            "wall": {
+              "nanos": 238048,
+              "smallAllocs": 13180
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 10400,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 126738,
+            "smallAllocs": 7501
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 94525,
+            "smallAllocs": 7949
+          },
+          "frobeniusPower": {
+            "nanos": 2088,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 12388,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 94765,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 12919,
+          "nullspaceBasisNanos": 12919,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1041,
+            "packNanos": 21892,
+            "rank": 20,
+            "reduceNanos": 17050,
+            "reduceNanosSamples": [
+              18137,
+              16725,
+              17376,
+              16585,
+              17676,
+              16404,
+              21923,
+              16675
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39799
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 871,
+            "packNanos": 21842,
+            "rank": 20,
+            "reduceNanos": 17010,
+            "reduceNanosSamples": [
+              16725,
+              17125,
+              25047,
+              16995,
+              17026,
+              16594,
+              16645,
+              21381
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39594
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1011,
+            "packNanos": 22028,
+            "rank": 20,
+            "reduceNanos": 14121,
+            "reduceNanosSamples": [
+              13770,
+              15012,
+              13901,
+              14612,
+              13560,
+              14332,
+              13911,
+              14692
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 37220
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84715,
+              "rank": 20,
+              "readbackNanos": 8898,
+              "reduceNanos": 22473,
+              "reduceNanosSamples": [
+                22353,
+                22664,
+                22103,
+                22563,
+                22463,
+                22483,
+                21943,
+                22904
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 116197
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83148,
+              "rank": 20,
+              "readbackNanos": 8758,
+              "reduceNanos": 20845,
+              "reduceNanosSamples": [
+                20800,
+                21242,
+                20890,
+                21221,
+                20641,
+                20761,
+                20450,
+                21122
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112822
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84225,
+              "rank": 20,
+              "readbackNanos": 8778,
+              "reduceNanos": 19088,
+              "reduceNanosSamples": [
+                18978,
+                19228,
+                19049,
+                19259,
+                18818,
+                19128,
+                18939,
+                19158
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112171
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83273,
+              "rank": 20,
+              "readbackNanos": 896,
+              "reduceNanos": 16620,
+              "reduceNanosSamples": [
+                20791,
+                16675,
+                16485,
+                16695,
+                16565,
+                16345,
+                17005,
+                16414
+              ],
+              "smallAllocs": 7215,
+              "totalNanos": 100984
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83103,
+              "rank": 20,
+              "readbackNanos": 8668,
+              "reduceNanos": 23320,
+              "reduceNanosSamples": [
+                23355,
+                23565,
+                23034,
+                23195,
+                23685,
+                23124,
+                23455,
+                23285
+              ],
+              "smallAllocs": 7806,
+              "totalNanos": 114956
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 82848,
+              "rank": 20,
+              "readbackNanos": 8733,
+              "reduceNanos": 23845,
+              "reduceNanosSamples": [
+                23966,
+                24096,
+                23455,
+                23815,
+                23875,
+                23805,
+                23615,
+                23885
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115456
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83087,
+              "rank": 20,
+              "readbackNanos": 8753,
+              "reduceNanos": 22253,
+              "reduceNanosSamples": [
+                22734,
+                21993,
+                22213,
+                22073,
+                22334,
+                25337,
+                22193,
+                22294
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 114665
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83188,
+              "rank": 20,
+              "readbackNanos": 8698,
+              "reduceNanos": 22483,
+              "reduceNanosSamples": [
+                22734,
+                22474,
+                22253,
+                22724,
+                22653,
+                22493,
+                22433,
+                22353
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 114394
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83283,
+              "rank": 20,
+              "readbackNanos": 8868,
+              "reduceNanos": 36859,
+              "reduceNanosSamples": [
+                36614,
+                37435,
+                36544,
+                37155,
+                37386,
+                36794,
+                36604,
+                36924
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 129001
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83158,
+              "rank": 20,
+              "readbackNanos": 8893,
+              "reduceNanos": 37406,
+              "reduceNanosSamples": [
+                37246,
+                37676,
+                37075,
+                37536,
+                37796,
+                37035,
+                51366,
+                37276
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 129536
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 83278,
+              "rank": 20,
+              "readbackNanos": 8683,
+              "reduceNanos": 19859,
+              "reduceNanosSamples": [
+                20079,
+                19930,
+                19809,
+                19909,
+                19659,
+                20030,
+                19739,
+                19729
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 111790
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84706,
+              "rank": 20,
+              "readbackNanos": 8667,
+              "reduceNanos": 19054,
+              "reduceNanosSamples": [
+                19039,
+                19008,
+                19119,
+                19449,
+                19229,
+                18918,
+                19069,
+                18959
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112436
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 83239,
+              "smallAllocs": 6771
+            },
+            "columnCount": {
+              "nanos": 7920,
+              "smallAllocs": 540
+            },
+            "eliminate": {
+              "nanos": 34257,
+              "smallAllocs": 540
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 2352,
+            "pivotSearch": {
+              "nanos": 642,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "readback": {
+              "nanos": 8677,
+              "smallAllocs": 411
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 4729,
+              "smallAllocs": 80
+            },
+            "scaleMultiplies": 480,
+            "stagedNanos": 39635,
+            "wall": {
+              "nanos": 49973,
+              "smallAllocs": 1282
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2709,
+            "packNanos": 20846,
+            "rank": 20,
+            "reduceNanos": 28762,
+            "reduceNanosSamples": [
+              39880,
+              29143,
+              26018,
+              28943,
+              26019,
+              28582,
+              25679,
+              29253
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 3687,
+            "totalNanos": 51962
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 94795,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 234077,
+            "smallAllocs": 12726
+          },
+          "productionRowReduce": {
+            "nanos": 220442,
+            "smallAllocs": 12037
+          },
+          "rank": 20,
+          "residentBytesAfter": 70172672,
+          "residentBytesBefore": 70172672,
+          "rowReduceMatrixRebuild": {
+            "nanos": 94805,
+            "smallAllocs": 0
+          },
+          "sink": 22,
+          "splitFactors": 4
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_U24",
+      "status": "ok"
+    },
+    {
+      "degree": 30,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 30,
+          "basisToPolynomials": {
+            "nanos": 2033,
+            "smallAllocs": 146
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1194882,
+            "smallAllocs": 116780
+          },
+          "berlekampSplit": {
+            "nanos": 1961418,
+            "smallAllocs": 167769
+          },
+          "columnPolys": {
+            "nanos": 1085965,
+            "smallAllocs": 106059
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 737,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 386551,
+              "smallAllocs": 21308
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 36879,
+              "smallAllocs": 2201
+            },
+            "stagedNanos": 424255,
+            "wall": {
+              "nanos": 438820,
+              "smallAllocs": 23741
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 771,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 695972,
+              "smallAllocs": 40208
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 51130,
+              "smallAllocs": 2891
+            },
+            "stagedNanos": 747914,
+            "wall": {
+              "nanos": 761859,
+              "smallAllocs": 43334
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 18587,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1331304,
+            "smallAllocs": 117032
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1213078,
+            "smallAllocs": 117711
+          },
+          "frobeniusPower": {
+            "nanos": 94084,
+            "smallAllocs": 8922
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 16399,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1219748,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 27300,
+          "nullspaceBasisNanos": 27300,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1878,
+            "packNanos": 35963,
+            "rank": 23,
+            "reduceNanos": 47069,
+            "reduceNanosSamples": [
+              48211,
+              46719,
+              47420,
+              45948,
+              47821,
+              46309,
+              47750,
+              46139
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 86037
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1357,
+            "packNanos": 35687,
+            "rank": 23,
+            "reduceNanos": 47124,
+            "reduceNanosSamples": [
+              47100,
+              47560,
+              46950,
+              46099,
+              47119,
+              47130,
+              47150,
+              47400
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 84129
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1723,
+            "packNanos": 36234,
+            "rank": 23,
+            "reduceNanos": 34506,
+            "reduceNanosSamples": [
+              33560,
+              35422,
+              33699,
+              35373,
+              33790,
+              35222,
+              33510,
+              35352
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 72472
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1202523,
+              "rank": 23,
+              "readbackNanos": 17361,
+              "reduceNanos": 48677,
+              "reduceNanosSamples": [
+                47991,
+                48482,
+                48081,
+                49293,
+                48221,
+                49123,
+                50525,
+                48872
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1268095
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1206057,
+              "rank": 23,
+              "readbackNanos": 17095,
+              "reduceNanos": 53314,
+              "reduceNanosSamples": [
+                53149,
+                53609,
+                53479,
+                54861,
+                53139,
+                53579,
+                53098,
+                53139
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1276747
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1208702,
+              "rank": 23,
+              "readbackNanos": 17090,
+              "reduceNanos": 45912,
+              "reduceNanosSamples": [
+                46760,
+                46899,
+                46088,
+                45708,
+                45558,
+                46989,
+                45737,
+                45437
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1272076
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1203519,
+              "rank": 23,
+              "readbackNanos": 1402,
+              "reduceNanos": 46484,
+              "reduceNanosSamples": [
+                46368,
+                46799,
+                46309,
+                45718,
+                46630,
+                46218,
+                46869,
+                46600
+              ],
+              "smallAllocs": 116328,
+              "totalNanos": 1251675
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1204341,
+              "rank": 23,
+              "readbackNanos": 17050,
+              "reduceNanos": 52768,
+              "reduceNanosSamples": [
+                52849,
+                52197,
+                52338,
+                54171,
+                52688,
+                53499,
+                52969,
+                51276
+              ],
+              "smallAllocs": 117788,
+              "totalNanos": 1272922
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1202718,
+              "rank": 23,
+              "readbackNanos": 17020,
+              "reduceNanos": 54866,
+              "reduceNanosSamples": [
+                54721,
+                62904,
+                54842,
+                54962,
+                54781,
+                54851,
+                54882,
+                55072
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1274659
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1202848,
+              "rank": 23,
+              "readbackNanos": 17070,
+              "reduceNanos": 48762,
+              "reduceNanosSamples": [
+                48762,
+                47720,
+                49193,
+                51596,
+                48762,
+                48132,
+                49013,
+                47781
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1267664
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1206563,
+              "rank": 23,
+              "readbackNanos": 17095,
+              "reduceNanos": 50069,
+              "reduceNanosSamples": [
+                50184,
+                49204,
+                50315,
+                50285,
+                49944,
+                49854,
+                49954,
+                53539
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1273813
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1200439,
+              "rank": 23,
+              "readbackNanos": 17351,
+              "reduceNanos": 119517,
+              "reduceNanosSamples": [
+                119287,
+                118135,
+                119617,
+                120799,
+                119086,
+                119417,
+                122773,
+                119948
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1338870
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1207981,
+              "rank": 23,
+              "readbackNanos": 17165,
+              "reduceNanos": 120974,
+              "reduceNanosSamples": [
+                120498,
+                118616,
+                120258,
+                121450,
+                134810,
+                122331,
+                121690,
+                120348
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1346511
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1204761,
+              "rank": 23,
+              "readbackNanos": 17165,
+              "reduceNanos": 49578,
+              "reduceNanosSamples": [
+                58096,
+                49623,
+                49534,
+                49743,
+                50094,
+                49273,
+                49173,
+                48933
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1271460
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1205087,
+              "rank": 23,
+              "readbackNanos": 17040,
+              "reduceNanos": 46899,
+              "reduceNanosSamples": [
+                47040,
+                46950,
+                46869,
+                46930,
+                46799,
+                68041,
+                46619,
+                46779
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1271736
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1203183,
+              "smallAllocs": 115879
+            },
+            "columnCount": {
+              "nanos": 10435,
+              "smallAllocs": 759
+            },
+            "eliminate": {
+              "nanos": 116104,
+              "smallAllocs": 759
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 9450,
+            "pivotSearch": {
+              "nanos": 790,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "readback": {
+              "nanos": 17395,
+              "smallAllocs": 852
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 6675,
+              "smallAllocs": 92
+            },
+            "scaleMultiplies": 690,
+            "stagedNanos": 123540,
+            "wall": {
+              "nanos": 138159,
+              "smallAllocs": 1759
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4281,
+            "packNanos": 34371,
+            "rank": 23,
+            "reduceNanos": 88676,
+            "reduceNanosSamples": [
+              80539,
+              91206,
+              81661,
+              91406,
+              78626,
+              90094,
+              87259,
+              91175
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 11552,
+            "totalNanos": 128445
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 1219468,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 777312,
+            "smallAllocs": 42855
+          },
+          "productionRowReduce": {
+            "nanos": 750167,
+            "smallAllocs": 41732
+          },
+          "rank": 23,
+          "residentBytesAfter": 64266240,
+          "residentBytesBefore": 64192512,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1217950,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 7
+        },
+        "modularDegree": 30,
+        "modularFactorCount": 7,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "legendre_P30",
+      "status": "ok"
+    },
+    {
+      "degree": 38,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 38,
+          "basisToPolynomials": {
+            "nanos": 1427,
+            "smallAllocs": 100
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2378942,
+            "smallAllocs": 232849
+          },
+          "berlekampSplit": {
+            "nanos": 2895598,
+            "smallAllocs": 251152
+          },
+          "columnPolys": {
+            "nanos": 2209090,
+            "smallAllocs": 215798
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 973,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 921605,
+              "smallAllocs": 51765
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 68300,
+              "smallAllocs": 4185
+            },
+            "stagedNanos": 991076,
+            "wall": {
+              "nanos": 1013442,
+              "smallAllocs": 56191
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 977,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 1702884,
+              "smallAllocs": 98885
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 94305,
+              "smallAllocs": 5515
+            },
+            "stagedNanos": 1798516,
+            "wall": {
+              "nanos": 1819247,
+              "smallAllocs": 104644
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 22807,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2685266,
+            "smallAllocs": 233069
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2401875,
+            "smallAllocs": 234332
+          },
+          "frobeniusPower": {
+            "nanos": 147568,
+            "smallAllocs": 14164
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 27115,
+          "matrixConversionNegative": true,
+          "matrixRebuild": {
+            "nanos": 2432176,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 79,
+          "nullspaceBasisMagnitudeNanos": 24436,
+          "nullspaceBasisNanos": 24436,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1592,
+            "packNanos": 59458,
+            "rank": 35,
+            "reduceNanos": 106257,
+            "reduceNanosSamples": [
+              107890,
+              105086,
+              106959,
+              105276,
+              110694,
+              105106,
+              106959,
+              105556
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 167498
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1342,
+            "packNanos": 59388,
+            "rank": 35,
+            "reduceNanos": 107173,
+            "reduceNanosSamples": [
+              107529,
+              106758,
+              106918,
+              105647,
+              108792,
+              107429,
+              104815,
+              108190
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 167758
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1632,
+            "packNanos": 59869,
+            "rank": 35,
+            "reduceNanos": 76138,
+            "reduceNanosSamples": [
+              86668,
+              79127,
+              76344,
+              79328,
+              73609,
+              75612,
+              75813,
+              75933
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 138430
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2384209,
+              "rank": 35,
+              "readbackNanos": 15828,
+              "reduceNanos": 104890,
+              "reduceNanosSamples": [
+                103894,
+                105366,
+                104155,
+                106458,
+                104415,
+                105907,
+                104114,
+                108431
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2504798
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2395786,
+              "rank": 35,
+              "readbackNanos": 15623,
+              "reduceNanos": 122807,
+              "reduceNanosSamples": [
+                121420,
+                122331,
+                121911,
+                126958,
+                126678,
+                122362,
+                124415,
+                123253
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2534702
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2391731,
+              "rank": 35,
+              "readbackNanos": 15608,
+              "reduceNanos": 105781,
+              "reduceNanosSamples": [
+                106107,
+                105316,
+                106207,
+                106879,
+                106538,
+                102692,
+                103073,
+                105456
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2510271
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2386868,
+              "rank": 35,
+              "readbackNanos": 1412,
+              "reduceNanos": 106328,
+              "reduceNanosSamples": [
+                107950,
+                108070,
+                105987,
+                104805,
+                108751,
+                104915,
+                106669,
+                104986
+              ],
+              "smallAllocs": 232204,
+              "totalNanos": 2494012
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2387509,
+              "rank": 35,
+              "readbackNanos": 15543,
+              "reduceNanos": 116377,
+              "reduceNanosSamples": [
+                116262,
+                116953,
+                122351,
+                116493,
+                119808,
+                113017,
+                114770,
+                113308
+              ],
+              "smallAllocs": 233930,
+              "totalNanos": 2518989
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2385596,
+              "rank": 35,
+              "readbackNanos": 15578,
+              "reduceNanos": 122010,
+              "reduceNanosSamples": [
+                121921,
+                122341,
+                121851,
+                122031,
+                122662,
+                121530,
+                121991,
+                122030
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2523125
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382948,
+              "rank": 35,
+              "readbackNanos": 15623,
+              "reduceNanos": 105666,
+              "reduceNanosSamples": [
+                105897,
+                108511,
+                105056,
+                138064,
+                107089,
+                105136,
+                105436,
+                104645
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2505995
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2385396,
+              "rank": 35,
+              "readbackNanos": 15633,
+              "reduceNanos": 109362,
+              "reduceNanosSamples": [
+                108982,
+                109332,
+                108611,
+                109443,
+                118075,
+                109392,
+                109062,
+                109652
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2511193
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2384610,
+              "rank": 35,
+              "readbackNanos": 15728,
+              "reduceNanos": 283300,
+              "reduceNanosSamples": [
+                285584,
+                281928,
+                282289,
+                283431,
+                283169,
+                286615,
+                283751,
+                280516
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2685295
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382797,
+              "rank": 35,
+              "readbackNanos": 15688,
+              "reduceNanos": 285823,
+              "reduceNanosSamples": [
+                286635,
+                285012,
+                282319,
+                287326,
+                280536,
+                290961,
+                284782,
+                288999
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2686292
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2384985,
+              "rank": 35,
+              "readbackNanos": 15563,
+              "reduceNanos": 112377,
+              "reduceNanosSamples": [
+                112467,
+                112767,
+                111595,
+                111645,
+                112287,
+                112487,
+                112807,
+                111145
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2513481
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2387650,
+              "rank": 35,
+              "readbackNanos": 15523,
+              "reduceNanos": 104610,
+              "reduceNanosSamples": [
+                104746,
+                102743,
+                111205,
+                108190,
+                107620,
+                104475,
+                102772,
+                104195
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2508644
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2386353,
+              "smallAllocs": 231404
+            },
+            "columnCount": {
+              "nanos": 18276,
+              "smallAllocs": 1435
+            },
+            "eliminate": {
+              "nanos": 275429,
+              "smallAllocs": 1435
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 23560,
+            "pivotSearch": {
+              "nanos": 986,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 15723,
+              "smallAllocs": 500
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 10831,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1330,
+            "stagedNanos": 287214,
+            "wall": {
+              "nanos": 309614,
+              "smallAllocs": 3203
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5788,
+            "packNanos": 58682,
+            "rank": 35,
+            "reduceNanos": 185060,
+            "reduceNanosSamples": [
+              184754,
+              184494,
+              185155,
+              193297,
+              193117,
+              192405,
+              184965,
+              184753
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 27175,
+            "totalNanos": 253906
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 2415310,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1803589,
+            "smallAllocs": 103304
+          },
+          "productionRowReduce": {
+            "nanos": 1782848,
+            "smallAllocs": 101686
+          },
+          "rank": 35,
+          "residentBytesAfter": 64413696,
+          "residentBytesBefore": 64311296,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2427569,
+            "smallAllocs": 0
+          },
+          "sink": 102,
+          "splitFactors": 3
+        },
+        "modularDegree": 38,
+        "modularFactorCount": 3,
+        "prime": 79,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "legendre_P38",
+      "status": "ok"
+    },
+    {
+      "degree": 16,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 16,
+          "basisToPolynomials": {
+            "nanos": 606,
+            "smallAllocs": 40
+          },
+          "berlekampMatrixWall": {
+            "nanos": 33114,
+            "smallAllocs": 2759
+          },
+          "berlekampSplit": {
+            "nanos": 49984,
+            "smallAllocs": 2865
+          },
+          "columnPolys": {
+            "nanos": 25703,
+            "smallAllocs": 2131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 407,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 45368,
+              "smallAllocs": 2385
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 14105,
+              "smallAllocs": 808
+            },
+            "stagedNanos": 59779,
+            "wall": {
+              "nanos": 64340,
+              "smallAllocs": 3296
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 413,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 73985,
+              "smallAllocs": 3985
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 19096,
+              "smallAllocs": 1048
+            },
+            "stagedNanos": 93434,
+            "wall": {
+              "nanos": 98215,
+              "smallAllocs": 5139
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 5213,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 50014,
+            "smallAllocs": 2823
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 38121,
+            "smallAllocs": 3032
+          },
+          "frobeniusPower": {
+            "nanos": 1998,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 1,
+          "matrixConversionNanos": 5472,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 37931,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 4302,
+          "nullspaceBasisNanos": 4302,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 450,
+            "packNanos": 8642,
+            "rank": 15,
+            "reduceNanos": 7952,
+            "reduceNanosSamples": [
+              9424,
+              7622,
+              8323,
+              7602,
+              8282,
+              7521,
+              8312,
+              7592
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 17050
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 340,
+            "packNanos": 8513,
+            "rank": 15,
+            "reduceNanos": 7747,
+            "reduceNanosSamples": [
+              8132,
+              7762,
+              7771,
+              7781,
+              7662,
+              7722,
+              7732,
+              7732
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16620
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 515,
+            "packNanos": 8713,
+            "rank": 15,
+            "reduceNanos": 7210,
+            "reduceNanosSamples": [
+              6910,
+              7742,
+              6760,
+              7751,
+              6850,
+              7511,
+              6690,
+              7531
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16469
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32463,
+              "rank": 15,
+              "readbackNanos": 2754,
+              "reduceNanos": 10816,
+              "reduceNanosSamples": [
+                10906,
+                11047,
+                10596,
+                10746,
+                10576,
+                10896,
+                10576,
+                10886
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46113
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32208,
+              "rank": 15,
+              "readbackNanos": 2684,
+              "reduceNanos": 9193,
+              "reduceNanosSamples": [
+                9454,
+                9715,
+                9033,
+                9204,
+                8934,
+                9183,
+                9013,
+                9274
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44145
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32418,
+              "rank": 15,
+              "readbackNanos": 2594,
+              "reduceNanos": 8542,
+              "reduceNanosSamples": [
+                9124,
+                8623,
+                8602,
+                8483,
+                8633,
+                8433,
+                8483,
+                8472
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 43595
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32498,
+              "rank": 15,
+              "readbackNanos": 415,
+              "reduceNanos": 7656,
+              "reduceNanosSamples": [
+                7772,
+                7742,
+                7612,
+                7602,
+                7681,
+                7591,
+                7712,
+                7631
+              ],
+              "smallAllocs": 2738,
+              "totalNanos": 40695
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32188,
+              "rank": 15,
+              "readbackNanos": 2618,
+              "reduceNanos": 10556,
+              "reduceNanosSamples": [
+                11066,
+                10726,
+                10606,
+                10265,
+                10566,
+                10546,
+                10426,
+                10395
+              ],
+              "smallAllocs": 2914,
+              "totalNanos": 45402
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32193,
+              "rank": 15,
+              "readbackNanos": 2604,
+              "reduceNanos": 11086,
+              "reduceNanosSamples": [
+                11426,
+                11126,
+                11127,
+                10976,
+                11046,
+                10976,
+                11006,
+                11127
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46013
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32293,
+              "rank": 15,
+              "readbackNanos": 2614,
+              "reduceNanos": 10455,
+              "reduceNanosSamples": [
+                11136,
+                10256,
+                10806,
+                10165,
+                10736,
+                10265,
+                10606,
+                10305
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45417
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32338,
+              "rank": 15,
+              "readbackNanos": 2609,
+              "reduceNanos": 10630,
+              "reduceNanosSamples": [
+                11027,
+                10566,
+                10806,
+                10556,
+                10826,
+                10636,
+                10625,
+                10536
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45773
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32468,
+              "rank": 15,
+              "readbackNanos": 2679,
+              "reduceNanos": 15057,
+              "reduceNanosSamples": [
+                14952,
+                15052,
+                14892,
+                14711,
+                15063,
+                15102,
+                15162,
+                15283
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 50254
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32368,
+              "rank": 15,
+              "readbackNanos": 2644,
+              "reduceNanos": 15322,
+              "reduceNanosSamples": [
+                15664,
+                15162,
+                15353,
+                14752,
+                15422,
+                15292,
+                15523,
+                15242
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 50484
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32337,
+              "rank": 15,
+              "readbackNanos": 2624,
+              "reduceNanos": 8723,
+              "reduceNanosSamples": [
+                9084,
+                8934,
+                8743,
+                8753,
+                8542,
+                8703,
+                8683,
+                8633
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 43775
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32733,
+              "rank": 15,
+              "readbackNanos": 2603,
+              "reduceNanos": 8558,
+              "reduceNanosSamples": [
+                9013,
+                8773,
+                8563,
+                8633,
+                8553,
+                8522,
+                8483,
+                8513
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44020
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 32453,
+              "smallAllocs": 2502
+            },
+            "columnCount": {
+              "nanos": 4001,
+              "smallAllocs": 285
+            },
+            "eliminate": {
+              "nanos": 13645,
+              "smallAllocs": 285
+            },
+            "freeColumns": 1,
+            "innerMultiplies": 800,
+            "pivotSearch": {
+              "nanos": 436,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "readback": {
+              "nanos": 2513,
+              "smallAllocs": 86
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 2733,
+              "smallAllocs": 60
+            },
+            "scaleMultiplies": 240,
+            "stagedNanos": 16814,
+            "wall": {
+              "nanos": 22403,
+              "smallAllocs": 715
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1171,
+            "packNanos": 8347,
+            "rank": 15,
+            "reduceNanos": 12768,
+            "reduceNanosSamples": [
+              12909,
+              12979,
+              12128,
+              12959,
+              11838,
+              12809,
+              11938,
+              12728
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 1551,
+            "totalNanos": 22013
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 37766,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 91846,
+            "smallAllocs": 4820
+          },
+          "productionRowReduce": {
+            "nanos": 87489,
+            "smallAllocs": 4531
+          },
+          "rank": 15,
+          "residentBytesAfter": 64212992,
+          "residentBytesBefore": 64212992,
+          "rowReduceMatrixRebuild": {
+            "nanos": 37681,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 1
+        },
+        "modularDegree": 16,
+        "modularFactorCount": 1,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi17",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 1753,
+            "smallAllocs": 142
+          },
+          "berlekampMatrixWall": {
+            "nanos": 168029,
+            "smallAllocs": 14819
+          },
+          "berlekampSplit": {
+            "nanos": 455816,
+            "smallAllocs": 32512
+          },
+          "columnPolys": {
+            "nanos": 129697,
+            "smallAllocs": 11503
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1009,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 202918,
+              "smallAllocs": 12335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 70995,
+              "smallAllocs": 4412
+            },
+            "stagedNanos": 275930,
+            "wall": {
+              "nanos": 299333,
+              "smallAllocs": 17021
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1028,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 331447,
+              "smallAllocs": 20335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 95544,
+              "smallAllocs": 5812
+            },
+            "stagedNanos": 428284,
+            "wall": {
+              "nanos": 449957,
+              "smallAllocs": 26424
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26279,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 248388,
+            "smallAllocs": 15115
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 193677,
+            "smallAllocs": 16460
+          },
+          "frobeniusPower": {
+            "nanos": 2063,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 5,
+          "matrixConversionNanos": 35813,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 197618,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 27600,
+          "nullspaceBasisNanos": 27600,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1712,
+            "packNanos": 66498,
+            "rank": 35,
+            "reduceNanos": 34997,
+            "reduceNanosSamples": [
+              35793,
+              34251,
+              35503,
+              34341,
+              35463,
+              34611,
+              35383,
+              34341
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 104134
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1612,
+            "packNanos": 66594,
+            "rank": 35,
+            "reduceNanos": 34646,
+            "reduceNanosSamples": [
+              34882,
+              35132,
+              34892,
+              34531,
+              34461,
+              34471,
+              34290,
+              34762
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 103088
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1828,
+            "packNanos": 66594,
+            "rank": 35,
+            "reduceNanos": 29122,
+            "reduceNanosSamples": [
+              28872,
+              29714,
+              28862,
+              29814,
+              28172,
+              29373,
+              28482,
+              30024
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 97599
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163321,
+              "rank": 35,
+              "readbackNanos": 21937,
+              "reduceNanos": 48596,
+              "reduceNanosSamples": [
+                47831,
+                48451,
+                48742,
+                49173,
+                48202,
+                49103,
+                48181,
+                49914
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 234227
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163106,
+              "rank": 35,
+              "readbackNanos": 21732,
+              "reduceNanos": 42467,
+              "reduceNanosSamples": [
+                42463,
+                42472,
+                41942,
+                42773,
+                41812,
+                42513,
+                42333,
+                42473
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 227201
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163578,
+              "rank": 35,
+              "readbackNanos": 21607,
+              "reduceNanos": 39703,
+              "reduceNanosSamples": [
+                40160,
+                39459,
+                39148,
+                39499,
+                39668,
+                39739,
+                39849,
+                43725
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 225514
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164975,
+              "rank": 35,
+              "readbackNanos": 1672,
+              "reduceNanos": 34200,
+              "reduceNanosSamples": [
+                34321,
+                34381,
+                34851,
+                34160,
+                34000,
+                34140,
+                34121,
+                34240
+              ],
+              "smallAllocs": 14612,
+              "totalNanos": 200873
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163392,
+              "rank": 35,
+              "readbackNanos": 21642,
+              "reduceNanos": 51577,
+              "reduceNanosSamples": [
+                55372,
+                50785,
+                51196,
+                51507,
+                54401,
+                51347,
+                51647,
+                51786
+              ],
+              "smallAllocs": 15632,
+              "totalNanos": 237181
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164603,
+              "rank": 35,
+              "readbackNanos": 21682,
+              "reduceNanos": 52107,
+              "reduceNanosSamples": [
+                51867,
+                51416,
+                52238,
+                52087,
+                52267,
+                52087,
+                52128,
+                53059
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238338
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164754,
+              "rank": 35,
+              "readbackNanos": 21672,
+              "reduceNanos": 49308,
+              "reduceNanosSamples": [
+                49954,
+                48301,
+                49313,
+                48822,
+                49613,
+                49233,
+                49303,
+                49614
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 235439
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164123,
+              "rank": 35,
+              "readbackNanos": 21727,
+              "reduceNanos": 49834,
+              "reduceNanosSamples": [
+                49333,
+                49223,
+                49834,
+                50254,
+                49944,
+                49834,
+                49524,
+                50255
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 235324
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163672,
+              "rank": 35,
+              "readbackNanos": 21842,
+              "reduceNanos": 68491,
+              "reduceNanosSamples": [
+                68251,
+                67821,
+                101300,
+                68401,
+                68582,
+                68872,
+                68031,
+                73509
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 254357
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164854,
+              "rank": 35,
+              "readbackNanos": 21707,
+              "reduceNanos": 69122,
+              "reduceNanosSamples": [
+                69172,
+                68181,
+                69222,
+                68792,
+                69452,
+                69073,
+                68912,
+                69313
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 255574
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164594,
+              "rank": 35,
+              "readbackNanos": 21612,
+              "reduceNanos": 40380,
+              "reduceNanosSamples": [
+                40350,
+                40590,
+                40199,
+                40430,
+                39929,
+                40370,
+                40390,
+                40550
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 226781
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163146,
+              "rank": 35,
+              "readbackNanos": 21717,
+              "reduceNanos": 39198,
+              "reduceNanosSamples": [
+                39599,
+                39107,
+                43134,
+                43966,
+                39048,
+                39138,
+                39008,
+                39259
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 224157
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 164734,
+              "smallAllocs": 13218
+            },
+            "columnCount": {
+              "nanos": 18822,
+              "smallAllocs": 1505
+            },
+            "eliminate": {
+              "nanos": 61176,
+              "smallAllocs": 1505
+            },
+            "freeColumns": 5,
+            "innerMultiplies": 4000,
+            "pivotSearch": {
+              "nanos": 1120,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 21396,
+              "smallAllocs": 838
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 10560,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1400,
+            "stagedNanos": 72887,
+            "wall": {
+              "nanos": 95311,
+              "smallAllocs": 3351
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6665,
+            "packNanos": 63038,
+            "rank": 35,
+            "reduceNanos": 53614,
+            "reduceNanosSamples": [
+              60649,
+              53599,
+              53449,
+              53870,
+              53989,
+              53370,
+              53630,
+              53249
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 8397,
+            "totalNanos": 125090
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 194798,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 452145,
+            "smallAllocs": 25145
+          },
+          "productionRowReduce": {
+            "nanos": 421605,
+            "smallAllocs": 23316
+          },
+          "rank": 35,
+          "residentBytesAfter": 64229376,
+          "residentBytesBefore": 64212992,
+          "rowReduceMatrixRebuild": {
+            "nanos": 197142,
+            "smallAllocs": 0
+          },
+          "sink": 100,
+          "splitFactors": 5
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 5,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi41",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 3325,
+            "smallAllocs": 308
+          },
+          "berlekampMatrixWall": {
+            "nanos": 151855,
+            "smallAllocs": 14147
+          },
+          "berlekampSplit": {
+            "nanos": 585663,
+            "smallAllocs": 46939
+          },
+          "columnPolys": {
+            "nanos": 130588,
+            "smallAllocs": 12411
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 582,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 21807,
+              "smallAllocs": 1342
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 14794,
+              "smallAllocs": 876
+            },
+            "stagedNanos": 37155,
+            "wall": {
+              "nanos": 48341,
+              "smallAllocs": 2543
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 620,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 31281,
+              "smallAllocs": 1870
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 19688,
+              "smallAllocs": 1140
+            },
+            "stagedNanos": 51556,
+            "wall": {
+              "nanos": 62513,
+              "smallAllocs": 3338
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9178,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 170593,
+            "smallAllocs": 14363
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 160383,
+            "smallAllocs": 14748
+          },
+          "frobeniusPower": {
+            "nanos": 7491,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 13,
+          "matrixConversionNanos": 13650,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 160884,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 17486,
+          "nullspaceBasisNanos": 17486,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1257,
+            "packNanos": 22012,
+            "rank": 11,
+            "reduceNanos": 6560,
+            "reduceNanosSamples": [
+              7341,
+              6089,
+              7171,
+              6029,
+              7201,
+              5959,
+              7031,
+              5959
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29799
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1081,
+            "packNanos": 21782,
+            "rank": 11,
+            "reduceNanos": 6174,
+            "reduceNanosSamples": [
+              6199,
+              6329,
+              6019,
+              6149,
+              6199,
+              6300,
+              6059,
+              6149
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29078
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1337,
+            "packNanos": 22148,
+            "rank": 11,
+            "reduceNanos": 6474,
+            "reduceNanosSamples": [
+              6059,
+              7291,
+              5969,
+              6890,
+              5999,
+              7221,
+              5949,
+              6951
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29960
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150097,
+              "rank": 11,
+              "readbackNanos": 19404,
+              "reduceNanos": 9835,
+              "reduceNanosSamples": [
+                9664,
+                9845,
+                9524,
+                9945,
+                9825,
+                9965,
+                9404,
+                9915
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 179205
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149907,
+              "rank": 11,
+              "readbackNanos": 19409,
+              "reduceNanos": 7556,
+              "reduceNanosSamples": [
+                7431,
+                7952,
+                7311,
+                7982,
+                7181,
+                7822,
+                7280,
+                7681
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 177868
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149802,
+              "rank": 11,
+              "readbackNanos": 19238,
+              "reduceNanos": 7035,
+              "reduceNanosSamples": [
+                7482,
+                7231,
+                7071,
+                7000,
+                6980,
+                7240,
+                6930,
+                6910
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 176076
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150032,
+              "rank": 11,
+              "readbackNanos": 1112,
+              "reduceNanos": 5988,
+              "reduceNanosSamples": [
+                6320,
+                6109,
+                5999,
+                5888,
+                5978,
+                5999,
+                5949,
+                5939
+              ],
+              "smallAllocs": 13885,
+              "totalNanos": 157053
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149862,
+              "rank": 11,
+              "readbackNanos": 19233,
+              "reduceNanos": 9459,
+              "reduceNanosSamples": [
+                9694,
+                9374,
+                9494,
+                9424,
+                9584,
+                9354,
+                9584,
+                9304
+              ],
+              "smallAllocs": 15031,
+              "totalNanos": 178605
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150718,
+              "rank": 11,
+              "readbackNanos": 19253,
+              "reduceNanos": 9559,
+              "reduceNanosSamples": [
+                9785,
+                9544,
+                9443,
+                9575,
+                9534,
+                9594,
+                9574,
+                9445
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 179481
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150589,
+              "rank": 11,
+              "readbackNanos": 19284,
+              "reduceNanos": 9424,
+              "reduceNanosSamples": [
+                9745,
+                9003,
+                9594,
+                9274,
+                9705,
+                9094,
+                9574,
+                9093
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 179236
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149998,
+              "rank": 11,
+              "readbackNanos": 19258,
+              "reduceNanos": 9489,
+              "reduceNanosSamples": [
+                9564,
+                9394,
+                9344,
+                9504,
+                9644,
+                9474,
+                9544,
+                9354
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 178860
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149877,
+              "rank": 11,
+              "readbackNanos": 19319,
+              "reduceNanos": 8773,
+              "reduceNanosSamples": [
+                8773,
+                8692,
+                8673,
+                8853,
+                8973,
+                8862,
+                8773,
+                8773
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177964
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149902,
+              "rank": 11,
+              "readbackNanos": 19273,
+              "reduceNanos": 9083,
+              "reduceNanosSamples": [
+                9364,
+                8863,
+                9284,
+                8944,
+                9354,
+                8844,
+                9223,
+                8833
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 178244
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150929,
+              "rank": 11,
+              "readbackNanos": 19223,
+              "reduceNanos": 7125,
+              "reduceNanosSamples": [
+                7431,
+                7341,
+                7090,
+                7111,
+                7140,
+                7171,
+                7100,
+                7111
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 177313
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 150142,
+              "rank": 11,
+              "readbackNanos": 19263,
+              "reduceNanos": 7156,
+              "reduceNanosSamples": [
+                7411,
+                7321,
+                7090,
+                7101,
+                7171,
+                7231,
+                7141,
+                7111
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 176572
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 150588,
+              "smallAllocs": 13570
+            },
+            "columnCount": {
+              "nanos": 4235,
+              "smallAllocs": 297
+            },
+            "eliminate": {
+              "nanos": 7021,
+              "smallAllocs": 297
+            },
+            "freeColumns": 13,
+            "innerMultiplies": 264,
+            "pivotSearch": {
+              "nanos": 644,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "readback": {
+              "nanos": 19178,
+              "smallAllocs": 1158
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 2917,
+              "smallAllocs": 44
+            },
+            "scaleMultiplies": 264,
+            "stagedNanos": 10528,
+            "wall": {
+              "nanos": 16990,
+              "smallAllocs": 751
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3209,
+            "packNanos": 20806,
+            "rank": 11,
+            "reduceNanos": 9439,
+            "reduceNanosSamples": [
+              9594,
+              9744,
+              9444,
+              9434,
+              9254,
+              9674,
+              9114,
+              9224
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 1470,
+            "totalNanos": 33520
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 160769,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 70139,
+            "smallAllocs": 3266
+          },
+          "productionRowReduce": {
+            "nanos": 52532,
+            "smallAllocs": 2654
+          },
+          "rank": 11,
+          "residentBytesAfter": 64266240,
+          "residentBytesBefore": 64266240,
+          "rowReduceMatrixRebuild": {
+            "nanos": 160528,
+            "smallAllocs": 0
+          },
+          "sink": 80,
+          "splitFactors": 13
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 13,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow24_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 20,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 20,
+          "basisToPolynomials": {
+            "nanos": 1166,
+            "smallAllocs": 75
+          },
+          "berlekampMatrixWall": {
+            "nanos": 170723,
+            "smallAllocs": 15130
+          },
+          "berlekampSplit": {
+            "nanos": 343770,
+            "smallAllocs": 23484
+          },
+          "columnPolys": {
+            "nanos": 158199,
+            "smallAllocs": 14054
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 491,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 205480,
+              "smallAllocs": 10529
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 18346,
+              "smallAllocs": 1043
+            },
+            "stagedNanos": 224448,
+            "wall": {
+              "nanos": 231393,
+              "smallAllocs": 11711
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 522,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 364853,
+              "smallAllocs": 19849
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 25043,
+              "smallAllocs": 1363
+            },
+            "stagedNanos": 390605,
+            "wall": {
+              "nanos": 398170,
+              "smallAllocs": 21354
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 6600,
+          "fixedSpaceDiagonalNegative": true,
+          "fixedSpaceKernelVectors": {
+            "nanos": 235985,
+            "smallAllocs": 15255
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 176006,
+            "smallAllocs": 15551
+          },
+          "frobeniusPower": {
+            "nanos": 4131,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 7861,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 179101,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 12363,
+          "nullspaceBasisNanos": 12363,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 866,
+            "packNanos": 14476,
+            "rank": 16,
+            "reduceNanos": 23345,
+            "reduceNanosSamples": [
+              24657,
+              22734,
+              23826,
+              22764,
+              23835,
+              22803,
+              23715,
+              22975
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38567
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 651,
+            "packNanos": 14341,
+            "rank": 16,
+            "reduceNanos": 23240,
+            "reduceNanosSamples": [
+              23514,
+              23265,
+              23215,
+              23335,
+              23365,
+              23014,
+              22914,
+              23164
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38246
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 901,
+            "packNanos": 14516,
+            "rank": 16,
+            "reduceNanos": 19589,
+            "reduceNanosSamples": [
+              18878,
+              20010,
+              19148,
+              20279,
+              18868,
+              20240,
+              19168,
+              20180
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 35037
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 172460,
+              "rank": 16,
+              "readbackNanos": 6830,
+              "reduceNanos": 25257,
+              "reduceNanosSamples": [
+                25097,
+                25347,
+                25227,
+                25718,
+                25207,
+                25548,
+                24967,
+                25288
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 204964
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168890,
+              "rank": 16,
+              "readbackNanos": 6645,
+              "reduceNanos": 27691,
+              "reduceNanosSamples": [
+                27531,
+                28483,
+                27380,
+                28141,
+                27421,
+                27881,
+                27401,
+                27851
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 203071
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167598,
+              "rank": 16,
+              "readbackNanos": 6610,
+              "reduceNanos": 24206,
+              "reduceNanosSamples": [
+                24035,
+                24577,
+                24036,
+                24697,
+                23926,
+                24357,
+                24086,
+                24327
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 198704
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166391,
+              "rank": 16,
+              "readbackNanos": 711,
+              "reduceNanos": 22859,
+              "reduceNanosSamples": [
+                23004,
+                22864,
+                22814,
+                22894,
+                22963,
+                22854,
+                22814,
+                22774
+              ],
+              "smallAllocs": 14870,
+              "totalNanos": 189921
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167308,
+              "rank": 16,
+              "readbackNanos": 6594,
+              "reduceNanos": 27306,
+              "reduceNanosSamples": [
+                27181,
+                27090,
+                27641,
+                27661,
+                27431,
+                27611,
+                27070,
+                26860
+              ],
+              "smallAllocs": 15663,
+              "totalNanos": 201579
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167839,
+              "rank": 16,
+              "readbackNanos": 6609,
+              "reduceNanos": 28357,
+              "reduceNanosSamples": [
+                28362,
+                28352,
+                28331,
+                28602,
+                28472,
+                28472,
+                28202,
+                28141
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 202971
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168189,
+              "rank": 16,
+              "readbackNanos": 6620,
+              "reduceNanos": 25157,
+              "reduceNanosSamples": [
+                25428,
+                24786,
+                25488,
+                25037,
+                25428,
+                25067,
+                25247,
+                24676
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 199951
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167022,
+              "rank": 16,
+              "readbackNanos": 6615,
+              "reduceNanos": 25808,
+              "reduceNanosSamples": [
+                25788,
+                25759,
+                26039,
+                25898,
+                25968,
+                25749,
+                25828,
+                25487
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 199500
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168825,
+              "rank": 16,
+              "readbackNanos": 6765,
+              "reduceNanos": 63003,
+              "reduceNanosSamples": [
+                62623,
+                63795,
+                63183,
+                63404,
+                63254,
+                62823,
+                61791,
+                60710
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 238503
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167448,
+              "rank": 16,
+              "readbackNanos": 6675,
+              "reduceNanos": 63149,
+              "reduceNanosSamples": [
+                62743,
+                64175,
+                64847,
+                63304,
+                63655,
+                62994,
+                62363,
+                61060
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 236966
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167578,
+              "rank": 16,
+              "readbackNanos": 6624,
+              "reduceNanos": 25493,
+              "reduceNanosSamples": [
+                25948,
+                25418,
+                25568,
+                25718,
+                25598,
+                25318,
+                25308,
+                24967
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 199886
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 170187,
+              "rank": 16,
+              "readbackNanos": 6614,
+              "reduceNanos": 24281,
+              "reduceNanosSamples": [
+                24576,
+                24036,
+                24236,
+                24406,
+                24326,
+                24466,
+                23836,
+                23705
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 201218
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 169021,
+              "smallAllocs": 14729
+            },
+            "columnCount": {
+              "nanos": 5577,
+              "smallAllocs": 368
+            },
+            "eliminate": {
+              "nanos": 61367,
+              "smallAllocs": 368
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4660,
+            "pivotSearch": {
+              "nanos": 552,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 6625,
+              "smallAllocs": 343
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 3319,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 320,
+            "stagedNanos": 65217,
+            "wall": {
+              "nanos": 72863,
+              "smallAllocs": 902
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2193,
+            "packNanos": 14066,
+            "rank": 16,
+            "reduceNanos": 42458,
+            "reduceNanosSamples": [
+              40500,
+              44806,
+              40039,
+              47480,
+              37646,
+              44446,
+              37726,
+              44416
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 5524,
+            "totalNanos": 58757
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 180593,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 398365,
+            "smallAllocs": 21079
+          },
+          "productionRowReduce": {
+            "nanos": 386222,
+            "smallAllocs": 20563
+          },
+          "rank": 16,
+          "residentBytesAfter": 64286720,
+          "residentBytesBefore": 64270336,
+          "rowReduceMatrixRebuild": {
+            "nanos": 176241,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 4
+        },
+        "modularDegree": 20,
+        "modularFactorCount": 4,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_10",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1752,
+            "smallAllocs": 128
+          },
+          "berlekampMatrixWall": {
+            "nanos": 571417,
+            "smallAllocs": 52728
+          },
+          "berlekampSplit": {
+            "nanos": 880815,
+            "smallAllocs": 68180
+          },
+          "columnPolys": {
+            "nanos": 539089,
+            "smallAllocs": 49657
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 585,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 348732,
+              "smallAllocs": 18538
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 22583,
+              "smallAllocs": 1310
+            },
+            "stagedNanos": 371877,
+            "wall": {
+              "nanos": 381725,
+              "smallAllocs": 20041
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 601,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 629428,
+              "smallAllocs": 35482
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 31009,
+              "smallAllocs": 1718
+            },
+            "stagedNanos": 661131,
+            "wall": {
+              "nanos": 670840,
+              "smallAllocs": 37396
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 15327,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 687129,
+            "smallAllocs": 52920
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 586114,
+            "smallAllocs": 53329
+          },
+          "frobeniusPower": {
+            "nanos": 22043,
+            "smallAllocs": 1920
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 9794,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 584842,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 23203,
+          "nullspaceBasisNanos": 23203,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1262,
+            "packNanos": 21987,
+            "rank": 17,
+            "reduceNanos": 38311,
+            "reduceNanosSamples": [
+              39188,
+              37516,
+              39098,
+              37496,
+              38527,
+              38096,
+              38917,
+              37315
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 62287
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 946,
+            "packNanos": 21712,
+            "rank": 17,
+            "reduceNanos": 38156,
+            "reduceNanosSamples": [
+              38347,
+              37826,
+              38056,
+              37786,
+              38256,
+              38738,
+              38667,
+              37696
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60991
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1317,
+            "packNanos": 22177,
+            "rank": 17,
+            "reduceNanos": 32674,
+            "reduceNanosSamples": [
+              32018,
+              32759,
+              31586,
+              32919,
+              35072,
+              32589,
+              31477,
+              33300
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 57009
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 572844,
+              "rank": 17,
+              "readbackNanos": 12313,
+              "reduceNanos": 38737,
+              "reduceNanosSamples": [
+                38647,
+                39309,
+                38658,
+                39048,
+                38557,
+                38817,
+                38307,
+                39349
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 624130
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 569098,
+              "rank": 17,
+              "readbackNanos": 12193,
+              "reduceNanos": 44826,
+              "reduceNanosSamples": [
+                44666,
+                45398,
+                44576,
+                45017,
+                44516,
+                45107,
+                44126,
+                44986
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 625643
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 569524,
+              "rank": 17,
+              "readbackNanos": 12098,
+              "reduceNanos": 37996,
+              "reduceNanosSamples": [
+                38097,
+                37886,
+                38788,
+                37776,
+                37896,
+                38978,
+                37866,
+                38837
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 619859
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 569850,
+              "rank": 17,
+              "readbackNanos": 1037,
+              "reduceNanos": 37756,
+              "reduceNanosSamples": [
+                56815,
+                37566,
+                37936,
+                37786,
+                37585,
+                38377,
+                37726,
+                37575
+              ],
+              "smallAllocs": 52268,
+              "totalNanos": 611536
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 573620,
+              "rank": 17,
+              "readbackNanos": 12078,
+              "reduceNanos": 42783,
+              "reduceNanosSamples": [
+                43184,
+                43093,
+                43624,
+                42764,
+                41842,
+                42302,
+                42063,
+                42803
+              ],
+              "smallAllocs": 53630,
+              "totalNanos": 628717
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 570145,
+              "rank": 17,
+              "readbackNanos": 12163,
+              "reduceNanos": 44556,
+              "reduceNanosSamples": [
+                44596,
+                44796,
+                44646,
+                44666,
+                44516,
+                44366,
+                44256,
+                44396
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 626759
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 571272,
+              "rank": 17,
+              "readbackNanos": 12057,
+              "reduceNanos": 38637,
+              "reduceNanosSamples": [
+                38878,
+                38597,
+                38847,
+                38407,
+                38688,
+                38146,
+                38677,
+                38257
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 622202
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 571833,
+              "rank": 17,
+              "readbackNanos": 12103,
+              "reduceNanos": 40009,
+              "reduceNanosSamples": [
+                39999,
+                40010,
+                43524,
+                40009,
+                43725,
+                39528,
+                40160,
+                39629
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 624421
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 571407,
+              "rank": 17,
+              "readbackNanos": 12243,
+              "reduceNanos": 106893,
+              "reduceNanosSamples": [
+                118616,
+                106928,
+                104966,
+                104945,
+                106859,
+                104856,
+                110574,
+                107028
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 689657
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 574036,
+              "rank": 17,
+              "readbackNanos": 12178,
+              "reduceNanos": 107053,
+              "reduceNanosSamples": [
+                106768,
+                107339,
+                105978,
+                104945,
+                107940,
+                104816,
+                107359,
+                111646
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 692301
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 570886,
+              "rank": 17,
+              "readbackNanos": 12158,
+              "reduceNanos": 40986,
+              "reduceNanosSamples": [
+                40800,
+                41311,
+                40800,
+                40911,
+                41371,
+                40700,
+                41061,
+                47641
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 623935
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 571501,
+              "rank": 17,
+              "readbackNanos": 12088,
+              "reduceNanos": 38462,
+              "reduceNanosSamples": [
+                39028,
+                38918,
+                38978,
+                37906,
+                38057,
+                37857,
+                37816,
+                38868
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 621641
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 569699,
+              "smallAllocs": 52151
+            },
+            "columnCount": {
+              "nanos": 6548,
+              "smallAllocs": 459
+            },
+            "eliminate": {
+              "nanos": 104020,
+              "smallAllocs": 459
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 8472,
+            "pivotSearch": {
+              "nanos": 622,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "readback": {
+              "nanos": 12268,
+              "smallAllocs": 678
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 4154,
+              "smallAllocs": 68
+            },
+            "scaleMultiplies": 408,
+            "stagedNanos": 108797,
+            "wall": {
+              "nanos": 117815,
+              "smallAllocs": 1105
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3069,
+            "packNanos": 20941,
+            "rank": 17,
+            "reduceNanos": 70429,
+            "reduceNanosSamples": [
+              64095,
+              76143,
+              64586,
+              79257,
+              64857,
+              75912,
+              64956,
+              75903
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 9576,
+            "totalNanos": 96187
+          },
+          "peakResidentBytes": 70836224,
+          "productionMatrixRebuild": {
+            "nanos": 587931,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 680704,
+            "smallAllocs": 37192
+          },
+          "productionRowReduce": {
+            "nanos": 657255,
+            "smallAllocs": 36406
+          },
+          "rank": 17,
+          "residentBytesAfter": 64315392,
+          "residentBytesBefore": 64315392,
+          "rowReduceMatrixRebuild": {
+            "nanos": 583530,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 7
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 7,
+        "prime": 17,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_21",
+      "status": "ok"
+    }
+  ],
+  "results": [
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 69176327,
+        "median_nanos": 68848150,
+        "min_nanos": 68618359,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0273324700808955,
+      "name": "sd5",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3352911,
+              "smallAllocs": 279386
+            },
+            "berlekampMatrix": {
+              "nanos": 2283,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 20761,
+              "smallAllocs": 1600
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 1683,
+              "smallAllocs": 78
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1594063,
+              "smallAllocs": 152147
+            },
+            "splittingNanos": 1756565
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8343,
+              "smallAllocs": 332
+            },
+            "henselLift": {
+              "nanos": 1600612,
+              "smallAllocs": 57192
+            },
+            "normalization": {
+              "nanos": 34361,
+              "smallAllocs": 1647
+            },
+            "primeWalk": {
+              "nanos": 6775775,
+              "smallAllocs": 569749
+            },
+            "quadratic": {
+              "nanos": 661,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 62274665,
+              "smallAllocs": 2749638
+            },
+            "total": {
+              "nanos": 70729940,
+              "smallAllocs": 3379518
+            },
+            "validation": {
+              "nanos": 6580,
+              "smallAllocs": 201
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 221306743312056565676926650,
+            "coeffBoundBits": 88,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32639,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 129,
+              "recordable": 129,
+              "trailingSurvivors": 129
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 71092287,
+        "total_nanos_median": 70729940,
+        "total_nanos_min": 70368204
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 64209513,
+        "median_nanos": 63756612,
+        "min_nanos": 63381115,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0146017796554183,
+      "name": "sd5_shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3157971,
+              "smallAllocs": 258979
+            },
+            "berlekampMatrix": {
+              "nanos": 1803,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 35433,
+              "smallAllocs": 2696
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2403,
+              "smallAllocs": 84
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2298047,
+              "smallAllocs": 211116
+            },
+            "splittingNanos": 858121
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10546,
+              "smallAllocs": 382
+            },
+            "henselLift": {
+              "nanos": 1620082,
+              "smallAllocs": 58655
+            },
+            "normalization": {
+              "nanos": 52007,
+              "smallAllocs": 2827
+            },
+            "primeWalk": {
+              "nanos": 7235908,
+              "smallAllocs": 588844
+            },
+            "quadratic": {
+              "nanos": 561,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 55732696,
+              "smallAllocs": 2560916
+            },
+            "total": {
+              "nanos": 64687572,
+              "smallAllocs": 3212631
+            },
+            "validation": {
+              "nanos": 7741,
+              "smallAllocs": 229
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 343800744604764214921668900,
+            "coeffBoundBits": 89,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 64848540,
+        "total_nanos_median": 64687572,
+        "total_nanos_min": 64642425
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 67199095,
+        "median_nanos": 66329346,
+        "min_nanos": 66135609,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0217242606311843,
+      "name": "sd5_shift2",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4713217,
+              "smallAllocs": 381697
+            },
+            "berlekampMatrix": {
+              "nanos": 1673,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34341,
+              "smallAllocs": 2673
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2513,
+              "smallAllocs": 85
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2365737,
+              "smallAllocs": 211421
+            },
+            "splittingNanos": 2345807
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 11086,
+              "smallAllocs": 391
+            },
+            "henselLift": {
+              "nanos": 1613102,
+              "smallAllocs": 58442
+            },
+            "normalization": {
+              "nanos": 51797,
+              "smallAllocs": 2834
+            },
+            "primeWalk": {
+              "nanos": 8863191,
+              "smallAllocs": 716169
+            },
+            "quadratic": {
+              "nanos": 510,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 57193521,
+              "smallAllocs": 2594103
+            },
+            "total": {
+              "nanos": 67770302,
+              "smallAllocs": 3372963
+            },
+            "validation": {
+              "nanos": 8333,
+              "smallAllocs": 234
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1319504980517760399369866460,
+            "coeffBoundBits": 91,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 68173290,
+        "total_nanos_median": 67770302,
+        "total_nanos_min": 67438842
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 18079354,
+        "median_nanos": 17969861,
+        "min_nanos": 17923242,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16,
+        16
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 0.9784681695645837,
+      "name": "sd4_x_sd4shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            16,
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 83,
+            "modulusBits": 83,
+            "precision": 17,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3900553,
+              "smallAllocs": 320808
+            },
+            "berlekampMatrix": {
+              "nanos": 1723,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 38737,
+              "smallAllocs": 2770
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2313,
+              "smallAllocs": 82
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2283796,
+              "smallAllocs": 210624
+            },
+            "splittingNanos": 1615034
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 21842,
+              "smallAllocs": 901
+            },
+            "henselLift": {
+              "nanos": 1544039,
+              "smallAllocs": 55974
+            },
+            "normalization": {
+              "nanos": 50445,
+              "smallAllocs": 2814
+            },
+            "primeWalk": {
+              "nanos": 6864728,
+              "smallAllocs": 562910
+            },
+            "quadratic": {
+              "nanos": 520,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 9055886,
+              "smallAllocs": 528057
+            },
+            "total": {
+              "nanos": 17582937,
+              "smallAllocs": 1152141
+            },
+            "validation": {
+              "nanos": 20500,
+              "smallAllocs": 745
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 17,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 13,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 489391641089022941499420,
+            "coeffBoundBits": 79,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10530,
+              "degreeSurvivors": 10540,
+              "exactDivisionsAttempted": 2,
+              "nodes": 10540,
+              "productsMaterialized": 10,
+              "recordable": 10,
+              "trailingSurvivors": 10
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 17604900,
+        "total_nanos_median": 17582937,
+        "total_nanos_min": 17567715
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          16,
+          16
+        ],
+        "mirror_nodes": 10540,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 10540,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          16,
+          16
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 42,
+      "end_to_end": {
+        "max_nanos": 138854457,
+        "median_nanos": 138623235,
+        "min_nanos": 138075153,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        32
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.0342422899018335,
+      "name": "sd5_x_phi11",
+      "phase_profile": {
+        "profile": {
+          "degree": 42,
+          "factorDegrees": [
+            10,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 17,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              10,
+              2
+            ],
+            "liftedMaxCoeffBits": 102,
+            "modulusBits": 103,
+            "precision": 21,
+            "prime": 29,
+            "treeInternalLifts": 16,
+            "treeLeaves": 17,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7822067,
+              "smallAllocs": 625572
+            },
+            "berlekampMatrix": {
+              "nanos": 2394,
+              "smallAllocs": 138
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 54631,
+              "smallAllocs": 4248
+            },
+            "kernelDimension": 17,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 42,
+            "modularImage": {
+              "nanos": 3315,
+              "smallAllocs": 108
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 4688250,
+              "smallAllocs": 428628
+            },
+            "splittingNanos": 3131423
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29364,
+              "smallAllocs": 1170
+            },
+            "henselLift": {
+              "nanos": 2440989,
+              "smallAllocs": 80497
+            },
+            "normalization": {
+              "nanos": 79407,
+              "smallAllocs": 4551
+            },
+            "primeWalk": {
+              "nanos": 16877893,
+              "smallAllocs": 1373405
+            },
+            "quadratic": {
+              "nanos": 621,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 123879406,
+              "smallAllocs": 6175336
+            },
+            "total": {
+              "nanos": 143370012,
+              "smallAllocs": 7636916
+            },
+            "validation": {
+              "nanos": 30755,
+              "smallAllocs": 1070
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  10,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 21,
+                "modularFactorCount": 17,
+                "prime": 29,
+                "reachableProperDegrees": 20,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 24,
+                "modularFactorCount": 17,
+                "prime": 19,
+                "reachableProperDegrees": 20,
+                "selected": false
+              }
+            ],
+            "coeffBound": 210602981274948990483361217040,
+            "coeffBoundBits": 98,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 65264,
+              "degreeSurvivors": 65522,
+              "exactDivisionsAttempted": 2,
+              "nodes": 65522,
+              "productsMaterialized": 258,
+              "recordable": 258,
+              "trailingSurvivors": 258
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 143875571,
+        "total_nanos_median": 143370012,
+        "total_nanos_min": 142248199
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          10,
+          32
+        ],
+        "mirror_nodes": 65522,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 65522,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          10,
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 10611983,
+        "median_nanos": 10546936,
+        "min_nanos": 10531874,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0016835221148588,
+      "name": "xpow48_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            2,
+            2,
+            2,
+            8,
+            8,
+            16,
+            1,
+            1,
+            4,
+            4
+          ],
+          "hensel": {
+            "liftedFactorCount": 19,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              4,
+              4,
+              2,
+              2,
+              4,
+              2,
+              2,
+              4,
+              4,
+              4,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 49,
+            "modulusBits": 49,
+            "precision": 14,
+            "prime": 11,
+            "treeInternalLifts": 18,
+            "treeLeaves": 19,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1961047,
+              "smallAllocs": 163103
+            },
+            "berlekampMatrix": {
+              "nanos": 2364,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6089,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 19,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 1171,
+              "smallAllocs": 104
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 745015,
+              "smallAllocs": 67517
+            },
+            "splittingNanos": 1213668
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 25278,
+              "smallAllocs": 2409
+            },
+            "henselLift": {
+              "nanos": 1118718,
+              "smallAllocs": 57566
+            },
+            "normalization": {
+              "nanos": 16414,
+              "smallAllocs": 563
+            },
+            "primeWalk": {
+              "nanos": 3990346,
+              "smallAllocs": 339932
+            },
+            "quadratic": {
+              "nanos": 611,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5379105,
+              "smallAllocs": 270316
+            },
+            "total": {
+              "nanos": 10564692,
+              "smallAllocs": 673192
+            },
+            "validation": {
+              "nanos": 19029,
+              "smallAllocs": 1688
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  2,
+                  4,
+                  4,
+                  4,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 262144,
+                "henselPrecision": 14,
+                "modularFactorCount": 19,
+                "prime": 11,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  2,
+                  2,
+                  4,
+                  2
+                ],
+                "forcedSubsetCost": 524288,
+                "henselPrecision": 21,
+                "modularFactorCount": 20,
+                "prime": 5,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 64495207366200,
+            "coeffBoundBits": 46,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 268,
+              "exactDivisionsAttempted": 10,
+              "nodes": 268,
+              "productsMaterialized": 268,
+              "recordable": 268,
+              "trailingSurvivors": 268
+            },
+            "successfulDivisors": 10
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 10609780,
+        "total_nanos_median": 10564692,
+        "total_nanos_min": 10521388
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "mirror_nodes": 268,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 268,
+        "production_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 105,
+      "end_to_end": {
+        "max_nanos": 44649335,
+        "median_nanos": 44489028,
+        "min_nanos": 44403480,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0109519587616074,
+      "name": "xpow105_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 105,
+          "factorDegrees": [
+            4,
+            24,
+            2,
+            12,
+            48,
+            8,
+            6,
+            1
+          ],
+          "hensel": {
+            "liftedFactorCount": 14,
+            "liftedFactorDegrees": [
+              1,
+              6,
+              4,
+              12,
+              12,
+              4,
+              12,
+              12,
+              6,
+              2,
+              6,
+              12,
+              12,
+              4
+            ],
+            "liftedMaxCoeffBits": 107,
+            "modulusBits": 107,
+            "precision": 26,
+            "prime": 17,
+            "treeInternalLifts": 13,
+            "treeLeaves": 14,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 8725356,
+              "smallAllocs": 750003
+            },
+            "berlekampMatrix": {
+              "nanos": 5227,
+              "smallAllocs": 327
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12038,
+              "smallAllocs": 1080
+            },
+            "kernelDimension": 14,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 105,
+            "modularImage": {
+              "nanos": 2093,
+              "smallAllocs": 218
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 4894467,
+              "smallAllocs": 462407
+            },
+            "splittingNanos": 3825662
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 58507,
+              "smallAllocs": 6483
+            },
+            "henselLift": {
+              "nanos": 10130199,
+              "smallAllocs": 304935
+            },
+            "normalization": {
+              "nanos": 27561,
+              "smallAllocs": 1190
+            },
+            "primeWalk": {
+              "nanos": 29836063,
+              "smallAllocs": 2625082
+            },
+            "quadratic": {
+              "nanos": 571,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 4840706,
+              "smallAllocs": 266987
+            },
+            "total": {
+              "nanos": 44976270,
+              "smallAllocs": 3211107
+            },
+            "validation": {
+              "nanos": 51207,
+              "smallAllocs": 5196
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  6,
+                  4,
+                  12,
+                  12,
+                  4,
+                  12,
+                  12,
+                  6,
+                  2,
+                  6,
+                  12,
+                  12,
+                  4
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 26,
+                "modularFactorCount": 14,
+                "prime": 17,
+                "reachableProperDegrees": 104,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  3,
+                  6,
+                  1,
+                  2,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 536870912,
+                "henselPrecision": 30,
+                "modularFactorCount": 30,
+                "prime": 11,
+                "reachableProperDegrees": 104,
+                "selected": false
+              }
+            ],
+            "coeffBound": 6272525058612251449529907677520,
+            "coeffBoundBits": 103,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 60,
+              "exactDivisionsAttempted": 8,
+              "nodes": 60,
+              "productsMaterialized": 60,
+              "recordable": 60,
+              "trailingSurvivors": 60
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 45076688,
+        "total_nanos_median": 44976270,
+        "total_nanos_min": 44402939
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "mirror_nodes": 60,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 60,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "production_prime": 17
+      }
+    },
+    {
+      "degree": 120,
+      "end_to_end": {
+        "max_nanos": 147276895,
+        "median_nanos": 146842981,
+        "min_nanos": 146513492,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9827181933878065,
+      "name": "xpow120_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 120,
+          "factorDegrees": [
+            16,
+            4,
+            32,
+            8,
+            8,
+            2,
+            8,
+            2,
+            4,
+            16,
+            4,
+            1,
+            4,
+            1,
+            2,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 39,
+            "liftedFactorDegrees": [
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4
+            ],
+            "liftedMaxCoeffBits": 121,
+            "modulusBits": 121,
+            "precision": 43,
+            "prime": 7,
+            "treeInternalLifts": 38,
+            "treeLeaves": 39,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 15825201,
+              "smallAllocs": 1312571
+            },
+            "berlekampMatrix": {
+              "nanos": 6059,
+              "smallAllocs": 372
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 13570,
+              "smallAllocs": 1230
+            },
+            "kernelDimension": 39,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 120,
+            "modularImage": {
+              "nanos": 2514,
+              "smallAllocs": 248
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3751783,
+              "smallAllocs": 329059
+            },
+            "splittingNanos": 12067359
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 104776,
+              "smallAllocs": 11833
+            },
+            "henselLift": {
+              "nanos": 13933277,
+              "smallAllocs": 453833
+            },
+            "normalization": {
+              "nanos": 31297,
+              "smallAllocs": 1355
+            },
+            "primeWalk": {
+              "nanos": 18598833,
+              "smallAllocs": 1585472
+            },
+            "quadratic": {
+              "nanos": 641,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 111525722,
+              "smallAllocs": 5264950
+            },
+            "total": {
+              "nanos": 144305269,
+              "smallAllocs": 7326822
+            },
+            "validation": {
+              "nanos": 79307,
+              "smallAllocs": 8230
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4
+                ],
+                "forcedSubsetCost": 274877906944,
+                "henselPrecision": 43,
+                "modularFactorCount": 39,
+                "prime": 7,
+                "reachableProperDegrees": 119,
+                "selected": true
+              }
+            ],
+            "coeffBound": 193229817680726645207786279042745312,
+            "coeffBoundBits": 118,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3538,
+              "degreeSurvivors": 5339,
+              "exactDivisionsAttempted": 16,
+              "nodes": 5339,
+              "productsMaterialized": 1801,
+              "recordable": 1801,
+              "trailingSurvivors": 1801
+            },
+            "successfulDivisors": 16
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 144619605,
+        "total_nanos_median": 144305269,
+        "total_nanos_min": 144117390
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "mirror_nodes": 5339,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5339,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 178,
+      "end_to_end": {
+        "max_nanos": 52453735,
+        "median_nanos": 34577603,
+        "min_nanos": 34458826,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        178
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 1.0007029116506427,
+      "name": "cyclo_phi179",
+      "phase_profile": {
+        "profile": {
+          "degree": 178,
+          "factorDegrees": [
+            178
+          ],
+          "hensel": {
+            "liftedFactorCount": 2,
+            "liftedFactorDegrees": [
+              89,
+              89
+            ],
+            "liftedMaxCoeffBits": 180,
+            "modulusBits": 180,
+            "precision": 113,
+            "prime": 3,
+            "treeInternalLifts": 1,
+            "treeLeaves": 2,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 6555859,
+              "smallAllocs": 339370
+            },
+            "berlekampMatrix": {
+              "nanos": 8853,
+              "smallAllocs": 546
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 36364,
+              "smallAllocs": 3356
+            },
+            "kernelDimension": 2,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 178,
+            "modularImage": {
+              "nanos": 3425,
+              "smallAllocs": 364
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 13864635,
+              "smallAllocs": 1226531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 20821,
+              "smallAllocs": 1446
+            },
+            "henselLift": {
+              "nanos": 26545155,
+              "smallAllocs": 567324
+            },
+            "normalization": {
+              "nanos": 66728,
+              "smallAllocs": 3772
+            },
+            "primeWalk": {
+              "nanos": 6740153,
+              "smallAllocs": 346865
+            },
+            "quadratic": {
+              "nanos": 561,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 1159709,
+              "smallAllocs": 46831
+            },
+            "total": {
+              "nanos": 34601908,
+              "smallAllocs": 968495
+            },
+            "validation": {
+              "nanos": 18237,
+              "smallAllocs": 901
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  89,
+                  89
+                ],
+                "forcedSubsetCost": 2,
+                "henselPrecision": 113,
+                "modularFactorCount": 2,
+                "prime": 3,
+                "reachableProperDegrees": 1,
+                "selected": true
+              }
+            ],
+            "coeffBound": 320322439463041003620181335381340475329049688753516000,
+            "coeffBoundBits": 178,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 2,
+              "exactDivisionsAttempted": 1,
+              "nodes": 2,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 34929154,
+        "total_nanos_median": 34601908,
+        "total_nanos_min": 34254514
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          178
+        ],
+        "mirror_nodes": 2,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 2,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          178
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 80,
+      "end_to_end": {
+        "max_nanos": 19017144,
+        "median_nanos": 18795836,
+        "min_nanos": 18732742,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9811087413190879,
+      "name": "cyclo_phi64_x_phi105",
+      "phase_profile": {
+        "profile": {
+          "degree": 80,
+          "factorDegrees": [
+            48,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 10,
+            "liftedFactorDegrees": [
+              16,
+              16,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6
+            ],
+            "liftedMaxCoeffBits": 84,
+            "modulusBits": 84,
+            "precision": 24,
+            "prime": 11,
+            "treeInternalLifts": 9,
+            "treeLeaves": 10,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 10290566,
+              "smallAllocs": 586770
+            },
+            "berlekampMatrix": {
+              "nanos": 3906,
+              "smallAllocs": 252
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 159837,
+              "smallAllocs": 13406
+            },
+            "kernelDimension": 10,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 80,
+            "modularImage": {
+              "nanos": 1893,
+              "smallAllocs": 168
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 18942363,
+              "smallAllocs": 1749247
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 26299,
+              "smallAllocs": 2390
+            },
+            "henselLift": {
+              "nanos": 5087022,
+              "smallAllocs": 178057
+            },
+            "normalization": {
+              "nanos": 191314,
+              "smallAllocs": 14419
+            },
+            "primeWalk": {
+              "nanos": 10760904,
+              "smallAllocs": 625728
+            },
+            "quadratic": {
+              "nanos": 560,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 2332047,
+              "smallAllocs": 89872
+            },
+            "total": {
+              "nanos": 18440759,
+              "smallAllocs": 913166
+            },
+            "validation": {
+              "nanos": 22964,
+              "smallAllocs": 2017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16,
+                  16,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
+                ],
+                "forcedSubsetCost": 512,
+                "henselPrecision": 24,
+                "modularFactorCount": 10,
+                "prime": 11,
+                "reachableProperDegrees": 25,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1075072087333361764616200,
+            "coeffBoundBits": 80,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 102,
+              "degreeSurvivors": 130,
+              "exactDivisionsAttempted": 2,
+              "nodes": 130,
+              "productsMaterialized": 28,
+              "recordable": 28,
+              "trailingSurvivors": 28
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 18597091,
+        "total_nanos_median": 18440759,
+        "total_nanos_min": 18350806
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          32,
+          48
+        ],
+        "mirror_nodes": 130,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 130,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          32,
+          48
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 144,
+      "end_to_end": {
+        "max_nanos": 75285373,
+        "median_nanos": 75133519,
+        "min_nanos": 74812273,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        64,
+        80
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9921091277516231,
+      "name": "cyclo_phi128_x_phi165",
+      "phase_profile": {
+        "profile": {
+          "degree": 144,
+          "factorDegrees": [
+            64,
+            80
+          ],
+          "hensel": {
+            "liftedFactorCount": 8,
+            "liftedFactorDegrees": [
+              20,
+              16,
+              20,
+              20,
+              16,
+              20,
+              16,
+              16
+            ],
+            "liftedMaxCoeffBits": 146,
+            "modulusBits": 146,
+            "precision": 52,
+            "prime": 7,
+            "treeInternalLifts": 7,
+            "treeLeaves": 8,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 33435620,
+              "smallAllocs": 1239327
+            },
+            "berlekampMatrix": {
+              "nanos": 7001,
+              "smallAllocs": 444
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 462706,
+              "smallAllocs": 39896
+            },
+            "kernelDimension": 8,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 144,
+            "modularImage": {
+              "nanos": 3124,
+              "smallAllocs": 296
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 90144613,
+              "smallAllocs": 8409957
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 60901,
+              "smallAllocs": 6582
+            },
+            "henselLift": {
+              "nanos": 33465404,
+              "smallAllocs": 761706
+            },
+            "normalization": {
+              "nanos": 549415,
+              "smallAllocs": 44226
+            },
+            "primeWalk": {
+              "nanos": 34477004,
+              "smallAllocs": 1328424
+            },
+            "quadratic": {
+              "nanos": 941,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5892546,
+              "smallAllocs": 275130
+            },
+            "total": {
+              "nanos": 74540650,
+              "smallAllocs": 2423177
+            },
+            "validation": {
+              "nanos": 57625,
+              "smallAllocs": 6017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  20,
+                  16,
+                  20,
+                  20,
+                  16,
+                  20,
+                  16,
+                  16
+                ],
+                "forcedSubsetCost": 128,
+                "henselPrecision": 52,
+                "modularFactorCount": 8,
+                "prime": 7,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 20722981978283006659913436536756243128265400,
+            "coeffBoundBits": 144,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 29,
+              "degreeSurvivors": 54,
+              "exactDivisionsAttempted": 2,
+              "nodes": 54,
+              "productsMaterialized": 25,
+              "recordable": 25,
+              "trailingSurvivors": 25
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 74724322,
+        "total_nanos_median": 74540650,
+        "total_nanos_min": 74257600
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          64,
+          80
+        ],
+        "mirror_nodes": 54,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 54,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          64,
+          80
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 240,
+      "end_to_end": {
+        "max_nanos": 145967273,
+        "median_nanos": 143565512,
+        "min_nanos": 142769101,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        240
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9890020174204512,
+      "name": "cyclo_phi385",
+      "phase_profile": {
+        "profile": {
+          "degree": 240,
+          "factorDegrees": [
+            240
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              60,
+              60,
+              60,
+              60
+            ],
+            "liftedMaxCoeffBits": 241,
+            "modulusBits": 241,
+            "precision": 152,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 56397332,
+              "smallAllocs": 1030964
+            },
+            "berlekampMatrix": {
+              "nanos": 11547,
+              "smallAllocs": 732
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 769732,
+              "smallAllocs": 68654
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 240,
+            "modularImage": {
+              "nanos": 4727,
+              "smallAllocs": 488
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 199400840,
+              "smallAllocs": 18194276
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 30025,
+              "smallAllocs": 1942
+            },
+            "henselLift": {
+              "nanos": 73011482,
+              "smallAllocs": 1636426
+            },
+            "normalization": {
+              "nanos": 1247189,
+              "smallAllocs": 101209
+            },
+            "primeWalk": {
+              "nanos": 57525174,
+              "smallAllocs": 1106201
+            },
+            "quadratic": {
+              "nanos": 781,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 10083620,
+              "smallAllocs": 401834
+            },
+            "total": {
+              "nanos": 141986581,
+              "smallAllocs": 3250608
+            },
+            "validation": {
+              "nanos": 25658,
+              "smallAllocs": 1211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  60,
+                  60,
+                  60,
+                  60
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 152,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 3,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1636264530784946322237683636362414673514576776816417689604042467199320800,
+            "coeffBoundBits": 240,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 8,
+              "exactDivisionsAttempted": 1,
+              "nodes": 8,
+              "productsMaterialized": 8,
+              "recordable": 8,
+              "trailingSurvivors": 8
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 158713130,
+        "total_nanos_median": 141986581,
+        "total_nanos_min": 141607950
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          240
+        ],
+        "mirror_nodes": 8,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 8,
+        "production_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          240
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 9354398,
+        "median_nanos": 9179489,
+        "min_nanos": 9155263,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9880339744401895,
+      "name": "wilkinson_40",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 104565,
+              "smallAllocs": 8327
+            },
+            "berlekampMatrix": {
+              "nanos": 1883,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 21703,
+              "smallAllocs": 1610
+            },
+            "kernelDimension": 40,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 3695,
+              "smallAllocs": 106
+            },
+            "prime": 47,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 254317,
+              "smallAllocs": 20522
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 198634,
+              "smallAllocs": 9051
+            },
+            "normalization": {
+              "nanos": 77175,
+              "smallAllocs": 4275
+            },
+            "primeWalk": {
+              "nanos": 1016346,
+              "smallAllocs": 68927
+            },
+            "proposal": {
+              "nanos": 7718213,
+              "smallAllocs": 237827
+            },
+            "quadratic": {
+              "nanos": 581,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 9069647,
+              "smallAllocs": 321410
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 37,
+                "modularFactorCount": 40,
+                "prime": 47,
+                "reachableProperDegrees": 39,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 38,
+                "modularFactorCount": 40,
+                "prime": 41,
+                "reachableProperDegrees": 39,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1921680168406855965121530973574373218685937570507447116882060,
+            "coeffBoundBits": 201,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 47
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 9174612,
+        "total_nanos_median": 9069647,
+        "total_nanos_min": 9026523
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 17304975,
+        "median_nanos": 16220208,
+        "min_nanos": 16161971,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9884039711451296,
+      "name": "wilkinson_48",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 162371,
+              "smallAllocs": 12707
+            },
+            "berlekampMatrix": {
+              "nanos": 2253,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 37787,
+              "smallAllocs": 2906
+            },
+            "kernelDimension": 48,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 4797,
+              "smallAllocs": 126
+            },
+            "prime": 61,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 364460,
+              "smallAllocs": 29406
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 310891,
+              "smallAllocs": 13013
+            },
+            "normalization": {
+              "nanos": 101931,
+              "smallAllocs": 5905
+            },
+            "primeWalk": {
+              "nanos": 1572631,
+              "smallAllocs": 108539
+            },
+            "proposal": {
+              "nanos": 13969531,
+              "smallAllocs": 350278
+            },
+            "quadratic": {
+              "nanos": 631,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 16032118,
+              "smallAllocs": 479346
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 43,
+                "modularFactorCount": 48,
+                "prime": 61,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 45,
+                "modularFactorCount": 48,
+                "prime": 53,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 8049068376844036118970558829637315745156559359405185594804704581012213098100,
+            "coeffBoundBits": 253,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 61
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 16062533,
+        "total_nanos_median": 16032118,
+        "total_nanos_min": 15981484
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 56,
+      "end_to_end": {
+        "max_nanos": 20931642,
+        "median_nanos": 20906765,
+        "min_nanos": 20895679,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9976024985214116,
+      "name": "wilkinson_56",
+      "phase_profile": {
+        "profile": {
+          "degree": 56,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 216851,
+              "smallAllocs": 16143
+            },
+            "berlekampMatrix": {
+              "nanos": 2604,
+              "smallAllocs": 180
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 39058,
+              "smallAllocs": 3046
+            },
+            "kernelDimension": 56,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 56,
+            "modularImage": {
+              "nanos": 5458,
+              "smallAllocs": 146
+            },
+            "prime": 67,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 571958,
+              "smallAllocs": 46891
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 426092,
+              "smallAllocs": 17680
+            },
+            "normalization": {
+              "nanos": 130523,
+              "smallAllocs": 7789
+            },
+            "primeWalk": {
+              "nanos": 2027616,
+              "smallAllocs": 143611
+            },
+            "proposal": {
+              "nanos": 18179512,
+              "smallAllocs": 458437
+            },
+            "quadratic": {
+              "nanos": 511,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 20856641,
+              "smallAllocs": 629418
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 51,
+                "modularFactorCount": 56,
+                "prime": 67,
+                "reachableProperDegrees": 55,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 53,
+                "modularFactorCount": 56,
+                "prime": 59,
+                "reachableProperDegrees": 55,
+                "selected": false
+              }
+            ],
+            "coeffBound": 125617627049250877181363592865834692949611771037125750170085410352200700179789256897773224080,
+            "coeffBoundBits": 306,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 20938052,
+        "total_nanos_median": 20856641,
+        "total_nanos_min": 20846556
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 466441,
+        "median_nanos": 448755,
+        "min_nanos": 435216,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        8,
+        16
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.8850018384196277,
+      "name": "chebyshev_T24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            16,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 52,
+            "modulusBits": 52,
+            "precision": 22,
+            "prime": 5,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 194418,
+              "smallAllocs": 13395
+            },
+            "berlekampMatrix": {
+              "nanos": 1021,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11818,
+              "smallAllocs": 1040
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 671,
+              "smallAllocs": 56
+            },
+            "prime": 5,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 288919,
+              "smallAllocs": 24421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5148,
+              "smallAllocs": 414
+            },
+            "henselLift": {
+              "nanos": 117244,
+              "smallAllocs": 7189
+            },
+            "normalization": {
+              "nanos": 17176,
+              "smallAllocs": 1007
+            },
+            "primeWalk": {
+              "nanos": 219165,
+              "smallAllocs": 15164
+            },
+            "quadratic": {
+              "nanos": 320,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 27991,
+              "smallAllocs": 1407
+            },
+            "total": {
+              "nanos": 397149,
+              "smallAllocs": 25790
+            },
+            "validation": {
+              "nanos": 4256,
+              "smallAllocs": 281
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 22,
+                "modularFactorCount": 3,
+                "prime": 5,
+                "reachableProperDegrees": 2,
+                "selected": true
+              }
+            ],
+            "coeffBound": 910214580246244,
+            "coeffBoundBits": 50,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 5
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 1,
+              "degreeSurvivors": 3,
+              "exactDivisionsAttempted": 2,
+              "nodes": 3,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 414434,
+        "total_nanos_median": 397149,
+        "total_nanos_min": 393424
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          8,
+          16
+        ],
+        "mirror_nodes": 3,
+        "mirror_prime": 5,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 3,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          8,
+          16
+        ],
+        "production_prime": 5
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 648081,
+        "median_nanos": 597456,
+        "min_nanos": 570396,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.9239810128277228,
+      "name": "chebyshev_U24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            10,
+            2,
+            10,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              2,
+              10,
+              2,
+              10
+            ],
+            "liftedMaxCoeffBits": 53,
+            "modulusBits": 53,
+            "precision": 33,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 189721,
+              "smallAllocs": 12764
+            },
+            "berlekampMatrix": {
+              "nanos": 1041,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6309,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 661,
+              "smallAllocs": 56
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 236972,
+              "smallAllocs": 19531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7151,
+              "smallAllocs": 612
+            },
+            "henselLift": {
+              "nanos": 263881,
+              "smallAllocs": 14113
+            },
+            "normalization": {
+              "nanos": 17676,
+              "smallAllocs": 1009
+            },
+            "primeWalk": {
+              "nanos": 211584,
+              "smallAllocs": 13912
+            },
+            "quadratic": {
+              "nanos": 290,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 38437,
+              "smallAllocs": 2144
+            },
+            "total": {
+              "nanos": 552038,
+              "smallAllocs": 32523
+            },
+            "validation": {
+              "nanos": 5749,
+              "smallAllocs": 389
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  10
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 33,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 7,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1560748913788064,
+            "coeffBoundBits": 51,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 4,
+              "nodes": 4,
+              "productsMaterialized": 4,
+              "recordable": 4,
+              "trailingSurvivors": 4
+            },
+            "successfulDivisors": 4
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 579840,
+        "total_nanos_median": 552038,
+        "total_nanos_min": 537036
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 30,
+      "end_to_end": {
+        "max_nanos": 8720178,
+        "median_nanos": 8638507,
+        "min_nanos": 8597716,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        30
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9780597503712157,
+      "name": "legendre_P30",
+      "phase_profile": {
+        "profile": {
+          "degree": 30,
+          "factorDegrees": [
+            30
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              6,
+              14,
+              2
+            ],
+            "liftedMaxCoeffBits": 91,
+            "modulusBits": 91,
+            "precision": 15,
+            "prime": 67,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2031242,
+              "smallAllocs": 167769
+            },
+            "berlekampMatrix": {
+              "nanos": 1412,
+              "smallAllocs": 102
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19149,
+              "smallAllocs": 1485
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 30,
+            "modularImage": {
+              "nanos": 1742,
+              "smallAllocs": 75
+            },
+            "prime": 67,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1693200,
+              "smallAllocs": 158865
+            },
+            "splittingNanos": 336630
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8232,
+              "smallAllocs": 329
+            },
+            "henselLift": {
+              "nanos": 1002887,
+              "smallAllocs": 30936
+            },
+            "normalization": {
+              "nanos": 30034,
+              "smallAllocs": 1502
+            },
+            "primeWalk": {
+              "nanos": 7196689,
+              "smallAllocs": 628129
+            },
+            "quadratic": {
+              "nanos": 441,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 179536,
+              "smallAllocs": 6057
+            },
+            "total": {
+              "nanos": 8448976,
+              "smallAllocs": 667849
+            },
+            "validation": {
+              "nanos": 5918,
+              "smallAllocs": 198
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  6,
+                  14,
+                  2
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 15,
+                "modularFactorCount": 7,
+                "prime": 67,
+                "reachableProperDegrees": 14,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 16384,
+                "henselPrecision": 15,
+                "modularFactorCount": 15,
+                "prime": 61,
+                "reachableProperDegrees": 14,
+                "selected": false
+              }
+            ],
+            "coeffBound": 124543935812132452094555520,
+            "coeffBoundBits": 87,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 63,
+              "degreeSurvivors": 64,
+              "exactDivisionsAttempted": 1,
+              "nodes": 64,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 8478640,
+        "total_nanos_median": 8448976,
+        "total_nanos_min": 8435286
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "mirror_factor_degrees": [
+          30
+        ],
+        "mirror_nodes": 64,
+        "mirror_prime": 67,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 64,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "production_factor_degrees": [
+          30
+        ],
+        "production_prime": 67
+      }
+    },
+    {
+      "degree": 38,
+      "end_to_end": {
+        "max_nanos": 4021352,
+        "median_nanos": 3924919,
+        "min_nanos": 3890167,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        38
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9587815697597836,
+      "name": "legendre_P38",
+      "phase_profile": {
+        "profile": {
+          "degree": 38,
+          "factorDegrees": [
+            38
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              36,
+              1,
+              1
+            ],
+            "liftedMaxCoeffBits": 120,
+            "modulusBits": 120,
+            "precision": 19,
+            "prime": 79,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2842173,
+              "smallAllocs": 251152
+            },
+            "berlekampMatrix": {
+              "nanos": 2023,
+              "smallAllocs": 126
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 27892,
+              "smallAllocs": 2184
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 38,
+            "modularImage": {
+              "nanos": 2423,
+              "smallAllocs": 94
+            },
+            "prime": 79,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3501231,
+              "smallAllocs": 334731
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10315,
+              "smallAllocs": 431
+            },
+            "henselLift": {
+              "nanos": 573901,
+              "smallAllocs": 18781
+            },
+            "normalization": {
+              "nanos": 45498,
+              "smallAllocs": 2237
+            },
+            "primeWalk": {
+              "nanos": 3027819,
+              "smallAllocs": 260183
+            },
+            "quadratic": {
+              "nanos": 661,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 65527,
+              "smallAllocs": 1980
+            },
+            "total": {
+              "nanos": 3763140,
+              "smallAllocs": 284570
+            },
+            "validation": {
+              "nanos": 7811,
+              "smallAllocs": 265
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  36,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 19,
+                "modularFactorCount": 3,
+                "prime": 79,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 14065077854436543582494269671679200,
+            "coeffBoundBits": 114,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 79
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 1,
+              "nodes": 4,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 3773014,
+        "total_nanos_median": 3763140,
+        "total_nanos_min": 3719414
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1
+        ],
+        "mirror_factor_degrees": [
+          38
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 79,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [
+          0,
+          1
+        ],
+        "production_factor_degrees": [
+          38
+        ],
+        "production_prime": 79
+      }
+    },
+    {
+      "degree": 16,
+      "end_to_end": {
+        "max_nanos": 117394,
+        "median_nanos": 108911,
+        "min_nanos": 105887,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.7796824930447797,
+      "name": "cyclo_phi17",
+      "phase_profile": {
+        "profile": {
+          "degree": 16,
+          "factorDegrees": [
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 1,
+            "liftedFactorDegrees": [
+              16
+            ],
+            "liftedMaxCoeffBits": 1,
+            "modulusBits": 18,
+            "precision": 11,
+            "prime": 3,
+            "treeInternalLifts": 0,
+            "treeLeaves": 1,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 53920,
+              "smallAllocs": 2865
+            },
+            "berlekampMatrix": {
+              "nanos": 641,
+              "smallAllocs": 60
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3785,
+              "smallAllocs": 332
+            },
+            "kernelDimension": 1,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 16,
+            "modularImage": {
+              "nanos": 431,
+              "smallAllocs": 40
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 94070,
+              "smallAllocs": 7303
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 2374,
+              "smallAllocs": 150
+            },
+            "henselLift": {
+              "nanos": 2033,
+              "smallAllocs": 72
+            },
+            "normalization": {
+              "nanos": 7141,
+              "smallAllocs": 370
+            },
+            "primeWalk": {
+              "nanos": 60450,
+              "smallAllocs": 3522
+            },
+            "quadratic": {
+              "nanos": 240,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 6800,
+              "smallAllocs": 424
+            },
+            "total": {
+              "nanos": 84916,
+              "smallAllocs": 4906
+            },
+            "validation": {
+              "nanos": 1913,
+              "smallAllocs": 91
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16
+                ],
+                "forcedSubsetCost": 1,
+                "henselPrecision": 11,
+                "modularFactorCount": 1,
+                "prime": 3,
+                "reachableProperDegrees": 0,
+                "selected": true
+              }
+            ],
+            "coeffBound": 64350,
+            "coeffBoundBits": 16,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 1,
+              "exactDivisionsAttempted": 1,
+              "nodes": 1,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 93689,
+        "total_nanos_median": 84916,
+        "total_nanos_min": 82592
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          16
+        ],
+        "mirror_nodes": 1,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 1,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          16
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 2031632,
+        "median_nanos": 2023280,
+        "min_nanos": 2008057,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        40
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9720725752243882,
+      "name": "cyclo_phi41",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            40
+          ],
+          "hensel": {
+            "liftedFactorCount": 5,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 42,
+            "modulusBits": 42,
+            "precision": 26,
+            "prime": 3,
+            "treeInternalLifts": 4,
+            "treeLeaves": 5,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 460573,
+              "smallAllocs": 32512
+            },
+            "berlekampMatrix": {
+              "nanos": 1853,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 8793,
+              "smallAllocs": 780
+            },
+            "kernelDimension": 5,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 1022,
+              "smallAllocs": 88
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 458249,
+              "smallAllocs": 38465
+            },
+            "splittingNanos": 471
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5308,
+              "smallAllocs": 342
+            },
+            "henselLift": {
+              "nanos": 643965,
+              "smallAllocs": 30651
+            },
+            "normalization": {
+              "nanos": 17215,
+              "smallAllocs": 874
+            },
+            "primeWalk": {
+              "nanos": 489105,
+              "smallAllocs": 34389
+            },
+            "quadratic": {
+              "nanos": 421,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 797552,
+              "smallAllocs": 32169
+            },
+            "total": {
+              "nanos": 1966775,
+              "smallAllocs": 99038
+            },
+            "validation": {
+              "nanos": 4277,
+              "smallAllocs": 211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 16,
+                "henselPrecision": 26,
+                "modularFactorCount": 5,
+                "prime": 3,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 964925701740,
+            "coeffBoundBits": 40,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 16,
+              "exactDivisionsAttempted": 1,
+              "nodes": 16,
+              "productsMaterialized": 16,
+              "recordable": 16,
+              "trailingSurvivors": 16
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1980576,
+        "total_nanos_median": 1966775,
+        "total_nanos_min": 1963811
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "mirror_factor_degrees": [
+          40
+        ],
+        "mirror_nodes": 16,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 16,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "production_factor_degrees": [
+          40
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 2349944,
+        "median_nanos": 2317196,
+        "min_nanos": 2305447,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9942646198249954,
+      "name": "xpow24_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            2,
+            1,
+            4,
+            4,
+            8,
+            1,
+            2,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 13,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2
+            ],
+            "liftedMaxCoeffBits": 25,
+            "modulusBits": 25,
+            "precision": 7,
+            "prime": 11,
+            "treeInternalLifts": 12,
+            "treeLeaves": 13,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 584787,
+              "smallAllocs": 46939
+            },
+            "berlekampMatrix": {
+              "nanos": 1092,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3215,
+              "smallAllocs": 270
+            },
+            "kernelDimension": 13,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 771,
+              "smallAllocs": 56
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 194548,
+              "smallAllocs": 17216
+            },
+            "splittingNanos": 389147
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10726,
+              "smallAllocs": 937
+            },
+            "henselLift": {
+              "nanos": 287196,
+              "smallAllocs": 17594
+            },
+            "normalization": {
+              "nanos": 7722,
+              "smallAllocs": 299
+            },
+            "primeWalk": {
+              "nanos": 1122665,
+              "smallAllocs": 89521
+            },
+            "quadratic": {
+              "nanos": 360,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 858423,
+              "smallAllocs": 48267
+            },
+            "total": {
+              "nanos": 2303906,
+              "smallAllocs": 157705
+            },
+            "validation": {
+              "nanos": 8142,
+              "smallAllocs": 574
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  2
+                ],
+                "forcedSubsetCost": 4096,
+                "henselPrecision": 7,
+                "modularFactorCount": 13,
+                "prime": 11,
+                "reachableProperDegrees": 23,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 11,
+                "modularFactorCount": 14,
+                "prime": 5,
+                "reachableProperDegrees": 23,
+                "selected": false
+              }
+            ],
+            "coeffBound": 5408312,
+            "coeffBoundBits": 23,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 113,
+              "exactDivisionsAttempted": 8,
+              "nodes": 113,
+              "productsMaterialized": 113,
+              "recordable": 113,
+              "trailingSurvivors": 113
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2318297,
+        "total_nanos_median": 2303906,
+        "total_nanos_min": 2294221
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "mirror_nodes": 113,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 113,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 20,
+      "end_to_end": {
+        "max_nanos": 681330,
+        "median_nanos": 635442,
+        "min_nanos": 621181,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        10
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9424589498333443,
+      "name": "randprod_10",
+      "phase_profile": {
+        "profile": {
+          "degree": 20,
+          "factorDegrees": [
+            10,
+            10
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              3,
+              4,
+              7,
+              6
+            ],
+            "liftedMaxCoeffBits": 31,
+            "modulusBits": 31,
+            "precision": 11,
+            "prime": 7,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 336529,
+              "smallAllocs": 23484
+            },
+            "berlekampMatrix": {
+              "nanos": 881,
+              "smallAllocs": 72
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12879,
+              "smallAllocs": 1018
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 20,
+            "modularImage": {
+              "nanos": 650,
+              "smallAllocs": 48
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 428746,
+              "smallAllocs": 35832
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 4647,
+              "smallAllocs": 338
+            },
+            "henselLift": {
+              "nanos": 166738,
+              "smallAllocs": 9769
+            },
+            "normalization": {
+              "nanos": 21312,
+              "smallAllocs": 1219
+            },
+            "primeWalk": {
+              "nanos": 366984,
+              "smallAllocs": 25144
+            },
+            "quadratic": {
+              "nanos": 331,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 28662,
+              "smallAllocs": 1357
+            },
+            "total": {
+              "nanos": 598878,
+              "smallAllocs": 38377
+            },
+            "validation": {
+              "nanos": 4086,
+              "smallAllocs": 237
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  3,
+                  4,
+                  7,
+                  6
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 11,
+                "modularFactorCount": 4,
+                "prime": 7,
+                "reachableProperDegrees": 11,
+                "selected": true
+              }
+            ],
+            "coeffBound": 161291988,
+            "coeffBoundBits": 28,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 5,
+              "exactDivisionsAttempted": 2,
+              "nodes": 5,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 619779,
+        "total_nanos_median": 598878,
+        "total_nanos_min": 576134
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          10,
+          10
+        ],
+        "mirror_nodes": 5,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5,
+        "production_completed_levels": [
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          10,
+          10
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 1507796,
+        "median_nanos": 1438243,
+        "min_nanos": 1414647,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        7,
+        8,
+        9
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9477821202675765,
+      "name": "randprod_21",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            7,
+            8,
+            9
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              9,
+              7,
+              1,
+              1,
+              1,
+              4,
+              1
+            ],
+            "liftedMaxCoeffBits": 37,
+            "modulusBits": 37,
+            "precision": 9,
+            "prime": 17,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 875648,
+              "smallAllocs": 68180
+            },
+            "berlekampMatrix": {
+              "nanos": 1062,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19378,
+              "smallAllocs": 1592
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 842,
+              "smallAllocs": 56
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1004760,
+              "smallAllocs": 89421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 6890,
+              "smallAllocs": 531
+            },
+            "henselLift": {
+              "nanos": 309188,
+              "smallAllocs": 17758
+            },
+            "normalization": {
+              "nanos": 25999,
+              "smallAllocs": 1651
+            },
+            "primeWalk": {
+              "nanos": 958641,
+              "smallAllocs": 74672
+            },
+            "quadratic": {
+              "nanos": 280,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 49133,
+              "smallAllocs": 2297
+            },
+            "total": {
+              "nanos": 1363141,
+              "smallAllocs": 97645
+            },
+            "validation": {
+              "nanos": 5889,
+              "smallAllocs": 386
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  9,
+                  7,
+                  1,
+                  1,
+                  1,
+                  4,
+                  1
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 9,
+                "modularFactorCount": 7,
+                "prime": 17,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 41749464484,
+            "coeffBoundBits": 36,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10,
+              "degreeSurvivors": 13,
+              "exactDivisionsAttempted": 3,
+              "nodes": 13,
+              "productsMaterialized": 3,
+              "recordable": 3,
+              "trailingSurvivors": 3
+            },
+            "successfulDivisors": 3
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1397271,
+        "total_nanos_median": 1363141,
+        "total_nanos_min": 1361709
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "mirror_nodes": 13,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 13,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "production_prime": 17
+      }
+    }
+  ],
+  "schema": "hexbz-phase-profile/3",
+  "scouts": [],
+  "validation": {
+    "disagreements": [],
+    "factors_agree": 368,
+    "instrumentation_ratio_max": 1.0342422899018335,
+    "instrumentation_ratio_median": 0.9882189727926596,
+    "kernel_disagreements": [],
+    "kernel_mirror_agree": 24,
+    "kernel_packed_agree": 24,
+    "kernel_rows": 24,
+    "levels_agree": 368,
+    "nodes_agree": 368,
+    "prime_agree": 368,
+    "sample_size": 368,
+    "scout_disagreements": [],
+    "scout_patterns_agree": 0,
+    "scout_rows": 0
+  }
+}

--- a/reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2-rerun.json
+++ b/reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2-rerun.json
@@ -1,0 +1,17771 @@
+{
+  "config": {
+    "controls": [
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "corpus": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "cpu": 1,
+    "cutoff_seconds": 120.0,
+    "hex_exe_sha256": "fcc8436ade195d36a9be4f9294e9c35e704de31ad68309269344351e13f9ba82",
+    "kernel_repeats": 8,
+    "names": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56",
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "plan_repeats": 3,
+    "repeat_ceiling_nanos": 1000000000,
+    "repeats": 5,
+    "representative": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56"
+    ],
+    "sampling_profiles": [
+      "sd5",
+      "sd5_x_phi11",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi385",
+      "wilkinson_56"
+    ],
+    "validate_cutoff_seconds": 2.0,
+    "warmup": 1
+  },
+  "counterfactuals": [],
+  "env": {
+    "arch": "x86_64",
+    "cpu_cores": 96,
+    "cpu_model": null,
+    "exe_name": "hexbz_factor_service",
+    "git_commit": "55fc3beef0f7dada6774c861cd1e71a2ba4beb18",
+    "git_dirty": true,
+    "hostname": "chungus2",
+    "lean_bench_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "lean_version": null,
+    "os": "linux",
+    "platform_target": null,
+    "timestamp_iso": "2026-08-05T00:21:54Z",
+    "timestamp_unix_ms": 1785889314785
+  },
+  "kernels": [
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4457,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1250503,
+            "smallAllocs": 120747
+          },
+          "berlekampSplit": {
+            "nanos": 3270744,
+            "smallAllocs": 279386
+          },
+          "columnPolys": {
+            "nanos": 1210670,
+            "smallAllocs": 116346
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 799,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 282363,
+              "smallAllocs": 15527
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 27410,
+              "smallAllocs": 1625
+            },
+            "stagedNanos": 310427,
+            "wall": {
+              "nanos": 327656,
+              "smallAllocs": 17591
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 846,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 511677,
+              "smallAllocs": 29287
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 37249,
+              "smallAllocs": 2137
+            },
+            "stagedNanos": 549835,
+            "wall": {
+              "nanos": 566434,
+              "smallAllocs": 31866
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 19119,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1318314,
+            "smallAllocs": 121100
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1275030,
+            "smallAllocs": 121804
+          },
+          "frobeniusPower": {
+            "nanos": 26514,
+            "smallAllocs": 2354
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 17451,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1286201,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 35212,
+          "nullspaceBasisNanos": 35212,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1908,
+            "packNanos": 41186,
+            "rank": 16,
+            "reduceNanos": 35087,
+            "reduceNanosSamples": [
+              37817,
+              36524,
+              34922,
+              33841,
+              35252,
+              33500,
+              35252,
+              33800
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 78631
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1738,
+            "packNanos": 41076,
+            "rank": 16,
+            "reduceNanos": 34892,
+            "reduceNanosSamples": [
+              35463,
+              34832,
+              34431,
+              35032,
+              34381,
+              34411,
+              34952,
+              34962
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 77490
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2138,
+            "packNanos": 41571,
+            "rank": 16,
+            "reduceNanos": 25748,
+            "reduceNanosSamples": [
+              24887,
+              26699,
+              24857,
+              26710,
+              24937,
+              26960,
+              24997,
+              26499
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 69393
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1253468,
+              "rank": 16,
+              "readbackNanos": 32233,
+              "reduceNanos": 35533,
+              "reduceNanosSamples": [
+                35943,
+                35884,
+                35263,
+                35473,
+                35153,
+                35673,
+                35322,
+                35593
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1321113
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1254379,
+              "rank": 16,
+              "readbackNanos": 32102,
+              "reduceNanos": 39403,
+              "reduceNanosSamples": [
+                39268,
+                39539,
+                39058,
+                39789,
+                38497,
+                39539,
+                38698,
+                39579
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1326076
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1256227,
+              "rank": 16,
+              "readbackNanos": 31882,
+              "reduceNanos": 34200,
+              "reduceNanosSamples": [
+                34682,
+                34311,
+                34080,
+                36734,
+                34021,
+                34321,
+                34090,
+                34060
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1322435
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1259822,
+              "rank": 16,
+              "readbackNanos": 1762,
+              "reduceNanos": 34130,
+              "reduceNanosSamples": [
+                37886,
+                34031,
+                33600,
+                34160,
+                34040,
+                34100,
+                34871,
+                34331
+              ],
+              "smallAllocs": 120097,
+              "totalNanos": 1295615
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1259167,
+              "rank": 16,
+              "readbackNanos": 32007,
+              "reduceNanos": 38387,
+              "reduceNanosSamples": [
+                39208,
+                38708,
+                38347,
+                38427,
+                37716,
+                38607,
+                37897,
+                38166
+              ],
+              "smallAllocs": 122378,
+              "totalNanos": 1329236
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1258591,
+              "rank": 16,
+              "readbackNanos": 32027,
+              "reduceNanos": 40460,
+              "reduceNanosSamples": [
+                41231,
+                40440,
+                40410,
+                40219,
+                40180,
+                44065,
+                40871,
+                40480
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1332891
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1259637,
+              "rank": 16,
+              "readbackNanos": 32008,
+              "reduceNanos": 35237,
+              "reduceNanosSamples": [
+                36404,
+                35262,
+                35212,
+                34832,
+                35383,
+                35042,
+                35513,
+                34932
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1326957
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1256698,
+              "rank": 16,
+              "readbackNanos": 32048,
+              "reduceNanos": 36560,
+              "reduceNanosSamples": [
+                37937,
+                36704,
+                36485,
+                36334,
+                36344,
+                36394,
+                36854,
+                36635
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1325264
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1256993,
+              "rank": 16,
+              "readbackNanos": 32202,
+              "reduceNanos": 35062,
+              "reduceNanosSamples": [
+                35442,
+                35312,
+                34712,
+                34622,
+                34662,
+                35042,
+                35443,
+                35082
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1324313
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1259863,
+              "rank": 16,
+              "readbackNanos": 31972,
+              "reduceNanos": 35433,
+              "reduceNanosSamples": [
+                36694,
+                35302,
+                35844,
+                34982,
+                35433,
+                35332,
+                35763,
+                35433
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1327112
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1262697,
+              "rank": 16,
+              "readbackNanos": 32037,
+              "reduceNanos": 36314,
+              "reduceNanosSamples": [
+                36394,
+                35723,
+                35723,
+                36884,
+                36234,
+                36855,
+                36594,
+                36023
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1331278
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1261901,
+              "rank": 16,
+              "readbackNanos": 32112,
+              "reduceNanos": 34316,
+              "reduceNanosSamples": [
+                35293,
+                37766,
+                33960,
+                33330,
+                34191,
+                36654,
+                34441,
+                33209
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1329436
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1259532,
+              "smallAllocs": 119722
+            },
+            "columnCount": {
+              "nanos": 7606,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 31417,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 6880,
+            "pivotSearch": {
+              "nanos": 865,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 31992,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 4942,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 37059,
+            "wall": {
+              "nanos": 47405,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5228,
+            "packNanos": 39664,
+            "rank": 16,
+            "reduceNanos": 58912,
+            "reduceNanosSamples": [
+              62042,
+              59859,
+              58857,
+              58547,
+              58657,
+              58968,
+              59127,
+              58777
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 8858,
+            "totalNanos": 104244
+          },
+          "peakResidentBytes": 63301632,
+          "productionMatrixRebuild": {
+            "nanos": 1289547,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 592638,
+            "smallAllocs": 31823
+          },
+          "productionRowReduce": {
+            "nanos": 556499,
+            "smallAllocs": 30631
+          },
+          "rank": 16,
+          "residentBytesAfter": 63086592,
+          "residentBytesBefore": 62857216,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1297803,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4486,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1609702,
+            "smallAllocs": 149530
+          },
+          "berlekampSplit": {
+            "nanos": 3065670,
+            "smallAllocs": 258979
+          },
+          "columnPolys": {
+            "nanos": 1559306,
+            "smallAllocs": 145131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 799,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 567103,
+              "smallAllocs": 30737
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 26881,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 595007,
+            "wall": {
+              "nanos": 612453,
+              "smallAllocs": 32793
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 847,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1040693,
+              "smallAllocs": 59473
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 37140,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1079300,
+            "wall": {
+              "nanos": 1095650,
+              "smallAllocs": 62044
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 18632,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1679900,
+            "smallAllocs": 149883
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1626110,
+            "smallAllocs": 150587
+          },
+          "frobeniusPower": {
+            "nanos": 26083,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 19353,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1630572,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 49102,
+          "nullspaceBasisNanos": 49102,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1878,
+            "packNanos": 41181,
+            "rank": 16,
+            "reduceNanos": 60505,
+            "reduceNanosSamples": [
+              60599,
+              59228,
+              60460,
+              58977,
+              60600,
+              59257,
+              60550,
+              62583
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 103954
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1743,
+            "packNanos": 40950,
+            "rank": 16,
+            "reduceNanos": 61331,
+            "reduceNanosSamples": [
+              61371,
+              61321,
+              63534,
+              61281,
+              61280,
+              61300,
+              64646,
+              61341
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 104174
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2053,
+            "packNanos": 41341,
+            "rank": 16,
+            "reduceNanos": 51901,
+            "reduceNanosSamples": [
+              51316,
+              52718,
+              51276,
+              52888,
+              51516,
+              52758,
+              51387,
+              52287
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 95286
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606481,
+              "rank": 16,
+              "readbackNanos": 32218,
+              "reduceNanos": 57315,
+              "reduceNanosSamples": [
+                57255,
+                57475,
+                57005,
+                57856,
+                57065,
+                57375,
+                57105,
+                57535
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1695789
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1604202,
+              "rank": 16,
+              "readbackNanos": 31962,
+              "reduceNanos": 69959,
+              "reduceNanosSamples": [
+                70544,
+                71847,
+                69733,
+                70185,
+                68792,
+                69543,
+                71386,
+                69242
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1707000
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1604854,
+              "rank": 16,
+              "readbackNanos": 31967,
+              "reduceNanos": 59193,
+              "reduceNanosSamples": [
+                59228,
+                58967,
+                59167,
+                59198,
+                59198,
+                59138,
+                59188,
+                59238
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1695939
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606812,
+              "rank": 16,
+              "readbackNanos": 1818,
+              "reduceNanos": 59964,
+              "reduceNanosSamples": [
+                60189,
+                59919,
+                60009,
+                59759,
+                61280,
+                59989,
+                59939,
+                59909
+              ],
+              "smallAllocs": 148646,
+              "totalNanos": 1668513
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607003,
+              "rank": 16,
+              "readbackNanos": 31957,
+              "reduceNanos": 63673,
+              "reduceNanosSamples": [
+                62543,
+                65026,
+                63383,
+                64135,
+                65107,
+                61992,
+                63964,
+                62313
+              ],
+              "smallAllocs": 151395,
+              "totalNanos": 1701953
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1602385,
+              "rank": 16,
+              "readbackNanos": 32058,
+              "reduceNanos": 67860,
+              "reduceNanosSamples": [
+                68041,
+                67880,
+                68191,
+                67831,
+                67841,
+                67741,
+                67430,
+                68001
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1702318
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606431,
+              "rank": 16,
+              "readbackNanos": 32008,
+              "reduceNanos": 57240,
+              "reduceNanosSamples": [
+                60420,
+                57044,
+                57185,
+                57445,
+                57416,
+                56964,
+                57295,
+                56954
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1695478
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1604093,
+              "rank": 16,
+              "readbackNanos": 31972,
+              "reduceNanos": 60009,
+              "reduceNanosSamples": [
+                60269,
+                59649,
+                65377,
+                60370,
+                60059,
+                59749,
+                59899,
+                59959
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1696270
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607523,
+              "rank": 16,
+              "readbackNanos": 32068,
+              "reduceNanos": 57089,
+              "reduceNanosSamples": [
+                57746,
+                57095,
+                57215,
+                57345,
+                57055,
+                56854,
+                57044,
+                57084
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1696906
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606927,
+              "rank": 16,
+              "readbackNanos": 32062,
+              "reduceNanos": 57575,
+              "reduceNanosSamples": [
+                57735,
+                57865,
+                57525,
+                57555,
+                57555,
+                57034,
+                57596,
+                61421
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1696470
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1605941,
+              "rank": 16,
+              "readbackNanos": 32102,
+              "reduceNanos": 63094,
+              "reduceNanosSamples": [
+                63134,
+                62453,
+                62693,
+                63163,
+                63635,
+                63054,
+                62934,
+                63945
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1700971
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1601199,
+              "rank": 16,
+              "readbackNanos": 32107,
+              "reduceNanos": 59398,
+              "reduceNanosSamples": [
+                59278,
+                59418,
+                59368,
+                59277,
+                59378,
+                59528,
+                59819,
+                59498
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1692965
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1603652,
+              "smallAllocs": 148505
+            },
+            "columnCount": {
+              "nanos": 7691,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 53604,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14368,
+            "pivotSearch": {
+              "nanos": 856,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 31887,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 4756,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 59187,
+            "wall": {
+              "nanos": 69603,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5277,
+            "packNanos": 39143,
+            "rank": 16,
+            "reduceNanos": 108100,
+            "reduceNanosSamples": [
+              107920,
+              110314,
+              108261,
+              108141,
+              107710,
+              108400,
+              108060,
+              107880
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 16080,
+            "totalNanos": 152811
+          },
+          "peakResidentBytes": 63363072,
+          "productionMatrixRebuild": {
+            "nanos": 1640071,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1134987,
+            "smallAllocs": 62101
+          },
+          "productionRowReduce": {
+            "nanos": 1086886,
+            "smallAllocs": 60809
+          },
+          "rank": 16,
+          "residentBytesAfter": 63254528,
+          "residentBytesBefore": 63205376,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1642209,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4507,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1587863,
+            "smallAllocs": 149061
+          },
+          "berlekampSplit": {
+            "nanos": 4556821,
+            "smallAllocs": 381697
+          },
+          "columnPolys": {
+            "nanos": 1540318,
+            "smallAllocs": 144662
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 800,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 567252,
+              "smallAllocs": 31127
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 26891,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 594992,
+            "wall": {
+              "nanos": 612203,
+              "smallAllocs": 33183
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 822,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1039208,
+              "smallAllocs": 60247
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 37220,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1077471,
+            "wall": {
+              "nanos": 1094777,
+              "smallAllocs": 62818
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 17155,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1656947,
+            "smallAllocs": 149414
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1604764,
+            "smallAllocs": 150118
+          },
+          "frobeniusPower": {
+            "nanos": 25738,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 22218,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1606156,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 48662,
+          "nullspaceBasisNanos": 48662,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1872,
+            "packNanos": 41086,
+            "rank": 16,
+            "reduceNanos": 60369,
+            "reduceNanosSamples": [
+              61211,
+              59729,
+              61000,
+              59669,
+              61170,
+              59668,
+              63253,
+              59738
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 103293
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1668,
+            "packNanos": 40986,
+            "rank": 16,
+            "reduceNanos": 61947,
+            "reduceNanosSamples": [
+              62072,
+              62072,
+              60660,
+              60850,
+              60960,
+              61972,
+              62132,
+              61922
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 104535
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2043,
+            "packNanos": 41757,
+            "rank": 16,
+            "reduceNanos": 52808,
+            "reduceNanosSamples": [
+              51897,
+              53629,
+              51757,
+              53760,
+              51987,
+              53689,
+              51947,
+              53709
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 97945
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1582601,
+              "rank": 16,
+              "readbackNanos": 32373,
+              "reduceNanos": 57991,
+              "reduceNanosSamples": [
+                57826,
+                58196,
+                57685,
+                58166,
+                57685,
+                57946,
+                58036,
+                58106
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1672744
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1582180,
+              "rank": 16,
+              "readbackNanos": 32303,
+              "reduceNanos": 70710,
+              "reduceNanosSamples": [
+                69553,
+                70364,
+                92428,
+                74861,
+                70835,
+                70585,
+                70314,
+                72948
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1685563
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1581644,
+              "rank": 16,
+              "readbackNanos": 31987,
+              "reduceNanos": 59879,
+              "reduceNanosSamples": [
+                59659,
+                57956,
+                60009,
+                59628,
+                60260,
+                59889,
+                60060,
+                59869
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1672685
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1583838,
+              "rank": 16,
+              "readbackNanos": 1857,
+              "reduceNanos": 61666,
+              "reduceNanosSamples": [
+                60670,
+                61941,
+                61712,
+                61621,
+                60610,
+                61822,
+                60670,
+                61952
+              ],
+              "smallAllocs": 148171,
+              "totalNanos": 1646901
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1582811,
+              "rank": 16,
+              "readbackNanos": 31997,
+              "reduceNanos": 64701,
+              "reduceNanosSamples": [
+                64716,
+                63585,
+                64476,
+                65156,
+                64686,
+                75072,
+                65116,
+                63404
+              ],
+              "smallAllocs": 150932,
+              "totalNanos": 1682429
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1580864,
+              "rank": 16,
+              "readbackNanos": 32173,
+              "reduceNanos": 69393,
+              "reduceNanosSamples": [
+                69403,
+                70965,
+                69383,
+                68121,
+                70374,
+                67860,
+                70605,
+                69012
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1682214
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1582736,
+              "rank": 16,
+              "readbackNanos": 32158,
+              "reduceNanos": 57686,
+              "reduceNanosSamples": [
+                58036,
+                57445,
+                57976,
+                57706,
+                57666,
+                57515,
+                58396,
+                57655
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1672519
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1581414,
+              "rank": 16,
+              "readbackNanos": 32002,
+              "reduceNanos": 60655,
+              "reduceNanosSamples": [
+                60460,
+                61120,
+                60600,
+                60710,
+                60800,
+                60390,
+                61111,
+                60329
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1674066
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1582401,
+              "rank": 16,
+              "readbackNanos": 32287,
+              "reduceNanos": 58106,
+              "reduceNanosSamples": [
+                58787,
+                57476,
+                58817,
+                57545,
+                58667,
+                57465,
+                58988,
+                57395
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1672609
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1580749,
+              "rank": 16,
+              "readbackNanos": 32138,
+              "reduceNanos": 57860,
+              "reduceNanosSamples": [
+                58126,
+                57515,
+                58076,
+                57645,
+                58396,
+                57606,
+                58658,
+                57505
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1670737
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1585890,
+              "rank": 16,
+              "readbackNanos": 32112,
+              "reduceNanos": 64801,
+              "reduceNanosSamples": [
+                63053,
+                64555,
+                63614,
+                64766,
+                65087,
+                67991,
+                65197,
+                64836
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1683075
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1583387,
+              "rank": 16,
+              "readbackNanos": 32107,
+              "reduceNanos": 60044,
+              "reduceNanosSamples": [
+                59739,
+                66088,
+                59739,
+                60119,
+                60049,
+                60039,
+                60480,
+                58157
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1678308
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1581960,
+              "smallAllocs": 148036
+            },
+            "columnCount": {
+              "nanos": 7626,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 54101,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14560,
+            "pivotSearch": {
+              "nanos": 835,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 32308,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 4832,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 59798,
+            "wall": {
+              "nanos": 70379,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5318,
+            "packNanos": 39523,
+            "rank": 16,
+            "reduceNanos": 109437,
+            "reduceNanosSamples": [
+              108772,
+              109172,
+              108942,
+              113359,
+              109542,
+              109913,
+              111355,
+              109332
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 16266,
+            "totalNanos": 154074
+          },
+          "peakResidentBytes": 63442944,
+          "productionMatrixRebuild": {
+            "nanos": 1622045,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1138252,
+            "smallAllocs": 62874
+          },
+          "productionRowReduce": {
+            "nanos": 1088528,
+            "smallAllocs": 61583
+          },
+          "rank": 16,
+          "residentBytesAfter": 63528960,
+          "residentBytesBefore": 63475712,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1625649,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift2",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4582,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1587309,
+            "smallAllocs": 149683
+          },
+          "berlekampSplit": {
+            "nanos": 3811325,
+            "smallAllocs": 320808
+          },
+          "columnPolys": {
+            "nanos": 1542927,
+            "smallAllocs": 145284
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 761,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 549104,
+              "smallAllocs": 30412
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 27225,
+              "smallAllocs": 1618
+            },
+            "stagedNanos": 577121,
+            "wall": {
+              "nanos": 594491,
+              "smallAllocs": 32469
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 830,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1008308,
+              "smallAllocs": 58828
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 37604,
+              "smallAllocs": 2130
+            },
+            "stagedNanos": 1046922,
+            "wall": {
+              "nanos": 1063456,
+              "smallAllocs": 61400
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 17451,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1669950,
+            "smallAllocs": 150036
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1611249,
+            "smallAllocs": 150740
+          },
+          "frobeniusPower": {
+            "nanos": 25698,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 17756,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1614643,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 48611,
+          "nullspaceBasisNanos": 48611,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1923,
+            "packNanos": 41171,
+            "rank": 16,
+            "reduceNanos": 59618,
+            "reduceNanosSamples": [
+              60299,
+              58888,
+              62603,
+              58777,
+              60249,
+              58938,
+              60510,
+              58988
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 103773
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1712,
+            "packNanos": 40845,
+            "rank": 16,
+            "reduceNanos": 60915,
+            "reduceNanosSamples": [
+              61100,
+              60820,
+              59678,
+              60910,
+              60921,
+              61110,
+              59879,
+              60950
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 103469
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2023,
+            "packNanos": 41271,
+            "rank": 16,
+            "reduceNanos": 52528,
+            "reduceNanosSamples": [
+              51346,
+              53830,
+              51386,
+              53459,
+              51616,
+              53440,
+              51536,
+              53469
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 95927
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1589962,
+              "rank": 16,
+              "readbackNanos": 32178,
+              "reduceNanos": 57055,
+              "reduceNanosSamples": [
+                56874,
+                57385,
+                56814,
+                57204,
+                56915,
+                57335,
+                56634,
+                57195
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1679044
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1596096,
+              "rank": 16,
+              "readbackNanos": 32313,
+              "reduceNanos": 69533,
+              "reduceNanosSamples": [
+                68091,
+                69523,
+                68791,
+                69543,
+                70455,
+                69604,
+                69102,
+                71576
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1697762
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1591589,
+              "rank": 16,
+              "readbackNanos": 32157,
+              "reduceNanos": 58817,
+              "reduceNanosSamples": [
+                58947,
+                63824,
+                58817,
+                58698,
+                59048,
+                58817,
+                58757,
+                58737
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1682745
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1590032,
+              "rank": 16,
+              "readbackNanos": 1838,
+              "reduceNanos": 60910,
+              "reduceNanosSamples": [
+                60910,
+                60910,
+                59568,
+                60950,
+                59698,
+                61091,
+                59779,
+                61091
+              ],
+              "smallAllocs": 148804,
+              "totalNanos": 1652405
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1589511,
+              "rank": 16,
+              "readbackNanos": 32017,
+              "reduceNanos": 63960,
+              "reduceNanosSamples": [
+                64065,
+                64336,
+                63775,
+                64556,
+                63665,
+                64926,
+                63494,
+                63855
+              ],
+              "smallAllocs": 151543,
+              "totalNanos": 1685979
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1589912,
+              "rank": 16,
+              "readbackNanos": 32163,
+              "reduceNanos": 67600,
+              "reduceNanosSamples": [
+                67650,
+                67460,
+                68292,
+                66989,
+                67910,
+                67550,
+                71526,
+                66919
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1689905
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1591004,
+              "rank": 16,
+              "readbackNanos": 32168,
+              "reduceNanos": 56959,
+              "reduceNanosSamples": [
+                57044,
+                56894,
+                57025,
+                56614,
+                57064,
+                60650,
+                56624,
+                56003
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1679975
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1591719,
+              "rank": 16,
+              "readbackNanos": 31872,
+              "reduceNanos": 59508,
+              "reduceNanosSamples": [
+                59719,
+                59468,
+                59548,
+                59358,
+                59608,
+                59618,
+                59288,
+                58987
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1682874
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1588700,
+              "rank": 16,
+              "readbackNanos": 32318,
+              "reduceNanos": 57009,
+              "reduceNanosSamples": [
+                56654,
+                56734,
+                57805,
+                56734,
+                57616,
+                57285,
+                57625,
+                56704
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1678088
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1590313,
+              "rank": 16,
+              "readbackNanos": 32148,
+              "reduceNanos": 57019,
+              "reduceNanosSamples": [
+                57284,
+                56804,
+                57245,
+                56915,
+                57124,
+                56834,
+                57385,
+                56544
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1679830
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1589696,
+              "rank": 16,
+              "readbackNanos": 32247,
+              "reduceNanos": 63304,
+              "reduceNanosSamples": [
+                62522,
+                62713,
+                64926,
+                63544,
+                62563,
+                63685,
+                63344,
+                63264
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1684231
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1590598,
+              "rank": 16,
+              "readbackNanos": 32002,
+              "reduceNanos": 59152,
+              "reduceNanosSamples": [
+                62463,
+                58987,
+                59158,
+                59147,
+                59078,
+                57395,
+                59187,
+                59759
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1683225
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1591649,
+              "smallAllocs": 148658
+            },
+            "columnCount": {
+              "nanos": 7766,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 53169,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14208,
+            "pivotSearch": {
+              "nanos": 826,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 32042,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 4760,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 58795,
+            "wall": {
+              "nanos": 69603,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5383,
+            "packNanos": 39328,
+            "rank": 16,
+            "reduceNanos": 107259,
+            "reduceNanosSamples": [
+              106858,
+              107269,
+              107249,
+              107099,
+              107830,
+              107029,
+              112366,
+              110373
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 15925,
+            "totalNanos": 152206
+          },
+          "peakResidentBytes": 63424512,
+          "productionMatrixRebuild": {
+            "nanos": 1621554,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1105459,
+            "smallAllocs": 61452
+          },
+          "productionRowReduce": {
+            "nanos": 1054438,
+            "smallAllocs": 60165
+          },
+          "rank": 16,
+          "residentBytesAfter": 63488000,
+          "residentBytesBefore": 63397888,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1627493,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd4_x_sd4shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 42,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 42,
+          "basisToPolynomials": {
+            "nanos": 5247,
+            "smallAllocs": 444
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2852468,
+            "smallAllocs": 263817
+          },
+          "berlekampSplit": {
+            "nanos": 7552056,
+            "smallAllocs": 625572
+          },
+          "columnPolys": {
+            "nanos": 2841562,
+            "smallAllocs": 258009
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1019,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 1478976,
+              "smallAllocs": 82650
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 53559,
+              "smallAllocs": 3279
+            },
+            "stagedNanos": 1533458,
+            "wall": {
+              "nanos": 1561249,
+              "smallAllocs": 86460
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1047,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 2770844,
+              "smallAllocs": 161190
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 74961,
+              "smallAllocs": 4329
+            },
+            "stagedNanos": 2846372,
+            "wall": {
+              "nanos": 2872003,
+              "smallAllocs": 166053
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 22408,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3041058,
+            "smallAllocs": 264369
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2889028,
+            "smallAllocs": 265624
+          },
+          "frobeniusPower": {
+            "nanos": 25793,
+            "smallAllocs": 2281
+          },
+          "kernelDimension": 17,
+          "matrixConversionNanos": 30930,
+          "matrixConversionNegative": true,
+          "matrixRebuild": {
+            "nanos": 2965927,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 76317,
+          "nullspaceBasisNanos": 76317,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2889,
+            "packNanos": 73649,
+            "rank": 25,
+            "reduceNanos": 156992,
+            "reduceNanosSamples": [
+              166507,
+              156712,
+              157363,
+              154008,
+              158385,
+              154158,
+              157273,
+              154318
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 233726
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2759,
+            "packNanos": 73504,
+            "rank": 25,
+            "reduceNanos": 161284,
+            "reduceNanosSamples": [
+              159927,
+              162281,
+              159847,
+              162121,
+              160448,
+              164985,
+              159766,
+              162231
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 237231
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3089,
+            "packNanos": 74129,
+            "rank": 25,
+            "reduceNanos": 139246,
+            "reduceNanosSamples": [
+              137524,
+              139266,
+              139407,
+              142522,
+              137504,
+              140558,
+              137564,
+              139227
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 216651
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2894011,
+              "rank": 25,
+              "readbackNanos": 53449,
+              "reduceNanos": 142441,
+              "reduceNanosSamples": [
+                143773,
+                141610,
+                143833,
+                141270,
+                143863,
+                141750,
+                143132,
+                141400
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3088939
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2885733,
+              "rank": 25,
+              "readbackNanos": 52938,
+              "reduceNanos": 181259,
+              "reduceNanosSamples": [
+                180688,
+                180708,
+                183192,
+                180257,
+                182781,
+                181419,
+                181229,
+                181289
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3120351
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2875973,
+              "rank": 25,
+              "readbackNanos": 52708,
+              "reduceNanos": 153317,
+              "reduceNanosSamples": [
+                153307,
+                155070,
+                152066,
+                155690,
+                153187,
+                150984,
+                153327,
+                153778
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3081333
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2883410,
+              "rank": 25,
+              "readbackNanos": 2884,
+              "reduceNanos": 158345,
+              "reduceNanosSamples": [
+                167788,
+                156362,
+                156883,
+                156492,
+                160488,
+                156232,
+                159807,
+                160789
+              ],
+              "smallAllocs": 262265,
+              "totalNanos": 3046306
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2878667,
+              "rank": 25,
+              "readbackNanos": 52588,
+              "reduceNanos": 158053,
+              "reduceNanosSamples": [
+                159546,
+                158304,
+                162031,
+                157063,
+                164744,
+                157803,
+                155110,
+                156762
+              ],
+              "smallAllocs": 266773,
+              "totalNanos": 3088323
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2880019,
+              "rank": 25,
+              "readbackNanos": 52758,
+              "reduceNanos": 169836,
+              "reduceNanosSamples": [
+                170162,
+                168800,
+                169471,
+                169741,
+                169902,
+                169952,
+                169942,
+                169771
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3103366
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2881837,
+              "rank": 25,
+              "readbackNanos": 53078,
+              "reduceNanos": 143868,
+              "reduceNanosSamples": [
+                145466,
+                141079,
+                146618,
+                141440,
+                144203,
+                140999,
+                146608,
+                143533
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3078880
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2875022,
+              "rank": 25,
+              "readbackNanos": 52698,
+              "reduceNanos": 148741,
+              "reduceNanosSamples": [
+                149372,
+                148621,
+                152095,
+                148060,
+                149742,
+                148861,
+                148500,
+                148521
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3076846
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2886584,
+              "rank": 25,
+              "readbackNanos": 53329,
+              "reduceNanos": 141489,
+              "reduceNanosSamples": [
+                142401,
+                141099,
+                141540,
+                140548,
+                141520,
+                141339,
+                141459,
+                142041
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3080887
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2878432,
+              "rank": 25,
+              "readbackNanos": 52607,
+              "reduceNanos": 143077,
+              "reduceNanosSamples": [
+                142802,
+                141349,
+                142441,
+                143483,
+                143352,
+                142221,
+                146097,
+                144254
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3075890
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2881938,
+              "rank": 25,
+              "readbackNanos": 52903,
+              "reduceNanos": 164148,
+              "reduceNanosSamples": [
+                164363,
+                163001,
+                161510,
+                168179,
+                169842,
+                171163,
+                163001,
+                163933
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3102264
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2881056,
+              "rank": 25,
+              "readbackNanos": 53635,
+              "reduceNanos": 154123,
+              "reduceNanosSamples": [
+                150463,
+                151785,
+                153097,
+                153627,
+                161699,
+                156572,
+                156081,
+                154619
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3090341
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2879944,
+              "smallAllocs": 262052
+            },
+            "columnCount": {
+              "nanos": 14749,
+              "smallAllocs": 1125
+            },
+            "eliminate": {
+              "nanos": 135057,
+              "smallAllocs": 1125
+            },
+            "freeColumns": 17,
+            "innerMultiplies": 39270,
+            "pivotSearch": {
+              "nanos": 1092,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "readback": {
+              "nanos": 52793,
+              "smallAllocs": 2680
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 8683,
+              "smallAllocs": 100
+            },
+            "scaleMultiplies": 1050,
+            "stagedNanos": 144910,
+            "wall": {
+              "nanos": 163422,
+              "smallAllocs": 2549
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8457,
+            "packNanos": 71816,
+            "rank": 25,
+            "reduceNanos": 301602,
+            "reduceNanosSamples": [
+              284502,
+              304531,
+              301967,
+              285173,
+              298152,
+              303751,
+              303490,
+              301237
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 42384,
+            "totalNanos": 380999
+          },
+          "peakResidentBytes": 63426560,
+          "productionMatrixRebuild": {
+            "nanos": 2921922,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2962212,
+            "smallAllocs": 166027
+          },
+          "productionRowReduce": {
+            "nanos": 2884687,
+            "smallAllocs": 163665
+          },
+          "rank": 25,
+          "residentBytesAfter": 63520768,
+          "residentBytesBefore": 63381504,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2929152,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 17
+        },
+        "modularDegree": 42,
+        "modularFactorCount": 17,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_x_phi11",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 6789,
+            "smallAllocs": 686
+          },
+          "berlekampMatrixWall": {
+            "nanos": 538784,
+            "smallAllocs": 51263
+          },
+          "berlekampSplit": {
+            "nanos": 1983426,
+            "smallAllocs": 163103
+          },
+          "columnPolys": {
+            "nanos": 473346,
+            "smallAllocs": 46071
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1196,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 121891,
+              "smallAllocs": 7891
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 71257,
+              "smallAllocs": 4425
+            },
+            "stagedNanos": 194124,
+            "wall": {
+              "nanos": 228203,
+              "smallAllocs": 13028
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1245,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 184304,
+              "smallAllocs": 11539
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 96357,
+              "smallAllocs": 5817
+            },
+            "stagedNanos": 284494,
+            "wall": {
+              "nanos": 317510,
+              "smallAllocs": 18071
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 32713,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 621080,
+            "smallAllocs": 51959
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 570456,
+            "smallAllocs": 53616
+          },
+          "frobeniusPower": {
+            "nanos": 7591,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 19,
+          "matrixConversionNanos": 57776,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 591837,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 64401,
+          "nullspaceBasisNanos": 64401,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3485,
+            "packNanos": 97184,
+            "rank": 29,
+            "reduceNanos": 27455,
+            "reduceNanosSamples": [
+              28533,
+              26839,
+              28122,
+              26779,
+              28132,
+              26669,
+              28071,
+              26770
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 128135
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3340,
+            "packNanos": 97144,
+            "rank": 29,
+            "reduceNanos": 27105,
+            "reduceNanosSamples": [
+              27541,
+              27170,
+              27330,
+              27341,
+              27040,
+              26980,
+              27000,
+              27010
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 127649
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3936,
+            "packNanos": 97905,
+            "rank": 29,
+            "reduceNanos": 25493,
+            "reduceNanosSamples": [
+              24957,
+              26359,
+              25028,
+              26339,
+              24577,
+              25959,
+              24756,
+              26098
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 127264
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537521,
+              "rank": 29,
+              "readbackNanos": 73659,
+              "reduceNanos": 41877,
+              "reduceNanosSamples": [
+                41632,
+                48061,
+                44997,
+                46719,
+                41702,
+                42053,
+                40550,
+                41110
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 654956
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 536099,
+              "rank": 29,
+              "readbackNanos": 73684,
+              "reduceNanos": 33229,
+              "reduceNanosSamples": [
+                32959,
+                33830,
+                33119,
+                33990,
+                32979,
+                33750,
+                32979,
+                33339
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 643975
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537387,
+              "rank": 29,
+              "readbackNanos": 73424,
+              "reduceNanos": 32057,
+              "reduceNanosSamples": [
+                35352,
+                31717,
+                32207,
+                31637,
+                32057,
+                32297,
+                31647,
+                32058
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 643289
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 533696,
+              "rank": 29,
+              "readbackNanos": 3455,
+              "reduceNanos": 27180,
+              "reduceNanosSamples": [
+                27500,
+                27100,
+                27561,
+                26980,
+                26909,
+                26889,
+                27321,
+                27260
+              ],
+              "smallAllocs": 50422,
+              "totalNanos": 564382
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 539920,
+              "rank": 29,
+              "readbackNanos": 73338,
+              "reduceNanos": 43364,
+              "reduceNanosSamples": [
+                43465,
+                43865,
+                43184,
+                43264,
+                44076,
+                43735,
+                42563,
+                43193
+              ],
+              "smallAllocs": 53866,
+              "totalNanos": 656654
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 534783,
+              "rank": 29,
+              "readbackNanos": 73068,
+              "reduceNanos": 44035,
+              "reduceNanosSamples": [
+                43856,
+                47370,
+                43675,
+                44135,
+                44586,
+                44235,
+                42934,
+                43935
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 655336
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537116,
+              "rank": 29,
+              "readbackNanos": 73548,
+              "reduceNanos": 42052,
+              "reduceNanosSamples": [
+                42232,
+                44646,
+                42213,
+                41261,
+                45617,
+                41892,
+                41211,
+                41121
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 654685
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 535954,
+              "rank": 29,
+              "readbackNanos": 73219,
+              "reduceNanos": 42693,
+              "reduceNanosSamples": [
+                66559,
+                42663,
+                42593,
+                42724,
+                43114,
+                42764,
+                41712,
+                42653
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 656303
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537171,
+              "rank": 29,
+              "readbackNanos": 74044,
+              "reduceNanos": 41627,
+              "reduceNanosSamples": [
+                41412,
+                41602,
+                47771,
+                44446,
+                41812,
+                41652,
+                41111,
+                41081
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 652968
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 537246,
+              "rank": 29,
+              "readbackNanos": 73429,
+              "reduceNanos": 41911,
+              "reduceNanosSamples": [
+                42162,
+                41632,
+                42052,
+                41771,
+                42753,
+                42273,
+                41422,
+                41552
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 652011
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 538228,
+              "rank": 29,
+              "readbackNanos": 73549,
+              "reduceNanos": 32252,
+              "reduceNanosSamples": [
+                32678,
+                32247,
+                32027,
+                32378,
+                32257,
+                32529,
+                32128,
+                32058
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 644315
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 534697,
+              "rank": 29,
+              "readbackNanos": 73469,
+              "reduceNanos": 31752,
+              "reduceNanosSamples": [
+                31457,
+                31437,
+                31858,
+                31577,
+                31677,
+                31827,
+                32038,
+                32297
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 641070
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 537812,
+              "smallAllocs": 48958
+            },
+            "columnCount": {
+              "nanos": 18118,
+              "smallAllocs": 1479
+            },
+            "eliminate": {
+              "nanos": 32396,
+              "smallAllocs": 1479
+            },
+            "freeColumns": 19,
+            "innerMultiplies": 1824,
+            "pivotSearch": {
+              "nanos": 1264,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "readback": {
+              "nanos": 73018,
+              "smallAllocs": 3414
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 10753,
+              "smallAllocs": 116
+            },
+            "scaleMultiplies": 1392,
+            "stagedNanos": 44388,
+            "wall": {
+              "nanos": 67099,
+              "smallAllocs": 3301
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10040,
+            "packNanos": 93388,
+            "rank": 29,
+            "reduceNanos": 41837,
+            "reduceNanosSamples": [
+              42202,
+              41612,
+              41802,
+              41531,
+              41873,
+              44065,
+              46599,
+              40991
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 7083,
+            "totalNanos": 146061
+          },
+          "peakResidentBytes": 63813632,
+          "productionMatrixRebuild": {
+            "nanos": 576574,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 340820,
+            "smallAllocs": 17567
+          },
+          "productionRowReduce": {
+            "nanos": 278187,
+            "smallAllocs": 14957
+          },
+          "rank": 29,
+          "residentBytesAfter": 63868928,
+          "residentBytesBefore": 63770624,
+          "rowReduceMatrixRebuild": {
+            "nanos": 581698,
+            "smallAllocs": 0
+          },
+          "sink": 104,
+          "splitFactors": 19
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 19,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow48_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 105,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 105,
+          "basisToPolynomials": {
+            "nanos": 7136,
+            "smallAllocs": 657
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3510740,
+            "smallAllocs": 337638
+          },
+          "berlekampSplit": {
+            "nanos": 8884521,
+            "smallAllocs": 750003
+          },
+          "columnPolys": {
+            "nanos": 3243583,
+            "smallAllocs": 314148
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2630,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 987766,
+              "smallAllocs": 65681
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 465950,
+              "smallAllocs": 29307
+            },
+            "stagedNanos": 1452672,
+            "wall": {
+              "nanos": 1589081,
+              "smallAllocs": 95903
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2684,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1595973,
+              "smallAllocs": 102431
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 628986,
+              "smallAllocs": 38862
+            },
+            "stagedNanos": 2225809,
+            "wall": {
+              "nanos": 2354776,
+              "smallAllocs": 142211
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 169711,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3902205,
+            "smallAllocs": 339228
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3677406,
+            "smallAllocs": 348769
+          },
+          "frobeniusPower": {
+            "nanos": 16845,
+            "smallAllocs": 1441
+          },
+          "kernelDimension": 14,
+          "matrixConversionNanos": 255538,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3743500,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 219875,
+          "nullspaceBasisNanos": 219875,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9358,
+            "packNanos": 503491,
+            "rank": 91,
+            "reduceNanos": 183131,
+            "reduceNanosSamples": [
+              184083,
+              183762,
+              182500,
+              182110,
+              184473,
+              185154,
+              181950,
+              181830
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 696532
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9239,
+            "packNanos": 501112,
+            "rank": 91,
+            "reduceNanos": 183963,
+            "reduceNanosSamples": [
+              184103,
+              185435,
+              186427,
+              183672,
+              182360,
+              182951,
+              183823,
+              189201
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 695151
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9789,
+            "packNanos": 499555,
+            "rank": 91,
+            "reduceNanos": 155295,
+            "reduceNanosSamples": [
+              153557,
+              155040,
+              155961,
+              155550,
+              165015,
+              154489,
+              152766,
+              158625
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 667660
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3457375,
+              "rank": 91,
+              "readbackNanos": 206741,
+              "reduceNanos": 270360,
+              "reduceNanosSamples": [
+                275228,
+                274136,
+                266545,
+                267456,
+                277251,
+                266004,
+                268728,
+                271993
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3940561
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3467105,
+              "rank": 91,
+              "readbackNanos": 207327,
+              "reduceNanos": 224888,
+              "reduceNanosSamples": [
+                222470,
+                224813,
+                225034,
+                224964,
+                225083,
+                224012,
+                222069,
+                235600
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3903452
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3461507,
+              "rank": 91,
+              "readbackNanos": 208299,
+              "reduceNanos": 209500,
+              "reduceNanosSamples": [
+                208119,
+                209330,
+                208008,
+                213476,
+                209671,
+                210853,
+                208920,
+                210812
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3883813
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3465738,
+              "rank": 91,
+              "readbackNanos": 9319,
+              "reduceNanos": 183106,
+              "reduceNanosSamples": [
+                182260,
+                183742,
+                182891,
+                186607,
+                183322,
+                181849,
+                192305,
+                182370
+              ],
+              "smallAllocs": 336216,
+              "totalNanos": 3658453
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3465272,
+              "rank": 91,
+              "readbackNanos": 208109,
+              "reduceNanos": 286470,
+              "reduceNanosSamples": [
+                283901,
+                282409,
+                285854,
+                287086,
+                292694,
+                284291,
+                287386,
+                287987
+              ],
+              "smallAllocs": 342378,
+              "totalNanos": 3963231
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3476970,
+              "rank": 91,
+              "readbackNanos": 207052,
+              "reduceNanos": 291747,
+              "reduceNanosSamples": [
+                293234,
+                292623,
+                288698,
+                290871,
+                302989,
+                286775,
+                290551,
+                296290
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3980346
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3452729,
+              "rank": 91,
+              "readbackNanos": 206641,
+              "reduceNanos": 276660,
+              "reduceNanosSamples": [
+                277571,
+                276119,
+                275359,
+                270431,
+                293004,
+                273566,
+                277201,
+                280627
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3939646
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3472969,
+              "rank": 91,
+              "readbackNanos": 207037,
+              "reduceNanos": 281422,
+              "reduceNanosSamples": [
+                282078,
+                282009,
+                279514,
+                276009,
+                288167,
+                278573,
+                280836,
+                285733
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3962219
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3461241,
+              "rank": 91,
+              "readbackNanos": 206792,
+              "reduceNanos": 277791,
+              "reduceNanosSamples": [
+                284442,
+                278903,
+                276330,
+                273726,
+                282519,
+                274376,
+                276680,
+                280496
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3948003
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3457285,
+              "rank": 91,
+              "readbackNanos": 208194,
+              "reduceNanos": 278277,
+              "reduceNanosSamples": [
+                279794,
+                277952,
+                276490,
+                273205,
+                287767,
+                273675,
+                278603,
+                282929
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3948073
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3458883,
+              "rank": 91,
+              "readbackNanos": 208604,
+              "reduceNanos": 215985,
+              "reduceNanosSamples": [
+                215419,
+                213607,
+                216531,
+                214548,
+                217182,
+                219586,
+                215439,
+                222240
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3886517
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3476644,
+              "rank": 91,
+              "readbackNanos": 208073,
+              "reduceNanos": 210336,
+              "reduceNanosSamples": [
+                211503,
+                210211,
+                210602,
+                206756,
+                209861,
+                207958,
+                212665,
+                210462
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3895504
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3478252,
+              "smallAllocs": 326612
+            },
+            "columnCount": {
+              "nanos": 111764,
+              "smallAllocs": 9828
+            },
+            "eliminate": {
+              "nanos": 224027,
+              "smallAllocs": 9828
+            },
+            "freeColumns": 14,
+            "innerMultiplies": 18375,
+            "pivotSearch": {
+              "nanos": 2661,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "readback": {
+              "nanos": 206261,
+              "smallAllocs": 5848
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 56819,
+              "smallAllocs": 364
+            },
+            "scaleMultiplies": 9555,
+            "stagedNanos": 283461,
+            "wall": {
+              "nanos": 408405,
+              "smallAllocs": 20537
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 46123,
+            "packNanos": 474208,
+            "rank": 91,
+            "reduceNanos": 309534,
+            "reduceNanosSamples": [
+              309118,
+              308647,
+              309439,
+              304131,
+              309629,
+              316269,
+              313094,
+              310130
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 48772,
+            "totalNanos": 834542
+          },
+          "peakResidentBytes": 65122304,
+          "productionMatrixRebuild": {
+            "nanos": 3722929,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2360869,
+            "smallAllocs": 134628
+          },
+          "productionRowReduce": {
+            "nanos": 2143538,
+            "smallAllocs": 122300
+          },
+          "rank": 91,
+          "residentBytesAfter": 64860160,
+          "residentBytesBefore": 63807488,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3728697,
+            "smallAllocs": 0
+          },
+          "sink": 136,
+          "splitFactors": 14
+        },
+        "modularDegree": 105,
+        "modularFactorCount": 14,
+        "prime": 17,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow105_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 120,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 120,
+          "basisToPolynomials": {
+            "nanos": 28037,
+            "smallAllocs": 2778
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2338311,
+            "smallAllocs": 214939
+          },
+          "berlekampSplit": {
+            "nanos": 16134816,
+            "smallAllocs": 1312571
+          },
+          "columnPolys": {
+            "nanos": 1972494,
+            "smallAllocs": 185863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3062,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 834895,
+              "smallAllocs": 57197
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 470110,
+              "smallAllocs": 30075
+            },
+            "stagedNanos": 1310050,
+            "wall": {
+              "nanos": 1506468,
+              "smallAllocs": 89910
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3061,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 1291368,
+              "smallAllocs": 85037
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 638242,
+              "smallAllocs": 39795
+            },
+            "stagedNanos": 1933174,
+            "wall": {
+              "nanos": 2118460,
+              "smallAllocs": 127473
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 172551,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2969256,
+            "smallAllocs": 218459
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2505885,
+            "smallAllocs": 229460
+          },
+          "frobeniusPower": {
+            "nanos": 4431,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 39,
+          "matrixConversionNanos": 357750,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2617635,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 492505,
+          "nullspaceBasisNanos": 492505,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16829,
+            "packNanos": 659828,
+            "rank": 81,
+            "reduceNanos": 172586,
+            "reduceNanosSamples": [
+              172446,
+              170713,
+              176552,
+              171484,
+              172726,
+              175781,
+              171865,
+              174699
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 849634
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16489,
+            "packNanos": 658606,
+            "rank": 81,
+            "reduceNanos": 174649,
+            "reduceNanosSamples": [
+              177463,
+              178535,
+              191234,
+              175210,
+              172596,
+              174088,
+              172466,
+              172796
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 851878
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16980,
+            "packNanos": 665036,
+            "rank": 81,
+            "reduceNanos": 151374,
+            "reduceNanosSamples": [
+              148910,
+              151545,
+              148199,
+              152215,
+              154089,
+              170883,
+              148490,
+              151204
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 832749
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2272559,
+              "rank": 81,
+              "readbackNanos": 574672,
+              "reduceNanos": 269019,
+              "reduceNanosSamples": [
+                270822,
+                267346,
+                261869,
+                258102,
+                262799,
+                270692,
+                272043,
+                271543
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3109790
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2269499,
+              "rank": 81,
+              "readbackNanos": 573840,
+              "reduceNanos": 211579,
+              "reduceNanosSamples": [
+                217092,
+                219024,
+                209280,
+                209190,
+                212115,
+                212344,
+                211043,
+                210523
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3056471
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2261828,
+              "rank": 81,
+              "readbackNanos": 574857,
+              "reduceNanos": 200392,
+              "reduceNanosSamples": [
+                199546,
+                199516,
+                200467,
+                200627,
+                203972,
+                202380,
+                200317,
+                199566
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3036732
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2268187,
+              "rank": 81,
+              "readbackNanos": 16434,
+              "reduceNanos": 172025,
+              "reduceNanosSamples": [
+                175700,
+                170763,
+                171243,
+                178634,
+                182321,
+                171554,
+                172496,
+                170954
+              ],
+              "smallAllocs": 210396,
+              "totalNanos": 2455555
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2281607,
+              "rank": 81,
+              "readbackNanos": 571632,
+              "reduceNanos": 281757,
+              "reduceNanosSamples": [
+                281738,
+                285383,
+                279314,
+                279815,
+                281777,
+                281918,
+                286185,
+                276881
+              ],
+              "smallAllocs": 228020,
+              "totalNanos": 3137356
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2301401,
+              "rank": 81,
+              "readbackNanos": 576820,
+              "reduceNanos": 285203,
+              "reduceNanosSamples": [
+                294387,
+                285383,
+                285934,
+                285023,
+                282680,
+                286495,
+                283821,
+                279735
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3159468
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2283846,
+              "rank": 81,
+              "readbackNanos": 573906,
+              "reduceNanos": 270331,
+              "reduceNanosSamples": [
+                279023,
+                271753,
+                268538,
+                264552,
+                268909,
+                274356,
+                272845,
+                267176
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3132794
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2283224,
+              "rank": 81,
+              "readbackNanos": 575498,
+              "reduceNanos": 276991,
+              "reduceNanosSamples": [
+                277572,
+                275718,
+                273205,
+                268779,
+                276410,
+                282659,
+                281427,
+                296780
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3130946
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2260812,
+              "rank": 81,
+              "readbackNanos": 575568,
+              "reduceNanos": 273365,
+              "reduceNanosSamples": [
+                271632,
+                276140,
+                275688,
+                270862,
+                272214,
+                276700,
+                274517,
+                267537
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3111883
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2265404,
+              "rank": 81,
+              "readbackNanos": 576109,
+              "reduceNanos": 271703,
+              "reduceNanosSamples": [
+                273195,
+                273286,
+                271092,
+                266545,
+                269690,
+                272314,
+                273736,
+                268278
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3111408
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2282734,
+              "rank": 81,
+              "readbackNanos": 574276,
+              "reduceNanos": 205139,
+              "reduceNanosSamples": [
+                205254,
+                204514,
+                204423,
+                205284,
+                206596,
+                205465,
+                205024,
+                204563
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3059481
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2273120,
+              "rank": 81,
+              "readbackNanos": 574762,
+              "reduceNanos": 200062,
+              "reduceNanosSamples": [
+                200517,
+                200017,
+                199686,
+                198875,
+                205405,
+                203431,
+                200017,
+                200107
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3046852
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2287085,
+              "smallAllocs": 200538
+            },
+            "columnCount": {
+              "nanos": 112594,
+              "smallAllocs": 9963
+            },
+            "eliminate": {
+              "nanos": 214055,
+              "smallAllocs": 9963
+            },
+            "freeColumns": 39,
+            "innerMultiplies": 13920,
+            "pivotSearch": {
+              "nanos": 3063,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "readback": {
+              "nanos": 569304,
+              "smallAllocs": 17478
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 59218,
+              "smallAllocs": 324
+            },
+            "scaleMultiplies": 9720,
+            "stagedNanos": 275575,
+            "wall": {
+              "nanos": 405011,
+              "smallAllocs": 20817
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 61426,
+            "packNanos": 630880,
+            "rank": 81,
+            "reduceNanos": 273460,
+            "reduceNanosSamples": [
+              274867,
+              270632,
+              271863,
+              276120,
+              276180,
+              273816,
+              273105,
+              271743
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 48141,
+            "totalNanos": 968030
+          },
+          "peakResidentBytes": 65558528,
+          "productionMatrixRebuild": {
+            "nanos": 2540737,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2430122,
+            "smallAllocs": 123505
+          },
+          "productionRowReduce": {
+            "nanos": 1934047,
+            "smallAllocs": 107187
+          },
+          "rank": 81,
+          "residentBytesAfter": 65470464,
+          "residentBytesBefore": 63881216,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2563580,
+            "smallAllocs": 0
+          },
+          "sink": 152,
+          "splitFactors": 39
+        },
+        "modularDegree": 120,
+        "modularFactorCount": 39,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "xpow120_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 178,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 178,
+          "basisToPolynomials": {
+            "nanos": 3605,
+            "smallAllocs": 371
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3094087,
+            "smallAllocs": 274190
+          },
+          "berlekampSplit": {
+            "nanos": 5252857,
+            "smallAllocs": 339370
+          },
+          "columnPolys": {
+            "nanos": 2361571,
+            "smallAllocs": 210706
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4497,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 7971434,
+              "smallAllocs": 491858
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1500273,
+              "smallAllocs": 95034
+            },
+            "stagedNanos": 9491215,
+            "wall": {
+              "nanos": 9886722,
+              "smallAllocs": 587969
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4614,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 14496379,
+              "smallAllocs": 888442
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 2069029,
+              "smallAllocs": 126362
+            },
+            "stagedNanos": 16596612,
+            "wall": {
+              "nanos": 16974946,
+              "smallAllocs": 1015884
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 477222,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4529665,
+            "smallAllocs": 275077
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3564915,
+            "smallAllocs": 306053
+          },
+          "frobeniusPower": {
+            "nanos": 2804,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 2,
+          "matrixConversionNanos": 706853,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3688243,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 323835,
+          "nullspaceBasisNanos": 323835,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14932,
+            "packNanos": 1499984,
+            "rank": 176,
+            "reduceNanos": 1063542,
+            "reduceNanosSamples": [
+              1066230,
+              1072730,
+              1057978,
+              1078288,
+              1061884,
+              1063357,
+              1063727,
+              1060472
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2577206
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14592,
+            "packNanos": 1497460,
+            "rank": 176,
+            "reduceNanos": 1088148,
+            "reduceNanosSamples": [
+              1084448,
+              1092941,
+              1087802,
+              1088494,
+              1085940,
+              1092920,
+              1079611,
+              1089806
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2600680
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14987,
+            "packNanos": 1494015,
+            "rank": 176,
+            "reduceNanos": 721695,
+            "reduceNanosSamples": [
+              725596,
+              718576,
+              707929,
+              718936,
+              715491,
+              727048,
+              724454,
+              725255
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2227968
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3070542,
+              "rank": 176,
+              "readbackNanos": 193571,
+              "reduceNanos": 1260489,
+              "reduceNanosSamples": [
+                1248031,
+                1236863,
+                1282782,
+                1293358,
+                1275280,
+                1239408,
+                1272948,
+                1235742
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4542624
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3073191,
+              "rank": 176,
+              "readbackNanos": 193897,
+              "reduceNanos": 1257565,
+              "reduceNanosSamples": [
+                1274599,
+                1258786,
+                1257505,
+                1257625,
+                1249993,
+                1244595,
+                1259618,
+                1249072
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4525640
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3051879,
+              "rank": 176,
+              "readbackNanos": 193947,
+              "reduceNanos": 1109715,
+              "reduceNanosSamples": [
+                1097297,
+                1112509,
+                1098018,
+                1100352,
+                1114092,
+                1111268,
+                1115885,
+                1108163
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4349338
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3080973,
+              "rank": 176,
+              "readbackNanos": 14777,
+              "reduceNanos": 1079180,
+              "reduceNanosSamples": [
+                1081274,
+                1066692,
+                1084047,
+                1069495,
+                1091478,
+                1094142,
+                1074162,
+                1077087
+              ],
+              "smallAllocs": 273089,
+              "totalNanos": 4183597
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3107532,
+              "rank": 176,
+              "readbackNanos": 192995,
+              "reduceNanos": 1364783,
+              "reduceNanosSamples": [
+                1341129,
+                1333317,
+                1387226,
+                1410641,
+                1376301,
+                1342881,
+                1393046,
+                1353266
+              ],
+              "smallAllocs": 276914,
+              "totalNanos": 4670328
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3064012,
+              "rank": 176,
+              "readbackNanos": 193607,
+              "reduceNanos": 1445267,
+              "reduceNanosSamples": [
+                1434857,
+                1408568,
+                1466985,
+                1473995,
+                1460465,
+                1420686,
+                1455678,
+                1415208
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4720663
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3070512,
+              "rank": 176,
+              "readbackNanos": 197779,
+              "reduceNanos": 1297138,
+              "reduceNanosSamples": [
+                1283643,
+                1270032,
+                1324864,
+                1330432,
+                1313367,
+                1276362,
+                1310633,
+                1276813
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4587325
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3109379,
+              "rank": 176,
+              "readbackNanos": 195615,
+              "reduceNanos": 1335124,
+              "reduceNanosSamples": [
+                1321179,
+                1311795,
+                1357383,
+                1364142,
+                1358093,
+                1312826,
+                1349070,
+                1308370
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4665226
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3098829,
+              "rank": 176,
+              "readbackNanos": 194143,
+              "reduceNanos": 1296036,
+              "reduceNanosSamples": [
+                1282201,
+                1268942,
+                1321689,
+                1325435,
+                1310843,
+                1272206,
+                1309872,
+                1266558
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4592453
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3039986,
+              "rank": 176,
+              "readbackNanos": 193006,
+              "reduceNanos": 1293898,
+              "reduceNanosSamples": [
+                1279867,
+                1275631,
+                1321410,
+                1324974,
+                1318665,
+                1278876,
+                1307929,
+                1272376
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4553030
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3050657,
+              "rank": 176,
+              "readbackNanos": 195309,
+              "reduceNanos": 1166925,
+              "reduceNanosSamples": [
+                1190835,
+                1162483,
+                1164747,
+                1169103,
+                1189754,
+                1157506,
+                1169985,
+                1163976
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4419807
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3040037,
+              "rank": 176,
+              "readbackNanos": 193412,
+              "reduceNanos": 1114031,
+              "reduceNanosSamples": [
+                1095554,
+                1100923,
+                1115784,
+                1112549,
+                1122744,
+                1115513,
+                1118589,
+                1103316
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4342353
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3113802,
+              "smallAllocs": 242505
+            },
+            "columnCount": {
+              "nanos": 352735,
+              "smallAllocs": 31856
+            },
+            "eliminate": {
+              "nanos": 1113432,
+              "smallAllocs": 31856
+            },
+            "freeColumns": 2,
+            "innerMultiplies": 198292,
+            "pivotSearch": {
+              "nanos": 4602,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "readback": {
+              "nanos": 178920,
+              "smallAllocs": 1609
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 167666,
+              "smallAllocs": 704
+            },
+            "scaleMultiplies": 31328,
+            "stagedNanos": 1284872,
+            "wall": {
+              "nanos": 1692404,
+              "smallAllocs": 65310
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 103263,
+            "packNanos": 1430405,
+            "rank": 176,
+            "reduceNanos": 1955724,
+            "reduceNanosSamples": [
+              1937162,
+              1989099,
+              1974287,
+              1936541,
+              1929310,
+              1981007,
+              1934759,
+              2008989
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 291357,
+            "totalNanos": 3497150
+          },
+          "peakResidentBytes": 67796992,
+          "productionMatrixRebuild": {
+            "nanos": 3657397,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 16945428,
+            "smallAllocs": 984110
+          },
+          "productionRowReduce": {
+            "nanos": 16634672,
+            "smallAllocs": 951807
+          },
+          "rank": 176,
+          "residentBytesAfter": 67723264,
+          "residentBytesBefore": 65769472,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3656315,
+            "smallAllocs": 0
+          },
+          "sink": 180,
+          "splitFactors": 2
+        },
+        "modularDegree": 178,
+        "modularFactorCount": 2,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi179",
+      "status": "ok"
+    },
+    {
+      "degree": 80,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 80,
+          "basisToPolynomials": {
+            "nanos": 4020,
+            "smallAllocs": 307
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3773484,
+            "smallAllocs": 346439
+          },
+          "berlekampSplit": {
+            "nanos": 7821896,
+            "smallAllocs": 586770
+          },
+          "columnPolys": {
+            "nanos": 3605916,
+            "smallAllocs": 333055
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2006,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 12083926,
+              "smallAllocs": 705467
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 281219,
+              "smallAllocs": 17180
+            },
+            "stagedNanos": 12371995,
+            "wall": {
+              "nanos": 12458865,
+              "smallAllocs": 723226
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2099,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 23326893,
+              "smallAllocs": 1389787
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 382333,
+              "smallAllocs": 22780
+            },
+            "stagedNanos": 23709503,
+            "wall": {
+              "nanos": 23791837,
+              "smallAllocs": 1413149
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 98455,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4962702,
+            "smallAllocs": 347380
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3878500,
+            "smallAllocs": 352920
+          },
+          "frobeniusPower": {
+            "nanos": 8467,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 10,
+          "matrixConversionNanos": 160213,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3925274,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 171214,
+          "nullspaceBasisNanos": 171214,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5844,
+            "packNanos": 279614,
+            "rank": 70,
+            "reduceNanos": 1278405,
+            "reduceNanosSamples": [
+              1313227,
+              1275972,
+              1278325,
+              1278485,
+              1282040,
+              1271775,
+              1275962,
+              1281991
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1564564
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5513,
+            "packNanos": 280771,
+            "rank": 70,
+            "reduceNanos": 1321584,
+            "reduceNanosSamples": [
+              1322391,
+              1374187,
+              1318374,
+              1320778,
+              1320738,
+              1320388,
+              1325045,
+              1340988
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1609301
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6093,
+            "packNanos": 280776,
+            "rank": 70,
+            "reduceNanos": 1007153,
+            "reduceNanosSamples": [
+              1004449,
+              1009857,
+              1002787,
+              1011169,
+              1001985,
+              1014544,
+              999752,
+              1018510
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1297884
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3734131,
+              "rank": 70,
+              "readbackNanos": 105872,
+              "reduceNanos": 1104377,
+              "reduceNanosSamples": [
+                1110045,
+                1118628,
+                1098118,
+                1104628,
+                1099390,
+                1118538,
+                1104126,
+                1101904
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4950609
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3750295,
+              "rank": 70,
+              "readbackNanos": 104931,
+              "reduceNanos": 1429594,
+              "reduceNanosSamples": [
+                1429029,
+                1438292,
+                1420506,
+                1444792,
+                1430160,
+                1424111,
+                1435929,
+                1426155
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5284054
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3750550,
+              "rank": 70,
+              "readbackNanos": 105091,
+              "reduceNanos": 1195962,
+              "reduceNanosSamples": [
+                1176614,
+                1186188,
+                1178497,
+                1169594,
+                1205818,
+                1206198,
+                1215442,
+                1205737
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5049345
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3735477,
+              "rank": 70,
+              "readbackNanos": 5859,
+              "reduceNanos": 1298540,
+              "reduceNanosSamples": [
+                1322661,
+                1294499,
+                1301530,
+                1323152,
+                1323372,
+                1290654,
+                1291695,
+                1295551
+              ],
+              "smallAllocs": 341535,
+              "totalNanos": 5052395
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3742008,
+              "rank": 70,
+              "readbackNanos": 103919,
+              "reduceNanos": 1242302,
+              "reduceNanosSamples": [
+                1200931,
+                1255492,
+                1259247,
+                1247600,
+                1208983,
+                1237004,
+                1218767,
+                1252617
+              ],
+              "smallAllocs": 353284,
+              "totalNanos": 5090181
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3746118,
+              "rank": 70,
+              "readbackNanos": 106142,
+              "reduceNanos": 1346111,
+              "reduceNanosSamples": [
+                1345164,
+                1342801,
+                1345895,
+                1348720,
+                1347578,
+                1346327,
+                1339957,
+                1362710
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 5196163
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3761962,
+              "rank": 70,
+              "readbackNanos": 105011,
+              "reduceNanos": 1110331,
+              "reduceNanosSamples": [
+                1115854,
+                1110486,
+                1108003,
+                1109525,
+                1114181,
+                1110176,
+                1108483,
+                1111438
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4975271
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3733069,
+              "rank": 70,
+              "readbackNanos": 106583,
+              "reduceNanos": 1167074,
+              "reduceNanosSamples": [
+                1169504,
+                1166630,
+                1166709,
+                1167440,
+                1165558,
+                1165618,
+                1192438,
+                1205407
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 5006632
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3753374,
+              "rank": 70,
+              "readbackNanos": 104585,
+              "reduceNanos": 1111688,
+              "reduceNanosSamples": [
+                1106992,
+                1114603,
+                1115674,
+                1136505,
+                1105719,
+                1106571,
+                1112870,
+                1110507
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4970649
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3746745,
+              "rank": 70,
+              "readbackNanos": 104144,
+              "reduceNanos": 1108092,
+              "reduceNanosSamples": [
+                1106842,
+                1119901,
+                1112570,
+                1107652,
+                1108533,
+                1106961,
+                1107562,
+                1109255
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4957310
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3759468,
+              "rank": 70,
+              "readbackNanos": 104019,
+              "reduceNanos": 1309752,
+              "reduceNanosSamples": [
+                1290063,
+                1314829,
+                1287228,
+                1325465,
+                1314659,
+                1304845,
+                1291505,
+                1321939
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5165528
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3742368,
+              "rank": 70,
+              "readbackNanos": 103909,
+              "reduceNanos": 1196118,
+              "reduceNanosSamples": [
+                1204867,
+                1167260,
+                1194752,
+                1196934,
+                1208251,
+                1196554,
+                1195683,
+                1181802
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5041659
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3751807,
+              "smallAllocs": 340038
+            },
+            "columnCount": {
+              "nanos": 73310,
+              "smallAllocs": 5810
+            },
+            "eliminate": {
+              "nanos": 1074683,
+              "smallAllocs": 5810
+            },
+            "freeColumns": 10,
+            "innerMultiplies": 342160,
+            "pivotSearch": {
+              "nanos": 2132,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "readback": {
+              "nanos": 103954,
+              "smallAllocs": 3223
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 34679,
+              "smallAllocs": 280
+            },
+            "scaleMultiplies": 5600,
+            "stagedNanos": 1111713,
+            "wall": {
+              "nanos": 1199773,
+              "smallAllocs": 12296
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 24486,
+            "packNanos": 270581,
+            "rank": 70,
+            "reduceNanos": 2546105,
+            "reduceNanosSamples": [
+              2546987,
+              2544723,
+              2543541,
+              2546195,
+              2548528,
+              2548108,
+              2546015,
+              2471073
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 355100,
+            "totalNanos": 2841112
+          },
+          "peakResidentBytes": 66437120,
+          "productionMatrixRebuild": {
+            "nanos": 3910382,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 24047957,
+            "smallAllocs": 1408888
+          },
+          "productionRowReduce": {
+            "nanos": 23814701,
+            "smallAllocs": 1401336
+          },
+          "rank": 70,
+          "residentBytesAfter": 64528384,
+          "residentBytesBefore": 66899968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3896286,
+            "smallAllocs": 0
+          },
+          "sink": 74,
+          "splitFactors": 10
+        },
+        "modularDegree": 80,
+        "modularFactorCount": 10,
+        "prime": 11,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi64_x_phi105",
+      "status": "ok"
+    },
+    {
+      "degree": 144,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 144,
+          "basisToPolynomials": {
+            "nanos": 6644,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7850028,
+            "smallAllocs": 722207
+          },
+          "berlekampSplit": {
+            "nanos": 19695063,
+            "smallAllocs": 1239327
+          },
+          "columnPolys": {
+            "nanos": 7329165,
+            "smallAllocs": 680459
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3698,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 65003968,
+              "smallAllocs": 3858949
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 960778,
+              "smallAllocs": 59552
+            },
+            "stagedNanos": 65971732,
+            "wall": {
+              "nanos": 66280499,
+              "smallAllocs": 3919428
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3934,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 128176802,
+              "smallAllocs": 7645861
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 1361350,
+              "smallAllocs": 79136
+            },
+            "stagedNanos": 129542134,
+            "wall": {
+              "nanos": 129822899,
+              "smallAllocs": 7725927
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 286569,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 13779318,
+            "smallAllocs": 723728
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8158891,
+            "smallAllocs": 743088
+          },
+          "frobeniusPower": {
+            "nanos": 5404,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 8,
+          "matrixConversionNanos": 512795,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8281543,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 709607,
+          "nullspaceBasisNanos": 709607,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 13310,
+            "packNanos": 966122,
+            "rank": 136,
+            "reduceNanos": 6855643,
+            "reduceNanosSamples": [
+              6861292,
+              6841943,
+              6902192,
+              6854401,
+              6851858,
+              6866550,
+              6856885,
+              6852760
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7834375
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 12618,
+            "packNanos": 967023,
+            "rank": 136,
+            "reduceNanos": 7109535,
+            "reduceNanosSamples": [
+              7111073,
+              7116871,
+              7143791,
+              7096091,
+              7068760,
+              7112534,
+              7107998,
+              6963103
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 8084705
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14461,
+            "packNanos": 969307,
+            "rank": 136,
+            "reduceNanos": 5095018,
+            "reduceNanosSamples": [
+              5091398,
+              5091668,
+              5148563,
+              5107612,
+              5078629,
+              5083426,
+              5101953,
+              5098368
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 6083078
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7825291,
+              "rank": 136,
+              "readbackNanos": 241032,
+              "reduceNanos": 5703962,
+              "reduceNanosSamples": [
+                5800800,
+                5687311,
+                5706841,
+                5696946,
+                5695504,
+                5701083,
+                5710656,
+                5715944
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13772773
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7826062,
+              "rank": 136,
+              "readbackNanos": 239746,
+              "reduceNanos": 7528191,
+              "reduceNanosSamples": [
+                7521050,
+                7560880,
+                7509943,
+                7504506,
+                7523254,
+                7533128,
+                7550734,
+                7548641
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 15606597
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7825637,
+              "rank": 136,
+              "readbackNanos": 241668,
+              "reduceNanos": 6209866,
+              "reduceNanosSamples": [
+                6140053,
+                6251878,
+                6274883,
+                6051081,
+                6256325,
+                6086563,
+                6167854,
+                6287391
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14287512
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7831475,
+              "rank": 136,
+              "readbackNanos": 13054,
+              "reduceNanos": 7014008,
+              "reduceNanosSamples": [
+                7100256,
+                7124002,
+                6955762,
+                7054589,
+                7146605,
+                6961170,
+                6973428,
+                6956964
+              ],
+              "smallAllocs": 708207,
+              "totalNanos": 14843346
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7842757,
+              "rank": 136,
+              "readbackNanos": 239374,
+              "reduceNanos": 6356259,
+              "reduceNanosSamples": [
+                6320761,
+                6174193,
+                6402512,
+                6244968,
+                6391757,
+                6397364,
+                6267732,
+                6396052
+              ],
+              "smallAllocs": 739204,
+              "totalNanos": 14475841
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7849792,
+              "rank": 136,
+              "readbackNanos": 239550,
+              "reduceNanos": 7029331,
+              "reduceNanosSamples": [
+                7029492,
+                7019226,
+                7140536,
+                7000459,
+                7002962,
+                7063502,
+                7029982,
+                7029171
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 15117287
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7884900,
+              "rank": 136,
+              "readbackNanos": 240487,
+              "reduceNanos": 5750335,
+              "reduceNanosSamples": [
+                5732759,
+                5716575,
+                5758397,
+                5784045,
+                5764787,
+                5759809,
+                5733170,
+                5742273
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13883548
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7820499,
+              "rank": 136,
+              "readbackNanos": 240386,
+              "reduceNanos": 6053063,
+              "reduceNanosSamples": [
+                6040385,
+                6058252,
+                6048247,
+                6114375,
+                6049969,
+                6070650,
+                6040636,
+                6056158
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 14122958
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7836192,
+              "rank": 136,
+              "readbackNanos": 243646,
+              "reduceNanos": 5735708,
+              "reduceNanosSamples": [
+                5739579,
+                5731307,
+                5715554,
+                5764966,
+                5716365,
+                5733901,
+                5752829,
+                5737516
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13804956
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7861475,
+              "rank": 136,
+              "readbackNanos": 242354,
+              "reduceNanos": 5741968,
+              "reduceNanosSamples": [
+                5727761,
+                5719520,
+                5740601,
+                5759699,
+                5776854,
+                5763865,
+                5727882,
+                5743335
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13850544
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7827419,
+              "rank": 136,
+              "readbackNanos": 240125,
+              "reduceNanos": 6863520,
+              "reduceNanosSamples": [
+                6847622,
+                6855173,
+                6871868,
+                6923745,
+                6778840,
+                6742636,
+                6895023,
+                6932217
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14885573
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7821546,
+              "rank": 136,
+              "readbackNanos": 239570,
+              "reduceNanos": 6178229,
+              "reduceNanosSamples": [
+                6179892,
+                6176567,
+                6143868,
+                6235394,
+                6101986,
+                6311206,
+                6278608,
+                6092943
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14221965
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7876222,
+              "smallAllocs": 701470
+            },
+            "columnCount": {
+              "nanos": 238850,
+              "smallAllocs": 19992
+            },
+            "eliminate": {
+              "nanos": 5612925,
+              "smallAllocs": 19992
+            },
+            "freeColumns": 8,
+            "innerMultiplies": 1893456,
+            "pivotSearch": {
+              "nanos": 3780,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "readback": {
+              "nanos": 238483,
+              "smallAllocs": 4723
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 111749,
+              "smallAllocs": 544
+            },
+            "scaleMultiplies": 19584,
+            "stagedNanos": 5726699,
+            "wall": {
+              "nanos": 6012684,
+              "smallAllocs": 41246
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 80659,
+            "packNanos": 935262,
+            "rank": 136,
+            "reduceNanos": 13473029,
+            "reduceNanosSamples": [
+              13481036,
+              13561776,
+              13563558,
+              13229583,
+              13591860,
+              13448428,
+              13448688,
+              13465023
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 1938068,
+            "totalNanos": 14512095
+          },
+          "peakResidentBytes": 66437120,
+          "productionMatrixRebuild": {
+            "nanos": 8296069,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 133052241,
+            "smallAllocs": 7708346
+          },
+          "productionRowReduce": {
+            "nanos": 132730153,
+            "smallAllocs": 7685628
+          },
+          "rank": 136,
+          "residentBytesAfter": 66121728,
+          "residentBytesBefore": 64630784,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8382151,
+            "smallAllocs": 0
+          },
+          "sink": 138,
+          "splitFactors": 8
+        },
+        "modularDegree": 144,
+        "modularFactorCount": 8,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi128_x_phi165",
+      "status": "ok"
+    },
+    {
+      "degree": 240,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 240,
+          "basisToPolynomials": {
+            "nanos": 7295,
+            "smallAllocs": 523
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7399791,
+            "smallAllocs": 660179
+          },
+          "berlekampSplit": {
+            "nanos": 25224316,
+            "smallAllocs": 1030964
+          },
+          "columnPolys": {
+            "nanos": 6084170,
+            "smallAllocs": 544863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6432,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 153604198,
+              "smallAllocs": 8803144
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 2888401,
+              "smallAllocs": 171267
+            },
+            "stagedNanos": 156506710,
+            "wall": {
+              "nanos": 157431354,
+              "smallAllocs": 8975874
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6560,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 300618226,
+              "smallAllocs": 17418184
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 3973765,
+              "smallAllocs": 227907
+            },
+            "stagedNanos": 304597225,
+            "wall": {
+              "nanos": 305446693,
+              "smallAllocs": 17647557
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 856233,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 21107903,
+            "smallAllocs": 661844
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8243992,
+            "smallAllocs": 718020
+          },
+          "frobeniusPower": {
+            "nanos": 3085,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 1302080,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8427574,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 1587113,
+          "nullspaceBasisNanos": 1587113,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 26944,
+            "packNanos": 2767092,
+            "rank": 236,
+            "reduceNanos": 15646892,
+            "reduceNanosSamples": [
+              15689110,
+              15624153,
+              15628010,
+              15748188,
+              15639777,
+              15604364,
+              15707688,
+              15654008
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18466057
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 26409,
+            "packNanos": 2758204,
+            "rank": 236,
+            "reduceNanos": 16087986,
+            "reduceNanosSamples": [
+              16012299,
+              16197744,
+              16188420,
+              16017537,
+              16028924,
+              16147048,
+              15882216,
+              16174400
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18896259
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 27360,
+            "packNanos": 2781108,
+            "rank": 236,
+            "reduceNanos": 9283378,
+            "reduceNanosSamples": [
+              9262853,
+              9280719,
+              9300228,
+              9269172,
+              9277654,
+              9300459,
+              9286037,
+              9289713
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 12095737
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7423445,
+              "rank": 236,
+              "readbackNanos": 425416,
+              "reduceNanos": 13180330,
+              "reduceNanosSamples": [
+                13137306,
+                13201732,
+                13158928,
+                13152709,
+                13208092,
+                13203525,
+                13119350,
+                13213139
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21058775
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7439510,
+              "rank": 236,
+              "readbackNanos": 424634,
+              "reduceNanos": 17088384,
+              "reduceNanosSamples": [
+                17092741,
+                17083858,
+                17084028,
+                17074073,
+                17154031,
+                17133381,
+                17115905,
+                17082265
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 24966789
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7454982,
+              "rank": 236,
+              "readbackNanos": 422431,
+              "reduceNanos": 13919285,
+              "reduceNanosSamples": [
+                13871685,
+                13836684,
+                14105372,
+                14041417,
+                13771126,
+                13966886,
+                14201034,
+                13866157
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21791677
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7469313,
+              "rank": 236,
+              "readbackNanos": 27035,
+              "reduceNanos": 16043415,
+              "reduceNanosSamples": [
+                16103734,
+                15879322,
+                15909537,
+                16410609,
+                16072257,
+                15897950,
+                16014573,
+                16251434
+              ],
+              "smallAllocs": 641764,
+              "totalNanos": 23574440
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7474341,
+              "rank": 236,
+              "readbackNanos": 422061,
+              "reduceNanos": 14473177,
+              "reduceNanosSamples": [
+                14561798,
+                14341542,
+                14420870,
+                14525484,
+                14565844,
+                14378817,
+                14558544,
+                14312850
+              ],
+              "smallAllocs": 681727,
+              "totalNanos": 22288739
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7553463,
+              "rank": 236,
+              "readbackNanos": 423768,
+              "reduceNanos": 16198525,
+              "reduceNanosSamples": [
+                16156263,
+                16218154,
+                16201670,
+                16131966,
+                16195381,
+                16214479,
+                16165135,
+                16228179
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 24165862
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7466474,
+              "rank": 236,
+              "readbackNanos": 418600,
+              "reduceNanos": 13280459,
+              "reduceNanosSamples": [
+                13266138,
+                13298847,
+                13221882,
+                13208523,
+                13294780,
+                13635896,
+                13198427,
+                13326948
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21214832
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7418413,
+              "rank": 236,
+              "readbackNanos": 423302,
+              "reduceNanos": 13995148,
+              "reduceNanosSamples": [
+                13930903,
+                14015048,
+                13957502,
+                14023360,
+                13983100,
+                14007196,
+                13934568,
+                14034207
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21839673
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7450000,
+              "rank": 236,
+              "readbackNanos": 419336,
+              "reduceNanos": 13282051,
+              "reduceNanosSamples": [
+                13317394,
+                13279327,
+                13223284,
+                13238577,
+                13284775,
+                13289151,
+                13223605,
+                13300428
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21162759
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7473530,
+              "rank": 236,
+              "readbackNanos": 418039,
+              "reduceNanos": 13252293,
+              "reduceNanosSamples": [
+                13202173,
+                13279267,
+                13230575,
+                13230455,
+                13271917,
+                13284986,
+                13232669,
+                13319226
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21189359
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7458187,
+              "rank": 236,
+              "readbackNanos": 423397,
+              "reduceNanos": 15582582,
+              "reduceNanosSamples": [
+                15593919,
+                15740656,
+                15571246,
+                15367122,
+                15618876,
+                15535322,
+                15629211,
+                15385029
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 23432785
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7449339,
+              "rank": 236,
+              "readbackNanos": 423953,
+              "reduceNanos": 13983706,
+              "reduceNanosSamples": [
+                14032424,
+                13860599,
+                13868671,
+                14009620,
+                13947698,
+                14147765,
+                13957793,
+                14053345
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21878476
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7507159,
+              "smallAllocs": 602578
+            },
+            "columnCount": {
+              "nanos": 717992,
+              "smallAllocs": 57348
+            },
+            "eliminate": {
+              "nanos": 12920977,
+              "smallAllocs": 57348
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4307520,
+            "pivotSearch": {
+              "nanos": 6317,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "readback": {
+              "nanos": 395616,
+              "smallAllocs": 4083
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 295207,
+              "smallAllocs": 944
+            },
+            "scaleMultiplies": 56640,
+            "stagedNanos": 13221321,
+            "wall": {
+              "nanos": 14053114,
+              "smallAllocs": 116842
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 266009,
+            "packNanos": 2678396,
+            "rank": 236,
+            "reduceNanos": 32382558,
+            "reduceNanosSamples": [
+              32566011,
+              33495388,
+              32367776,
+              32503088,
+              32397341,
+              32353415,
+              31523285,
+              32292315
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 4446309,
+            "totalNanos": 35371530
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 8478584,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 313435778,
+            "smallAllocs": 17591476
+          },
+          "productionRowReduce": {
+            "nanos": 311807970,
+            "smallAllocs": 17532366
+          },
+          "rank": 236,
+          "residentBytesAfter": 70643712,
+          "residentBytesBefore": 66224128,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8769396,
+            "smallAllocs": 0
+          },
+          "sink": 238,
+          "splitFactors": 4
+        },
+        "modularDegree": 240,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi385",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 18227,
+            "smallAllocs": 1843
+          },
+          "berlekampMatrixWall": {
+            "nanos": 191654,
+            "smallAllocs": 17281
+          },
+          "berlekampSplit": {
+            "nanos": 105131,
+            "smallAllocs": 8327
+          },
+          "columnPolys": {
+            "nanos": 74125,
+            "smallAllocs": 6155
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 936,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 936,
+            "wall": {
+              "nanos": 42392,
+              "smallAllocs": 1807
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 976,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 976,
+            "wall": {
+              "nanos": 40840,
+              "smallAllocs": 1810
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26854,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 222695,
+            "smallAllocs": 17402
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 218564,
+            "smallAllocs": 18922
+          },
+          "frobeniusPower": {
+            "nanos": 84270,
+            "smallAllocs": 7927
+          },
+          "kernelDimension": 40,
+          "matrixConversionNanos": 33740,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 219440,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 47,
+          "nullspaceBasisMagnitudeNanos": 40615,
+          "nullspaceBasisNanos": 40615,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1442,
+            "packNanos": 66608,
+            "rank": 0,
+            "reduceNanos": 4567,
+            "reduceNanosSamples": [
+              6489,
+              4457,
+              5077,
+              4006,
+              4737,
+              4036,
+              4677,
+              4036
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72612
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1302,
+            "packNanos": 66294,
+            "rank": 0,
+            "reduceNanos": 4081,
+            "reduceNanosSamples": [
+              4256,
+              4496,
+              4036,
+              4116,
+              4046,
+              4576,
+              4035,
+              4046
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 71902
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1507,
+            "packNanos": 66779,
+            "rank": 0,
+            "reduceNanos": 4291,
+            "reduceNanosSamples": [
+              4096,
+              5819,
+              4006,
+              5038,
+              4036,
+              4877,
+              4076,
+              4487
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72753
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 188940,
+              "rank": 0,
+              "readbackNanos": 81816,
+              "reduceNanos": 3736,
+              "reduceNanosSamples": [
+                3976,
+                3986,
+                3716,
+                3795,
+                3736,
+                3725,
+                3735,
+                3736
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274717
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189050,
+              "rank": 0,
+              "readbackNanos": 81851,
+              "reduceNanos": 3740,
+              "reduceNanosSamples": [
+                3745,
+                3996,
+                3595,
+                3946,
+                3585,
+                3735,
+                3585,
+                3746
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274571
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189030,
+              "rank": 0,
+              "readbackNanos": 81896,
+              "reduceNanos": 3585,
+              "reduceNanosSamples": [
+                3575,
+                3575,
+                3585,
+                3596,
+                3575,
+                3585,
+                3586,
+                3585
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274687
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189671,
+              "rank": 0,
+              "readbackNanos": 1367,
+              "reduceNanos": 4141,
+              "reduceNanosSamples": [
+                4246,
+                4146,
+                4347,
+                4136,
+                4137,
+                4076,
+                4136,
+                4186
+              ],
+              "smallAllocs": 15774,
+              "totalNanos": 195199
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 188739,
+              "rank": 0,
+              "readbackNanos": 81530,
+              "reduceNanos": 3585,
+              "reduceNanosSamples": [
+                3585,
+                3586,
+                3575,
+                3585,
+                3576,
+                3595,
+                3596,
+                3696
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274156
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189235,
+              "rank": 0,
+              "readbackNanos": 81721,
+              "reduceNanos": 3580,
+              "reduceNanosSamples": [
+                3586,
+                3576,
+                3596,
+                3575,
+                3585,
+                3575,
+                3586,
+                3576
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274336
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189210,
+              "rank": 0,
+              "readbackNanos": 81611,
+              "reduceNanos": 3615,
+              "reduceNanosSamples": [
+                3815,
+                3575,
+                3615,
+                3575,
+                3615,
+                3595,
+                3625,
+                3616
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 275028
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189510,
+              "rank": 0,
+              "readbackNanos": 82076,
+              "reduceNanos": 3590,
+              "reduceNanosSamples": [
+                3595,
+                3586,
+                3586,
+                3586,
+                3585,
+                3756,
+                3595,
+                3646
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 277075
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189130,
+              "rank": 0,
+              "readbackNanos": 82007,
+              "reduceNanos": 3675,
+              "reduceNanosSamples": [
+                3715,
+                3706,
+                3675,
+                3685,
+                3645,
+                3675,
+                3646,
+                3676
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274988
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 192260,
+              "rank": 0,
+              "readbackNanos": 81851,
+              "reduceNanos": 3670,
+              "reduceNanosSamples": [
+                4246,
+                3595,
+                3866,
+                3596,
+                3776,
+                3605,
+                3735,
+                3595
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 277777
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189295,
+              "rank": 0,
+              "readbackNanos": 81801,
+              "reduceNanos": 3620,
+              "reduceNanosSamples": [
+                3585,
+                3615,
+                3575,
+                3625,
+                3685,
+                3606,
+                3755,
+                3626
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274697
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 191324,
+              "rank": 0,
+              "readbackNanos": 81971,
+              "reduceNanos": 3580,
+              "reduceNanosSamples": [
+                3575,
+                3575,
+                3675,
+                3586,
+                3575,
+                3585,
+                3575,
+                3586
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 276845
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 189240,
+              "smallAllocs": 15680
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 40,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1046,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 81005,
+              "smallAllocs": 5003
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1046,
+            "wall": {
+              "nanos": 6349,
+              "smallAllocs": 166
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5473,
+            "packNanos": 64010,
+            "rank": 0,
+            "reduceNanos": 5158,
+            "reduceNanosSamples": [
+              6359,
+              5448,
+              5218,
+              5408,
+              5098,
+              4907,
+              4647,
+              4777
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 75021
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 219320,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 84264,
+            "smallAllocs": 1728
+          },
+          "productionRowReduce": {
+            "nanos": 43504,
+            "smallAllocs": 1607
+          },
+          "rank": 0,
+          "residentBytesAfter": 69976064,
+          "residentBytesBefore": 69971968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 220657,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 40
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 40,
+        "prime": 47,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_40",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 24912,
+            "smallAllocs": 2595
+          },
+          "berlekampMatrixWall": {
+            "nanos": 275388,
+            "smallAllocs": 24749
+          },
+          "berlekampSplit": {
+            "nanos": 169792,
+            "smallAllocs": 12707
+          },
+          "columnPolys": {
+            "nanos": 103082,
+            "smallAllocs": 8727
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1120,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1120,
+            "wall": {
+              "nanos": 60489,
+              "smallAllocs": 2551
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1166,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1166,
+            "wall": {
+              "nanos": 57250,
+              "smallAllocs": 2554
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 37235,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 317961,
+            "smallAllocs": 24894
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 312583,
+            "smallAllocs": 27102
+          },
+          "frobeniusPower": {
+            "nanos": 122821,
+            "smallAllocs": 11415
+          },
+          "kernelDimension": 48,
+          "matrixConversionNanos": 50024,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 316064,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 61,
+          "nullspaceBasisMagnitudeNanos": 56439,
+          "nullspaceBasisNanos": 56439,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1768,
+            "packNanos": 96899,
+            "rank": 0,
+            "reduceNanos": 6059,
+            "reduceNanosSamples": [
+              6279,
+              5608,
+              6830,
+              5909,
+              6389,
+              5568,
+              6209,
+              5558
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104490
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1687,
+            "packNanos": 97018,
+            "rank": 0,
+            "reduceNanos": 5648,
+            "reduceNanosSamples": [
+              5649,
+              5648,
+              5939,
+              5939,
+              5588,
+              5619,
+              5969,
+              5638
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104354
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1817,
+            "packNanos": 97254,
+            "rank": 0,
+            "reduceNanos": 6004,
+            "reduceNanosSamples": [
+              5588,
+              6900,
+              5618,
+              6459,
+              5598,
+              6099,
+              5909,
+              6159
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 105075
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 269755,
+              "rank": 0,
+              "readbackNanos": 124775,
+              "reduceNanos": 5243,
+              "reduceNanosSamples": [
+                5238,
+                5257,
+                5218,
+                5207,
+                5307,
+                5168,
+                5257,
+                5248
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 400669
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272414,
+              "rank": 0,
+              "readbackNanos": 124148,
+              "reduceNanos": 5138,
+              "reduceNanosSamples": [
+                5078,
+                5489,
+                5037,
+                5247,
+                5047,
+                5198,
+                5057,
+                5228
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 402001
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270185,
+              "rank": 0,
+              "readbackNanos": 124004,
+              "reduceNanos": 5047,
+              "reduceNanosSamples": [
+                5068,
+                5058,
+                5037,
+                5038,
+                9134,
+                5027,
+                5037,
+                5057
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 399907
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271472,
+              "rank": 0,
+              "readbackNanos": 2243,
+              "reduceNanos": 5768,
+              "reduceNanosSamples": [
+                5739,
+                5719,
+                6039,
+                6219,
+                5798,
+                5639,
+                5908,
+                5639
+              ],
+              "smallAllocs": 22554,
+              "totalNanos": 279409
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270756,
+              "rank": 0,
+              "readbackNanos": 124439,
+              "reduceNanos": 5057,
+              "reduceNanosSamples": [
+                5038,
+                5218,
+                5238,
+                5048,
+                5037,
+                5067,
+                5047,
+                5067
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 400598
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271608,
+              "rank": 0,
+              "readbackNanos": 124269,
+              "reduceNanos": 5057,
+              "reduceNanosSamples": [
+                5027,
+                5057,
+                5057,
+                5137,
+                5067,
+                5037,
+                5058,
+                5057
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 400819
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270365,
+              "rank": 0,
+              "readbackNanos": 125931,
+              "reduceNanos": 5067,
+              "reduceNanosSamples": [
+                5078,
+                5158,
+                5047,
+                5128,
+                5077,
+                5047,
+                5057,
+                5038
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 402071
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271106,
+              "rank": 0,
+              "readbackNanos": 124405,
+              "reduceNanos": 5052,
+              "reduceNanosSamples": [
+                5048,
+                5057,
+                5057,
+                5037,
+                5028,
+                5137,
+                5137,
+                5048
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 401054
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272278,
+              "rank": 0,
+              "readbackNanos": 124399,
+              "reduceNanos": 5213,
+              "reduceNanosSamples": [
+                5238,
+                5188,
+                5168,
+                5318,
+                5267,
+                5148,
+                6249,
+                5158
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 402276
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270546,
+              "rank": 0,
+              "readbackNanos": 125075,
+              "reduceNanos": 5127,
+              "reduceNanosSamples": [
+                5258,
+                5037,
+                5328,
+                5028,
+                5197,
+                5027,
+                5207,
+                5058
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 401369
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271532,
+              "rank": 0,
+              "readbackNanos": 124039,
+              "reduceNanos": 5057,
+              "reduceNanosSamples": [
+                5067,
+                5058,
+                5038,
+                5037,
+                5057,
+                5137,
+                5228,
+                5047
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 401565
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270020,
+              "rank": 0,
+              "readbackNanos": 124239,
+              "reduceNanos": 5047,
+              "reduceNanosSamples": [
+                5047,
+                5048,
+                5037,
+                5138,
+                5228,
+                5037,
+                5047,
+                5138
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 399442
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 271061,
+              "smallAllocs": 22444
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 48,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1198,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 122947,
+              "smallAllocs": 7155
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1198,
+            "wall": {
+              "nanos": 8162,
+              "smallAllocs": 198
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 7140,
+            "packNanos": 93809,
+            "rank": 0,
+            "reduceNanos": 6440,
+            "reduceNanosSamples": [
+              6469,
+              6901,
+              6420,
+              6790,
+              6239,
+              6290,
+              6460,
+              6420
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 107730
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 313334,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 120118,
+            "smallAllocs": 2456
+          },
+          "productionRowReduce": {
+            "nanos": 63869,
+            "smallAllocs": 2311
+          },
+          "rank": 0,
+          "residentBytesAfter": 70041600,
+          "residentBytesBefore": 69992448,
+          "rowReduceMatrixRebuild": {
+            "nanos": 315673,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 48
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 48,
+        "prime": 61,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_48",
+      "status": "ok"
+    },
+    {
+      "degree": 56,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 56,
+          "basisToPolynomials": {
+            "nanos": 33875,
+            "smallAllocs": 3475
+          },
+          "berlekampMatrixWall": {
+            "nanos": 455505,
+            "smallAllocs": 40562
+          },
+          "berlekampSplit": {
+            "nanos": 220337,
+            "smallAllocs": 16143
+          },
+          "columnPolys": {
+            "nanos": 138024,
+            "smallAllocs": 11747
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1324,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1324,
+            "wall": {
+              "nanos": 81020,
+              "smallAllocs": 3423
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1333,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1333,
+            "wall": {
+              "nanos": 78040,
+              "smallAllocs": 3426
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 47035,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 510812,
+            "smallAllocs": 40731
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 502024,
+            "smallAllocs": 43755
+          },
+          "frobeniusPower": {
+            "nanos": 246395,
+            "smallAllocs": 22544
+          },
+          "kernelDimension": 56,
+          "matrixConversionNanos": 71620,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 505695,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 74340,
+          "nullspaceBasisNanos": 74340,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2259,
+            "packNanos": 136132,
+            "rank": 0,
+            "reduceNanos": 7942,
+            "reduceNanosSamples": [
+              8142,
+              7661,
+              8793,
+              7691,
+              8403,
+              7471,
+              8432,
+              7742
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 146667
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1998,
+            "packNanos": 135876,
+            "rank": 0,
+            "reduceNanos": 7711,
+            "reduceNanosSamples": [
+              7621,
+              7691,
+              7591,
+              7752,
+              7791,
+              7582,
+              7771,
+              7731
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145565
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2188,
+            "packNanos": 136187,
+            "rank": 0,
+            "reduceNanos": 7972,
+            "reduceNanosSamples": [
+              7461,
+              8223,
+              7571,
+              12709,
+              7822,
+              8122,
+              7821,
+              8352
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 146456
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 446502,
+              "rank": 0,
+              "readbackNanos": 172340,
+              "reduceNanos": 6945,
+              "reduceNanosSamples": [
+                6950,
+                6961,
+                6970,
+                6961,
+                6931,
+                6940,
+                6911,
+                6940
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 625532
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 446527,
+              "rank": 0,
+              "readbackNanos": 171484,
+              "reduceNanos": 6880,
+              "reduceNanosSamples": [
+                6820,
+                6941,
+                6780,
+                6970,
+                6770,
+                6991,
+                6760,
+                6950
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 625062
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 447764,
+              "rank": 0,
+              "readbackNanos": 171284,
+              "reduceNanos": 6775,
+              "reduceNanosSamples": [
+                6850,
+                6800,
+                6740,
+                6780,
+                6770,
+                6780,
+                6750,
+                6760
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 627035
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 447153,
+              "rank": 0,
+              "readbackNanos": 2459,
+              "reduceNanos": 7736,
+              "reduceNanosSamples": [
+                7631,
+                7731,
+                7741,
+                7811,
+                7882,
+                7581,
+                7861,
+                7731
+              ],
+              "smallAllocs": 37551,
+              "totalNanos": 457358
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 448605,
+              "rank": 0,
+              "readbackNanos": 171499,
+              "reduceNanos": 6770,
+              "reduceNanosSamples": [
+                6880,
+                6800,
+                6771,
+                6760,
+                6780,
+                6770,
+                6760,
+                6770
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 626874
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 446822,
+              "rank": 0,
+              "readbackNanos": 173272,
+              "reduceNanos": 6770,
+              "reduceNanosSamples": [
+                6830,
+                6850,
+                6770,
+                6770,
+                6750,
+                6750,
+                6770,
+                6740
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 627640
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 446417,
+              "rank": 0,
+              "readbackNanos": 171919,
+              "reduceNanos": 6780,
+              "reduceNanosSamples": [
+                6890,
+                6870,
+                6770,
+                6800,
+                6790,
+                6770,
+                6770,
+                6770
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 625452
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 446136,
+              "rank": 0,
+              "readbackNanos": 171374,
+              "reduceNanos": 6775,
+              "reduceNanosSamples": [
+                6850,
+                6841,
+                6780,
+                6771,
+                6760,
+                6760,
+                6791,
+                6760
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 625557
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 447318,
+              "rank": 0,
+              "readbackNanos": 173186,
+              "reduceNanos": 6890,
+              "reduceNanosSamples": [
+                6920,
+                6891,
+                6920,
+                6910,
+                6890,
+                6890,
+                6870,
+                6881
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 626894
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 447769,
+              "rank": 0,
+              "readbackNanos": 171930,
+              "reduceNanos": 6935,
+              "reduceNanosSamples": [
+                7080,
+                6810,
+                6971,
+                6740,
+                6950,
+                6790,
+                6920,
+                8793
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 626438
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 449406,
+              "rank": 0,
+              "readbackNanos": 172125,
+              "reduceNanos": 6770,
+              "reduceNanosSamples": [
+                6860,
+                6900,
+                6770,
+                6770,
+                6750,
+                6760,
+                6750,
+                6790
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 627996
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 445691,
+              "rank": 0,
+              "readbackNanos": 171945,
+              "reduceNanos": 6765,
+              "reduceNanosSamples": [
+                6841,
+                6860,
+                6760,
+                6759,
+                6760,
+                6750,
+                6780,
+                6770
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 623955
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 447383,
+              "smallAllocs": 37425
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 56,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1407,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 169260,
+              "smallAllocs": 9691
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1407,
+            "wall": {
+              "nanos": 10701,
+              "smallAllocs": 230
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10641,
+            "packNanos": 130258,
+            "rank": 0,
+            "reduceNanos": 8453,
+            "reduceNanosSamples": [
+              8633,
+              8333,
+              8533,
+              8302,
+              8673,
+              8292,
+              8622,
+              8373
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 149591
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 503417,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 161003,
+            "smallAllocs": 3312
+          },
+          "productionRowReduce": {
+            "nanos": 84885,
+            "smallAllocs": 3143
+          },
+          "rank": 0,
+          "residentBytesAfter": 70070272,
+          "residentBytesBefore": 70070272,
+          "rowReduceMatrixRebuild": {
+            "nanos": 505924,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 56
+        },
+        "modularDegree": 56,
+        "modularFactorCount": 56,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_56",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1196,
+            "smallAllocs": 90
+          },
+          "berlekampMatrixWall": {
+            "nanos": 122632,
+            "smallAllocs": 10805
+          },
+          "berlekampSplit": {
+            "nanos": 182310,
+            "smallAllocs": 13395
+          },
+          "columnPolys": {
+            "nanos": 105531,
+            "smallAllocs": 9437
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 625,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 128085,
+              "smallAllocs": 7021
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 28938,
+              "smallAllocs": 1639
+            },
+            "stagedNanos": 157854,
+            "wall": {
+              "nanos": 167278,
+              "smallAllocs": 8826
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 616,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 221810,
+              "smallAllocs": 12397
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 39169,
+              "smallAllocs": 2143
+            },
+            "stagedNanos": 261763,
+            "wall": {
+              "nanos": 270746,
+              "smallAllocs": 14709
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9714,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 151600,
+            "smallAllocs": 10941
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 132466,
+            "smallAllocs": 11406
+          },
+          "frobeniusPower": {
+            "nanos": 3390,
+            "smallAllocs": 217
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 13185,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 131996,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 5,
+          "nullspaceBasisMagnitudeNanos": 11637,
+          "nullspaceBasisNanos": 11637,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 896,
+            "packNanos": 21858,
+            "rank": 21,
+            "reduceNanos": 18752,
+            "reduceNanosSamples": [
+              21072,
+              18138,
+              19609,
+              18207,
+              19038,
+              18617,
+              18888,
+              18447
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 41567
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 766,
+            "packNanos": 21772,
+            "rank": 21,
+            "reduceNanos": 18277,
+            "reduceNanosSamples": [
+              18888,
+              18437,
+              18267,
+              18267,
+              18077,
+              18317,
+              18146,
+              18287
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 40845
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 986,
+            "packNanos": 22068,
+            "rank": 21,
+            "reduceNanos": 14962,
+            "reduceNanosSamples": [
+              14902,
+              15843,
+              14462,
+              15073,
+              14101,
+              15022,
+              14070,
+              15053
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 37901
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121845,
+              "rank": 21,
+              "readbackNanos": 7922,
+              "reduceNanos": 23630,
+              "reduceNanosSamples": [
+                23896,
+                23705,
+                23444,
+                23665,
+                23455,
+                23595,
+                23525,
+                23725
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 153282
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121450,
+              "rank": 21,
+              "readbackNanos": 7827,
+              "reduceNanos": 22949,
+              "reduceNanosSamples": [
+                23465,
+                23605,
+                22543,
+                22984,
+                22643,
+                22914,
+                22463,
+                25658
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 152205
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120393,
+              "rank": 21,
+              "readbackNanos": 7751,
+              "reduceNanos": 20726,
+              "reduceNanosSamples": [
+                21462,
+                21031,
+                20811,
+                23104,
+                20641,
+                20370,
+                20230,
+                20311
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 149026
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120809,
+              "rank": 21,
+              "readbackNanos": 881,
+              "reduceNanos": 18072,
+              "reduceNanosSamples": [
+                18578,
+                18117,
+                18057,
+                18056,
+                17977,
+                18027,
+                18327,
+                18087
+              ],
+              "smallAllocs": 10682,
+              "totalNanos": 139937
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121605,
+              "rank": 21,
+              "readbackNanos": 7741,
+              "reduceNanos": 25247,
+              "reduceNanosSamples": [
+                26550,
+                25477,
+                25087,
+                25227,
+                25217,
+                25268,
+                25157,
+                25348
+              ],
+              "smallAllocs": 11210,
+              "totalNanos": 154529
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121816,
+              "rank": 21,
+              "readbackNanos": 7737,
+              "reduceNanos": 25878,
+              "reduceNanosSamples": [
+                27030,
+                26369,
+                26028,
+                25868,
+                25888,
+                25798,
+                25869,
+                25688
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 155636
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121685,
+              "rank": 21,
+              "readbackNanos": 7776,
+              "reduceNanos": 23550,
+              "reduceNanosSamples": [
+                24437,
+                23424,
+                23665,
+                23505,
+                23565,
+                23535,
+                23645,
+                23365
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 153222
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120729,
+              "rank": 21,
+              "readbackNanos": 7771,
+              "reduceNanos": 24551,
+              "reduceNanosSamples": [
+                25918,
+                24757,
+                24767,
+                24306,
+                24426,
+                24356,
+                24676,
+                24346
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 153007
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121460,
+              "rank": 21,
+              "readbackNanos": 7911,
+              "reduceNanos": 23414,
+              "reduceNanosSamples": [
+                23425,
+                23404,
+                23325,
+                23485,
+                23395,
+                23385,
+                23434,
+                23435
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 152826
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121469,
+              "rank": 21,
+              "readbackNanos": 7811,
+              "reduceNanos": 23660,
+              "reduceNanosSamples": [
+                24426,
+                23485,
+                23835,
+                23445,
+                24056,
+                23415,
+                23976,
+                23435
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 152866
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 121355,
+              "rank": 21,
+              "readbackNanos": 7781,
+              "reduceNanos": 21552,
+              "reduceNanosSamples": [
+                22324,
+                21442,
+                21572,
+                21662,
+                21211,
+                21532,
+                21451,
+                21692
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 150653
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120598,
+              "rank": 21,
+              "readbackNanos": 7736,
+              "reduceNanos": 20450,
+              "reduceNanosSamples": [
+                21251,
+                20521,
+                23114,
+                20391,
+                20300,
+                20410,
+                20069,
+                20491
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 149492
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 121986,
+              "smallAllocs": 10228
+            },
+            "columnCount": {
+              "nanos": 8337,
+              "smallAllocs": 567
+            },
+            "eliminate": {
+              "nanos": 20253,
+              "smallAllocs": 567
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 2688,
+            "pivotSearch": {
+              "nanos": 656,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "readback": {
+              "nanos": 7566,
+              "smallAllocs": 318
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 4918,
+              "smallAllocs": 84
+            },
+            "scaleMultiplies": 504,
+            "stagedNanos": 25834,
+            "wall": {
+              "nanos": 36534,
+              "smallAllocs": 1341
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2504,
+            "packNanos": 21191,
+            "rank": 21,
+            "reduceNanos": 31927,
+            "reduceNanosSamples": [
+              31838,
+              32648,
+              30214,
+              32148,
+              29854,
+              32017,
+              29824,
+              32479
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 4129,
+            "totalNanos": 55572
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 131826,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 262519,
+            "smallAllocs": 14185
+          },
+          "productionRowReduce": {
+            "nanos": 251107,
+            "smallAllocs": 13515
+          },
+          "rank": 21,
+          "residentBytesAfter": 70270976,
+          "residentBytesBefore": 70270976,
+          "rowReduceMatrixRebuild": {
+            "nanos": 131650,
+            "smallAllocs": 0
+          },
+          "sink": 92,
+          "splitFactors": 3
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 3,
+        "prime": 5,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_T24",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1262,
+            "smallAllocs": 99
+          },
+          "berlekampMatrixWall": {
+            "nanos": 85997,
+            "smallAllocs": 7348
+          },
+          "berlekampSplit": {
+            "nanos": 178690,
+            "smallAllocs": 12764
+          },
+          "columnPolys": {
+            "nanos": 70775,
+            "smallAllocs": 6080
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 608,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 113698,
+              "smallAllocs": 6262
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 26820,
+              "smallAllocs": 1560
+            },
+            "stagedNanos": 141117,
+            "wall": {
+              "nanos": 152371,
+              "smallAllocs": 7993
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 600,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 193412,
+              "smallAllocs": 10966
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 36486,
+              "smallAllocs": 2040
+            },
+            "stagedNanos": 230457,
+            "wall": {
+              "nanos": 239460,
+              "smallAllocs": 13180
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9864,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 112647,
+            "smallAllocs": 7501
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 95822,
+            "smallAllocs": 7949
+          },
+          "frobeniusPower": {
+            "nanos": 2013,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 13054,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 95366,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 13089,
+          "nullspaceBasisNanos": 13089,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 961,
+            "packNanos": 21857,
+            "rank": 20,
+            "reduceNanos": 16780,
+            "reduceNanosSamples": [
+              17595,
+              16344,
+              17146,
+              16414,
+              17205,
+              16304,
+              17416,
+              16164
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39564
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 791,
+            "packNanos": 21862,
+            "rank": 20,
+            "reduceNanos": 16204,
+            "reduceNanosSamples": [
+              16675,
+              16334,
+              16144,
+              16264,
+              16134,
+              16084,
+              16504,
+              16064
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 38838
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1001,
+            "packNanos": 22078,
+            "rank": 20,
+            "reduceNanos": 13305,
+            "reduceNanosSamples": [
+              13620,
+              14051,
+              13180,
+              13430,
+              12739,
+              13089,
+              12669,
+              13480
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 36369
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84795,
+              "rank": 20,
+              "readbackNanos": 9174,
+              "reduceNanos": 21601,
+              "reduceNanosSamples": [
+                21672,
+                21702,
+                21482,
+                21532,
+                21512,
+                21561,
+                21642,
+                21752
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115511
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84690,
+              "rank": 20,
+              "readbackNanos": 9053,
+              "reduceNanos": 20831,
+              "reduceNanosSamples": [
+                20871,
+                21191,
+                20731,
+                21191,
+                20571,
+                20791,
+                20651,
+                21051
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 114370
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84330,
+              "rank": 20,
+              "readbackNanos": 9003,
+              "reduceNanos": 18933,
+              "reduceNanosSamples": [
+                19179,
+                18928,
+                19368,
+                18637,
+                18938,
+                18788,
+                19068,
+                18548
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112321
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84305,
+              "rank": 20,
+              "readbackNanos": 906,
+              "reduceNanos": 16149,
+              "reduceNanosSamples": [
+                16395,
+                16174,
+                16444,
+                16074,
+                16014,
+                16094,
+                16254,
+                16124
+              ],
+              "smallAllocs": 7215,
+              "totalNanos": 101465
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 85041,
+              "rank": 20,
+              "readbackNanos": 8978,
+              "reduceNanos": 23049,
+              "reduceNanosSamples": [
+                22974,
+                22924,
+                23224,
+                23345,
+                22844,
+                23124,
+                23214,
+                22894
+              ],
+              "smallAllocs": 7806,
+              "totalNanos": 117218
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84645,
+              "rank": 20,
+              "readbackNanos": 9008,
+              "reduceNanos": 23675,
+              "reduceNanosSamples": [
+                23845,
+                23846,
+                23705,
+                23625,
+                23575,
+                23505,
+                23645,
+                23765
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 117309
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84526,
+              "rank": 20,
+              "readbackNanos": 8993,
+              "reduceNanos": 21607,
+              "reduceNanosSamples": [
+                21842,
+                21802,
+                21742,
+                21532,
+                21532,
+                21411,
+                21682,
+                21372
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115035
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84255,
+              "rank": 20,
+              "readbackNanos": 8968,
+              "reduceNanos": 22368,
+              "reduceNanosSamples": [
+                22684,
+                22413,
+                22654,
+                22203,
+                22323,
+                22304,
+                22593,
+                22283
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115592
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84686,
+              "rank": 20,
+              "readbackNanos": 9113,
+              "reduceNanos": 21391,
+              "reduceNanosSamples": [
+                21432,
+                21351,
+                21381,
+                21412,
+                21402,
+                21262,
+                21381,
+                21472
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115161
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84470,
+              "rank": 20,
+              "readbackNanos": 9018,
+              "reduceNanos": 21797,
+              "reduceNanosSamples": [
+                21923,
+                21532,
+                21912,
+                24717,
+                21682,
+                21562,
+                21962,
+                21673
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115221
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84660,
+              "rank": 20,
+              "readbackNanos": 8979,
+              "reduceNanos": 20060,
+              "reduceNanosSamples": [
+                20090,
+                23815,
+                19939,
+                20129,
+                20120,
+                20009,
+                19739,
+                20030
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 113814
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84400,
+              "rank": 20,
+              "readbackNanos": 8948,
+              "reduceNanos": 18873,
+              "reduceNanosSamples": [
+                19109,
+                18828,
+                18818,
+                19158,
+                18959,
+                18728,
+                18727,
+                18918
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112181
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 84816,
+              "smallAllocs": 6771
+            },
+            "columnCount": {
+              "nanos": 7541,
+              "smallAllocs": 540
+            },
+            "eliminate": {
+              "nanos": 18349,
+              "smallAllocs": 540
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 2352,
+            "pivotSearch": {
+              "nanos": 661,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "readback": {
+              "nanos": 8923,
+              "smallAllocs": 411
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 4627,
+              "smallAllocs": 80
+            },
+            "scaleMultiplies": 480,
+            "stagedNanos": 23638,
+            "wall": {
+              "nanos": 33249,
+              "smallAllocs": 1282
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2543,
+            "packNanos": 21251,
+            "rank": 20,
+            "reduceNanos": 27621,
+            "reduceNanosSamples": [
+              26850,
+              28462,
+              26419,
+              28582,
+              26380,
+              28392,
+              26539,
+              28392
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 3687,
+            "totalNanos": 51591
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 95391,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 235624,
+            "smallAllocs": 12726
+          },
+          "productionRowReduce": {
+            "nanos": 222204,
+            "smallAllocs": 12037
+          },
+          "rank": 20,
+          "residentBytesAfter": 70270976,
+          "residentBytesBefore": 70270976,
+          "rowReduceMatrixRebuild": {
+            "nanos": 95387,
+            "smallAllocs": 0
+          },
+          "sink": 22,
+          "splitFactors": 4
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_U24",
+      "status": "ok"
+    },
+    {
+      "degree": 30,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 30,
+          "basisToPolynomials": {
+            "nanos": 1953,
+            "smallAllocs": 146
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1247439,
+            "smallAllocs": 116780
+          },
+          "berlekampSplit": {
+            "nanos": 1948233,
+            "smallAllocs": 167769
+          },
+          "columnPolys": {
+            "nanos": 1131837,
+            "smallAllocs": 106059
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 781,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 393096,
+              "smallAllocs": 21308
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 37103,
+              "smallAllocs": 2201
+            },
+            "stagedNanos": 431069,
+            "wall": {
+              "nanos": 445340,
+              "smallAllocs": 23741
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 770,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 712800,
+              "smallAllocs": 40208
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 51241,
+              "smallAllocs": 2891
+            },
+            "stagedNanos": 766751,
+            "wall": {
+              "nanos": 780127,
+              "smallAllocs": 43334
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 15433,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1303872,
+            "smallAllocs": 117032
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1264389,
+            "smallAllocs": 117711
+          },
+          "frobeniusPower": {
+            "nanos": 97595,
+            "smallAllocs": 8922
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 17086,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1266327,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 26049,
+          "nullspaceBasisNanos": 26049,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1492,
+            "packNanos": 35973,
+            "rank": 23,
+            "reduceNanos": 46434,
+            "reduceNanosSamples": [
+              47170,
+              45828,
+              47160,
+              45958,
+              46539,
+              46329,
+              47370,
+              45988
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 83929
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1286,
+            "packNanos": 35737,
+            "rank": 23,
+            "reduceNanos": 46839,
+            "reduceNanosSamples": [
+              46218,
+              47120,
+              45958,
+              47140,
+              46319,
+              46559,
+              49905,
+              47380
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 83794
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1572,
+            "packNanos": 36279,
+            "rank": 23,
+            "reduceNanos": 33850,
+            "reduceNanosSamples": [
+              32999,
+              34371,
+              33159,
+              34802,
+              33329,
+              34591,
+              33199,
+              34481
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 71671
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248145,
+              "rank": 23,
+              "readbackNanos": 18011,
+              "reduceNanos": 47871,
+              "reduceNanosSamples": [
+                47701,
+                48402,
+                47831,
+                48311,
+                47842,
+                47901,
+                47691,
+                48021
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1313973
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246983,
+              "rank": 23,
+              "readbackNanos": 17936,
+              "reduceNanos": 53634,
+              "reduceNanosSamples": [
+                53028,
+                54161,
+                53660,
+                54872,
+                52858,
+                53609,
+                52667,
+                56274
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1319356
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246698,
+              "rank": 23,
+              "readbackNanos": 17807,
+              "reduceNanos": 45983,
+              "reduceNanosSamples": [
+                45317,
+                46689,
+                45508,
+                46459,
+                45498,
+                45548,
+                46419,
+                46869
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1310673
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248556,
+              "rank": 23,
+              "readbackNanos": 1362,
+              "reduceNanos": 46318,
+              "reduceNanosSamples": [
+                46018,
+                46239,
+                46118,
+                46529,
+                46649,
+                46469,
+                45998,
+                46398
+              ],
+              "smallAllocs": 116328,
+              "totalNanos": 1296332
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1249572,
+              "rank": 23,
+              "readbackNanos": 17781,
+              "reduceNanos": 52578,
+              "reduceNanosSamples": [
+                52548,
+                52669,
+                51516,
+                52678,
+                52689,
+                52448,
+                51446,
+                52608
+              ],
+              "smallAllocs": 117788,
+              "totalNanos": 1319957
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1247098,
+              "rank": 23,
+              "readbackNanos": 17776,
+              "reduceNanos": 54846,
+              "reduceNanosSamples": [
+                54411,
+                54801,
+                54892,
+                54972,
+                54731,
+                54781,
+                54891,
+                55383
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1319927
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1251185,
+              "rank": 23,
+              "readbackNanos": 17841,
+              "reduceNanos": 48141,
+              "reduceNanosSamples": [
+                48021,
+                48302,
+                48282,
+                48061,
+                48222,
+                47871,
+                48052,
+                58296
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1318249
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248145,
+              "rank": 23,
+              "readbackNanos": 17716,
+              "reduceNanos": 50059,
+              "reduceNanosSamples": [
+                49884,
+                49754,
+                50195,
+                50124,
+                49944,
+                50234,
+                49994,
+                50214
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1316131
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248666,
+              "rank": 23,
+              "readbackNanos": 17981,
+              "reduceNanos": 47806,
+              "reduceNanosSamples": [
+                47160,
+                47911,
+                47901,
+                47621,
+                47660,
+                47871,
+                50895,
+                47741
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1314103
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1249817,
+              "rank": 23,
+              "readbackNanos": 17821,
+              "reduceNanos": 48201,
+              "reduceNanosSamples": [
+                48181,
+                48282,
+                48362,
+                47911,
+                48311,
+                47781,
+                48221,
+                47701
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1315460
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1248751,
+              "rank": 23,
+              "readbackNanos": 17886,
+              "reduceNanos": 49322,
+              "reduceNanosSamples": [
+                49494,
+                49363,
+                48732,
+                49644,
+                48583,
+                48652,
+                49282,
+                49493
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1315255
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1249187,
+              "rank": 23,
+              "readbackNanos": 17816,
+              "reduceNanos": 46664,
+              "reduceNanosSamples": [
+                46709,
+                46859,
+                45628,
+                46940,
+                46619,
+                46770,
+                46609,
+                45358
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1313863
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1248166,
+              "smallAllocs": 115879
+            },
+            "columnCount": {
+              "nanos": 10318,
+              "smallAllocs": 759
+            },
+            "eliminate": {
+              "nanos": 43235,
+              "smallAllocs": 759
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 9450,
+            "pivotSearch": {
+              "nanos": 816,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "readback": {
+              "nanos": 17886,
+              "smallAllocs": 852
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 6623,
+              "smallAllocs": 92
+            },
+            "scaleMultiplies": 690,
+            "stagedNanos": 50663,
+            "wall": {
+              "nanos": 63824,
+              "smallAllocs": 1759
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3991,
+            "packNanos": 35007,
+            "rank": 23,
+            "reduceNanos": 87529,
+            "reduceNanosSamples": [
+              84575,
+              90865,
+              83975,
+              91265,
+              83854,
+              90484,
+              83925,
+              93879
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 11552,
+            "totalNanos": 126382
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 1263558,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 791178,
+            "smallAllocs": 42855
+          },
+          "productionRowReduce": {
+            "nanos": 764053,
+            "smallAllocs": 41732
+          },
+          "rank": 23,
+          "residentBytesAfter": 64212992,
+          "residentBytesBefore": 64139264,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1265210,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 7
+        },
+        "modularDegree": 30,
+        "modularFactorCount": 7,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "legendre_P30",
+      "status": "ok"
+    },
+    {
+      "degree": 38,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 38,
+          "basisToPolynomials": {
+            "nanos": 1392,
+            "smallAllocs": 100
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2439872,
+            "smallAllocs": 232849
+          },
+          "berlekampSplit": {
+            "nanos": 2796065,
+            "smallAllocs": 251152
+          },
+          "columnPolys": {
+            "nanos": 2264091,
+            "smallAllocs": 215798
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 957,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 929246,
+              "smallAllocs": 51765
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 69368,
+              "smallAllocs": 4185
+            },
+            "stagedNanos": 999879,
+            "wall": {
+              "nanos": 1021564,
+              "smallAllocs": 56191
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 972,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 1716030,
+              "smallAllocs": 98885
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 95241,
+              "smallAllocs": 5515
+            },
+            "stagedNanos": 1812607,
+            "wall": {
+              "nanos": 1832867,
+              "smallAllocs": 104644
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26649,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2566840,
+            "smallAllocs": 233069
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2472841,
+            "smallAllocs": 234332
+          },
+          "frobeniusPower": {
+            "nanos": 152140,
+            "smallAllocs": 14164
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 26148,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2483952,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 79,
+          "nullspaceBasisMagnitudeNanos": 23911,
+          "nullspaceBasisNanos": 23911,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1562,
+            "packNanos": 59753,
+            "rank": 35,
+            "reduceNanos": 105661,
+            "reduceNanosSamples": [
+              105786,
+              103364,
+              105537,
+              121781,
+              106478,
+              104104,
+              107830,
+              105046
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 167683
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1226,
+            "packNanos": 59438,
+            "rank": 35,
+            "reduceNanos": 107364,
+            "reduceNanosSamples": [
+              107470,
+              106428,
+              106518,
+              107449,
+              106348,
+              107279,
+              109692,
+              111015
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 168014
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1612,
+            "packNanos": 59613,
+            "rank": 35,
+            "reduceNanos": 73488,
+            "reduceNanosSamples": [
+              72677,
+              74400,
+              72628,
+              74410,
+              72718,
+              73869,
+              73108,
+              75472
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 134989
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2459616,
+              "rank": 35,
+              "readbackNanos": 16093,
+              "reduceNanos": 104295,
+              "reduceNanosSamples": [
+                104385,
+                104566,
+                104205,
+                106618,
+                107739,
+                102522,
+                104014,
+                104115
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2581862
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2467914,
+              "rank": 35,
+              "readbackNanos": 15909,
+              "reduceNanos": 122762,
+              "reduceNanosSamples": [
+                120929,
+                123303,
+                122141,
+                123784,
+                122281,
+                121020,
+                123243,
+                126467
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2605403
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2457753,
+              "rank": 35,
+              "readbackNanos": 15913,
+              "reduceNanos": 105085,
+              "reduceNanosSamples": [
+                105716,
+                107589,
+                106167,
+                104404,
+                106608,
+                104455,
+                103323,
+                102391
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2580400
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2468474,
+              "rank": 35,
+              "readbackNanos": 1377,
+              "reduceNanos": 105647,
+              "reduceNanosSamples": [
+                108121,
+                104424,
+                104515,
+                105306,
+                106428,
+                105427,
+                109222,
+                105867
+              ],
+              "smallAllocs": 232204,
+              "totalNanos": 2576149
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2459792,
+              "rank": 35,
+              "readbackNanos": 15789,
+              "reduceNanos": 116828,
+              "reduceNanosSamples": [
+                116973,
+                116713,
+                116943,
+                114199,
+                117243,
+                114450,
+                115190,
+                118326
+              ],
+              "smallAllocs": 233930,
+              "totalNanos": 2592619
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2459736,
+              "rank": 35,
+              "readbackNanos": 15783,
+              "reduceNanos": 122021,
+              "reduceNanosSamples": [
+                122121,
+                121801,
+                121850,
+                122061,
+                121700,
+                121981,
+                122171,
+                122191
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2597565
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2460322,
+              "rank": 35,
+              "readbackNanos": 15883,
+              "reduceNanos": 104710,
+              "reduceNanosSamples": [
+                105296,
+                104736,
+                111596,
+                104455,
+                105056,
+                102512,
+                104605,
+                104685
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2581432
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2464008,
+              "rank": 35,
+              "readbackNanos": 15823,
+              "reduceNanos": 109292,
+              "reduceNanosSamples": [
+                110133,
+                109312,
+                109542,
+                109272,
+                109512,
+                107369,
+                109181,
+                109132
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2589724
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2458174,
+              "rank": 35,
+              "readbackNanos": 16138,
+              "reduceNanos": 104290,
+              "reduceNanosSamples": [
+                104455,
+                104214,
+                104305,
+                104275,
+                104375,
+                104084,
+                104055,
+                104485
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2578753
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2459216,
+              "rank": 35,
+              "readbackNanos": 15888,
+              "reduceNanos": 105050,
+              "reduceNanosSamples": [
+                105366,
+                104885,
+                105247,
+                104635,
+                105427,
+                103433,
+                104875,
+                105216
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2580261
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2467553,
+              "rank": 35,
+              "readbackNanos": 15913,
+              "reduceNanos": 113182,
+              "reduceNanosSamples": [
+                114009,
+                113448,
+                112797,
+                114089,
+                113599,
+                112917,
+                111956,
+                112888
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2596705
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2463632,
+              "rank": 35,
+              "readbackNanos": 15733,
+              "reduceNanos": 106834,
+              "reduceNanosSamples": [
+                105186,
+                109282,
+                107780,
+                109152,
+                106107,
+                106278,
+                107390,
+                103634
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2585317
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2466747,
+              "smallAllocs": 231404
+            },
+            "columnCount": {
+              "nanos": 18342,
+              "smallAllocs": 1435
+            },
+            "eliminate": {
+              "nanos": 96394,
+              "smallAllocs": 1435
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 23560,
+            "pivotSearch": {
+              "nanos": 1052,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 15743,
+              "smallAllocs": 500
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 11142,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1330,
+            "stagedNanos": 108506,
+            "wall": {
+              "nanos": 130994,
+              "smallAllocs": 3203
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5223,
+            "packNanos": 56814,
+            "rank": 35,
+            "reduceNanos": 194969,
+            "reduceNanosSamples": [
+              196412,
+              195100,
+              195299,
+              194839,
+              194589,
+              198625,
+              184183,
+              183032
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 27175,
+            "totalNanos": 257051
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 2489050,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1820459,
+            "smallAllocs": 103304
+          },
+          "productionRowReduce": {
+            "nanos": 1796317,
+            "smallAllocs": 101686
+          },
+          "rank": 35,
+          "residentBytesAfter": 64086016,
+          "residentBytesBefore": 63971328,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2490286,
+            "smallAllocs": 0
+          },
+          "sink": 102,
+          "splitFactors": 3
+        },
+        "modularDegree": 38,
+        "modularFactorCount": 3,
+        "prime": 79,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "legendre_P38",
+      "status": "ok"
+    },
+    {
+      "degree": 16,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 16,
+          "basisToPolynomials": {
+            "nanos": 631,
+            "smallAllocs": 40
+          },
+          "berlekampMatrixWall": {
+            "nanos": 33099,
+            "smallAllocs": 2759
+          },
+          "berlekampSplit": {
+            "nanos": 45512,
+            "smallAllocs": 2865
+          },
+          "columnPolys": {
+            "nanos": 25598,
+            "smallAllocs": 2131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 389,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 44916,
+              "smallAllocs": 2385
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 14316,
+              "smallAllocs": 808
+            },
+            "stagedNanos": 59608,
+            "wall": {
+              "nanos": 64150,
+              "smallAllocs": 3296
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 416,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 72808,
+              "smallAllocs": 3985
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 19138,
+              "smallAllocs": 1048
+            },
+            "stagedNanos": 92301,
+            "wall": {
+              "nanos": 96848,
+              "smallAllocs": 5139
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 4877,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 45187,
+            "smallAllocs": 2823
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 37821,
+            "smallAllocs": 3032
+          },
+          "frobeniusPower": {
+            "nanos": 1993,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 1,
+          "matrixConversionNanos": 5468,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 37876,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 4286,
+          "nullspaceBasisNanos": 4286,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 421,
+            "packNanos": 8682,
+            "rank": 15,
+            "reduceNanos": 7866,
+            "reduceNanosSamples": [
+              8844,
+              7471,
+              8242,
+              7601,
+              8422,
+              7491,
+              8132,
+              7501
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16955
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 355,
+            "packNanos": 8597,
+            "rank": 15,
+            "reduceNanos": 7646,
+            "reduceNanosSamples": [
+              8103,
+              7732,
+              7621,
+              7592,
+              7912,
+              7672,
+              7572,
+              7621
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16574
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 506,
+            "packNanos": 8853,
+            "rank": 15,
+            "reduceNanos": 6469,
+            "reduceNanosSamples": [
+              6730,
+              7090,
+              6179,
+              6710,
+              5999,
+              6670,
+              5818,
+              6269
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 15968
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32808,
+              "rank": 15,
+              "readbackNanos": 2824,
+              "reduceNanos": 10336,
+              "reduceNanosSamples": [
+                10606,
+                10516,
+                10356,
+                10316,
+                10145,
+                10356,
+                10125,
+                10285
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45752
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32698,
+              "rank": 15,
+              "readbackNanos": 2699,
+              "reduceNanos": 9399,
+              "reduceNanosSamples": [
+                9524,
+                9754,
+                9274,
+                9534,
+                9083,
+                9264,
+                8963,
+                9625
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44782
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32593,
+              "rank": 15,
+              "readbackNanos": 2674,
+              "reduceNanos": 8487,
+              "reduceNanosSamples": [
+                8723,
+                8782,
+                8573,
+                8412,
+                8562,
+                8352,
+                8132,
+                8262
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 43669
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32718,
+              "rank": 15,
+              "readbackNanos": 380,
+              "reduceNanos": 7656,
+              "reduceNanosSamples": [
+                7842,
+                7651,
+                7621,
+                7571,
+                7732,
+                7691,
+                7661,
+                7571
+              ],
+              "smallAllocs": 2738,
+              "totalNanos": 40710
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32548,
+              "rank": 15,
+              "readbackNanos": 2699,
+              "reduceNanos": 10580,
+              "reduceNanosSamples": [
+                10996,
+                10545,
+                10825,
+                10585,
+                10656,
+                10576,
+                10436,
+                10245
+              ],
+              "smallAllocs": 2914,
+              "totalNanos": 45878
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32649,
+              "rank": 15,
+              "readbackNanos": 2679,
+              "reduceNanos": 11181,
+              "reduceNanosSamples": [
+                11547,
+                11197,
+                11237,
+                11157,
+                11076,
+                11197,
+                11166,
+                11046
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46479
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32513,
+              "rank": 15,
+              "readbackNanos": 2679,
+              "reduceNanos": 10290,
+              "reduceNanosSamples": [
+                10947,
+                10205,
+                10315,
+                10325,
+                10285,
+                10295,
+                10175,
+                10115
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45497
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32759,
+              "rank": 15,
+              "readbackNanos": 2669,
+              "reduceNanos": 10676,
+              "reduceNanosSamples": [
+                11116,
+                10796,
+                10747,
+                10586,
+                10596,
+                10786,
+                10606,
+                10445
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46199
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32629,
+              "rank": 15,
+              "readbackNanos": 2774,
+              "reduceNanos": 10255,
+              "reduceNanosSamples": [
+                10185,
+                10225,
+                10225,
+                10195,
+                10285,
+                10335,
+                10296,
+                10336
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45678
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32593,
+              "rank": 15,
+              "readbackNanos": 2694,
+              "reduceNanos": 10445,
+              "reduceNanosSamples": [
+                10806,
+                10336,
+                10616,
+                10376,
+                10626,
+                10285,
+                10515,
+                10276
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 45817
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32508,
+              "rank": 15,
+              "readbackNanos": 2684,
+              "reduceNanos": 8928,
+              "reduceNanosSamples": [
+                9334,
+                9063,
+                9003,
+                8994,
+                8863,
+                8733,
+                8613,
+                8643
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44060
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32573,
+              "rank": 15,
+              "readbackNanos": 2664,
+              "reduceNanos": 8417,
+              "reduceNanosSamples": [
+                8803,
+                8483,
+                8352,
+                8563,
+                8322,
+                8222,
+                8172,
+                8512
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 43705
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 32663,
+              "smallAllocs": 2502
+            },
+            "columnCount": {
+              "nanos": 4183,
+              "smallAllocs": 285
+            },
+            "eliminate": {
+              "nanos": 8754,
+              "smallAllocs": 285
+            },
+            "freeColumns": 1,
+            "innerMultiplies": 800,
+            "pivotSearch": {
+              "nanos": 411,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "readback": {
+              "nanos": 2584,
+              "smallAllocs": 86
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 2678,
+              "smallAllocs": 60
+            },
+            "scaleMultiplies": 240,
+            "stagedNanos": 11841,
+            "wall": {
+              "nanos": 17375,
+              "smallAllocs": 715
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1181,
+            "packNanos": 8402,
+            "rank": 15,
+            "reduceNanos": 12503,
+            "reduceNanosSamples": [
+              12659,
+              13099,
+              12068,
+              12599,
+              11837,
+              12709,
+              11677,
+              12408
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 1551,
+            "totalNanos": 21992
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 37801,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 90734,
+            "smallAllocs": 4820
+          },
+          "productionRowReduce": {
+            "nanos": 86648,
+            "smallAllocs": 4531
+          },
+          "rank": 15,
+          "residentBytesAfter": 64454656,
+          "residentBytesBefore": 64454656,
+          "rowReduceMatrixRebuild": {
+            "nanos": 37796,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 1
+        },
+        "modularDegree": 16,
+        "modularFactorCount": 1,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi17",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 1732,
+            "smallAllocs": 142
+          },
+          "berlekampMatrixWall": {
+            "nanos": 168269,
+            "smallAllocs": 14819
+          },
+          "berlekampSplit": {
+            "nanos": 437994,
+            "smallAllocs": 32512
+          },
+          "columnPolys": {
+            "nanos": 131594,
+            "smallAllocs": 11503
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1019,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 202315,
+              "smallAllocs": 12335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 72943,
+              "smallAllocs": 4412
+            },
+            "stagedNanos": 277000,
+            "wall": {
+              "nanos": 299639,
+              "smallAllocs": 17021
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1021,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 332143,
+              "smallAllocs": 20335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 97534,
+              "smallAllocs": 5812
+            },
+            "stagedNanos": 430592,
+            "wall": {
+              "nanos": 451984,
+              "smallAllocs": 26424
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26318,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 233756,
+            "smallAllocs": 15115
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 194899,
+            "smallAllocs": 16460
+          },
+          "frobeniusPower": {
+            "nanos": 2008,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 5,
+          "matrixConversionNanos": 34477,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 197698,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 30635,
+          "nullspaceBasisNanos": 30635,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1672,
+            "packNanos": 66384,
+            "rank": 35,
+            "reduceNanos": 34581,
+            "reduceNanosSamples": [
+              35512,
+              34040,
+              35333,
+              34000,
+              35232,
+              33991,
+              34842,
+              34321
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 102702
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1462,
+            "packNanos": 66153,
+            "rank": 35,
+            "reduceNanos": 34546,
+            "reduceNanosSamples": [
+              34481,
+              34762,
+              34451,
+              34161,
+              34761,
+              34682,
+              34611,
+              34461
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 102207
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1753,
+            "packNanos": 66604,
+            "rank": 35,
+            "reduceNanos": 28872,
+            "reduceNanosSamples": [
+              28722,
+              29474,
+              28212,
+              29173,
+              28372,
+              29023,
+              28482,
+              29243
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 97299
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166827,
+              "rank": 35,
+              "readbackNanos": 22198,
+              "reduceNanos": 48737,
+              "reduceNanosSamples": [
+                48051,
+                48412,
+                48071,
+                48833,
+                49303,
+                48903,
+                48642,
+                49003
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 237732
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166201,
+              "rank": 35,
+              "readbackNanos": 22088,
+              "reduceNanos": 42583,
+              "reduceNanosSamples": [
+                42553,
+                42813,
+                42523,
+                43305,
+                42654,
+                42613,
+                42152,
+                42203
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 230561
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166086,
+              "rank": 35,
+              "readbackNanos": 21973,
+              "reduceNanos": 39388,
+              "reduceNanosSamples": [
+                39518,
+                39849,
+                40500,
+                39749,
+                39188,
+                39259,
+                38688,
+                38677
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 227272
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166622,
+              "rank": 35,
+              "readbackNanos": 1617,
+              "reduceNanos": 34275,
+              "reduceNanosSamples": [
+                34280,
+                34230,
+                34461,
+                34051,
+                34271,
+                34251,
+                34491,
+                34390
+              ],
+              "smallAllocs": 14612,
+              "totalNanos": 202595
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166487,
+              "rank": 35,
+              "readbackNanos": 21957,
+              "reduceNanos": 52122,
+              "reduceNanosSamples": [
+                51977,
+                51737,
+                51707,
+                52157,
+                52588,
+                52157,
+                52088,
+                52217
+              ],
+              "smallAllocs": 15632,
+              "totalNanos": 240697
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166151,
+              "rank": 35,
+              "readbackNanos": 21997,
+              "reduceNanos": 53214,
+              "reduceNanosSamples": [
+                53149,
+                53109,
+                53089,
+                53279,
+                53600,
+                53610,
+                53129,
+                53540
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 241533
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166507,
+              "rank": 35,
+              "readbackNanos": 22013,
+              "reduceNanos": 49568,
+              "reduceNanosSamples": [
+                49384,
+                49033,
+                49453,
+                49473,
+                50255,
+                49663,
+                49724,
+                49764
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238068
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166652,
+              "rank": 35,
+              "readbackNanos": 22027,
+              "reduceNanos": 50825,
+              "reduceNanosSamples": [
+                50816,
+                50195,
+                50655,
+                50745,
+                51216,
+                51286,
+                50835,
+                50956
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 239595
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166341,
+              "rank": 35,
+              "readbackNanos": 22183,
+              "reduceNanos": 49388,
+              "reduceNanosSamples": [
+                49363,
+                49273,
+                49393,
+                49384,
+                49804,
+                50005,
+                49323,
+                49503
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238223
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166531,
+              "rank": 35,
+              "readbackNanos": 22032,
+              "reduceNanos": 50029,
+              "reduceNanosSamples": [
+                49664,
+                49293,
+                49784,
+                50034,
+                50495,
+                50024,
+                50245,
+                50194
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238518
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166131,
+              "rank": 35,
+              "readbackNanos": 21983,
+              "reduceNanos": 41126,
+              "reduceNanosSamples": [
+                40981,
+                41341,
+                41000,
+                45237,
+                41291,
+                41241,
+                41011,
+                40791
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 229490
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166407,
+              "rank": 35,
+              "readbackNanos": 22022,
+              "reduceNanos": 39839,
+              "reduceNanosSamples": [
+                39399,
+                39939,
+                40380,
+                40440,
+                40150,
+                39739,
+                38848,
+                39047
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 228373
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 166411,
+              "smallAllocs": 13218
+            },
+            "columnCount": {
+              "nanos": 20043,
+              "smallAllocs": 1505
+            },
+            "eliminate": {
+              "nanos": 41583,
+              "smallAllocs": 1505
+            },
+            "freeColumns": 5,
+            "innerMultiplies": 4000,
+            "pivotSearch": {
+              "nanos": 1078,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 21707,
+              "smallAllocs": 838
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 10593,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1400,
+            "stagedNanos": 53243,
+            "wall": {
+              "nanos": 76959,
+              "smallAllocs": 3351
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6018,
+            "packNanos": 63484,
+            "rank": 35,
+            "reduceNanos": 53539,
+            "reduceNanosSamples": [
+              53789,
+              53669,
+              53389,
+              58066,
+              53769,
+              53409,
+              53008,
+              53309
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 8397,
+            "totalNanos": 123177
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 194778,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 450828,
+            "smallAllocs": 25145
+          },
+          "productionRowReduce": {
+            "nanos": 419862,
+            "smallAllocs": 23316
+          },
+          "rank": 35,
+          "residentBytesAfter": 64544768,
+          "residentBytesBefore": 64462848,
+          "rowReduceMatrixRebuild": {
+            "nanos": 197518,
+            "smallAllocs": 0
+          },
+          "sink": 100,
+          "splitFactors": 5
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 5,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi41",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 3225,
+            "smallAllocs": 308
+          },
+          "berlekampMatrixWall": {
+            "nanos": 150142,
+            "smallAllocs": 14147
+          },
+          "berlekampSplit": {
+            "nanos": 577310,
+            "smallAllocs": 46939
+          },
+          "columnPolys": {
+            "nanos": 129477,
+            "smallAllocs": 12411
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 606,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 21652,
+              "smallAllocs": 1342
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 14841,
+              "smallAllocs": 876
+            },
+            "stagedNanos": 37120,
+            "wall": {
+              "nanos": 48121,
+              "smallAllocs": 2543
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 635,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 30610,
+              "smallAllocs": 1870
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 19678,
+              "smallAllocs": 1140
+            },
+            "stagedNanos": 50885,
+            "wall": {
+              "nanos": 61331,
+              "smallAllocs": 3338
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 8798,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 168640,
+            "smallAllocs": 14363
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 159146,
+            "smallAllocs": 14748
+          },
+          "frobeniusPower": {
+            "nanos": 7421,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 13,
+          "matrixConversionNanos": 13330,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 160002,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 17380,
+          "nullspaceBasisNanos": 17380,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1206,
+            "packNanos": 21887,
+            "rank": 11,
+            "reduceNanos": 6379,
+            "reduceNanosSamples": [
+              7421,
+              5879,
+              7100,
+              5929,
+              6950,
+              5878,
+              6780,
+              5979
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29438
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1061,
+            "packNanos": 21682,
+            "rank": 11,
+            "reduceNanos": 6069,
+            "reduceNanosSamples": [
+              6229,
+              6119,
+              6029,
+              6109,
+              5999,
+              5959,
+              5989,
+              6120
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28807
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1277,
+            "packNanos": 22043,
+            "rank": 11,
+            "reduceNanos": 6144,
+            "reduceNanosSamples": [
+              5868,
+              6779,
+              5659,
+              6580,
+              5658,
+              6420,
+              5548,
+              6489
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29523
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148605,
+              "rank": 11,
+              "readbackNanos": 19108,
+              "reduceNanos": 9299,
+              "reduceNanosSamples": [
+                9434,
+                9504,
+                9154,
+                9274,
+                9183,
+                9384,
+                9003,
+                9324
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177067
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149316,
+              "rank": 11,
+              "readbackNanos": 18993,
+              "reduceNanos": 7501,
+              "reduceNanosSamples": [
+                7270,
+                7641,
+                7220,
+                7681,
+                7361,
+                7681,
+                7210,
+                7741
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175700
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148054,
+              "rank": 11,
+              "readbackNanos": 18888,
+              "reduceNanos": 7071,
+              "reduceNanosSamples": [
+                7161,
+                7101,
+                7051,
+                7050,
+                7381,
+                7091,
+                6780,
+                6950
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 174098
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149001,
+              "rank": 11,
+              "readbackNanos": 1147,
+              "reduceNanos": 5968,
+              "reduceNanosSamples": [
+                6039,
+                5978,
+                6018,
+                5968,
+                5968,
+                5869,
+                5929,
+                5969
+              ],
+              "smallAllocs": 13885,
+              "totalNanos": 156086
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149681,
+              "rank": 11,
+              "readbackNanos": 18878,
+              "reduceNanos": 9559,
+              "reduceNanosSamples": [
+                9925,
+                9665,
+                9614,
+                9504,
+                9625,
+                9444,
+                9423,
+                9445
+              ],
+              "smallAllocs": 15031,
+              "totalNanos": 178274
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149922,
+              "rank": 11,
+              "readbackNanos": 18903,
+              "reduceNanos": 9574,
+              "reduceNanosSamples": [
+                9974,
+                9784,
+                9604,
+                9534,
+                9524,
+                9544,
+                9485,
+                9645
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 178615
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148826,
+              "rank": 11,
+              "readbackNanos": 18958,
+              "reduceNanos": 9088,
+              "reduceNanosSamples": [
+                9483,
+                8943,
+                9184,
+                8903,
+                9194,
+                8883,
+                9223,
+                8993
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177217
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148009,
+              "rank": 11,
+              "readbackNanos": 18918,
+              "reduceNanos": 9469,
+              "reduceNanosSamples": [
+                9715,
+                9655,
+                9564,
+                9374,
+                9654,
+                9274,
+                9144,
+                9244
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 176126
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149631,
+              "rank": 11,
+              "readbackNanos": 19083,
+              "reduceNanos": 8888,
+              "reduceNanosSamples": [
+                8993,
+                8924,
+                9054,
+                8813,
+                8853,
+                8953,
+                8742,
+                8843
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177568
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148635,
+              "rank": 11,
+              "readbackNanos": 18963,
+              "reduceNanos": 9128,
+              "reduceNanosSamples": [
+                9524,
+                9063,
+                9294,
+                8933,
+                9304,
+                8953,
+                9194,
+                8903
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 176502
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149096,
+              "rank": 11,
+              "readbackNanos": 18938,
+              "reduceNanos": 7171,
+              "reduceNanosSamples": [
+                7321,
+                7231,
+                7251,
+                7181,
+                7111,
+                7161,
+                7111,
+                7131
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175170
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149236,
+              "rank": 11,
+              "readbackNanos": 18963,
+              "reduceNanos": 7045,
+              "reduceNanosSamples": [
+                7321,
+                7131,
+                7020,
+                7031,
+                7070,
+                7060,
+                6891,
+                6961
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175505
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 149215,
+              "smallAllocs": 13570
+            },
+            "columnCount": {
+              "nanos": 4256,
+              "smallAllocs": 297
+            },
+            "eliminate": {
+              "nanos": 6985,
+              "smallAllocs": 297
+            },
+            "freeColumns": 13,
+            "innerMultiplies": 264,
+            "pivotSearch": {
+              "nanos": 625,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "readback": {
+              "nanos": 18792,
+              "smallAllocs": 1158
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 2830,
+              "smallAllocs": 44
+            },
+            "scaleMultiplies": 264,
+            "stagedNanos": 10457,
+            "wall": {
+              "nanos": 16895,
+              "smallAllocs": 751
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3084,
+            "packNanos": 21036,
+            "rank": 11,
+            "reduceNanos": 9258,
+            "reduceNanosSamples": [
+              9474,
+              9374,
+              9324,
+              9234,
+              9064,
+              9283,
+              8954,
+              9203
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 1470,
+            "totalNanos": 33334
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 159727,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 69898,
+            "smallAllocs": 3266
+          },
+          "productionRowReduce": {
+            "nanos": 52518,
+            "smallAllocs": 2654
+          },
+          "rank": 11,
+          "residentBytesAfter": 64729088,
+          "residentBytesBefore": 64729088,
+          "rowReduceMatrixRebuild": {
+            "nanos": 159111,
+            "smallAllocs": 0
+          },
+          "sink": 80,
+          "splitFactors": 13
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 13,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow24_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 20,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 20,
+          "basisToPolynomials": {
+            "nanos": 1112,
+            "smallAllocs": 75
+          },
+          "berlekampMatrixWall": {
+            "nanos": 167758,
+            "smallAllocs": 15130
+          },
+          "berlekampSplit": {
+            "nanos": 298232,
+            "smallAllocs": 23484
+          },
+          "columnPolys": {
+            "nanos": 154388,
+            "smallAllocs": 14054
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 507,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 203054,
+              "smallAllocs": 10529
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 17926,
+              "smallAllocs": 1043
+            },
+            "stagedNanos": 221447,
+            "wall": {
+              "nanos": 228338,
+              "smallAllocs": 11711
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 530,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 360652,
+              "smallAllocs": 19849
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 24482,
+              "smallAllocs": 1363
+            },
+            "stagedNanos": 385875,
+            "wall": {
+              "nanos": 392582,
+              "smallAllocs": 21354
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 6635,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 197232,
+            "smallAllocs": 15255
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 173973,
+            "smallAllocs": 15551
+          },
+          "frobeniusPower": {
+            "nanos": 4056,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 9734,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 174488,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 11145,
+          "nullspaceBasisNanos": 11145,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 776,
+            "packNanos": 14361,
+            "rank": 16,
+            "reduceNanos": 22893,
+            "reduceNanosSamples": [
+              23655,
+              22524,
+              23494,
+              22563,
+              23355,
+              22393,
+              23224,
+              22513
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38077
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 621,
+            "packNanos": 14261,
+            "rank": 16,
+            "reduceNanos": 22793,
+            "reduceNanosSamples": [
+              23315,
+              22813,
+              23124,
+              22684,
+              22773,
+              22644,
+              23055,
+              22764
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 37740
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 861,
+            "packNanos": 14516,
+            "rank": 16,
+            "reduceNanos": 18377,
+            "reduceNanosSamples": [
+              18267,
+              19128,
+              18067,
+              18878,
+              17806,
+              18487,
+              17817,
+              19038
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 33750
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167438,
+              "rank": 16,
+              "readbackNanos": 6675,
+              "reduceNanos": 24677,
+              "reduceNanosSamples": [
+                24677,
+                24807,
+                24647,
+                24756,
+                24527,
+                24837,
+                24286,
+                24677
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 198705
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166877,
+              "rank": 16,
+              "readbackNanos": 6540,
+              "reduceNanos": 27636,
+              "reduceNanosSamples": [
+                27671,
+                27861,
+                27421,
+                27861,
+                27170,
+                27661,
+                27511,
+                27611
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 200872
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167823,
+              "rank": 16,
+              "readbackNanos": 6480,
+              "reduceNanos": 24041,
+              "reduceNanosSamples": [
+                24316,
+                23745,
+                24276,
+                23615,
+                24246,
+                24316,
+                23635,
+                23836
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 198233
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166085,
+              "rank": 16,
+              "readbackNanos": 741,
+              "reduceNanos": 22693,
+              "reduceNanosSamples": [
+                22743,
+                22824,
+                22694,
+                22693,
+                22644,
+                22714,
+                22654,
+                22604
+              ],
+              "smallAllocs": 14870,
+              "totalNanos": 189526
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167082,
+              "rank": 16,
+              "readbackNanos": 6494,
+              "reduceNanos": 26930,
+              "reduceNanosSamples": [
+                27591,
+                26960,
+                27491,
+                26900,
+                27521,
+                26729,
+                26860,
+                26699
+              ],
+              "smallAllocs": 15663,
+              "totalNanos": 201133
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166712,
+              "rank": 16,
+              "readbackNanos": 6505,
+              "reduceNanos": 28141,
+              "reduceNanosSamples": [
+                28272,
+                28312,
+                28151,
+                28402,
+                28132,
+                28131,
+                27971,
+                28132
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 201439
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 169917,
+              "rank": 16,
+              "readbackNanos": 6509,
+              "reduceNanos": 24511,
+              "reduceNanosSamples": [
+                24827,
+                24466,
+                24707,
+                24486,
+                24586,
+                24537,
+                24466,
+                24326
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 200948
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 165585,
+              "rank": 16,
+              "readbackNanos": 6490,
+              "reduceNanos": 25673,
+              "reduceNanosSamples": [
+                25869,
+                25668,
+                25828,
+                25728,
+                25647,
+                25598,
+                25678,
+                25638
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 197733
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166156,
+              "rank": 16,
+              "readbackNanos": 6650,
+              "reduceNanos": 24531,
+              "reduceNanosSamples": [
+                24556,
+                24616,
+                24426,
+                24456,
+                24556,
+                24506,
+                24336,
+                24577
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 197262
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166387,
+              "rank": 16,
+              "readbackNanos": 6550,
+              "reduceNanos": 24741,
+              "reduceNanosSamples": [
+                25077,
+                24596,
+                24837,
+                24666,
+                25037,
+                24586,
+                24816,
+                24517
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 197748
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 166637,
+              "rank": 16,
+              "readbackNanos": 6499,
+              "reduceNanos": 25713,
+              "reduceNanosSamples": [
+                25798,
+                25788,
+                25718,
+                25708,
+                25778,
+                25588,
+                25688,
+                25668
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 198870
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167417,
+              "rank": 16,
+              "readbackNanos": 6490,
+              "reduceNanos": 23795,
+              "reduceNanosSamples": [
+                23796,
+                23615,
+                24496,
+                23826,
+                23746,
+                24316,
+                23795,
+                23635
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 197883
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 166812,
+              "smallAllocs": 14729
+            },
+            "columnCount": {
+              "nanos": 5595,
+              "smallAllocs": 368
+            },
+            "eliminate": {
+              "nanos": 22689,
+              "smallAllocs": 368
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4660,
+            "pivotSearch": {
+              "nanos": 547,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 6399,
+              "smallAllocs": 343
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 3264,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 320,
+            "stagedNanos": 26518,
+            "wall": {
+              "nanos": 33745,
+              "smallAllocs": 902
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2128,
+            "packNanos": 13941,
+            "rank": 16,
+            "reduceNanos": 42072,
+            "reduceNanosSamples": [
+              39889,
+              44627,
+              39228,
+              44255,
+              39338,
+              44446,
+              39198,
+              44286
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 5524,
+            "totalNanos": 58451
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 173878,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 391580,
+            "smallAllocs": 21079
+          },
+          "productionRowReduce": {
+            "nanos": 380689,
+            "smallAllocs": 20563
+          },
+          "rank": 16,
+          "residentBytesAfter": 64741376,
+          "residentBytesBefore": 64729088,
+          "rowReduceMatrixRebuild": {
+            "nanos": 173797,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 4
+        },
+        "modularDegree": 20,
+        "modularFactorCount": 4,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_10",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1698,
+            "smallAllocs": 128
+          },
+          "berlekampMatrixWall": {
+            "nanos": 576580,
+            "smallAllocs": 52728
+          },
+          "berlekampSplit": {
+            "nanos": 813791,
+            "smallAllocs": 68180
+          },
+          "columnPolys": {
+            "nanos": 544272,
+            "smallAllocs": 49657
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 586,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 347256,
+              "smallAllocs": 18538
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 22213,
+              "smallAllocs": 1310
+            },
+            "stagedNanos": 370084,
+            "wall": {
+              "nanos": 379823,
+              "smallAllocs": 20041
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 632,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 627508,
+              "smallAllocs": 35482
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 30240,
+              "smallAllocs": 1718
+            },
+            "stagedNanos": 659340,
+            "wall": {
+              "nanos": 669798,
+              "smallAllocs": 37396
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 12132,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 622678,
+            "smallAllocs": 52920
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 587356,
+            "smallAllocs": 53329
+          },
+          "frobeniusPower": {
+            "nanos": 22083,
+            "smallAllocs": 1920
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 8216,
+          "matrixConversionNegative": true,
+          "matrixRebuild": {
+            "nanos": 590800,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 22853,
+          "nullspaceBasisNanos": 22853,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1086,
+            "packNanos": 21947,
+            "rank": 17,
+            "reduceNanos": 37590,
+            "reduceNanosSamples": [
+              38137,
+              37185,
+              38157,
+              37185,
+              38216,
+              37005,
+              37996,
+              36904
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60710
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 896,
+            "packNanos": 21802,
+            "rank": 17,
+            "reduceNanos": 37806,
+            "reduceNanosSamples": [
+              38267,
+              37275,
+              39168,
+              37426,
+              37326,
+              37476,
+              38207,
+              38136
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60559
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1202,
+            "packNanos": 22057,
+            "rank": 17,
+            "reduceNanos": 31897,
+            "reduceNanosSamples": [
+              31216,
+              31958,
+              31216,
+              32298,
+              33760,
+              32067,
+              30976,
+              31837
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 55747
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575673,
+              "rank": 17,
+              "readbackNanos": 12233,
+              "reduceNanos": 38091,
+              "reduceNanosSamples": [
+                38096,
+                38376,
+                38006,
+                38317,
+                38107,
+                37916,
+                37886,
+                38087
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 627094
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 577631,
+              "rank": 17,
+              "readbackNanos": 12077,
+              "reduceNanos": 45051,
+              "reduceNanosSamples": [
+                44436,
+                45097,
+                44827,
+                45247,
+                44496,
+                45007,
+                45798,
+                45096
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 634450
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575743,
+              "rank": 17,
+              "readbackNanos": 12002,
+              "reduceNanos": 38662,
+              "reduceNanosSamples": [
+                38708,
+                38647,
+                38748,
+                38457,
+                38677,
+                38708,
+                37506,
+                38627
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 626523
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576555,
+              "rank": 17,
+              "readbackNanos": 1022,
+              "reduceNanos": 37295,
+              "reduceNanosSamples": [
+                37295,
+                37185,
+                40580,
+                37295,
+                37365,
+                37275,
+                38567,
+                37255
+              ],
+              "smallAllocs": 52268,
+              "totalNanos": 615548
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576039,
+              "rank": 17,
+              "readbackNanos": 11977,
+              "reduceNanos": 42182,
+              "reduceNanosSamples": [
+                42844,
+                42683,
+                41742,
+                42623,
+                41501,
+                41452,
+                42743,
+                41571
+              ],
+              "smallAllocs": 53630,
+              "totalNanos": 630094
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576555,
+              "rank": 17,
+              "readbackNanos": 12007,
+              "reduceNanos": 44160,
+              "reduceNanosSamples": [
+                44396,
+                44155,
+                44226,
+                44416,
+                44146,
+                43995,
+                44165,
+                44066
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 632598
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576108,
+              "rank": 17,
+              "readbackNanos": 11988,
+              "reduceNanos": 37951,
+              "reduceNanosSamples": [
+                38247,
+                37956,
+                38277,
+                37947,
+                38197,
+                37917,
+                37936,
+                37896
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 625993
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575402,
+              "rank": 17,
+              "readbackNanos": 12002,
+              "reduceNanos": 39669,
+              "reduceNanosSamples": [
+                40009,
+                39599,
+                39980,
+                39689,
+                39649,
+                39589,
+                42322,
+                39599
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 627144
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 574937,
+              "rank": 17,
+              "readbackNanos": 12233,
+              "reduceNanos": 38062,
+              "reduceNanosSamples": [
+                37997,
+                38177,
+                38077,
+                38086,
+                38216,
+                38047,
+                37876,
+                37966
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 625151
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575523,
+              "rank": 17,
+              "readbackNanos": 12008,
+              "reduceNanos": 38361,
+              "reduceNanosSamples": [
+                38437,
+                37997,
+                38598,
+                48222,
+                38417,
+                37876,
+                38306,
+                37976
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 626173
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576410,
+              "rank": 17,
+              "readbackNanos": 11988,
+              "reduceNanos": 41377,
+              "reduceNanosSamples": [
+                41631,
+                41271,
+                41382,
+                41362,
+                41372,
+                41511,
+                41491,
+                40550
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 629838
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576605,
+              "rank": 17,
+              "readbackNanos": 12033,
+              "reduceNanos": 38226,
+              "reduceNanosSamples": [
+                37816,
+                38768,
+                38787,
+                38698,
+                37526,
+                38567,
+                37505,
+                37886
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 626834
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 576960,
+              "smallAllocs": 52151
+            },
+            "columnCount": {
+              "nanos": 6539,
+              "smallAllocs": 459
+            },
+            "eliminate": {
+              "nanos": 35261,
+              "smallAllocs": 459
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 8472,
+            "pivotSearch": {
+              "nanos": 632,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "readback": {
+              "nanos": 11887,
+              "smallAllocs": 678
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 4080,
+              "smallAllocs": 68
+            },
+            "scaleMultiplies": 408,
+            "stagedNanos": 39999,
+            "wall": {
+              "nanos": 48642,
+              "smallAllocs": 1105
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2969,
+            "packNanos": 21046,
+            "rank": 17,
+            "reduceNanos": 72387,
+            "reduceNanosSamples": [
+              66538,
+              76092,
+              66198,
+              75522,
+              69503,
+              75272,
+              66108,
+              75932
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 9576,
+            "totalNanos": 96338
+          },
+          "peakResidentBytes": 71225344,
+          "productionMatrixRebuild": {
+            "nanos": 586640,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 676427,
+            "smallAllocs": 37192
+          },
+          "productionRowReduce": {
+            "nanos": 653574,
+            "smallAllocs": 36406
+          },
+          "rank": 17,
+          "residentBytesAfter": 64741376,
+          "residentBytesBefore": 64741376,
+          "rowReduceMatrixRebuild": {
+            "nanos": 586369,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 7
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 7,
+        "prime": 17,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_21",
+      "status": "ok"
+    }
+  ],
+  "results": [
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 78171503,
+        "median_nanos": 68164878,
+        "min_nanos": 67897591,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0227092609187975,
+      "name": "sd5",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3242717,
+              "smallAllocs": 279386
+            },
+            "berlekampMatrix": {
+              "nanos": 2003,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 20180,
+              "smallAllocs": 1600
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 1633,
+              "smallAllocs": 78
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1628214,
+              "smallAllocs": 152147
+            },
+            "splittingNanos": 1612500
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7922,
+              "smallAllocs": 332
+            },
+            "henselLift": {
+              "nanos": 1608304,
+              "smallAllocs": 57192
+            },
+            "normalization": {
+              "nanos": 33089,
+              "smallAllocs": 1647
+            },
+            "primeWalk": {
+              "nanos": 6689497,
+              "smallAllocs": 569749
+            },
+            "quadratic": {
+              "nanos": 541,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 61339238,
+              "smallAllocs": 2749638
+            },
+            "total": {
+              "nanos": 69712852,
+              "smallAllocs": 3379518
+            },
+            "validation": {
+              "nanos": 6419,
+              "smallAllocs": 201
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 221306743312056565676926650,
+            "coeffBoundBits": 88,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32639,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 129,
+              "recordable": 129,
+              "trailingSurvivors": 129
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 69990374,
+        "total_nanos_median": 69712852,
+        "total_nanos_min": 69581408
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 62507239,
+        "median_nanos": 62450696,
+        "min_nanos": 62079786,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.033918757286548,
+      "name": "sd5_shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2993788,
+              "smallAllocs": 258979
+            },
+            "berlekampMatrix": {
+              "nanos": 1853,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 33931,
+              "smallAllocs": 2696
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2483,
+              "smallAllocs": 84
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2289474,
+              "smallAllocs": 211116
+            },
+            "splittingNanos": 702461
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10455,
+              "smallAllocs": 382
+            },
+            "henselLift": {
+              "nanos": 1627103,
+              "smallAllocs": 58655
+            },
+            "normalization": {
+              "nanos": 49413,
+              "smallAllocs": 2827
+            },
+            "primeWalk": {
+              "nanos": 6875674,
+              "smallAllocs": 588844
+            },
+            "quadratic": {
+              "nanos": 521,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 55969938,
+              "smallAllocs": 2560916
+            },
+            "total": {
+              "nanos": 64568946,
+              "smallAllocs": 3212631
+            },
+            "validation": {
+              "nanos": 7902,
+              "smallAllocs": 229
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 343800744604764214921668900,
+            "coeffBoundBits": 89,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 64629496,
+        "total_nanos_median": 64568946,
+        "total_nanos_min": 64315480
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 66765133,
+        "median_nanos": 66039917,
+        "min_nanos": 65210437,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0222136105955433,
+      "name": "sd5_shift2",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4551828,
+              "smallAllocs": 381697
+            },
+            "berlekampMatrix": {
+              "nanos": 2063,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34752,
+              "smallAllocs": 2673
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2543,
+              "smallAllocs": 85
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2330115,
+              "smallAllocs": 211421
+            },
+            "splittingNanos": 2219650
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 11337,
+              "smallAllocs": 391
+            },
+            "henselLift": {
+              "nanos": 1628304,
+              "smallAllocs": 58442
+            },
+            "normalization": {
+              "nanos": 56655,
+              "smallAllocs": 2834
+            },
+            "primeWalk": {
+              "nanos": 8532410,
+              "smallAllocs": 716169
+            },
+            "quadratic": {
+              "nanos": 600,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 57238850,
+              "smallAllocs": 2594103
+            },
+            "total": {
+              "nanos": 67506902,
+              "smallAllocs": 3372963
+            },
+            "validation": {
+              "nanos": 8733,
+              "smallAllocs": 234
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1319504980517760399369866460,
+            "coeffBoundBits": 91,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 68513965,
+        "total_nanos_median": 67506902,
+        "total_nanos_min": 67489837
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 17835843,
+        "median_nanos": 17625641,
+        "min_nanos": 17533925,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16,
+        16
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.0012443235397794,
+      "name": "sd4_x_sd4shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            16,
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 83,
+            "modulusBits": 83,
+            "precision": 17,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3979590,
+              "smallAllocs": 320808
+            },
+            "berlekampMatrix": {
+              "nanos": 1802,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 35522,
+              "smallAllocs": 2770
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2314,
+              "smallAllocs": 82
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2323515,
+              "smallAllocs": 210624
+            },
+            "splittingNanos": 1654273
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 22123,
+              "smallAllocs": 901
+            },
+            "henselLift": {
+              "nanos": 1655855,
+              "smallAllocs": 55974
+            },
+            "normalization": {
+              "nanos": 50825,
+              "smallAllocs": 2814
+            },
+            "primeWalk": {
+              "nanos": 6754304,
+              "smallAllocs": 562910
+            },
+            "quadratic": {
+              "nanos": 541,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 9115544,
+              "smallAllocs": 528057
+            },
+            "total": {
+              "nanos": 17647573,
+              "smallAllocs": 1152141
+            },
+            "validation": {
+              "nanos": 20931,
+              "smallAllocs": 745
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 17,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 13,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 489391641089022941499420,
+            "coeffBoundBits": 79,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10530,
+              "degreeSurvivors": 10540,
+              "exactDivisionsAttempted": 2,
+              "nodes": 10540,
+              "productsMaterialized": 10,
+              "recordable": 10,
+              "trailingSurvivors": 10
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 17666051,
+        "total_nanos_median": 17647573,
+        "total_nanos_min": 17543469
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          16,
+          16
+        ],
+        "mirror_nodes": 10540,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 10540,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          16,
+          16
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 42,
+      "end_to_end": {
+        "max_nanos": 136992507,
+        "median_nanos": 136792842,
+        "min_nanos": 136600577,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        32
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.036146123786214,
+      "name": "sd5_x_phi11",
+      "phase_profile": {
+        "profile": {
+          "degree": 42,
+          "factorDegrees": [
+            10,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 17,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              10,
+              2
+            ],
+            "liftedMaxCoeffBits": 102,
+            "modulusBits": 103,
+            "precision": 21,
+            "prime": 29,
+            "treeInternalLifts": 16,
+            "treeLeaves": 17,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7433110,
+              "smallAllocs": 625572
+            },
+            "berlekampMatrix": {
+              "nanos": 2684,
+              "smallAllocs": 138
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 54251,
+              "smallAllocs": 4248
+            },
+            "kernelDimension": 17,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 42,
+            "modularImage": {
+              "nanos": 3184,
+              "smallAllocs": 108
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 4775780,
+              "smallAllocs": 428628
+            },
+            "splittingNanos": 2654646
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29353,
+              "smallAllocs": 1170
+            },
+            "henselLift": {
+              "nanos": 2430643,
+              "smallAllocs": 80497
+            },
+            "normalization": {
+              "nanos": 77605,
+              "smallAllocs": 4551
+            },
+            "primeWalk": {
+              "nanos": 15872732,
+              "smallAllocs": 1373405
+            },
+            "quadratic": {
+              "nanos": 621,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 123263374,
+              "smallAllocs": 6175336
+            },
+            "total": {
+              "nanos": 141737373,
+              "smallAllocs": 7636916
+            },
+            "validation": {
+              "nanos": 30845,
+              "smallAllocs": 1070
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  10,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 21,
+                "modularFactorCount": 17,
+                "prime": 29,
+                "reachableProperDegrees": 20,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 24,
+                "modularFactorCount": 17,
+                "prime": 19,
+                "reachableProperDegrees": 20,
+                "selected": false
+              }
+            ],
+            "coeffBound": 210602981274948990483361217040,
+            "coeffBoundBits": 98,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 65264,
+              "degreeSurvivors": 65522,
+              "exactDivisionsAttempted": 2,
+              "nodes": 65522,
+              "productsMaterialized": 258,
+              "recordable": 258,
+              "trailingSurvivors": 258
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 143021015,
+        "total_nanos_median": 141737373,
+        "total_nanos_min": 140185140
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          10,
+          32
+        ],
+        "mirror_nodes": 65522,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 65522,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          10,
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 10490102,
+        "median_nanos": 10457994,
+        "min_nanos": 10425837,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0056108274684419,
+      "name": "xpow48_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            2,
+            2,
+            2,
+            8,
+            8,
+            16,
+            1,
+            1,
+            4,
+            4
+          ],
+          "hensel": {
+            "liftedFactorCount": 19,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              4,
+              4,
+              2,
+              2,
+              4,
+              2,
+              2,
+              4,
+              4,
+              4,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 49,
+            "modulusBits": 49,
+            "precision": 14,
+            "prime": 11,
+            "treeInternalLifts": 18,
+            "treeLeaves": 19,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1968579,
+              "smallAllocs": 163103
+            },
+            "berlekampMatrix": {
+              "nanos": 2374,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 5739,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 19,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 1151,
+              "smallAllocs": 104
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 763151,
+              "smallAllocs": 67517
+            },
+            "splittingNanos": 1203054
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 25798,
+              "smallAllocs": 2409
+            },
+            "henselLift": {
+              "nanos": 1099369,
+              "smallAllocs": 57566
+            },
+            "normalization": {
+              "nanos": 14231,
+              "smallAllocs": 563
+            },
+            "primeWalk": {
+              "nanos": 4038928,
+              "smallAllocs": 339932
+            },
+            "quadratic": {
+              "nanos": 381,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5304343,
+              "smallAllocs": 270316
+            },
+            "total": {
+              "nanos": 10516672,
+              "smallAllocs": 673192
+            },
+            "validation": {
+              "nanos": 20030,
+              "smallAllocs": 1688
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  2,
+                  4,
+                  4,
+                  4,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 262144,
+                "henselPrecision": 14,
+                "modularFactorCount": 19,
+                "prime": 11,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  2,
+                  2,
+                  4,
+                  2
+                ],
+                "forcedSubsetCost": 524288,
+                "henselPrecision": 21,
+                "modularFactorCount": 20,
+                "prime": 5,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 64495207366200,
+            "coeffBoundBits": 46,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 268,
+              "exactDivisionsAttempted": 10,
+              "nodes": 268,
+              "productsMaterialized": 268,
+              "recordable": 268,
+              "trailingSurvivors": 268
+            },
+            "successfulDivisors": 10
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 10538744,
+        "total_nanos_median": 10516672,
+        "total_nanos_min": 10498854
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "mirror_nodes": 268,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 268,
+        "production_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 105,
+      "end_to_end": {
+        "max_nanos": 44716394,
+        "median_nanos": 44625419,
+        "min_nanos": 44376139,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0032742773798942,
+      "name": "xpow105_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 105,
+          "factorDegrees": [
+            4,
+            24,
+            2,
+            12,
+            48,
+            8,
+            6,
+            1
+          ],
+          "hensel": {
+            "liftedFactorCount": 14,
+            "liftedFactorDegrees": [
+              1,
+              6,
+              4,
+              12,
+              12,
+              4,
+              12,
+              12,
+              6,
+              2,
+              6,
+              12,
+              12,
+              4
+            ],
+            "liftedMaxCoeffBits": 107,
+            "modulusBits": 107,
+            "precision": 26,
+            "prime": 17,
+            "treeInternalLifts": 13,
+            "treeLeaves": 14,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 8905082,
+              "smallAllocs": 750003
+            },
+            "berlekampMatrix": {
+              "nanos": 5117,
+              "smallAllocs": 327
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11987,
+              "smallAllocs": 1080
+            },
+            "kernelDimension": 14,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 105,
+            "modularImage": {
+              "nanos": 2123,
+              "smallAllocs": 218
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 4968867,
+              "smallAllocs": 462407
+            },
+            "splittingNanos": 3931098
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 61401,
+              "smallAllocs": 6483
+            },
+            "henselLift": {
+              "nanos": 10090460,
+              "smallAllocs": 304935
+            },
+            "normalization": {
+              "nanos": 27010,
+              "smallAllocs": 1190
+            },
+            "primeWalk": {
+              "nanos": 29594605,
+              "smallAllocs": 2625082
+            },
+            "quadratic": {
+              "nanos": 531,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 4912613,
+              "smallAllocs": 266987
+            },
+            "total": {
+              "nanos": 44771535,
+              "smallAllocs": 3211107
+            },
+            "validation": {
+              "nanos": 54210,
+              "smallAllocs": 5196
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  6,
+                  4,
+                  12,
+                  12,
+                  4,
+                  12,
+                  12,
+                  6,
+                  2,
+                  6,
+                  12,
+                  12,
+                  4
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 26,
+                "modularFactorCount": 14,
+                "prime": 17,
+                "reachableProperDegrees": 104,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  3,
+                  6,
+                  1,
+                  2,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 536870912,
+                "henselPrecision": 30,
+                "modularFactorCount": 30,
+                "prime": 11,
+                "reachableProperDegrees": 104,
+                "selected": false
+              }
+            ],
+            "coeffBound": 6272525058612251449529907677520,
+            "coeffBoundBits": 103,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 60,
+              "exactDivisionsAttempted": 8,
+              "nodes": 60,
+              "productsMaterialized": 60,
+              "recordable": 60,
+              "trailingSurvivors": 60
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 44947096,
+        "total_nanos_median": 44771535,
+        "total_nanos_min": 44626621
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "mirror_nodes": 60,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 60,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "production_prime": 17
+      }
+    },
+    {
+      "degree": 120,
+      "end_to_end": {
+        "max_nanos": 146238376,
+        "median_nanos": 145716271,
+        "min_nanos": 145102722,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0076118129594465,
+      "name": "xpow120_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 120,
+          "factorDegrees": [
+            16,
+            4,
+            32,
+            8,
+            8,
+            2,
+            8,
+            2,
+            4,
+            16,
+            4,
+            1,
+            4,
+            1,
+            2,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 39,
+            "liftedFactorDegrees": [
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4
+            ],
+            "liftedMaxCoeffBits": 121,
+            "modulusBits": 121,
+            "precision": 43,
+            "prime": 7,
+            "treeInternalLifts": 38,
+            "treeLeaves": 39,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 16097946,
+              "smallAllocs": 1312571
+            },
+            "berlekampMatrix": {
+              "nanos": 5949,
+              "smallAllocs": 372
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 13700,
+              "smallAllocs": 1230
+            },
+            "kernelDimension": 39,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 120,
+            "modularImage": {
+              "nanos": 2434,
+              "smallAllocs": 248
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3752423,
+              "smallAllocs": 329059
+            },
+            "splittingNanos": 12339574
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 109612,
+              "smallAllocs": 11833
+            },
+            "henselLift": {
+              "nanos": 14009440,
+              "smallAllocs": 453833
+            },
+            "normalization": {
+              "nanos": 31487,
+              "smallAllocs": 1355
+            },
+            "primeWalk": {
+              "nanos": 18742787,
+              "smallAllocs": 1585472
+            },
+            "quadratic": {
+              "nanos": 621,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 113815246,
+              "smallAllocs": 5264950
+            },
+            "total": {
+              "nanos": 146825436,
+              "smallAllocs": 7326822
+            },
+            "validation": {
+              "nanos": 85297,
+              "smallAllocs": 8230
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4
+                ],
+                "forcedSubsetCost": 274877906944,
+                "henselPrecision": 43,
+                "modularFactorCount": 39,
+                "prime": 7,
+                "reachableProperDegrees": 119,
+                "selected": true
+              }
+            ],
+            "coeffBound": 193229817680726645207786279042745312,
+            "coeffBoundBits": 118,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3538,
+              "degreeSurvivors": 5339,
+              "exactDivisionsAttempted": 16,
+              "nodes": 5339,
+              "productsMaterialized": 1801,
+              "recordable": 1801,
+              "trailingSurvivors": 1801
+            },
+            "successfulDivisors": 16
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 148201766,
+        "total_nanos_median": 146825436,
+        "total_nanos_min": 146262481
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "mirror_nodes": 5339,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5339,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 178,
+      "end_to_end": {
+        "max_nanos": 33211347,
+        "median_nanos": 33189385,
+        "min_nanos": 33118540,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        178
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9972501448881924,
+      "name": "cyclo_phi179",
+      "phase_profile": {
+        "profile": {
+          "degree": 178,
+          "factorDegrees": [
+            178
+          ],
+          "hensel": {
+            "liftedFactorCount": 2,
+            "liftedFactorDegrees": [
+              89,
+              89
+            ],
+            "liftedMaxCoeffBits": 180,
+            "modulusBits": 180,
+            "precision": 113,
+            "prime": 3,
+            "treeInternalLifts": 1,
+            "treeLeaves": 2,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 5337073,
+              "smallAllocs": 339370
+            },
+            "berlekampMatrix": {
+              "nanos": 8883,
+              "smallAllocs": 546
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 36123,
+              "smallAllocs": 3356
+            },
+            "kernelDimension": 2,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 178,
+            "modularImage": {
+              "nanos": 3355,
+              "smallAllocs": 364
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 13663427,
+              "smallAllocs": 1226531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 20741,
+              "smallAllocs": 1446
+            },
+            "henselLift": {
+              "nanos": 26341783,
+              "smallAllocs": 567324
+            },
+            "normalization": {
+              "nanos": 67250,
+              "smallAllocs": 3772
+            },
+            "primeWalk": {
+              "nanos": 5380827,
+              "smallAllocs": 346865
+            },
+            "quadratic": {
+              "nanos": 811,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 1218847,
+              "smallAllocs": 46831
+            },
+            "total": {
+              "nanos": 33098119,
+              "smallAllocs": 968495
+            },
+            "validation": {
+              "nanos": 18067,
+              "smallAllocs": 901
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  89,
+                  89
+                ],
+                "forcedSubsetCost": 2,
+                "henselPrecision": 113,
+                "modularFactorCount": 2,
+                "prime": 3,
+                "reachableProperDegrees": 1,
+                "selected": true
+              }
+            ],
+            "coeffBound": 320322439463041003620181335381340475329049688753516000,
+            "coeffBoundBits": 178,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 2,
+              "exactDivisionsAttempted": 1,
+              "nodes": 2,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 33234181,
+        "total_nanos_median": 33098119,
+        "total_nanos_min": 32868960
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          178
+        ],
+        "mirror_nodes": 2,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 2,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          178
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 80,
+      "end_to_end": {
+        "max_nanos": 16465391,
+        "median_nanos": 16257122,
+        "min_nanos": 16247758,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9836253304859249,
+      "name": "cyclo_phi64_x_phi105",
+      "phase_profile": {
+        "profile": {
+          "degree": 80,
+          "factorDegrees": [
+            48,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 10,
+            "liftedFactorDegrees": [
+              16,
+              16,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6
+            ],
+            "liftedMaxCoeffBits": 84,
+            "modulusBits": 84,
+            "precision": 24,
+            "prime": 11,
+            "treeInternalLifts": 9,
+            "treeLeaves": 10,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7861365,
+              "smallAllocs": 586770
+            },
+            "berlekampMatrix": {
+              "nanos": 3865,
+              "smallAllocs": 252
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 161650,
+              "smallAllocs": 13406
+            },
+            "kernelDimension": 10,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 80,
+            "modularImage": {
+              "nanos": 1843,
+              "smallAllocs": 168
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 19286223,
+              "smallAllocs": 1749247
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 26169,
+              "smallAllocs": 2390
+            },
+            "henselLift": {
+              "nanos": 5086992,
+              "smallAllocs": 178057
+            },
+            "normalization": {
+              "nanos": 190853,
+              "smallAllocs": 14419
+            },
+            "primeWalk": {
+              "nanos": 8302870,
+              "smallAllocs": 625728
+            },
+            "quadratic": {
+              "nanos": 510,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 2341771,
+              "smallAllocs": 89872
+            },
+            "total": {
+              "nanos": 15990917,
+              "smallAllocs": 913166
+            },
+            "validation": {
+              "nanos": 22774,
+              "smallAllocs": 2017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16,
+                  16,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
+                ],
+                "forcedSubsetCost": 512,
+                "henselPrecision": 24,
+                "modularFactorCount": 10,
+                "prime": 11,
+                "reachableProperDegrees": 25,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1075072087333361764616200,
+            "coeffBoundBits": 80,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 102,
+              "degreeSurvivors": 130,
+              "exactDivisionsAttempted": 2,
+              "nodes": 130,
+              "productsMaterialized": 28,
+              "recordable": 28,
+              "trailingSurvivors": 28
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 16110695,
+        "total_nanos_median": 15990917,
+        "total_nanos_min": 15774026
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          32,
+          48
+        ],
+        "mirror_nodes": 130,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 130,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          32,
+          48
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 144,
+      "end_to_end": {
+        "max_nanos": 61308653,
+        "median_nanos": 61133443,
+        "min_nanos": 60747391,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        64,
+        80
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9939209869138239,
+      "name": "cyclo_phi128_x_phi165",
+      "phase_profile": {
+        "profile": {
+          "degree": 144,
+          "factorDegrees": [
+            64,
+            80
+          ],
+          "hensel": {
+            "liftedFactorCount": 8,
+            "liftedFactorDegrees": [
+              20,
+              16,
+              20,
+              20,
+              16,
+              20,
+              16,
+              16
+            ],
+            "liftedMaxCoeffBits": 146,
+            "modulusBits": 146,
+            "precision": 52,
+            "prime": 7,
+            "treeInternalLifts": 7,
+            "treeLeaves": 8,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 20208350,
+              "smallAllocs": 1239327
+            },
+            "berlekampMatrix": {
+              "nanos": 7180,
+              "smallAllocs": 444
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 479882,
+              "smallAllocs": 39896
+            },
+            "kernelDimension": 8,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 144,
+            "modularImage": {
+              "nanos": 3125,
+              "smallAllocs": 296
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 91809382,
+              "smallAllocs": 8409957
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 66018,
+              "smallAllocs": 6582
+            },
+            "henselLift": {
+              "nanos": 32945063,
+              "smallAllocs": 761706
+            },
+            "normalization": {
+              "nanos": 564317,
+              "smallAllocs": 44226
+            },
+            "primeWalk": {
+              "nanos": 21148453,
+              "smallAllocs": 1328424
+            },
+            "quadratic": {
+              "nanos": 731,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5939025,
+              "smallAllocs": 275130
+            },
+            "total": {
+              "nanos": 60761812,
+              "smallAllocs": 2423177
+            },
+            "validation": {
+              "nanos": 62152,
+              "smallAllocs": 6017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  20,
+                  16,
+                  20,
+                  20,
+                  16,
+                  20,
+                  16,
+                  16
+                ],
+                "forcedSubsetCost": 128,
+                "henselPrecision": 52,
+                "modularFactorCount": 8,
+                "prime": 7,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 20722981978283006659913436536756243128265400,
+            "coeffBoundBits": 144,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 29,
+              "degreeSurvivors": 54,
+              "exactDivisionsAttempted": 2,
+              "nodes": 54,
+              "productsMaterialized": 25,
+              "recordable": 25,
+              "trailingSurvivors": 25
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 61170117,
+        "total_nanos_median": 60761812,
+        "total_nanos_min": 60754421
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          64,
+          80
+        ],
+        "mirror_nodes": 54,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 54,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          64,
+          80
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 240,
+      "end_to_end": {
+        "max_nanos": 112903965,
+        "median_nanos": 112700624,
+        "min_nanos": 112450393,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        240
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9803655834239214,
+      "name": "cyclo_phi385",
+      "phase_profile": {
+        "profile": {
+          "degree": 240,
+          "factorDegrees": [
+            240
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              60,
+              60,
+              60,
+              60
+            ],
+            "liftedMaxCoeffBits": 241,
+            "modulusBits": 241,
+            "precision": 152,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 25081354,
+              "smallAllocs": 1030964
+            },
+            "berlekampMatrix": {
+              "nanos": 12168,
+              "smallAllocs": 732
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 780587,
+              "smallAllocs": 68654
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 240,
+            "modularImage": {
+              "nanos": 4687,
+              "smallAllocs": 488
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 199411306,
+              "smallAllocs": 18194276
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29303,
+              "smallAllocs": 1942
+            },
+            "henselLift": {
+              "nanos": 73168626,
+              "smallAllocs": 1636426
+            },
+            "normalization": {
+              "nanos": 1207490,
+              "smallAllocs": 101209
+            },
+            "primeWalk": {
+              "nanos": 25928170,
+              "smallAllocs": 1106201
+            },
+            "quadratic": {
+              "nanos": 1171,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 10059704,
+              "smallAllocs": 401834
+            },
+            "total": {
+              "nanos": 110487813,
+              "smallAllocs": 3250608
+            },
+            "validation": {
+              "nanos": 25978,
+              "smallAllocs": 1211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  60,
+                  60,
+                  60,
+                  60
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 152,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 3,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1636264530784946322237683636362414673514576776816417689604042467199320800,
+            "coeffBoundBits": 240,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 8,
+              "exactDivisionsAttempted": 1,
+              "nodes": 8,
+              "productsMaterialized": 8,
+              "recordable": 8,
+              "trailingSurvivors": 8
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 111139700,
+        "total_nanos_median": 110487813,
+        "total_nanos_min": 109976425
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          240
+        ],
+        "mirror_nodes": 8,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 8,
+        "production_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          240
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 9192489,
+        "median_nanos": 9172529,
+        "min_nanos": 9155334,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.994110675474561,
+      "name": "wilkinson_40",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 113539,
+              "smallAllocs": 8327
+            },
+            "berlekampMatrix": {
+              "nanos": 1793,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 21732,
+              "smallAllocs": 1610
+            },
+            "kernelDimension": 40,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 3796,
+              "smallAllocs": 106
+            },
+            "prime": 47,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 253966,
+              "smallAllocs": 20522
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 200397,
+              "smallAllocs": 9051
+            },
+            "normalization": {
+              "nanos": 78407,
+              "smallAllocs": 4275
+            },
+            "primeWalk": {
+              "nanos": 1021204,
+              "smallAllocs": 68927
+            },
+            "proposal": {
+              "nanos": 7759364,
+              "smallAllocs": 237827
+            },
+            "quadratic": {
+              "nanos": 530,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 9118509,
+              "smallAllocs": 321410
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 37,
+                "modularFactorCount": 40,
+                "prime": 47,
+                "reachableProperDegrees": 39,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 38,
+                "modularFactorCount": 40,
+                "prime": 41,
+                "reachableProperDegrees": 39,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1921680168406855965121530973574373218685937570507447116882060,
+            "coeffBoundBits": 201,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 47
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 9130506,
+        "total_nanos_median": 9118509,
+        "total_nanos_min": 9112750
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 16267027,
+        "median_nanos": 16248910,
+        "min_nanos": 16232725,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9978877967814457,
+      "name": "wilkinson_48",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 161089,
+              "smallAllocs": 12707
+            },
+            "berlekampMatrix": {
+              "nanos": 2263,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 38247,
+              "smallAllocs": 2906
+            },
+            "kernelDimension": 48,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 4727,
+              "smallAllocs": 126
+            },
+            "prime": 61,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 371861,
+              "smallAllocs": 29406
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 317621,
+              "smallAllocs": 13013
+            },
+            "normalization": {
+              "nanos": 102792,
+              "smallAllocs": 5905
+            },
+            "primeWalk": {
+              "nanos": 1569487,
+              "smallAllocs": 108539
+            },
+            "proposal": {
+              "nanos": 14149417,
+              "smallAllocs": 350278
+            },
+            "quadratic": {
+              "nanos": 531,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 16214589,
+              "smallAllocs": 479346
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 43,
+                "modularFactorCount": 48,
+                "prime": 61,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 45,
+                "modularFactorCount": 48,
+                "prime": 53,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 8049068376844036118970558829637315745156559359405185594804704581012213098100,
+            "coeffBoundBits": 253,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 61
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 16271033,
+        "total_nanos_median": 16214589,
+        "total_nanos_min": 15918850
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 56,
+      "end_to_end": {
+        "max_nanos": 21004400,
+        "median_nanos": 20972352,
+        "min_nanos": 20842650,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9982609008279091,
+      "name": "wilkinson_56",
+      "phase_profile": {
+        "profile": {
+          "degree": 56,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 213847,
+              "smallAllocs": 16143
+            },
+            "berlekampMatrix": {
+              "nanos": 2724,
+              "smallAllocs": 180
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 39749,
+              "smallAllocs": 3046
+            },
+            "kernelDimension": 56,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 56,
+            "modularImage": {
+              "nanos": 5408,
+              "smallAllocs": 146
+            },
+            "prime": 67,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 563325,
+              "smallAllocs": 46891
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 429366,
+              "smallAllocs": 17680
+            },
+            "normalization": {
+              "nanos": 130354,
+              "smallAllocs": 7789
+            },
+            "primeWalk": {
+              "nanos": 2040415,
+              "smallAllocs": 143611
+            },
+            "proposal": {
+              "nanos": 18243337,
+              "smallAllocs": 458437
+            },
+            "quadratic": {
+              "nanos": 530,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 20935879,
+              "smallAllocs": 629418
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 51,
+                "modularFactorCount": 56,
+                "prime": 67,
+                "reachableProperDegrees": 55,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 53,
+                "modularFactorCount": 56,
+                "prime": 59,
+                "reachableProperDegrees": 55,
+                "selected": false
+              }
+            ],
+            "coeffBound": 125617627049250877181363592865834692949611771037125750170085410352200700179789256897773224080,
+            "coeffBoundBits": 306,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 20998131,
+        "total_nanos_median": 20935879,
+        "total_nanos_min": 20836871
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 443167,
+        "median_nanos": 422526,
+        "min_nanos": 412661,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        8,
+        16
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.8893819551932899,
+      "name": "chebyshev_T24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            16,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 52,
+            "modulusBits": 52,
+            "precision": 22,
+            "prime": 5,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 182240,
+              "smallAllocs": 13395
+            },
+            "berlekampMatrix": {
+              "nanos": 1111,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11748,
+              "smallAllocs": 1040
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 641,
+              "smallAllocs": 56
+            },
+            "prime": 5,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 292053,
+              "smallAllocs": 24421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5198,
+              "smallAllocs": 414
+            },
+            "henselLift": {
+              "nanos": 113519,
+              "smallAllocs": 7189
+            },
+            "normalization": {
+              "nanos": 16755,
+              "smallAllocs": 1007
+            },
+            "primeWalk": {
+              "nanos": 201649,
+              "smallAllocs": 15164
+            },
+            "quadratic": {
+              "nanos": 260,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 27791,
+              "smallAllocs": 1407
+            },
+            "total": {
+              "nanos": 375787,
+              "smallAllocs": 25790
+            },
+            "validation": {
+              "nanos": 4446,
+              "smallAllocs": 281
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 22,
+                "modularFactorCount": 3,
+                "prime": 5,
+                "reachableProperDegrees": 2,
+                "selected": true
+              }
+            ],
+            "coeffBound": 910214580246244,
+            "coeffBoundBits": 50,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 5
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 1,
+              "degreeSurvivors": 3,
+              "exactDivisionsAttempted": 2,
+              "nodes": 3,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 403899,
+        "total_nanos_median": 375787,
+        "total_nanos_min": 372312
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          8,
+          16
+        ],
+        "mirror_nodes": 3,
+        "mirror_prime": 5,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 3,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          8,
+          16
+        ],
+        "production_prime": 5
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 621381,
+        "median_nanos": 578578,
+        "min_nanos": 557036,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.9408014131197522,
+      "name": "chebyshev_U24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            10,
+            2,
+            10,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              2,
+              10,
+              2,
+              10
+            ],
+            "liftedMaxCoeffBits": 53,
+            "modulusBits": 53,
+            "precision": 33,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 175821,
+              "smallAllocs": 12764
+            },
+            "berlekampMatrix": {
+              "nanos": 1001,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6179,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 661,
+              "smallAllocs": 56
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 238143,
+              "smallAllocs": 19531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7261,
+              "smallAllocs": 612
+            },
+            "henselLift": {
+              "nanos": 274477,
+              "smallAllocs": 14113
+            },
+            "normalization": {
+              "nanos": 17457,
+              "smallAllocs": 1009
+            },
+            "primeWalk": {
+              "nanos": 193216,
+              "smallAllocs": 13912
+            },
+            "quadratic": {
+              "nanos": 260,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 38908,
+              "smallAllocs": 2144
+            },
+            "total": {
+              "nanos": 544327,
+              "smallAllocs": 32523
+            },
+            "validation": {
+              "nanos": 5939,
+              "smallAllocs": 389
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  10
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 33,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 7,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1560748913788064,
+            "coeffBoundBits": 51,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 4,
+              "nodes": 4,
+              "productsMaterialized": 4,
+              "recordable": 4,
+              "trailingSurvivors": 4
+            },
+            "successfulDivisors": 4
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 565218,
+        "total_nanos_median": 544327,
+        "total_nanos_min": 527702
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 30,
+      "end_to_end": {
+        "max_nanos": 8334827,
+        "median_nanos": 8310991,
+        "min_nanos": 8304902,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        30
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9968464651207058,
+      "name": "legendre_P30",
+      "phase_profile": {
+        "profile": {
+          "degree": 30,
+          "factorDegrees": [
+            30
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              6,
+              14,
+              2
+            ],
+            "liftedMaxCoeffBits": 91,
+            "modulusBits": 91,
+            "precision": 15,
+            "prime": 67,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1877594,
+              "smallAllocs": 167769
+            },
+            "berlekampMatrix": {
+              "nanos": 1422,
+              "smallAllocs": 102
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 18678,
+              "smallAllocs": 1485
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 30,
+            "modularImage": {
+              "nanos": 1723,
+              "smallAllocs": 75
+            },
+            "prime": 67,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1691848,
+              "smallAllocs": 158865
+            },
+            "splittingNanos": 184324
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8332,
+              "smallAllocs": 329
+            },
+            "henselLift": {
+              "nanos": 1011990,
+              "smallAllocs": 30936
+            },
+            "normalization": {
+              "nanos": 30114,
+              "smallAllocs": 1502
+            },
+            "primeWalk": {
+              "nanos": 7027649,
+              "smallAllocs": 628129
+            },
+            "quadratic": {
+              "nanos": 471,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 174940,
+              "smallAllocs": 6057
+            },
+            "total": {
+              "nanos": 8284782,
+              "smallAllocs": 667849
+            },
+            "validation": {
+              "nanos": 6129,
+              "smallAllocs": 198
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  6,
+                  14,
+                  2
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 15,
+                "modularFactorCount": 7,
+                "prime": 67,
+                "reachableProperDegrees": 14,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 16384,
+                "henselPrecision": 15,
+                "modularFactorCount": 15,
+                "prime": 61,
+                "reachableProperDegrees": 14,
+                "selected": false
+              }
+            ],
+            "coeffBound": 124543935812132452094555520,
+            "coeffBoundBits": 87,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 63,
+              "degreeSurvivors": 64,
+              "exactDivisionsAttempted": 1,
+              "nodes": 64,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 8341617,
+        "total_nanos_median": 8284782,
+        "total_nanos_min": 8269089
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "mirror_factor_degrees": [
+          30
+        ],
+        "mirror_nodes": 64,
+        "mirror_prime": 67,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 64,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "production_factor_degrees": [
+          30
+        ],
+        "production_prime": 67
+      }
+    },
+    {
+      "degree": 38,
+      "end_to_end": {
+        "max_nanos": 3684222,
+        "median_nanos": 3644874,
+        "min_nanos": 3636762,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        38
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.988190538273751,
+      "name": "legendre_P38",
+      "phase_profile": {
+        "profile": {
+          "degree": 38,
+          "factorDegrees": [
+            38
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              36,
+              1,
+              1
+            ],
+            "liftedMaxCoeffBits": 120,
+            "modulusBits": 120,
+            "precision": 19,
+            "prime": 79,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2724219,
+              "smallAllocs": 251152
+            },
+            "berlekampMatrix": {
+              "nanos": 1712,
+              "smallAllocs": 126
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 26980,
+              "smallAllocs": 2184
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 38,
+            "modularImage": {
+              "nanos": 2294,
+              "smallAllocs": 94
+            },
+            "prime": 79,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3599867,
+              "smallAllocs": 334731
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10165,
+              "smallAllocs": 431
+            },
+            "henselLift": {
+              "nanos": 555413,
+              "smallAllocs": 18781
+            },
+            "normalization": {
+              "nanos": 41632,
+              "smallAllocs": 2237
+            },
+            "primeWalk": {
+              "nanos": 2896484,
+              "smallAllocs": 260183
+            },
+            "quadratic": {
+              "nanos": 391,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 61221,
+              "smallAllocs": 1980
+            },
+            "total": {
+              "nanos": 3601830,
+              "smallAllocs": 284570
+            },
+            "validation": {
+              "nanos": 7741,
+              "smallAllocs": 265
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  36,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 19,
+                "modularFactorCount": 3,
+                "prime": 79,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 14065077854436543582494269671679200,
+            "coeffBoundBits": 114,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 79
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 1,
+              "nodes": 4,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 3639135,
+        "total_nanos_median": 3601830,
+        "total_nanos_min": 3595110
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1
+        ],
+        "mirror_factor_degrees": [
+          38
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 79,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [
+          0,
+          1
+        ],
+        "production_factor_degrees": [
+          38
+        ],
+        "production_prime": 79
+      }
+    },
+    {
+      "degree": 16,
+      "end_to_end": {
+        "max_nanos": 109703,
+        "median_nanos": 101450,
+        "min_nanos": 98846,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.7813405618531296,
+      "name": "cyclo_phi17",
+      "phase_profile": {
+        "profile": {
+          "degree": 16,
+          "factorDegrees": [
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 1,
+            "liftedFactorDegrees": [
+              16
+            ],
+            "liftedMaxCoeffBits": 1,
+            "modulusBits": 18,
+            "precision": 11,
+            "prime": 3,
+            "treeInternalLifts": 0,
+            "treeLeaves": 1,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 44666,
+              "smallAllocs": 2865
+            },
+            "berlekampMatrix": {
+              "nanos": 711,
+              "smallAllocs": 60
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3956,
+              "smallAllocs": 332
+            },
+            "kernelDimension": 1,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 16,
+            "modularImage": {
+              "nanos": 421,
+              "smallAllocs": 40
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 97935,
+              "smallAllocs": 7303
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 2343,
+              "smallAllocs": 150
+            },
+            "henselLift": {
+              "nanos": 2003,
+              "smallAllocs": 72
+            },
+            "normalization": {
+              "nanos": 7331,
+              "smallAllocs": 370
+            },
+            "primeWalk": {
+              "nanos": 54871,
+              "smallAllocs": 3522
+            },
+            "quadratic": {
+              "nanos": 210,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 6640,
+              "smallAllocs": 424
+            },
+            "total": {
+              "nanos": 79267,
+              "smallAllocs": 4906
+            },
+            "validation": {
+              "nanos": 1923,
+              "smallAllocs": 91
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16
+                ],
+                "forcedSubsetCost": 1,
+                "henselPrecision": 11,
+                "modularFactorCount": 1,
+                "prime": 3,
+                "reachableProperDegrees": 0,
+                "selected": true
+              }
+            ],
+            "coeffBound": 64350,
+            "coeffBoundBits": 16,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 1,
+              "exactDivisionsAttempted": 1,
+              "nodes": 1,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 87159,
+        "total_nanos_median": 79267,
+        "total_nanos_min": 77876
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          16
+        ],
+        "mirror_nodes": 1,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 1,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          16
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 2004952,
+        "median_nanos": 1982860,
+        "min_nanos": 1970511,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        40
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9772006092210241,
+      "name": "cyclo_phi41",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            40
+          ],
+          "hensel": {
+            "liftedFactorCount": 5,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 42,
+            "modulusBits": 42,
+            "precision": 26,
+            "prime": 3,
+            "treeInternalLifts": 4,
+            "treeLeaves": 5,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 446122,
+              "smallAllocs": 32512
+            },
+            "berlekampMatrix": {
+              "nanos": 1863,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 8953,
+              "smallAllocs": 780
+            },
+            "kernelDimension": 5,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 992,
+              "smallAllocs": 88
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 455205,
+              "smallAllocs": 38465
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5358,
+              "smallAllocs": 342
+            },
+            "henselLift": {
+              "nanos": 645377,
+              "smallAllocs": 30651
+            },
+            "normalization": {
+              "nanos": 18197,
+              "smallAllocs": 874
+            },
+            "primeWalk": {
+              "nanos": 469867,
+              "smallAllocs": 34389
+            },
+            "quadratic": {
+              "nanos": 340,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 785274,
+              "smallAllocs": 32169
+            },
+            "total": {
+              "nanos": 1937652,
+              "smallAllocs": 99038
+            },
+            "validation": {
+              "nanos": 4466,
+              "smallAllocs": 211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 16,
+                "henselPrecision": 26,
+                "modularFactorCount": 5,
+                "prime": 3,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 964925701740,
+            "coeffBoundBits": 40,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 16,
+              "exactDivisionsAttempted": 1,
+              "nodes": 16,
+              "productsMaterialized": 16,
+              "recordable": 16,
+              "trailingSurvivors": 16
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1954658,
+        "total_nanos_median": 1937652,
+        "total_nanos_min": 1919395
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "mirror_factor_degrees": [
+          40
+        ],
+        "mirror_nodes": 16,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 16,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "production_factor_degrees": [
+          40
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 2337686,
+        "median_nanos": 2299890,
+        "min_nanos": 2290456,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9931761953832574,
+      "name": "xpow24_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            2,
+            1,
+            4,
+            4,
+            8,
+            1,
+            2,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 13,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2
+            ],
+            "liftedMaxCoeffBits": 25,
+            "modulusBits": 25,
+            "precision": 7,
+            "prime": 11,
+            "treeInternalLifts": 12,
+            "treeLeaves": 13,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 580050,
+              "smallAllocs": 46939
+            },
+            "berlekampMatrix": {
+              "nanos": 1042,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3235,
+              "smallAllocs": 270
+            },
+            "kernelDimension": 13,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 681,
+              "smallAllocs": 56
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 195419,
+              "smallAllocs": 17216
+            },
+            "splittingNanos": 383589
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 11046,
+              "smallAllocs": 937
+            },
+            "henselLift": {
+              "nanos": 291122,
+              "smallAllocs": 17594
+            },
+            "normalization": {
+              "nanos": 8142,
+              "smallAllocs": 299
+            },
+            "primeWalk": {
+              "nanos": 1104298,
+              "smallAllocs": 89521
+            },
+            "quadratic": {
+              "nanos": 430,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 851973,
+              "smallAllocs": 48267
+            },
+            "total": {
+              "nanos": 2284196,
+              "smallAllocs": 157705
+            },
+            "validation": {
+              "nanos": 8512,
+              "smallAllocs": 574
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  2
+                ],
+                "forcedSubsetCost": 4096,
+                "henselPrecision": 7,
+                "modularFactorCount": 13,
+                "prime": 11,
+                "reachableProperDegrees": 23,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 11,
+                "modularFactorCount": 14,
+                "prime": 5,
+                "reachableProperDegrees": 23,
+                "selected": false
+              }
+            ],
+            "coeffBound": 5408312,
+            "coeffBoundBits": 23,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 113,
+              "exactDivisionsAttempted": 8,
+              "nodes": 113,
+              "productsMaterialized": 113,
+              "recordable": 113,
+              "trailingSurvivors": 113
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2310755,
+        "total_nanos_median": 2284196,
+        "total_nanos_min": 2281672
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "mirror_nodes": 113,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 113,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 20,
+      "end_to_end": {
+        "max_nanos": 635102,
+        "median_nanos": 586560,
+        "min_nanos": 571057,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        10
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9469159165302782,
+      "name": "randprod_10",
+      "phase_profile": {
+        "profile": {
+          "degree": 20,
+          "factorDegrees": [
+            10,
+            10
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              3,
+              4,
+              7,
+              6
+            ],
+            "liftedMaxCoeffBits": 31,
+            "modulusBits": 31,
+            "precision": 11,
+            "prime": 7,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 301087,
+              "smallAllocs": 23484
+            },
+            "berlekampMatrix": {
+              "nanos": 851,
+              "smallAllocs": 72
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12669,
+              "smallAllocs": 1018
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 20,
+            "modularImage": {
+              "nanos": 651,
+              "smallAllocs": 48
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 426893,
+              "smallAllocs": 35832
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 4657,
+              "smallAllocs": 338
+            },
+            "henselLift": {
+              "nanos": 164935,
+              "smallAllocs": 9769
+            },
+            "normalization": {
+              "nanos": 21372,
+              "smallAllocs": 1219
+            },
+            "primeWalk": {
+              "nanos": 326955,
+              "smallAllocs": 25144
+            },
+            "quadratic": {
+              "nanos": 290,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 27400,
+              "smallAllocs": 1357
+            },
+            "total": {
+              "nanos": 555423,
+              "smallAllocs": 38377
+            },
+            "validation": {
+              "nanos": 4006,
+              "smallAllocs": 237
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  3,
+                  4,
+                  7,
+                  6
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 11,
+                "modularFactorCount": 4,
+                "prime": 7,
+                "reachableProperDegrees": 11,
+                "selected": true
+              }
+            ],
+            "coeffBound": 161291988,
+            "coeffBoundBits": 28,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 5,
+              "exactDivisionsAttempted": 2,
+              "nodes": 5,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 582043,
+        "total_nanos_median": 555423,
+        "total_nanos_min": 544277
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          10,
+          10
+        ],
+        "mirror_nodes": 5,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5,
+        "production_completed_levels": [
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          10,
+          10
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 1376851,
+        "median_nanos": 1340608,
+        "min_nanos": 1331965,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        7,
+        8,
+        9
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9681316238602187,
+      "name": "randprod_21",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            7,
+            8,
+            9
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              9,
+              7,
+              1,
+              1,
+              1,
+              4,
+              1
+            ],
+            "liftedMaxCoeffBits": 37,
+            "modulusBits": 37,
+            "precision": 9,
+            "prime": 17,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 807076,
+              "smallAllocs": 68180
+            },
+            "berlekampMatrix": {
+              "nanos": 1071,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19438,
+              "smallAllocs": 1592
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 771,
+              "smallAllocs": 56
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1012722,
+              "smallAllocs": 89421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7050,
+              "smallAllocs": 531
+            },
+            "henselLift": {
+              "nanos": 312904,
+              "smallAllocs": 17758
+            },
+            "normalization": {
+              "nanos": 26600,
+              "smallAllocs": 1651
+            },
+            "primeWalk": {
+              "nanos": 887556,
+              "smallAllocs": 74672
+            },
+            "quadratic": {
+              "nanos": 250,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 50185,
+              "smallAllocs": 2297
+            },
+            "total": {
+              "nanos": 1297885,
+              "smallAllocs": 97645
+            },
+            "validation": {
+              "nanos": 6059,
+              "smallAllocs": 386
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  9,
+                  7,
+                  1,
+                  1,
+                  1,
+                  4,
+                  1
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 9,
+                "modularFactorCount": 7,
+                "prime": 17,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 41749464484,
+            "coeffBoundBits": 36,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10,
+              "degreeSurvivors": 13,
+              "exactDivisionsAttempted": 3,
+              "nodes": 13,
+              "productsMaterialized": 3,
+              "recordable": 3,
+              "trailingSurvivors": 3
+            },
+            "successfulDivisors": 3
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1321109,
+        "total_nanos_median": 1297885,
+        "total_nanos_min": 1291975
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "mirror_nodes": 13,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 13,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "production_prime": 17
+      }
+    }
+  ],
+  "schema": "hexbz-phase-profile/3",
+  "scouts": [],
+  "validation": {
+    "disagreements": [],
+    "factors_agree": 368,
+    "instrumentation_ratio_max": 1.036146123786214,
+    "instrumentation_ratio_median": 0.9954785702976334,
+    "kernel_disagreements": [],
+    "kernel_mirror_agree": 24,
+    "kernel_packed_agree": 24,
+    "kernel_rows": 24,
+    "levels_agree": 368,
+    "nodes_agree": 368,
+    "prime_agree": 368,
+    "sample_size": 368,
+    "scout_disagreements": [],
+    "scout_patterns_agree": 0,
+    "scout_rows": 0
+  }
+}

--- a/reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
+++ b/reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
@@ -1,0 +1,17771 @@
+{
+  "config": {
+    "controls": [
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "corpus": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "cpu": 1,
+    "cutoff_seconds": 120.0,
+    "hex_exe_sha256": "fcc8436ade195d36a9be4f9294e9c35e704de31ad68309269344351e13f9ba82",
+    "kernel_repeats": 8,
+    "names": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56",
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "plan_repeats": 3,
+    "repeat_ceiling_nanos": 1000000000,
+    "repeats": 5,
+    "representative": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56"
+    ],
+    "sampling_profiles": [
+      "sd5",
+      "sd5_x_phi11",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi385",
+      "wilkinson_56"
+    ],
+    "validate_cutoff_seconds": 2.0,
+    "warmup": 1
+  },
+  "counterfactuals": [],
+  "env": {
+    "arch": "x86_64",
+    "cpu_cores": 96,
+    "cpu_model": null,
+    "exe_name": "hexbz_factor_service",
+    "git_commit": "55fc3beef0f7dada6774c861cd1e71a2ba4beb18",
+    "git_dirty": true,
+    "hostname": "chungus2",
+    "lean_bench_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "lean_version": null,
+    "os": "linux",
+    "platform_target": null,
+    "timestamp_iso": "2026-08-05T00:16:43Z",
+    "timestamp_unix_ms": 1785889003721
+  },
+  "kernels": [
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4516,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1243969,
+            "smallAllocs": 120747
+          },
+          "berlekampSplit": {
+            "nanos": 3261189,
+            "smallAllocs": 279386
+          },
+          "columnPolys": {
+            "nanos": 1198577,
+            "smallAllocs": 116346
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 806,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 279979,
+              "smallAllocs": 15527
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 27640,
+              "smallAllocs": 1625
+            },
+            "stagedNanos": 308536,
+            "wall": {
+              "nanos": 326399,
+              "smallAllocs": 17591
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 897,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 510841,
+              "smallAllocs": 29287
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 37675,
+              "smallAllocs": 2137
+            },
+            "stagedNanos": 549353,
+            "wall": {
+              "nanos": 566069,
+              "smallAllocs": 31866
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 19078,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1302531,
+            "smallAllocs": 121100
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1262176,
+            "smallAllocs": 121804
+          },
+          "frobeniusPower": {
+            "nanos": 26068,
+            "smallAllocs": 2354
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 20530,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1269767,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 35522,
+          "nullspaceBasisNanos": 35522,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2128,
+            "packNanos": 40950,
+            "rank": 16,
+            "reduceNanos": 34206,
+            "reduceNanosSamples": [
+              37977,
+              33730,
+              35413,
+              33320,
+              34721,
+              33349,
+              34682,
+              33560
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 77369
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1923,
+            "packNanos": 40309,
+            "rank": 16,
+            "reduceNanos": 34552,
+            "reduceNanosSamples": [
+              35112,
+              34922,
+              34552,
+              34431,
+              34632,
+              33990,
+              34151,
+              34552
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 76989
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2163,
+            "packNanos": 41436,
+            "rank": 16,
+            "reduceNanos": 25853,
+            "reduceNanosSamples": [
+              24907,
+              27371,
+              24957,
+              26860,
+              25137,
+              26570,
+              24977,
+              27270
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 70980
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1244445,
+              "rank": 16,
+              "readbackNanos": 33644,
+              "reduceNanos": 35783,
+              "reduceNanosSamples": [
+                36023,
+                35923,
+                35653,
+                35773,
+                35633,
+                36084,
+                35793,
+                35703
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1313828
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1242897,
+              "rank": 16,
+              "readbackNanos": 33409,
+              "reduceNanos": 39613,
+              "reduceNanosSamples": [
+                39598,
+                40790,
+                39629,
+                40259,
+                39248,
+                40100,
+                38877,
+                39258
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1316261
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1245116,
+              "rank": 16,
+              "readbackNanos": 33204,
+              "reduceNanos": 34461,
+              "reduceNanosSamples": [
+                35052,
+                34561,
+                34371,
+                34340,
+                34401,
+                34681,
+                34521,
+                33430
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1313587
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246362,
+              "rank": 16,
+              "readbackNanos": 1953,
+              "reduceNanos": 34005,
+              "reduceNanosSamples": [
+                34741,
+                34050,
+                33961,
+                36174,
+                34562,
+                33780,
+                33831,
+                33930
+              ],
+              "smallAllocs": 120097,
+              "totalNanos": 1282166
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1244310,
+              "rank": 16,
+              "readbackNanos": 33314,
+              "reduceNanos": 38242,
+              "reduceNanosSamples": [
+                38877,
+                38047,
+                38948,
+                37776,
+                38908,
+                38287,
+                37946,
+                38197
+              ],
+              "smallAllocs": 122378,
+              "totalNanos": 1316046
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1243558,
+              "rank": 16,
+              "readbackNanos": 33514,
+              "reduceNanos": 41446,
+              "reduceNanosSamples": [
+                42854,
+                41912,
+                42012,
+                41422,
+                41361,
+                41471,
+                41301,
+                40991
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1318980
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1245146,
+              "rank": 16,
+              "readbackNanos": 33389,
+              "reduceNanos": 35528,
+              "reduceNanosSamples": [
+                36875,
+                35203,
+                35653,
+                35132,
+                35813,
+                35403,
+                35843,
+                35062
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1313958
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1245171,
+              "rank": 16,
+              "readbackNanos": 33294,
+              "reduceNanos": 37531,
+              "reduceNanosSamples": [
+                38397,
+                37546,
+                37616,
+                37095,
+                40170,
+                37516,
+                37085,
+                37115
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1317098
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1243814,
+              "rank": 16,
+              "readbackNanos": 33490,
+              "reduceNanos": 35397,
+              "reduceNanosSamples": [
+                35213,
+                35382,
+                35322,
+                35373,
+                35512,
+                35603,
+                35803,
+                35412
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1312982
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1247369,
+              "rank": 16,
+              "readbackNanos": 33389,
+              "reduceNanos": 35953,
+              "reduceNanosSamples": [
+                36485,
+                35443,
+                36094,
+                35292,
+                36084,
+                36013,
+                35893,
+                35723
+              ],
+              "smallAllocs": 122163,
+              "totalNanos": 1316507
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1246417,
+              "rank": 16,
+              "readbackNanos": 33299,
+              "reduceNanos": 36724,
+              "reduceNanosSamples": [
+                36784,
+                37375,
+                36724,
+                36544,
+                37405,
+                36554,
+                36013,
+                36725
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1317944
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1244670,
+              "rank": 16,
+              "readbackNanos": 33324,
+              "reduceNanos": 34676,
+              "reduceNanosSamples": [
+                35092,
+                35172,
+                34501,
+                34942,
+                34852,
+                33900,
+                34071,
+                33599
+              ],
+              "smallAllocs": 121882,
+              "totalNanos": 1312275
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1244280,
+              "smallAllocs": 119722
+            },
+            "columnCount": {
+              "nanos": 7813,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 31711,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 6880,
+            "pivotSearch": {
+              "nanos": 880,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 33304,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 5032,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 37602,
+            "wall": {
+              "nanos": 48377,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5543,
+            "packNanos": 39043,
+            "rank": 16,
+            "reduceNanos": 60940,
+            "reduceNanosSamples": [
+              62643,
+              60940,
+              62092,
+              60941,
+              73580,
+              60420,
+              60700,
+              60279
+            ],
+            "rowAdds": 215,
+            "smallAllocs": 8858,
+            "totalNanos": 106507
+          },
+          "peakResidentBytes": 63387648,
+          "productionMatrixRebuild": {
+            "nanos": 1280398,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 592128,
+            "smallAllocs": 31823
+          },
+          "productionRowReduce": {
+            "nanos": 556700,
+            "smallAllocs": 30631
+          },
+          "rank": 16,
+          "residentBytesAfter": 63188992,
+          "residentBytesBefore": 62947328,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1286172,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4667,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1603432,
+            "smallAllocs": 149530
+          },
+          "berlekampSplit": {
+            "nanos": 3057558,
+            "smallAllocs": 258979
+          },
+          "columnPolys": {
+            "nanos": 1562421,
+            "smallAllocs": 145131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 788,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 554122,
+              "smallAllocs": 30737
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 26834,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 581619,
+            "wall": {
+              "nanos": 599013,
+              "smallAllocs": 32793
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 822,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1033478,
+              "smallAllocs": 59473
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 37054,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1073384,
+            "wall": {
+              "nanos": 1089976,
+              "smallAllocs": 62044
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 21832,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1686250,
+            "smallAllocs": 149883
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1618223,
+            "smallAllocs": 150587
+          },
+          "frobeniusPower": {
+            "nanos": 26173,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 16820,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1627697,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 50139,
+          "nullspaceBasisNanos": 50139,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2013,
+            "packNanos": 40549,
+            "rank": 16,
+            "reduceNanos": 60680,
+            "reduceNanosSamples": [
+              60670,
+              59178,
+              60690,
+              63374,
+              60860,
+              59218,
+              60910,
+              59218
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 103838
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1863,
+            "packNanos": 40404,
+            "rank": 16,
+            "reduceNanos": 61536,
+            "reduceNanosSamples": [
+              61340,
+              61501,
+              61361,
+              61431,
+              61571,
+              65077,
+              61862,
+              64225
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 103974
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2563,
+            "packNanos": 41396,
+            "rank": 16,
+            "reduceNanos": 52012,
+            "reduceNanosSamples": [
+              51447,
+              53229,
+              51407,
+              52618,
+              51406,
+              52848,
+              51336,
+              52578
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 97124
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1605525,
+              "rank": 16,
+              "readbackNanos": 33335,
+              "reduceNanos": 57465,
+              "reduceNanosSamples": [
+                57325,
+                57536,
+                57365,
+                57656,
+                57395,
+                57565,
+                57245,
+                57796
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1696170
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1608279,
+              "rank": 16,
+              "readbackNanos": 33334,
+              "reduceNanos": 70124,
+              "reduceNanosSamples": [
+                69162,
+                70164,
+                69363,
+                70394,
+                70955,
+                70404,
+                69713,
+                70084
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1711277
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1602781,
+              "rank": 16,
+              "readbackNanos": 32913,
+              "reduceNanos": 59614,
+              "reduceNanosSamples": [
+                59528,
+                59519,
+                59729,
+                72438,
+                59599,
+                59539,
+                59668,
+                59629
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1698973
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1604659,
+              "rank": 16,
+              "readbackNanos": 1832,
+              "reduceNanos": 60134,
+              "reduceNanosSamples": [
+                60149,
+                60049,
+                60369,
+                59829,
+                61842,
+                59869,
+                60120,
+                61201
+              ],
+              "smallAllocs": 148646,
+              "totalNanos": 1667357
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606356,
+              "rank": 16,
+              "readbackNanos": 33209,
+              "reduceNanos": 63900,
+              "reduceNanosSamples": [
+                63144,
+                65136,
+                62552,
+                64165,
+                64265,
+                63885,
+                63915,
+                62363
+              ],
+              "smallAllocs": 151395,
+              "totalNanos": 1702474
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607638,
+              "rank": 16,
+              "readbackNanos": 33019,
+              "reduceNanos": 68331,
+              "reduceNanosSamples": [
+                68402,
+                67951,
+                71576,
+                68522,
+                67961,
+                68261,
+                68422,
+                67900
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1708553
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1602530,
+              "rank": 16,
+              "readbackNanos": 33279,
+              "reduceNanos": 57520,
+              "reduceNanosSamples": [
+                57596,
+                57205,
+                57625,
+                57445,
+                58156,
+                56884,
+                57715,
+                57445
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1693045
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607498,
+              "rank": 16,
+              "readbackNanos": 32874,
+              "reduceNanos": 60379,
+              "reduceNanosSamples": [
+                60680,
+                60109,
+                60019,
+                60029,
+                60971,
+                60249,
+                60820,
+                60509
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1701032
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1605695,
+              "rank": 16,
+              "readbackNanos": 33244,
+              "reduceNanos": 57405,
+              "reduceNanosSamples": [
+                57846,
+                57305,
+                57526,
+                57505,
+                57205,
+                57205,
+                57195,
+                57786
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1696139
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609611,
+              "rank": 16,
+              "readbackNanos": 33064,
+              "reduceNanos": 57576,
+              "reduceNanosSamples": [
+                57926,
+                57646,
+                57506,
+                57255,
+                58177,
+                56824,
+                57966,
+                57355
+              ],
+              "smallAllocs": 150946,
+              "totalNanos": 1700516
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606857,
+              "rank": 16,
+              "readbackNanos": 32969,
+              "reduceNanos": 65006,
+              "reduceNanosSamples": [
+                63744,
+                63805,
+                64936,
+                64675,
+                66118,
+                65076,
+                65307,
+                65668
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1704356
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1606287,
+              "rank": 16,
+              "readbackNanos": 32999,
+              "reduceNanos": 60400,
+              "reduceNanosSamples": [
+                59798,
+                57905,
+                61511,
+                61240,
+                59829,
+                58246,
+                60971,
+                61551
+              ],
+              "smallAllocs": 150899,
+              "totalNanos": 1699374
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1603973,
+              "smallAllocs": 148505
+            },
+            "columnCount": {
+              "nanos": 7582,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 53754,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14368,
+            "pivotSearch": {
+              "nanos": 846,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 33044,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 4877,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 59473,
+            "wall": {
+              "nanos": 69978,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5187,
+            "packNanos": 39087,
+            "rank": 16,
+            "reduceNanos": 107990,
+            "reduceNanosSamples": [
+              107990,
+              107990,
+              108642,
+              108481,
+              108571,
+              107850,
+              107830,
+              107719
+            ],
+            "rowAdds": 449,
+            "smallAllocs": 16080,
+            "totalNanos": 152561
+          },
+          "peakResidentBytes": 63432704,
+          "productionMatrixRebuild": {
+            "nanos": 1649981,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1133610,
+            "smallAllocs": 62101
+          },
+          "productionRowReduce": {
+            "nanos": 1079505,
+            "smallAllocs": 60809
+          },
+          "rank": 16,
+          "residentBytesAfter": 63332352,
+          "residentBytesBefore": 63287296,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1645780,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4477,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1607222,
+            "smallAllocs": 149061
+          },
+          "berlekampSplit": {
+            "nanos": 4597556,
+            "smallAllocs": 381697
+          },
+          "columnPolys": {
+            "nanos": 1561815,
+            "smallAllocs": 144662
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 787,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 560852,
+              "smallAllocs": 31127
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 26843,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 588336,
+            "wall": {
+              "nanos": 606394,
+              "smallAllocs": 33183
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 795,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1052385,
+              "smallAllocs": 60247
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 37024,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1090341,
+            "wall": {
+              "nanos": 1107171,
+              "smallAllocs": 62818
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 12869,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1686440,
+            "smallAllocs": 149414
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1619381,
+            "smallAllocs": 150118
+          },
+          "frobeniusPower": {
+            "nanos": 26069,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 21598,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1631609,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 46418,
+          "nullspaceBasisNanos": 46418,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1898,
+            "packNanos": 40655,
+            "rank": 16,
+            "reduceNanos": 60535,
+            "reduceNanosSamples": [
+              61011,
+              59799,
+              61031,
+              60059,
+              60891,
+              60180,
+              60950,
+              59898
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 103779
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1707,
+            "packNanos": 40445,
+            "rank": 16,
+            "reduceNanos": 62092,
+            "reduceNanosSamples": [
+              64917,
+              63374,
+              62082,
+              62052,
+              62223,
+              61961,
+              62032,
+              62102
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 104374
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2037,
+            "packNanos": 40956,
+            "rank": 16,
+            "reduceNanos": 52242,
+            "reduceNanosSamples": [
+              51717,
+              53229,
+              51727,
+              52698,
+              51636,
+              53059,
+              51787,
+              52888
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 95336
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610622,
+              "rank": 16,
+              "readbackNanos": 32869,
+              "reduceNanos": 58021,
+              "reduceNanosSamples": [
+                57846,
+                58126,
+                57876,
+                58316,
+                57916,
+                62663,
+                58147,
+                57866
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1701673
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610442,
+              "rank": 16,
+              "readbackNanos": 32828,
+              "reduceNanos": 70879,
+              "reduceNanosSamples": [
+                70104,
+                70654,
+                71537,
+                72898,
+                70134,
+                71226,
+                69303,
+                71105
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1713620
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609125,
+              "rank": 16,
+              "readbackNanos": 32683,
+              "reduceNanos": 59728,
+              "reduceNanosSamples": [
+                60239,
+                59759,
+                59919,
+                58136,
+                59819,
+                59698,
+                58266,
+                58036
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1701487
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610848,
+              "rank": 16,
+              "readbackNanos": 1742,
+              "reduceNanos": 60725,
+              "reduceNanosSamples": [
+                62152,
+                60590,
+                60810,
+                60579,
+                60530,
+                60640,
+                83584,
+                60880
+              ],
+              "smallAllocs": 148171,
+              "totalNanos": 1673320
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1607478,
+              "rank": 16,
+              "readbackNanos": 32678,
+              "reduceNanos": 64416,
+              "reduceNanosSamples": [
+                66018,
+                62683,
+                62653,
+                64666,
+                64366,
+                64726,
+                64366,
+                64466
+              ],
+              "smallAllocs": 150932,
+              "totalNanos": 1703545
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609060,
+              "rank": 16,
+              "readbackNanos": 32633,
+              "reduceNanos": 68977,
+              "reduceNanosSamples": [
+                69112,
+                68932,
+                69022,
+                68852,
+                69073,
+                68933,
+                69443,
+                68392
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1710385
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609055,
+              "rank": 16,
+              "readbackNanos": 32668,
+              "reduceNanos": 57876,
+              "reduceNanosSamples": [
+                58147,
+                57365,
+                58226,
+                57685,
+                58056,
+                57706,
+                58046,
+                57365
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1699339
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1608965,
+              "rank": 16,
+              "readbackNanos": 32788,
+              "reduceNanos": 60625,
+              "reduceNanosSamples": [
+                60710,
+                60400,
+                61160,
+                60760,
+                60409,
+                60660,
+                60590,
+                60560
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1702679
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1611654,
+              "rank": 16,
+              "readbackNanos": 32844,
+              "reduceNanos": 57841,
+              "reduceNanosSamples": [
+                58066,
+                57596,
+                57776,
+                61521,
+                57755,
+                57776,
+                58147,
+                57906
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1704321
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1610512,
+              "rank": 16,
+              "readbackNanos": 32699,
+              "reduceNanos": 58141,
+              "reduceNanosSamples": [
+                58256,
+                57706,
+                61031,
+                58026,
+                58176,
+                58106,
+                58347,
+                57725
+              ],
+              "smallAllocs": 150477,
+              "totalNanos": 1700541
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1609576,
+              "rank": 16,
+              "readbackNanos": 32743,
+              "reduceNanos": 65182,
+              "reduceNanosSamples": [
+                65447,
+                65658,
+                64385,
+                64846,
+                65587,
+                64917,
+                64646,
+                66328
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1707461
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1613001,
+              "rank": 16,
+              "readbackNanos": 32883,
+              "reduceNanos": 58211,
+              "reduceNanosSamples": [
+                58216,
+                58417,
+                58207,
+                58006,
+                58006,
+                58077,
+                60169,
+                58276
+              ],
+              "smallAllocs": 150436,
+              "totalNanos": 1704762
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1613191,
+              "smallAllocs": 148036
+            },
+            "columnCount": {
+              "nanos": 7475,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 54029,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14560,
+            "pivotSearch": {
+              "nanos": 837,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 32769,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 4807,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 59695,
+            "wall": {
+              "nanos": 69939,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5122,
+            "packNanos": 38932,
+            "rank": 16,
+            "reduceNanos": 108981,
+            "reduceNanosSamples": [
+              109202,
+              109062,
+              111896,
+              108711,
+              108711,
+              108911,
+              108992,
+              108971
+            ],
+            "rowAdds": 455,
+            "smallAllocs": 16266,
+            "totalNanos": 153012
+          },
+          "peakResidentBytes": 63045632,
+          "productionMatrixRebuild": {
+            "nanos": 1645920,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1143671,
+            "smallAllocs": 62874
+          },
+          "productionRowReduce": {
+            "nanos": 1096956,
+            "smallAllocs": 61583
+          },
+          "rank": 16,
+          "residentBytesAfter": 63602688,
+          "residentBytesBefore": 63553536,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1644898,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift2",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4602,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1620077,
+            "smallAllocs": 149683
+          },
+          "berlekampSplit": {
+            "nanos": 3858175,
+            "smallAllocs": 320808
+          },
+          "columnPolys": {
+            "nanos": 1573853,
+            "smallAllocs": 145284
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 786,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 550516,
+              "smallAllocs": 30412
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 27105,
+              "smallAllocs": 1618
+            },
+            "stagedNanos": 578541,
+            "wall": {
+              "nanos": 596078,
+              "smallAllocs": 32469
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 830,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1023577,
+              "smallAllocs": 58828
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 37719,
+              "smallAllocs": 2130
+            },
+            "stagedNanos": 1062465,
+            "wall": {
+              "nanos": 1080712,
+              "smallAllocs": 61400
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 15342,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1698828,
+            "smallAllocs": 150036
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1637317,
+            "smallAllocs": 150740
+          },
+          "frobeniusPower": {
+            "nanos": 26154,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 22504,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1641534,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 46944,
+          "nullspaceBasisNanos": 46944,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1943,
+            "packNanos": 41091,
+            "rank": 16,
+            "reduceNanos": 61025,
+            "reduceNanosSamples": [
+              60479,
+              58747,
+              62783,
+              61721,
+              62563,
+              58837,
+              61571,
+              58947
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 103863
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1773,
+            "packNanos": 40756,
+            "rank": 16,
+            "reduceNanos": 60589,
+            "reduceNanosSamples": [
+              61071,
+              61010,
+              59879,
+              61050,
+              59819,
+              61160,
+              60169,
+              59949
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 103007
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2078,
+            "packNanos": 41356,
+            "rank": 16,
+            "reduceNanos": 52227,
+            "reduceNanosSamples": [
+              51626,
+              52829,
+              51576,
+              55001,
+              51496,
+              54561,
+              51416,
+              53449
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 95556
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1618359,
+              "rank": 16,
+              "readbackNanos": 32629,
+              "reduceNanos": 57360,
+              "reduceNanosSamples": [
+                57345,
+                57775,
+                57375,
+                58006,
+                57265,
+                57475,
+                56904,
+                57115
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1708648
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1615555,
+              "rank": 16,
+              "readbackNanos": 32618,
+              "reduceNanos": 69723,
+              "reduceNanosSamples": [
+                69122,
+                69523,
+                70754,
+                71126,
+                69333,
+                71075,
+                69753,
+                69693
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1719995
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1615780,
+              "rank": 16,
+              "readbackNanos": 32403,
+              "reduceNanos": 59072,
+              "reduceNanosSamples": [
+                58847,
+                57235,
+                59338,
+                59318,
+                59108,
+                59177,
+                59037,
+                58857
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1707581
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1621033,
+              "rank": 16,
+              "readbackNanos": 1877,
+              "reduceNanos": 60064,
+              "reduceNanosSamples": [
+                59839,
+                59688,
+                61772,
+                62422,
+                60309,
+                59809,
+                60289,
+                59748
+              ],
+              "smallAllocs": 148804,
+              "totalNanos": 1683846
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1624578,
+              "rank": 16,
+              "readbackNanos": 32623,
+              "reduceNanos": 63729,
+              "reduceNanosSamples": [
+                63454,
+                64055,
+                68231,
+                62863,
+                62263,
+                64005,
+                62904,
+                64816
+              ],
+              "smallAllocs": 151543,
+              "totalNanos": 1720865
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1617889,
+              "rank": 16,
+              "readbackNanos": 32443,
+              "reduceNanos": 68571,
+              "reduceNanosSamples": [
+                67471,
+                67790,
+                68791,
+                68872,
+                69423,
+                69002,
+                68351,
+                67260
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1719284
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619676,
+              "rank": 16,
+              "readbackNanos": 32568,
+              "reduceNanos": 57109,
+              "reduceNanosSamples": [
+                56995,
+                57055,
+                57715,
+                57285,
+                57976,
+                56895,
+                57164,
+                56494
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1709649
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1622941,
+              "rank": 16,
+              "readbackNanos": 32478,
+              "reduceNanos": 60514,
+              "reduceNanosSamples": [
+                59528,
+                64826,
+                60960,
+                60741,
+                60630,
+                60399,
+                59959,
+                59408
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1715438
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1619766,
+              "rank": 16,
+              "readbackNanos": 32768,
+              "reduceNanos": 57244,
+              "reduceNanosSamples": [
+                56714,
+                57435,
+                57255,
+                57496,
+                57245,
+                57244,
+                56934,
+                56865
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1710025
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1622445,
+              "rank": 16,
+              "readbackNanos": 32633,
+              "reduceNanos": 57540,
+              "reduceNanosSamples": [
+                57265,
+                57745,
+                58116,
+                57746,
+                57916,
+                57315,
+                57335,
+                56975
+              ],
+              "smallAllocs": 151099,
+              "totalNanos": 1712723
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1615264,
+              "rank": 16,
+              "readbackNanos": 32478,
+              "reduceNanos": 65046,
+              "reduceNanosSamples": [
+                65417,
+                64305,
+                64465,
+                66098,
+                64706,
+                65006,
+                65717,
+                65087
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1713004
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1620983,
+              "rank": 16,
+              "readbackNanos": 32543,
+              "reduceNanos": 59213,
+              "reduceNanosSamples": [
+                59047,
+                57175,
+                59298,
+                59839,
+                59468,
+                59798,
+                57556,
+                59128
+              ],
+              "smallAllocs": 151047,
+              "totalNanos": 1712193
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1626762,
+              "smallAllocs": 148658
+            },
+            "columnCount": {
+              "nanos": 7982,
+              "smallAllocs": 560
+            },
+            "eliminate": {
+              "nanos": 53412,
+              "smallAllocs": 560
+            },
+            "freeColumns": 16,
+            "innerMultiplies": 14208,
+            "pivotSearch": {
+              "nanos": 850,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 32558,
+              "smallAllocs": 1891
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 5002,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 512,
+            "stagedNanos": 59261,
+            "wall": {
+              "nanos": 71140,
+              "smallAllocs": 1334
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5758,
+            "packNanos": 39298,
+            "rank": 16,
+            "reduceNanos": 109487,
+            "reduceNanosSamples": [
+              107049,
+              106888,
+              109752,
+              109132,
+              109652,
+              111776,
+              109322,
+              110293
+            ],
+            "rowAdds": 444,
+            "smallAllocs": 15925,
+            "totalNanos": 155410
+          },
+          "peakResidentBytes": 63045632,
+          "productionMatrixRebuild": {
+            "nanos": 1658904,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1118773,
+            "smallAllocs": 61452
+          },
+          "productionRowReduce": {
+            "nanos": 1070717,
+            "smallAllocs": 60165
+          },
+          "rank": 16,
+          "residentBytesAfter": 62173184,
+          "residentBytesBefore": 62087168,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1660116,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd4_x_sd4shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 42,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 42,
+          "basisToPolynomials": {
+            "nanos": 5293,
+            "smallAllocs": 444
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2831307,
+            "smallAllocs": 263817
+          },
+          "berlekampSplit": {
+            "nanos": 7476439,
+            "smallAllocs": 625572
+          },
+          "columnPolys": {
+            "nanos": 2776546,
+            "smallAllocs": 258009
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1012,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 1457426,
+              "smallAllocs": 82650
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 53163,
+              "smallAllocs": 3279
+            },
+            "stagedNanos": 1511600,
+            "wall": {
+              "nanos": 1539472,
+              "smallAllocs": 86460
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1043,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 2766798,
+              "smallAllocs": 161190
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 73787,
+              "smallAllocs": 4329
+            },
+            "stagedNanos": 2841356,
+            "wall": {
+              "nanos": 2866795,
+              "smallAllocs": 166053
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 39238,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3033512,
+            "smallAllocs": 264369
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2882268,
+            "smallAllocs": 265624
+          },
+          "frobeniusPower": {
+            "nanos": 26018,
+            "smallAllocs": 2281
+          },
+          "kernelDimension": 17,
+          "matrixConversionNanos": 35246,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2940929,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 78492,
+          "nullspaceBasisNanos": 78492,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2949,
+            "packNanos": 72693,
+            "rank": 25,
+            "reduceNanos": 155805,
+            "reduceNanosSamples": [
+              155630,
+              153998,
+              158876,
+              157494,
+              155981,
+              153918,
+              155481,
+              158324
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 232379
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2724,
+            "packNanos": 72563,
+            "rank": 25,
+            "reduceNanos": 160012,
+            "reduceNanosSamples": [
+              159807,
+              159967,
+              160057,
+              163362,
+              160178,
+              159817,
+              156352,
+              160207
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 235193
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3044,
+            "packNanos": 73258,
+            "rank": 25,
+            "reduceNanos": 138185,
+            "reduceNanosSamples": [
+              137454,
+              138656,
+              137714,
+              138855,
+              137344,
+              138706,
+              137524,
+              139076
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 214272
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2852459,
+              "rank": 25,
+              "readbackNanos": 53319,
+              "reduceNanos": 142286,
+              "reduceNanosSamples": [
+                141239,
+                142111,
+                142591,
+                142060,
+                141860,
+                142461,
+                145736,
+                142762
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3048314
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2858873,
+              "rank": 25,
+              "readbackNanos": 53139,
+              "reduceNanos": 179796,
+              "reduceNanosSamples": [
+                179627,
+                179786,
+                184103,
+                180288,
+                179045,
+                182561,
+                178434,
+                179806
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3092069
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2857982,
+              "rank": 25,
+              "readbackNanos": 52913,
+              "reduceNanos": 150914,
+              "reduceNanosSamples": [
+                151645,
+                156813,
+                153157,
+                154048,
+                148420,
+                148820,
+                148760,
+                150183
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3061548
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2862173,
+              "rank": 25,
+              "readbackNanos": 2839,
+              "reduceNanos": 156782,
+              "reduceNanosSamples": [
+                156933,
+                156331,
+                159646,
+                162831,
+                156542,
+                158355,
+                156632,
+                156251
+              ],
+              "smallAllocs": 262265,
+              "totalNanos": 3021930
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2857922,
+              "rank": 25,
+              "readbackNanos": 52923,
+              "reduceNanos": 161855,
+              "reduceNanosSamples": [
+                158776,
+                167659,
+                163052,
+                165525,
+                161319,
+                162391,
+                160028,
+                160838
+              ],
+              "smallAllocs": 266773,
+              "totalNanos": 3073221
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2845924,
+              "rank": 25,
+              "readbackNanos": 52973,
+              "reduceNanos": 171048,
+              "reduceNanosSamples": [
+                175820,
+                170383,
+                170083,
+                173948,
+                169882,
+                170884,
+                171213,
+                175350
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3071438
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2867065,
+              "rank": 25,
+              "readbackNanos": 52928,
+              "reduceNanos": 142105,
+              "reduceNanosSamples": [
+                146166,
+                142090,
+                141980,
+                141921,
+                142121,
+                141970,
+                142651,
+                142211
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3061829
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2851132,
+              "rank": 25,
+              "readbackNanos": 52843,
+              "reduceNanos": 149402,
+              "reduceNanosSamples": [
+                152115,
+                149432,
+                148891,
+                148810,
+                149372,
+                149091,
+                152456,
+                152946
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3054428
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2847736,
+              "rank": 25,
+              "readbackNanos": 53335,
+              "reduceNanos": 142151,
+              "reduceNanosSamples": [
+                141470,
+                142151,
+                141831,
+                142451,
+                141589,
+                142151,
+                142401,
+                142311
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3043747
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2849585,
+              "rank": 25,
+              "readbackNanos": 53269,
+              "reduceNanos": 142341,
+              "reduceNanosSamples": [
+                142241,
+                142421,
+                142341,
+                142010,
+                142491,
+                142141,
+                142911,
+                142341
+              ],
+              "smallAllocs": 265838,
+              "totalNanos": 3044884
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2856284,
+              "rank": 25,
+              "readbackNanos": 53103,
+              "reduceNanos": 164894,
+              "reduceNanosSamples": [
+                165415,
+                171885,
+                165435,
+                163482,
+                168310,
+                164373,
+                161289,
+                164123
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3073051
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2852349,
+              "rank": 25,
+              "readbackNanos": 53459,
+              "reduceNanos": 155450,
+              "reduceNanosSamples": [
+                157323,
+                158025,
+                156172,
+                155821,
+                151284,
+                154799,
+                155080,
+                151875
+              ],
+              "smallAllocs": 265748,
+              "totalNanos": 3061974
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2853456,
+              "smallAllocs": 262052
+            },
+            "columnCount": {
+              "nanos": 14491,
+              "smallAllocs": 1125
+            },
+            "eliminate": {
+              "nanos": 135355,
+              "smallAllocs": 1125
+            },
+            "freeColumns": 17,
+            "innerMultiplies": 39270,
+            "pivotSearch": {
+              "nanos": 1101,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "readback": {
+              "nanos": 53379,
+              "smallAllocs": 2680
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 8672,
+              "smallAllocs": 100
+            },
+            "scaleMultiplies": 1050,
+            "stagedNanos": 145071,
+            "wall": {
+              "nanos": 163383,
+              "smallAllocs": 2549
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8197,
+            "packNanos": 69588,
+            "rank": 25,
+            "reduceNanos": 292333,
+            "reduceNanosSamples": [
+              287086,
+              284011,
+              286795,
+              293214,
+              293015,
+              292364,
+              295468,
+              292303
+            ],
+            "rowAdds": 935,
+            "smallAllocs": 42384,
+            "totalNanos": 369928
+          },
+          "peakResidentBytes": 63045632,
+          "productionMatrixRebuild": {
+            "nanos": 2901030,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2955506,
+            "smallAllocs": 166027
+          },
+          "productionRowReduce": {
+            "nanos": 2863711,
+            "smallAllocs": 163665
+          },
+          "rank": 25,
+          "residentBytesAfter": 62214144,
+          "residentBytesBefore": 62074880,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2904140,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 17
+        },
+        "modularDegree": 42,
+        "modularFactorCount": 17,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_x_phi11",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 6870,
+            "smallAllocs": 686
+          },
+          "berlekampMatrixWall": {
+            "nanos": 529795,
+            "smallAllocs": 51263
+          },
+          "berlekampSplit": {
+            "nanos": 1952850,
+            "smallAllocs": 163103
+          },
+          "columnPolys": {
+            "nanos": 467628,
+            "smallAllocs": 46071
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1203,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 120548,
+              "smallAllocs": 7891
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 70943,
+              "smallAllocs": 4425
+            },
+            "stagedNanos": 192775,
+            "wall": {
+              "nanos": 228243,
+              "smallAllocs": 13028
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1282,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 178335,
+              "smallAllocs": 11539
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 96427,
+              "smallAllocs": 5817
+            },
+            "stagedNanos": 275704,
+            "wall": {
+              "nanos": 308072,
+              "smallAllocs": 18071
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 36765,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 615347,
+            "smallAllocs": 51959
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 566790,
+            "smallAllocs": 53616
+          },
+          "frobeniusPower": {
+            "nanos": 7591,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 19,
+          "matrixConversionNanos": 54310,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 581672,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 64200,
+          "nullspaceBasisNanos": 64200,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3690,
+            "packNanos": 95586,
+            "rank": 29,
+            "reduceNanos": 27536,
+            "reduceNanosSamples": [
+              28692,
+              26960,
+              28112,
+              26870,
+              28142,
+              26870,
+              28322,
+              26689
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 126688
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3240,
+            "packNanos": 95887,
+            "rank": 29,
+            "reduceNanos": 27300,
+            "reduceNanosSamples": [
+              27441,
+              27301,
+              27360,
+              27300,
+              27009,
+              27300,
+              27221,
+              27071
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 126647
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3560,
+            "packNanos": 96283,
+            "rank": 29,
+            "reduceNanos": 25272,
+            "reduceNanosSamples": [
+              24737,
+              26109,
+              24707,
+              26309,
+              24727,
+              25808,
+              24566,
+              26530
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 125706
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 526811,
+              "rank": 29,
+              "readbackNanos": 72202,
+              "reduceNanos": 42282,
+              "reduceNanosSamples": [
+                42192,
+                41912,
+                42183,
+                42924,
+                41912,
+                43034,
+                42373,
+                42513
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 641090
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 528043,
+              "rank": 29,
+              "readbackNanos": 71936,
+              "reduceNanos": 33880,
+              "reduceNanosSamples": [
+                33550,
+                34361,
+                33579,
+                34231,
+                33450,
+                34181,
+                33460,
+                34371
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 635302
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 525969,
+              "rank": 29,
+              "readbackNanos": 71456,
+              "reduceNanos": 32087,
+              "reduceNanosSamples": [
+                31767,
+                32468,
+                32077,
+                32127,
+                31957,
+                32438,
+                31887,
+                32097
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 630234
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 526740,
+              "rank": 29,
+              "readbackNanos": 3350,
+              "reduceNanos": 27205,
+              "reduceNanosSamples": [
+                27190,
+                27180,
+                27171,
+                27221,
+                27300,
+                27200,
+                27210,
+                27210
+              ],
+              "smallAllocs": 50422,
+              "totalNanos": 557556
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 528488,
+              "rank": 29,
+              "readbackNanos": 71501,
+              "reduceNanos": 44171,
+              "reduceNanosSamples": [
+                44536,
+                43324,
+                44166,
+                44356,
+                43915,
+                44176,
+                43995,
+                44185
+              ],
+              "smallAllocs": 53866,
+              "totalNanos": 644560
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 530131,
+              "rank": 29,
+              "readbackNanos": 71646,
+              "reduceNanos": 45382,
+              "reduceNanosSamples": [
+                45508,
+                44787,
+                45618,
+                45348,
+                45397,
+                45397,
+                45307,
+                45367
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 647420
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 531988,
+              "rank": 29,
+              "readbackNanos": 71726,
+              "reduceNanos": 42828,
+              "reduceNanosSamples": [
+                43474,
+                41482,
+                42744,
+                42503,
+                42873,
+                42783,
+                42984,
+                42914
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 646583
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 526896,
+              "rank": 29,
+              "readbackNanos": 71605,
+              "reduceNanos": 43795,
+              "reduceNanosSamples": [
+                43745,
+                43344,
+                43464,
+                43885,
+                43615,
+                43955,
+                43935,
+                43845
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 642317
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 528027,
+              "rank": 29,
+              "readbackNanos": 72001,
+              "reduceNanos": 42473,
+              "reduceNanosSamples": [
+                42473,
+                41632,
+                42473,
+                42613,
+                42633,
+                42983,
+                42353,
+                42433
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 642061
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 527351,
+              "rank": 29,
+              "readbackNanos": 72046,
+              "reduceNanos": 43018,
+              "reduceNanosSamples": [
+                43495,
+                41962,
+                43485,
+                46729,
+                42753,
+                42913,
+                43124,
+                42614
+              ],
+              "smallAllocs": 53828,
+              "totalNanos": 643168
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 525995,
+              "rank": 29,
+              "readbackNanos": 72808,
+              "reduceNanos": 32748,
+              "reduceNanosSamples": [
+                35753,
+                32918,
+                32559,
+                32598,
+                32598,
+                33029,
+                32528,
+                32899
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 632923
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 528818,
+              "rank": 29,
+              "readbackNanos": 71871,
+              "reduceNanos": 32363,
+              "reduceNanosSamples": [
+                32609,
+                31667,
+                32278,
+                32268,
+                32028,
+                32448,
+                32589,
+                32518
+              ],
+              "smallAllocs": 52503,
+              "totalNanos": 633288
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 529405,
+              "smallAllocs": 48958
+            },
+            "columnCount": {
+              "nanos": 18603,
+              "smallAllocs": 1479
+            },
+            "eliminate": {
+              "nanos": 33396,
+              "smallAllocs": 1479
+            },
+            "freeColumns": 19,
+            "innerMultiplies": 1824,
+            "pivotSearch": {
+              "nanos": 1301,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "readback": {
+              "nanos": 71922,
+              "smallAllocs": 3414
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 10786,
+              "smallAllocs": 116
+            },
+            "scaleMultiplies": 1392,
+            "stagedNanos": 45475,
+            "wall": {
+              "nanos": 68551,
+              "smallAllocs": 3301
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9985,
+            "packNanos": 92111,
+            "rank": 29,
+            "reduceNanos": 40696,
+            "reduceNanosSamples": [
+              41021,
+              40650,
+              40651,
+              40921,
+              40961,
+              40741,
+              40510,
+              40470
+            ],
+            "rowAdds": 38,
+            "smallAllocs": 7083,
+            "totalNanos": 143217
+          },
+          "peakResidentBytes": 63045632,
+          "productionMatrixRebuild": {
+            "nanos": 566741,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 335442,
+            "smallAllocs": 17567
+          },
+          "productionRowReduce": {
+            "nanos": 272799,
+            "smallAllocs": 14957
+          },
+          "rank": 29,
+          "residentBytesAfter": 62570496,
+          "residentBytesBefore": 62468096,
+          "rowReduceMatrixRebuild": {
+            "nanos": 574571,
+            "smallAllocs": 0
+          },
+          "sink": 104,
+          "splitFactors": 19
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 19,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow48_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 105,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 105,
+          "basisToPolynomials": {
+            "nanos": 7210,
+            "smallAllocs": 657
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3516403,
+            "smallAllocs": 337638
+          },
+          "berlekampSplit": {
+            "nanos": 8844177,
+            "smallAllocs": 750003
+          },
+          "columnPolys": {
+            "nanos": 3249092,
+            "smallAllocs": 314148
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2614,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 988633,
+              "smallAllocs": 65681
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 461187,
+              "smallAllocs": 29307
+            },
+            "stagedNanos": 1456061,
+            "wall": {
+              "nanos": 1598730,
+              "smallAllocs": 95903
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2705,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1588947,
+              "smallAllocs": 102431
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 631425,
+              "smallAllocs": 38862
+            },
+            "stagedNanos": 2226657,
+            "wall": {
+              "nanos": 2354810,
+              "smallAllocs": 142211
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 170172,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3928895,
+            "smallAllocs": 339228
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3694206,
+            "smallAllocs": 348769
+          },
+          "frobeniusPower": {
+            "nanos": 17055,
+            "smallAllocs": 1441
+          },
+          "kernelDimension": 14,
+          "matrixConversionNanos": 250481,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3775336,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 226596,
+          "nullspaceBasisNanos": 226596,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9694,
+            "packNanos": 503642,
+            "rank": 91,
+            "reduceNanos": 182886,
+            "reduceNanosSamples": [
+              189471,
+              180608,
+              182821,
+              180808,
+              183061,
+              181238,
+              182951,
+              185435
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 696302
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9123,
+            "packNanos": 503587,
+            "rank": 91,
+            "reduceNanos": 183837,
+            "reduceNanosSamples": [
+              183722,
+              184714,
+              183281,
+              183091,
+              181438,
+              187979,
+              184784,
+              183953
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 697429
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 9629,
+            "packNanos": 502160,
+            "rank": 91,
+            "reduceNanos": 154754,
+            "reduceNanosSamples": [
+              152055,
+              157724,
+              157193,
+              155220,
+              151775,
+              154749,
+              153898,
+              154759
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 666959
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3523058,
+              "rank": 91,
+              "readbackNanos": 210952,
+              "reduceNanos": 272153,
+              "reduceNanosSamples": [
+                271683,
+                271513,
+                269039,
+                272685,
+                272624,
+                274096,
+                293936,
+                271453
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4003750
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3497910,
+              "rank": 91,
+              "readbackNanos": 207743,
+              "reduceNanos": 226771,
+              "reduceNanosSamples": [
+                227838,
+                226145,
+                227397,
+                225604,
+                223351,
+                227878,
+                224213,
+                227478
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3932104
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3512231,
+              "rank": 91,
+              "readbackNanos": 209730,
+              "reduceNanos": 211764,
+              "reduceNanosSamples": [
+                211644,
+                210082,
+                210072,
+                212365,
+                214528,
+                220367,
+                211885,
+                211633
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3928914
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3503414,
+              "rank": 91,
+              "readbackNanos": 9644,
+              "reduceNanos": 183106,
+              "reduceNanosSamples": [
+                223752,
+                184764,
+                185555,
+                181179,
+                181830,
+                181529,
+                182911,
+                183302
+              ],
+              "smallAllocs": 336216,
+              "totalNanos": 3697912
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3514355,
+              "rank": 91,
+              "readbackNanos": 210843,
+              "reduceNanos": 288823,
+              "reduceNanosSamples": [
+                288708,
+                286805,
+                285423,
+                288939,
+                289439,
+                293305,
+                292744,
+                288548
+              ],
+              "smallAllocs": 342378,
+              "totalNanos": 4010360
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3528797,
+              "rank": 91,
+              "readbackNanos": 211864,
+              "reduceNanos": 297005,
+              "reduceNanosSamples": [
+                306785,
+                297281,
+                292173,
+                294977,
+                297912,
+                296990,
+                296960,
+                297020
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4040765
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3505096,
+              "rank": 91,
+              "readbackNanos": 210472,
+              "reduceNanos": 279143,
+              "reduceNanosSamples": [
+                279685,
+                276310,
+                274888,
+                277512,
+                281357,
+                281367,
+                284582,
+                278602
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3990050
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3526623,
+              "rank": 91,
+              "readbackNanos": 211419,
+              "reduceNanos": 285062,
+              "reduceNanosSamples": [
+                286054,
+                283110,
+                286785,
+                284181,
+                282879,
+                285943,
+                286775,
+                283791
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4023650
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3510764,
+              "rank": 91,
+              "readbackNanos": 210983,
+              "reduceNanos": 280922,
+              "reduceNanosSamples": [
+                281658,
+                276880,
+                278023,
+                279395,
+                282308,
+                282518,
+                283991,
+                280186
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 3996695
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3520795,
+              "rank": 91,
+              "readbackNanos": 210652,
+              "reduceNanos": 281287,
+              "reduceNanosSamples": [
+                280886,
+                279264,
+                278593,
+                281217,
+                282939,
+                282518,
+                285634,
+                281357
+              ],
+              "smallAllocs": 342203,
+              "totalNanos": 4010996
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3503804,
+              "rank": 91,
+              "readbackNanos": 207262,
+              "reduceNanos": 217042,
+              "reduceNanosSamples": [
+                222139,
+                217102,
+                214819,
+                216982,
+                216351,
+                219555,
+                215360,
+                217142
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3926711
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3504695,
+              "rank": 91,
+              "readbackNanos": 206611,
+              "reduceNanos": 212680,
+              "reduceNanosSamples": [
+                215290,
+                212966,
+                209271,
+                212626,
+                212735,
+                218795,
+                208629,
+                211864
+              ],
+              "smallAllocs": 332914,
+              "totalNanos": 3922255
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3509848,
+              "smallAllocs": 326612
+            },
+            "columnCount": {
+              "nanos": 111260,
+              "smallAllocs": 9828
+            },
+            "eliminate": {
+              "nanos": 226297,
+              "smallAllocs": 9828
+            },
+            "freeColumns": 14,
+            "innerMultiplies": 18375,
+            "pivotSearch": {
+              "nanos": 2680,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "readback": {
+              "nanos": 204859,
+              "smallAllocs": 5848
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 56899,
+              "smallAllocs": 364
+            },
+            "scaleMultiplies": 9555,
+            "stagedNanos": 285862,
+            "wall": {
+              "nanos": 411931,
+              "smallAllocs": 20537
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 46994,
+            "packNanos": 478018,
+            "rank": 91,
+            "reduceNanos": 302759,
+            "reduceNanosSamples": [
+              305663,
+              305503,
+              301417,
+              302068,
+              301497,
+              303050,
+              302468,
+              304602
+            ],
+            "rowAdds": 175,
+            "smallAllocs": 48772,
+            "totalNanos": 828138
+          },
+          "peakResidentBytes": 63864832,
+          "productionMatrixRebuild": {
+            "nanos": 3752348,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2374210,
+            "smallAllocs": 134628
+          },
+          "productionRowReduce": {
+            "nanos": 2151319,
+            "smallAllocs": 122300
+          },
+          "rank": 91,
+          "residentBytesAfter": 63578112,
+          "residentBytesBefore": 62525440,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3759403,
+            "smallAllocs": 0
+          },
+          "sink": 136,
+          "splitFactors": 14
+        },
+        "modularDegree": 105,
+        "modularFactorCount": 14,
+        "prime": 17,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow105_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 120,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 120,
+          "basisToPolynomials": {
+            "nanos": 28292,
+            "smallAllocs": 2778
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2385377,
+            "smallAllocs": 214939
+          },
+          "berlekampSplit": {
+            "nanos": 16068256,
+            "smallAllocs": 1312571
+          },
+          "columnPolys": {
+            "nanos": 2013885,
+            "smallAllocs": 185863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 2961,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 840422,
+              "smallAllocs": 57197
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 472160,
+              "smallAllocs": 30075
+            },
+            "stagedNanos": 1314137,
+            "wall": {
+              "nanos": 1511350,
+              "smallAllocs": 89910
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3049,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 1300331,
+              "smallAllocs": 85037
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 635874,
+              "smallAllocs": 39795
+            },
+            "stagedNanos": 1940540,
+            "wall": {
+              "nanos": 2127885,
+              "smallAllocs": 127473
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 191808,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3005180,
+            "smallAllocs": 218459
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2579128,
+            "smallAllocs": 229460
+          },
+          "frobeniusPower": {
+            "nanos": 4496,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 39,
+          "matrixConversionNanos": 362929,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2656603,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 499746,
+          "nullspaceBasisNanos": 499746,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16509,
+            "packNanos": 659512,
+            "rank": 81,
+            "reduceNanos": 171174,
+            "reduceNanosSamples": [
+              172175,
+              169612,
+              172325,
+              169491,
+              175550,
+              170713,
+              171635,
+              170383
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 849319
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16479,
+            "packNanos": 661665,
+            "rank": 81,
+            "reduceNanos": 172215,
+            "reduceNanosSamples": [
+              172526,
+              171595,
+              171764,
+              173587,
+              172736,
+              172175,
+              172095,
+              172255
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 849774
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16995,
+            "packNanos": 665807,
+            "rank": 81,
+            "reduceNanos": 150233,
+            "reduceNanosSamples": [
+              149021,
+              151035,
+              150133,
+              151053,
+              148881,
+              150363,
+              148981,
+              150333
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 832694
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2267517,
+              "rank": 81,
+              "readbackNanos": 570020,
+              "reduceNanos": 272464,
+              "reduceNanosSamples": [
+                262529,
+                273215,
+                271222,
+                273665,
+                268979,
+                275729,
+                271993,
+                272935
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3112619
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2275789,
+              "rank": 81,
+              "readbackNanos": 569544,
+              "reduceNanos": 215204,
+              "reduceNanosSamples": [
+                214498,
+                215910,
+                213997,
+                218194,
+                212686,
+                217222,
+                217994,
+                213747
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3058724
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2269659,
+              "rank": 81,
+              "readbackNanos": 573315,
+              "reduceNanos": 206020,
+              "reduceNanosSamples": [
+                203872,
+                206526,
+                205515,
+                224102,
+                206927,
+                210362,
+                205274,
+                202991
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3054138
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2274983,
+              "rank": 81,
+              "readbackNanos": 16389,
+              "reduceNanos": 171944,
+              "reduceNanosSamples": [
+                171954,
+                170813,
+                176472,
+                171935,
+                172295,
+                171084,
+                172286,
+                170733
+              ],
+              "smallAllocs": 210396,
+              "totalNanos": 2462846
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2286860,
+              "rank": 81,
+              "readbackNanos": 573665,
+              "reduceNanos": 283109,
+              "reduceNanosSamples": [
+                275559,
+                284201,
+                285664,
+                281838,
+                282018,
+                290270,
+                281508,
+                290751
+              ],
+              "smallAllocs": 228020,
+              "totalNanos": 3143130
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2279704,
+              "rank": 81,
+              "readbackNanos": 573825,
+              "reduceNanos": 290706,
+              "reduceNanosSamples": [
+                284482,
+                289069,
+                292343,
+                292934,
+                288839,
+                294406,
+                286946,
+                294486
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3145878
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2263560,
+              "rank": 81,
+              "readbackNanos": 568463,
+              "reduceNanos": 278157,
+              "reduceNanosSamples": [
+                270942,
+                278273,
+                280877,
+                281787,
+                275238,
+                285794,
+                273886,
+                278042
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3114311
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2278207,
+              "rank": 81,
+              "readbackNanos": 570195,
+              "reduceNanos": 281057,
+              "reduceNanosSamples": [
+                278412,
+                280335,
+                281928,
+                280436,
+                279685,
+                285003,
+                287566,
+                281678
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3131868
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2275613,
+              "rank": 81,
+              "readbackNanos": 573310,
+              "reduceNanos": 277156,
+              "reduceNanosSamples": [
+                266335,
+                284061,
+                273325,
+                276190,
+                280255,
+                280876,
+                272595,
+                278122
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3123656
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2262179,
+              "rank": 81,
+              "readbackNanos": 569479,
+              "reduceNanos": 279669,
+              "reduceNanosSamples": [
+                267827,
+                286044,
+                278694,
+                290842,
+                278954,
+                285223,
+                274357,
+                280385
+              ],
+              "smallAllocs": 227904,
+              "totalNanos": 3112033
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2293815,
+              "rank": 81,
+              "readbackNanos": 570811,
+              "reduceNanos": 209265,
+              "reduceNanosSamples": [
+                207839,
+                209691,
+                208459,
+                213116,
+                205425,
+                208840,
+                211664,
+                222990
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3076951
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2267466,
+              "rank": 81,
+              "readbackNanos": 570095,
+              "reduceNanos": 202835,
+              "reduceNanosSamples": [
+                200838,
+                203492,
+                201989,
+                203021,
+                207298,
+                205615,
+                202470,
+                202650
+              ],
+              "smallAllocs": 218381,
+              "totalNanos": 3042490
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2279700,
+              "smallAllocs": 200538
+            },
+            "columnCount": {
+              "nanos": 113155,
+              "smallAllocs": 9963
+            },
+            "eliminate": {
+              "nanos": 218703,
+              "smallAllocs": 9963
+            },
+            "freeColumns": 39,
+            "innerMultiplies": 13920,
+            "pivotSearch": {
+              "nanos": 3085,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "readback": {
+              "nanos": 565914,
+              "smallAllocs": 17478
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 57325,
+              "smallAllocs": 324
+            },
+            "scaleMultiplies": 9720,
+            "stagedNanos": 278396,
+            "wall": {
+              "nanos": 409842,
+              "smallAllocs": 20817
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 62913,
+            "packNanos": 632067,
+            "rank": 81,
+            "reduceNanos": 271212,
+            "reduceNanosSamples": [
+              276891,
+              270111,
+              271062,
+              282599,
+              274086,
+              269860,
+              266114,
+              271362
+            ],
+            "rowAdds": 116,
+            "smallAllocs": 48141,
+            "totalNanos": 967119
+          },
+          "peakResidentBytes": 64856064,
+          "productionMatrixRebuild": {
+            "nanos": 2587596,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2441474,
+            "smallAllocs": 123505
+          },
+          "productionRowReduce": {
+            "nanos": 1942910,
+            "smallAllocs": 107187
+          },
+          "rank": 81,
+          "residentBytesAfter": 64184320,
+          "residentBytesBefore": 62595072,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2627641,
+            "smallAllocs": 0
+          },
+          "sink": 152,
+          "splitFactors": 39
+        },
+        "modularDegree": 120,
+        "modularFactorCount": 39,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "xpow120_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 178,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 178,
+          "basisToPolynomials": {
+            "nanos": 3590,
+            "smallAllocs": 371
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3147856,
+            "smallAllocs": 274190
+          },
+          "berlekampSplit": {
+            "nanos": 5282396,
+            "smallAllocs": 339370
+          },
+          "columnPolys": {
+            "nanos": 2411344,
+            "smallAllocs": 210706
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4562,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 7937764,
+              "smallAllocs": 491858
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1524945,
+              "smallAllocs": 95034
+            },
+            "stagedNanos": 9450333,
+            "wall": {
+              "nanos": 9838711,
+              "smallAllocs": 587969
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4582,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 14637985,
+              "smallAllocs": 888442
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 2074411,
+              "smallAllocs": 126362
+            },
+            "stagedNanos": 16714509,
+            "wall": {
+              "nanos": 17106936,
+              "smallAllocs": 1015884
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 480553,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4559645,
+            "smallAllocs": 275077
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3625605,
+            "smallAllocs": 306053
+          },
+          "frobeniusPower": {
+            "nanos": 2909,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 2,
+          "matrixConversionNanos": 713087,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3716940,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 335833,
+          "nullspaceBasisNanos": 335833,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 15122,
+            "packNanos": 1496468,
+            "rank": 176,
+            "reduceNanos": 1063942,
+            "reduceNanosSamples": [
+              1068104,
+              1058239,
+              1065499,
+              1061203,
+              1095955,
+              1062375,
+              1067693,
+              1062385
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2586870
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14556,
+            "packNanos": 1498035,
+            "rank": 176,
+            "reduceNanos": 1086896,
+            "reduceNanosSamples": [
+              1099239,
+              1085899,
+              1085129,
+              1087893,
+              1084748,
+              1074503,
+              1096456,
+              1091758
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2603114
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 14827,
+            "packNanos": 1501876,
+            "rank": 176,
+            "reduceNanos": 723347,
+            "reduceNanosSamples": [
+              723803,
+              724484,
+              720498,
+              752525,
+              722882,
+              728570,
+              716793,
+              722892
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2244247
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3099581,
+              "rank": 176,
+              "readbackNanos": 199711,
+              "reduceNanos": 1267949,
+              "reduceNanosSamples": [
+                1255752,
+                1281480,
+                1270764,
+                1301749,
+                1262882,
+                1259768,
+                1265135,
+                1281029
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4565924
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3080592,
+              "rank": 176,
+              "readbackNanos": 197042,
+              "reduceNanos": 1257840,
+              "reduceNanosSamples": [
+                1252497,
+                1265366,
+                1258546,
+                1263944,
+                1262842,
+                1257134,
+                1256703,
+                1255942
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4536600
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3091803,
+              "rank": 176,
+              "readbackNanos": 196386,
+              "reduceNanos": 1124938,
+              "reduceNanosSamples": [
+                1104287,
+                1121282,
+                1104307,
+                1124497,
+                1135273,
+                1125379,
+                1128493,
+                1125739
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4400994
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3084828,
+              "rank": 176,
+              "readbackNanos": 14792,
+              "reduceNanos": 1076966,
+              "reduceNanosSamples": [
+                1094944,
+                1129024,
+                1076806,
+                1068624,
+                1113982,
+                1077127,
+                1074453,
+                1071359
+              ],
+              "smallAllocs": 273089,
+              "totalNanos": 4189636
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3103842,
+              "rank": 176,
+              "readbackNanos": 193457,
+              "reduceNanos": 1376565,
+              "reduceNanosSamples": [
+                1350152,
+                1394707,
+                1380677,
+                1374387,
+                1378744,
+                1361788,
+                1373566,
+                1386996
+              ],
+              "smallAllocs": 276914,
+              "totalNanos": 4665056
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3096946,
+              "rank": 176,
+              "readbackNanos": 194182,
+              "reduceNanos": 1451962,
+              "reduceNanosSamples": [
+                1434647,
+                1468367,
+                1450920,
+                1463189,
+                1446054,
+                1438233,
+                1453005,
+                1457691
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4735640
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3107362,
+              "rank": 176,
+              "readbackNanos": 197933,
+              "reduceNanos": 1306482,
+              "reduceNanosSamples": [
+                1290193,
+                1316292,
+                1309802,
+                1314108,
+                1303162,
+                1296663,
+                1300068,
+                1317994
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4617796
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3098043,
+              "rank": 176,
+              "readbackNanos": 195215,
+              "reduceNanos": 1343577,
+              "reduceNanosSamples": [
+                1328098,
+                1451332,
+                1349351,
+                1358023,
+                1337803,
+                1331243,
+                1332195,
+                1354728
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4636784
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3106711,
+              "rank": 176,
+              "readbackNanos": 197823,
+              "reduceNanos": 1307352,
+              "reduceNanosSamples": [
+                1303632,
+                1313548,
+                1311073,
+                1317954,
+                1297994,
+                1297704,
+                1298755,
+                1314740
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4617130
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3095469,
+              "rank": 176,
+              "readbackNanos": 197778,
+              "reduceNanos": 1307603,
+              "reduceNanosSamples": [
+                1290763,
+                1319336,
+                1317904,
+                1321569,
+                1301109,
+                1292416,
+                1299106,
+                1314098
+              ],
+              "smallAllocs": 275800,
+              "totalNanos": 4604641
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3116946,
+              "rank": 176,
+              "readbackNanos": 196656,
+              "reduceNanos": 1177300,
+              "reduceNanosSamples": [
+                1188773,
+                1171517,
+                1168372,
+                1181712,
+                1215812,
+                1165378,
+                1192338,
+                1172889
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4482410
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3096210,
+              "rank": 176,
+              "readbackNanos": 196451,
+              "reduceNanos": 1122989,
+              "reduceNanosSamples": [
+                1102354,
+                1123616,
+                1100061,
+                1130156,
+                1132168,
+                1125739,
+                1122363,
+                1112359
+              ],
+              "smallAllocs": 245762,
+              "totalNanos": 4406217
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3113681,
+              "smallAllocs": 242505
+            },
+            "columnCount": {
+              "nanos": 359481,
+              "smallAllocs": 31856
+            },
+            "eliminate": {
+              "nanos": 1128107,
+              "smallAllocs": 31856
+            },
+            "freeColumns": 2,
+            "innerMultiplies": 198292,
+            "pivotSearch": {
+              "nanos": 4780,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "readback": {
+              "nanos": 184518,
+              "smallAllocs": 1609
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 168731,
+              "smallAllocs": 704
+            },
+            "scaleMultiplies": 31328,
+            "stagedNanos": 1303594,
+            "wall": {
+              "nanos": 1714502,
+              "smallAllocs": 65310
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 109943,
+            "packNanos": 1428658,
+            "rank": 176,
+            "reduceNanos": 1929270,
+            "reduceNanosSamples": [
+              1936161,
+              1929140,
+              1933837,
+              1938334,
+              1929400,
+              1887369,
+              1890102,
+              1884373
+            ],
+            "rowAdds": 1114,
+            "smallAllocs": 291357,
+            "totalNanos": 3456234
+          },
+          "peakResidentBytes": 66484224,
+          "productionMatrixRebuild": {
+            "nanos": 3701102,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 17031134,
+            "smallAllocs": 984110
+          },
+          "productionRowReduce": {
+            "nanos": 16684145,
+            "smallAllocs": 951807
+          },
+          "rank": 176,
+          "residentBytesAfter": 66342912,
+          "residentBytesBefore": 64487424,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3693565,
+            "smallAllocs": 0
+          },
+          "sink": 180,
+          "splitFactors": 2
+        },
+        "modularDegree": 178,
+        "modularFactorCount": 2,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi179",
+      "status": "ok"
+    },
+    {
+      "degree": 80,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 80,
+          "basisToPolynomials": {
+            "nanos": 3966,
+            "smallAllocs": 307
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3731302,
+            "smallAllocs": 346439
+          },
+          "berlekampSplit": {
+            "nanos": 7720375,
+            "smallAllocs": 586770
+          },
+          "columnPolys": {
+            "nanos": 3563898,
+            "smallAllocs": 333055
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2026,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 12045384,
+              "smallAllocs": 705467
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 276905,
+              "smallAllocs": 17180
+            },
+            "stagedNanos": 12327448,
+            "wall": {
+              "nanos": 12414880,
+              "smallAllocs": 723226
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2101,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 23097044,
+              "smallAllocs": 1389787
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 379790,
+              "smallAllocs": 22780
+            },
+            "stagedNanos": 23477449,
+            "wall": {
+              "nanos": 23563063,
+              "smallAllocs": 1413149
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 90784,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4927205,
+            "smallAllocs": 347380
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3823778,
+            "smallAllocs": 352920
+          },
+          "frobeniusPower": {
+            "nanos": 8518,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 10,
+          "matrixConversionNanos": 153412,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3901434,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 165625,
+          "nullspaceBasisNanos": 165625,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6084,
+            "packNanos": 279614,
+            "rank": 70,
+            "reduceNanos": 1273934,
+            "reduceNanosSamples": [
+              1275221,
+              1273919,
+              1277664,
+              1272346,
+              1276382,
+              1272216,
+              1273748,
+              1273949
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1560674
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5343,
+            "packNanos": 277461,
+            "rank": 70,
+            "reduceNanos": 1321624,
+            "reduceNanosSamples": [
+              1323011,
+              1321669,
+              1289532,
+              1290132,
+              1291094,
+              1328129,
+              1329691,
+              1321579
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1605200
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5788,
+            "packNanos": 280505,
+            "rank": 70,
+            "reduceNanos": 1006011,
+            "reduceNanosSamples": [
+              1001154,
+              1014774,
+              1010629,
+              1005501,
+              1006522,
+              1003919,
+              999842,
+              1007624
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1292321
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3699665,
+              "rank": 70,
+              "readbackNanos": 105987,
+              "reduceNanos": 1102675,
+              "reduceNanosSamples": [
+                1103066,
+                1102284,
+                1100912,
+                1103937,
+                1114663,
+                1105239,
+                1095364,
+                1101053
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4913419
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3705813,
+              "rank": 70,
+              "readbackNanos": 104129,
+              "reduceNanos": 1439544,
+              "reduceNanosSamples": [
+                1438913,
+                1450220,
+                1420986,
+                1447216,
+                1441167,
+                1440175,
+                1437311,
+                1425754
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5247439
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3708458,
+              "rank": 70,
+              "readbackNanos": 104780,
+              "reduceNanos": 1184746,
+              "reduceNanosSamples": [
+                1207470,
+                1209503,
+                1175793,
+                1171817,
+                1211266,
+                1170536,
+                1177646,
+                1191847
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5002761
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3706420,
+              "rank": 70,
+              "readbackNanos": 5633,
+              "reduceNanos": 1292907,
+              "reduceNanosSamples": [
+                1320748,
+                1289282,
+                1321279,
+                1289602,
+                1292326,
+                1293488,
+                1291335,
+                1329491
+              ],
+              "smallAllocs": 341535,
+              "totalNanos": 5015345
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3700941,
+              "rank": 70,
+              "readbackNanos": 104114,
+              "reduceNanos": 1241571,
+              "reduceNanosSamples": [
+                1259808,
+                1222803,
+                1226608,
+                1255030,
+                1221721,
+                1247519,
+                1244275,
+                1238867
+              ],
+              "smallAllocs": 353284,
+              "totalNanos": 5047778
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3696836,
+              "rank": 70,
+              "readbackNanos": 104224,
+              "reduceNanos": 1352385,
+              "reduceNanosSamples": [
+                1354598,
+                1352545,
+                1349030,
+                1354859,
+                1355649,
+                1347909,
+                1352225,
+                1345515
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 5154907
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3709289,
+              "rank": 70,
+              "readbackNanos": 104690,
+              "reduceNanos": 1112675,
+              "reduceNanosSamples": [
+                1114923,
+                1112039,
+                1116946,
+                1113311,
+                1113601,
+                1111098,
+                1108223,
+                1109926
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4924616
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3692148,
+              "rank": 70,
+              "readbackNanos": 105236,
+              "reduceNanos": 1170726,
+              "reduceNanosSamples": [
+                1169033,
+                1168752,
+                1171948,
+                1169634,
+                1170165,
+                1171657,
+                1172057,
+                1171287
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4971450
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3700721,
+              "rank": 70,
+              "readbackNanos": 104570,
+              "reduceNanos": 1115604,
+              "reduceNanosSamples": [
+                1116205,
+                1120211,
+                1118207,
+                1115043,
+                1116165,
+                1112279,
+                1108133,
+                1108623
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4919918
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3698944,
+              "rank": 70,
+              "readbackNanos": 105281,
+              "reduceNanos": 1113390,
+              "reduceNanosSamples": [
+                1110136,
+                1110978,
+                1122925,
+                1111608,
+                1115173,
+                1117517,
+                1116886,
+                1111137
+              ],
+              "smallAllocs": 349007,
+              "totalNanos": 4918922
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3709394,
+              "rank": 70,
+              "readbackNanos": 104975,
+              "reduceNanos": 1302445,
+              "reduceNanosSamples": [
+                1289272,
+                1309140,
+                1277104,
+                1310734,
+                1286187,
+                1323402,
+                1297213,
+                1307678
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 5113431
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 3697376,
+              "rank": 70,
+              "readbackNanos": 105051,
+              "reduceNanos": 1186078,
+              "reduceNanosSamples": [
+                1182883,
+                1176784,
+                1172769,
+                1206929,
+                1189273,
+                1191827,
+                1182833,
+                1217024
+              ],
+              "smallAllocs": 347754,
+              "totalNanos": 4994609
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 3720586,
+              "smallAllocs": 340038
+            },
+            "columnCount": {
+              "nanos": 74321,
+              "smallAllocs": 5810
+            },
+            "eliminate": {
+              "nanos": 1078016,
+              "smallAllocs": 5810
+            },
+            "freeColumns": 10,
+            "innerMultiplies": 342160,
+            "pivotSearch": {
+              "nanos": 2269,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "readback": {
+              "nanos": 102251,
+              "smallAllocs": 3223
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 36793,
+              "smallAllocs": 280
+            },
+            "scaleMultiplies": 5600,
+            "stagedNanos": 1116827,
+            "wall": {
+              "nanos": 1206709,
+              "smallAllocs": 12296
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 25993,
+            "packNanos": 266254,
+            "rank": 70,
+            "reduceNanos": 2441840,
+            "reduceNanosSamples": [
+              2414179,
+              2482331,
+              2469501,
+              2402181,
+              2408030,
+              2404114,
+              2479035,
+              2470352
+            ],
+            "rowAdds": 4277,
+            "smallAllocs": 355100,
+            "totalNanos": 2734213
+          },
+          "peakResidentBytes": 66478080,
+          "productionMatrixRebuild": {
+            "nanos": 3875786,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 23986150,
+            "smallAllocs": 1408888
+          },
+          "productionRowReduce": {
+            "nanos": 23728038,
+            "smallAllocs": 1401336
+          },
+          "rank": 70,
+          "residentBytesAfter": 63229952,
+          "residentBytesBefore": 65601536,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3870813,
+            "smallAllocs": 0
+          },
+          "sink": 74,
+          "splitFactors": 10
+        },
+        "modularDegree": 80,
+        "modularFactorCount": 10,
+        "prime": 11,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi64_x_phi105",
+      "status": "ok"
+    },
+    {
+      "degree": 144,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 144,
+          "basisToPolynomials": {
+            "nanos": 5363,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7982925,
+            "smallAllocs": 722207
+          },
+          "berlekampSplit": {
+            "nanos": 19853163,
+            "smallAllocs": 1239327
+          },
+          "columnPolys": {
+            "nanos": 7492262,
+            "smallAllocs": 680459
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3731,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 65453473,
+              "smallAllocs": 3858949
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 966847,
+              "smallAllocs": 59552
+            },
+            "stagedNanos": 66416768,
+            "wall": {
+              "nanos": 66758461,
+              "smallAllocs": 3919428
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 4090,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 128925282,
+              "smallAllocs": 7645861
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 1374022,
+              "smallAllocs": 79136
+            },
+            "stagedNanos": 130301445,
+            "wall": {
+              "nanos": 130597376,
+              "smallAllocs": 7725927
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 305131,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 13908560,
+            "smallAllocs": 723728
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8269359,
+            "smallAllocs": 743088
+          },
+          "frobeniusPower": {
+            "nanos": 5297,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 8,
+          "matrixConversionNanos": 472225,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8385276,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 426808,
+          "nullspaceBasisNanos": 426808,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 13049,
+            "packNanos": 966894,
+            "rank": 136,
+            "reduceNanos": 6855969,
+            "reduceNanosSamples": [
+              7105544,
+              6851537,
+              6869404,
+              6860401,
+              6845779,
+              6839860,
+              6863936,
+              6846731
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7835561
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 12909,
+            "packNanos": 962702,
+            "rank": 136,
+            "reduceNanos": 7020167,
+            "reduceNanosSamples": [
+              7130471,
+              6943715,
+              6949012,
+              6981140,
+              7103601,
+              7059195,
+              6961180,
+              7113176
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 8012013
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 13619,
+            "packNanos": 969057,
+            "rank": 136,
+            "reduceNanos": 5080587,
+            "reduceNanosSamples": [
+              5097778,
+              5079841,
+              5096205,
+              5079350,
+              5081333,
+              5070737,
+              5115594,
+              5067623
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 6064757
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7931919,
+              "rank": 136,
+              "readbackNanos": 246010,
+              "reduceNanos": 5708212,
+              "reduceNanosSamples": [
+                5708313,
+                5737086,
+                5701542,
+                5722924,
+                5709985,
+                5693060,
+                5708112,
+                5705409
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13874399
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7942405,
+              "rank": 136,
+              "readbackNanos": 244447,
+              "reduceNanos": 7551270,
+              "reduceNanosSamples": [
+                7560679,
+                7538927,
+                7547810,
+                7630151,
+                7497425,
+                7533699,
+                7576062,
+                7554730
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 15738117
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7872962,
+              "rank": 136,
+              "readbackNanos": 241943,
+              "reduceNanos": 6177132,
+              "reduceNanosSamples": [
+                6277857,
+                6180853,
+                6173412,
+                6162356,
+                6210858,
+                6161665,
+                6114785,
+                6275844
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14286510
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7943867,
+              "rank": 136,
+              "readbackNanos": 13369,
+              "reduceNanos": 6968065,
+              "reduceNanosSamples": [
+                6995531,
+                6946819,
+                6959628,
+                6950344,
+                7124753,
+                6961530,
+                7070843,
+                6974600
+              ],
+              "smallAllocs": 708207,
+              "totalNanos": 14909899
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7967132,
+              "rank": 136,
+              "readbackNanos": 243441,
+              "reduceNanos": 6330590,
+              "reduceNanosSamples": [
+                6317897,
+                6215664,
+                6445515,
+                6344075,
+                6332057,
+                6425266,
+                6329123,
+                6254362
+              ],
+              "smallAllocs": 739204,
+              "totalNanos": 14545739
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7949350,
+              "rank": 136,
+              "readbackNanos": 243867,
+              "reduceNanos": 7030222,
+              "reduceNanosSamples": [
+                7057723,
+                7029521,
+                7015370,
+                7019017,
+                7040387,
+                7041310,
+                7030924,
+                7017834
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 15211422
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7959606,
+              "rank": 136,
+              "readbackNanos": 247282,
+              "reduceNanos": 5743850,
+              "reduceNanosSamples": [
+                5787430,
+                5782783,
+                5755462,
+                5736455,
+                5745198,
+                5723084,
+                5742503,
+                5732508
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13942009
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7934774,
+              "rank": 136,
+              "readbackNanos": 245784,
+              "reduceNanos": 6054806,
+              "reduceNanosSamples": [
+                6045022,
+                6062278,
+                6054145,
+                6051111,
+                6069758,
+                6039664,
+                6058291,
+                6055468
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 14226942
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7980632,
+              "rank": 136,
+              "readbackNanos": 244793,
+              "reduceNanos": 5738553,
+              "reduceNanosSamples": [
+                5728532,
+                5759128,
+                5735043,
+                5742063,
+                5778046,
+                5721923,
+                5744376,
+                5726279
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13971864
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7942375,
+              "rank": 136,
+              "readbackNanos": 245869,
+              "reduceNanos": 5744797,
+              "reduceNanosSamples": [
+                5730075,
+                5780750,
+                5729765,
+                5749674,
+                5742343,
+                5747251,
+                5754271,
+                5735984
+              ],
+              "smallAllocs": 726055,
+              "totalNanos": 13937488
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7932064,
+              "rank": 136,
+              "readbackNanos": 243086,
+              "reduceNanos": 6837532,
+              "reduceNanosSamples": [
+                6828534,
+                6734574,
+                6870115,
+                6781444,
+                6757008,
+                6933990,
+                6846530,
+                6918177
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 15000879
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7922996,
+              "rank": 136,
+              "readbackNanos": 242223,
+              "reduceNanos": 6213737,
+              "reduceNanosSamples": [
+                6079864,
+                6186953,
+                6298648,
+                6266931,
+                6066224,
+                6240522,
+                6307782,
+                6127174
+              ],
+              "smallAllocs": 719756,
+              "totalNanos": 14386608
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7967051,
+              "smallAllocs": 701470
+            },
+            "columnCount": {
+              "nanos": 244975,
+              "smallAllocs": 19992
+            },
+            "eliminate": {
+              "nanos": 5621118,
+              "smallAllocs": 19992
+            },
+            "freeColumns": 8,
+            "innerMultiplies": 1893456,
+            "pivotSearch": {
+              "nanos": 3906,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "readback": {
+              "nanos": 238949,
+              "smallAllocs": 4723
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 108682,
+              "smallAllocs": 544
+            },
+            "scaleMultiplies": 19584,
+            "stagedNanos": 5741705,
+            "wall": {
+              "nanos": 6030260,
+              "smallAllocs": 41246
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 80043,
+            "packNanos": 923474,
+            "rank": 136,
+            "reduceNanos": 13558501,
+            "reduceNanosSamples": [
+              13575627,
+              13537870,
+              13103937,
+              13486224,
+              13541376,
+              13863893,
+              13910072,
+              13899707
+            ],
+            "rowAdds": 13149,
+            "smallAllocs": 1938068,
+            "totalNanos": 14578303
+          },
+          "peakResidentBytes": 66478080,
+          "productionMatrixRebuild": {
+            "nanos": 8423728,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 132991755,
+            "smallAllocs": 7708346
+          },
+          "productionRowReduce": {
+            "nanos": 132626043,
+            "smallAllocs": 7685628
+          },
+          "rank": 136,
+          "residentBytesAfter": 64819200,
+          "residentBytesBefore": 63361024,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8486156,
+            "smallAllocs": 0
+          },
+          "sink": 138,
+          "splitFactors": 8
+        },
+        "modularDegree": 144,
+        "modularFactorCount": 8,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi128_x_phi165",
+      "status": "ok"
+    },
+    {
+      "degree": 240,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 240,
+          "basisToPolynomials": {
+            "nanos": 7265,
+            "smallAllocs": 523
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7457426,
+            "smallAllocs": 660179
+          },
+          "berlekampSplit": {
+            "nanos": 25297519,
+            "smallAllocs": 1030964
+          },
+          "columnPolys": {
+            "nanos": 6117579,
+            "smallAllocs": 544863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6395,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 152134761,
+              "smallAllocs": 8803144
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 2894965,
+              "smallAllocs": 171267
+            },
+            "stagedNanos": 155043832,
+            "wall": {
+              "nanos": 155979716,
+              "smallAllocs": 8975874
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6556,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 298257952,
+              "smallAllocs": 17418184
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 3952160,
+              "smallAllocs": 227907
+            },
+            "stagedNanos": 302195121,
+            "wall": {
+              "nanos": 302998442,
+              "smallAllocs": 17647557
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 864371,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 21139560,
+            "smallAllocs": 661844
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8297086,
+            "smallAllocs": 718020
+          },
+          "frobeniusPower": {
+            "nanos": 3765,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 1292170,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8683658,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 2418359,
+          "nullspaceBasisNanos": 2418359,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 27035,
+            "packNanos": 2826865,
+            "rank": 236,
+            "reduceNanos": 15647863,
+            "reduceNanosSamples": [
+              15647628,
+              15648099,
+              15627488,
+              15712183,
+              15647588,
+              15638575,
+              15660638,
+              15698574
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18502931
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 26975,
+            "packNanos": 2811033,
+            "rank": 236,
+            "reduceNanos": 16206006,
+            "reduceNanosSamples": [
+              16270542,
+              15965349,
+              16208730,
+              15982495,
+              15903307,
+              16234198,
+              16264363,
+              16203282
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 19055395
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 28051,
+            "packNanos": 2831978,
+            "rank": 236,
+            "reduceNanos": 9275311,
+            "reduceNanosSamples": [
+              9289232,
+              9293888,
+              9268861,
+              9274050,
+              9334459,
+              9270775,
+              9276573,
+              9264855
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 12132536
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7413060,
+              "rank": 236,
+              "readbackNanos": 417544,
+              "reduceNanos": 13178212,
+              "reduceNanosSamples": [
+                13171948,
+                13193970,
+                13184477,
+                13163735,
+                13146911,
+                13146010,
+                13235201,
+                13186429
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21052135
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7403206,
+              "rank": 236,
+              "readbackNanos": 420774,
+              "reduceNanos": 17103256,
+              "reduceNanosSamples": [
+                17133751,
+                17104298,
+                17136555,
+                17102215,
+                17148433,
+                17069517,
+                17086051,
+                17077848
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 24925203
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7442434,
+              "rank": 236,
+              "readbackNanos": 417999,
+              "reduceNanos": 13905866,
+              "reduceNanosSamples": [
+                13859767,
+                13921350,
+                13890824,
+                13920908,
+                13984012,
+                13945054,
+                13777536,
+                13817595
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21698674
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7398654,
+              "rank": 236,
+              "readbackNanos": 26980,
+              "reduceNanos": 15912806,
+              "reduceNanosSamples": [
+                16277532,
+                15929166,
+                16217743,
+                15939671,
+                15871860,
+                15896447,
+                15872151,
+                15874074
+              ],
+              "smallAllocs": 641764,
+              "totalNanos": 23410207
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7424501,
+              "rank": 236,
+              "readbackNanos": 420288,
+              "reduceNanos": 14445025,
+              "reduceNanosSamples": [
+                14617181,
+                14348081,
+                14270487,
+                14456893,
+                14468730,
+                14414109,
+                14550902,
+                14433158
+              ],
+              "smallAllocs": 681727,
+              "totalNanos": 22297070
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7421107,
+              "rank": 236,
+              "readbackNanos": 417338,
+              "reduceNanos": 16196266,
+              "reduceNanosSamples": [
+                16160699,
+                16219255,
+                16215820,
+                16245685,
+                16162712,
+                16149382,
+                16195620,
+                16196913
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 24020371
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7446680,
+              "rank": 236,
+              "readbackNanos": 416277,
+              "reduceNanos": 13245196,
+              "reduceNanosSamples": [
+                13292947,
+                13243153,
+                13307679,
+                13247239,
+                13213149,
+                13231646,
+                13247710,
+                13215071
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21107277
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7408027,
+              "rank": 236,
+              "readbackNanos": 416727,
+              "reduceNanos": 13974497,
+              "reduceNanosSamples": [
+                14013526,
+                14005724,
+                13969690,
+                14035859,
+                13921910,
+                13930062,
+                13965274,
+                13979305
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21822312
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7491787,
+              "rank": 236,
+              "readbackNanos": 420018,
+              "reduceNanos": 13259878,
+              "reduceNanosSamples": [
+                13224676,
+                13259388,
+                13266568,
+                13259178,
+                13239839,
+                13260369,
+                13302121,
+                13278266
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21212989
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7398493,
+              "rank": 236,
+              "readbackNanos": 417283,
+              "reduceNanos": 13249598,
+              "reduceNanosSamples": [
+                13219699,
+                13250705,
+                13250945,
+                13266278,
+                13248441,
+                13248492,
+                13265276,
+                13231907
+              ],
+              "smallAllocs": 663779,
+              "totalNanos": 21065350
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7460040,
+              "rank": 236,
+              "readbackNanos": 418500,
+              "reduceNanos": 15571510,
+              "reduceNanosSamples": [
+                15670583,
+                15601299,
+                15493439,
+                15541721,
+                15627719,
+                15396546,
+                15649370,
+                15466650
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 23436696
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 7442924,
+              "rank": 236,
+              "readbackNanos": 420689,
+              "reduceNanos": 13865050,
+              "reduceNanosSamples": [
+                13843854,
+                14067305,
+                13828641,
+                13938334,
+                13985174,
+                13886247,
+                13777866,
+                13836974
+              ],
+              "smallAllocs": 625323,
+              "totalNanos": 21712475
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 7496653,
+              "smallAllocs": 602578
+            },
+            "columnCount": {
+              "nanos": 712847,
+              "smallAllocs": 57348
+            },
+            "eliminate": {
+              "nanos": 12923453,
+              "smallAllocs": 57348
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4307520,
+            "pivotSearch": {
+              "nanos": 6440,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "readback": {
+              "nanos": 402992,
+              "smallAllocs": 4083
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 297858,
+              "smallAllocs": 944
+            },
+            "scaleMultiplies": 56640,
+            "stagedNanos": 13229755,
+            "wall": {
+              "nanos": 14050295,
+              "smallAllocs": 116842
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 266715,
+            "packNanos": 2653684,
+            "rank": 236,
+            "reduceNanos": 32415061,
+            "reduceNanosSamples": [
+              31731824,
+              32603506,
+              32400955,
+              33479976,
+              31643663,
+              32429168,
+              32571989,
+              31672505
+            ],
+            "rowAdds": 17948,
+            "smallAllocs": 4446309,
+            "totalNanos": 35346868
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 8566450,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 310588915,
+            "smallAllocs": 17591476
+          },
+          "productionRowReduce": {
+            "nanos": 307298542,
+            "smallAllocs": 17532366
+          },
+          "rank": 236,
+          "residentBytesAfter": 69279744,
+          "residentBytesBefore": 64860160,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8915146,
+            "smallAllocs": 0
+          },
+          "sink": 238,
+          "splitFactors": 4
+        },
+        "modularDegree": 240,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi385",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 18647,
+            "smallAllocs": 1843
+          },
+          "berlekampMatrixWall": {
+            "nanos": 191634,
+            "smallAllocs": 17281
+          },
+          "berlekampSplit": {
+            "nanos": 102747,
+            "smallAllocs": 8327
+          },
+          "columnPolys": {
+            "nanos": 74195,
+            "smallAllocs": 6155
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 947,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 947,
+            "wall": {
+              "nanos": 43820,
+              "smallAllocs": 1807
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 970,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 970,
+            "wall": {
+              "nanos": 41712,
+              "smallAllocs": 1810
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26309,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 223656,
+            "smallAllocs": 17402
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 217517,
+            "smallAllocs": 18922
+          },
+          "frobeniusPower": {
+            "nanos": 83558,
+            "smallAllocs": 7927
+          },
+          "kernelDimension": 40,
+          "matrixConversionNanos": 33895,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 218834,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 47,
+          "nullspaceBasisMagnitudeNanos": 39989,
+          "nullspaceBasisNanos": 39989,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1487,
+            "packNanos": 66153,
+            "rank": 0,
+            "reduceNanos": 4351,
+            "reduceNanosSamples": [
+              5248,
+              4036,
+              4707,
+              4076,
+              4587,
+              4116,
+              4586,
+              4006
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72207
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1307,
+            "packNanos": 65817,
+            "rank": 0,
+            "reduceNanos": 4066,
+            "reduceNanosSamples": [
+              4106,
+              4036,
+              4066,
+              4166,
+              4066,
+              4056,
+              4076,
+              4056
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 71250
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1507,
+            "packNanos": 66153,
+            "rank": 0,
+            "reduceNanos": 4291,
+            "reduceNanosSamples": [
+              4056,
+              4597,
+              4096,
+              4646,
+              3966,
+              4487,
+              4026,
+              4547
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72031
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 188739,
+              "rank": 0,
+              "readbackNanos": 80905,
+              "reduceNanos": 3755,
+              "reduceNanosSamples": [
+                3936,
+                3746,
+                3766,
+                3765,
+                3765,
+                3746,
+                3716,
+                3736
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 273250
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189566,
+              "rank": 0,
+              "readbackNanos": 80954,
+              "reduceNanos": 3720,
+              "reduceNanosSamples": [
+                3585,
+                3725,
+                3585,
+                3766,
+                3586,
+                3785,
+                3715,
+                6540
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274091
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189461,
+              "rank": 0,
+              "readbackNanos": 80805,
+              "reduceNanos": 3595,
+              "reduceNanosSamples": [
+                3595,
+                3595,
+                3585,
+                3695,
+                3606,
+                3575,
+                3586,
+                3605
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274642
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189756,
+              "rank": 0,
+              "readbackNanos": 1362,
+              "reduceNanos": 4136,
+              "reduceNanosSamples": [
+                4277,
+                4106,
+                4126,
+                4146,
+                4166,
+                4095,
+                4177,
+                4046
+              ],
+              "smallAllocs": 15774,
+              "totalNanos": 195340
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189170,
+              "rank": 0,
+              "readbackNanos": 81000,
+              "reduceNanos": 3580,
+              "reduceNanosSamples": [
+                3575,
+                3676,
+                3575,
+                3575,
+                3776,
+                3575,
+                3585,
+                3685
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 273575
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189441,
+              "rank": 0,
+              "readbackNanos": 80689,
+              "reduceNanos": 3590,
+              "reduceNanosSamples": [
+                3566,
+                3595,
+                3585,
+                3585,
+                3595,
+                3606,
+                3575,
+                3606
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 275093
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189000,
+              "rank": 0,
+              "readbackNanos": 80734,
+              "reduceNanos": 3595,
+              "reduceNanosSamples": [
+                3666,
+                3595,
+                3595,
+                3576,
+                6229,
+                3575,
+                3615,
+                3596
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274186
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189340,
+              "rank": 0,
+              "readbackNanos": 81551,
+              "reduceNanos": 3585,
+              "reduceNanosSamples": [
+                3576,
+                3585,
+                3595,
+                3585,
+                3575,
+                3576,
+                3595,
+                3615
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 275273
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 190152,
+              "rank": 0,
+              "readbackNanos": 81085,
+              "reduceNanos": 3665,
+              "reduceNanosSamples": [
+                3846,
+                3676,
+                3626,
+                3675,
+                3656,
+                3815,
+                3616,
+                3616
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 275603
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189776,
+              "rank": 0,
+              "readbackNanos": 82447,
+              "reduceNanos": 3660,
+              "reduceNanosSamples": [
+                3886,
+                3605,
+                3785,
+                3585,
+                3715,
+                3585,
+                3766,
+                3595
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 276294
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 189631,
+              "rank": 0,
+              "readbackNanos": 81580,
+              "reduceNanos": 3625,
+              "reduceNanosSamples": [
+                3615,
+                3726,
+                3676,
+                3786,
+                3605,
+                3635,
+                3585,
+                3605
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 275743
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 188444,
+              "rank": 0,
+              "readbackNanos": 81535,
+              "reduceNanos": 3590,
+              "reduceNanosSamples": [
+                3686,
+                3596,
+                3595,
+                3585,
+                3585,
+                3565,
+                3595,
+                3576
+              ],
+              "smallAllocs": 20689,
+              "totalNanos": 274326
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 190247,
+              "smallAllocs": 15680
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 40,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1006,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 80720,
+              "smallAllocs": 5003
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1006,
+            "wall": {
+              "nanos": 6344,
+              "smallAllocs": 166
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6124,
+            "packNanos": 62788,
+            "rank": 0,
+            "reduceNanos": 5082,
+            "reduceNanosSamples": [
+              5489,
+              5137,
+              5518,
+              5268,
+              5028,
+              4787,
+              4808,
+              4707
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 74080
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 218298,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 85847,
+            "smallAllocs": 1728
+          },
+          "productionRowReduce": {
+            "nanos": 45838,
+            "smallAllocs": 1607
+          },
+          "rank": 0,
+          "residentBytesAfter": 68616192,
+          "residentBytesBefore": 68603904,
+          "rowReduceMatrixRebuild": {
+            "nanos": 220422,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 40
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 40,
+        "prime": 47,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_40",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 25913,
+            "smallAllocs": 2595
+          },
+          "berlekampMatrixWall": {
+            "nanos": 275994,
+            "smallAllocs": 24749
+          },
+          "berlekampSplit": {
+            "nanos": 163577,
+            "smallAllocs": 12707
+          },
+          "columnPolys": {
+            "nanos": 104184,
+            "smallAllocs": 8727
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1132,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1132,
+            "wall": {
+              "nanos": 62437,
+              "smallAllocs": 2551
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1142,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1142,
+            "wall": {
+              "nanos": 58732,
+              "smallAllocs": 2554
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 35913,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 322558,
+            "smallAllocs": 24894
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 311677,
+            "smallAllocs": 27102
+          },
+          "frobeniusPower": {
+            "nanos": 121475,
+            "smallAllocs": 11415
+          },
+          "kernelDimension": 48,
+          "matrixConversionNanos": 50169,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 314942,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 61,
+          "nullspaceBasisMagnitudeNanos": 56047,
+          "nullspaceBasisNanos": 56047,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1863,
+            "packNanos": 96448,
+            "rank": 0,
+            "reduceNanos": 5808,
+            "reduceNanosSamples": [
+              6169,
+              5588,
+              6029,
+              5548,
+              6129,
+              5538,
+              6149,
+              5518
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104339
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1683,
+            "packNanos": 96799,
+            "rank": 0,
+            "reduceNanos": 5613,
+            "reduceNanosSamples": [
+              5629,
+              5648,
+              5649,
+              5548,
+              5578,
+              5568,
+              5619,
+              5608
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104059
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1863,
+            "packNanos": 97364,
+            "rank": 0,
+            "reduceNanos": 5849,
+            "reduceNanosSamples": [
+              5599,
+              6120,
+              5608,
+              6099,
+              5609,
+              6099,
+              5579,
+              6089
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 105521
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272358,
+              "rank": 0,
+              "readbackNanos": 120734,
+              "reduceNanos": 5192,
+              "reduceNanosSamples": [
+                5258,
+                5208,
+                5168,
+                5188,
+                5188,
+                5168,
+                5197,
+                5248
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397695
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271703,
+              "rank": 0,
+              "readbackNanos": 121109,
+              "reduceNanos": 5137,
+              "reduceNanosSamples": [
+                5078,
+                5198,
+                5058,
+                5218,
+                5067,
+                5197,
+                5038,
+                5227
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 398796
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271047,
+              "rank": 0,
+              "readbackNanos": 120358,
+              "reduceNanos": 5047,
+              "reduceNanosSamples": [
+                5037,
+                5058,
+                5047,
+                5048,
+                5047,
+                5047,
+                5028,
+                5058
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397805
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272434,
+              "rank": 0,
+              "readbackNanos": 2168,
+              "reduceNanos": 5688,
+              "reduceNanosSamples": [
+                5919,
+                5678,
+                5698,
+                5769,
+                5678,
+                5638,
+                5759,
+                5668
+              ],
+              "smallAllocs": 22554,
+              "totalNanos": 280271
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271683,
+              "rank": 0,
+              "readbackNanos": 120809,
+              "reduceNanos": 5048,
+              "reduceNanosSamples": [
+                5057,
+                5128,
+                5058,
+                5048,
+                5038,
+                5037,
+                5027,
+                5048
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397559
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271291,
+              "rank": 0,
+              "readbackNanos": 120378,
+              "reduceNanos": 5057,
+              "reduceNanosSamples": [
+                5088,
+                5058,
+                5057,
+                5038,
+                5048,
+                5057,
+                5258,
+                5098
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397865
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271948,
+              "rank": 0,
+              "readbackNanos": 120193,
+              "reduceNanos": 5048,
+              "reduceNanosSamples": [
+                5087,
+                5048,
+                8002,
+                5238,
+                5048,
+                5047,
+                5038,
+                5047
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397074
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 270400,
+              "rank": 0,
+              "readbackNanos": 121034,
+              "reduceNanos": 5048,
+              "reduceNanosSamples": [
+                5158,
+                5048,
+                5057,
+                5027,
+                5048,
+                5047,
+                5057,
+                5047
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 396127
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271813,
+              "rank": 0,
+              "readbackNanos": 121050,
+              "reduceNanos": 5107,
+              "reduceNanosSamples": [
+                5087,
+                5108,
+                5078,
+                5248,
+                5087,
+                5208,
+                5107,
+                5167
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 397945
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 271637,
+              "rank": 0,
+              "readbackNanos": 120959,
+              "reduceNanos": 5112,
+              "reduceNanosSamples": [
+                5258,
+                5048,
+                5248,
+                5047,
+                5218,
+                5057,
+                5168,
+                5047
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 398641
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272404,
+              "rank": 0,
+              "readbackNanos": 121004,
+              "reduceNanos": 5078,
+              "reduceNanosSamples": [
+                5077,
+                5078,
+                5067,
+                5078,
+                5248,
+                5078,
+                5038,
+                5257
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 398090
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 272249,
+              "rank": 0,
+              "readbackNanos": 121019,
+              "reduceNanos": 5047,
+              "reduceNanosSamples": [
+                5037,
+                5047,
+                5057,
+                5057,
+                5037,
+                5047,
+                5057,
+                5037
+              ],
+              "smallAllocs": 29605,
+              "totalNanos": 398090
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 270792,
+              "smallAllocs": 22444
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 48,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1206,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 119587,
+              "smallAllocs": 7155
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1206,
+            "wall": {
+              "nanos": 8016,
+              "smallAllocs": 198
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8362,
+            "packNanos": 91891,
+            "rank": 0,
+            "reduceNanos": 6419,
+            "reduceNanosSamples": [
+              6549,
+              6429,
+              6479,
+              6419,
+              6420,
+              6289,
+              6370,
+              6310
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106638
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 312558,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 122241,
+            "smallAllocs": 2456
+          },
+          "productionRowReduce": {
+            "nanos": 65993,
+            "smallAllocs": 2311
+          },
+          "rank": 0,
+          "residentBytesAfter": 68681728,
+          "residentBytesBefore": 68632576,
+          "rowReduceMatrixRebuild": {
+            "nanos": 315091,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 48
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 48,
+        "prime": 61,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_48",
+      "status": "ok"
+    },
+    {
+      "degree": 56,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 56,
+          "basisToPolynomials": {
+            "nanos": 33775,
+            "smallAllocs": 3475
+          },
+          "berlekampMatrixWall": {
+            "nanos": 448515,
+            "smallAllocs": 40562
+          },
+          "berlekampSplit": {
+            "nanos": 210992,
+            "smallAllocs": 16143
+          },
+          "columnPolys": {
+            "nanos": 138255,
+            "smallAllocs": 11747
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1319,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1319,
+            "wall": {
+              "nanos": 81526,
+              "smallAllocs": 3423
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1310,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1310,
+            "wall": {
+              "nanos": 77074,
+              "smallAllocs": 3426
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 42628,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 504913,
+            "smallAllocs": 40731
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 491588,
+            "smallAllocs": 43755
+          },
+          "frobeniusPower": {
+            "nanos": 236200,
+            "smallAllocs": 22544
+          },
+          "kernelDimension": 56,
+          "matrixConversionNanos": 73815,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 496966,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 75121,
+          "nullspaceBasisNanos": 75121,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2093,
+            "packNanos": 134013,
+            "rank": 0,
+            "reduceNanos": 7802,
+            "reduceNanosSamples": [
+              8152,
+              7591,
+              8172,
+              7521,
+              8002,
+              7531,
+              8032,
+              7602
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 143718
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1997,
+            "packNanos": 133938,
+            "rank": 0,
+            "reduceNanos": 7621,
+            "reduceNanosSamples": [
+              7631,
+              7611,
+              7621,
+              7591,
+              7551,
+              7621,
+              7642,
+              7731
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 143577
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2203,
+            "packNanos": 135055,
+            "rank": 0,
+            "reduceNanos": 7841,
+            "reduceNanosSamples": [
+              7561,
+              8172,
+              7671,
+              8043,
+              7551,
+              8012,
+              7671,
+              8183
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145390
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 438105,
+              "rank": 0,
+              "readbackNanos": 168575,
+              "reduceNanos": 6960,
+              "reduceNanosSamples": [
+                6961,
+                6911,
+                6960,
+                6920,
+                6950,
+                7040,
+                7040,
+                7191
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 612758
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 439211,
+              "rank": 0,
+              "readbackNanos": 165565,
+              "reduceNanos": 6915,
+              "reduceNanosSamples": [
+                6860,
+                6990,
+                6730,
+                7030,
+                6780,
+                6971,
+                6750,
+                7021
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 611241
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 436662,
+              "rank": 0,
+              "readbackNanos": 165570,
+              "reduceNanos": 6780,
+              "reduceNanosSamples": [
+                6880,
+                6750,
+                6750,
+                6810,
+                6770,
+                6790,
+                6760,
+                6840
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 609303
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 440027,
+              "rank": 0,
+              "readbackNanos": 2523,
+              "reduceNanos": 7691,
+              "reduceNanosSamples": [
+                7942,
+                7722,
+                7702,
+                7621,
+                7681,
+                7551,
+                7732,
+                7631
+              ],
+              "smallAllocs": 37551,
+              "totalNanos": 450302
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 437999,
+              "rank": 0,
+              "readbackNanos": 167252,
+              "reduceNanos": 6775,
+              "reduceNanosSamples": [
+                6820,
+                6770,
+                6780,
+                6820,
+                6759,
+                6760,
+                6750,
+                6840
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 611666
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 438850,
+              "rank": 0,
+              "readbackNanos": 166752,
+              "reduceNanos": 6780,
+              "reduceNanosSamples": [
+                6850,
+                6770,
+                6761,
+                6800,
+                6790,
+                6770,
+                6750,
+                6830
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 611842
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 438019,
+              "rank": 0,
+              "readbackNanos": 165670,
+              "reduceNanos": 6805,
+              "reduceNanosSamples": [
+                6850,
+                6760,
+                6780,
+                6831,
+                6860,
+                6770,
+                6780,
+                6830
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 610690
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 440398,
+              "rank": 0,
+              "readbackNanos": 165540,
+              "reduceNanos": 6800,
+              "reduceNanosSamples": [
+                6840,
+                6739,
+                6770,
+                6850,
+                6800,
+                6800,
+                6770,
+                6820
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 612928
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 439977,
+              "rank": 0,
+              "readbackNanos": 166216,
+              "reduceNanos": 6835,
+              "reduceNanosSamples": [
+                6810,
+                6881,
+                6820,
+                6861,
+                6860,
+                6820,
+                6770,
+                6850
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 612187
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 440733,
+              "rank": 0,
+              "readbackNanos": 165380,
+              "reduceNanos": 6895,
+              "reduceNanosSamples": [
+                6970,
+                6810,
+                7041,
+                6840,
+                6950,
+                6760,
+                7031,
+                6830
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 613810
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 440068,
+              "rank": 0,
+              "readbackNanos": 165450,
+              "reduceNanos": 6800,
+              "reduceNanosSamples": [
+                6820,
+                6790,
+                6760,
+                6860,
+                6770,
+                6810,
+                6770,
+                6860
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 613309
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 437979,
+              "rank": 0,
+              "readbackNanos": 165485,
+              "reduceNanos": 6785,
+              "reduceNanosSamples": [
+                6870,
+                6750,
+                6780,
+                6830,
+                6790,
+                6780,
+                6770,
+                6850
+              ],
+              "smallAllocs": 47122,
+              "totalNanos": 610265
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 438661,
+              "smallAllocs": 37425
+            },
+            "columnCount": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "eliminate": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "freeColumns": 56,
+            "innerMultiplies": 0,
+            "pivotSearch": {
+              "nanos": 1379,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "readback": {
+              "nanos": 164083,
+              "smallAllocs": 9691
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "scaleMultiplies": 0,
+            "stagedNanos": 1379,
+            "wall": {
+              "nanos": 10771,
+              "smallAllocs": 230
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11667,
+            "packNanos": 126953,
+            "rank": 0,
+            "reduceNanos": 8653,
+            "reduceNanosSamples": [
+              8512,
+              8823,
+              8663,
+              8362,
+              11908,
+              8643,
+              8683,
+              8622
+            ],
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 147638
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 493917,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 162836,
+            "smallAllocs": 3312
+          },
+          "productionRowReduce": {
+            "nanos": 87665,
+            "smallAllocs": 3143
+          },
+          "rank": 0,
+          "residentBytesAfter": 68710400,
+          "residentBytesBefore": 68710400,
+          "rowReduceMatrixRebuild": {
+            "nanos": 496330,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 56
+        },
+        "modularDegree": 56,
+        "modularFactorCount": 56,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_56",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1136,
+            "smallAllocs": 90
+          },
+          "berlekampMatrixWall": {
+            "nanos": 121189,
+            "smallAllocs": 10805
+          },
+          "berlekampSplit": {
+            "nanos": 179852,
+            "smallAllocs": 13395
+          },
+          "columnPolys": {
+            "nanos": 104125,
+            "smallAllocs": 9437
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 600,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 129308,
+              "smallAllocs": 7021
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 28905,
+              "smallAllocs": 1639
+            },
+            "stagedNanos": 158945,
+            "wall": {
+              "nanos": 168295,
+              "smallAllocs": 8826
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 614,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 222324,
+              "smallAllocs": 12397
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 39126,
+              "smallAllocs": 2143
+            },
+            "stagedNanos": 262515,
+            "wall": {
+              "nanos": 272569,
+              "smallAllocs": 14709
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9160,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 149596,
+            "smallAllocs": 10941
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 130417,
+            "smallAllocs": 11406
+          },
+          "frobeniusPower": {
+            "nanos": 3440,
+            "smallAllocs": 217
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 13780,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 130684,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 5,
+          "nullspaceBasisMagnitudeNanos": 10505,
+          "nullspaceBasisNanos": 10505,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1052,
+            "packNanos": 21957,
+            "rank": 21,
+            "reduceNanos": 18973,
+            "reduceNanosSamples": [
+              21291,
+              18477,
+              19950,
+              18367,
+              19749,
+              18167,
+              19469,
+              18237
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 42062
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 806,
+            "packNanos": 21732,
+            "rank": 21,
+            "reduceNanos": 18297,
+            "reduceNanosSamples": [
+              18968,
+              18327,
+              18437,
+              18167,
+              18528,
+              18267,
+              18217,
+              18107
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 40910
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1161,
+            "packNanos": 22163,
+            "rank": 21,
+            "reduceNanos": 15378,
+            "reduceNanosSamples": [
+              15153,
+              16995,
+              14471,
+              16335,
+              14511,
+              15753,
+              14481,
+              15603
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 39178
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119802,
+              "rank": 21,
+              "readbackNanos": 7781,
+              "reduceNanos": 23995,
+              "reduceNanosSamples": [
+                24276,
+                24316,
+                23796,
+                24056,
+                23835,
+                24346,
+                23715,
+                23935
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 151549
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119913,
+              "rank": 21,
+              "readbackNanos": 7671,
+              "reduceNanos": 23319,
+              "reduceNanosSamples": [
+                23866,
+                23996,
+                22804,
+                23304,
+                22804,
+                23274,
+                23334,
+                23395
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 150598
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119332,
+              "rank": 21,
+              "readbackNanos": 7591,
+              "reduceNanos": 20770,
+              "reduceNanosSamples": [
+                21572,
+                21442,
+                20911,
+                21192,
+                20451,
+                20630,
+                20270,
+                20330
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 147604
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119632,
+              "rank": 21,
+              "readbackNanos": 831,
+              "reduceNanos": 18202,
+              "reduceNanosSamples": [
+                18648,
+                18217,
+                18377,
+                18107,
+                18268,
+                18146,
+                18187,
+                17936
+              ],
+              "smallAllocs": 10682,
+              "totalNanos": 138706
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119843,
+              "rank": 21,
+              "readbackNanos": 7581,
+              "reduceNanos": 25433,
+              "reduceNanosSamples": [
+                26750,
+                25558,
+                25518,
+                25518,
+                25348,
+                25237,
+                25168,
+                25208
+              ],
+              "smallAllocs": 11210,
+              "totalNanos": 152662
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119942,
+              "rank": 21,
+              "readbackNanos": 7611,
+              "reduceNanos": 27331,
+              "reduceNanosSamples": [
+                28582,
+                27822,
+                27721,
+                27431,
+                26970,
+                27231,
+                27080,
+                27120
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 154929
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120093,
+              "rank": 21,
+              "readbackNanos": 7601,
+              "reduceNanos": 24000,
+              "reduceNanosSamples": [
+                25178,
+                23735,
+                24075,
+                23685,
+                24186,
+                23836,
+                24065,
+                23935
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 151655
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119211,
+              "rank": 21,
+              "readbackNanos": 7621,
+              "reduceNanos": 25332,
+              "reduceNanosSamples": [
+                26389,
+                25748,
+                25408,
+                25318,
+                25347,
+                25067,
+                25077,
+                24937
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 151980
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119141,
+              "rank": 21,
+              "readbackNanos": 7736,
+              "reduceNanos": 23820,
+              "reduceNanosSamples": [
+                24196,
+                23715,
+                23865,
+                23785,
+                23835,
+                23816,
+                23825,
+                23806
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 150698
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119893,
+              "rank": 21,
+              "readbackNanos": 7636,
+              "reduceNanos": 24331,
+              "reduceNanosSamples": [
+                25197,
+                23905,
+                24576,
+                27270,
+                24346,
+                24005,
+                24316,
+                23845
+              ],
+              "smallAllocs": 11098,
+              "totalNanos": 151890
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 119818,
+              "rank": 21,
+              "readbackNanos": 7611,
+              "reduceNanos": 22178,
+              "reduceNanosSamples": [
+                22684,
+                22313,
+                22123,
+                22233,
+                22233,
+                22003,
+                21512,
+                21912
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 149111
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 120043,
+              "rank": 21,
+              "readbackNanos": 7591,
+              "reduceNanos": 20815,
+              "reduceNanosSamples": [
+                21421,
+                21302,
+                21001,
+                20921,
+                20701,
+                20710,
+                20551,
+                20681
+              ],
+              "smallAllocs": 10727,
+              "totalNanos": 148776
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 120203,
+              "smallAllocs": 10228
+            },
+            "columnCount": {
+              "nanos": 8737,
+              "smallAllocs": 567
+            },
+            "eliminate": {
+              "nanos": 20558,
+              "smallAllocs": 567
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 2688,
+            "pivotSearch": {
+              "nanos": 641,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "readback": {
+              "nanos": 7401,
+              "smallAllocs": 318
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 4948,
+              "smallAllocs": 84
+            },
+            "scaleMultiplies": 504,
+            "stagedNanos": 26129,
+            "wall": {
+              "nanos": 37050,
+              "smallAllocs": 1341
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3029,
+            "packNanos": 20775,
+            "rank": 21,
+            "reduceNanos": 32874,
+            "reduceNanosSamples": [
+              32639,
+              34081,
+              31317,
+              33370,
+              30755,
+              33300,
+              29854,
+              33109
+            ],
+            "rowAdds": 112,
+            "smallAllocs": 4129,
+            "totalNanos": 56779
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 130623,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 263461,
+            "smallAllocs": 14185
+          },
+          "productionRowReduce": {
+            "nanos": 253355,
+            "smallAllocs": 13515
+          },
+          "rank": 21,
+          "residentBytesAfter": 68907008,
+          "residentBytesBefore": 68907008,
+          "rowReduceMatrixRebuild": {
+            "nanos": 130423,
+            "smallAllocs": 0
+          },
+          "sink": 92,
+          "splitFactors": 3
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 3,
+        "prime": 5,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_T24",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1271,
+            "smallAllocs": 99
+          },
+          "berlekampMatrixWall": {
+            "nanos": 86303,
+            "smallAllocs": 7348
+          },
+          "berlekampSplit": {
+            "nanos": 176967,
+            "smallAllocs": 12764
+          },
+          "columnPolys": {
+            "nanos": 71225,
+            "smallAllocs": 6080
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 604,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 113909,
+              "smallAllocs": 6262
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 27455,
+              "smallAllocs": 1560
+            },
+            "stagedNanos": 142176,
+            "wall": {
+              "nanos": 151699,
+              "smallAllocs": 7993
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 636,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 195461,
+              "smallAllocs": 10966
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 36930,
+              "smallAllocs": 2040
+            },
+            "stagedNanos": 233035,
+            "wall": {
+              "nanos": 242114,
+              "smallAllocs": 13180
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9869,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 112913,
+            "smallAllocs": 7501
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 96048,
+            "smallAllocs": 7949
+          },
+          "frobeniusPower": {
+            "nanos": 2083,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 12954,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 96012,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 12668,
+          "nullspaceBasisNanos": 12668,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 977,
+            "packNanos": 22017,
+            "rank": 20,
+            "reduceNanos": 16800,
+            "reduceNanosSamples": [
+              21542,
+              16204,
+              17526,
+              16384,
+              17216,
+              16033,
+              17436,
+              16365
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 40560
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 831,
+            "packNanos": 21757,
+            "rank": 20,
+            "reduceNanos": 16414,
+            "reduceNanosSamples": [
+              16595,
+              16584,
+              16224,
+              16454,
+              16354,
+              16374,
+              16324,
+              16525
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39027
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1117,
+            "packNanos": 22193,
+            "rank": 20,
+            "reduceNanos": 13770,
+            "reduceNanosSamples": [
+              13630,
+              14571,
+              12890,
+              14190,
+              12899,
+              13911,
+              12899,
+              14081
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 36920
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84911,
+              "rank": 20,
+              "readbackNanos": 9068,
+              "reduceNanos": 22353,
+              "reduceNanosSamples": [
+                22343,
+                22694,
+                22363,
+                22554,
+                22262,
+                22644,
+                22263,
+                22273
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 116418
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84926,
+              "rank": 20,
+              "readbackNanos": 8963,
+              "reduceNanos": 21237,
+              "reduceNanosSamples": [
+                21182,
+                21852,
+                24816,
+                21361,
+                20921,
+                21292,
+                20811,
+                21051
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 114925
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84946,
+              "rank": 20,
+              "readbackNanos": 8883,
+              "reduceNanos": 18968,
+              "reduceNanosSamples": [
+                19319,
+                19109,
+                18918,
+                18908,
+                18948,
+                18818,
+                19249,
+                18988
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112812
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84760,
+              "rank": 20,
+              "readbackNanos": 891,
+              "reduceNanos": 16164,
+              "reduceNanosSamples": [
+                16505,
+                16044,
+                16215,
+                16174,
+                16064,
+                16044,
+                16194,
+                16154
+              ],
+              "smallAllocs": 7215,
+              "totalNanos": 101866
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84641,
+              "rank": 20,
+              "readbackNanos": 8873,
+              "reduceNanos": 23560,
+              "reduceNanosSamples": [
+                23815,
+                23385,
+                23615,
+                27781,
+                23595,
+                23415,
+                23525,
+                23215
+              ],
+              "smallAllocs": 7806,
+              "totalNanos": 117229
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84696,
+              "rank": 20,
+              "readbackNanos": 8868,
+              "reduceNanos": 24927,
+              "reduceNanosSamples": [
+                25458,
+                25217,
+                24937,
+                25037,
+                24887,
+                24908,
+                24917,
+                24696
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 118421
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84620,
+              "rank": 20,
+              "readbackNanos": 8848,
+              "reduceNanos": 22383,
+              "reduceNanosSamples": [
+                23114,
+                22002,
+                22594,
+                22143,
+                22433,
+                22333,
+                22534,
+                21993
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115826
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84916,
+              "rank": 20,
+              "readbackNanos": 8858,
+              "reduceNanos": 23465,
+              "reduceNanosSamples": [
+                23796,
+                28952,
+                23475,
+                23455,
+                23665,
+                23415,
+                23224,
+                23454
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 117234
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84740,
+              "rank": 20,
+              "readbackNanos": 9013,
+              "reduceNanos": 22172,
+              "reduceNanosSamples": [
+                22223,
+                22132,
+                22323,
+                22012,
+                22032,
+                22213,
+                22223,
+                21982
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115951
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84570,
+              "rank": 20,
+              "readbackNanos": 8898,
+              "reduceNanos": 22273,
+              "reduceNanosSamples": [
+                22704,
+                22103,
+                22824,
+                21952,
+                22243,
+                22303,
+                22663,
+                22013
+              ],
+              "smallAllocs": 7708,
+              "totalNanos": 115897
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84971,
+              "rank": 20,
+              "readbackNanos": 8833,
+              "reduceNanos": 20170,
+              "reduceNanosSamples": [
+                20431,
+                20571,
+                20150,
+                20190,
+                20040,
+                20280,
+                19830,
+                20140
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 114029
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 84530,
+              "rank": 20,
+              "readbackNanos": 8853,
+              "reduceNanos": 19349,
+              "reduceNanosSamples": [
+                19559,
+                19359,
+                19539,
+                19489,
+                19159,
+                19339,
+                19298,
+                18758
+              ],
+              "smallAllocs": 7346,
+              "totalNanos": 112757
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 85021,
+              "smallAllocs": 6771
+            },
+            "columnCount": {
+              "nanos": 8291,
+              "smallAllocs": 540
+            },
+            "eliminate": {
+              "nanos": 19022,
+              "smallAllocs": 540
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 2352,
+            "pivotSearch": {
+              "nanos": 647,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "readback": {
+              "nanos": 8733,
+              "smallAllocs": 411
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 4636,
+              "smallAllocs": 80
+            },
+            "scaleMultiplies": 480,
+            "stagedNanos": 24312,
+            "wall": {
+              "nanos": 34807,
+              "smallAllocs": 1282
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2995,
+            "packNanos": 20926,
+            "rank": 20,
+            "reduceNanos": 27736,
+            "reduceNanosSamples": [
+              27080,
+              29123,
+              26319,
+              28632,
+              26109,
+              28703,
+              26219,
+              28392
+            ],
+            "rowAdds": 98,
+            "smallAllocs": 3687,
+            "totalNanos": 51866
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 95712,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 237157,
+            "smallAllocs": 12726
+          },
+          "productionRowReduce": {
+            "nanos": 223211,
+            "smallAllocs": 12037
+          },
+          "rank": 20,
+          "residentBytesAfter": 68907008,
+          "residentBytesBefore": 68907008,
+          "rowReduceMatrixRebuild": {
+            "nanos": 95817,
+            "smallAllocs": 0
+          },
+          "sink": 22,
+          "splitFactors": 4
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_U24",
+      "status": "ok"
+    },
+    {
+      "degree": 30,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 30,
+          "basisToPolynomials": {
+            "nanos": 1987,
+            "smallAllocs": 146
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1227885,
+            "smallAllocs": 116780
+          },
+          "berlekampSplit": {
+            "nanos": 1905054,
+            "smallAllocs": 167769
+          },
+          "columnPolys": {
+            "nanos": 1111888,
+            "smallAllocs": 106059
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 735,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 385454,
+              "smallAllocs": 21308
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 37326,
+              "smallAllocs": 2201
+            },
+            "stagedNanos": 423551,
+            "wall": {
+              "nanos": 438339,
+              "smallAllocs": 23741
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 787,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 696883,
+              "smallAllocs": 40208
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 51357,
+              "smallAllocs": 2891
+            },
+            "stagedNanos": 752477,
+            "wall": {
+              "nanos": 766331,
+              "smallAllocs": 43334
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 14782,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1290988,
+            "smallAllocs": 117032
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1242792,
+            "smallAllocs": 117711
+          },
+          "frobeniusPower": {
+            "nanos": 95727,
+            "smallAllocs": 8922
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 20004,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1251475,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 26093,
+          "nullspaceBasisNanos": 26093,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1482,
+            "packNanos": 35899,
+            "rank": 23,
+            "reduceNanos": 46344,
+            "reduceNanosSamples": [
+              46579,
+              45747,
+              46639,
+              46109,
+              46969,
+              45398,
+              46909,
+              45387
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 84125
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1342,
+            "packNanos": 35638,
+            "rank": 23,
+            "reduceNanos": 46388,
+            "reduceNanosSamples": [
+              46278,
+              50745,
+              46048,
+              47370,
+              45788,
+              46859,
+              45958,
+              46499
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 83424
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1642,
+            "packNanos": 36058,
+            "rank": 23,
+            "reduceNanos": 33970,
+            "reduceNanosSamples": [
+              33309,
+              34751,
+              33309,
+              34772,
+              33239,
+              34421,
+              33520,
+              34892
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 71546
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1233253,
+              "rank": 23,
+              "readbackNanos": 17686,
+              "reduceNanos": 48636,
+              "reduceNanosSamples": [
+                53299,
+                48702,
+                48612,
+                48661,
+                48452,
+                48943,
+                48422,
+                48292
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1300753
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1233469,
+              "rank": 23,
+              "readbackNanos": 17496,
+              "reduceNanos": 53259,
+              "reduceNanosSamples": [
+                52568,
+                53629,
+                53820,
+                53189,
+                52638,
+                57055,
+                52548,
+                53330
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1303702
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1233182,
+              "rank": 23,
+              "readbackNanos": 17436,
+              "reduceNanos": 45547,
+              "reduceNanosSamples": [
+                45548,
+                45547,
+                46749,
+                45387,
+                45347,
+                46920,
+                50074,
+                45448
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1296302
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1232342,
+              "rank": 23,
+              "readbackNanos": 1402,
+              "reduceNanos": 46148,
+              "reduceNanosSamples": [
+                45778,
+                46268,
+                46669,
+                46299,
+                45538,
+                45828,
+                46709,
+                46028
+              ],
+              "smallAllocs": 116328,
+              "totalNanos": 1279426
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1231410,
+              "rank": 23,
+              "readbackNanos": 17471,
+              "reduceNanos": 53164,
+              "reduceNanosSamples": [
+                53269,
+                53439,
+                52498,
+                53219,
+                53109,
+                52177,
+                53349,
+                51897
+              ],
+              "smallAllocs": 117788,
+              "totalNanos": 1302110
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1232477,
+              "rank": 23,
+              "readbackNanos": 17456,
+              "reduceNanos": 56148,
+              "reduceNanosSamples": [
+                56333,
+                56464,
+                56153,
+                60370,
+                56053,
+                56143,
+                56103,
+                56033
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1306131
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1231911,
+              "rank": 23,
+              "readbackNanos": 17486,
+              "reduceNanos": 48797,
+              "reduceNanosSamples": [
+                48712,
+                48492,
+                48883,
+                48311,
+                52328,
+                49353,
+                49133,
+                48241
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1299246
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1231711,
+              "rank": 23,
+              "readbackNanos": 17446,
+              "reduceNanos": 50785,
+              "reduceNanosSamples": [
+                50825,
+                51306,
+                54941,
+                50715,
+                50775,
+                50766,
+                50795,
+                50625
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1299977
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1235406,
+              "rank": 23,
+              "readbackNanos": 17671,
+              "reduceNanos": 48361,
+              "reduceNanosSamples": [
+                48311,
+                48412,
+                48451,
+                49363,
+                48182,
+                48291,
+                51797,
+                48282
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1301785
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1231020,
+              "rank": 23,
+              "readbackNanos": 17496,
+              "reduceNanos": 49003,
+              "reduceNanosSamples": [
+                49083,
+                48421,
+                49043,
+                48452,
+                49003,
+                48502,
+                49253,
+                49003
+              ],
+              "smallAllocs": 117473,
+              "totalNanos": 1297313
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1232613,
+              "rank": 23,
+              "readbackNanos": 17471,
+              "reduceNanos": 49198,
+              "reduceNanosSamples": [
+                49183,
+                52538,
+                49273,
+                48742,
+                48502,
+                49213,
+                49524,
+                49063
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1299416
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 1234520,
+              "rank": 23,
+              "readbackNanos": 17446,
+              "reduceNanos": 45673,
+              "reduceNanosSamples": [
+                46148,
+                45568,
+                45778,
+                45567,
+                46599,
+                46999,
+                45237,
+                45478
+              ],
+              "smallAllocs": 117121,
+              "totalNanos": 1298044
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 1232337,
+              "smallAllocs": 115879
+            },
+            "columnCount": {
+              "nanos": 10942,
+              "smallAllocs": 759
+            },
+            "eliminate": {
+              "nanos": 43781,
+              "smallAllocs": 759
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 9450,
+            "pivotSearch": {
+              "nanos": 780,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "readback": {
+              "nanos": 17466,
+              "smallAllocs": 852
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 6566,
+              "smallAllocs": 92
+            },
+            "scaleMultiplies": 690,
+            "stagedNanos": 51144,
+            "wall": {
+              "nanos": 64916,
+              "smallAllocs": 1759
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4586,
+            "packNanos": 34216,
+            "rank": 23,
+            "reduceNanos": 86533,
+            "reduceNanosSamples": [
+              82513,
+              90885,
+              79988,
+              90554,
+              80610,
+              93829,
+              79849,
+              91336
+            ],
+            "rowAdds": 315,
+            "smallAllocs": 11552,
+            "totalNanos": 125531
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 1250484,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 771293,
+            "smallAllocs": 42855
+          },
+          "productionRowReduce": {
+            "nanos": 747719,
+            "smallAllocs": 41732
+          },
+          "rank": 23,
+          "residentBytesAfter": 62849024,
+          "residentBytesBefore": 62775296,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1251745,
+            "smallAllocs": 0
+          },
+          "sink": 94,
+          "splitFactors": 7
+        },
+        "modularDegree": 30,
+        "modularFactorCount": 7,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "legendre_P30",
+      "status": "ok"
+    },
+    {
+      "degree": 38,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 38,
+          "basisToPolynomials": {
+            "nanos": 1472,
+            "smallAllocs": 100
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2376203,
+            "smallAllocs": 232849
+          },
+          "berlekampSplit": {
+            "nanos": 2718595,
+            "smallAllocs": 251152
+          },
+          "columnPolys": {
+            "nanos": 2213311,
+            "smallAllocs": 215798
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 930,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 913263,
+              "smallAllocs": 51765
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 69713,
+              "smallAllocs": 4185
+            },
+            "stagedNanos": 983652,
+            "wall": {
+              "nanos": 1004869,
+              "smallAllocs": 56191
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 1002,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 1683960,
+              "smallAllocs": 98885
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 95388,
+              "smallAllocs": 5515
+            },
+            "stagedNanos": 1780340,
+            "wall": {
+              "nanos": 1803478,
+              "smallAllocs": 104644
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 24511,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2508839,
+            "smallAllocs": 233069
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2401295,
+            "smallAllocs": 234332
+          },
+          "frobeniusPower": {
+            "nanos": 147268,
+            "smallAllocs": 14164
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 16224,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2428320,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 79,
+          "nullspaceBasisMagnitudeNanos": 21742,
+          "nullspaceBasisNanos": 21742,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1512,
+            "packNanos": 58982,
+            "rank": 35,
+            "reduceNanos": 105521,
+            "reduceNanosSamples": [
+              106377,
+              104345,
+              109993,
+              105607,
+              105436,
+              104715,
+              104776,
+              106929
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 166181
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1307,
+            "packNanos": 58978,
+            "rank": 35,
+            "reduceNanos": 107008,
+            "reduceNanosSamples": [
+              107770,
+              106818,
+              106518,
+              107329,
+              105226,
+              107369,
+              105126,
+              107199
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 167328
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1677,
+            "packNanos": 59593,
+            "rank": 35,
+            "reduceNanos": 73840,
+            "reduceNanosSamples": [
+              72908,
+              74981,
+              72758,
+              74721,
+              73008,
+              74671,
+              73009,
+              74721
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 136567
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382347,
+              "rank": 35,
+              "readbackNanos": 15974,
+              "reduceNanos": 105411,
+              "reduceNanosSamples": [
+                104976,
+                106127,
+                105466,
+                105867,
+                105076,
+                105927,
+                105356,
+                105146
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2503481
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2387489,
+              "rank": 35,
+              "readbackNanos": 15884,
+              "reduceNanos": 121630,
+              "reduceNanosSamples": [
+                120949,
+                121330,
+                121931,
+                126828,
+                120098,
+                123633,
+                121150,
+                123243
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2526050
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382442,
+              "rank": 35,
+              "readbackNanos": 15613,
+              "reduceNanos": 106397,
+              "reduceNanosSamples": [
+                106407,
+                102853,
+                106387,
+                103603,
+                105827,
+                107249,
+                106528,
+                106578
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2504263
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2387734,
+              "rank": 35,
+              "readbackNanos": 1447,
+              "reduceNanos": 104965,
+              "reduceNanosSamples": [
+                104855,
+                105076,
+                104855,
+                104235,
+                105887,
+                105926,
+                105927,
+                104595
+              ],
+              "smallAllocs": 232204,
+              "totalNanos": 2493667
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2380414,
+              "rank": 35,
+              "readbackNanos": 15613,
+              "reduceNanos": 116412,
+              "reduceNanosSamples": [
+                115441,
+                121460,
+                118345,
+                116613,
+                115751,
+                119688,
+                115722,
+                116212
+              ],
+              "smallAllocs": 233930,
+              "totalNanos": 2516210
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382878,
+              "rank": 35,
+              "readbackNanos": 15678,
+              "reduceNanos": 124204,
+              "reduceNanosSamples": [
+                124214,
+                124605,
+                124274,
+                124024,
+                124194,
+                123974,
+                123704,
+                124704
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2522670
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2395666,
+              "rank": 35,
+              "readbackNanos": 15813,
+              "reduceNanos": 106393,
+              "reduceNanosSamples": [
+                108401,
+                108731,
+                106418,
+                106047,
+                106368,
+                106198,
+                106558,
+                105646
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2518378
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2385110,
+              "rank": 35,
+              "readbackNanos": 15678,
+              "reduceNanos": 110584,
+              "reduceNanosSamples": [
+                111345,
+                115081,
+                110464,
+                110544,
+                110514,
+                111125,
+                110624,
+                109963
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2514277
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2385351,
+              "rank": 35,
+              "readbackNanos": 16013,
+              "reduceNanos": 105717,
+              "reduceNanosSamples": [
+                105246,
+                105917,
+                105296,
+                106167,
+                105617,
+                106087,
+                105817,
+                105487
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2506932
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2381721,
+              "rank": 35,
+              "readbackNanos": 15688,
+              "reduceNanos": 106478,
+              "reduceNanosSamples": [
+                109262,
+                106358,
+                111205,
+                106358,
+                105937,
+                106598,
+                107099,
+                105446
+              ],
+              "smallAllocs": 233310,
+              "totalNanos": 2503962
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2382913,
+              "rank": 35,
+              "readbackNanos": 15703,
+              "reduceNanos": 112892,
+              "reduceNanosSamples": [
+                112317,
+                111204,
+                115651,
+                112927,
+                111605,
+                112947,
+                112857,
+                113398
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2511744
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 2376553,
+              "rank": 35,
+              "readbackNanos": 15578,
+              "reduceNanos": 107214,
+              "reduceNanosSamples": [
+                106518,
+                106999,
+                110914,
+                106428,
+                107429,
+                107820,
+                105146,
+                108030
+              ],
+              "smallAllocs": 232635,
+              "totalNanos": 2498499
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 2396157,
+              "smallAllocs": 231404
+            },
+            "columnCount": {
+              "nanos": 19264,
+              "smallAllocs": 1435
+            },
+            "eliminate": {
+              "nanos": 97653,
+              "smallAllocs": 1435
+            },
+            "freeColumns": 3,
+            "innerMultiplies": 23560,
+            "pivotSearch": {
+              "nanos": 1038,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 15938,
+              "smallAllocs": 500
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 11249,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1330,
+            "stagedNanos": 109871,
+            "wall": {
+              "nanos": 133342,
+              "smallAllocs": 3203
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6038,
+            "packNanos": 56494,
+            "rank": 35,
+            "reduceNanos": 185505,
+            "reduceNanosSamples": [
+              186186,
+              184273,
+              190663,
+              184703,
+              185616,
+              194899,
+              184885,
+              185395
+            ],
+            "rowAdds": 620,
+            "smallAllocs": 27175,
+            "totalNanos": 248819
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 2419782,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1791330,
+            "smallAllocs": 103304
+          },
+          "productionRowReduce": {
+            "nanos": 1770665,
+            "smallAllocs": 101686
+          },
+          "rank": 35,
+          "residentBytesAfter": 62722048,
+          "residentBytesBefore": 62607360,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2418090,
+            "smallAllocs": 0
+          },
+          "sink": 102,
+          "splitFactors": 3
+        },
+        "modularDegree": 38,
+        "modularFactorCount": 3,
+        "prime": 79,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "legendre_P38",
+      "status": "ok"
+    },
+    {
+      "degree": 16,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 16,
+          "basisToPolynomials": {
+            "nanos": 640,
+            "smallAllocs": 40
+          },
+          "berlekampMatrixWall": {
+            "nanos": 33094,
+            "smallAllocs": 2759
+          },
+          "berlekampSplit": {
+            "nanos": 45738,
+            "smallAllocs": 2865
+          },
+          "columnPolys": {
+            "nanos": 25488,
+            "smallAllocs": 2131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 430,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 45008,
+              "smallAllocs": 2385
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 14600,
+              "smallAllocs": 808
+            },
+            "stagedNanos": 59999,
+            "wall": {
+              "nanos": 64561,
+              "smallAllocs": 3296
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 390,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 73092,
+              "smallAllocs": 3985
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 19449,
+              "smallAllocs": 1048
+            },
+            "stagedNanos": 92882,
+            "wall": {
+              "nanos": 97614,
+              "smallAllocs": 5139
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 4657,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 45397,
+            "smallAllocs": 2823
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 37776,
+            "smallAllocs": 3032
+          },
+          "frobeniusPower": {
+            "nanos": 2072,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 1,
+          "matrixConversionNanos": 5484,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 37770,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 4311,
+          "nullspaceBasisNanos": 4311,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 525,
+            "packNanos": 8687,
+            "rank": 15,
+            "reduceNanos": 7927,
+            "reduceNanosSamples": [
+              9183,
+              7471,
+              8262,
+              7701,
+              8693,
+              7492,
+              8153,
+              7381
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 17135
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 416,
+            "packNanos": 8552,
+            "rank": 15,
+            "reduceNanos": 7852,
+            "reduceNanosSamples": [
+              8062,
+              11628,
+              7832,
+              7912,
+              7681,
+              7872,
+              7671,
+              7742
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16805
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 576,
+            "packNanos": 8808,
+            "rank": 15,
+            "reduceNanos": 6980,
+            "reduceNanosSamples": [
+              6830,
+              7321,
+              10385,
+              7140,
+              6109,
+              6991,
+              6009,
+              6970
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16940
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32823,
+              "rank": 15,
+              "readbackNanos": 2844,
+              "reduceNanos": 10786,
+              "reduceNanosSamples": [
+                10806,
+                10786,
+                10616,
+                10916,
+                10596,
+                10896,
+                10596,
+                10786
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46564
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32638,
+              "rank": 15,
+              "readbackNanos": 2739,
+              "reduceNanos": 9474,
+              "reduceNanosSamples": [
+                9564,
+                9685,
+                9153,
+                9384,
+                9003,
+                9895,
+                9314,
+                9624
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 45042
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32573,
+              "rank": 15,
+              "readbackNanos": 2653,
+              "reduceNanos": 8492,
+              "reduceNanosSamples": [
+                8723,
+                8573,
+                8462,
+                8382,
+                8403,
+                8532,
+                8522,
+                8313
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 43725
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32668,
+              "rank": 15,
+              "readbackNanos": 451,
+              "reduceNanos": 7681,
+              "reduceNanosSamples": [
+                7702,
+                7671,
+                7691,
+                7691,
+                7611,
+                7652,
+                7882,
+                7641
+              ],
+              "smallAllocs": 2738,
+              "totalNanos": 40801
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32678,
+              "rank": 15,
+              "readbackNanos": 2674,
+              "reduceNanos": 10746,
+              "reduceNanosSamples": [
+                11237,
+                10596,
+                10756,
+                10736,
+                10726,
+                10756,
+                15233,
+                10616
+              ],
+              "smallAllocs": 2914,
+              "totalNanos": 46153
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32723,
+              "rank": 15,
+              "readbackNanos": 2664,
+              "reduceNanos": 11877,
+              "reduceNanosSamples": [
+                12138,
+                11878,
+                11748,
+                11877,
+                11858,
+                11998,
+                14661,
+                11877
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 47355
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32699,
+              "rank": 15,
+              "readbackNanos": 2703,
+              "reduceNanos": 10616,
+              "reduceNanosSamples": [
+                11167,
+                10465,
+                10705,
+                10626,
+                10735,
+                10606,
+                10586,
+                10426
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46008
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32643,
+              "rank": 15,
+              "readbackNanos": 2689,
+              "reduceNanos": 11347,
+              "reduceNanosSamples": [
+                11527,
+                11297,
+                11397,
+                11297,
+                11167,
+                11467,
+                12178,
+                11217
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46699
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32803,
+              "rank": 15,
+              "readbackNanos": 2804,
+              "reduceNanos": 10485,
+              "reduceNanosSamples": [
+                10525,
+                10475,
+                10405,
+                10465,
+                10496,
+                10606,
+                10446,
+                10526
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46133
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32633,
+              "rank": 15,
+              "readbackNanos": 2694,
+              "reduceNanos": 10711,
+              "reduceNanosSamples": [
+                11156,
+                10465,
+                10926,
+                10645,
+                10827,
+                10676,
+                10746,
+                10495
+              ],
+              "smallAllocs": 2864,
+              "totalNanos": 46064
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32613,
+              "rank": 15,
+              "readbackNanos": 2659,
+              "reduceNanos": 8963,
+              "reduceNanosSamples": [
+                9063,
+                9043,
+                8943,
+                8793,
+                8983,
+                9033,
+                8913,
+                8884
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44216
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 32643,
+              "rank": 15,
+              "readbackNanos": 2659,
+              "reduceNanos": 8562,
+              "reduceNanosSamples": [
+                8863,
+                8562,
+                8492,
+                8422,
+                8563,
+                8773,
+                8603,
+                8522
+              ],
+              "smallAllocs": 2689,
+              "totalNanos": 44090
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 32743,
+              "smallAllocs": 2502
+            },
+            "columnCount": {
+              "nanos": 4384,
+              "smallAllocs": 285
+            },
+            "eliminate": {
+              "nanos": 8985,
+              "smallAllocs": 285
+            },
+            "freeColumns": 1,
+            "innerMultiplies": 800,
+            "pivotSearch": {
+              "nanos": 405,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "readback": {
+              "nanos": 2614,
+              "smallAllocs": 86
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 2798,
+              "smallAllocs": 60
+            },
+            "scaleMultiplies": 240,
+            "stagedNanos": 12173,
+            "wall": {
+              "nanos": 18052,
+              "smallAllocs": 715
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1392,
+            "packNanos": 8352,
+            "rank": 15,
+            "reduceNanos": 12974,
+            "reduceNanosSamples": [
+              13119,
+              13029,
+              12178,
+              12919,
+              12218,
+              13070,
+              12729,
+              13189
+            ],
+            "rowAdds": 50,
+            "smallAllocs": 1551,
+            "totalNanos": 22584
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 37636,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 92026,
+            "smallAllocs": 4820
+          },
+          "productionRowReduce": {
+            "nanos": 87685,
+            "smallAllocs": 4531
+          },
+          "rank": 15,
+          "residentBytesAfter": 63086592,
+          "residentBytesBefore": 63086592,
+          "rowReduceMatrixRebuild": {
+            "nanos": 37826,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 1
+        },
+        "modularDegree": 16,
+        "modularFactorCount": 1,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi17",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 1827,
+            "smallAllocs": 142
+          },
+          "berlekampMatrixWall": {
+            "nanos": 167538,
+            "smallAllocs": 14819
+          },
+          "berlekampSplit": {
+            "nanos": 441289,
+            "smallAllocs": 32512
+          },
+          "columnPolys": {
+            "nanos": 130669,
+            "smallAllocs": 11503
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 980,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 202129,
+              "smallAllocs": 12335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 73408,
+              "smallAllocs": 4412
+            },
+            "stagedNanos": 276759,
+            "wall": {
+              "nanos": 299854,
+              "smallAllocs": 17021
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1020,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 333624,
+              "smallAllocs": 20335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 98230,
+              "smallAllocs": 5812
+            },
+            "stagedNanos": 432836,
+            "wall": {
+              "nanos": 455009,
+              "smallAllocs": 26424
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26965,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 231829,
+            "smallAllocs": 15115
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 194613,
+            "smallAllocs": 16460
+          },
+          "frobeniusPower": {
+            "nanos": 2168,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 5,
+          "matrixConversionNanos": 34671,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 197098,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 29854,
+          "nullspaceBasisNanos": 29854,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1688,
+            "packNanos": 65046,
+            "rank": 35,
+            "reduceNanos": 34967,
+            "reduceNanosSamples": [
+              35673,
+              33860,
+              35362,
+              34942,
+              35172,
+              33830,
+              34992,
+              34131
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 101595
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1482,
+            "packNanos": 64991,
+            "rank": 35,
+            "reduceNanos": 34596,
+            "reduceNanosSamples": [
+              34561,
+              34822,
+              37825,
+              35152,
+              34140,
+              34171,
+              34331,
+              34631
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 101145
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1788,
+            "packNanos": 65597,
+            "rank": 35,
+            "reduceNanos": 29438,
+            "reduceNanosSamples": [
+              32127,
+              29935,
+              28492,
+              29694,
+              28322,
+              29183,
+              28372,
+              29734
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 97289
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164118,
+              "rank": 35,
+              "readbackNanos": 22107,
+              "reduceNanos": 49999,
+              "reduceNanosSamples": [
+                49503,
+                49793,
+                56885,
+                49834,
+                49613,
+                50164,
+                51867,
+                50645
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238123
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164078,
+              "rank": 35,
+              "readbackNanos": 21873,
+              "reduceNanos": 42748,
+              "reduceNanosSamples": [
+                42543,
+                42954,
+                42523,
+                43193,
+                42493,
+                43023,
+                42273,
+                43474
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 228493
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163968,
+              "rank": 35,
+              "readbackNanos": 21947,
+              "reduceNanos": 40059,
+              "reduceNanosSamples": [
+                40489,
+                39839,
+                39869,
+                40611,
+                40250,
+                40891,
+                39158,
+                39549
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 226280
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163998,
+              "rank": 35,
+              "readbackNanos": 1702,
+              "reduceNanos": 34311,
+              "reduceNanosSamples": [
+                34211,
+                34041,
+                34431,
+                34531,
+                34071,
+                34461,
+                34401,
+                34221
+              ],
+              "smallAllocs": 14612,
+              "totalNanos": 200116
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164228,
+              "rank": 35,
+              "readbackNanos": 21857,
+              "reduceNanos": 52678,
+              "reduceNanosSamples": [
+                56304,
+                52458,
+                52178,
+                52417,
+                52548,
+                53379,
+                53128,
+                52808
+              ],
+              "smallAllocs": 15632,
+              "totalNanos": 239324
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 165010,
+              "rank": 35,
+              "readbackNanos": 21892,
+              "reduceNanos": 54771,
+              "reduceNanosSamples": [
+                54771,
+                54781,
+                54541,
+                55352,
+                54771,
+                55812,
+                54561,
+                54751
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 241803
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164549,
+              "rank": 35,
+              "readbackNanos": 21958,
+              "reduceNanos": 50369,
+              "reduceNanosSamples": [
+                50735,
+                49954,
+                50365,
+                49894,
+                50946,
+                50374,
+                50364,
+                50384
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 237036
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163803,
+              "rank": 35,
+              "readbackNanos": 21822,
+              "reduceNanos": 51942,
+              "reduceNanosSamples": [
+                51937,
+                51757,
+                51647,
+                51988,
+                52107,
+                52709,
+                51866,
+                51947
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 237747
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163743,
+              "rank": 35,
+              "readbackNanos": 22043,
+              "reduceNanos": 50264,
+              "reduceNanosSamples": [
+                50284,
+                49954,
+                50304,
+                49864,
+                50245,
+                50464,
+                49894,
+                50465
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 236010
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164599,
+              "rank": 35,
+              "readbackNanos": 21877,
+              "reduceNanos": 50735,
+              "reduceNanosSamples": [
+                50896,
+                53800,
+                50395,
+                50385,
+                50755,
+                51006,
+                50445,
+                50716
+              ],
+              "smallAllocs": 15532,
+              "totalNanos": 238468
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 163827,
+              "rank": 35,
+              "readbackNanos": 22027,
+              "reduceNanos": 41246,
+              "reduceNanosSamples": [
+                41132,
+                41031,
+                41011,
+                41242,
+                41381,
+                41582,
+                41251,
+                41421
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 227137
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 164083,
+              "rank": 35,
+              "readbackNanos": 21752,
+              "reduceNanos": 40039,
+              "reduceNanosSamples": [
+                39879,
+                39368,
+                39980,
+                40870,
+                55573,
+                40290,
+                39819,
+                40099
+              ],
+              "smallAllocs": 14267,
+              "totalNanos": 225920
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 164098,
+              "smallAllocs": 13218
+            },
+            "columnCount": {
+              "nanos": 20451,
+              "smallAllocs": 1505
+            },
+            "eliminate": {
+              "nanos": 42273,
+              "smallAllocs": 1505
+            },
+            "freeColumns": 5,
+            "innerMultiplies": 4000,
+            "pivotSearch": {
+              "nanos": 1077,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "readback": {
+              "nanos": 21612,
+              "smallAllocs": 838
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 10675,
+              "smallAllocs": 140
+            },
+            "scaleMultiplies": 1400,
+            "stagedNanos": 54083,
+            "wall": {
+              "nanos": 78451,
+              "smallAllocs": 3351
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6159,
+            "packNanos": 62532,
+            "rank": 35,
+            "reduceNanos": 54076,
+            "reduceNanosSamples": [
+              54300,
+              54121,
+              53980,
+              53750,
+              54031,
+              66439,
+              53600,
+              55652
+            ],
+            "rowAdds": 100,
+            "smallAllocs": 8397,
+            "totalNanos": 122787
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 193897,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 453357,
+            "smallAllocs": 25145
+          },
+          "productionRowReduce": {
+            "nanos": 424564,
+            "smallAllocs": 23316
+          },
+          "rank": 35,
+          "residentBytesAfter": 63168512,
+          "residentBytesBefore": 63090688,
+          "rowReduceMatrixRebuild": {
+            "nanos": 195540,
+            "smallAllocs": 0
+          },
+          "sink": 100,
+          "splitFactors": 5
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 5,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi41",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 3390,
+            "smallAllocs": 308
+          },
+          "berlekampMatrixWall": {
+            "nanos": 149616,
+            "smallAllocs": 14147
+          },
+          "berlekampSplit": {
+            "nanos": 580270,
+            "smallAllocs": 46939
+          },
+          "columnPolys": {
+            "nanos": 130013,
+            "smallAllocs": 12411
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 618,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 21722,
+              "smallAllocs": 1342
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 14818,
+              "smallAllocs": 876
+            },
+            "stagedNanos": 37162,
+            "wall": {
+              "nanos": 48421,
+              "smallAllocs": 2543
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 612,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 31061,
+              "smallAllocs": 1870
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 19740,
+              "smallAllocs": 1140
+            },
+            "stagedNanos": 51412,
+            "wall": {
+              "nanos": 62312,
+              "smallAllocs": 3338
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 9660,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 168515,
+            "smallAllocs": 14363
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 159366,
+            "smallAllocs": 14748
+          },
+          "frobeniusPower": {
+            "nanos": 7486,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 13,
+          "matrixConversionNanos": 12792,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 160057,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 17566,
+          "nullspaceBasisNanos": 17566,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1246,
+            "packNanos": 21541,
+            "rank": 11,
+            "reduceNanos": 6545,
+            "reduceNanosSamples": [
+              7622,
+              5869,
+              7221,
+              5949,
+              7231,
+              6009,
+              7081,
+              5839
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29383
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1071,
+            "packNanos": 21446,
+            "rank": 11,
+            "reduceNanos": 6104,
+            "reduceNanosSamples": [
+              6139,
+              6089,
+              6159,
+              6029,
+              6139,
+              6119,
+              5949,
+              5999
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28587
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1292,
+            "packNanos": 21772,
+            "rank": 11,
+            "reduceNanos": 6194,
+            "reduceNanosSamples": [
+              5918,
+              7121,
+              5658,
+              6470,
+              5688,
+              6680,
+              5699,
+              6710
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29238
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148715,
+              "rank": 11,
+              "readbackNanos": 19228,
+              "reduceNanos": 9715,
+              "reduceNanosSamples": [
+                9615,
+                9815,
+                9484,
+                9905,
+                9525,
+                9905,
+                9444,
+                9905
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177693
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148851,
+              "rank": 11,
+              "readbackNanos": 19198,
+              "reduceNanos": 7696,
+              "reduceNanosSamples": [
+                7431,
+                8041,
+                7491,
+                7912,
+                7351,
+                8012,
+                7461,
+                7902
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175941
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148255,
+              "rank": 11,
+              "readbackNanos": 19073,
+              "reduceNanos": 7215,
+              "reduceNanosSamples": [
+                7181,
+                19398,
+                7041,
+                7240,
+                7261,
+                7261,
+                7140,
+                7191
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 174784
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149396,
+              "rank": 11,
+              "readbackNanos": 1127,
+              "reduceNanos": 5958,
+              "reduceNanosSamples": [
+                6079,
+                5928,
+                5908,
+                6039,
+                5989,
+                5889,
+                6079,
+                5898
+              ],
+              "smallAllocs": 13885,
+              "totalNanos": 156416
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148845,
+              "rank": 11,
+              "readbackNanos": 19103,
+              "reduceNanos": 9694,
+              "reduceNanosSamples": [
+                9965,
+                9775,
+                9684,
+                9504,
+                9664,
+                15193,
+                9704,
+                9494
+              ],
+              "smallAllocs": 15031,
+              "totalNanos": 177688
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148390,
+              "rank": 11,
+              "readbackNanos": 19058,
+              "reduceNanos": 10230,
+              "reduceNanosSamples": [
+                10445,
+                10225,
+                10145,
+                10255,
+                10235,
+                10295,
+                10065,
+                10155
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177563
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149937,
+              "rank": 11,
+              "readbackNanos": 19109,
+              "reduceNanos": 9414,
+              "reduceNanosSamples": [
+                9804,
+                9083,
+                9574,
+                9203,
+                9464,
+                9364,
+                9494,
+                9163
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 178379
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148705,
+              "rank": 11,
+              "readbackNanos": 19053,
+              "reduceNanos": 9805,
+              "reduceNanosSamples": [
+                10055,
+                9734,
+                10145,
+                10055,
+                9815,
+                9795,
+                9764,
+                9795
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177683
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149071,
+              "rank": 11,
+              "readbackNanos": 19293,
+              "reduceNanos": 9113,
+              "reduceNanosSamples": [
+                9023,
+                9004,
+                9114,
+                9163,
+                9113,
+                9164,
+                9054,
+                9163
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177498
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149266,
+              "rank": 11,
+              "readbackNanos": 19068,
+              "reduceNanos": 9344,
+              "reduceNanosSamples": [
+                9595,
+                9153,
+                9564,
+                9163,
+                9474,
+                9154,
+                9504,
+                9214
+              ],
+              "smallAllocs": 15020,
+              "totalNanos": 177633
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 148986,
+              "rank": 11,
+              "readbackNanos": 19098,
+              "reduceNanos": 7331,
+              "reduceNanosSamples": [
+                7331,
+                7501,
+                7221,
+                7371,
+                7301,
+                7431,
+                7200,
+                7331
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175330
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 149742,
+              "rank": 11,
+              "readbackNanos": 19123,
+              "reduceNanos": 7225,
+              "reduceNanosSamples": [
+                7241,
+                7280,
+                7061,
+                7301,
+                7221,
+                7230,
+                7131,
+                7120
+              ],
+              "smallAllocs": 14778,
+              "totalNanos": 175961
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 150057,
+              "smallAllocs": 13570
+            },
+            "columnCount": {
+              "nanos": 4466,
+              "smallAllocs": 297
+            },
+            "eliminate": {
+              "nanos": 7131,
+              "smallAllocs": 297
+            },
+            "freeColumns": 13,
+            "innerMultiplies": 264,
+            "pivotSearch": {
+              "nanos": 600,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "readback": {
+              "nanos": 19073,
+              "smallAllocs": 1158
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 2950,
+              "smallAllocs": 44
+            },
+            "scaleMultiplies": 264,
+            "stagedNanos": 10700,
+            "wall": {
+              "nanos": 17421,
+              "smallAllocs": 751
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3280,
+            "packNanos": 20911,
+            "rank": 11,
+            "reduceNanos": 9449,
+            "reduceNanosSamples": [
+              9615,
+              9925,
+              9274,
+              14792,
+              9184,
+              9494,
+              9174,
+              9404
+            ],
+            "rowAdds": 11,
+            "smallAllocs": 1470,
+            "totalNanos": 33655
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 159666,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 70689,
+            "smallAllocs": 3266
+          },
+          "productionRowReduce": {
+            "nanos": 53039,
+            "smallAllocs": 2654
+          },
+          "rank": 11,
+          "residentBytesAfter": 63352832,
+          "residentBytesBefore": 63352832,
+          "rowReduceMatrixRebuild": {
+            "nanos": 160318,
+            "smallAllocs": 0
+          },
+          "sink": 80,
+          "splitFactors": 13
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 13,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow24_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 20,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 20,
+          "basisToPolynomials": {
+            "nanos": 1201,
+            "smallAllocs": 75
+          },
+          "berlekampMatrixWall": {
+            "nanos": 168860,
+            "smallAllocs": 15130
+          },
+          "berlekampSplit": {
+            "nanos": 302378,
+            "smallAllocs": 23484
+          },
+          "columnPolys": {
+            "nanos": 155480,
+            "smallAllocs": 14054
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 514,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 204127,
+              "smallAllocs": 10529
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 18657,
+              "smallAllocs": 1043
+            },
+            "stagedNanos": 223265,
+            "wall": {
+              "nanos": 230156,
+              "smallAllocs": 11711
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 544,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 363899,
+              "smallAllocs": 19849
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 25483,
+              "smallAllocs": 1363
+            },
+            "stagedNanos": 389734,
+            "wall": {
+              "nanos": 396418,
+              "smallAllocs": 21354
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 7036,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 199240,
+            "smallAllocs": 15255
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 175324,
+            "smallAllocs": 15551
+          },
+          "frobeniusPower": {
+            "nanos": 4106,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 9244,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 176377,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 14226,
+          "nullspaceBasisNanos": 14226,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 851,
+            "packNanos": 14421,
+            "rank": 16,
+            "reduceNanos": 22858,
+            "reduceNanosSamples": [
+              23735,
+              22583,
+              23445,
+              22513,
+              23134,
+              22463,
+              23225,
+              22524
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38102
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 681,
+            "packNanos": 14236,
+            "rank": 16,
+            "reduceNanos": 22869,
+            "reduceNanosSamples": [
+              22934,
+              23004,
+              22784,
+              22804,
+              23195,
+              22744,
+              22663,
+              23124
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 37901
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 921,
+            "packNanos": 14456,
+            "rank": 16,
+            "reduceNanos": 18742,
+            "reduceNanosSamples": [
+              18567,
+              19589,
+              18288,
+              18918,
+              17927,
+              18969,
+              18167,
+              19118
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 34095
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167858,
+              "rank": 16,
+              "readbackNanos": 6805,
+              "reduceNanos": 25222,
+              "reduceNanosSamples": [
+                28071,
+                25417,
+                24877,
+                25237,
+                34612,
+                25158,
+                24797,
+                25208
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 201028
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167864,
+              "rank": 16,
+              "readbackNanos": 6630,
+              "reduceNanos": 27781,
+              "reduceNanosSamples": [
+                27801,
+                28232,
+                27461,
+                27851,
+                27461,
+                27761,
+                27601,
+                28011
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 202706
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168434,
+              "rank": 16,
+              "readbackNanos": 6590,
+              "reduceNanos": 23970,
+              "reduceNanosSamples": [
+                24056,
+                23885,
+                24416,
+                24366,
+                24286,
+                23695,
+                23585,
+                23856
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 198825
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168535,
+              "rank": 16,
+              "readbackNanos": 746,
+              "reduceNanos": 22899,
+              "reduceNanosSamples": [
+                22804,
+                22994,
+                23175,
+                23004,
+                23034,
+                22583,
+                22684,
+                22633
+              ],
+              "smallAllocs": 14870,
+              "totalNanos": 191854
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 169907,
+              "rank": 16,
+              "readbackNanos": 6620,
+              "reduceNanos": 27170,
+              "reduceNanosSamples": [
+                27942,
+                27060,
+                26989,
+                27461,
+                27170,
+                26960,
+                27601,
+                27170
+              ],
+              "smallAllocs": 15663,
+              "totalNanos": 203717
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167874,
+              "rank": 16,
+              "readbackNanos": 6594,
+              "reduceNanos": 28827,
+              "reduceNanosSamples": [
+                28933,
+                29013,
+                28862,
+                28622,
+                28693,
+                28932,
+                28763,
+                28793
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 203276
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 169897,
+              "rank": 16,
+              "readbackNanos": 6620,
+              "reduceNanos": 24912,
+              "reduceNanosSamples": [
+                25157,
+                24817,
+                24977,
+                24757,
+                25317,
+                24817,
+                25027,
+                24847
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 201374
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168124,
+              "rank": 16,
+              "readbackNanos": 6580,
+              "reduceNanos": 26198,
+              "reduceNanosSamples": [
+                26289,
+                29524,
+                26278,
+                26089,
+                26178,
+                26099,
+                26219,
+                26159
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 201443
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 167953,
+              "rank": 16,
+              "readbackNanos": 6745,
+              "reduceNanos": 24916,
+              "reduceNanosSamples": [
+                25047,
+                25047,
+                24937,
+                24797,
+                24877,
+                24896,
+                25057,
+                24707
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 199595
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 169371,
+              "rank": 16,
+              "readbackNanos": 6665,
+              "reduceNanos": 25062,
+              "reduceNanosSamples": [
+                25348,
+                24857,
+                25187,
+                24997,
+                25237,
+                25017,
+                25107,
+                24806
+              ],
+              "smallAllocs": 15430,
+              "totalNanos": 201007
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168289,
+              "rank": 16,
+              "readbackNanos": 6585,
+              "reduceNanos": 25938,
+              "reduceNanosSamples": [
+                25889,
+                26139,
+                25889,
+                26168,
+                25988,
+                25878,
+                25617,
+                26038
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 201098
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 168109,
+              "rank": 16,
+              "readbackNanos": 6595,
+              "reduceNanos": 24136,
+              "reduceNanosSamples": [
+                27541,
+                24466,
+                23765,
+                24386,
+                23875,
+                24136,
+                23805,
+                24136
+              ],
+              "smallAllocs": 15359,
+              "totalNanos": 199536
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 170142,
+              "smallAllocs": 14729
+            },
+            "columnCount": {
+              "nanos": 5765,
+              "smallAllocs": 368
+            },
+            "eliminate": {
+              "nanos": 22914,
+              "smallAllocs": 368
+            },
+            "freeColumns": 4,
+            "innerMultiplies": 4660,
+            "pivotSearch": {
+              "nanos": 507,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "readback": {
+              "nanos": 6565,
+              "smallAllocs": 343
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 3350,
+              "smallAllocs": 64
+            },
+            "scaleMultiplies": 320,
+            "stagedNanos": 26767,
+            "wall": {
+              "nanos": 34311,
+              "smallAllocs": 902
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2188,
+            "packNanos": 13976,
+            "rank": 16,
+            "reduceNanos": 42407,
+            "reduceNanosSamples": [
+              40199,
+              44646,
+              39679,
+              44616,
+              39408,
+              44677,
+              39448,
+              44787
+            ],
+            "rowAdds": 233,
+            "smallAllocs": 5524,
+            "totalNanos": 58847
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 175850,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 397619,
+            "smallAllocs": 21079
+          },
+          "productionRowReduce": {
+            "nanos": 384059,
+            "smallAllocs": 20563
+          },
+          "rank": 16,
+          "residentBytesAfter": 63365120,
+          "residentBytesBefore": 63352832,
+          "rowReduceMatrixRebuild": {
+            "nanos": 175650,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 4
+        },
+        "modularDegree": 20,
+        "modularFactorCount": 4,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_10",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1873,
+            "smallAllocs": 128
+          },
+          "berlekampMatrixWall": {
+            "nanos": 576795,
+            "smallAllocs": 52728
+          },
+          "berlekampSplit": {
+            "nanos": 818898,
+            "smallAllocs": 68180
+          },
+          "columnPolys": {
+            "nanos": 546931,
+            "smallAllocs": 49657
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 590,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 350193,
+              "smallAllocs": 18538
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 22476,
+              "smallAllocs": 1310
+            },
+            "stagedNanos": 373524,
+            "wall": {
+              "nanos": 383248,
+              "smallAllocs": 20041
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 630,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 640643,
+              "smallAllocs": 35482
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 31128,
+              "smallAllocs": 1718
+            },
+            "stagedNanos": 672926,
+            "wall": {
+              "nanos": 682291,
+              "smallAllocs": 37396
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 14742,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 623859,
+            "smallAllocs": 52920
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 589559,
+            "smallAllocs": 53329
+          },
+          "frobeniusPower": {
+            "nanos": 22398,
+            "smallAllocs": 1920
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 5934,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 589323,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 22057,
+          "nullspaceBasisNanos": 22057,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1207,
+            "packNanos": 21727,
+            "rank": 17,
+            "reduceNanos": 37550,
+            "reduceNanosSamples": [
+              38176,
+              36955,
+              38026,
+              36854,
+              42774,
+              36925,
+              38257,
+              37075
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60504
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 946,
+            "packNanos": 21507,
+            "rank": 17,
+            "reduceNanos": 37675,
+            "reduceNanosSamples": [
+              37786,
+              37516,
+              38546,
+              38126,
+              37565,
+              38156,
+              37456,
+              37426
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60214
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1292,
+            "packNanos": 22568,
+            "rank": 17,
+            "reduceNanos": 32248,
+            "reduceNanosSamples": [
+              31247,
+              32298,
+              31076,
+              32198,
+              31226,
+              32368,
+              33710,
+              32398
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 56323
+          },
+          "packedLadder": {
+            "arrayPivots": {
+              "agreesWithNullspace": true,
+              "buildNanos": 577090,
+              "rank": 17,
+              "readbackNanos": 12413,
+              "reduceNanos": 38687,
+              "reduceNanosSamples": [
+                38367,
+                38988,
+                38447,
+                38657,
+                38757,
+                38897,
+                38407,
+                38717
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 629002
+            },
+            "doubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575172,
+              "rank": 17,
+              "readbackNanos": 12348,
+              "reduceNanos": 45247,
+              "reduceNanosSamples": [
+                44866,
+                45297,
+                44406,
+                45227,
+                45788,
+                45498,
+                44416,
+                45267
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 633083
+            },
+            "flatBothLoops": {
+              "agreesWithNullspace": true,
+              "buildNanos": 574706,
+              "rank": 17,
+              "readbackNanos": 12138,
+              "reduceNanos": 38762,
+              "reduceNanosSamples": [
+                42103,
+                38948,
+                38787,
+                37615,
+                39017,
+                37806,
+                38737,
+                38738
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 626093
+            },
+            "flatBuffer": {
+              "agreesWithNullspace": true,
+              "buildNanos": 578272,
+              "rank": 17,
+              "readbackNanos": 1031,
+              "reduceNanos": 37415,
+              "reduceNanosSamples": [
+                37746,
+                37285,
+                37295,
+                37366,
+                37465,
+                37475,
+                38538,
+                37316
+              ],
+              "smallAllocs": 52268,
+              "totalNanos": 617350
+            },
+            "flatRowWrite": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576920,
+              "rank": 17,
+              "readbackNanos": 12133,
+              "reduceNanos": 42483,
+              "reduceNanosSamples": [
+                41962,
+                42883,
+                41952,
+                42654,
+                43605,
+                43314,
+                42312,
+                41672
+              ],
+              "smallAllocs": 53630,
+              "totalNanos": 631476
+            },
+            "hoistedDoubledMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 577341,
+              "rank": 17,
+              "readbackNanos": 12143,
+              "reduceNanos": 45202,
+              "reduceNanosSamples": [
+                45167,
+                45237,
+                45086,
+                44936,
+                48271,
+                45637,
+                44856,
+                45468
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 634771
+            },
+            "hoistedPivotRow": {
+              "agreesWithNullspace": true,
+              "buildNanos": 577331,
+              "rank": 17,
+              "readbackNanos": 12138,
+              "reduceNanos": 38667,
+              "reduceNanosSamples": [
+                38587,
+                40550,
+                38747,
+                38057,
+                39018,
+                38227,
+                38957,
+                38457
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 628471
+            },
+            "hoistedSaltedMin": {
+              "agreesWithNullspace": true,
+              "buildNanos": 575889,
+              "rank": 17,
+              "readbackNanos": 12188,
+              "reduceNanos": 40575,
+              "reduceNanosSamples": [
+                40460,
+                40309,
+                40440,
+                40209,
+                41602,
+                41121,
+                40690,
+                40700
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 628397
+            },
+            "integrated": {
+              "agreesWithNullspace": true,
+              "buildNanos": 579273,
+              "rank": 17,
+              "readbackNanos": 12333,
+              "reduceNanos": 38416,
+              "reduceNanosSamples": [
+                38326,
+                38697,
+                38277,
+                38507,
+                38678,
+                38307,
+                38156,
+                38557
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 630359
+            },
+            "ladderForward": [
+              true,
+              false,
+              true,
+              false,
+              true,
+              false,
+              true,
+              false
+            ],
+            "mirrored": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576089,
+              "rank": 17,
+              "readbackNanos": 12223,
+              "reduceNanos": 38682,
+              "reduceNanosSamples": [
+                38758,
+                38617,
+                38988,
+                38237,
+                39349,
+                38468,
+                38747,
+                38297
+              ],
+              "smallAllocs": 53277,
+              "totalNanos": 626890
+            },
+            "saltedMinMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576946,
+              "rank": 17,
+              "readbackNanos": 12228,
+              "reduceNanos": 41566,
+              "reduceNanosSamples": [
+                41842,
+                40980,
+                40831,
+                41311,
+                41771,
+                41791,
+                41361,
+                42032
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 632518
+            },
+            "saltedMultiply": {
+              "agreesWithNullspace": true,
+              "buildNanos": 576975,
+              "rank": 17,
+              "readbackNanos": 12203,
+              "reduceNanos": 38176,
+              "reduceNanosSamples": [
+                37786,
+                37877,
+                38918,
+                37896,
+                39288,
+                38457,
+                39718,
+                37837
+              ],
+              "smallAllocs": 53239,
+              "totalNanos": 627811
+            }
+          },
+          "packedStages": {
+            "agreesWithNullspace": true,
+            "agreesWithPackedReduce": true,
+            "build": {
+              "nanos": 576475,
+              "smallAllocs": 52151
+            },
+            "columnCount": {
+              "nanos": 7095,
+              "smallAllocs": 459
+            },
+            "eliminate": {
+              "nanos": 35663,
+              "smallAllocs": 459
+            },
+            "freeColumns": 7,
+            "innerMultiplies": 8472,
+            "pivotSearch": {
+              "nanos": 626,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "readback": {
+              "nanos": 12299,
+              "smallAllocs": 678
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 4122,
+              "smallAllocs": 68
+            },
+            "scaleMultiplies": 408,
+            "stagedNanos": 40409,
+            "wall": {
+              "nanos": 49894,
+              "smallAllocs": 1105
+            }
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3125,
+            "packNanos": 21096,
+            "rank": 17,
+            "reduceNanos": 74896,
+            "reduceNanosSamples": [
+              66649,
+              79468,
+              66448,
+              75632,
+              69082,
+              76523,
+              74160,
+              75912
+            ],
+            "rowAdds": 353,
+            "smallAllocs": 9576,
+            "totalNanos": 99062
+          },
+          "peakResidentBytes": 70463488,
+          "productionMatrixRebuild": {
+            "nanos": 587361,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 691164,
+            "smallAllocs": 37192
+          },
+          "productionRowReduce": {
+            "nanos": 667019,
+            "smallAllocs": 36406
+          },
+          "rank": 17,
+          "residentBytesAfter": 63365120,
+          "residentBytesBefore": 63365120,
+          "rowReduceMatrixRebuild": {
+            "nanos": 586815,
+            "smallAllocs": 0
+          },
+          "sink": 84,
+          "splitFactors": 7
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 7,
+        "prime": 17,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_21",
+      "status": "ok"
+    }
+  ],
+  "results": [
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 70189589,
+        "median_nanos": 68875381,
+        "min_nanos": 68339406,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0132292553125768,
+      "name": "sd5",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3241426,
+              "smallAllocs": 279386
+            },
+            "berlekampMatrix": {
+              "nanos": 2153,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 20450,
+              "smallAllocs": 1600
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 1763,
+              "smallAllocs": 78
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1606241,
+              "smallAllocs": 152147
+            },
+            "splittingNanos": 1633032
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7882,
+              "smallAllocs": 332
+            },
+            "henselLift": {
+              "nanos": 1595235,
+              "smallAllocs": 57192
+            },
+            "normalization": {
+              "nanos": 32278,
+              "smallAllocs": 1647
+            },
+            "primeWalk": {
+              "nanos": 6654786,
+              "smallAllocs": 569749
+            },
+            "quadratic": {
+              "nanos": 521,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 61460197,
+              "smallAllocs": 2749638
+            },
+            "total": {
+              "nanos": 69786551,
+              "smallAllocs": 3379518
+            },
+            "validation": {
+              "nanos": 6369,
+              "smallAllocs": 201
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 221306743312056565676926650,
+            "coeffBoundBits": 88,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32639,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 129,
+              "recordable": 129,
+              "trailingSurvivors": 129
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 70383386,
+        "total_nanos_median": 69786551,
+        "total_nanos_min": 69354371
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 63338291,
+        "median_nanos": 62689019,
+        "min_nanos": 62384257,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0280471130039537,
+      "name": "sd5_shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3017543,
+              "smallAllocs": 258979
+            },
+            "berlekampMatrix": {
+              "nanos": 1793,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34982,
+              "smallAllocs": 2696
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2494,
+              "smallAllocs": 84
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2302634,
+              "smallAllocs": 211116
+            },
+            "splittingNanos": 713116
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10436,
+              "smallAllocs": 382
+            },
+            "henselLift": {
+              "nanos": 1754091,
+              "smallAllocs": 58655
+            },
+            "normalization": {
+              "nanos": 51977,
+              "smallAllocs": 2827
+            },
+            "primeWalk": {
+              "nanos": 6934410,
+              "smallAllocs": 588844
+            },
+            "quadratic": {
+              "nanos": 591,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 55659297,
+              "smallAllocs": 2560916
+            },
+            "total": {
+              "nanos": 64447265,
+              "smallAllocs": 3212631
+            },
+            "validation": {
+              "nanos": 7811,
+              "smallAllocs": 229
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 343800744604764214921668900,
+            "coeffBoundBits": 89,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 64772047,
+        "total_nanos_median": 64447265,
+        "total_nanos_min": 64219558
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 65847051,
+        "median_nanos": 65301873,
+        "min_nanos": 65114695,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0304189437261624,
+      "name": "sd5_shift2",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4577026,
+              "smallAllocs": 381697
+            },
+            "berlekampMatrix": {
+              "nanos": 1993,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34972,
+              "smallAllocs": 2673
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2543,
+              "smallAllocs": 85
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2305428,
+              "smallAllocs": 211421
+            },
+            "splittingNanos": 2269605
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10906,
+              "smallAllocs": 391
+            },
+            "henselLift": {
+              "nanos": 1630467,
+              "smallAllocs": 58442
+            },
+            "normalization": {
+              "nanos": 54120,
+              "smallAllocs": 2834
+            },
+            "primeWalk": {
+              "nanos": 8569275,
+              "smallAllocs": 716169
+            },
+            "quadratic": {
+              "nanos": 851,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 56984202,
+              "smallAllocs": 2594103
+            },
+            "total": {
+              "nanos": 67288287,
+              "smallAllocs": 3372963
+            },
+            "validation": {
+              "nanos": 8333,
+              "smallAllocs": 234
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1319504980517760399369866460,
+            "coeffBoundBits": 91,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 68101553,
+        "total_nanos_median": 67288287,
+        "total_nanos_min": 66993450
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 17747892,
+        "median_nanos": 17661754,
+        "min_nanos": 17527977,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16,
+        16
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 0.9843628781150502,
+      "name": "sd4_x_sd4shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            16,
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 83,
+            "modulusBits": 83,
+            "precision": 17,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3831550,
+              "smallAllocs": 320808
+            },
+            "berlekampMatrix": {
+              "nanos": 1602,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 35183,
+              "smallAllocs": 2770
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2223,
+              "smallAllocs": 82
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 2281202,
+              "smallAllocs": 210624
+            },
+            "splittingNanos": 1548746
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 21823,
+              "smallAllocs": 901
+            },
+            "henselLift": {
+              "nanos": 1555195,
+              "smallAllocs": 55974
+            },
+            "normalization": {
+              "nanos": 50975,
+              "smallAllocs": 2814
+            },
+            "primeWalk": {
+              "nanos": 6712802,
+              "smallAllocs": 562910
+            },
+            "quadratic": {
+              "nanos": 431,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 8999022,
+              "smallAllocs": 528057
+            },
+            "total": {
+              "nanos": 17385575,
+              "smallAllocs": 1152141
+            },
+            "validation": {
+              "nanos": 20491,
+              "smallAllocs": 745
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 17,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 13,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 489391641089022941499420,
+            "coeffBoundBits": 79,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10530,
+              "degreeSurvivors": 10540,
+              "exactDivisionsAttempted": 2,
+              "nodes": 10540,
+              "productsMaterialized": 10,
+              "recordable": 10,
+              "trailingSurvivors": 10
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 17538261,
+        "total_nanos_median": 17385575,
+        "total_nanos_min": 17344233
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          16,
+          16
+        ],
+        "mirror_nodes": 10540,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 10540,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          16,
+          16
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 42,
+      "end_to_end": {
+        "max_nanos": 139389600,
+        "median_nanos": 138920815,
+        "min_nanos": 137729209,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        32
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.0189759828287792,
+      "name": "sd5_x_phi11",
+      "phase_profile": {
+        "profile": {
+          "degree": 42,
+          "factorDegrees": [
+            10,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 17,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              10,
+              2
+            ],
+            "liftedMaxCoeffBits": 102,
+            "modulusBits": 103,
+            "precision": 21,
+            "prime": 29,
+            "treeInternalLifts": 16,
+            "treeLeaves": 17,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7495843,
+              "smallAllocs": 625572
+            },
+            "berlekampMatrix": {
+              "nanos": 4257,
+              "smallAllocs": 138
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 56284,
+              "smallAllocs": 4248
+            },
+            "kernelDimension": 17,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 42,
+            "modularImage": {
+              "nanos": 3304,
+              "smallAllocs": 108
+            },
+            "prime": 29,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 4667269,
+              "smallAllocs": 428628
+            },
+            "splittingNanos": 2824317
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29984,
+              "smallAllocs": 1170
+            },
+            "henselLift": {
+              "nanos": 2470572,
+              "smallAllocs": 80497
+            },
+            "normalization": {
+              "nanos": 84586,
+              "smallAllocs": 4551
+            },
+            "primeWalk": {
+              "nanos": 16046550,
+              "smallAllocs": 1373405
+            },
+            "quadratic": {
+              "nanos": 1041,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 122857050,
+              "smallAllocs": 6175336
+            },
+            "total": {
+              "nanos": 141556974,
+              "smallAllocs": 7636916
+            },
+            "validation": {
+              "nanos": 31736,
+              "smallAllocs": 1070
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  10,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 21,
+                "modularFactorCount": 17,
+                "prime": 29,
+                "reachableProperDegrees": 20,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 24,
+                "modularFactorCount": 17,
+                "prime": 19,
+                "reachableProperDegrees": 20,
+                "selected": false
+              }
+            ],
+            "coeffBound": 210602981274948990483361217040,
+            "coeffBoundBits": 98,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 65264,
+              "degreeSurvivors": 65522,
+              "exactDivisionsAttempted": 2,
+              "nodes": 65522,
+              "productsMaterialized": 258,
+              "recordable": 258,
+              "trailingSurvivors": 258
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 142065227,
+        "total_nanos_median": 141556974,
+        "total_nanos_min": 140446268
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          10,
+          32
+        ],
+        "mirror_nodes": 65522,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 65522,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          10,
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 10482301,
+        "median_nanos": 10444515,
+        "min_nanos": 10405937,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9985750415409428,
+      "name": "xpow48_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            2,
+            2,
+            2,
+            8,
+            8,
+            16,
+            1,
+            1,
+            4,
+            4
+          ],
+          "hensel": {
+            "liftedFactorCount": 19,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              4,
+              4,
+              2,
+              2,
+              4,
+              2,
+              2,
+              4,
+              4,
+              4,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 49,
+            "modulusBits": 49,
+            "precision": 14,
+            "prime": 11,
+            "treeInternalLifts": 18,
+            "treeLeaves": 19,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1965083,
+              "smallAllocs": 163103
+            },
+            "berlekampMatrix": {
+              "nanos": 2373,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 5898,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 19,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 1242,
+              "smallAllocs": 104
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 746367,
+              "smallAllocs": 67517
+            },
+            "splittingNanos": 1216343
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 24146,
+              "smallAllocs": 2409
+            },
+            "henselLift": {
+              "nanos": 1095103,
+              "smallAllocs": 57566
+            },
+            "normalization": {
+              "nanos": 13640,
+              "smallAllocs": 563
+            },
+            "primeWalk": {
+              "nanos": 3984667,
+              "smallAllocs": 339932
+            },
+            "quadratic": {
+              "nanos": 421,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5277474,
+              "smallAllocs": 270316
+            },
+            "total": {
+              "nanos": 10429632,
+              "smallAllocs": 673192
+            },
+            "validation": {
+              "nanos": 18698,
+              "smallAllocs": 1688
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  2,
+                  4,
+                  4,
+                  4,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 262144,
+                "henselPrecision": 14,
+                "modularFactorCount": 19,
+                "prime": 11,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  2,
+                  2,
+                  4,
+                  2
+                ],
+                "forcedSubsetCost": 524288,
+                "henselPrecision": 21,
+                "modularFactorCount": 20,
+                "prime": 5,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 64495207366200,
+            "coeffBoundBits": 46,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 268,
+              "exactDivisionsAttempted": 10,
+              "nodes": 268,
+              "productsMaterialized": 268,
+              "recordable": 268,
+              "trailingSurvivors": 268
+            },
+            "successfulDivisors": 10
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 10492014,
+        "total_nanos_median": 10429632,
+        "total_nanos_min": 10410364
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "mirror_nodes": 268,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 268,
+        "production_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 105,
+      "end_to_end": {
+        "max_nanos": 45962361,
+        "median_nanos": 45913239,
+        "min_nanos": 45238438,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9744799533746683,
+      "name": "xpow105_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 105,
+          "factorDegrees": [
+            4,
+            24,
+            2,
+            12,
+            48,
+            8,
+            6,
+            1
+          ],
+          "hensel": {
+            "liftedFactorCount": 14,
+            "liftedFactorDegrees": [
+              1,
+              6,
+              4,
+              12,
+              12,
+              4,
+              12,
+              12,
+              6,
+              2,
+              6,
+              12,
+              12,
+              4
+            ],
+            "liftedMaxCoeffBits": 107,
+            "modulusBits": 107,
+            "precision": 26,
+            "prime": 17,
+            "treeInternalLifts": 13,
+            "treeLeaves": 14,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 8893886,
+              "smallAllocs": 750003
+            },
+            "berlekampMatrix": {
+              "nanos": 7221,
+              "smallAllocs": 327
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 20511,
+              "smallAllocs": 1080
+            },
+            "kernelDimension": 14,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 105,
+            "modularImage": {
+              "nanos": 3605,
+              "smallAllocs": 218
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 5029095,
+              "smallAllocs": 462407
+            },
+            "splittingNanos": 3857570
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 103163,
+              "smallAllocs": 6483
+            },
+            "henselLift": {
+              "nanos": 10173242,
+              "smallAllocs": 304935
+            },
+            "normalization": {
+              "nanos": 27630,
+              "smallAllocs": 1190
+            },
+            "primeWalk": {
+              "nanos": 29357324,
+              "smallAllocs": 2625082
+            },
+            "quadratic": {
+              "nanos": 571,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 4951631,
+              "smallAllocs": 266987
+            },
+            "total": {
+              "nanos": 44741531,
+              "smallAllocs": 3211107
+            },
+            "validation": {
+              "nanos": 92497,
+              "smallAllocs": 5196
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  6,
+                  4,
+                  12,
+                  12,
+                  4,
+                  12,
+                  12,
+                  6,
+                  2,
+                  6,
+                  12,
+                  12,
+                  4
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 26,
+                "modularFactorCount": 14,
+                "prime": 17,
+                "reachableProperDegrees": 104,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  3,
+                  6,
+                  1,
+                  2,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 536870912,
+                "henselPrecision": 30,
+                "modularFactorCount": 30,
+                "prime": 11,
+                "reachableProperDegrees": 104,
+                "selected": false
+              }
+            ],
+            "coeffBound": 6272525058612251449529907677520,
+            "coeffBoundBits": 103,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 60,
+              "exactDivisionsAttempted": 8,
+              "nodes": 60,
+              "productsMaterialized": 60,
+              "recordable": 60,
+              "trailingSurvivors": 60
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 44863882,
+        "total_nanos_median": 44741531,
+        "total_nanos_min": 44290653
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "mirror_nodes": 60,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 60,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "production_prime": 17
+      }
+    },
+    {
+      "degree": 120,
+      "end_to_end": {
+        "max_nanos": 149561631,
+        "median_nanos": 148326840,
+        "min_nanos": 146518930,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9957072974789998,
+      "name": "xpow120_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 120,
+          "factorDegrees": [
+            16,
+            4,
+            32,
+            8,
+            8,
+            2,
+            8,
+            2,
+            4,
+            16,
+            4,
+            1,
+            4,
+            1,
+            2,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 39,
+            "liftedFactorDegrees": [
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4
+            ],
+            "liftedMaxCoeffBits": 121,
+            "modulusBits": 121,
+            "precision": 43,
+            "prime": 7,
+            "treeInternalLifts": 38,
+            "treeLeaves": 39,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 15956866,
+              "smallAllocs": 1312571
+            },
+            "berlekampMatrix": {
+              "nanos": 5999,
+              "smallAllocs": 372
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 13801,
+              "smallAllocs": 1230
+            },
+            "kernelDimension": 39,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 120,
+            "modularImage": {
+              "nanos": 2554,
+              "smallAllocs": 248
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3728638,
+              "smallAllocs": 329059
+            },
+            "splittingNanos": 12222229
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 103142,
+              "smallAllocs": 11833
+            },
+            "henselLift": {
+              "nanos": 14183808,
+              "smallAllocs": 453833
+            },
+            "normalization": {
+              "nanos": 33540,
+              "smallAllocs": 1355
+            },
+            "primeWalk": {
+              "nanos": 18782917,
+              "smallAllocs": 1585472
+            },
+            "quadratic": {
+              "nanos": 971,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 114471679,
+              "smallAllocs": 5264950
+            },
+            "total": {
+              "nanos": 147690117,
+              "smallAllocs": 7326822
+            },
+            "validation": {
+              "nanos": 80028,
+              "smallAllocs": 8230
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4
+                ],
+                "forcedSubsetCost": 274877906944,
+                "henselPrecision": 43,
+                "modularFactorCount": 39,
+                "prime": 7,
+                "reachableProperDegrees": 119,
+                "selected": true
+              }
+            ],
+            "coeffBound": 193229817680726645207786279042745312,
+            "coeffBoundBits": 118,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3538,
+              "degreeSurvivors": 5339,
+              "exactDivisionsAttempted": 16,
+              "nodes": 5339,
+              "productsMaterialized": 1801,
+              "recordable": 1801,
+              "trailingSurvivors": 1801
+            },
+            "successfulDivisors": 16
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 148010872,
+        "total_nanos_median": 147690117,
+        "total_nanos_min": 146371411
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "mirror_nodes": 5339,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5339,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 178,
+      "end_to_end": {
+        "max_nanos": 33862923,
+        "median_nanos": 33724028,
+        "min_nanos": 33679532,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        178
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9887616331002927,
+      "name": "cyclo_phi179",
+      "phase_profile": {
+        "profile": {
+          "degree": 178,
+          "factorDegrees": [
+            178
+          ],
+          "hensel": {
+            "liftedFactorCount": 2,
+            "liftedFactorDegrees": [
+              89,
+              89
+            ],
+            "liftedMaxCoeffBits": 180,
+            "modulusBits": 180,
+            "precision": 113,
+            "prime": 3,
+            "treeInternalLifts": 1,
+            "treeLeaves": 2,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 5329171,
+              "smallAllocs": 339370
+            },
+            "berlekampMatrix": {
+              "nanos": 8683,
+              "smallAllocs": 546
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 36334,
+              "smallAllocs": 3356
+            },
+            "kernelDimension": 2,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 178,
+            "modularImage": {
+              "nanos": 3395,
+              "smallAllocs": 364
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 13748272,
+              "smallAllocs": 1226531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 20881,
+              "smallAllocs": 1446
+            },
+            "henselLift": {
+              "nanos": 26653866,
+              "smallAllocs": 567324
+            },
+            "normalization": {
+              "nanos": 67009,
+              "smallAllocs": 3772
+            },
+            "primeWalk": {
+              "nanos": 5364854,
+              "smallAllocs": 346865
+            },
+            "quadratic": {
+              "nanos": 511,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 1169584,
+              "smallAllocs": 46831
+            },
+            "total": {
+              "nanos": 33345025,
+              "smallAllocs": 968495
+            },
+            "validation": {
+              "nanos": 18267,
+              "smallAllocs": 901
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  89,
+                  89
+                ],
+                "forcedSubsetCost": 2,
+                "henselPrecision": 113,
+                "modularFactorCount": 2,
+                "prime": 3,
+                "reachableProperDegrees": 1,
+                "selected": true
+              }
+            ],
+            "coeffBound": 320322439463041003620181335381340475329049688753516000,
+            "coeffBoundBits": 178,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 2,
+              "exactDivisionsAttempted": 1,
+              "nodes": 2,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 33716446,
+        "total_nanos_median": 33345025,
+        "total_nanos_min": 33257115
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          178
+        ],
+        "mirror_nodes": 2,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 2,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          178
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 80,
+      "end_to_end": {
+        "max_nanos": 16390910,
+        "median_nanos": 16262510,
+        "min_nanos": 16102453,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9820610717533763,
+      "name": "cyclo_phi64_x_phi105",
+      "phase_profile": {
+        "profile": {
+          "degree": 80,
+          "factorDegrees": [
+            48,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 10,
+            "liftedFactorDegrees": [
+              16,
+              16,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6
+            ],
+            "liftedMaxCoeffBits": 84,
+            "modulusBits": 84,
+            "precision": 24,
+            "prime": 11,
+            "treeInternalLifts": 9,
+            "treeLeaves": 10,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7719875,
+              "smallAllocs": 586770
+            },
+            "berlekampMatrix": {
+              "nanos": 3756,
+              "smallAllocs": 252
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 158985,
+              "smallAllocs": 13406
+            },
+            "kernelDimension": 10,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 80,
+            "modularImage": {
+              "nanos": 1853,
+              "smallAllocs": 168
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 18946459,
+              "smallAllocs": 1749247
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 26149,
+              "smallAllocs": 2390
+            },
+            "henselLift": {
+              "nanos": 5149494,
+              "smallAllocs": 178057
+            },
+            "normalization": {
+              "nanos": 190172,
+              "smallAllocs": 14419
+            },
+            "primeWalk": {
+              "nanos": 8178725,
+              "smallAllocs": 625728
+            },
+            "quadratic": {
+              "nanos": 521,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 2379929,
+              "smallAllocs": 89872
+            },
+            "total": {
+              "nanos": 15970778,
+              "smallAllocs": 913166
+            },
+            "validation": {
+              "nanos": 26149,
+              "smallAllocs": 2017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16,
+                  16,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
+                ],
+                "forcedSubsetCost": 512,
+                "henselPrecision": 24,
+                "modularFactorCount": 10,
+                "prime": 11,
+                "reachableProperDegrees": 25,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1075072087333361764616200,
+            "coeffBoundBits": 80,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 102,
+              "degreeSurvivors": 130,
+              "exactDivisionsAttempted": 2,
+              "nodes": 130,
+              "productsMaterialized": 28,
+              "recordable": 28,
+              "trailingSurvivors": 28
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 16100360,
+        "total_nanos_median": 15970778,
+        "total_nanos_min": 15893843
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          32,
+          48
+        ],
+        "mirror_nodes": 130,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 130,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          32,
+          48
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 144,
+      "end_to_end": {
+        "max_nanos": 61822354,
+        "median_nanos": 61574887,
+        "min_nanos": 61308873,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        64,
+        80
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9846204671069879,
+      "name": "cyclo_phi128_x_phi165",
+      "phase_profile": {
+        "profile": {
+          "degree": 144,
+          "factorDegrees": [
+            64,
+            80
+          ],
+          "hensel": {
+            "liftedFactorCount": 8,
+            "liftedFactorDegrees": [
+              20,
+              16,
+              20,
+              20,
+              16,
+              20,
+              16,
+              16
+            ],
+            "liftedMaxCoeffBits": 146,
+            "modulusBits": 146,
+            "precision": 52,
+            "prime": 7,
+            "treeInternalLifts": 7,
+            "treeLeaves": 8,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 19461592,
+              "smallAllocs": 1239327
+            },
+            "berlekampMatrix": {
+              "nanos": 6841,
+              "smallAllocs": 444
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 467843,
+              "smallAllocs": 39896
+            },
+            "kernelDimension": 8,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 144,
+            "modularImage": {
+              "nanos": 3185,
+              "smallAllocs": 296
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 88037539,
+              "smallAllocs": 8409957
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 60900,
+              "smallAllocs": 6582
+            },
+            "henselLift": {
+              "nanos": 33489249,
+              "smallAllocs": 761706
+            },
+            "normalization": {
+              "nanos": 550426,
+              "smallAllocs": 44226
+            },
+            "primeWalk": {
+              "nanos": 20518770,
+              "smallAllocs": 1328424
+            },
+            "quadratic": {
+              "nanos": 661,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5913778,
+              "smallAllocs": 275130
+            },
+            "total": {
+              "nanos": 60627894,
+              "smallAllocs": 2423177
+            },
+            "validation": {
+              "nanos": 57906,
+              "smallAllocs": 6017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  20,
+                  16,
+                  20,
+                  20,
+                  16,
+                  20,
+                  16,
+                  16
+                ],
+                "forcedSubsetCost": 128,
+                "henselPrecision": 52,
+                "modularFactorCount": 8,
+                "prime": 7,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 20722981978283006659913436536756243128265400,
+            "coeffBoundBits": 144,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 29,
+              "degreeSurvivors": 54,
+              "exactDivisionsAttempted": 2,
+              "nodes": 54,
+              "productsMaterialized": 25,
+              "recordable": 25,
+              "trailingSurvivors": 25
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 60706730,
+        "total_nanos_median": 60627894,
+        "total_nanos_min": 60422708
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          64,
+          80
+        ],
+        "mirror_nodes": 54,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 54,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          64,
+          80
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 240,
+      "end_to_end": {
+        "max_nanos": 116945967,
+        "median_nanos": 115069475,
+        "min_nanos": 114832453,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        240
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9614648107154395,
+      "name": "cyclo_phi385",
+      "phase_profile": {
+        "profile": {
+          "degree": 240,
+          "factorDegrees": [
+            240
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              60,
+              60,
+              60,
+              60
+            ],
+            "liftedMaxCoeffBits": 241,
+            "modulusBits": 241,
+            "precision": 152,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 25196555,
+              "smallAllocs": 1030964
+            },
+            "berlekampMatrix": {
+              "nanos": 11437,
+              "smallAllocs": 732
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 778004,
+              "smallAllocs": 68654
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 240,
+            "modularImage": {
+              "nanos": 4677,
+              "smallAllocs": 488
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 196399019,
+              "smallAllocs": 18194276
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29173,
+              "smallAllocs": 1942
+            },
+            "henselLift": {
+              "nanos": 73116078,
+              "smallAllocs": 1636426
+            },
+            "normalization": {
+              "nanos": 1201241,
+              "smallAllocs": 101209
+            },
+            "primeWalk": {
+              "nanos": 26062478,
+              "smallAllocs": 1106201
+            },
+            "quadratic": {
+              "nanos": 1262,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 10132682,
+              "smallAllocs": 401834
+            },
+            "total": {
+              "nanos": 110635251,
+              "smallAllocs": 3250608
+            },
+            "validation": {
+              "nanos": 26138,
+              "smallAllocs": 1211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  60,
+                  60,
+                  60,
+                  60
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 152,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 3,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1636264530784946322237683636362414673514576776816417689604042467199320800,
+            "coeffBoundBits": 240,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 8,
+              "exactDivisionsAttempted": 1,
+              "nodes": 8,
+              "productsMaterialized": 8,
+              "recordable": 8,
+              "trailingSurvivors": 8
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 111214760,
+        "total_nanos_median": 110635251,
+        "total_nanos_min": 110420803
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          240
+        ],
+        "mirror_nodes": 8,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 8,
+        "production_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          240
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 9401398,
+        "median_nanos": 9329262,
+        "min_nanos": 9260919,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9892972241534218,
+      "name": "wilkinson_40",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 102883,
+              "smallAllocs": 8327
+            },
+            "berlekampMatrix": {
+              "nanos": 1902,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 22023,
+              "smallAllocs": 1610
+            },
+            "kernelDimension": 40,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 3896,
+              "smallAllocs": 106
+            },
+            "prime": 47,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 250141,
+              "smallAllocs": 20522
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 203051,
+              "smallAllocs": 9051
+            },
+            "normalization": {
+              "nanos": 80349,
+              "smallAllocs": 4275
+            },
+            "primeWalk": {
+              "nanos": 1008234,
+              "smallAllocs": 68927
+            },
+            "proposal": {
+              "nanos": 7878510,
+              "smallAllocs": 237827
+            },
+            "quadratic": {
+              "nanos": 601,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 9229413,
+              "smallAllocs": 321410
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 37,
+                "modularFactorCount": 40,
+                "prime": 47,
+                "reachableProperDegrees": 39,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 38,
+                "modularFactorCount": 40,
+                "prime": 41,
+                "reachableProperDegrees": 39,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1921680168406855965121530973574373218685937570507447116882060,
+            "coeffBoundBits": 201,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 47
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 9395490,
+        "total_nanos_median": 9229413,
+        "total_nanos_min": 9138919
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 16234528,
+        "median_nanos": 16171725,
+        "min_nanos": 16138907,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9974411511449768,
+      "name": "wilkinson_48",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 160878,
+              "smallAllocs": 12707
+            },
+            "berlekampMatrix": {
+              "nanos": 2204,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 37205,
+              "smallAllocs": 2906
+            },
+            "kernelDimension": 48,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 4717,
+              "smallAllocs": 126
+            },
+            "prime": 61,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 360234,
+              "smallAllocs": 29406
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 312333,
+              "smallAllocs": 13013
+            },
+            "normalization": {
+              "nanos": 100970,
+              "smallAllocs": 5905
+            },
+            "primeWalk": {
+              "nanos": 1538721,
+              "smallAllocs": 108539
+            },
+            "proposal": {
+              "nanos": 14102358,
+              "smallAllocs": 350278
+            },
+            "quadratic": {
+              "nanos": 621,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 16130344,
+              "smallAllocs": 479346
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 43,
+                "modularFactorCount": 48,
+                "prime": 61,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 45,
+                "modularFactorCount": 48,
+                "prime": 53,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 8049068376844036118970558829637315745156559359405185594804704581012213098100,
+            "coeffBoundBits": 253,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 61
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 16241629,
+        "total_nanos_median": 16130344,
+        "total_nanos_min": 16095041
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 56,
+      "end_to_end": {
+        "max_nanos": 21119770,
+        "median_nanos": 20931932,
+        "min_nanos": 20928497,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 1.000231560087239,
+      "name": "wilkinson_56",
+      "phase_profile": {
+        "profile": {
+          "degree": 56,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 213967,
+              "smallAllocs": 16143
+            },
+            "berlekampMatrix": {
+              "nanos": 2593,
+              "smallAllocs": 180
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 39528,
+              "smallAllocs": 3046
+            },
+            "kernelDimension": 56,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 56,
+            "modularImage": {
+              "nanos": 5468,
+              "smallAllocs": 146
+            },
+            "prime": 67,
+            "rootExtraction": true,
+            "rowReduction": {
+              "nanos": 564007,
+              "smallAllocs": 46891
+            },
+            "splittingNanos": "not-applicable"
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 428325,
+              "smallAllocs": 17680
+            },
+            "normalization": {
+              "nanos": 129462,
+              "smallAllocs": 7789
+            },
+            "primeWalk": {
+              "nanos": 2019194,
+              "smallAllocs": 143611
+            },
+            "proposal": {
+              "nanos": 18265049,
+              "smallAllocs": 458437
+            },
+            "quadratic": {
+              "nanos": 540,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 20936779,
+              "smallAllocs": 629418
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 51,
+                "modularFactorCount": 56,
+                "prime": 67,
+                "reachableProperDegrees": 55,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 53,
+                "modularFactorCount": 56,
+                "prime": 59,
+                "reachableProperDegrees": 55,
+                "selected": false
+              }
+            ],
+            "coeffBound": 125617627049250877181363592865834692949611771037125750170085410352200700179789256897773224080,
+            "coeffBoundBits": 306,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 20974015,
+        "total_nanos_median": 20936779,
+        "total_nanos_min": 20807759
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 451960,
+        "median_nanos": 420604,
+        "min_nanos": 411370,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        8,
+        16
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.8927328318323173,
+      "name": "chebyshev_T24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            16,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 52,
+            "modulusBits": 52,
+            "precision": 22,
+            "prime": 5,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 175470,
+              "smallAllocs": 13395
+            },
+            "berlekampMatrix": {
+              "nanos": 1031,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11727,
+              "smallAllocs": 1040
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 641,
+              "smallAllocs": 56
+            },
+            "prime": 5,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 289710,
+              "smallAllocs": 24421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5137,
+              "smallAllocs": 414
+            },
+            "henselLift": {
+              "nanos": 114710,
+              "smallAllocs": 7189
+            },
+            "normalization": {
+              "nanos": 17105,
+              "smallAllocs": 1007
+            },
+            "primeWalk": {
+              "nanos": 199636,
+              "smallAllocs": 15164
+            },
+            "quadratic": {
+              "nanos": 240,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 28242,
+              "smallAllocs": 1407
+            },
+            "total": {
+              "nanos": 375487,
+              "smallAllocs": 25790
+            },
+            "validation": {
+              "nanos": 4347,
+              "smallAllocs": 281
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 22,
+                "modularFactorCount": 3,
+                "prime": 5,
+                "reachableProperDegrees": 2,
+                "selected": true
+              }
+            ],
+            "coeffBound": 910214580246244,
+            "coeffBoundBits": 50,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 5
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 1,
+              "degreeSurvivors": 3,
+              "exactDivisionsAttempted": 2,
+              "nodes": 3,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 394205,
+        "total_nanos_median": 375487,
+        "total_nanos_min": 371200
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          8,
+          16
+        ],
+        "mirror_nodes": 3,
+        "mirror_prime": 5,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 3,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          8,
+          16
+        ],
+        "production_prime": 5
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 622783,
+        "median_nanos": 579800,
+        "min_nanos": 551768,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.9321869610210417,
+      "name": "chebyshev_U24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            10,
+            2,
+            10,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              2,
+              10,
+              2,
+              10
+            ],
+            "liftedMaxCoeffBits": 53,
+            "modulusBits": 53,
+            "precision": 33,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 176081,
+              "smallAllocs": 12764
+            },
+            "berlekampMatrix": {
+              "nanos": 1061,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6129,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 651,
+              "smallAllocs": 56
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 236291,
+              "smallAllocs": 19531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7120,
+              "smallAllocs": 612
+            },
+            "henselLift": {
+              "nanos": 264201,
+              "smallAllocs": 14113
+            },
+            "normalization": {
+              "nanos": 17887,
+              "smallAllocs": 1009
+            },
+            "primeWalk": {
+              "nanos": 199516,
+              "smallAllocs": 13912
+            },
+            "quadratic": {
+              "nanos": 300,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 38738,
+              "smallAllocs": 2144
+            },
+            "total": {
+              "nanos": 540482,
+              "smallAllocs": 32523
+            },
+            "validation": {
+              "nanos": 5698,
+              "smallAllocs": 389
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  10
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 33,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 7,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1560748913788064,
+            "coeffBoundBits": 51,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 4,
+              "nodes": 4,
+              "productsMaterialized": 4,
+              "recordable": 4,
+              "trailingSurvivors": 4
+            },
+            "successfulDivisors": 4
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 566380,
+        "total_nanos_median": 540482,
+        "total_nanos_min": 525078
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 30,
+      "end_to_end": {
+        "max_nanos": 8424069,
+        "median_nanos": 8384100,
+        "min_nanos": 8289159,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        30
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9896364547178588,
+      "name": "legendre_P30",
+      "phase_profile": {
+        "profile": {
+          "degree": 30,
+          "factorDegrees": [
+            30
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              6,
+              14,
+              2
+            ],
+            "liftedMaxCoeffBits": 91,
+            "modulusBits": 91,
+            "precision": 15,
+            "prime": 67,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1880928,
+              "smallAllocs": 167769
+            },
+            "berlekampMatrix": {
+              "nanos": 1482,
+              "smallAllocs": 102
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 18748,
+              "smallAllocs": 1485
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 30,
+            "modularImage": {
+              "nanos": 1713,
+              "smallAllocs": 75
+            },
+            "prime": 67,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1700361,
+              "smallAllocs": 158865
+            },
+            "splittingNanos": 179085
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8052,
+              "smallAllocs": 329
+            },
+            "henselLift": {
+              "nanos": 1005200,
+              "smallAllocs": 30936
+            },
+            "normalization": {
+              "nanos": 29704,
+              "smallAllocs": 1502
+            },
+            "primeWalk": {
+              "nanos": 7046787,
+              "smallAllocs": 628129
+            },
+            "quadratic": {
+              "nanos": 431,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 175991,
+              "smallAllocs": 6057
+            },
+            "total": {
+              "nanos": 8297211,
+              "smallAllocs": 667849
+            },
+            "validation": {
+              "nanos": 5999,
+              "smallAllocs": 198
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  6,
+                  14,
+                  2
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 15,
+                "modularFactorCount": 7,
+                "prime": 67,
+                "reachableProperDegrees": 14,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 16384,
+                "henselPrecision": 15,
+                "modularFactorCount": 15,
+                "prime": 61,
+                "reachableProperDegrees": 14,
+                "selected": false
+              }
+            ],
+            "coeffBound": 124543935812132452094555520,
+            "coeffBoundBits": 87,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 63,
+              "degreeSurvivors": 64,
+              "exactDivisionsAttempted": 1,
+              "nodes": 64,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 8307035,
+        "total_nanos_median": 8297211,
+        "total_nanos_min": 8274738
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "mirror_factor_degrees": [
+          30
+        ],
+        "mirror_nodes": 64,
+        "mirror_prime": 67,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 64,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "production_factor_degrees": [
+          30
+        ],
+        "production_prime": 67
+      }
+    },
+    {
+      "degree": 38,
+      "end_to_end": {
+        "max_nanos": 3719024,
+        "median_nanos": 3682389,
+        "min_nanos": 3669781,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        38
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9712667510140836,
+      "name": "legendre_P38",
+      "phase_profile": {
+        "profile": {
+          "degree": 38,
+          "factorDegrees": [
+            38
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              36,
+              1,
+              1
+            ],
+            "liftedMaxCoeffBits": 120,
+            "modulusBits": 120,
+            "precision": 19,
+            "prime": 79,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2688155,
+              "smallAllocs": 251152
+            },
+            "berlekampMatrix": {
+              "nanos": 1823,
+              "smallAllocs": 126
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 27270,
+              "smallAllocs": 2184
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 38,
+            "modularImage": {
+              "nanos": 2284,
+              "smallAllocs": 94
+            },
+            "prime": 79,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 3513609,
+              "smallAllocs": 334731
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10135,
+              "smallAllocs": 431
+            },
+            "henselLift": {
+              "nanos": 559349,
+              "smallAllocs": 18781
+            },
+            "normalization": {
+              "nanos": 41481,
+              "smallAllocs": 2237
+            },
+            "primeWalk": {
+              "nanos": 2866089,
+              "smallAllocs": 260183
+            },
+            "quadratic": {
+              "nanos": 401,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 62102,
+              "smallAllocs": 1980
+            },
+            "total": {
+              "nanos": 3576582,
+              "smallAllocs": 284570
+            },
+            "validation": {
+              "nanos": 7521,
+              "smallAllocs": 265
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  36,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 19,
+                "modularFactorCount": 3,
+                "prime": 79,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 14065077854436543582494269671679200,
+            "coeffBoundBits": 114,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 79
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 1,
+              "nodes": 4,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 3581660,
+        "total_nanos_median": 3576582,
+        "total_nanos_min": 3539857
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1
+        ],
+        "mirror_factor_degrees": [
+          38
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 79,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [
+          0,
+          1
+        ],
+        "production_factor_degrees": [
+          38
+        ],
+        "production_prime": 79
+      }
+    },
+    {
+      "degree": 16,
+      "end_to_end": {
+        "max_nanos": 111435,
+        "median_nanos": 102873,
+        "min_nanos": 100109,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.7972062640342947,
+      "name": "cyclo_phi17",
+      "phase_profile": {
+        "profile": {
+          "degree": 16,
+          "factorDegrees": [
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 1,
+            "liftedFactorDegrees": [
+              16
+            ],
+            "liftedMaxCoeffBits": 1,
+            "modulusBits": 18,
+            "precision": 11,
+            "prime": 3,
+            "treeInternalLifts": 0,
+            "treeLeaves": 1,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 44727,
+              "smallAllocs": 2865
+            },
+            "berlekampMatrix": {
+              "nanos": 721,
+              "smallAllocs": 60
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3896,
+              "smallAllocs": 332
+            },
+            "kernelDimension": 1,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 16,
+            "modularImage": {
+              "nanos": 470,
+              "smallAllocs": 40
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 93979,
+              "smallAllocs": 7303
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 2403,
+              "smallAllocs": 150
+            },
+            "henselLift": {
+              "nanos": 2173,
+              "smallAllocs": 72
+            },
+            "normalization": {
+              "nanos": 7591,
+              "smallAllocs": 370
+            },
+            "primeWalk": {
+              "nanos": 56004,
+              "smallAllocs": 3522
+            },
+            "quadratic": {
+              "nanos": 290,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 7301,
+              "smallAllocs": 424
+            },
+            "total": {
+              "nanos": 82011,
+              "smallAllocs": 4906
+            },
+            "validation": {
+              "nanos": 1922,
+              "smallAllocs": 91
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16
+                ],
+                "forcedSubsetCost": 1,
+                "henselPrecision": 11,
+                "modularFactorCount": 1,
+                "prime": 3,
+                "reachableProperDegrees": 0,
+                "selected": true
+              }
+            ],
+            "coeffBound": 64350,
+            "coeffBoundBits": 16,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 1,
+              "exactDivisionsAttempted": 1,
+              "nodes": 1,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 88211,
+        "total_nanos_median": 82011,
+        "total_nanos_min": 78566
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          16
+        ],
+        "mirror_nodes": 1,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 1,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          16
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 2042749,
+        "median_nanos": 1991763,
+        "min_nanos": 1980035,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        40
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9748243139369493,
+      "name": "cyclo_phi41",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            40
+          ],
+          "hensel": {
+            "liftedFactorCount": 5,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 42,
+            "modulusBits": 42,
+            "precision": 26,
+            "prime": 3,
+            "treeInternalLifts": 4,
+            "treeLeaves": 5,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 437499,
+              "smallAllocs": 32512
+            },
+            "berlekampMatrix": {
+              "nanos": 1843,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 8693,
+              "smallAllocs": 780
+            },
+            "kernelDimension": 5,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 982,
+              "smallAllocs": 88
+            },
+            "prime": 3,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 456066,
+              "smallAllocs": 38465
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5278,
+              "smallAllocs": 342
+            },
+            "henselLift": {
+              "nanos": 650815,
+              "smallAllocs": 30651
+            },
+            "normalization": {
+              "nanos": 17206,
+              "smallAllocs": 874
+            },
+            "primeWalk": {
+              "nanos": 465320,
+              "smallAllocs": 34389
+            },
+            "quadratic": {
+              "nanos": 400,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 789721,
+              "smallAllocs": 32169
+            },
+            "total": {
+              "nanos": 1941619,
+              "smallAllocs": 99038
+            },
+            "validation": {
+              "nanos": 4196,
+              "smallAllocs": 211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 16,
+                "henselPrecision": 26,
+                "modularFactorCount": 5,
+                "prime": 3,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 964925701740,
+            "coeffBoundBits": 40,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 16,
+              "exactDivisionsAttempted": 1,
+              "nodes": 16,
+              "productsMaterialized": 16,
+              "recordable": 16,
+              "trailingSurvivors": 16
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2007647,
+        "total_nanos_median": 1941619,
+        "total_nanos_min": 1926506
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "mirror_factor_degrees": [
+          40
+        ],
+        "mirror_nodes": 16,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 16,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "production_factor_degrees": [
+          40
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 2357275,
+        "median_nanos": 2323534,
+        "min_nanos": 2311156,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9830095019052874,
+      "name": "xpow24_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            2,
+            1,
+            4,
+            4,
+            8,
+            1,
+            2,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 13,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2
+            ],
+            "liftedMaxCoeffBits": 25,
+            "modulusBits": 25,
+            "precision": 7,
+            "prime": 11,
+            "treeInternalLifts": 12,
+            "treeLeaves": 13,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 583726,
+              "smallAllocs": 46939
+            },
+            "berlekampMatrix": {
+              "nanos": 1102,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3295,
+              "smallAllocs": 270
+            },
+            "kernelDimension": 13,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 741,
+              "smallAllocs": 56
+            },
+            "prime": 11,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 193226,
+              "smallAllocs": 17216
+            },
+            "splittingNanos": 389398
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10646,
+              "smallAllocs": 937
+            },
+            "henselLift": {
+              "nanos": 293405,
+              "smallAllocs": 17594
+            },
+            "normalization": {
+              "nanos": 8472,
+              "smallAllocs": 299
+            },
+            "primeWalk": {
+              "nanos": 1094973,
+              "smallAllocs": 89521
+            },
+            "quadratic": {
+              "nanos": 321,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 859194,
+              "smallAllocs": 48267
+            },
+            "total": {
+              "nanos": 2284056,
+              "smallAllocs": 157705
+            },
+            "validation": {
+              "nanos": 7932,
+              "smallAllocs": 574
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  2
+                ],
+                "forcedSubsetCost": 4096,
+                "henselPrecision": 7,
+                "modularFactorCount": 13,
+                "prime": 11,
+                "reachableProperDegrees": 23,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 11,
+                "modularFactorCount": 14,
+                "prime": 5,
+                "reachableProperDegrees": 23,
+                "selected": false
+              }
+            ],
+            "coeffBound": 5408312,
+            "coeffBoundBits": 23,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 113,
+              "exactDivisionsAttempted": 8,
+              "nodes": 113,
+              "productsMaterialized": 113,
+              "recordable": 113,
+              "trailingSurvivors": 113
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2318467,
+        "total_nanos_median": 2284056,
+        "total_nanos_min": 2280260
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "mirror_nodes": 113,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 113,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 20,
+      "end_to_end": {
+        "max_nanos": 631537,
+        "median_nanos": 604046,
+        "min_nanos": 578798,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        10
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9174814500882383,
+      "name": "randprod_10",
+      "phase_profile": {
+        "profile": {
+          "degree": 20,
+          "factorDegrees": [
+            10,
+            10
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              3,
+              4,
+              7,
+              6
+            ],
+            "liftedMaxCoeffBits": 31,
+            "modulusBits": 31,
+            "precision": 11,
+            "prime": 7,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 295509,
+              "smallAllocs": 23484
+            },
+            "berlekampMatrix": {
+              "nanos": 852,
+              "smallAllocs": 72
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12709,
+              "smallAllocs": 1018
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 20,
+            "modularImage": {
+              "nanos": 621,
+              "smallAllocs": 48
+            },
+            "prime": 7,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 418009,
+              "smallAllocs": 35832
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 4607,
+              "smallAllocs": 338
+            },
+            "henselLift": {
+              "nanos": 167628,
+              "smallAllocs": 9769
+            },
+            "normalization": {
+              "nanos": 20991,
+              "smallAllocs": 1219
+            },
+            "primeWalk": {
+              "nanos": 323379,
+              "smallAllocs": 25144
+            },
+            "quadratic": {
+              "nanos": 280,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 27591,
+              "smallAllocs": 1357
+            },
+            "total": {
+              "nanos": 554201,
+              "smallAllocs": 38377
+            },
+            "validation": {
+              "nanos": 3926,
+              "smallAllocs": 237
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  3,
+                  4,
+                  7,
+                  6
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 11,
+                "modularFactorCount": 4,
+                "prime": 7,
+                "reachableProperDegrees": 11,
+                "selected": true
+              }
+            ],
+            "coeffBound": 161291988,
+            "coeffBoundBits": 28,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 5,
+              "exactDivisionsAttempted": 2,
+              "nodes": 5,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 580481,
+        "total_nanos_median": 554201,
+        "total_nanos_min": 539379
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          10,
+          10
+        ],
+        "mirror_nodes": 5,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5,
+        "production_completed_levels": [
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          10,
+          10
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 1403931,
+        "median_nanos": 1358134,
+        "min_nanos": 1329741,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        7,
+        8,
+        9
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9466635840057019,
+      "name": "randprod_21",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            7,
+            8,
+            9
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              9,
+              7,
+              1,
+              1,
+              1,
+              4,
+              1
+            ],
+            "liftedMaxCoeffBits": 37,
+            "modulusBits": 37,
+            "precision": 9,
+            "prime": 17,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 798744,
+              "smallAllocs": 68180
+            },
+            "berlekampMatrix": {
+              "nanos": 1082,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19529,
+              "smallAllocs": 1592
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 761,
+              "smallAllocs": 56
+            },
+            "prime": 17,
+            "rootExtraction": false,
+            "rowReduction": {
+              "nanos": 1004850,
+              "smallAllocs": 89421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 6961,
+              "smallAllocs": 531
+            },
+            "henselLift": {
+              "nanos": 310670,
+              "smallAllocs": 17758
+            },
+            "normalization": {
+              "nanos": 26900,
+              "smallAllocs": 1651
+            },
+            "primeWalk": {
+              "nanos": 878212,
+              "smallAllocs": 74672
+            },
+            "quadratic": {
+              "nanos": 280,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 49554,
+              "smallAllocs": 2297
+            },
+            "total": {
+              "nanos": 1285696,
+              "smallAllocs": 97645
+            },
+            "validation": {
+              "nanos": 5839,
+              "smallAllocs": 386
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  9,
+                  7,
+                  1,
+                  1,
+                  1,
+                  4,
+                  1
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 9,
+                "modularFactorCount": 7,
+                "prime": 17,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 41749464484,
+            "coeffBoundBits": 36,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10,
+              "degreeSurvivors": 13,
+              "exactDivisionsAttempted": 3,
+              "nodes": 13,
+              "productsMaterialized": 3,
+              "recordable": 3,
+              "trailingSurvivors": 3
+            },
+            "successfulDivisors": 3
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1312976,
+        "total_nanos_median": 1285696,
+        "total_nanos_min": 1277554
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "mirror_nodes": 13,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 13,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "production_prime": 17
+      }
+    }
+  ],
+  "schema": "hexbz-phase-profile/3",
+  "scouts": [],
+  "validation": {
+    "disagreements": [],
+    "factors_agree": 368,
+    "instrumentation_ratio_max": 1.0304189437261624,
+    "instrumentation_ratio_median": 0.9844916726110191,
+    "kernel_disagreements": [],
+    "kernel_mirror_agree": 24,
+    "kernel_packed_agree": 24,
+    "kernel_rows": 24,
+    "levels_agree": 368,
+    "nodes_agree": 368,
+    "prime_agree": 368,
+    "sample_size": 368,
+    "scout_disagreements": [],
+    "scout_patterns_agree": 0,
+    "scout_rows": 0
+  }
+}

--- a/reports/figures/hexbz-cactus-certificate-boundary.svg
+++ b/reports/figures/hexbz-cactus-certificate-boundary.svg
@@ -1037,7 +1037,7 @@ z
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 290.301172 191.670645
+    <path d="M 290.301172 184.18902
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1053,7 +1053,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="191.670645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="184.18902" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_32">
@@ -1791,7 +1791,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1891,7 +1891,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-chebyshev.svg
+++ b/reports/figures/hexbz-cactus-chebyshev.svg
@@ -1407,34 +1407,34 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 279.204586
-L 101.569768 264.720949
-L 116.41548 256.499319
-L 131.261192 250.607981
-L 146.106905 244.103953
-L 160.952617 238.704217
-L 175.798329 234.441476
-L 190.644042 230.902988
-L 205.489754 227.78277
-L 220.335466 225.094986
-L 235.181179 221.944416
-L 250.026891 219.23054
-L 264.872603 216.512924
-L 279.718316 213.997607
-L 294.564028 211.416734
-L 309.40974 209.072625
-L 324.255453 206.836189
-L 339.101165 204.745779
-L 353.946877 202.590572
-L 368.79259 200.419058
-L 383.638302 198.265534
-L 398.484014 196.005601
-L 413.329727 193.895233
-L 428.175439 191.055164
-L 443.021151 188.276252
-L 457.866864 185.617758
-L 472.712576 183.101729
-L 487.558288 180.463784
+    <path d="M 86.724055 279.733201
+L 101.569768 265.088834
+L 116.41548 256.85214
+L 131.261192 250.371725
+L 146.106905 244.393803
+L 160.952617 239.431825
+L 175.798329 235.212661
+L 190.644042 231.691593
+L 205.489754 228.626159
+L 220.335466 225.876474
+L 235.181179 222.817223
+L 250.026891 220.167604
+L 264.872603 217.504344
+L 279.718316 214.936047
+L 294.564028 212.369209
+L 309.40974 209.956427
+L 324.255453 207.769705
+L 339.101165 205.567374
+L 353.946877 203.357712
+L 368.79259 201.185687
+L 383.638302 199.036126
+L 398.484014 196.779606
+L 413.329727 194.626163
+L 428.175439 191.852132
+L 443.021151 189.061496
+L 457.866864 186.422399
+L 472.712576 183.882153
+L 487.558288 181.23149
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1450,34 +1450,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="279.204586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="264.720949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="256.499319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="250.607981" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="146.106905" y="244.103953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.952617" y="238.704217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="234.441476" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.644042" y="230.902988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.489754" y="227.78277" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="225.094986" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.181179" y="221.944416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="250.026891" y="219.23054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="216.512924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.718316" y="213.997607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.564028" y="211.416734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="209.072625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="324.255453" y="206.836189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.101165" y="204.745779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="202.590572" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.79259" y="200.419058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.638302" y="198.265534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="196.005601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.329727" y="193.895233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="428.175439" y="191.055164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="188.276252" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.866864" y="185.617758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.712576" y="183.101729" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="180.463784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="279.733201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="265.088834" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="256.85214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="250.371725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="146.106905" y="244.393803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.952617" y="239.431825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="235.212661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.644042" y="231.691593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.489754" y="228.626159" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="225.876474" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.181179" y="222.817223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="250.026891" y="220.167604" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="217.504344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.718316" y="214.936047" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.564028" y="212.369209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="209.956427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="324.255453" y="207.769705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.101165" y="205.567374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="203.357712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.79259" y="201.185687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.638302" y="199.036126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="196.779606" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.329727" y="194.626163" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="428.175439" y="191.852132" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="189.061496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.866864" y="186.422399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.712576" y="183.882153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.23149" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2530,7 +2530,7 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2656,7 +2656,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-combined.svg
+++ b/reports/figures/hexbz-cactus-combined.svg
@@ -1656,58 +1656,54 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <path d="M 86.724055 272.822216
-L 89.260981 260.869746
-L 91.797906 253.909865
-L 94.334832 248.968687
-L 96.871757 245.030581
-L 99.408683 241.793272
-L 101.945609 238.877557
-L 104.482534 236.387288
-L 112.093311 229.840178
-L 114.630236 227.88842
-L 122.241013 222.686397
-L 127.314864 219.567832
-L 142.536417 211.243794
-L 150.147194 207.688352
-L 155.221045 205.586397
-L 175.516449 197.879113
-L 183.127225 195.340624
-L 190.738002 192.987197
-L 213.570332 186.498648
-L 221.181108 184.501914
-L 236.402661 180.63099
-L 259.234991 174.554641
-L 287.141172 167.519657
-L 302.362725 164.024378
-L 340.416608 155.727329
-L 348.027384 153.658852
-L 358.175087 150.907563
-L 363.248938 149.495734
-L 378.470491 144.247468
-L 383.544342 141.904979
-L 388.618193 139.521048
-L 393.692044 137.179808
-L 398.765895 134.31761
-L 403.839746 130.346759
-L 408.913597 126.8806
-L 411.450523 125.181891
-L 416.524374 120.762134
-L 419.061299 118.277833
-L 421.598225 115.475095
-L 424.13515 112.842139
-L 426.672076 110.479394
-L 429.209001 108.320403
-L 431.745927 106.311798
-L 434.282852 103.13549
-L 436.819778 100.437393
-L 439.356703 98.019061
-L 441.893629 93.72944
-L 444.430554 84.981351
-L 446.96748 72.711009
-L 449.504405 64.13924
-L 452.041331 52.935247
-L 452.041331 52.935247
+    <path d="M 86.724055 275.589544
+L 89.260981 263.088253
+L 91.797906 255.563638
+L 94.334832 250.324935
+L 96.871757 246.313518
+L 99.408683 243.061028
+L 101.945609 240.260825
+L 104.482534 237.797153
+L 112.093311 231.202868
+L 114.630236 228.965137
+L 117.167162 226.989335
+L 119.704087 225.214343
+L 124.777938 221.99256
+L 129.851789 219.072331
+L 134.92564 216.17307
+L 142.536417 212.226802
+L 150.147194 208.637978
+L 157.75797 205.516362
+L 170.442598 200.542315
+L 178.053374 197.804852
+L 185.664151 195.2987
+L 193.274927 193.008801
+L 218.644183 185.842346
+L 279.530395 170.169901
+L 289.678097 167.778381
+L 322.658129 160.55547
+L 335.342757 157.819956
+L 345.490459 155.247891
+L 353.101236 153.066243
+L 363.248938 150.232789
+L 378.470491 144.939356
+L 396.228969 136.280792
+L 398.765895 134.787469
+L 401.302821 132.702034
+L 406.376672 129.07137
+L 408.913597 127.459133
+L 411.450523 125.690411
+L 421.598225 116.656191
+L 424.13515 113.991824
+L 426.672076 111.571729
+L 431.745927 107.419492
+L 439.356703 99.168323
+L 441.893629 94.60573
+L 444.430554 85.646712
+L 446.96748 73.089808
+L 449.504405 64.517379
+L 452.041331 52.921879
+L 452.041331 52.921879
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1723,151 +1719,151 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.822216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.260981" y="260.869746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.797906" y="253.909865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.334832" y="248.968687" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.871757" y="245.030581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.408683" y="241.793272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.945609" y="238.877557" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.482534" y="236.387288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.01946" y="234.212982" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.556385" y="232.046493" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.093311" y="229.840178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.630236" y="227.88842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.167162" y="226.133513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.704087" y="224.442028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="122.241013" y="222.686397" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.777938" y="221.089873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.314864" y="219.567832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="129.851789" y="218.165877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.388715" y="216.665576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.92564" y="215.285828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="137.462566" y="213.896586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.999491" y="212.521618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.536417" y="211.243794" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.073342" y="210.04841" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.610268" y="208.843366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.147194" y="207.688352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="152.684119" y="206.60468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.221045" y="205.586397" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="157.75797" y="204.609939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.294896" y="203.621762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.831821" y="202.650437" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="165.368747" y="201.618741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="167.905672" y="200.635674" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="170.442598" y="199.693403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.979523" y="198.795223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.516449" y="197.879113" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.053374" y="197.000235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.5903" y="196.15339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.127225" y="195.340624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.664151" y="194.527288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.201076" y="193.749177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.738002" y="192.987197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.274927" y="192.255972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.811853" y="191.530827" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.348778" y="190.823839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.885704" y="190.13077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.42263" y="189.40792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.959555" y="188.688815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.496481" y="187.943176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.033406" y="187.2107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.570332" y="186.498648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.107257" y="185.807216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.644183" y="185.14187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.181108" y="184.501914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.718034" y="183.870765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="226.254959" y="183.227319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="228.791885" y="182.573691" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.32881" y="181.936908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="233.865736" y="181.289059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.402661" y="180.63099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.939587" y="179.945461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="241.476512" y="179.261117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.013438" y="178.567466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="246.550363" y="177.881094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.087289" y="177.194062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.624215" y="176.532961" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="254.16114" y="175.885623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.698066" y="175.217797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="259.234991" y="174.554641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.771917" y="173.908817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.308842" y="173.283741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.845768" y="172.668462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="269.382693" y="172.012415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.919619" y="171.340005" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="274.456544" y="170.669645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.99347" y="170.015566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.530395" y="169.379851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.067321" y="168.752667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="284.604246" y="168.126241" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="167.519657" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="289.678097" y="166.922057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.215023" y="166.338799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.751948" y="165.741537" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.288874" y="165.157925" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.8258" y="164.587952" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.362725" y="164.024378" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.899651" y="163.475501" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.436576" y="162.942735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.973502" y="162.385028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.510427" y="161.840812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.047353" y="161.294106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.584278" y="160.759234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.121204" y="160.215319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.658129" y="159.679861" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.195055" y="159.159138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.73198" y="158.645378" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="330.268906" y="158.07463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="332.805831" y="157.509717" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.342757" y="156.957437" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="337.879682" y="156.370382" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.416608" y="155.727329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.953533" y="155.074054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="345.490459" y="154.379975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.027384" y="153.658852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.56431" y="152.948483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.101236" y="152.260547" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.638161" y="151.598578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="358.175087" y="150.907563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.712012" y="150.241149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.248938" y="149.495734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="365.785863" y="148.629042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.322789" y="147.786148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.859714" y="146.950348" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.39664" y="146.106936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="375.933565" y="145.198626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.470491" y="144.247468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.007416" y="143.037329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.544342" y="141.904979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="386.081267" y="140.767986" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="388.618193" y="139.521048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="391.155118" y="138.332847" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="393.692044" y="137.179808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.228969" y="135.786754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.765895" y="134.31761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.302821" y="132.30877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.839746" y="130.346759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.376672" y="128.568318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="408.913597" y="126.8806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.450523" y="125.181891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.987448" y="122.945507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.524374" y="120.762134" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="419.061299" y="118.277833" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="421.598225" y="115.475095" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.13515" y="112.842139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.672076" y="110.479394" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.209001" y="108.320403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.745927" y="106.311798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="434.282852" y="103.13549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.819778" y="100.437393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.356703" y="98.019061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.893629" y="93.72944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.430554" y="84.981351" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.96748" y="72.711009" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="449.504405" y="64.13924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.041331" y="52.935247" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.589544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.260981" y="263.088253" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.797906" y="255.563638" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.334832" y="250.324935" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.871757" y="246.313518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.408683" y="243.061028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.945609" y="240.260825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.482534" y="237.797153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.01946" y="235.636377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.556385" y="233.570508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.093311" y="231.202868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.630236" y="228.965137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.167162" y="226.989335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.704087" y="225.214343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="122.241013" y="223.58332" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.777938" y="221.99256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.314864" y="220.473551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="129.851789" y="219.072331" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.388715" y="217.58159" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.92564" y="216.17307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="137.462566" y="214.839813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.999491" y="213.487121" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.536417" y="212.226802" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.073342" y="210.993598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.610268" y="209.782619" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.147194" y="208.637978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="152.684119" y="207.56049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.221045" y="206.541411" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="157.75797" y="205.516362" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.294896" y="204.505039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.831821" y="203.506962" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="165.368747" y="202.477882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="167.905672" y="201.482527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="170.442598" y="200.542315" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.979523" y="199.595744" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.516449" y="198.689803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.053374" y="197.804852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.5903" y="196.94238" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.127225" y="196.112561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.664151" y="195.2987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.201076" y="194.509892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.738002" y="193.752009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.274927" y="193.008801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.811853" y="192.280819" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.348778" y="191.560629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.885704" y="190.849082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.42263" y="190.097154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.959555" y="189.374516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.496481" y="188.618701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.033406" y="187.893667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.570332" y="187.193115" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.107257" y="186.504628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.644183" y="185.842346" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.181108" y="185.186162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.718034" y="184.530776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="226.254959" y="183.868202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="228.791885" y="183.21725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.32881" y="182.571294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="233.865736" y="181.917782" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.402661" y="181.252202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.939587" y="180.595909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="241.476512" y="179.933839" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.013438" y="179.276464" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="246.550363" y="178.604234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.087289" y="177.955162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.624215" y="177.29764" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="254.16114" y="176.652703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.698066" y="176.028147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="259.234991" y="175.355064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.771917" y="174.706624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.308842" y="174.06198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.845768" y="173.416402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="269.382693" y="172.76048" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.919619" y="172.107722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="274.456544" y="171.449675" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.99347" y="170.801363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.530395" y="170.169901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.067321" y="169.553132" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="284.604246" y="168.946514" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="168.354208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="289.678097" y="167.778381" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.215023" y="167.214867" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.751948" y="166.65603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.288874" y="166.104265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.8258" y="165.538366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.362725" y="164.982015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.899651" y="164.423724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.436576" y="163.881482" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.973502" y="163.351364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.510427" y="162.800661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.047353" y="162.24244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.584278" y="161.66834" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.121204" y="161.10284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.658129" y="160.55547" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.195055" y="160.02465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.73198" y="159.506298" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="330.268906" y="158.947222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="332.805831" y="158.386157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.342757" y="157.819956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="337.879682" y="157.199504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.416608" y="156.548269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.953533" y="155.891054" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="345.490459" y="155.247891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.027384" y="154.494999" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.56431" y="153.767006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.101236" y="153.066243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.638161" y="152.38599" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="358.175087" y="151.695563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.712012" y="151.005636" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.248938" y="150.232789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="365.785863" y="149.353257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.322789" y="148.502947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.859714" y="147.680758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.39664" y="146.825201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="375.933565" y="145.884979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.470491" y="144.939356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.007416" y="143.719759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.544342" y="142.53593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="386.081267" y="141.358268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="388.618193" y="140.105879" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="391.155118" y="138.895954" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="393.692044" y="137.72308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.228969" y="136.280792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.765895" y="134.787469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.302821" y="132.702034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.839746" y="130.818897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.376672" y="129.07137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="408.913597" y="127.459133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.450523" y="125.690411" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.987448" y="123.437086" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.524374" y="121.258448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="419.061299" y="118.911616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="421.598225" y="116.656191" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.13515" y="113.991824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.672076" y="111.571729" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.209001" y="109.432302" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.745927" y="107.419492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="434.282852" y="104.635504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.819778" y="101.763889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.356703" y="99.168323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.893629" y="94.60573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.430554" y="85.646712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.96748" y="73.089808" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="449.504405" y="64.517379" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.041331" y="52.921879" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -3729,7 +3725,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3853,7 +3849,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-conway.svg
+++ b/reports/figures/hexbz-cactus-conway.svg
@@ -1637,42 +1637,42 @@ z
     </g>
    </g>
    <g id="line2d_157">
-    <path d="M 86.724055 275.604485
-L 88.890727 264.450546
-L 91.057398 257.944374
-L 93.22407 253.306908
-L 95.390742 249.679101
-L 97.557413 246.71587
-L 99.724085 244.158795
-L 101.890756 241.924828
-L 106.224099 237.919133
-L 108.390771 236.112956
-L 110.557442 234.465721
-L 114.890785 231.587742
-L 119.224128 229.115252
-L 125.724143 225.647239
-L 130.057486 223.62872
-L 136.557501 220.88805
-L 143.057515 218.472184
-L 151.724201 215.51706
-L 158.224216 213.489632
-L 164.72423 211.674471
-L 184.224274 206.644408
-L 195.057632 204.001953
-L 208.057661 201.142205
-L 223.224362 198.14651
-L 236.224391 195.719616
-L 264.391121 190.52063
-L 305.55788 182.662532
-L 333.72461 177.216328
-L 346.724639 174.87956
-L 383.558055 168.709108
-L 407.391442 164.860908
-L 465.891573 155.732742
-L 476.724931 153.7441
-L 485.391617 151.922322
-L 487.558288 151.425013
-L 487.558288 151.425013
+    <path d="M 86.724055 277.401416
+L 88.890727 266.158918
+L 91.057398 259.590209
+L 93.22407 254.954328
+L 95.390742 251.331413
+L 97.557413 248.337191
+L 101.890756 243.397643
+L 104.057428 241.085283
+L 106.224099 239.057036
+L 108.390771 237.225646
+L 112.724114 234.01724
+L 117.057457 231.122499
+L 121.3908 228.623303
+L 125.724143 226.30262
+L 130.057486 224.206919
+L 134.390829 222.346074
+L 140.890844 219.810717
+L 147.390858 217.54022
+L 156.057544 214.65598
+L 162.557559 212.708273
+L 175.557588 209.189718
+L 188.557617 205.87367
+L 197.224303 203.781355
+L 210.224333 200.950565
+L 223.224362 198.410772
+L 238.391062 195.602128
+L 266.557792 190.455808
+L 307.724551 182.864131
+L 327.224595 179.247446
+L 355.391325 174.305722
+L 387.891398 169.172873
+L 426.891486 163.362595
+L 455.058215 159.307141
+L 474.558259 155.809326
+L 487.558288 153.041121
+L 487.558288 153.041121
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1688,192 +1688,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.604485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.890727" y="264.450546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.057398" y="257.944374" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.22407" y="253.306908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="95.390742" y="249.679101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.557413" y="246.71587" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.724085" y="244.158795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.890756" y="241.924828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.057428" y="239.894878" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.224099" y="237.919133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.390771" y="236.112956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.557442" y="234.465721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.724114" y="232.964309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.890785" y="231.587742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.057457" y="230.311522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.224128" y="229.115252" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.3908" y="227.917354" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.557471" y="226.749358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.724143" y="225.647239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.890814" y="224.609411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="130.057486" y="223.62872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.224158" y="222.684627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.390829" y="221.76915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.557501" y="220.88805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.724172" y="220.049107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="140.890844" y="219.244613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.057515" y="218.472184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.224187" y="217.705013" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.390858" y="216.972937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="149.55753" y="216.245087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="151.724201" y="215.51706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.890873" y="214.817473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.057544" y="214.139946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.224216" y="213.489632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.390887" y="212.863735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.557559" y="212.260049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="164.72423" y="211.674471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="211.103027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.057574" y="210.538281" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.224245" y="209.959336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.390917" y="209.389625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.557588" y="208.818562" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.72426" y="208.266252" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.890931" y="207.709895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="182.057603" y="207.168432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="184.224274" y="206.644408" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.390946" y="206.09429" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.557617" y="205.550981" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.724289" y="205.022461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.89096" y="204.507719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.057632" y="204.001953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.224303" y="203.510338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.390975" y="203.023801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.557646" y="202.53596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.724318" y="202.062222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.89099" y="201.595966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.057661" y="201.142205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.224333" y="200.699635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.391004" y="200.265107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.557676" y="199.840328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.724347" y="199.411698" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.891019" y="198.993799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.05769" y="198.577322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.224362" y="198.14651" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="225.391033" y="197.726637" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="227.557705" y="197.317161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.724376" y="196.916863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.891048" y="196.511874" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.057719" y="196.114962" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.224391" y="195.719616" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.391062" y="195.328251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.557734" y="194.932761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.724406" y="194.532155" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.891077" y="194.129844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="193.733535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.22442" y="193.336039" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.391092" y="192.940922" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="253.557763" y="192.544644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.724435" y="192.153834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="257.891106" y="191.743808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="260.057778" y="191.343694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="262.224449" y="190.934879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.391121" y="190.52063" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.557792" y="190.112711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.724464" y="189.710751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="270.891135" y="189.306303" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="273.057807" y="188.906781" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="275.224478" y="188.494279" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="277.39115" y="188.092046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.557822" y="187.690434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.724493" y="187.288354" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.891165" y="186.885568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="286.057836" y="186.482306" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="288.224508" y="186.071852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="290.391179" y="185.662733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.557851" y="185.249865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.724522" y="184.840553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="296.891194" y="184.432977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.057865" y="183.985037" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.224537" y="183.54678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="303.391208" y="183.098845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.55788" y="182.662532" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.724551" y="182.236333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.891223" y="181.803936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.057894" y="181.382387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="314.224566" y="180.951696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="316.391238" y="180.526119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.557909" y="180.106868" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.724581" y="179.69747" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.891252" y="179.265591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.057924" y="178.841108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="178.427623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.391267" y="178.016877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.557938" y="177.612138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.72461" y="177.216328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.891281" y="176.812787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="338.057953" y="176.414475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.224624" y="176.021599" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.391296" y="175.63535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.557967" y="175.254781" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="346.724639" y="174.87956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.89131" y="174.510184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="351.057982" y="174.143318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.224654" y="173.778197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.391325" y="173.407338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="357.557997" y="173.026581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="359.724668" y="172.65264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="361.89134" y="172.285839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.058011" y="171.925108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.224683" y="171.571033" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.391354" y="171.221436" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.558026" y="170.872883" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="372.724697" y="170.529159" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.891369" y="170.15293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="377.05804" y="169.783855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="379.224712" y="169.422794" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.391383" y="169.069711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.558055" y="168.709108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="385.724726" y="168.350138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="387.891398" y="167.992257" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.05807" y="167.64025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="392.224741" y="167.295807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.391413" y="166.939072" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.558084" y="166.585402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.724756" y="166.238137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="400.891427" y="165.88798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.058099" y="165.539659" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.22477" y="165.198713" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="407.391442" y="164.860908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="409.558113" y="164.526047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.724785" y="164.190676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.891456" y="163.857997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.058128" y="163.529575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.224799" y="163.206305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.391471" y="162.87704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="422.558142" y="162.554393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.724814" y="162.209488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.891486" y="161.866092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.058157" y="161.527906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.224829" y="161.195983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="433.3915" y="160.870254" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="435.558172" y="160.532366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="437.724843" y="160.201344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.891515" y="159.875036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="442.058186" y="159.544057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.224858" y="159.218472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.391529" y="158.896969" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="448.558201" y="158.581103" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="450.724872" y="158.246908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.891544" y="157.919633" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="455.058215" y="157.592041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.224887" y="157.231774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.391558" y="156.857644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="461.55823" y="156.485157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.724902" y="156.106282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.891573" y="155.732742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="468.058245" y="155.355718" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="470.224916" y="154.984612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.391588" y="154.607083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="474.558259" y="154.182518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="476.724931" y="153.7441" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="478.891602" y="153.310844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="481.058274" y="152.848871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="483.224945" y="152.385285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="485.391617" y="151.922322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="151.425013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.401416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.890727" y="266.158918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.057398" y="259.590209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.22407" y="254.954328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="95.390742" y="251.331413" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.557413" y="248.337191" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.724085" y="245.798852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.890756" y="243.397643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.057428" y="241.085283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.224099" y="239.057036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.390771" y="237.225646" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.557442" y="235.552309" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.724114" y="234.01724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.890785" y="232.510858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.057457" y="231.122499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.224128" y="229.829821" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.3908" y="228.623303" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.557471" y="227.440232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.724143" y="226.30262" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.890814" y="225.221595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="130.057486" y="224.206919" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.224158" y="223.252598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.390829" y="222.346074" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.557501" y="221.480613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.724172" y="220.626218" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="140.890844" y="219.810717" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.057515" y="219.024431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.224187" y="218.271491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.390858" y="217.54022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="149.55753" y="216.803667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="151.724201" y="216.092299" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.890873" y="215.358026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.057544" y="214.65598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.224216" y="213.982568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.390887" y="213.336621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.557559" y="212.708273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="164.72423" y="212.103376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="211.516216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.057574" y="210.918153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.224245" y="210.341498" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.390917" y="209.756938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.557588" y="209.189718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.72426" y="208.620614" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.890931" y="208.048314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="182.057603" y="207.49181" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="184.224274" y="206.948291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.390946" y="206.415907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.557617" y="205.87367" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.724289" y="205.333639" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.89096" y="204.80062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.057632" y="204.284015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.224303" y="203.781355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.390975" y="203.29186" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.557646" y="202.808027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.724318" y="202.32693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.89099" y="201.858666" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.057661" y="201.400546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.224333" y="200.950565" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.391004" y="200.510963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.557676" y="200.077893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.724347" y="199.654051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.891019" y="199.241255" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.05769" y="198.831043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.224362" y="198.410772" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="225.391033" y="197.995893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="227.557705" y="197.58281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.724376" y="197.174579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.891048" y="196.771304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.057719" y="196.376174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.224391" y="195.986593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.391062" y="195.602128" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.557734" y="195.214479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.724406" y="194.822584" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.891077" y="194.424015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="194.021817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.22442" y="193.60742" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.391092" y="193.200157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="253.557763" y="192.800401" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.724435" y="192.406814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="257.891106" y="192.019402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="260.057778" y="191.626354" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="262.224449" y="191.236955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.391121" y="190.842436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.557792" y="190.455808" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.724464" y="190.061256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="270.891135" y="189.667226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="273.057807" y="189.271722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="275.224478" y="188.884503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="277.39115" y="188.503868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.557822" y="188.131786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.724493" y="187.742882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.891165" y="187.3438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="286.057836" y="186.935847" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="288.224508" y="186.530851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.391179" y="186.13175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.557851" y="185.738653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.724522" y="185.342841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="296.891194" y="184.931951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.057865" y="184.52339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.224537" y="184.10211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="303.391208" y="183.686489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.55788" y="183.280673" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.724551" y="182.864131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.891223" y="182.450117" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.057894" y="182.041067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="314.224566" y="181.629278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="316.391238" y="181.222939" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.557909" y="180.825529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.724581" y="180.427755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.891252" y="180.028189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.057924" y="179.636718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="179.247446" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.391267" y="178.860003" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.557938" y="178.453158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.72461" y="178.050921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.891281" y="177.655467" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="338.057953" y="177.267814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.224624" y="176.883641" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.391296" y="176.504307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.557967" y="176.126504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="346.724639" y="175.756201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.89131" y="175.385154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="351.057982" y="175.019405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.224654" y="174.658813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.391325" y="174.305722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="357.557997" y="173.956651" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="359.724668" y="173.614558" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="361.89134" y="173.273295" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.058011" y="172.937297" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.224683" y="172.595371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.391354" y="172.246979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.558026" y="171.905058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="372.724697" y="171.561446" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.891369" y="171.211614" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="377.05804" y="170.862887" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="379.224712" y="170.521135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.391383" y="170.184965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.558055" y="169.841246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="385.724726" y="169.504692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="387.891398" y="169.172873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.05807" y="168.844349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="392.224741" y="168.520997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.391413" y="168.198688" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.558084" y="167.856587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.724756" y="167.51824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="400.891427" y="167.183045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.058099" y="166.85456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.22477" y="166.5323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="407.391442" y="166.212817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="409.558113" y="165.885183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.724785" y="165.560128" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.891456" y="165.240421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.058128" y="164.919095" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.224799" y="164.603427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.391471" y="164.289241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="422.558142" y="163.978033" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.724814" y="163.67025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.891486" y="163.362595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.058157" y="163.058425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.224829" y="162.752531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="433.3915" y="162.448995" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="435.558172" y="162.148701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="437.724843" y="161.848365" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.891515" y="161.540545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="442.058186" y="161.234897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.224858" y="160.932745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.391529" y="160.630536" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="448.558201" y="160.301799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="450.724872" y="159.974652" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.891544" y="159.650921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="455.058215" y="159.307141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.224887" y="158.928282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.391558" y="158.538455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="461.55823" y="158.150146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.724902" y="157.763845" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.891573" y="157.373823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="468.058245" y="156.990708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="470.224916" y="156.612483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.391588" y="156.236321" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="474.558259" y="155.809326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="476.724931" y="155.361041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="478.891602" y="154.918204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="481.058274" y="154.458368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="483.224945" y="154.007901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="485.391617" y="153.539132" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="153.041121" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_158">
@@ -3789,7 +3789,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3915,7 +3915,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic-products.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic-products.svg
@@ -1423,25 +1423,25 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 272.925492
-L 108.992624 248.697796
-L 131.261192 237.28653
-L 153.529761 229.185135
-L 175.798329 221.771294
-L 198.066898 215.547321
-L 220.335466 208.899689
-L 242.604035 197.932969
-L 264.872603 188.9158
-L 287.141172 181.906381
-L 309.40974 176.672536
-L 331.678309 168.817744
-L 353.946877 162.179157
-L 376.215446 154.857609
-L 398.484014 146.116595
-L 420.752583 135.774189
-L 443.021151 127.489615
-L 465.28972 118.455942
-L 487.558288 107.683241
+    <path d="M 86.724055 273.564331
+L 108.992624 248.579087
+L 131.261192 237.301462
+L 153.529761 229.37807
+L 175.798329 222.217775
+L 198.066898 215.860901
+L 220.335466 209.675294
+L 242.604035 198.539816
+L 264.872603 189.383814
+L 287.141172 182.835897
+L 309.40974 177.523096
+L 331.678309 169.399516
+L 353.946877 162.908788
+L 376.215446 155.441022
+L 398.484014 147.403113
+L 420.752583 138.210009
+L 443.021151 129.024265
+L 465.28972 120.826419
+L 487.558288 109.068837
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1457,25 +1457,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.925492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.992624" y="248.697796" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="237.28653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="229.185135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="221.771294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="215.547321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="208.899689" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="197.932969" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="188.9158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="181.906381" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="176.672536" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="168.817744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="162.179157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="154.857609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="146.116595" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="135.774189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="127.489615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.28972" y="118.455942" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="107.683241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.564331" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.992624" y="248.579087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="237.301462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="229.37807" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="222.217775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="215.860901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="209.675294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="198.539816" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="189.383814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="182.835897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="177.523096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="169.399516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="162.908788" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="155.441022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="147.403113" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="138.210009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="129.024265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.28972" y="120.826419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="109.068837" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2411,7 +2411,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2530,7 +2530,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic.svg
@@ -1503,40 +1503,40 @@ z
     </g>
    </g>
    <g id="line2d_133">
-    <path d="M 86.724055 272.245867
-L 98.870547 258.20751
-L 111.017039 243.179318
-L 123.163531 234.891992
-L 135.310023 229.183558
-L 147.456515 224.311262
-L 159.603007 219.97488
-L 171.749499 214.664895
-L 183.895991 210.524764
-L 196.042483 206.713332
-L 208.188974 202.615186
-L 220.335466 198.78884
-L 232.481958 195.202844
-L 244.62845 191.185025
-L 256.774942 187.561638
-L 268.921434 184.29675
-L 281.067926 180.499406
-L 293.214418 176.023658
-L 305.36091 171.503059
-L 317.507402 164.534758
-L 329.653894 158.080471
-L 341.800385 152.921371
-L 353.946877 148.718397
-L 366.093369 143.740455
-L 378.239861 139.037843
-L 390.386353 132.926902
-L 402.532845 126.448148
-L 414.679337 121.186216
-L 426.825829 116.004375
-L 438.972321 111.679006
-L 451.118813 107.465948
-L 463.265305 100.183847
-L 475.411796 83.418184
-L 487.558288 60.795421
+    <path d="M 86.724055 275.196015
+L 98.870547 259.98151
+L 111.017039 245.049516
+L 123.163531 236.747013
+L 135.310023 230.969939
+L 147.456515 225.970333
+L 159.603007 221.598495
+L 171.749499 216.131049
+L 183.895991 211.866733
+L 196.042483 207.840528
+L 208.188974 203.641646
+L 220.335466 199.984525
+L 232.481958 196.712613
+L 244.62845 192.826544
+L 256.774942 189.083549
+L 268.921434 185.878794
+L 281.067926 181.989244
+L 293.214418 177.692554
+L 305.36091 172.865361
+L 317.507402 165.957445
+L 329.653894 159.499601
+L 341.800385 154.707232
+L 353.946877 150.178752
+L 366.093369 145.716544
+L 378.239861 141.281687
+L 390.386353 135.663353
+L 402.532845 128.466245
+L 414.679337 122.838738
+L 426.825829 117.946797
+L 438.972321 113.84628
+L 451.118813 110.274676
+L 463.265305 103.402549
+L 475.411796 84.841174
+L 487.558288 61.296212
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1552,40 +1552,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.245867" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.870547" y="258.20751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="111.017039" y="243.179318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.163531" y="234.891992" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.310023" y="229.183558" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.456515" y="224.311262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="159.603007" y="219.97488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.749499" y="214.664895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.895991" y="210.524764" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="196.042483" y="206.713332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.188974" y="202.615186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="198.78884" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="232.481958" y="195.202844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.62845" y="191.185025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.774942" y="187.561638" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.921434" y="184.29675" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.067926" y="180.499406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="293.214418" y="176.023658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.36091" y="171.503059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.507402" y="164.534758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.653894" y="158.080471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="341.800385" y="152.921371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="148.718397" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.093369" y="143.740455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.239861" y="139.037843" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.386353" y="132.926902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="402.532845" y="126.448148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="414.679337" y="121.186216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.825829" y="116.004375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="438.972321" y="111.679006" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="451.118813" y="107.465948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.265305" y="100.183847" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="475.411796" y="83.418184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="60.795421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.196015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.870547" y="259.98151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="111.017039" y="245.049516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.163531" y="236.747013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.310023" y="230.969939" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.456515" y="225.970333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="159.603007" y="221.598495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.749499" y="216.131049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.895991" y="211.866733" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="196.042483" y="207.840528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.188974" y="203.641646" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="199.984525" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="232.481958" y="196.712613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.62845" y="192.826544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.774942" y="189.083549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.921434" y="185.878794" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.067926" y="181.989244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="293.214418" y="177.692554" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.36091" y="172.865361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.507402" y="165.957445" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.653894" y="159.499601" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="341.800385" y="154.707232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="150.178752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.093369" y="145.716544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.239861" y="141.281687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.386353" y="135.663353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="402.532845" y="128.466245" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="414.679337" y="122.838738" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.825829" y="117.946797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="438.972321" y="113.84628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="451.118813" y="110.274676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.265305" y="103.402549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="475.411796" y="84.841174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="61.296212" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -2643,7 +2643,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2750,7 +2750,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
@@ -791,8 +791,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 66.682344 275.858344
-L 507.6 275.858344
+      <path d="M 66.682344 275.806263
+L 507.6 275.806263
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
@@ -802,12 +802,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.858344" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.806263" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.657172) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.605091) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250
 Q 1547 4250 1301 3770
@@ -840,18 +840,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 66.682344 185.917247
-L 507.6 185.917247
+      <path d="M 66.682344 185.553174
+L 507.6 185.553174
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="185.917247" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="185.553174" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 189.716076) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 189.352002) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -862,18 +862,18 @@ L 507.6 185.917247
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 66.682344 95.976151
-L 507.6 95.976151
+      <path d="M 66.682344 95.300085
+L 507.6 95.300085
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="95.976151" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="95.300085" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 99.774979) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 99.098913) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -881,8 +881,8 @@ L 507.6 95.976151
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 66.682344 302.933312
-L 507.6 302.933312
+      <path d="M 66.682344 302.975149
+L 507.6 302.975149
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
@@ -892,295 +892,295 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.933312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.975149" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 66.682344 295.811664
-L 507.6 295.811664
+      <path d="M 66.682344 295.828797
+L 507.6 295.828797
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.811664" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.828797" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_29">
-      <path d="M 66.682344 289.790396
-L 507.6 289.790396
+      <path d="M 66.682344 289.786643
+L 507.6 289.786643
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.790396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.786643" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_31">
-      <path d="M 66.682344 284.574537
-L 507.6 284.574537
+      <path d="M 66.682344 284.552691
+L 507.6 284.552691
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.574537" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.552691" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
-      <path d="M 66.682344 279.973823
-L 507.6 279.973823
+      <path d="M 66.682344 279.936017
+L 507.6 279.936017
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.973823" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.936017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_35">
-      <path d="M 66.682344 248.783376
-L 507.6 248.783376
+      <path d="M 66.682344 248.637376
+L 507.6 248.637376
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.783376" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.637376" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_37">
-      <path d="M 66.682344 232.945535
-L 507.6 232.945535
+      <path d="M 66.682344 232.744596
+L 507.6 232.744596
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.945535" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.744596" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_39">
-      <path d="M 66.682344 221.708408
-L 507.6 221.708408
+      <path d="M 66.682344 221.468489
+L 507.6 221.468489
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="221.708408" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="221.468489" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_41">
-      <path d="M 66.682344 212.992215
-L 507.6 212.992215
+      <path d="M 66.682344 212.722061
+L 507.6 212.722061
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="212.992215" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="212.722061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 66.682344 205.870567
-L 507.6 205.870567
+      <path d="M 66.682344 205.575709
+L 507.6 205.575709
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="205.870567" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="205.575709" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 66.682344 199.8493
-L 507.6 199.8493
+      <path d="M 66.682344 199.533554
+L 507.6 199.533554
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.8493" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.533554" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 66.682344 194.63344
-L 507.6 194.63344
+      <path d="M 66.682344 194.299602
+L 507.6 194.299602
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.63344" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.299602" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 66.682344 190.032726
-L 507.6 190.032726
+      <path d="M 66.682344 189.682929
+L 507.6 189.682929
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.032726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="189.682929" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 66.682344 158.84228
-L 507.6 158.84228
+      <path d="M 66.682344 158.384287
+L 507.6 158.384287
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="158.84228" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="158.384287" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 66.682344 143.004439
-L 507.6 143.004439
+      <path d="M 66.682344 142.491507
+L 507.6 142.491507
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.004439" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="142.491507" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_55">
-      <path d="M 66.682344 131.767312
-L 507.6 131.767312
+      <path d="M 66.682344 131.2154
+L 507.6 131.2154
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.767312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.2154" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_57">
-      <path d="M 66.682344 123.051119
-L 507.6 123.051119
+      <path d="M 66.682344 122.468972
+L 507.6 122.468972
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="123.051119" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.468972" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_59">
-      <path d="M 66.682344 115.929471
-L 507.6 115.929471
+      <path d="M 66.682344 115.32262
+L 507.6 115.32262
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.929471" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.32262" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_61">
-      <path d="M 66.682344 109.908203
-L 507.6 109.908203
+      <path d="M 66.682344 109.280466
+L 507.6 109.280466
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.908203" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.280466" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_63">
-      <path d="M 66.682344 104.692344
-L 507.6 104.692344
+      <path d="M 66.682344 104.046513
+L 507.6 104.046513
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="104.692344" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="104.046513" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_65">
-      <path d="M 66.682344 100.09163
-L 507.6 100.09163
+      <path d="M 66.682344 99.42984
+L 507.6 99.42984
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.09163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="99.42984" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_67">
-      <path d="M 66.682344 68.901183
-L 507.6 68.901183
+      <path d="M 66.682344 68.131198
+L 507.6 68.131198
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.901183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.131198" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_69">
-      <path d="M 66.682344 53.063342
-L 507.6 53.063342
+      <path d="M 66.682344 52.238418
+L 507.6 52.238418
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.063342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="52.238418" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_71">
-      <path d="M 66.682344 41.826215
-L 507.6 41.826215
+      <path d="M 66.682344 40.962311
+L 507.6 40.962311
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.826215" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.962311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_73">
-      <path d="M 66.682344 33.110023
-L 507.6 33.110023
+      <path d="M 66.682344 32.215883
+L 507.6 32.215883
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="33.110023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="32.215883" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1258,7 +1258,7 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 86.724055 96.778884
+    <path d="M 86.724055 96.953435
 L 136.828335 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1275,20 +1275,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="96.778884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="96.953435" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.828335" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_76">
     <path d="M 86.724055 290.872308
-L 136.828335 240.305101
-L 186.932614 204.996525
-L 237.036893 163.611045
-L 287.141172 141.618497
-L 337.245451 108.576138
-L 387.34973 88.984145
-L 437.454009 70.348329
-L 487.558288 50.926689
+L 136.828335 240.129691
+L 186.932614 204.698635
+L 237.036893 163.169595
+L 287.141172 141.100758
+L 337.245451 107.94378
+L 387.34973 88.283825
+L 437.454009 69.583364
+L 487.558288 50.094354
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1299,26 +1299,26 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.828335" y="240.305101" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="186.932614" y="204.996525" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="237.036893" y="163.611045" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="141.618497" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="337.245451" y="108.576138" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="387.34973" y="88.984145" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="437.454009" y="70.348329" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="50.926689" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.828335" y="240.129691" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="186.932614" y="204.698635" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="237.036893" y="163.169595" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="141.100758" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="337.245451" y="107.94378" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="387.34973" y="88.283825" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="437.454009" y="69.583364" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="50.094354" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
-    <path d="M 86.724055 254.023753
-L 136.828335 210.927892
-L 186.932614 170.698873
-L 237.036893 145.553573
-L 287.141172 117.991802
-L 337.245451 100.4118
-L 387.34973 77.360478
-L 437.454009 58.339887
-L 487.558288 42.558219
+    <path d="M 86.724055 253.895931
+L 136.828335 210.650577
+L 186.932614 170.282009
+L 237.036893 145.049484
+L 287.141172 117.392105
+L 337.245451 99.751121
+L 387.34973 76.619837
+L 437.454009 57.533267
+L 487.558288 41.696854
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1328,27 +1328,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="254.023753" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.828335" y="210.927892" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="186.932614" y="170.698873" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="237.036893" y="145.553573" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="117.991802" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="337.245451" y="100.4118" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="387.34973" y="77.360478" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="437.454009" y="58.339887" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="42.558219" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="253.895931" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.828335" y="210.650577" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="186.932614" y="170.282009" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="237.036893" y="145.049484" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="117.392105" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="337.245451" y="99.751121" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="387.34973" y="76.619837" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="437.454009" y="57.533267" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="41.696854" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
-    <path d="M 86.724055 254.438181
-L 136.828335 217.437266
-L 186.932614 190.647502
-L 237.036893 151.147734
-L 287.141172 130.365504
-L 337.245451 114.698496
-L 387.34973 92.219055
-L 437.454009 76.793556
-L 487.558288 58.72941
+    <path d="M 86.724055 254.311797
+L 136.828335 217.182531
+L 186.932614 190.299837
+L 237.036893 150.66305
+L 287.141172 129.80873
+L 337.245451 114.087376
+L 387.34973 91.529956
+L 437.454009 76.050948
+L 487.558288 57.924141
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1367,15 +1367,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="254.438181" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.828335" y="217.437266" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="186.932614" y="190.647502" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="237.036893" y="151.147734" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="130.365504" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="337.245451" y="114.698496" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="387.34973" y="92.219055" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="437.454009" y="76.793556" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="58.72941" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="254.311797" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.828335" y="217.182531" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="186.932614" y="190.299837" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="237.036893" y="150.66305" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="129.80873" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="337.245451" y="114.087376" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="387.34973" y="91.529956" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="437.454009" y="76.050948" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="57.924141" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1859,7 +1859,7 @@ z
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1983,7 +1983,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-laguerre.svg
+++ b/reports/figures/hexbz-cactus-laguerre.svg
@@ -1489,26 +1489,26 @@ z
     </g>
    </g>
    <g id="line2d_131">
-    <path d="M 86.724055 276.291881
-L 107.820594 257.100644
-L 128.917133 245.23099
-L 150.013671 236.862202
-L 171.11021 230.414078
-L 192.206748 225.442801
-L 213.303287 220.749444
-L 234.399825 216.49592
-L 255.496364 211.971937
-L 276.592903 206.588222
-L 297.689441 202.05865
-L 318.78598 197.088487
-L 339.882518 192.241166
-L 360.979057 187.33973
-L 382.075595 183.133125
-L 403.172134 179.587443
-L 424.268673 174.951919
-L 445.365211 171.170592
-L 466.46175 166.417789
-L 487.558288 159.806835
+    <path d="M 86.724055 278.166723
+L 107.820594 259.5321
+L 128.917133 246.817453
+L 150.013671 238.257682
+L 171.11021 231.535235
+L 192.206748 226.565444
+L 213.303287 221.795495
+L 234.399825 217.486008
+L 255.496364 212.928629
+L 276.592903 207.336376
+L 297.689441 202.822573
+L 318.78598 197.852749
+L 339.882518 192.956938
+L 360.979057 188.002029
+L 382.075595 183.933667
+L 403.172134 180.337511
+L 424.268673 175.675659
+L 445.365211 171.89746
+L 466.46175 167.126306
+L 487.558288 160.490756
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1524,26 +1524,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="276.291881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="257.100644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="245.23099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="236.862202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="230.414078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="225.442801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="220.749444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="216.49592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="211.971937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="206.588222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="202.05865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="197.088487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="192.241166" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="187.33973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="183.133125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="179.587443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="174.951919" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="171.170592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="166.417789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="159.806835" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="278.166723" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="259.5321" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="246.817453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="238.257682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="231.535235" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="226.565444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="221.795495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="217.486008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="212.928629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="207.336376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="202.822573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="197.852749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="192.956938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="188.002029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="183.933667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="180.337511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="175.675659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="171.89746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="167.126306" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="160.490756" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_132">
@@ -2477,7 +2477,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2613,7 +2613,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-legendre.svg
+++ b/reports/figures/hexbz-cactus-legendre.svg
@@ -1477,26 +1477,26 @@ z
     </g>
    </g>
    <g id="line2d_129">
-    <path d="M 86.724055 273.369466
-L 107.820594 259.836393
-L 128.917133 247.903092
-L 150.013671 239.456413
-L 171.11021 232.633233
-L 192.206748 224.56642
-L 213.303287 218.39571
-L 234.399825 212.480796
-L 255.496364 207.059992
-L 276.592903 199.743417
-L 297.689441 193.633201
-L 318.78598 186.826694
-L 339.882518 180.395782
-L 360.979057 174.265809
-L 382.075595 169.256642
-L 403.172134 165.262357
-L 424.268673 160.173256
-L 445.365211 155.233844
-L 466.46175 148.523963
-L 487.558288 142.710827
+    <path d="M 86.724055 275.134799
+L 107.820594 261.601301
+L 128.917133 249.210344
+L 150.013671 240.71912
+L 171.11021 233.670803
+L 192.206748 225.399277
+L 213.303287 219.216405
+L 234.399825 213.329985
+L 255.496364 207.839209
+L 276.592903 200.446784
+L 297.689441 194.299776
+L 318.78598 187.569616
+L 339.882518 181.129748
+L 360.979057 174.99209
+L 382.075595 170.029054
+L 403.172134 165.932156
+L 424.268673 160.818216
+L 445.365211 155.938582
+L 466.46175 149.112617
+L 487.558288 143.190757
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1512,26 +1512,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.369466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="259.836393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="247.903092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="239.456413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="232.633233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="224.56642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="218.39571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="212.480796" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="207.059992" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="199.743417" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="193.633201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="186.826694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="180.395782" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="174.265809" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="169.256642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="165.262357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="160.173256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="155.233844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="148.523963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="142.710827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.134799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="261.601301" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="249.210344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="240.71912" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="233.670803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="225.399277" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="219.216405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="213.329985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="207.839209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="200.446784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="194.299776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="187.569616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="181.129748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="174.99209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="170.029054" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="165.932156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="160.818216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="155.938582" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="149.112617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="143.190757" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_130">
@@ -2480,7 +2480,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2597,7 +2597,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-random-products.svg
+++ b/reports/figures/hexbz-cactus-random-products.svg
@@ -1439,36 +1439,36 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 266.842854
-L 100.545925 248.993908
-L 114.367796 238.89587
-L 128.189666 232.187909
-L 142.011536 226.443806
-L 155.833406 221.999359
-L 169.655276 218.364834
-L 183.477146 215.0101
-L 197.299016 211.946968
-L 211.120886 209.238057
-L 224.942756 206.623659
-L 238.764627 204.145832
-L 252.586497 201.845997
-L 266.408367 199.724182
-L 280.230237 197.806728
-L 294.052107 195.99361
-L 307.873977 194.273248
-L 321.695847 192.617658
-L 335.517717 191.019315
-L 349.339587 189.416646
-L 363.161457 187.887772
-L 376.983328 186.320538
-L 390.805198 184.638423
-L 404.627068 182.932403
-L 418.448938 181.224323
-L 432.270808 179.531964
-L 446.092678 177.911558
-L 459.914548 176.344928
-L 473.736418 174.526079
-L 487.558288 172.311134
+    <path d="M 86.724055 266.566372
+L 100.545925 249.318207
+L 114.367796 239.370687
+L 128.189666 232.672072
+L 142.011536 226.88708
+L 155.833406 222.409713
+L 169.655276 218.755516
+L 183.477146 215.546592
+L 197.299016 212.495333
+L 211.120886 209.819061
+L 224.942756 207.292439
+L 238.764627 204.79555
+L 252.586497 202.473382
+L 266.408367 200.38761
+L 280.230237 198.469408
+L 294.052107 196.667552
+L 307.873977 194.91956
+L 321.695847 193.305107
+L 335.517717 191.685946
+L 349.339587 190.030929
+L 363.161457 188.501676
+L 376.983328 186.955671
+L 390.805198 185.237266
+L 404.627068 183.615839
+L 418.448938 181.928003
+L 432.270808 180.206469
+L 446.092678 178.603436
+L 459.914548 176.958749
+L 473.736418 175.195114
+L 487.558288 172.998406
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1484,36 +1484,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="266.842854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="248.993908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="238.89587" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="232.187909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="226.443806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="221.999359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="218.364834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="215.0101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="211.946968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="209.238057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="206.623659" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="204.145832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="201.845997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="199.724182" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.230237" y="197.806728" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="195.99361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.873977" y="194.273248" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="192.617658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.517717" y="191.019315" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="189.416646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.161457" y="187.887772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="186.320538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.805198" y="184.638423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="404.627068" y="182.932403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.448938" y="181.224323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="179.531964" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.092678" y="177.911558" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.914548" y="176.344928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="473.736418" y="174.526079" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="172.311134" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="266.566372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="249.318207" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="239.370687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="232.672072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="226.88708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="222.409713" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="218.755516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="215.546592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="212.495333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="209.819061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="207.292439" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="204.79555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="202.473382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="200.38761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.230237" y="198.469408" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="196.667552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.873977" y="194.91956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="193.305107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.517717" y="191.685946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="190.030929" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.161457" y="188.501676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="186.955671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.805198" y="185.237266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="404.627068" y="183.615839" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.448938" y="181.928003" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="180.206469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.092678" y="178.603436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.914548" y="176.958749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="473.736418" y="175.195114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="172.998406" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2526,7 +2526,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2669,7 +2669,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-sd-products.svg
+++ b/reports/figures/hexbz-cactus-sd-products.svg
@@ -1316,16 +1316,16 @@ z
     </g>
    </g>
    <g id="line2d_101">
-    <path d="M 86.724055 267.614988
-L 117.557458 249.548964
-L 148.39086 222.777671
-L 179.224263 208.642743
-L 210.057666 195.975296
-L 240.891068 174.733108
-L 271.724471 136.464395
-L 302.557873 121.59467
-L 333.391276 83.342327
-L 364.224678 57.141897
+    <path d="M 86.724055 268.582978
+L 117.557458 249.82863
+L 148.39086 223.617863
+L 179.224263 209.561952
+L 210.057666 196.842248
+L 240.891068 175.970895
+L 271.724471 137.405699
+L 302.557873 122.426679
+L 333.391276 83.730488
+L 364.224678 57.25455
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1341,16 +1341,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.614988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="249.548964" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="222.777671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="208.642743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="195.975296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="174.733108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="136.464395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="121.59467" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="83.342327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="57.141897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="268.582978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="249.82863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="223.617863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="209.561952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="196.842248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="175.970895" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="137.405699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="122.426679" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="83.730488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="57.25455" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_102">
@@ -2226,7 +2226,7 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2350,7 +2350,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-cactus-swinnerton-dyer.svg
@@ -674,8 +674,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.112614
-L 507.6 270.112614
+      <path d="M 66.682344 270.15256
+L 507.6 270.15256
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -685,12 +685,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.112614" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.15256" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 273.911442) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 273.951388) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -701,18 +701,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 223.01326
-L 507.6 223.01326
+      <path d="M 66.682344 223.143833
+L 507.6 223.143833
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.01326" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.143833" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 226.812088) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 226.942661) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -721,18 +721,18 @@ L 507.6 223.01326
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 175.913906
-L 507.6 175.913906
+      <path d="M 66.682344 176.135107
+L 507.6 176.135107
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="175.913906" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="176.135107" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 179.712734) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 179.933935) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -742,18 +742,18 @@ L 507.6 175.913906
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 128.814552
-L 507.6 128.814552
+      <path d="M 66.682344 129.12638
+L 507.6 129.12638
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="128.814552" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="129.12638" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 132.61338) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 132.925208) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -764,18 +764,18 @@ L 507.6 128.814552
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 81.715197
-L 507.6 81.715197
+      <path d="M 66.682344 82.117653
+L 507.6 82.117653
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="81.715197" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="82.117653" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 85.514026) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 85.916482) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -783,18 +783,18 @@ L 507.6 81.715197
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 34.615843
-L 507.6 34.615843
+      <path d="M 66.682344 35.108927
+L 507.6 35.108927
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="34.615843" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="35.108927" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 38.414671) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 38.907755) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -803,8 +803,8 @@ L 507.6 34.615843
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 303.03365
-L 507.6 303.03365
+      <path d="M 66.682344 303.010249
+L 507.6 303.010249
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -814,571 +814,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.03365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.010249" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.739865
-L 507.6 294.739865
+      <path d="M 66.682344 294.732424
+L 507.6 294.732424
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.739865" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.732424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.855332
-L 507.6 288.855332
+      <path d="M 66.682344 288.859213
+L 507.6 288.859213
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.855332" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.859213" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.290933
-L 507.6 284.290933
+      <path d="M 66.682344 284.303596
+L 507.6 284.303596
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.290933" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.303596" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.561547
-L 507.6 280.561547
+      <path d="M 66.682344 280.581387
+L 507.6 280.581387
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.561547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.581387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.408396
-L 507.6 277.408396
+      <path d="M 66.682344 277.434303
+L 507.6 277.434303
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.408396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.434303" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.677013
-L 507.6 274.677013
+      <path d="M 66.682344 274.708176
+L 507.6 274.708176
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.677013" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.708176" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.267762
-L 507.6 272.267762
+      <path d="M 66.682344 272.303561
+L 507.6 272.303561
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.267762" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.303561" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 255.934296
-L 507.6 255.934296
+      <path d="M 66.682344 256.001523
+L 507.6 256.001523
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="255.934296" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.001523" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.640511
-L 507.6 247.640511
+      <path d="M 66.682344 247.723697
+L 507.6 247.723697
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.640511" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.723697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.755977
-L 507.6 241.755977
+      <path d="M 66.682344 241.850486
+L 507.6 241.850486
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.755977" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.850486" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.191578
-L 507.6 237.191578
+      <path d="M 66.682344 237.29487
+L 507.6 237.29487
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.191578" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.29487" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.462193
-L 507.6 233.462193
+      <path d="M 66.682344 233.57266
+L 507.6 233.57266
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.462193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.57266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.309042
-L 507.6 230.309042
+      <path d="M 66.682344 230.425577
+L 507.6 230.425577
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.309042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.425577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.577659
-L 507.6 227.577659
+      <path d="M 66.682344 227.699449
+L 507.6 227.699449
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.577659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.699449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.168408
-L 507.6 225.168408
+      <path d="M 66.682344 225.294834
+L 507.6 225.294834
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.168408" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.294834" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 208.834942
-L 507.6 208.834942
+      <path d="M 66.682344 208.992796
+L 507.6 208.992796
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.834942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.992796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.541157
-L 507.6 200.541157
+      <path d="M 66.682344 200.71497
+L 507.6 200.71497
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.541157" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.71497" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 194.656623
-L 507.6 194.656623
+      <path d="M 66.682344 194.84176
+L 507.6 194.84176
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.656623" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.84176" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 190.092224
-L 507.6 190.092224
+      <path d="M 66.682344 190.286143
+L 507.6 190.286143
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.092224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.286143" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.362839
-L 507.6 186.362839
+      <path d="M 66.682344 186.563934
+L 507.6 186.563934
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.362839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.563934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 183.209688
-L 507.6 183.209688
+      <path d="M 66.682344 183.41685
+L 507.6 183.41685
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.209688" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.41685" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 180.478305
-L 507.6 180.478305
+      <path d="M 66.682344 180.690723
+L 507.6 180.690723
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.478305" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.690723" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 178.069054
-L 507.6 178.069054
+      <path d="M 66.682344 178.286108
+L 507.6 178.286108
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.069054" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.286108" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 161.735587
-L 507.6 161.735587
+      <path d="M 66.682344 161.98407
+L 507.6 161.98407
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.735587" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.98407" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 153.441803
-L 507.6 153.441803
+      <path d="M 66.682344 153.706244
+L 507.6 153.706244
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.441803" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.706244" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 147.557269
-L 507.6 147.557269
+      <path d="M 66.682344 147.833033
+L 507.6 147.833033
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.557269" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.833033" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 142.99287
-L 507.6 142.99287
+      <path d="M 66.682344 143.277417
+L 507.6 143.277417
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="142.99287" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.277417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 139.263484
-L 507.6 139.263484
+      <path d="M 66.682344 139.555207
+L 507.6 139.555207
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.263484" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.555207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 136.110334
-L 507.6 136.110334
+      <path d="M 66.682344 136.408124
+L 507.6 136.408124
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.110334" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.408124" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 133.378951
-L 507.6 133.378951
+      <path d="M 66.682344 133.681996
+L 507.6 133.681996
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.378951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.681996" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 130.9697
-L 507.6 130.9697
+      <path d="M 66.682344 131.277381
+L 507.6 131.277381
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.9697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.277381" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 114.636233
-L 507.6 114.636233
+      <path d="M 66.682344 114.975343
+L 507.6 114.975343
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="114.636233" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="114.975343" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 106.342449
-L 507.6 106.342449
+      <path d="M 66.682344 106.697517
+L 507.6 106.697517
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.342449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.697517" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 100.457915
-L 507.6 100.457915
+      <path d="M 66.682344 100.824306
+L 507.6 100.824306
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.457915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.824306" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 95.893516
-L 507.6 95.893516
+      <path d="M 66.682344 96.26869
+L 507.6 96.26869
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.893516" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.26869" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 92.16413
-L 507.6 92.16413
+      <path d="M 66.682344 92.546481
+L 507.6 92.546481
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.16413" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.546481" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 89.01098
-L 507.6 89.01098
+      <path d="M 66.682344 89.399397
+L 507.6 89.399397
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.01098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.399397" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 86.279596
-L 507.6 86.279596
+      <path d="M 66.682344 86.67327
+L 507.6 86.67327
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.279596" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.67327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 83.870346
-L 507.6 83.870346
+      <path d="M 66.682344 84.268655
+L 507.6 84.268655
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="83.870346" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.268655" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 67.536879
-L 507.6 67.536879
+      <path d="M 66.682344 67.966617
+L 507.6 67.966617
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="67.536879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="67.966617" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 59.243094
-L 507.6 59.243094
+      <path d="M 66.682344 59.688791
+L 507.6 59.688791
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.243094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.688791" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 53.358561
-L 507.6 53.358561
+      <path d="M 66.682344 53.81558
+L 507.6 53.81558
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.358561" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.81558" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 48.794162
-L 507.6 48.794162
+      <path d="M 66.682344 49.259964
+L 507.6 49.259964
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.794162" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.259964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 45.064776
-L 507.6 45.064776
+      <path d="M 66.682344 45.537754
+L 507.6 45.537754
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.064776" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.537754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 41.911626
-L 507.6 41.911626
+      <path d="M 66.682344 42.390671
+L 507.6 42.390671
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.911626" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.390671" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 39.180242
-L 507.6 39.180242
+      <path d="M 66.682344 39.664543
+L 507.6 39.664543
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.180242" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.664543" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 36.770991
-L 507.6 36.770991
+      <path d="M 66.682344 37.259928
+L 507.6 37.259928
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.770991" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="37.259928" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1456,17 +1456,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 283.363964
-L 115.355072 269.142684
-L 143.986089 249.756908
-L 172.617105 239.78954
-L 201.248122 233.09778
-L 229.879139 215.783757
-L 258.510155 205.936974
-L 287.141172 199.218958
-L 315.772189 136.226165
-L 344.403205 122.11387
-L 373.034222 113.534
+    <path d="M 86.724055 283.721553
+L 115.355072 267.708603
+L 143.986089 249.836096
+L 172.617105 240.329481
+L 201.248122 233.692648
+L 229.879139 216.556212
+L 258.510155 206.760232
+L 287.141172 200.113815
+L 315.772189 136.60073
+L 344.403205 122.783453
+L 373.034222 114.186282
 L 401.665238 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1483,36 +1483,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.363964" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="269.142684" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="249.756908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="239.78954" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="233.09778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="215.783757" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="205.936974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="199.218958" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="136.226165" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="122.11387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="113.534" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.721553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="267.708603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="249.836096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="240.329481" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="233.692648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="216.556212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="206.760232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="200.113815" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="136.60073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="122.783453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="114.186282" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="401.665238" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 115.355072 276.202728
-L 143.986089 265.581789
-L 172.617105 258.320982
-L 201.248122 251.345284
-L 229.879139 238.718373
-L 258.510155 230.946671
-L 287.141172 224.698274
-L 315.772189 210.162834
-L 344.403205 201.67943
-L 373.034222 194.777223
-L 401.665238 178.409321
-L 430.296255 169.396502
-L 458.927272 163.038718
-L 487.558288 141.313113
+L 115.355072 276.230954
+L 143.986089 265.630452
+L 172.617105 258.383616
+L 201.248122 251.421341
+L 229.879139 238.818726
+L 258.510155 231.061979
+L 287.141172 224.825605
+L 315.772189 210.318134
+L 344.403205 201.851053
+L 373.034222 194.962127
+L 401.665238 178.62572
+L 430.296255 169.630243
+L 458.927272 163.284693
+L 487.558288 141.600892
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1523,38 +1523,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.202728" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="143.986089" y="265.581789" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.320982" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="201.248122" y="251.345284" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="229.879139" y="238.718373" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="258.510155" y="230.946671" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="224.698274" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="315.772189" y="210.162834" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="344.403205" y="201.67943" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="373.034222" y="194.777223" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="401.665238" y="178.409321" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="430.296255" y="169.396502" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="458.927272" y="163.038718" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="141.313113" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.230954" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="143.986089" y="265.630452" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.383616" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="201.248122" y="251.421341" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="229.879139" y="238.818726" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="258.510155" y="231.061979" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="224.825605" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="315.772189" y="210.318134" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="344.403205" y="201.851053" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="373.034222" y="194.962127" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="401.665238" y="178.62572" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="430.296255" y="169.630243" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="458.927272" y="163.284693" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="141.600892" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.172348
-L 115.355072 259.989492
-L 143.986089 245.656879
-L 172.617105 237.227611
-L 201.248122 229.557787
-L 229.879139 220.152012
-L 258.510155 213.63547
-L 287.141172 207.243703
-L 315.772189 192.125402
-L 344.403205 183.422937
-L 373.034222 176.266974
-L 401.665238 160.607027
-L 430.296255 151.772777
-L 458.927272 144.708859
-L 487.558288 121.80051
+    <path d="M 86.724055 275.202558
+L 115.355072 260.048916
+L 143.986089 245.743882
+L 172.617105 237.330833
+L 201.248122 229.675768
+L 229.879139 220.288091
+L 258.510155 213.784088
+L 287.141172 207.40462
+L 315.772189 192.315409
+L 344.403205 183.629689
+L 373.034222 176.487495
+L 401.665238 160.857681
+L 430.296255 152.04043
+L 458.927272 144.990104
+L 487.558288 122.125835
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1564,39 +1564,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.172348" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="115.355072" y="259.989492" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="143.986089" y="245.656879" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="172.617105" y="237.227611" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="201.248122" y="229.557787" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="229.879139" y="220.152012" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="258.510155" y="213.63547" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="207.243703" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="315.772189" y="192.125402" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="344.403205" y="183.422937" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="373.034222" y="176.266974" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="401.665238" y="160.607027" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="430.296255" y="151.772777" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="458.927272" y="144.708859" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="121.80051" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.202558" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="115.355072" y="260.048916" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="143.986089" y="245.743882" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="172.617105" y="237.330833" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="201.248122" y="229.675768" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="229.879139" y="220.288091" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="258.510155" y="213.784088" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="207.40462" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="315.772189" y="192.315409" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="344.403205" y="183.629689" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="373.034222" y="176.487495" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="401.665238" y="160.857681" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="430.296255" y="152.04043" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="458.927272" y="144.990104" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="122.125835" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.575078
-L 115.355072 274.458296
-L 143.986089 262.644754
-L 172.617105 254.768087
-L 201.248122 247.949799
-L 229.879139 239.89124
-L 258.510155 233.974579
-L 287.141172 227.835968
-L 315.772189 212.243194
-L 344.403205 203.249371
-L 373.034222 196.352096
-L 401.665238 179.754162
-L 430.296255 170.563922
-L 458.927272 163.164285
-L 487.558288 138.347294
+    <path d="M 86.724055 289.577575
+L 115.355072 274.489879
+L 143.986089 262.699069
+L 172.617105 254.837558
+L 201.248122 248.03239
+L 229.879139 239.989337
+L 258.510155 234.084061
+L 287.141172 227.957261
+L 315.772189 212.39449
+L 344.403205 203.417973
+L 373.034222 196.53397
+L 401.665238 179.967973
+L 430.296255 170.795417
+L 458.927272 163.410018
+L 487.558288 138.64078
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1615,35 +1615,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.575078" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.458296" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="143.986089" y="262.644754" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="172.617105" y="254.768087" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="201.248122" y="247.949799" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="229.879139" y="239.89124" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="258.510155" y="233.974579" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="227.835968" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="315.772189" y="212.243194" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="344.403205" y="203.249371" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="373.034222" y="196.352096" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="401.665238" y="179.754162" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="430.296255" y="170.563922" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="458.927272" y="163.164285" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="138.347294" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.577575" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.489879" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="143.986089" y="262.699069" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="172.617105" y="254.837558" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="201.248122" y="248.03239" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="229.879139" y="239.989337" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="258.510155" y="234.084061" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="227.957261" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="315.772189" y="212.39449" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="344.403205" y="203.417973" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="373.034222" y="196.53397" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="401.665238" y="179.967973" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="430.296255" y="170.795417" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="458.927272" y="163.410018" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="138.64078" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.699564
-L 115.355072 257.613869
-L 143.986089 238.649591
-L 172.617105 228.80017
-L 201.248122 220.157704
-L 229.879139 205.5735
-L 258.510155 197.059556
-L 287.141172 190.970742
-L 315.772189 162.247771
-L 344.403205 150.68982
-L 373.034222 140.33767
+    <path d="M 86.724055 278.722987
+L 115.355072 257.677864
+L 143.986089 238.750077
+L 172.617105 228.919608
+L 201.248122 220.293772
+L 229.879139 205.737631
+L 258.510155 197.240068
+L 287.141172 191.162971
+L 315.772189 162.495268
+L 344.403205 150.959556
+L 373.034222 140.627326
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1660,28 +1660,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.699564" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="115.355072" y="257.613869" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="143.986089" y="238.649591" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="172.617105" y="228.80017" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="201.248122" y="220.157704" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="229.879139" y="205.5735" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="258.510155" y="197.059556" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="287.141172" y="190.970742" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="315.772189" y="162.247771" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="344.403205" y="150.68982" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="373.034222" y="140.33767" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.722987" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="115.355072" y="257.677864" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="143.986089" y="238.750077" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="172.617105" y="228.919608" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="201.248122" y="220.293772" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="229.879139" y="205.737631" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="258.510155" y="197.240068" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="287.141172" y="191.162971" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="315.772189" y="162.495268" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="344.403205" y="150.959556" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="373.034222" y="140.627326" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.11426
-L 115.355072 241.289492
-L 143.986089 179.38232
-L 172.617105 165.558127
-L 201.248122 156.963091
-L 229.879139 80.418269
-L 258.510155 63.096692
-L 287.141172 53.354599
+    <path d="M 86.724055 259.175368
+L 115.355072 241.384898
+L 143.986089 179.596846
+L 172.617105 165.799254
+L 201.248122 157.220756
+L 229.879139 80.823221
+L 258.510155 63.534973
+L 287.141172 53.811626
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1694,14 +1694,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.11426" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="115.355072" y="241.289492" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="143.986089" y="179.38232" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="172.617105" y="165.558127" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="201.248122" y="156.963091" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="229.879139" y="80.418269" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="258.510155" y="63.096692" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="287.141172" y="53.354599" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.175368" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="115.355072" y="241.384898" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="143.986089" y="179.596846" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="172.617105" y="165.799254" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="201.248122" y="157.220756" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="229.879139" y="80.823221" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="258.510155" y="63.534973" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="287.141172" y="53.811626" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2376,7 +2376,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2483,7 +2483,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-wilkinson.svg
+++ b/reports/figures/hexbz-cactus-wilkinson.svg
@@ -1352,21 +1352,21 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 269.714576
-L 115.355072 247.874688
-L 143.986089 233.053254
-L 172.617105 216.147146
-L 201.248122 203.75743
-L 229.879139 193.179072
-L 258.510155 183.823846
-L 287.141172 174.767973
-L 315.772189 166.500821
-L 344.403205 157.563877
-L 373.034222 148.43613
-L 401.665238 140.437434
-L 430.296255 132.540566
-L 458.927272 123.087688
-L 487.558288 114.674793
+    <path d="M 86.724055 271.938347
+L 115.355072 249.106913
+L 143.986089 233.676667
+L 172.617105 216.642399
+L 201.248122 204.282277
+L 229.879139 193.618651
+L 258.510155 184.07883
+L 287.141172 174.99858
+L 315.772189 166.7226
+L 344.403205 157.76951
+L 373.034222 148.534549
+L 401.665238 140.450852
+L 430.296255 132.524659
+L 458.927272 122.985869
+L 487.558288 114.547548
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1382,21 +1382,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="269.714576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="247.874688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="233.053254" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="216.147146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="203.75743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="193.179072" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="183.823846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="174.767973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="166.500821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="157.563877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="148.43613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="140.437434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="132.540566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="123.087688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="114.674793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.938347" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="249.106913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="233.676667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="216.642399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="204.282277" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="193.618651" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="184.07883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="174.99858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="166.7226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="157.76951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="148.534549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="140.450852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="132.524659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="122.985869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="114.547548" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -2278,7 +2278,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2402,7 +2402,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
+++ b/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
@@ -1139,7 +1139,7 @@ z
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 290.301172 191.670645
+    <path d="M 290.301172 184.18902
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1155,7 +1155,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="191.670645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="184.18902" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_40">
@@ -1851,7 +1851,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1951,7 +1951,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-chebyshev.svg
+++ b/reports/figures/hexbz-runtime-degree-chebyshev.svg
@@ -1403,34 +1403,34 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.469038 279.06024
-L 86.469038 276.320596
-L 105.313508 275.260197
-L 105.313508 267.078484
-L 124.157979 275.96258
-L 124.157979 264.637562
-L 143.002449 262.865842
-L 143.002449 256.757146
-L 161.846919 264.288684
-L 161.846919 262.949667
-L 180.69139 263.910398
-L 180.69139 249.08922
-L 199.53586 256.869057
-L 199.53586 253.981441
-L 218.380331 252.813016
-L 218.380331 247.670153
-L 256.069271 246.771545
-L 256.069271 244.038595
-L 312.602683 241.704278
-L 312.602683 235.615124
-L 331.447153 249.741047
-L 331.447153 239.674144
-L 369.136094 236.517533
-L 369.136094 224.99955
-L 406.825035 223.095112
-L 406.825035 218.015474
-L 482.202916 227.427093
-L 482.202916 221.529854
+    <path d="M 86.469038 279.595396
+L 86.469038 273.48202
+L 105.313508 276.291864
+L 105.313508 268.731909
+L 124.157979 276.553161
+L 124.157979 264.794516
+L 143.002449 263.252526
+L 143.002449 258.269701
+L 161.846919 265.244508
+L 161.846919 264.114968
+L 180.69139 266.778118
+L 180.69139 249.466273
+L 199.53586 258.131888
+L 199.53586 255.344308
+L 218.380331 253.391015
+L 218.380331 249.020069
+L 256.069271 246.662342
+L 256.069271 244.365476
+L 312.602683 242.476154
+L 312.602683 235.990418
+L 331.447153 250.80255
+L 331.447153 240.487488
+L 369.136094 237.328309
+L 369.136094 225.719858
+L 406.825035 224.040032
+L 406.825035 218.707065
+L 482.202916 228.65085
+L 482.202916 222.148898
 " clip-path="url(#pe3690171c9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1446,34 +1446,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pe3690171c9)">
-     <use xlink:href="#md73ba6276e" x="86.469038" y="279.06024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.469038" y="276.320596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="275.260197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="267.078484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="275.96258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="264.637562" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="262.865842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="256.757146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="264.288684" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="262.949667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="263.910398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="249.08922" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="256.869057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="253.981441" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="252.813016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="247.670153" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="246.771545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="244.038595" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="241.704278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="235.615124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="249.741047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="239.674144" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="236.517533" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="224.99955" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="223.095112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="218.015474" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="227.427093" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="221.529854" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="279.595396" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="273.48202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="276.291864" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="268.731909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="276.553161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="264.794516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="263.252526" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="258.269701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="265.244508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="264.114968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="266.778118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="249.466273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="258.131888" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="255.344308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="253.391015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="249.020069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="246.662342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="244.365476" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="242.476154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="235.990418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="250.80255" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="240.487488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="237.328309" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="225.719858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="224.040032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="218.707065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="228.65085" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="222.148898" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2427,7 +2427,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2553,7 +2553,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-conway.svg
+++ b/reports/figures/hexbz-runtime-degree-conway.svg
@@ -1583,89 +1583,90 @@ z
     </g>
    </g>
    <g id="line2d_139">
-    <path d="M 86.724055 273.375657
-L 86.724055 260.080135
-L 97.001856 270.605642
-L 97.001856 262.961398
-L 107.279657 268.799787
-L 107.279657 259.67488
-L 117.557458 264.783735
-L 117.557458 252.393256
-L 127.835259 263.583989
-L 127.835259 252.122569
-L 138.11306 260.449614
-L 138.11306 260.35124
-L 138.11306 248.59748
-L 148.39086 259.236757
-L 148.39086 249.824665
-L 158.668661 254.609528
-L 158.668661 244.917032
-L 168.946462 253.645256
-L 168.946462 244.716929
-L 179.224263 250.944218
-L 179.224263 236.872754
-L 189.502064 252.293975
-L 189.502064 237.658208
-L 199.779865 247.000972
-L 199.779865 231.877299
-L 210.057666 248.980061
-L 210.057666 231.023447
-L 220.335466 241.415599
-L 220.335466 235.51138
-L 230.613267 241.806933
-L 230.613267 231.053957
-L 240.891068 240.84212
-L 240.891068 225.647058
-L 251.168869 242.517034
-L 251.168869 219.285003
-L 261.44667 235.82628
-L 261.44667 222.964138
-L 271.724471 239.56012
-L 271.724471 222.717504
-L 282.002271 231.806621
-L 282.002271 222.890821
-L 292.280072 231.909288
-L 292.280072 225.503902
-L 302.557873 230.14768
-L 302.557873 216.041237
-L 312.835674 232.924604
-L 312.835674 217.197826
-L 323.113475 227.629223
-L 323.113475 216.271565
-L 333.391276 228.166399
-L 333.391276 212.316064
-L 343.669077 224.168563
-L 343.669077 214.218314
-L 353.946877 229.87275
-L 353.946877 212.201536
-L 364.224678 223.262245
-L 364.224678 206.148827
-L 374.502479 227.428002
-L 374.502479 220.074483
-L 384.78028 218.484002
-L 384.78028 203.785243
-L 395.058081 223.15598
-L 395.058081 223.079711
-L 395.058081 208.653655
-L 405.335882 218.490813
-L 405.335882 210.946198
-L 415.613682 217.449092
-L 415.613682 199.725867
-L 425.891483 214.930951
-L 425.891483 203.960288
-L 436.169284 216.263062
-L 436.169284 195.594272
-L 446.447085 212.118423
-L 446.447085 196.100897
-L 456.724886 215.813879
-L 456.724886 198.366028
-L 467.002687 210.312906
-L 467.002687 193.751737
-L 477.280488 212.155149
-L 477.280488 198.651609
-L 487.558288 208.652516
-L 487.558288 196.694136
-L 487.558288 196.694136
+    <path d="M 86.724055 275.434908
+L 86.724055 268.91716
+L 97.001856 269.775943
+L 97.001856 263.371017
+L 107.279657 268.637381
+L 107.279657 260.064101
+L 117.557458 264.576273
+L 117.557458 252.19757
+L 127.835259 263.11208
+L 127.835259 263.012743
+L 127.835259 252.617857
+L 138.11306 260.104212
+L 138.11306 260.068108
+L 138.11306 249.16534
+L 148.39086 258.65605
+L 148.39086 249.448653
+L 158.668661 254.612786
+L 158.668661 245.054353
+L 168.946462 253.650873
+L 168.946462 244.880532
+L 179.224263 251.865801
+L 179.224263 237.26121
+L 189.502064 252.482551
+L 189.502064 237.971837
+L 199.779865 247.725866
+L 199.779865 232.568419
+L 210.057666 249.693116
+L 210.057666 230.964101
+L 220.335466 242.962925
+L 220.335466 236.684853
+L 230.613267 243.045633
+L 230.613267 231.49557
+L 240.891068 242.148909
+L 240.891068 225.878869
+L 251.168869 243.730699
+L 251.168869 219.057884
+L 261.44667 237.637368
+L 261.44667 223.897416
+L 271.724471 241.201205
+L 271.724471 241.134937
+L 271.724471 222.351052
+L 282.002271 233.876645
+L 282.002271 223.954379
+L 292.280072 234.151569
+L 292.280072 226.074436
+L 302.557873 232.314603
+L 302.557873 217.529957
+L 312.835674 235.180658
+L 312.835674 217.460103
+L 323.113475 229.996766
+L 323.113475 217.761272
+L 333.391276 231.436296
+L 333.391276 213.897424
+L 343.669077 227.523045
+L 343.669077 215.398613
+L 353.946877 231.723788
+L 353.946877 213.533317
+L 364.224678 226.426026
+L 364.224678 207.195012
+L 374.502479 230.426085
+L 374.502479 221.103938
+L 384.78028 222.229189
+L 384.78028 204.775269
+L 395.058081 227.314437
+L 395.058081 209.363583
+L 405.335882 222.320261
+L 405.335882 213.183574
+L 415.613682 221.30213
+L 415.613682 201.488537
+L 425.891483 218.825787
+L 425.891483 206.239199
+L 436.169284 220.705307
+L 436.169284 197.225369
+L 446.447085 216.340198
+L 446.447085 198.471256
+L 456.724886 221.429189
+L 456.724886 199.81851
+L 467.002687 214.690397
+L 467.002687 195.578696
+L 477.280488 217.001595
+L 477.280488 200.108344
+L 487.558288 213.67382
+L 487.558288 198.621129
+L 487.558288 198.621129
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1681,192 +1682,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.375657" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.846694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.708162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.499544" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.222465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.112813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.618337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.316962" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="260.080135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="270.605642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.254976" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="267.941138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="267.812068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="265.035772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.643269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.509525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.245862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.961398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="268.799787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.731635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.579125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.331165" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="265.934752" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.033575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.020175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="261.288218" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="259.67488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="264.783735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="264.093588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="262.79238" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="260.120281" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.132997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="257.765227" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.20794" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="253.971378" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="252.393256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="263.583989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="263.145789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="260.14079" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="257.028041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="256.121907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="256.102593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="253.272309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="252.122569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.449614" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.35124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.028078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="259.896604" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="257.068724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="253.70432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="251.387977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="248.59748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="259.236757" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="256.260933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="254.09215" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.665668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.644403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.356615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.039913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="249.824665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="254.609528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="251.360739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="249.747566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="249.075732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="247.689285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.769228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.423473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="244.917032" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="253.645256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="248.329416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="246.278087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="244.716929" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="250.944218" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="249.847631" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="243.369017" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="236.872754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="252.293975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="249.802182" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="241.613955" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="237.658208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="247.000972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="240.602727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="235.120065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="231.877299" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="248.980061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="246.464271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="243.391282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="231.023447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="241.415599" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="238.141424" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="236.461988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="235.51138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="241.806933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="238.634259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="232.811498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="231.053957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="240.84212" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="239.54854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="226.340842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="225.647058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="242.517034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="227.981491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="225.205134" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="219.285003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="235.82628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="229.613737" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="225.824531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="222.964138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="239.56012" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="239.11579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="226.135651" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="222.717504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="231.806621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="227.987593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="226.564803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="222.890821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="231.909288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="227.372146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="225.996417" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="225.503902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="230.14768" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="220.182553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="218.598731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="216.041237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="232.924604" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="229.659128" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="224.871815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="217.197826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="227.629223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="220.080214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="216.576848" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="216.271565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="228.166399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="217.126232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="215.402361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="212.316064" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="224.168563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="215.165118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="215.018817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="214.218314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="229.87275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="218.954635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="212.631251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="212.201536" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="223.262245" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="222.226724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="210.044667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="206.148827" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="227.428002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="222.37141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="220.102108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="220.074483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="218.484002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="208.259752" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="204.697891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="203.785243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="223.15598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="223.079711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="210.233463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="208.653655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="218.490813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="210.946198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="217.449092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="211.063898" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="199.725867" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="214.930951" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="203.960288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="216.263062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="210.090486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="203.187546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="195.594272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="212.118423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="203.044518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="202.305773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="196.100897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="215.813879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="214.225274" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="205.046163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="198.366028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="210.312906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="193.751737" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="212.155149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="211.076412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="198.651609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="208.652516" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="196.694136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.434908" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.706443" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.45489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.392767" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.137654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.800156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.620157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.794701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="268.91716" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.775943" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.659687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.293957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.60448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.982557" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.632946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.555709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.239416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="263.371017" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.637381" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.235549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.051131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="266.80503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="266.619175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="262.689684" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.71864" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.517339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="260.064101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="264.576273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="264.417509" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="263.486388" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="260.116664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.641232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="257.729985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="255.559712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="254.066264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="252.19757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.11208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.012743" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="259.832806" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="257.613823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="256.902837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="255.802354" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.124114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="252.617857" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.104212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.068108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="259.813039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="259.667431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="256.00633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="253.47172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="251.505068" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="249.16534" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="258.65605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="256.147691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.687425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.560934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.673649" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.2859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.967866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="249.448653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="254.612786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="251.863257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="250.346387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="249.359625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="248.369205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.338015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.180773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.054353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="253.650873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="248.960554" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="246.345432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="244.880532" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="251.865801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="250.591778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="244.010625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="237.26121" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="252.482551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="249.950313" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="241.720991" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="237.971837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="247.725866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="241.004658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="235.547519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="232.568419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="249.693116" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="246.967963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="244.718642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="230.964101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="242.962925" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="239.749281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.441384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="236.684853" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="243.045633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="238.831217" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="233.916243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="231.49557" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="242.148909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="240.983756" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="226.953683" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="225.878869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="243.730699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="228.299261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="225.499766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="219.057884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="237.637368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="230.342382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="226.103796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="223.897416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.201205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.134937" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="228.041376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="222.351052" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="233.876645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="229.636753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="227.891429" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="223.954379" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="234.151569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="227.802485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="226.887083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="226.074436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="232.314603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="221.01694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="219.248525" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="217.529957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="235.180658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="232.93441" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="226.263576" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="217.460103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="229.996766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="221.43867" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="218.586963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="217.761272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="231.436296" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="218.798415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="216.495072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="213.897424" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="227.523045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="216.957332" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="216.681458" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.398613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="231.723788" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="222.694223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="215.189166" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="213.533317" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="226.426026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="225.392444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="211.302727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="207.195012" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="230.426085" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="224.68822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="223.415508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="221.103938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="222.229189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="211.014485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="205.863797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="204.775269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="227.314437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="225.847463" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="210.83107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="209.363583" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="222.320261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="213.183574" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="221.30213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="215.850264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="201.488537" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="218.825787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="206.239199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="220.705307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="215.037044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="204.89566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="197.225369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="216.340198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="204.571019" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="204.23753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="198.471256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="221.429189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="218.840938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="205.51361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="199.81851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="214.690397" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="195.578696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="217.001595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="215.995075" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="200.108344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="213.67382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="198.621129" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_140">
@@ -3864,7 +3865,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3971,7 +3972,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
@@ -1455,25 +1455,25 @@ z
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 86.724055 271.61926
-L 104.151631 253.445157
-L 112.865418 248.79342
-L 115.770014 251.676786
-L 115.770014 242.421106
-L 127.388398 238.941628
-L 139.006781 230.594974
-L 139.006781 203.723597
-L 156.434357 210.105461
-L 162.243549 180.498943
-L 173.861932 200.494844
-L 185.480316 200.669051
-L 208.717083 170.862802
-L 243.572234 184.580138
-L 301.664151 158.347613
-L 374.279049 139.302121
-L 394.61122 144.390067
-L 417.847987 113.579969
-L 487.558288 128.103899
+    <path d="M 86.724055 272.304596
+L 104.151631 251.883671
+L 112.865418 249.393785
+L 115.770014 252.97502
+L 115.770014 243.52808
+L 127.388398 238.88669
+L 139.006781 232.756997
+L 139.006781 203.962703
+L 156.434357 210.507094
+L 162.243549 181.695913
+L 173.861932 201.122592
+L 185.480316 202.911873
+L 208.717083 171.132822
+L 243.572234 184.608101
+L 301.664151 161.198108
+L 374.279049 139.154282
+L 394.61122 148.99485
+L 417.847987 113.645689
+L 487.558288 132.339175
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1489,25 +1489,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.61926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.151631" y="253.445157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.865418" y="248.79342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="251.676786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="242.421106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.388398" y="238.941628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="230.594974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="203.723597" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.434357" y="210.105461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.243549" y="180.498943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.861932" y="200.494844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.480316" y="200.669051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.717083" y="170.862802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="243.572234" y="184.580138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.664151" y="158.347613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.279049" y="139.302121" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.61122" y="144.390067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="417.847987" y="113.579969" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="128.103899" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.304596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.151631" y="251.883671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.865418" y="249.393785" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="252.97502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="243.52808" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.388398" y="238.88669" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="232.756997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="203.962703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.434357" y="210.507094" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.243549" y="181.695913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.861932" y="201.122592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.480316" y="202.911873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.717083" y="171.132822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="243.572234" y="184.608101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.664151" y="161.198108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.279049" y="139.154282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.61122" y="148.99485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="417.847987" y="113.645689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="132.339175" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_120">
@@ -2365,7 +2365,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2425,6 +2425,31 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2472,7 +2497,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic.svg
@@ -1509,40 +1509,40 @@ z
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 271.691088
-L 87.505409 269.239914
-L 88.286762 252.910968
-L 89.068115 252.59571
-L 89.849469 238.79846
-L 91.412175 252.567515
-L 92.193528 250.154249
-L 92.974882 247.641833
-L 93.756235 236.180635
-L 94.537588 227.953208
-L 96.100295 238.694458
-L 97.663001 230.722459
-L 99.225708 217.327838
-L 100.788414 197.025592
-L 101.569768 225.375416
-L 103.913828 177.372634
-L 105.476534 219.288742
-L 106.257887 215.769595
-L 108.601947 174.791655
-L 110.164654 209.249409
-L 116.41548 166.827423
-L 119.540893 201.848443
-L 128.135779 137.601433
-L 135.167959 182.809534
-L 143.762845 144.738016
-L 148.450965 175.690526
-L 154.701791 142.685015
-L 163.296677 87.077233
-L 178.923743 115.854893
-L 185.174569 162.932009
-L 214.08464 152.343414
-L 280.499669 132.269912
-L 283.625082 136.163369
-L 487.558288 60.568671
+    <path d="M 86.724055 274.729105
+L 87.505409 270.062106
+L 88.286762 254.478393
+L 89.068115 254.91617
+L 89.849469 239.575457
+L 91.412175 254.213145
+L 92.193528 251.43448
+L 92.974882 249.176375
+L 93.756235 236.404806
+L 94.537588 229.961174
+L 96.100295 239.829282
+L 97.663001 231.367272
+L 99.225708 218.336539
+L 100.788414 197.330846
+L 101.569768 228.517869
+L 103.913828 178.752525
+L 105.476534 221.548257
+L 106.257887 217.722493
+L 108.601947 175.036896
+L 110.164654 210.372858
+L 116.41548 170.689614
+L 119.540893 204.255509
+L 128.135779 137.987069
+L 135.167959 184.411082
+L 143.762845 145.162185
+L 148.450965 178.825272
+L 154.701791 143.287461
+L 163.296677 87.385693
+L 178.923743 120.074588
+L 185.174569 166.22616
+L 214.08464 156.520612
+L 280.499669 139.299791
+L 283.625082 140.554864
+L 487.558288 60.70244
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1558,40 +1558,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.691088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="87.505409" y="269.239914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.286762" y="252.910968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.068115" y="252.59571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.849469" y="238.79846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.412175" y="252.567515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.193528" y="250.154249" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.974882" y="247.641833" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.756235" y="236.180635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.537588" y="227.953208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.100295" y="238.694458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.663001" y="230.722459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.225708" y="217.327838" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.788414" y="197.025592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="225.375416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="103.913828" y="177.372634" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.476534" y="219.288742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.257887" y="215.769595" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.601947" y="174.791655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.164654" y="209.249409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="166.827423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.540893" y="201.848443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.135779" y="137.601433" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.167959" y="182.809534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.762845" y="144.738016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.450965" y="175.690526" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="154.701791" y="142.685015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.296677" y="87.077233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.923743" y="115.854893" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.174569" y="162.932009" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.08464" y="152.343414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.499669" y="132.269912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.625082" y="136.163369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="60.568671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.729105" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="87.505409" y="270.062106" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.286762" y="254.478393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.068115" y="254.91617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.849469" y="239.575457" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.412175" y="254.213145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.193528" y="251.43448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.974882" y="249.176375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.756235" y="236.404806" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.537588" y="229.961174" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.100295" y="239.829282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.663001" y="231.367272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.225708" y="218.336539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.788414" y="197.330846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="228.517869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="103.913828" y="178.752525" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.476534" y="221.548257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.257887" y="217.722493" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.601947" y="175.036896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.164654" y="210.372858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="170.689614" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.540893" y="204.255509" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.135779" y="137.987069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.167959" y="184.411082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.762845" y="145.162185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.450965" y="178.825272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="154.701791" y="143.287461" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.296677" y="87.385693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.923743" y="120.074588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.174569" y="166.22616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.08464" y="156.520612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.499669" y="139.299791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.625082" y="140.554864" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="60.70244" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_128">
@@ -2570,7 +2570,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2630,6 +2630,31 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2677,7 +2702,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
@@ -600,8 +600,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 66.682344 275.236284
-L 507.6 275.236284
+      <path d="M 66.682344 275.179283
+L 507.6 275.179283
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
@@ -611,12 +611,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.236284" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.179283" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.035112) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 278.978111) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-14" d="M 794 531
 L 1825 531
@@ -673,18 +673,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 66.682344 181.568743
-L 507.6 181.568743
+      <path d="M 66.682344 181.170276
+L 507.6 181.170276
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="181.568743" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="181.170276" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100ms -->
-      <g transform="translate(25.644844 185.367571) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 184.969104) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -695,18 +695,18 @@ L 507.6 181.568743
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 66.682344 87.901201
-L 507.6 87.901201
+      <path d="M 66.682344 87.161269
+L 507.6 87.161269
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="87.901201" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="87.161269" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1s -->
-      <g transform="translate(48.110469 91.70003) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 90.960097) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -714,8 +714,8 @@ L 507.6 87.901201
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 66.682344 303.433024
-L 507.6 303.433024
+      <path d="M 66.682344 296.035064
+L 507.6 296.035064
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
@@ -725,283 +725,271 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.433024" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="296.035064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 66.682344 296.016311
-L 507.6 296.016311
+      <path d="M 66.682344 289.741463
+L 507.6 289.741463
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="296.016311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.741463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 66.682344 289.74557
-L 507.6 289.74557
+      <path d="M 66.682344 284.289697
+L 507.6 284.289697
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.74557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.289697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 66.682344 284.313607
-L 507.6 284.313607
+      <path d="M 66.682344 279.480899
+L 507.6 279.480899
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.313607" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.480899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 66.682344 279.522276
-L 507.6 279.522276
+      <path d="M 66.682344 246.879752
+L 507.6 246.879752
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.522276" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="246.879752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 66.682344 247.039545
-L 507.6 247.039545
+      <path d="M 66.682344 230.325588
+L 507.6 230.325588
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.039545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.325588" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 66.682344 230.545509
-L 507.6 230.545509
+      <path d="M 66.682344 218.580221
+L 507.6 218.580221
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.545509" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="218.580221" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 66.682344 218.842805
-L 507.6 218.842805
+      <path d="M 66.682344 209.469807
+L 507.6 209.469807
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="218.842805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.469807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 66.682344 209.765482
-L 507.6 209.765482
+      <path d="M 66.682344 202.026057
+L 507.6 202.026057
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.765482" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.026057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 66.682344 202.34877
-L 507.6 202.34877
+      <path d="M 66.682344 195.732456
+L 507.6 195.732456
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.34877" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="195.732456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 66.682344 196.078029
-L 507.6 196.078029
+      <path d="M 66.682344 190.28069
+L 507.6 190.28069
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.078029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.28069" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 66.682344 190.646066
-L 507.6 190.646066
+      <path d="M 66.682344 185.471892
+L 507.6 185.471892
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.646066" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="185.471892" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 66.682344 185.854735
-L 507.6 185.854735
+      <path d="M 66.682344 152.870745
+L 507.6 152.870745
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="185.854735" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="152.870745" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 66.682344 153.372003
-L 507.6 153.372003
+      <path d="M 66.682344 136.316581
+L 507.6 136.316581
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.372003" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.316581" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 66.682344 136.877968
-L 507.6 136.877968
+      <path d="M 66.682344 124.571214
+L 507.6 124.571214
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.877968" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="124.571214" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 66.682344 125.175264
-L 507.6 125.175264
+      <path d="M 66.682344 115.4608
+L 507.6 115.4608
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.175264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.4608" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 66.682344 116.097941
-L 507.6 116.097941
+      <path d="M 66.682344 108.01705
+L 507.6 108.01705
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.097941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="108.01705" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 66.682344 108.681228
-L 507.6 108.681228
+      <path d="M 66.682344 101.723449
+L 507.6 101.723449
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="108.681228" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.723449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 66.682344 102.410487
-L 507.6 102.410487
+      <path d="M 66.682344 96.271683
+L 507.6 96.271683
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="102.410487" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.271683" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 66.682344 96.978524
-L 507.6 96.978524
+      <path d="M 66.682344 91.462886
+L 507.6 91.462886
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.978524" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.462886" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 66.682344 92.187193
-L 507.6 92.187193
+      <path d="M 66.682344 58.861738
+L 507.6 58.861738
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.187193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="58.861738" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 66.682344 59.704462
-L 507.6 59.704462
+      <path d="M 66.682344 42.307574
+L 507.6 42.307574
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.704462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.307574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 66.682344 43.210427
-L 507.6 43.210427
+      <path d="M 66.682344 30.562207
+L 507.6 30.562207
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.210427" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_27">
-     <g id="line2d_63">
-      <path d="M 66.682344 31.507722
-L 507.6 31.507722
-" clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_64">
-      <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.507722" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="30.562207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1088,8 +1076,8 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_65">
-    <path d="M 89.917954 88.737193
+   <g id="line2d_63">
+    <path d="M 89.917954 88.883424
 L 136.229479 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1106,20 +1094,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="89.917954" y="88.737193" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.917954" y="88.883424" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.229479" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
-   <g id="line2d_66">
-    <path d="M 86.724055 222.557077
+   <g id="line2d_64">
+    <path d="M 86.724055 222.308033
 L 89.917954 290.872308
-L 136.229479 251.236557
-L 137.826428 123.830141
-L 188.9288 100.634646
-L 188.9288 79.104266
-L 264.783884 169.717529
-L 291.133545 175.651637
-L 487.558288 118.46462
+L 136.229479 251.092065
+L 137.826428 123.221188
+L 188.9288 99.941134
+L 188.9288 78.332265
+L 264.783884 169.275859
+L 291.133545 175.231599
+L 487.558288 117.836107
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1129,27 +1117,27 @@ z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="222.557077" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="222.308033" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      <use xlink:href="#meef3cfac8d" x="89.917954" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.236557" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="137.826428" y="123.830141" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="100.634646" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="79.104266" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="264.783884" y="169.717529" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="291.133545" y="175.651637" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="118.46462" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.092065" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="137.826428" y="123.221188" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="99.941134" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="78.332265" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="264.783884" y="169.275859" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="291.133545" y="175.231599" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="117.836107" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_67">
-    <path d="M 86.724055 183.686844
-L 89.917954 252.497041
-L 136.229479 224.014681
-L 137.826428 133.808806
-L 188.9288 87.481639
-L 188.9288 77.078082
-L 264.783884 169.843537
-L 291.133545 138.525013
-L 487.558288 101.383081
+   <g id="line2d_65">
+    <path d="M 86.724055 183.296099
+L 89.917954 252.357144
+L 136.229479 223.770951
+L 137.826428 133.236231
+L 188.9288 86.740177
+L 188.9288 76.298694
+L 264.783884 169.402327
+L 291.133545 137.96963
+L 487.558288 100.692298
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1159,27 +1147,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="183.686844" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="89.917954" y="252.497041" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.229479" y="224.014681" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="137.826428" y="133.808806" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="87.481639" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="77.078082" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="264.783884" y="169.843537" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="291.133545" y="138.525013" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="101.383081" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="183.296099" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="89.917954" y="252.357144" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.229479" y="223.770951" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="137.826428" y="133.236231" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="86.740177" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="76.298694" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="264.783884" y="169.402327" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="291.133545" y="137.96963" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="100.692298" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_68">
-    <path d="M 86.724055 214.990927
-L 89.917954 252.92864
-L 136.229479 234.355978
-L 137.826428 159.727963
-L 188.9288 117.610198
-L 188.9288 113.487302
-L 264.783884 152.448201
-L 291.133545 163.753604
-L 487.558288 89.52729
+   <g id="line2d_66">
+    <path d="M 86.724055 214.714301
+L 89.917954 252.790317
+L 136.229479 234.149948
+L 137.826428 159.249876
+L 188.9288 116.97857
+L 188.9288 112.840644
+L 264.783884 151.943575
+L 291.133545 163.290192
+L 487.558288 88.793286
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1198,15 +1186,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="214.990927" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="89.917954" y="252.92864" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.229479" y="234.355978" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="137.826428" y="159.727963" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="117.610198" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="113.487302" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="264.783884" y="152.448201" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="291.133545" y="163.753604" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="89.52729" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="214.714301" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="89.917954" y="252.790317" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.229479" y="234.149948" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="137.826428" y="159.249876" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="116.97857" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="112.840644" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="264.783884" y="151.943575" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="291.133545" y="163.290192" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="88.793286" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1419,7 +1407,7 @@ Q 70.682344 80.5625 72.282344 80.5625
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_69">
+    <g id="line2d_67">
      <path d="M 73.882344 36.63875
 L 81.882344 36.63875
 L 89.882344 36.63875
@@ -1509,7 +1497,7 @@ z
       <use xlink:href="#DejaVuSans-c" transform="translate(546.109375 0)"/>
      </g>
     </g>
-    <g id="line2d_70">
+    <g id="line2d_68">
      <path d="M 73.882344 48.639375
 L 81.882344 48.639375
 L 89.882344 48.639375
@@ -1583,7 +1571,7 @@ z
       <use xlink:href="#DejaVuSans-37" transform="translate(217.546875 0)"/>
      </g>
     </g>
-    <g id="line2d_71">
+    <g id="line2d_69">
      <path d="M 73.882344 60.64
 L 81.882344 60.64
 L 89.882344 60.64
@@ -1600,7 +1588,7 @@ L 89.882344 60.64
       <use xlink:href="#DejaVuSans-2f" transform="translate(135.890625 0)"/>
      </g>
     </g>
-    <g id="line2d_72">
+    <g id="line2d_70">
      <path d="M 73.882344 72.640625
 L 81.882344 72.640625
 L 89.882344 72.640625
@@ -1695,7 +1683,7 @@ z
    </g>
   </g>
   <g id="text_16">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1802,7 +1790,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-laguerre.svg
+++ b/reports/figures/hexbz-runtime-degree-laguerre.svg
@@ -1424,26 +1424,26 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 275.291561
-L 100.545925 263.7903
-L 114.367796 257.393049
-L 128.189666 253.777907
-L 142.011536 246.346058
-L 155.833406 251.174093
-L 169.655276 250.34606
-L 183.477146 237.619074
-L 197.299016 243.55486
-L 211.120886 228.80457
-L 224.942756 227.003692
-L 238.764627 220.050381
-L 252.586497 215.311257
-L 266.408367 209.877837
-L 294.052107 207.41131
-L 321.695847 197.626345
-L 349.339587 208.102185
-L 376.983328 197.24419
-L 432.270808 188.064063
-L 487.558288 175.3029
+    <path d="M 86.724055 277.295031
+L 100.545925 266.732333
+L 114.367796 258.107387
+L 128.189666 254.909544
+L 142.011536 247.177385
+L 155.833406 251.671939
+L 169.655276 251.550982
+L 183.477146 238.510546
+L 197.299016 244.378653
+L 211.120886 228.945418
+L 224.942756 227.882106
+L 238.764627 220.868278
+L 252.586497 215.900652
+L 266.408367 210.394585
+L 294.052107 207.954552
+L 321.695847 198.035968
+L 349.339587 209.558822
+L 376.983328 198.299272
+L 432.270808 188.753041
+L 487.558288 175.971397
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1459,26 +1459,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.291561" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="263.7903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="257.393049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="253.777907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="246.346058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="251.174093" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="250.34606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="237.619074" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="243.55486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="228.80457" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="227.003692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="220.050381" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="215.311257" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="209.877837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="207.41131" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="197.626345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="208.102185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="197.24419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="188.064063" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="175.3029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.295031" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="266.732333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="258.107387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="254.909544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="247.177385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="251.671939" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="251.550982" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="238.510546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="244.378653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="228.945418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="227.882106" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="220.868278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="215.900652" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="210.394585" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="207.954552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="198.035968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="209.558822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="198.299272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="188.753041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="175.971397" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2347,7 +2347,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2473,7 +2473,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-legendre.svg
+++ b/reports/figures/hexbz-runtime-degree-legendre.svg
@@ -1443,26 +1443,26 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 272.629391
-L 98.176462 272.761509
-L 109.628869 262.073177
-L 121.081275 255.080738
-L 132.533682 258.634256
-L 143.986089 243.969622
-L 155.438495 242.050859
-L 166.890902 232.557911
-L 189.795715 236.656258
-L 212.700529 216.596667
-L 235.605342 219.884538
-L 258.510155 202.02791
-L 281.414969 194.825945
-L 304.319782 207.724191
-L 327.224595 196.501329
-L 350.129408 168.331412
-L 373.034222 194.740387
-L 395.939035 164.761824
-L 441.748662 185.148293
-L 487.558288 180.563478
+    <path d="M 86.724055 274.58816
+L 98.176462 274.455166
+L 109.628869 262.881373
+L 121.081275 255.611182
+L 132.533682 259.856443
+L 143.986089 244.426032
+L 155.438495 242.86643
+L 166.890902 233.140824
+L 189.795715 237.618043
+L 212.700529 217.183722
+L 235.605342 220.441736
+L 258.510155 202.763766
+L 281.414969 194.974679
+L 304.319782 208.682518
+L 327.224595 197.231414
+L 350.129408 168.652206
+L 373.034222 195.788366
+L 395.939035 164.93926
+L 441.748662 185.730046
+L 487.558288 181.507894
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1478,26 +1478,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.629391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.176462" y="272.761509" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.628869" y="262.073177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.081275" y="255.080738" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.533682" y="258.634256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="243.969622" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.438495" y="242.050859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="232.557911" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.795715" y="236.656258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.700529" y="216.596667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.605342" y="219.884538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="202.02791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.414969" y="194.825945" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.319782" y="207.724191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="196.501329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.129408" y="168.331412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="194.740387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.939035" y="164.761824" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.748662" y="185.148293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="180.563478" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.58816" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.176462" y="274.455166" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.628869" y="262.881373" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.081275" y="255.611182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.533682" y="259.856443" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="244.426032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.438495" y="242.86643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="233.140824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.795715" y="237.618043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.700529" y="217.183722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.605342" y="220.441736" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="202.763766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.414969" y="194.974679" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.319782" y="208.682518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="197.231414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.129408" y="168.652206" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="195.788366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.939035" y="164.93926" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.748662" y="185.730046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.507894" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2360,7 +2360,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2486,7 +2486,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-random-products.svg
+++ b/reports/figures/hexbz-runtime-degree-random-products.svg
@@ -1419,36 +1419,36 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 265.245158
-L 153.529761 254.465663
-L 153.529761 254.185215
-L 153.529761 250.815726
-L 175.798329 256.972131
-L 198.066898 250.68918
-L 220.335466 250.776129
-L 220.335466 242.933961
-L 242.604035 248.641523
-L 242.604035 241.946827
-L 242.604035 241.275296
-L 242.604035 240.422132
-L 242.604035 239.636642
-L 242.604035 229.811193
-L 264.872603 246.620962
-L 264.872603 238.639344
-L 287.141172 247.12478
-L 287.141172 244.525995
-L 287.141172 241.240731
-L 309.40974 235.193168
-L 331.678309 237.64039
-L 353.946877 235.876926
-L 353.946877 233.02379
-L 353.946877 224.243635
-L 353.946877 222.392647
-L 376.215446 223.386085
-L 398.484014 227.709253
-L 420.752583 225.863464
-L 443.021151 217.464282
-L 487.558288 211.190187
+    <path d="M 86.724055 264.950293
+L 153.529761 255.212597
+L 153.529761 254.726019
+L 153.529761 251.160903
+L 175.798329 257.760676
+L 198.066898 251.003143
+L 220.335466 251.076355
+L 220.335466 243.476592
+L 242.604035 250.067214
+L 242.604035 242.425546
+L 242.604035 242.322187
+L 242.604035 241.265253
+L 242.604035 240.007314
+L 242.604035 230.022637
+L 264.872603 247.477045
+L 264.872603 239.876956
+L 287.141172 247.784629
+L 287.141172 245.907498
+L 287.141172 241.939696
+L 309.40974 235.842909
+L 331.678309 238.091723
+L 353.946877 235.88755
+L 353.946877 233.975147
+L 353.946877 224.620958
+L 353.946877 222.071696
+L 376.215446 224.340192
+L 398.484014 229.456987
+L 420.752583 226.852576
+L 443.021151 218.793347
+L 487.558288 212.086483
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1464,36 +1464,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.245158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.465663" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.185215" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="250.815726" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="256.972131" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="250.68918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="250.776129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="242.933961" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="248.641523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.946827" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.275296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="240.422132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="239.636642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="229.811193" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="246.620962" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="238.639344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="247.12478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="244.525995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="241.240731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="235.193168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="237.64039" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="235.876926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="233.02379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="224.243635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="222.392647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="223.386085" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="227.709253" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="225.863464" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="217.464282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="211.190187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="264.950293" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="255.212597" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="254.726019" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="251.160903" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="257.760676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="251.003143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="251.076355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.476592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="250.067214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.425546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.322187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.265253" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.007314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="230.022637" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="247.477045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="239.876956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="247.784629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="245.907498" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="241.939696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="235.842909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="238.091723" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="235.88755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="233.975147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="224.620958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="222.071696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="224.340192" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="229.456987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="226.852576" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="218.793347" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="212.086483" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2475,7 +2475,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2594,7 +2594,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-sd-products.svg
+++ b/reports/figures/hexbz-runtime-degree-sd-products.svg
@@ -1264,16 +1264,16 @@ z
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 86.724055 265.34426
-L 86.724055 264.723329
-L 113.446338 228.354469
-L 113.446338 224.799518
-L 113.446338 213.246219
-L 166.890902 179.565163
-L 166.890902 128.190977
-L 193.613184 128.565235
-L 200.293755 70.261813
-L 247.057749 46.893458
+    <path d="M 86.724055 266.40676
+L 86.724055 264.310358
+L 113.446338 229.616918
+L 113.446338 225.92691
+L 113.446338 214.108215
+L 166.890902 181.243726
+L 166.890902 128.952208
+L 193.613184 129.504676
+L 200.293755 70.5479
+L 247.057749 46.848337
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1289,16 +1289,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.34426" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="264.723329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="228.354469" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="224.799518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="213.246219" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="179.565163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="128.190977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.613184" y="128.565235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.293755" y="70.261813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="46.893458" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="266.40676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="264.310358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="229.616918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="225.92691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="214.108215" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="181.243726" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="128.952208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.613184" y="129.504676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.293755" y="70.5479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="46.848337" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_92">
@@ -2088,7 +2088,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2148,6 +2148,31 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2195,7 +2220,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
@@ -632,8 +632,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.068399
-L 507.6 270.068399
+      <path d="M 66.682344 270.110224
+L 507.6 270.110224
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -643,12 +643,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.068399" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.110224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 273.867227) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 273.909052) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-58" d="M 544 1381
 L 544 3500
@@ -714,18 +714,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 222.868731
-L 507.6 222.868731
+      <path d="M 66.682344 223.005448
+L 507.6 223.005448
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="222.868731" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.005448" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 226.667559) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 226.804276) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -734,18 +734,18 @@ L 507.6 222.868731
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 175.669063
-L 507.6 175.669063
+      <path d="M 66.682344 175.900672
+L 507.6 175.900672
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="175.669063" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="175.900672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 179.467891) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 179.6995) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -755,18 +755,18 @@ L 507.6 175.669063
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 128.469394
-L 507.6 128.469394
+      <path d="M 66.682344 128.795895
+L 507.6 128.795895
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="128.469394" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="128.795895" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 132.268222) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 132.594724) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -777,18 +777,18 @@ L 507.6 128.469394
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 81.269726
-L 507.6 81.269726
+      <path d="M 66.682344 81.691119
+L 507.6 81.691119
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="81.269726" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="81.691119" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 85.068554) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 85.489947) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -796,18 +796,18 @@ L 507.6 81.269726
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 34.070057
-L 507.6 34.070057
+      <path d="M 66.682344 34.586343
+L 507.6 34.586343
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="34.070057" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="34.586343" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 37.868885) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 38.385171) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -816,8 +816,8 @@ L 507.6 34.070057
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 303.059552
-L 507.6 303.059552
+      <path d="M 66.682344 303.03505
+L 507.6 303.03505
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -827,571 +827,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.059552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.03505" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.748103
-L 507.6 294.748103
+      <path d="M 66.682344 294.740311
+L 507.6 294.740311
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.748103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.740311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.851036
-L 507.6 288.851036
+      <path d="M 66.682344 288.855099
+L 507.6 288.855099
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.851036" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.855099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.276915
-L 507.6 284.276915
+      <path d="M 66.682344 284.290175
+L 507.6 284.290175
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.276915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.290175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.539587
-L 507.6 280.539587
+      <path d="M 66.682344 280.56036
+L 507.6 280.56036
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.539587" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.56036" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.37972
-L 507.6 277.37972
+      <path d="M 66.682344 277.406847
+L 507.6 277.406847
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.37972" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.406847" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.64252
-L 507.6 274.64252
+      <path d="M 66.682344 274.675149
+L 507.6 274.675149
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.64252" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.675149" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.228138
-L 507.6 272.228138
+      <path d="M 66.682344 272.265621
+L 507.6 272.265621
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.228138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.265621" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 255.859883
-L 507.6 255.859883
+      <path d="M 66.682344 255.930274
+L 507.6 255.930274
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="255.859883" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="255.930274" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.548434
-L 507.6 247.548434
+      <path d="M 66.682344 247.635534
+L 507.6 247.635534
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.548434" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.635534" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.651367
-L 507.6 241.651367
+      <path d="M 66.682344 241.750323
+L 507.6 241.750323
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.651367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.750323" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.077247
-L 507.6 237.077247
+      <path d="M 66.682344 237.185399
+L 507.6 237.185399
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.077247" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.185399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.339918
-L 507.6 233.339918
+      <path d="M 66.682344 233.455584
+L 507.6 233.455584
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.339918" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.455584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.180052
-L 507.6 230.180052
+      <path d="M 66.682344 230.30207
+L 507.6 230.30207
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.180052" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.30207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.442851
-L 507.6 227.442851
+      <path d="M 66.682344 227.570373
+L 507.6 227.570373
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.442851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.570373" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.028469
-L 507.6 225.028469
+      <path d="M 66.682344 225.160844
+L 507.6 225.160844
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.028469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.160844" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 208.660215
-L 507.6 208.660215
+      <path d="M 66.682344 208.825497
+L 507.6 208.825497
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.660215" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.825497" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.348766
-L 507.6 200.348766
+      <path d="M 66.682344 200.530758
+L 507.6 200.530758
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.348766" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.530758" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 194.451699
-L 507.6 194.451699
+      <path d="M 66.682344 194.645547
+L 507.6 194.645547
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.451699" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.645547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 189.877579
-L 507.6 189.877579
+      <path d="M 66.682344 190.080622
+L 507.6 190.080622
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="189.877579" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.080622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.14025
-L 507.6 186.14025
+      <path d="M 66.682344 186.350807
+L 507.6 186.350807
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.14025" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.350807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 182.980384
-L 507.6 182.980384
+      <path d="M 66.682344 183.197294
+L 507.6 183.197294
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.980384" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.197294" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 180.243183
-L 507.6 180.243183
+      <path d="M 66.682344 180.465596
+L 507.6 180.465596
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.243183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.465596" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 177.828801
-L 507.6 177.828801
+      <path d="M 66.682344 178.056068
+L 507.6 178.056068
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="177.828801" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.056068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 161.460547
-L 507.6 161.460547
+      <path d="M 66.682344 161.720721
+L 507.6 161.720721
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.460547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.720721" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 153.149098
-L 507.6 153.149098
+      <path d="M 66.682344 153.425982
+L 507.6 153.425982
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.149098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.425982" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 147.252031
-L 507.6 147.252031
+      <path d="M 66.682344 147.54077
+L 507.6 147.54077
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.252031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.54077" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 142.67791
-L 507.6 142.67791
+      <path d="M 66.682344 142.975846
+L 507.6 142.975846
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="142.67791" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="142.975846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 138.940582
-L 507.6 138.940582
+      <path d="M 66.682344 139.246031
+L 507.6 139.246031
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.940582" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.246031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 135.780715
-L 507.6 135.780715
+      <path d="M 66.682344 136.092518
+L 507.6 136.092518
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.780715" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.092518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 133.043515
-L 507.6 133.043515
+      <path d="M 66.682344 133.36082
+L 507.6 133.36082
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.043515" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.36082" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 130.629133
-L 507.6 130.629133
+      <path d="M 66.682344 130.951292
+L 507.6 130.951292
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.629133" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.951292" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 114.260878
-L 507.6 114.260878
+      <path d="M 66.682344 114.615945
+L 507.6 114.615945
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="114.260878" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="114.615945" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 105.949429
-L 507.6 105.949429
+      <path d="M 66.682344 106.321205
+L 507.6 106.321205
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="105.949429" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.321205" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 100.052362
-L 507.6 100.052362
+      <path d="M 66.682344 100.435994
+L 507.6 100.435994
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.052362" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.435994" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 95.478242
-L 507.6 95.478242
+      <path d="M 66.682344 95.87107
+L 507.6 95.87107
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.478242" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.87107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 91.740913
-L 507.6 91.740913
+      <path d="M 66.682344 92.141255
+L 507.6 92.141255
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.740913" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.141255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 88.581047
-L 507.6 88.581047
+      <path d="M 66.682344 88.987741
+L 507.6 88.987741
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="88.581047" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="88.987741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 85.843846
-L 507.6 85.843846
+      <path d="M 66.682344 86.256044
+L 507.6 86.256044
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="85.843846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.256044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 83.429464
-L 507.6 83.429464
+      <path d="M 66.682344 83.846515
+L 507.6 83.846515
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="83.429464" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="83.846515" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 67.06121
-L 507.6 67.06121
+      <path d="M 66.682344 67.511168
+L 507.6 67.511168
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="67.06121" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="67.511168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 58.749761
-L 507.6 58.749761
+      <path d="M 66.682344 59.216429
+L 507.6 59.216429
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="58.749761" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.216429" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 52.852694
-L 507.6 52.852694
+      <path d="M 66.682344 53.331218
+L 507.6 53.331218
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="52.852694" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.331218" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 48.278573
-L 507.6 48.278573
+      <path d="M 66.682344 48.766293
+L 507.6 48.766293
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.278573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.766293" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 44.541245
-L 507.6 44.541245
+      <path d="M 66.682344 45.036478
+L 507.6 45.036478
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="44.541245" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.036478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 41.381379
-L 507.6 41.381379
+      <path d="M 66.682344 41.882965
+L 507.6 41.882965
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.381379" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.882965" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 38.644178
-L 507.6 38.644178
+      <path d="M 66.682344 39.151267
+L 507.6 39.151267
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.644178" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.151267" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 36.229796
-L 507.6 36.229796
+      <path d="M 66.682344 36.741739
+L 507.6 36.741739
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.229796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.741739" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1479,17 +1479,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 283.347973
-L 86.724055 283.261956
-L 99.654192 259.721894
-L 99.654192 259.209261
-L 99.654192 259.140465
-L 125.514465 227.108268
-L 125.514465 225.478534
-L 125.514465 225.121653
-L 177.235011 136.861642
-L 177.235011 136.029335
-L 177.235011 135.114629
+    <path d="M 86.724055 283.706942
+L 86.724055 280.131531
+L 99.654192 260.779216
+L 99.654192 260.440548
+L 99.654192 259.798232
+L 125.514465 227.974979
+L 125.514465 226.322911
+L 125.514465 226.12581
+L 177.235011 137.21795
+L 177.235011 136.95996
+L 177.235011 135.674601
 L 280.676104 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1506,36 +1506,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.347973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.261956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="259.721894" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="259.209261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="259.140465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="227.108268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="225.478534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="225.121653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="136.861642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="136.029335" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="135.114629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.706942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="280.131531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="260.779216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="260.440548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="259.798232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="227.974979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="226.322911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="226.12581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="137.21795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="136.95996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="135.674601" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="280.676104" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 86.724055 289.899238
-L 99.654192 284.05469
-L 99.654192 283.013373
-L 99.654192 276.709371
-L 125.514465 254.498186
-L 125.514465 254.427243
-L 125.514465 251.917826
-L 177.235011 223.847711
-L 177.235011 223.634584
-L 177.235011 220.203188
-L 280.676104 190.396397
-L 280.676104 190.288417
-L 280.676104 189.823194
-L 487.558288 149.690562
+L 86.724055 289.901194
+L 99.654192 284.068396
+L 99.654192 283.029172
+L 99.654192 276.737845
+L 125.514465 254.571314
+L 125.514465 254.500514
+L 125.514465 251.996142
+L 177.235011 223.98246
+L 177.235011 223.769761
+L 177.235011 220.345264
+L 280.676104 190.598398
+L 280.676104 190.490635
+L 280.676104 190.026347
+L 487.558288 149.9744
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1546,38 +1546,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.899238" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.05469" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.013373" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.709371" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.498186" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.427243" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="251.917826" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.847711" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.634584" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="220.203188" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.396397" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.288417" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="189.823194" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="149.690562" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.901194" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.068396" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.029172" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.737845" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.571314" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.500514" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="251.996142" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.98246" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.769761" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="220.345264" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.598398" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.490635" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.026347" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="149.9744" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.13891
-L 86.724055 273.172687
-L 99.654192 259.615628
-L 99.654192 259.364445
-L 99.654192 253.258048
-L 125.514465 240.459405
-L 125.514465 240.097516
-L 125.514465 234.029197
-L 177.235011 205.223011
-L 177.235011 204.91871
-L 177.235011 201.033297
-L 280.676104 173.153638
-L 280.676104 172.954378
-L 280.676104 169.629894
-L 487.558288 129.536723
+    <path d="M 86.724055 275.170541
+L 86.724055 273.208271
+L 99.654192 259.678468
+L 99.654192 259.42779
+L 99.654192 253.333669
+L 125.514465 240.560757
+L 125.514465 240.199596
+L 125.514465 234.143477
+L 177.235011 205.395204
+L 177.235011 205.091515
+L 177.235011 201.213913
+L 280.676104 173.390304
+L 280.676104 173.191445
+L 280.676104 169.873644
+L 487.558288 129.861078
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1587,39 +1587,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.13891" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.172687" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.615628" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.364445" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.258048" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.459405" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.097516" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="234.029197" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.223011" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="204.91871" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="201.033297" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.153638" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="172.954378" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="169.629894" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="129.536723" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.170541" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.208271" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.678468" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.42779" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.333669" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.560757" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.199596" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="234.143477" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.395204" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.091515" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="201.213913" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.390304" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.191445" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="169.873644" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="129.861078" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.572316
-L 86.724055 287.732651
-L 99.654192 279.47319
-L 99.654192 278.073644
-L 99.654192 273.700064
-L 125.514465 262.782369
-L 125.514465 262.174145
-L 125.514465 255.373328
-L 177.235011 224.958484
-L 177.235011 224.247816
-L 177.235011 221.793735
-L 280.676104 191.55797
-L 280.676104 191.141051
-L 280.676104 187.331182
-L 487.558288 145.252808
+    <path d="M 86.724055 289.574929
+L 86.724055 287.738963
+L 99.654192 279.496107
+L 99.654192 278.099375
+L 99.654192 273.734588
+L 125.514465 262.838842
+L 125.514465 262.231841
+L 125.514465 255.444697
+L 177.235011 225.091
+L 177.235011 224.381761
+L 177.235011 221.932613
+L 280.676104 191.757635
+L 280.676104 191.341554
+L 280.676104 187.539345
+L 487.558288 145.545567
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1638,35 +1638,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.572316" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.732651" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.47319" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.073644" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.700064" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.782369" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.174145" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.373328" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.958484" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.247816" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="221.793735" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.55797" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.141051" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="187.331182" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="145.252808" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.574929" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.738963" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.496107" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.099375" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.734588" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.838842" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.231841" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.444697" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="225.091" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.381761" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="221.932613" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.757635" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.341554" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="187.539345" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="145.545567" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.673638
-L 86.724055 266.58615
-L 99.654192 248.862855
-L 99.654192 248.386152
-L 99.654192 241.845586
-L 125.514465 219.201508
-L 125.514465 218.945455
-L 125.514465 218.572844
-L 177.235011 167.749963
-L 177.235011 167.612232
-L 177.235011 158.94604
+    <path d="M 86.724055 278.698163
+L 86.724055 266.634976
+L 99.654192 248.947313
+L 99.654192 248.471567
+L 99.654192 241.944151
+L 125.514465 219.345597
+L 125.514465 219.09006
+L 125.514465 218.718197
+L 177.235011 167.997493
+L 177.235011 167.860039
+L 177.235011 159.21127
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1683,28 +1683,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.673638" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="266.58615" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.862855" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.386152" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="241.845586" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.201508" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.945455" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.572844" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="167.749963" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="167.612232" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="158.94604" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.698163" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="266.634976" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.947313" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.471567" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="241.944151" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.345597" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.09006" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.718197" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="167.997493" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="167.860039" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="159.21127" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.04662
-L 86.724055 252.292111
-L 99.654192 180.163632
-L 99.654192 179.860875
-L 99.654192 178.607085
-L 125.514465 80.461785
-L 125.514465 74.090319
-L 125.514465 72.742002
+    <path d="M 86.724055 259.110604
+L 86.724055 252.369674
+L 99.654192 180.386205
+L 99.654192 180.084057
+L 99.654192 178.832787
+L 125.514465 80.884803
+L 125.514465 74.526146
+L 125.514465 73.18054
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1717,14 +1717,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.04662" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.292111" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.163632" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="179.860875" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="178.607085" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="80.461785" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="74.090319" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="72.742002" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.110604" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.369674" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.386205" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.084057" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="178.832787" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="80.884803" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="74.526146" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="73.18054" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2327,7 +2327,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2387,6 +2387,31 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2434,7 +2459,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-wilkinson.svg
+++ b/reports/figures/hexbz-runtime-degree-wilkinson.svg
@@ -1298,21 +1298,21 @@ z
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 86.724055 268.45617
-L 102.140757 257.490369
-L 117.557458 248.089173
-L 132.974159 227.919994
-L 148.39086 220.295943
-L 163.807562 212.095487
-L 179.224263 204.604571
-L 194.640964 195.66191
-L 210.057666 188.752589
-L 240.891068 177.700795
-L 271.724471 167.605058
-L 302.557873 161.817104
-L 364.224678 153.714834
-L 425.891483 140.048803
-L 487.558288 133.486814
+    <path d="M 86.724055 270.812205
+L 102.140757 258.146047
+L 117.557458 248.047214
+L 132.974159 228.318631
+L 148.39086 220.89654
+L 163.807562 212.405472
+L 179.224263 204.485264
+L 194.640964 195.852183
+L 210.057666 188.965705
+L 240.891068 177.882264
+L 271.724471 167.475151
+L 302.557873 161.613737
+L 364.224678 153.621461
+L 425.891483 139.760801
+L 487.558288 133.290427
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1328,21 +1328,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="268.45617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="102.140757" y="257.490369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="248.089173" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.974159" y="227.919994" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="220.295943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.807562" y="212.095487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="204.604571" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="194.640964" y="195.66191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="188.752589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="177.700795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="167.605058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="161.817104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="153.714834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="140.048803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="133.486814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.812205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="102.140757" y="258.146047" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="248.047214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.974159" y="228.318631" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="220.89654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.807562" y="212.405472" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="204.485264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="194.640964" y="195.852183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="188.965705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="177.882264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="167.475151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="161.613737" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="153.621461" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="139.760801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="133.290427" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_100">
@@ -2168,7 +2168,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 44 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 45 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2275,7 +2275,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-17" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-17" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/hexbz-hoisted-pivot-row.md
+++ b/reports/hexbz-hoisted-pivot-row.md
@@ -1,0 +1,418 @@
+# Hoisting the packed pivot-row read (issue #9166)
+
+[reports/hexbz-packed-kernel-attribution.md](hexbz-packed-kernel-attribution.md)
+measured `Hex.Matrix.getRow`'s source-row copy inside
+`Hex.Berlekamp.Packed.rowAdd` at 70.4% of the packed reduction on
+`cyclo_phi385`, 71.5% on `cyclo_phi128_x_phi165` and 63.7% on `randprod_21`, as
+the median of eight within-repeat paired differences. This page records what
+happened when that read was hoisted out of the row addition and taken once per
+pivot column instead.
+
+**The packed reduction on `cyclo_phi385` goes from 45.095 ms to 13.260 ms,
+0.29x, and the whole `Hex.ZPoly.factorize` call on that row goes from 143.566 ms
+to 115.069 ms, 0.80x.** The reduction is now **0.83x the prototype it was
+2.80x slower than**, and 0.82x on `cyclo_phi128_x_phi165` against 2.76x before,
+which is what #9160 projected from the `hoistedPivotRow` ladder rung.
+
+The saving tracks one count and nothing else: the pivot row was read once per
+row addition and is now read once per pivot column, so a row saves
+`rowAdds - pivots` copies of `n` words. On the two rows where those counts are
+equal (`xpow24_minus1`, 11 and 11) or both zero (the three Wilkinson rows) there
+is no saving to have, and none is measured.
+
+## Revision and protocol
+
+- Source revision `dcecc57e`, this PR's first commit: `a5a55cbf` plus the hoist.
+  Lean toolchain `leanprover/lean4:v4.33.0-rc1`.
+- Host `chungus2`, AMD EPYC 9455, Linux x86-64, 96 cores, measured 2026-08-05.
+  The host was shared with other work throughout. The driver pins itself to one
+  idle logical CPU before spawning any service; all three runs below landed on
+  cpu 1.
+- Three runs, in the order **after, before, after**, so the before run is
+  bracketed by two after runs on the same host within six minutes:
+
+  | record | `hexbz_factor_service` SHA-256 | `HexBerlekamp/PackedKernel.lean` |
+  |---|---|---|
+  | `hexbz-phase-profile-dcecc57e-chungus2.json` | `fcc8436a...` | hoisted |
+  | `hexbz-phase-profile-a5a55cbf-chungus2.json` | `f2865db2...` | at `a5a55cbf`, the parent commit |
+  | `hexbz-phase-profile-dcecc57e-chungus2-rerun.json` | `fcc8436a...` | hoisted |
+
+  The before run was taken with `HexBerlekamp/PackedKernel.lean` and
+  `bench/HexBench/BerlekampKernel.lean` checked out at the parent commit and the
+  rest of the tree unchanged, so all three records carry the same `git_commit`
+  (`55fc3bee`, this branch's pre-rebase SHA for the tree the runs were taken on)
+  with `git_dirty` set. The service binary's SHA-256 is what distinguishes them,
+  and the two after runs share one binary.
+- Record SHA-256s:
+  `2b3c505288973e75e9173a852cd85bfb6df0d63d1ca0cf6d636655e54d702390`,
+  `17e6ce73388727eed4ae585ece66f5795503cf45e686d4af9bb749b1cc1238f3`,
+  `1a18cff40b47b3110988b0d10aee1bf2ad88a5cda49187952279bb6114fa2a42`;
+  corpus `bench/corpus/hexbz-factor-corpus.jsonl`, SHA-256
+  `619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d`.
+- Eight repeats per instance per run, in one process, with the ladder rungs and
+  the prototype variants run in alternating directions. Every rung's reduction
+  is kept per repeat in `reduceNanosSamples`, so every difference *within* a run
+  is a median of within-repeat paired differences, and every table below that
+  compares one run against another states both runs' full sample ranges rather
+  than a paired difference, because there is no pairing across processes.
+- Every ladder rung, the stage mirror and the four prototype variants are
+  compared against `Hex.Matrix.nullspace` on all 24 rows in each run, and the
+  driver exits non-zero on any disagreement. All three runs agreed on 24 of 24,
+  and the wider validation sample agreed with the production `factorTrace` on
+  368 of 368 instances in each.
+
+## What changed
+
+`Packed.eliminateColumn` reads the pivot row once, before the fold, and threads
+it into the new `Packed.rowAddFrom`:
+
+```lean
+def eliminateColumn (q : UInt32) (A : Matrix UInt32 n m) (pivotRow : Fin n)
+    (col : Fin m) : Matrix UInt32 n m :=
+  let rsrc := Matrix.getRow A pivotRow
+  (List.finRange n).foldl
+    (fun A j =>
+      if j = pivotRow then A
+      else
+        let c := negMod q A[(j, col)]
+        if c == 0 then A else rowAddFrom q A rsrc j c)
+    A
+```
+
+`Packed.rowAdd` is retained, defined as `rowAddFrom` on `Matrix.getRow A src`,
+so its existing correspondence lemma is a one-line consequence of
+`Rep.rowAddFrom` and nothing outside the elimination changed shape.
+
+The correspondence proof carries one extra invariant through
+`rep_eliminateColumn_foldl`: `∀ k, rsrc[k] = A[pivotRow][k]` for the accumulated
+buffer `A` at every step. `elim_step_pivotRow` establishes preservation from the
+step either doing nothing or writing a row `j ≠ pivotRow`, and the invariant
+holds at entry by `rfl`. No `axiom`, `sorry`, `native_decide` or unchecked
+oracle.
+
+**Aliasing.** `Matrix.getRow` is `Vector.ofFn`, a fresh allocation, so the
+hoisted row is not a borrow of `A`'s backing buffer and `A` stays uniquely
+referenced through the fold. This is the trap #9166 named: a borrow would leave
+the buffer multiply referenced and turn every row addition into a whole-matrix
+copy. The measured direction rules that out on its own, but the reason it is
+safe is the `ofFn`, not the measurement.
+
+## The reduction, before and after
+
+`integrated` is the production `Packed.reduce`, no mirror and no ladder
+parameter. "reads saved" is `rowAdds - pivots`: the number of `n`-word row
+copies the hoist removes.
+
+| instance | n | row additions | pivots | reads saved | `integrated` before | `integrated` after | after (rerun) | after/before |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `sd5` | 32 | 215 | 16 | 199 | 87.845 us | 35.397 us | 35.062 us | 0.40x |
+| `sd5_shift1` | 32 | 449 | 16 | 433 | 174.423 us | 57.405 us | 57.090 us | 0.33x |
+| `sd5_shift2` | 32 | 455 | 16 | 439 | 173.642 us | 57.841 us | 58.106 us | 0.33x |
+| `sd4_x_sd4shift1` | 32 | 444 | 16 | 428 | 169.366 us | 57.245 us | 57.010 us | 0.34x |
+| `sd5_x_phi11` | 42 | 935 | 25 | 910 | 448.610 us | 142.151 us | 141.489 us | 0.32x |
+| `xpow48_minus1` | 48 | 38 | 29 | 9 | 44.476 us | 42.473 us | 41.627 us | 0.95x |
+| `xpow105_minus1` | 105 | 175 | 91 | 84 | 340.325 us | 280.922 us | 277.791 us | 0.83x |
+| `xpow120_minus1` | 120 | 116 | 81 | 35 | 301.046 us | 277.156 us | 273.365 us | 0.92x |
+| `cyclo_phi179` | 178 | 1114 | 176 | 938 | 2.540 ms | 1.307 ms | 1.296 ms | 0.51x |
+| `cyclo_phi64_x_phi105` | 80 | 4277 | 70 | 4207 | 3.642 ms | 1.116 ms | 1.112 ms | 0.31x |
+| `cyclo_phi128_x_phi165` | 144 | 13149 | 136 | 13013 | 19.529 ms | 5.739 ms | 5.736 ms | 0.29x |
+| `cyclo_phi385` | 240 | 17948 | 236 | 17712 | 45.095 ms | 13.260 ms | 13.282 ms | 0.29x |
+| `wilkinson_40` | 40 | 0 | 0 | 0 | 3.605 us | 3.666 us | 3.675 us | 1.02x |
+| `wilkinson_48` | 48 | 0 | 0 | 0 | 5.013 us | 5.107 us | 5.213 us | 1.02x |
+| `wilkinson_56` | 56 | 0 | 0 | 0 | 6.685 us | 6.835 us | 6.891 us | 1.02x |
+| `chebyshev_T24` (control) | 24 | 112 | 21 | 91 | 41.892 us | 23.820 us | 23.415 us | 0.57x |
+| `chebyshev_U24` (control) | 24 | 98 | 20 | 78 | 36.859 us | 22.172 us | 21.392 us | 0.60x |
+| `legendre_P30` (control) | 30 | 315 | 23 | 292 | 119.517 us | 48.361 us | 47.806 us | 0.40x |
+| `legendre_P38` (control) | 38 | 620 | 35 | 585 | 283.300 us | 105.717 us | 104.290 us | 0.37x |
+| `cyclo_phi17` (control) | 16 | 50 | 15 | 35 | 15.057 us | 10.486 us | 10.255 us | 0.70x |
+| `cyclo_phi41` (control) | 40 | 100 | 35 | 65 | 68.492 us | 50.264 us | 49.389 us | 0.73x |
+| `xpow24_minus1` (control) | 24 | 11 | 11 | 0 | 8.773 us | 9.114 us | 8.889 us | 1.04x |
+| `randprod_10` (control) | 20 | 233 | 16 | 217 | 63.003 us | 24.916 us | 24.531 us | 0.40x |
+| `randprod_21` (control) | 24 | 353 | 17 | 336 | 106.894 us | 38.416 us | 38.062 us | 0.36x |
+
+The full sample ranges, since these are cross-run comparisons and the medians
+above are not paired:
+
+| instance | before range | after range | after (rerun) range |
+|---|---:|---:|---:|
+| `sd5` | 86.699 us to 89.022 us | 35.213 us to 35.803 us | 34.622 us to 35.443 us |
+| `sd5_shift1` | 171.414 us to 189.241 us | 57.195 us to 57.846 us | 56.854 us to 57.746 us |
+| `sd5_shift2` | 170.042 us to 177.994 us | 57.596 us to 61.521 us | 57.395 us to 58.988 us |
+| `sd4_x_sd4shift1` | 164.454 us to 183.592 us | 56.714 us to 57.496 us | 56.654 us to 57.805 us |
+| `sd5_x_phi11` | 442.707 us to 457.508 us | 141.470 us to 142.451 us | 140.548 us to 142.401 us |
+| `xpow48_minus1` | 43.184 us to 47.961 us | 41.632 us to 42.983 us | 41.081 us to 47.771 us |
+| `xpow105_minus1` | 337.340 us to 343.098 us | 276.880 us to 283.991 us | 273.726 us to 284.442 us |
+| `xpow120_minus1` | 295.478 us to 303.420 us | 266.335 us to 284.061 us | 267.537 us to 276.700 us |
+| `cyclo_phi179` | 2.527 ms to 2.561 ms | 1.298 ms to 1.318 ms | 1.267 ms to 1.325 ms |
+| `cyclo_phi64_x_phi105` | 3.616 ms to 3.674 ms | 1.108 ms to 1.120 ms | 1.106 ms to 1.137 ms |
+| `cyclo_phi128_x_phi165` | 18.760 ms to 19.996 ms | 5.722 ms to 5.778 ms | 5.716 ms to 5.765 ms |
+| `cyclo_phi385` | 44.090 ms to 45.406 ms | 13.225 ms to 13.302 ms | 13.223 ms to 13.317 ms |
+| `wilkinson_40` | 3.575 us to 3.616 us | 3.616 us to 3.846 us | 3.645 us to 3.715 us |
+| `wilkinson_48` | 4.987 us to 5.047 us | 5.078 us to 5.248 us | 5.148 us to 6.249 us |
+| `wilkinson_56` | 6.640 us to 6.710 us | 6.770 us to 6.881 us | 6.870 us to 6.920 us |
+| `chebyshev_T24` (control) | 41.281 us to 46.509 us | 23.715 us to 24.196 us | 23.325 us to 23.485 us |
+| `chebyshev_U24` (control) | 36.544 us to 37.435 us | 21.982 us to 22.323 us | 21.262 us to 21.472 us |
+| `legendre_P30` (control) | 118.135 us to 122.773 us | 48.182 us to 51.797 us | 47.160 us to 50.895 us |
+| `legendre_P38` (control) | 280.516 us to 286.615 us | 105.246 us to 106.167 us | 104.055 us to 104.485 us |
+| `cyclo_phi17` (control) | 14.711 us to 15.283 us | 10.405 us to 10.606 us | 10.185 us to 10.336 us |
+| `cyclo_phi41` (control) | 67.821 us to 101.300 us | 49.864 us to 50.465 us | 49.273 us to 50.005 us |
+| `xpow24_minus1` (control) | 8.673 us to 8.973 us | 9.004 us to 9.164 us | 8.742 us to 9.054 us |
+| `randprod_10` (control) | 60.710 us to 63.795 us | 24.707 us to 25.057 us | 24.336 us to 24.616 us |
+| `randprod_21` (control) | 104.856 us to 118.616 us | 38.156 us to 38.697 us | 37.876 us to 38.216 us |
+
+### The rows that do not improve, and why they do not
+
+Four rows are at or above 1.00x. **They are the four rows with nothing to save,
+and one of them proves that the residual is not the change.**
+
+The three Wilkinson rows find **no pivot column at all**: `pivots` is 0, so
+`eliminateColumn` is never called on them and the hoisted read never executes.
+Their 1.02x is therefore an artifact of comparing two different binaries in two
+different processes, not of the change, and it bounds this report's cross-run
+noise floor at about 2% on a 3 to 7 us span. `xpow24_minus1` has 11 pivots and
+11 row additions, so the hoist replaces 11 reads with 11 reads and saves
+exactly nothing; it measures 1.04x in one after run and 1.01x in the other,
+inside the same floor.
+
+`xpow48_minus1` (9 reads saved of 38) and `xpow120_minus1` (35 of 116) are the
+genuinely small savings, at 0.95x and 0.92x, and both reproduce in the second
+after run. These are the rows #9160 already flagged as dominated by already-zero
+columns rather than by arithmetic, and the `List.finRange n` scan they are
+dominated by is explicitly out of this issue's scope.
+
+## The hoist is where it was measured
+
+`mirrored - hoistedPivotRow` is the paired within-run difference #9160 used to
+attribute the copy. `mirrored` runs the production `Packed.eliminateColumn`
+through the ladder, so after this change both rungs read the pivot row once per
+column and their difference should collapse to nothing. It does.
+
+| instance | before (paired median) | before paired range | after (paired median) | after paired range |
+|---|---:|---:|---:|---:|
+| `sd5` | 52.418 us | 49.875 us to 53.670 us | 256 ns | -390 ns to 661 ns |
+| `sd5_shift1` | 116.077 us | 112.896 us to 124.264 us | -20 ns | -190 ns to 441 ns |
+| `sd5_shift2` | 114.109 us | 112.477 us to 119.598 us | 341 ns | 109 ns to 2.805 us |
+| `sd4_x_sd4shift1` | 111.706 us | 107.700 us to 116.182 us | 410 ns | -60 ns to 690 ns |
+| `sd5_x_phi11` | 304.687 us | 299.504 us to 312.944 us | 216 ns | -3.925 us to 370 ns |
+| `xpow48_minus1` | 2.679 us | 2.123 us to 3.485 us | 135 ns | -300 ns to 4.226 us |
+| `xpow105_minus1` | 62.508 us | 47.080 us to 65.538 us | 2.168 us | 1.052 us to 3.705 us |
+| `xpow120_minus1` | 30.275 us | 28.351 us to 35.122 us | 1.407 us | -3.115 us to 9.055 us |
+| `cyclo_phi179` | 1.244 ms | 1.232 ms to 1.259 ms | -196 ns | -4.247 us to 8.102 us |
+| `cyclo_phi64_x_phi105` | 2.529 ms | 2.492 ms to 2.568 ms | 1.391 us | -4.787 us to 8.663 us |
+| `cyclo_phi128_x_phi165` | 13.836 ms | 13.111 ms to 14.293 ms | 722 ns | -57.355 us to 24.167 us |
+| `cyclo_phi385` | 31.606 ms | 30.766 ms to 32.138 ms | 16.841 us | -73.248 us to 35.292 us |
+| `wilkinson_40` | 105 ns | -29 ns to 621 ns | 10 ns | -2.514 us to 220 ns |
+| `wilkinson_48` | 60 ns | -110 ns to 301 ns | 5 ns | -2.754 us to 171 ns |
+| `wilkinson_56` | 106 ns | -10 ns to 271 ns | 70 ns | -10 ns to 261 ns |
+| `chebyshev_T24` (control) | 17.826 us | 16.805 us to 21.993 us | 170 ns | -90 ns to 3.585 us |
+| `chebyshev_U24` (control) | 15.222 us | 11.698 us to 29.173 us | -5 ns | -410 ns to 230 ns |
+| `legendre_P30` (control) | 72.151 us | 69.854 us to 86.048 us | 130 ns | -3.325 us to 762 ns |
+| `legendre_P38` (control) | 178.304 us | 149.262 us to 185.825 us | 356 ns | -2.373 us to 4.787 us |
+| `cyclo_phi17` (control) | 4.796 us | 4.528 us to 5.027 us | 70 ns | -11 ns to 221 ns |
+| `cyclo_phi41` (control) | 19.840 us | 19.218 us to 19.970 us | 246 ns | -191 ns to 3.846 us |
+| `xpow24_minus1` (control) | -320 ns | -381 ns to -140 ns | 0 ns | -210 ns to 70 ns |
+| `randprod_10` (control) | 38.077 us | 36.384 us to 39.389 us | 136 ns | -80 ns to 240 ns |
+| `randprod_21` (control) | 68.286 us | 66.538 us to 73.389 us | 176 ns | -1.933 us to 331 ns |
+
+Both columns are within-run paired medians. The before column reproduces
+#9160's, taken on the same host four commits earlier, within about 1%
+on every arithmetic row: 31.606 ms against 31.378 ms on `cyclo_phi385`,
+68.286 us against 67.320 us on `randprod_21`.
+
+On `cyclo_phi385` the difference goes from 31.606 ms to 16.841 us, 0.1% of the
+rung, and its paired range now straddles zero on 12 of 24 rows. Every remaining
+positive median is under 1% and is the ladder's own scaffolding.
+
+The other direction of the same check: `integrated` after (13.260 ms and
+13.282 ms on `cyclo_phi385`) lands on `hoistedPivotRow` before (13.225 ms in the
+`a5a55cbf` run), within 0.4%. That is the check #9166's verification asked for.
+
+## Against the prototype
+
+`flatBuffer` is the benchmark prototype the 2.6x was measured against, run on
+the packed buffer in the same process. It did not change.
+
+| instance | `integrated`/prototype before | after |
+|---|---:|---:|
+| `sd5` | 2.58x | 1.04x |
+| `sd5_shift1` | 2.85x | 0.95x |
+| `sd5_shift2` | 2.84x | 0.95x |
+| `sd4_x_sd4shift1` | 2.80x | 0.95x |
+| `sd5_x_phi11` | 2.84x | 0.91x |
+| `xpow48_minus1` | 1.65x | 1.56x |
+| `xpow105_minus1` | 1.85x | 1.53x |
+| `xpow120_minus1` | 1.76x | 1.61x |
+| `cyclo_phi179` | 2.37x | 1.21x |
+| `cyclo_phi64_x_phi105` | 2.77x | 0.86x |
+| `cyclo_phi128_x_phi165` | 2.76x | 0.82x |
+| `cyclo_phi385` | 2.80x | 0.83x |
+| `wilkinson_40` | 0.78x | 0.89x |
+| `wilkinson_48` | 0.82x | 0.90x |
+| `wilkinson_56` | 0.81x | 0.89x |
+| `chebyshev_T24` (control) | 2.26x | 1.31x |
+| `chebyshev_U24` (control) | 2.22x | 1.37x |
+| `legendre_P30` (control) | 2.57x | 1.05x |
+| `legendre_P38` (control) | 2.66x | 1.01x |
+| `cyclo_phi17` (control) | 1.97x | 1.37x |
+| `cyclo_phi41` (control) | 2.00x | 1.46x |
+| `xpow24_minus1` (control) | 1.46x | 1.53x |
+| `randprod_10` (control) | 2.76x | 1.09x |
+| `randprod_21` (control) | 2.83x | 1.03x |
+
+0.82x and 0.83x on the two heaviest rows, against the 0.82x to 0.83x #9160
+projected from the ladder. The rows still above 1.00x are the sparse ones, where
+the residual is the `List.finRange n` scan and the prototype's `Nat` range beats
+it; that is the second of the two findings this issue held out of scope.
+
+## End to end
+
+The reduction is one stage of one prime's Berlekamp split, so the end-to-end
+effect is bounded by that stage's share.
+
+| instance | `factor` before | `factor` after | after/before | `fixedSpaceKernelVectors` before | after | after/before |
+|---|---:|---:|---:|---:|---:|---:|
+| `sd5` | 68.848 ms | 68.875 ms | 1.00x | 1.357 ms | 1.303 ms | 0.96x |
+| `sd5_shift1` | 63.757 ms | 62.689 ms | 0.98x | 1.809 ms | 1.686 ms | 0.93x |
+| `sd5_shift2` | 66.329 ms | 65.302 ms | 0.98x | 1.802 ms | 1.686 ms | 0.94x |
+| `sd4_x_sd4shift1` | 17.970 ms | 17.662 ms | 0.98x | 1.806 ms | 1.699 ms | 0.94x |
+| `sd5_x_phi11` | 138.623 ms | 138.921 ms | 1.00x | 3.305 ms | 3.034 ms | 0.92x |
+| `xpow48_minus1` | 10.547 ms | 10.445 ms | 0.99x | 625.602 us | 615.347 us | 0.98x |
+| `xpow105_minus1` | 44.489 ms | 45.913 ms | 1.03x | 4.014 ms | 3.929 ms | 0.98x |
+| `xpow120_minus1` | 146.843 ms | 148.327 ms | 1.01x | 2.957 ms | 3.005 ms | 1.02x |
+| `cyclo_phi179` | 34.578 ms | 33.724 ms | 0.98x | 5.741 ms | 4.560 ms | 0.79x |
+| `cyclo_phi64_x_phi105` | 18.796 ms | 16.263 ms | 0.87x | 7.451 ms | 4.927 ms | 0.66x |
+| `cyclo_phi128_x_phi165` | 75.134 ms | 61.575 ms | 0.82x | 27.580 ms | 13.909 ms | 0.50x |
+| `cyclo_phi385` | 143.566 ms | 115.069 ms | 0.80x | 52.252 ms | 21.140 ms | 0.40x |
+| `wilkinson_40` | 9.179 ms | 9.329 ms | 1.02x | 218.554 us | 223.656 us | 1.02x |
+| `wilkinson_48` | 16.220 ms | 16.172 ms | 1.00x | 313.055 us | 322.558 us | 1.03x |
+| `wilkinson_56` | 20.907 ms | 20.932 ms | 1.00x | 498.213 us | 504.913 us | 1.01x |
+| `chebyshev_T24` (control) | 448.755 us | 420.604 us | 0.94x | 167.128 us | 149.596 us | 0.90x |
+| `chebyshev_U24` (control) | 597.456 us | 579.800 us | 0.97x | 126.738 us | 112.913 us | 0.89x |
+| `legendre_P30` (control) | 8.639 ms | 8.384 ms | 0.97x | 1.331 ms | 1.291 ms | 0.97x |
+| `legendre_P38` (control) | 3.925 ms | 3.682 ms | 0.94x | 2.685 ms | 2.509 ms | 0.93x |
+| `cyclo_phi17` (control) | 108.911 us | 102.873 us | 0.94x | 50.014 us | 45.397 us | 0.91x |
+| `cyclo_phi41` (control) | 2.023 ms | 1.992 ms | 0.98x | 248.388 us | 231.829 us | 0.93x |
+| `xpow24_minus1` (control) | 2.317 ms | 2.324 ms | 1.00x | 170.593 us | 168.515 us | 0.99x |
+| `randprod_10` (control) | 635.442 us | 604.046 us | 0.95x | 235.985 us | 199.240 us | 0.84x |
+| `randprod_21` (control) | 1.438 ms | 1.358 ms | 0.94x | 687.129 us | 623.859 us | 0.91x |
+
+`fixedSpaceKernelVectors` is one call each, not a median of eight, so its column
+carries the ordinary spread of a single observation. The end-to-end column is a
+median over the driver's `--repeats` end-to-end calls. The 1.03x on
+`xpow105_minus1` and 1.01x on `xpow120_minus1` are rows whose reduction improved
+and whose end-to-end time did not; on those rows the kernel is a small share of
+`factor` and the difference is between-run drift on a 45 to 148 ms wall.
+
+**Allocations do not resolve this change and are not reported as if they did.**
+The driver's `smallAllocs` counter reports 663,779 for `cyclo_phi385` on the
+`integrated`, `mirrored` *and* `hoistedPivotRow` rungs, in the before run, where
+`mirrored` and `hoistedPivotRow` differ by 17,712 row copies. Whatever that
+counter tracks, it does not see the row vectors, so its being unchanged before
+and after says nothing either way.
+
+## The multiply's share moved, as predicted
+
+#9160 priced the inner modular multiply by a doubled-multiply rung against a
+salted-select control and measured it at about 5% of the integrated reduction.
+Removing two thirds of the reduction does not remove any multiplies, so its
+share rises.
+
+| instance | multiply before | share of `integrated` before | multiply after | share after |
+|---|---:|---:|---:|---:|
+| `sd5` | 3.761 us | 4.3% | 4.271 us | 12.1% |
+| `sd5_shift1` | 7.867 us | 4.5% | 7.782 us | 13.6% |
+| `sd5_x_phi11` | 21.262 us | 4.7% | 21.492 us | 15.1% |
+| `cyclo_phi179` | 106.062 us | 4.2% | 105.858 us | 8.1% |
+| `cyclo_phi64_x_phi105` | 183.673 us | 5.0% | 181.981 us | 16.3% |
+| `cyclo_phi128_x_phi165` | 982.912 us | 5.0% | 969.268 us | 16.9% |
+| `cyclo_phi385` | 2.193 ms | 4.9% | 2.218 ms | 16.7% |
+| `randprod_21` (control) | 4.627 us | 4.3% | 4.717 us | 12.3% |
+
+The absolute cost is unchanged, within a few percent, on every row: 2.193 ms
+against 2.218 ms on `cyclo_phi385`. That is the check that this is a share
+moving and not a multiply getting more expensive.
+
+This is the condition #9166 set for re-opening the Barrett reciprocal: the
+reciprocal resolved on two of 24 rows at 1.4% to 2.2% in its favour when the
+multiply was 5% of the reduction, and it is now about 17%.
+
+## What this does not establish
+
+- **The before and after are not paired.** They are separate processes with
+  separate binaries, so no difference in the cross-run tables has a paired
+  range. What is paired is the within-run collapse of
+  `mirrored - hoistedPivotRow`, and the Wilkinson rows bound the cross-run floor
+  at about 2%.
+- **This is one host on one day.** `chungus2` was shared with other work
+  throughout, which is why the before run is bracketed by two after runs rather
+  than run once beside one.
+- **Nothing here says the residual is now arithmetic.** The sparse rows are
+  still 1.5x to 1.6x the prototype, and the two findings #9166 held out of scope
+  (the `nullspaceArray` pivot search and the `List.finRange n` scan) are
+  untouched and unmeasured here.
+- **No claim about non-corpus shapes.** The corpus is 24 rows of the committed
+  factorization corpus, and the saving is proportional to
+  `rowAdds - pivots`, which a different distribution of matrices would change.
+
+## Verification
+
+- `lake build` green (9,737 jobs), `lake build HexConformance` green,
+  `hexbz_factor_service` builds, zero warnings from the changed files. The only
+  `sorry` warnings in the tree are the pre-existing ones in
+  `HexNumberFieldTowerMathlib`.
+- `lake exe hexberlekamp_emit_fixtures` and `lake exe hexbz_emit_fixtures`
+  reproduce `conformance-fixtures/HexBerlekamp/berlekamp.jsonl` and
+  `conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl` byte for byte.
+- No `axiom`, `sorry`, `native_decide` or unchecked oracle added.
+- All three profile runs: 24 of 24 kernel rows agree with
+  `Hex.Matrix.nullspace` on every ladder rung and every packed variant, the
+  counted mirror agrees with `Packed.reduce` and with the production
+  `rowReduce`, and 368 of 368 wider-sample instances agree with the production
+  `factorTrace` on leaf count, selected prime, subset cardinalities and factor
+  degrees.
+
+## Regeneration
+
+```sh
+lake build hexbz_factor_service
+
+python3 scripts/bench/factor_phase_profile.py \
+  --no-counterfactual --no-scout --kernel-repeats 8 \
+  --output reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
+
+# the before run, with only the two measured files reverted
+git checkout a5a55cbf -- HexBerlekamp/PackedKernel.lean bench/HexBench/BerlekampKernel.lean
+lake build hexbz_factor_service
+python3 scripts/bench/factor_phase_profile.py \
+  --no-counterfactual --no-scout --kernel-repeats 8 \
+  --output reports/bench-results/hexbz-phase-profile-a5a55cbf-chungus2.json
+git checkout HEAD -- HexBerlekamp/PackedKernel.lean bench/HexBench/BerlekampKernel.lean
+```
+
+Use an **even** `--kernel-repeats`: the ladder and the prototype variants flip
+direction on every call, and an odd count leaves the median picking the majority
+direction.
+
+The tables come out of `scripts/bench/packed_ladder_diff.py`:
+
+```sh
+# the within-run paired collapse
+python3 scripts/bench/packed_ladder_diff.py \
+  reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
+
+# the cross-run before/after on any single rung
+python3 scripts/bench/packed_ladder_diff.py --rung integrated \
+  reports/bench-results/hexbz-phase-profile-a5a55cbf-chungus2.json \
+  reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
+```
+
+## Follow-up
+
+- **Re-open the Barrett reciprocal.** #9160 measured it at 1.4% to 2.2% in
+  Barrett's favour on two of 24 rows and unresolved elsewhere, against a
+  multiply that was 5% of the reduction. It is 17% now, and a measurement
+  designed for a two-percent effect is worth running.
+- The two findings #9166 held out of scope are unchanged: `nullspaceArray`'s
+  per-entry pivot-column search, and the `List.finRange n` scan in
+  `eliminateColumn`, which is what the sparse rows' remaining 1.5x to 1.6x
+  against the prototype is.

--- a/reports/hexbz-hoisted-pivot-row.md
+++ b/reports/hexbz-hoisted-pivot-row.md
@@ -168,11 +168,12 @@ and one of them proves that the residual is not the change.**
 The three Wilkinson rows find **no pivot column at all**: `pivots` is 0, so
 `eliminateColumn` is never called on them and the hoisted read never executes.
 Their 1.02x is therefore an artifact of comparing two different binaries in two
-different processes, not of the change, and it bounds this report's cross-run
-noise floor at about 2% on a 3 to 7 us span. `xpow24_minus1` has 11 pivots and
-11 row additions, so the hoist replaces 11 reads with 11 reads and saves
-exactly nothing; it measures 1.04x in one after run and 1.01x in the other,
-inside the same floor.
+different processes, not of the change. Three no-work rows on a 3 to 7 us span
+show about 2% of cross-run drift; that is a demonstration on those rows, not a
+bound on the drift a longer measurement carries. `xpow24_minus1` has 11 pivots
+and 11 row additions, so the hoist replaces 11 reads with 11 reads and saves
+exactly nothing; it measures 1.04x in one after run and 1.01x in the other, the
+same size of effect.
 
 `xpow48_minus1` (9 reads saved of 38) and `xpow120_minus1` (35 of 116) are the
 genuinely small savings, at 0.95x and 0.92x, and both reproduce in the second
@@ -215,13 +216,19 @@ column and their difference should collapse to nothing. It does.
 | `randprod_21` (control) | 68.286 us | 66.538 us to 73.389 us | 176 ns | -1.933 us to 331 ns |
 
 Both columns are within-run paired medians. The before column reproduces
-#9160's, taken on the same host four commits earlier, within about 1%
-on every arithmetic row: 31.606 ms against 31.378 ms on `cyclo_phi385`,
-68.286 us against 67.320 us on `randprod_21`.
+#9160's attribution, taken on the same host four commits earlier, but it is not
+the same number row for row: the heaviest rows agree closely (31.606 ms against
+31.378 ms on `cyclo_phi385`, 68.286 us against 67.320 us on `randprod_21`, both
+within 1.5%), and the sparse rows do not (2.679 us against 3.791 us on
+`xpow48_minus1`, 62.508 us against 70.325 us on `xpow105_minus1`). Those four
+intervening commits include two that change the factorization path itself
+(#9171, #9172), and the sparse rows are the ones whose reduction is small
+enough for that to matter.
 
 On `cyclo_phi385` the difference goes from 31.606 ms to 16.841 us, 0.1% of the
-rung, and its paired range now straddles zero on 12 of 24 rows. Every remaining
-positive median is under 1% and is the ladder's own scaffolding.
+rung, and its paired range now straddles zero on **22 of 24** rows. Only
+`sd5_shift2` (341 ns) and `xpow105_minus1` (2.168 us) stay wholly positive, at
+0.6% and 0.8% of their rungs, which is the ladder's own scaffolding.
 
 The other direction of the same check: `integrated` after (13.260 ms and
 13.282 ms on `cyclo_phi385`) lands on `hoistedPivotRow` before (13.225 ms in the
@@ -296,9 +303,10 @@ effect is bounded by that stage's share.
 | `randprod_10` (control) | 635.442 us | 604.046 us | 0.95x | 235.985 us | 199.240 us | 0.84x |
 | `randprod_21` (control) | 1.438 ms | 1.358 ms | 0.94x | 687.129 us | 623.859 us | 0.91x |
 
-`fixedSpaceKernelVectors` is one call each, not a median of eight, so its column
-carries the ordinary spread of a single observation. The end-to-end column is a
-median over the driver's `--repeats` end-to-end calls. The 1.03x on
+`fixedSpaceKernelVectors` is the median of eight one-call observations, one per
+kernel repeat, and unlike the ladder rungs its raw samples are not retained, so
+no range is available for it. The end-to-end column is a median over the
+driver's `--repeats` end-to-end calls. The 1.03x on
 `xpow105_minus1` and 1.01x on `xpow120_minus1` are rows whose reduction improved
 and whose end-to-end time did not; on those rows the kernel is a small share of
 `factor` and the difference is between-run drift on a 45 to 148 ms wall.
@@ -341,8 +349,9 @@ multiply was 5% of the reduction, and it is now about 17%.
 - **The before and after are not paired.** They are separate processes with
   separate binaries, so no difference in the cross-run tables has a paired
   range. What is paired is the within-run collapse of
-  `mirrored - hoistedPivotRow`, and the Wilkinson rows bound the cross-run floor
-  at about 2%.
+  `mirrored - hoistedPivotRow`. The Wilkinson rows show that cross-run drift on
+  a no-work row is about 2%, which is a demonstration on three 3 to 7 us rows,
+  not a bound that transfers to the millisecond rows.
 - **This is one host on one day.** `chungus2` was shared with other work
   throughout, which is why the before run is bracketed by two after runs rather
   than run once beside one.

--- a/reports/hexbz-hoisted-pivot-row.md
+++ b/reports/hexbz-hoisted-pivot-row.md
@@ -311,6 +311,40 @@ driver's `--repeats` end-to-end calls. The 1.03x on
 and whose end-to-end time did not; on those rows the kernel is a small share of
 `factor` and the difference is between-run drift on a 45 to 148 ms wall.
 
+### The full corpus sweep
+
+Touching executable factorization code invalidates the committed cross-system
+sweep, so a fresh `hex-factor` sweep was recorded at `8ed3c378` on a clean tree,
+against the committed `48bdfb8e` baseline, and the figures under
+`reports/figures/` were regenerated from it.
+
+`hexbz-factor-sweep-8ed3c378-hex-chungus2.json`, SHA-256
+`30d8ebad55a52b953cc3af05788ec33cf1177334adb8bd285d5efb2cbd22ddbb`: **377 of
+392 instances solved at the 10 s cutoff, the same 377 as the baseline**, with
+the cross-system factor-degree check clean. 64 instances improve by more than
+10%, led by `conway_p11_n1` at 0.61x, `cyclo_phi625` 60.110 ms to 41.545 ms
+(0.69x), `cyclo_phi509` 48.989 ms to 38.894 ms (0.79x), `cyclo_phi385`
+142.409 ms to 114.089 ms (0.80x) and `cyclo_phi331` 20.935 ms to 16.809 ms
+(0.80x), plus most of the `conway_p*_n3*` family at 0.76x to 0.81x.
+
+Eight instances regress by more than 5%, and **every one of them is
+sub-millisecond**, where the absolute change is single-digit microseconds:
+
+| instance | before | after | ratio |
+|---|---:|---:|---:|
+| `sd2` | 53 us | 61 us | 1.17x |
+| `chebyshev_T3` | 34 us | 39 us | 1.16x |
+| `conway_p11_n2` | 29 us | 33 us | 1.13x |
+| `xpow12_minus1` | 238 us | 255 us | 1.07x |
+| `quartic_a4` | 52 us | 56 us | 1.07x |
+| `conway_p5_n6` | 53 us | 56 us | 1.06x |
+| `conway_p5_n2` | 25 us | 26 us | 1.05x |
+| `conway_p2_n1` | 22 us | 24 us | 1.05x |
+
+These are single sweep observations at the scale where the sweep's own
+per-call protocol overhead is 18.7 us, so they are reported rather than
+explained. Nothing above 300 us regresses at all.
+
 **Allocations do not resolve this change and are not reported as if they did.**
 The driver's `smallAllocs` counter reports 663,779 for `cyclo_phi385` on the
 `integrated`, `mirrored` *and* `hoistedPivotRow` rungs, in the before run, where
@@ -373,6 +407,13 @@ multiply was 5% of the reduction, and it is now about 17%.
   reproduce `conformance-fixtures/HexBerlekamp/berlekamp.jsonl` and
   `conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl` byte for byte.
 - No `axiom`, `sorry`, `native_decide` or unchecked oracle added.
+- A fresh `hex-factor` corpus sweep at `8ed3c378` on a clean tree solves the
+  same 377 of 392 instances as the `48bdfb8e` baseline with a clean
+  cross-system factor-degree check, and the 25 figures under `reports/figures/`
+  are regenerated from it.
+  `python3 scripts/bench/check_factor_sweep_freshness.py` and
+  `uv run --with matplotlib==3.11.1 python3 scripts/plots/hexbz-cactus.py
+  --check` both pass.
 - All three profile runs: 24 of 24 kernel rows agree with
   `Hex.Matrix.nullspace` on every ladder rung and every packed variant, the
   counted mirror agrees with `Packed.reduce` and with the production
@@ -413,6 +454,14 @@ python3 scripts/bench/packed_ladder_diff.py \
 python3 scripts/bench/packed_ladder_diff.py --rung integrated \
   reports/bench-results/hexbz-phase-profile-a5a55cbf-chungus2.json \
   reports/bench-results/hexbz-phase-profile-dcecc57e-chungus2.json
+```
+
+The corpus sweep and the figures, on a clean tree:
+
+```sh
+python3 scripts/bench/factor_sweep.py --systems hex-factor \
+  --output reports/bench-results/hexbz-factor-sweep-8ed3c378-hex-chungus2.json
+uv run --with matplotlib==3.11.1 python3 scripts/plots/hexbz-cactus.py
 ```
 
 ## Follow-up

--- a/reports/hexbz-hoisted-pivot-row.md
+++ b/reports/hexbz-hoisted-pivot-row.md
@@ -215,9 +215,9 @@ column and their difference should collapse to nothing. It does.
 | `randprod_10` (control) | 38.077 us | 36.384 us to 39.389 us | 136 ns | -80 ns to 240 ns |
 | `randprod_21` (control) | 68.286 us | 66.538 us to 73.389 us | 176 ns | -1.933 us to 331 ns |
 
-Both columns are within-run paired medians. The before column reproduces
-#9160's attribution, taken on the same host four commits earlier, but it is not
-the same number row for row: the heaviest rows agree closely (31.606 ms against
+Both columns are within-run paired medians. The before column reproduces the
+attribution #9160 made, taken on the same host four commits earlier, but it is
+not the same number row for row: the heaviest rows agree closely (31.606 ms against
 31.378 ms on `cyclo_phi385`, 68.286 us against 67.320 us on `randprod_21`, both
 within 1.5%), and the sparse rows do not (2.679 us against 3.791 us on
 `xpow48_minus1`, 62.508 us against 70.325 us on `xpow105_minus1`). Those four
@@ -354,8 +354,8 @@ and after says nothing either way.
 
 ## The multiply's share moved, as predicted
 
-#9160 priced the inner modular multiply by a doubled-multiply rung against a
-salted-select control and measured it at about 5% of the integrated reduction.
+Issue #9160 priced the inner modular multiply by a doubled-multiply rung against
+a salted-select control and measured it at about 5% of the integrated reduction.
 Removing two thirds of the reduction does not remove any multiplies, so its
 share rises.
 

--- a/reports/hexbz-packed-kernel-attribution.md
+++ b/reports/hexbz-packed-kernel-attribution.md
@@ -868,4 +868,8 @@ reduction, or if the recombination mirror disagrees with the production trace.
 https://github.com/kim-em/hex-dev/issues/9166 "Berlekamp packed kernel: hoist
 the pivot-row read out of the row addition" carries the one change this
 attribution justifies, with the two secondary findings recorded there as out of
-its scope.
+its scope. It landed, and
+[reports/hexbz-hoisted-pivot-row.md](hexbz-hoisted-pivot-row.md) is its before
+and after: the packed reduction on `cyclo_phi385` goes to 0.29x, `mirrored -
+hoistedPivotRow` collapses to 0.1% of the rung, and the multiply's incremental
+share rises from about 5% to about 17%, which re-opens the Barrett reciprocal.

--- a/scripts/bench/packed_ladder_diff.py
+++ b/scripts/bench/packed_ladder_diff.py
@@ -55,7 +55,26 @@ def samples(ladder: dict, rung: str) -> list[int]:
     block = ladder.get(rung)
     if block is None:
         raise SystemExit(f"no rung {rung!r}; have {sorted(ladder)}")
-    return block["reduceNanosSamples"]
+    values = block["reduceNanosSamples"]
+    if not values:
+        raise SystemExit(f"rung {rung!r} has no reduction samples")
+    return values
+
+
+def pairable(name: str, a: list[int], b: list[int]) -> None:
+    """Refuse to call a difference paired when the repeats do not line up.
+
+    `zip` would silently truncate to the shorter list and the result would still
+    be printed as a paired median, which is exactly the claim it would not
+    support.
+    """
+    if len(a) != len(b):
+        raise SystemExit(
+            f"{name}: {len(a)} samples against {len(b)}; not pairable")
+    if len(a) % 2:
+        raise SystemExit(
+            f"{name}: {len(a)} samples is odd, so the alternating call "
+            "directions are unbalanced under a median")
 
 
 def paired(record: dict, left: str, right: str) -> None:
@@ -64,6 +83,7 @@ def paired(record: dict, left: str, right: str) -> None:
     print("|---|---:|---:|---:|---:|---:|")
     for name, ladder in ladders(record).items():
         a, b = samples(ladder, left), samples(ladder, right)
+        pairable(name, a, b)
         diffs = [x - y for x, y in zip(a, b)]
         med = statistics.median(diffs)
         base = statistics.median(a)

--- a/scripts/bench/packed_ladder_diff.py
+++ b/scripts/bench/packed_ladder_diff.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Paired-difference tables over the packed Berlekamp ladder (issue #9166).
+
+`factor_phase_profile.py` keeps every ladder rung's reduction per repeat in
+`reduceNanosSamples`, and runs the rungs in alternating directions within one
+process, so a difference between two rungs can be taken *within* each repeat and
+merged by median. This script prints those paired differences, and -- given two
+records -- the unpaired before/after comparison of a single rung across runs.
+
+Run::
+
+    python3 scripts/bench/packed_ladder_diff.py RECORD.json
+    python3 scripts/bench/packed_ladder_diff.py --diff mirrored,hoistedPivotRow RECORD.json
+    python3 scripts/bench/packed_ladder_diff.py --rung integrated BEFORE.json AFTER.json
+
+A paired range that crosses zero means the protocol does not resolve that effect
+on that row; the range is printed rather than rounded away.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+
+
+def ladders(record: dict) -> dict[str, dict]:
+    """Instance name -> its `packedLadder` block, for rows that have one."""
+    out: dict[str, dict] = {}
+    for row in record.get("kernels", []):
+        ladder = (row.get("kernel") or {}).get("kernel", {}).get("packedLadder")
+        if ladder:
+            out[row["name"]] = ladder
+    return out
+
+
+def label(record: dict, name: str) -> str:
+    """Mark the control instances the phase-profile driver distinguishes."""
+    for row in record.get("results", []):
+        if row["name"] == name and not row.get("representative", True):
+            return f"`{name}` (control)"
+    return f"`{name}`"
+
+
+def duration(nanos: float) -> str:
+    if abs(nanos) >= 1e6:
+        return f"{nanos / 1e6:.3f} ms"
+    if abs(nanos) >= 1e3:
+        return f"{nanos / 1e3:.3f} us"
+    return f"{nanos:.0f} ns"
+
+
+def samples(ladder: dict, rung: str) -> list[int]:
+    block = ladder.get(rung)
+    if block is None:
+        raise SystemExit(f"no rung {rung!r}; have {sorted(ladder)}")
+    return block["reduceNanosSamples"]
+
+
+def paired(record: dict, left: str, right: str) -> None:
+    print(f"| instance | `{left}` | `{right}` | "
+          f"`{left} - {right}` (paired median) | paired range | share of `{left}` |")
+    print("|---|---:|---:|---:|---:|---:|")
+    for name, ladder in ladders(record).items():
+        a, b = samples(ladder, left), samples(ladder, right)
+        diffs = [x - y for x, y in zip(a, b)]
+        med = statistics.median(diffs)
+        base = statistics.median(a)
+        share = f"{100 * med / base:.1f}%" if base else "n/a"
+        print(f"| {label(record, name)} | {duration(base)} | "
+              f"{duration(statistics.median(b))} | {duration(med)} | "
+              f"{duration(min(diffs))} to {duration(max(diffs))} | {share} |")
+
+
+def across(before: dict, after: dict, rung: str) -> None:
+    print(f"| instance | `{rung}` before | `{rung}` after | after/before | "
+          f"before range | after range |")
+    print("|---|---:|---:|---:|---:|---:|")
+    lb, la = ladders(before), ladders(after)
+    for name in lb:
+        if name not in la:
+            continue
+        b, a = samples(lb[name], rung), samples(la[name], rung)
+        mb, ma = statistics.median(b), statistics.median(a)
+        ratio = f"{ma / mb:.2f}x" if mb else "n/a"
+        print(f"| {label(after, name)} | {duration(mb)} | {duration(ma)} | "
+              f"{ratio} | {duration(min(b))} to {duration(max(b))} | "
+              f"{duration(min(a))} to {duration(max(a))} |")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("records", type=Path, nargs="+",
+                   help="one record for --diff, two (before, after) for --rung")
+    p.add_argument("--diff", default="mirrored,hoistedPivotRow",
+                   help="comma-separated rung pair to difference within one "
+                        "record (default mirrored,hoistedPivotRow)")
+    p.add_argument("--rung", default=None,
+                   help="rung to compare across two records instead")
+    args = p.parse_args()
+
+    loaded = [json.loads(path.read_text()) for path in args.records]
+    if args.rung:
+        if len(loaded) != 2:
+            raise SystemExit("--rung needs exactly two records: before after")
+        across(loaded[0], loaded[1], args.rung)
+    else:
+        if len(loaded) != 1:
+            raise SystemExit("--diff needs exactly one record")
+        left, right = args.diff.split(",")
+        paired(loaded[0], left, right)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR reads the pivot row once per pivot column in
`Hex.Berlekamp.Packed.eliminateColumn` and threads it into the new
`Packed.rowAddFrom`, instead of reading it out of the matrix once per row
addition. The fold skips `j = pivotRow`, so nothing it writes can change what the
next row addition reads, and a row saves `rowAdds - pivots` copies of `n` words.
`Packed.rowAdd` is kept, defined as `rowAddFrom` on `Matrix.getRow A src`, so its
correspondence lemma is a one-line consequence of the new `Rep.rowAddFrom`.

The correspondence proof carries one extra invariant through
`rep_eliminateColumn_foldl`: `∀ k, rsrc[k] = A[pivotRow][k]` on the accumulated
buffer at every step. `elim_step_pivotRow` establishes preservation from the fold
step either doing nothing or writing a row `j ≠ pivotRow`, and the invariant holds
at entry by `rfl`. The hoisted row is `Matrix.getRow`'s `Vector.ofFn`, a fresh
allocation rather than a borrow of the buffer, so the buffer stays uniquely
referenced and every row addition still writes in place. No `axiom`, `sorry`,
`native_decide` or unchecked oracle.

On `chungus2`, in three runs ordered after, before, after, with the before run
taken by reverting only the two measured files to `a5a55cbf`: the packed
reduction on `cyclo_phi385` goes from 45.095 ms to 13.260 ms (0.29x) and the
whole `Hex.ZPoly.factorize` call from 143.566 ms to 115.069 ms (0.80x);
`cyclo_phi128_x_phi165` goes 19.529 ms to 5.739 ms and 0.82x end to end. Against
the benchmark prototype the reduction goes from 2.80x to **0.83x** and from
2.76x to **0.82x** on those two rows, which is what #9160 projected from the
`hoistedPivotRow` ladder rung. The within-run paired `mirrored -
hoistedPivotRow` difference, which #9160 used to attribute the copy, collapses
from 31.606 ms to 16.841 us (0.1% of the rung), so the hoist is in production and
not only in the ladder.

The four rows at or above 1.00x are the four with nothing to save: the three
Wilkinson rows find no pivot column at all, so `eliminateColumn` never executes
and their 1.02x bounds the cross-run noise floor, and `xpow24_minus1` has 11
pivots and 11 row additions, so the hoist replaces 11 reads with 11 reads.

The inner multiply's incremental share rises from about 5% to about 17% of the
reduction at unchanged absolute cost, which is the condition #9166 set for
re-opening the Barrett reciprocal.

Evidence is `reports/hexbz-hoisted-pivot-row.md`, reading three new records under
`reports/bench-results/`; `scripts/bench/packed_ladder_diff.py` generates its
paired and cross-run tables and reproduces #9160's paired medians from the
committed record. All three runs agreed with `Hex.Matrix.nullspace` on 24 of 24
kernel rows on every ladder rung and packed variant, and with the production
`factorTrace` on 368 of 368 wider-sample instances. `lake build` and
`lake build HexConformance` are green and the Berlekamp and BZ conformance
fixtures reproduce byte for byte.

Closes #9166.

🤖 Prepared with Claude Code