### PR TITLE
chore: record the issue-9170 second-opinion and merge session

### DIFF
--- a/progress/20260809T130521Z_issue-9170.md
+++ b/progress/20260809T130521Z_issue-9170.md
@@ -1,0 +1,106 @@
+# issue-9170, session 2: second opinion, CI, merge
+
+## Accomplished
+
+Merged https://github.com/kim-em/hex-dev/pull/9181 ("feat: reach the
+quadratic-norm certificate from factorize behind a width floor") as
+`d0bfdd6c`, closing #9170.
+
+**Fixed the CI failure.** `Examples/Release4.lean` pinned Swinnerton-Dyer
+SD₆ to the lattice tier (`method == .lattice && classicalDecline.isSome`),
+and the certificate now answers SD₆, so its `#guard` failed. Release 4's
+stated contract in `PLAN/Releases.md` is "factor a high modular-factor-count
+polynomial and assert the trace selects the LLL-assisted lattice tier", which
+is still worth pinning, so the file keeps that seam with a polynomial that
+still belongs to it: `latticeInput`, the minimal polynomial of
+√2+√3+√5+√7+√11+√13+√6, which generates the same degree-64 multiquadratic
+field and splits into the same 32 modular factors but is not an iterated
+quadratic norm. SD₆ stays as `normInput` with a second check requiring
+`quadraticNorm` and no classical decline. Same adversarial pairing the
+conformance fixtures already use.
+
+**Ran the second opinion** (Codex, invoked directly -- see Blockers). It
+found no soundness, gate-placement or recovery defect, and independently
+reproduced the artifact SHA-256s, the 377 → 383 solved counts, the
+17.225 s → 8.965 s common-row total and the 0.707x worst ratio. It found
+three places where `reports/hexbz-quadratic-norm-certificate.md` claimed
+more than the committed artifacts establish, all now corrected in
+`f34400e6`:
+
+- The headline table was headed "at one revision", but only its first five
+  rows are the controlled `5dabd026` A/B; the cactus row's integrated side
+  is the clean `d27e0bf2` sweep taken after merging main.
+- All four `5dabd026` records carry `git_dirty: true`, not just the
+  gate-closed pair as the report implied. `factor_sweep.py` reads
+  `git status --porcelain`, which counts the untracked report drafts every
+  one of them ran with. The report now names the one further edit the
+  gate-closed pair carried and admits the records pin neither the literal
+  used nor the binary.
+- The offered-miss table listed eight rows while the prose said nineteen.
+  Measured the real set with `--entry factorTrace` over all 368 declining
+  rows: **25** at width ≥ 16, of which **17** are solved and 8 reach the
+  10 s cutoff. The eight table entries also matched no committed record
+  within 0.75%, so the table was rebuilt from one named record
+  (`d27e0bf2` for row times, the certificate probe for miss costs), all 17
+  listed, the 8 timeouts named with their misses, and the refusals split
+  into the 19 the degree test catches and the 6 that reach the trace test.
+  The headline claim is unchanged: worst share is `wilkinson_16` at 0.014%.
+
+Also reworded "consulted once", which was true of the call site but not of
+an execution: proposal replay re-enters `classicalInput` per peeled piece,
+which is how `sd6_x_phi13`'s SD₆ piece certifies.
+
+**Reported the acceptance measurement on #9126**
+(https://github.com/kim-em/hex-dev/issues/9126#issuecomment-5231666750).
+Worst cumulative Hex/Isabelle over ranks 125--140 is **0.707x at rank 133**
+against the 0.85x criterion; Hex solves 151 of 160 against Isabelle's 141
+and holds its lead past rank 140.
+
+The issue asked for the simulation to be confirmed or refuted rather than
+restated, and it is **refuted**. The simulation predicted about 5.5% margin
+from Swinnerton-Dyer parity and said Wilkinson parity was needed on top to
+reach 16%. Wilkinson parity was never reached -- Hex is still behind
+Isabelle on `wilkinson_28`, `wilkinson_32` and `wilkinson_48`, and on
+`cyclo_phi179`, one of the four rows the simulation named -- yet the margin
+is 29.3%. The simulation substituted Isabelle's time into Hex's row and
+re-summed, which prices parity on a fixed curve; a cactus is a *sorted*
+curve, so moving `sd6` from 8.148 s to 27.6 ms pulls cheaper rows up into
+the elbow and re-sorts everything above it, and six previously-unsolved
+rows enter the solved set.
+
+## Current frontier
+
+#9170 is closed and #9126's acceptance measurement is on the issue. #9126
+itself is still open; closing it is a judgement call for whoever owns the
+roadmap, since every work item under it is now complete or a documented
+no-go.
+
+## Next step
+
+Nothing outstanding on this issue. The natural follow-ups, none claimed:
+
+- The floor is 16 and the report prices a floor of 8 from the data
+  (`sd3_x_phi24` would pay 17.6 us on a 0.591 ms row, 3.0%). Lowering it
+  buys the `sd4` rows; whether 3.0% on one row is worth it is a policy
+  call, not a measurement one.
+- `hoeij_F630` and `hoeij_F351` pay 2.2 us and 1.5 us to be refused at the
+  *degree* test, because the sign normalization and array conversion ahead
+  of it are linear in the degree. Testing the degree before converting
+  would make those refusals free. Worth roughly nothing on rows that run
+  for ten seconds, but it is the only non-flat part of the miss curve.
+
+## Blockers
+
+None outstanding. Two environment notes for whoever comes next:
+
+- **`HexReleaseExamples` is not a `@[default_target]`.** A bare `lake build`
+  does not reach `Examples/Release3--5.lean`, but CI builds them by explicit
+  name in `HEX_LIB_TARGETS`. This is exactly how the Release 4 failure got
+  past local verification. Build the `HEX_LIB_TARGETS` list from
+  `.github/workflows/ci.yml:146` rather than trusting a bare `lake build`.
+- **The `second-opinion` skill's `codex-opinion` wrapper is broken on this
+  host**: it passes `--full-auto`, which the installed `codex exec` rejects
+  with `error: unexpected argument '--full-auto' found`. Worked around by
+  invoking `SECOND_OPINION_ACTIVE=1 codex exec --sandbox workspace-write -o
+  <file>` directly. The wrapper lives in Kim's `~/.claude/skills`, outside
+  this repo, so it was left alone rather than edited.


### PR DESCRIPTION
This PR records the progress entry for the session that landed the
quadratic-norm certificate integration: the Release 4 tier pin fix, the
three report-provenance corrections the second opinion asked for, and the
acceptance measurement reported on
https://github.com/kim-em/hex-dev/issues/9126.

It also notes two traps for the next session. `HexReleaseExamples` is not
a `@[default_target]`, so a bare `lake build` never reaches
`Examples/Release3--5.lean` while CI builds them by explicit name in
`HEX_LIB_TARGETS` -- which is how the Release 4 failure got past local
verification. And the `second-opinion` skill's `codex-opinion` wrapper
passes `--full-auto`, which the installed `codex exec` rejects; the
wrapper lives outside this repo, so it was worked around rather than
edited.

🤖 Prepared with Claude Code