### PR TITLE
Reconcile number-field completion documentation

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -310,9 +310,9 @@ convention:
 
 {docstring Hex.DensePoly.eval_resultant}
 
-Independently, Mathlib's resultant has the following proved root-product
-formula. It is the algebraic identity the later executable correspondence will
-carry into one-level field norms and Trager collision bounds:
+Mathlib's resultant has the following proved root-product formula. Together
+with the executable correspondence, this identity underlies one-level field
+norms and the Trager collision bound:
 
 {docstring Hex.DensePoly.resultant_eq_leadingCoeff_mul_prod_roots}
 

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -160,8 +160,8 @@ equality with `b ≠ 0`.
 `Int` supplies the law via `Int.mul_ediv_cancel`. There is a recursive
 instance for `DensePoly R` whenever `R` has the law, so `ZPoly = DensePoly
 Int` supports bivariate elimination, including nonunit constant and nonmonic
-polynomial divisors. A future `NumberTower.Elem T` uses its existing `/`; its
-Mathlib adjunct supplies the law once it installs the field laws. The tower's
+polynomial divisors. `NumberTower.Elem T` uses its existing `/`; its Mathlib
+adjunct supplies the law through its scoped field instance. The tower's
 computational core therefore remains law-free.
 
 ## Exact-division totality

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -87,9 +87,9 @@ about, namely whether they divide at all:
   recombining, using the modular techniques below with a coefficient
   bound from the matrix norm.
 
-Isolating the roots of `χ_A` with hex-real-roots and hex-roots gives
-certified eigenvalue enclosures, and exact eigenvalues once
-hex-number-field can name them.
+Isolating the roots of `χ_A` with hex-real-roots and hex-roots would give
+certified eigenvalue enclosures; hex-number-field can name the resulting exact
+eigenvalues.
 
 **Minimal polynomial.** A separate computation from the characteristic
 polynomial. The Krylov sequence `v, Av, A²v, …` yields the minimal
@@ -603,11 +603,11 @@ certified order: `g^x = h` witnesses a solution and settles neither
 uniqueness nor minimality nor, on failure, nonexistence, and the unit
 group mod a composite need not be cyclic.
 
-**Ring of integers.** hex-number-field and hex-number-field-tower are
-specified to construct towers, factor by Trager, and build splitting
-fields; both are registered with no phases complete. The maximal order
-`O_K` is the next object: the Round 2 (Pohst-Zassenhaus) algorithm gives
-an integral basis and the field discriminant.
+**Ring of integers.** hex-number-field and hex-number-field-tower implement
+towers, Trager factorization, and splitting fields; their computational and
+Mathlib libraries remain registered with no phases complete. The maximal order
+`O_K` is the next object: the Round 2 (Pohst-Zassenhaus) algorithm gives an
+integral basis and the field discriminant.
 
 The dependency is the integer factorization item, for the squarefree
 part of the polynomial discriminant, and it is where such computations
@@ -682,16 +682,14 @@ cell decomposition of `ℝ` by the roots of a single polynomial does the
 work; CAD lifts that to several variables, and
 [hex-rcf](Libraries/hex-rcf.md) puts it out of scope.
 
-Part of the base layer is in place. hex-real-roots isolates the real
-roots of a squarefree `p ∈ ℤ[x]` with exact Sturm-count witnesses, and
-hex-roots does the complex case with Newton-Kantorovich and Pellet
-witnesses on dyadic squares. hex-resultant holds univariate
-subresultants, and hex-number-field and hex-number-field-tower are
-specified to supply exact arithmetic on algebraic numbers with
-certified isolations maintained throughout, which is the sample-point
-arithmetic a CAD needs. hex-resultant is one phase in and the two
-number-field libraries are at zero, so all three are prerequisites here
-rather than foundations.
+The implemented base layer is in place. hex-real-roots isolates the real roots
+of a squarefree `p ∈ ℤ[x]` with exact Sturm-count witnesses, and hex-roots
+does the complex case with Newton-Kantorovich and Pellet witnesses on dyadic
+squares. hex-resultant holds univariate subresultants, while hex-number-field
+and hex-number-field-tower implement exact arithmetic on algebraic numbers with
+certified isolations maintained throughout. Their phase attestations remain
+pending. Together these provide the exact sample-point arithmetic a CAD builds
+on; sign determination at those points is part of the lifting work below.
 
 The lifting structure on top is entirely to come: multivariate
 polynomials, a projection operator (Collins, with the McCallum and Hong

--- a/progress/20260808T040318Z.md
+++ b/progress/20260808T040318Z.md
@@ -1,0 +1,35 @@
+# Accomplished
+
+- Audited the merged Resultant, NumberField, and NumberFieldTower runtime and
+  Mathlib libraries against all six current SPEC documents, including their
+  named APIs, proof obligations, conformance cases, benchmark registrations,
+  oracle fixtures, and manual chapters.
+- Confirmed milestone PRs #9143, #9145, #9146, and #9179 are merged. The exact
+  Tower merge tree passed CI, including all three external oracle suites,
+  conformance, benchmark smoke gates, and the complete manual build.
+- Re-ran the published trust-surface check: all 419 Lean files are free of
+  `sorry`, `axiom`, and `native_decide`. The expansion-plan document is absent.
+- Corrected the remaining stale pre-completion wording in the Resultant SPEC,
+  Resultant manual, and future-work notes. The revised text distinguishes the
+  implemented and proved number-field surface from its still-pending formal
+  phase attestations and keeps CAD sign determination in future scope.
+- Incorporated an independent pre-merge review of the documentation cleanup,
+  including its corrections to phase status, CAD scope, the scoped tower field
+  instance, and root-product attribution.
+- Verified copyright and source-line lints, diff hygiene, and `lake build
+  HexManual` (9,711 jobs) after the review fixes.
+
+# Current frontier
+
+The requested implementations, Mathlib adjuncts, documentation, tests,
+benchmarks, oracles, and manual chapters are merged and audited. One final
+documentation-only cleanup remains to publish and merge.
+
+# Next step
+
+Commit and push the single cleanup branch, open one PR with auto-merge, monitor
+its underlying Actions job, and confirm the workstream has no open PRs.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- remove stale pre-implementation language from the Resultant SPEC and manual
- distinguish the implemented/proved number-field surface from pending formal phase attestations
- keep CAD sign determination correctly scoped as future lifting work
- record the final Resultant/NumberField/Tower completion audit

## Review

An independent Opus review checked the cleanup against source and libraries.yml. Its phase-status, CAD-scope, scoped-field-instance, and root-product-attribution findings are incorporated.

## Validation

- lake build HexManual (9,711 jobs)
- lake build HexResultantMathlib HexNumberFieldMathlib HexNumberFieldTowerMathlib (9,714 jobs before prose-only review refinements)
- python3 scripts/check_copyright_headers.py
- python3 scripts/check_file_line_counts.py
- python3 scripts/release/check_trust_surface.py (419 files)
- git diff --check