### PR TITLE
feat(poly-mathlib): read a coefficient array off as a Mathlib sum

### DIFF
--- a/HexBerlekampZassenhausMathlib/FactorTransport.lean
+++ b/HexBerlekampZassenhausMathlib/FactorTransport.lean
@@ -179,7 +179,7 @@ open HexBerlekampZassenhausMathlib
 every certification slot is a Boolean check on reified literal data (filled by
 `Eq.refl true` in emitted terms), and `hP` is the parser-built translation equality
 tying the reified executable polynomial to the user's Mathlib polynomial. -/
-@[expose, simp]
+@[expose]
 noncomputable def FactoredPoly.ofZ (P : Polynomial ℤ) (f : Hex.ZPoly) (s : Int)
     (factors : List Hex.ZPoly)
     (certified : List (Hex.ZPoly × Hex.ZPoly.IrredWitness))

--- a/HexBerlekampZassenhausMathlib/FactorTransport.lean
+++ b/HexBerlekampZassenhausMathlib/FactorTransport.lean
@@ -179,7 +179,7 @@ open HexBerlekampZassenhausMathlib
 every certification slot is a Boolean check on reified literal data (filled by
 `Eq.refl true` in emitted terms), and `hP` is the parser-built translation equality
 tying the reified executable polynomial to the user's Mathlib polynomial. -/
-@[expose]
+@[expose, simp]
 noncomputable def FactoredPoly.ofZ (P : Polynomial ℤ) (f : Hex.ZPoly) (s : Int)
     (factors : List Hex.ZPoly)
     (certified : List (Hex.ZPoly × Hex.ZPoly.IrredWitness))

--- a/HexNumberFieldTowerMathlib/NormCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Basic.lean
@@ -1101,10 +1101,7 @@ theorem eval_shiftBase (lower : List Level)
     · simp [base, Array.getD]
     · rcases n with _ | n
       · simp [base, Array.getD]
-      · simp [base, Array.getD, show n + 2 ≠ 0 by omega,
-          show n + 2 ≠ 1 by omega]
-        change (0 : DensePoly (Arithmetic.Coeff lower)).coeff _ = 0
-        simp
+      · simp [base, Array.getD]
   have hone : LevelSemantics.denote lower
       (1 : Arithmetic.Coeff lower).data = 1 :=
     LevelSemantics.coeffDenote_one lower hvalid

--- a/HexPolyMathlib/PolynomialEquivalence.lean
+++ b/HexPolyMathlib/PolynomialEquivalence.lean
@@ -373,6 +373,33 @@ theorem toPolynomial_one [Semiring R] [DecidableEq R] :
   show toPolynomial (Hex.DensePoly.C 1) = 1
   rw [toPolynomial_C, Polynomial.C_1]
 
+/-- {name}`toPolynomial` reads a raw coefficient array off as the obvious sum,
+ascending. This is what makes a concrete `#p[...]` literal readable on the
+Mathlib side: with `Finset.sum_range_succ` to expand the range,
+`toPolynomial #p[1, 1, 1]` becomes `C 1 * X ^ 0 + C 1 * X ^ 1 + C 1 * X ^ 2`.
+
+Stated with `C _ * X ^ i` rather than `monomial i _` because that is the form a
+reader writes a polynomial in, so a use site needs no `C_mul_X_pow_eq_monomial`
+rewrite of its own. -/
+@[simp, grind =]
+theorem toPolynomial_ofCoeffs [Semiring R] [DecidableEq R] (cs : Array R) :
+    toPolynomial (Hex.DensePoly.ofCoeffs cs) =
+      ∑ i ∈ Finset.range cs.size,
+        Polynomial.C (cs.getD i (Zero.zero : R)) * Polynomial.X ^ i := by
+  ext n
+  simp only [Polynomial.C_mul_X_pow_eq_monomial]
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_ofCoeffs, Polynomial.finsetSum_coeff]
+  by_cases hn : n < cs.size
+  · simp [Polynomial.coeff_monomial, hn]
+  · rw [Finset.sum_eq_zero]
+    · simp [Array.getD, hn]
+      rfl
+    · intro i hi
+      have hne : i ≠ n := by
+        have := Finset.mem_range.mp hi
+        omega
+      simp [Polynomial.coeff_monomial, hne]
+
 /-- `toPolynomial` sends executable coefficient scaling to multiplication by
 the corresponding constant polynomial. -/
 @[simp, grind =]

--- a/progress/20260810T050325Z_to-polynomial-of-coeffs.md
+++ b/progress/20260810T050325Z_to-polynomial-of-coeffs.md
@@ -1,0 +1,44 @@
+# Reading a coefficient literal off on the Mathlib side
+
+## Accomplished
+
+`factor_poly` on a `Polynomial ℤ` returns factors as
+`factors.map HexPolyZMathlib.toPolynomial` over `Hex.DensePoly.ofCoeffs`
+literals, so nothing could state what factorization it actually found:
+`cyclo.factors = [Φ₅, Φ₇]` was not `rfl`, and `simp` stalled at
+`toPolynomial (ofCoeffs #[1, 1, 1, 1, 1])` because no lemma normalized it.
+
+- `HexPolyMathlib.toPolynomial_ofCoeffs` closes that gap:
+  `toPolynomial (ofCoeffs cs) = ∑ i ∈ range cs.size, C (cs.getD i 0) * X ^ i`.
+  Stated with `C _ * X ^ i` rather than `monomial i _` so a use site needs
+  no `C_mul_X_pow_eq_monomial` rewrite of its own.
+- Tagged `@[simp, grind =]`. A full `lake build` (9754 jobs) says the only
+  downstream effect is that one case of
+  `HexNumberFieldTowerMathlib.NormCore.Basic` now closes by `simp` alone;
+  its four-line tail and two now-unused simp arguments are gone.
+
+Concretely this turns the announcement's factoring example into a
+statement of the answer rather than a statement about the product:
+
+    example : cyclo.factors = [1+X+X^2+X^3+X^4, 1+X+X^2+X^3+X^4+X^5+X^6] := by
+      simp [cyclo, Hex.FactoredPoly.ofZ, Finset.sum_range_succ]
+
+## Current frontier
+
+`feat/to-polynomial-of-coeffs`, branched from main, independent of the
+release-tooling work on `docs/release-token-scope`.
+
+## Next step
+
+Nothing pending on this thread.
+
+## Blockers
+
+`Hex.FactoredPoly.ofZ` cannot be dropped from that simp set, so the call
+cannot get below three arguments. Projection lemmas (`factors_ofZ`,
+`scalar_ofZ`) look like the fix and do not work: an emitted term fills its
+certificate slots with `Eq.refl true`, which is only type-correct once
+`beqCoeffs` computes on the literals, so at the reducible transparency
+`rw`/`simp` match under, the `ofZ` application is ill-typed and no pattern
+can match it. Unfolding `ofZ` avoids matching altogether, which is why only
+that works. Two such lemmas were written, confirmed dead, and removed.


### PR DESCRIPTION
This PR adds `HexPolyMathlib.toPolynomial_ofCoeffs`, so a proof can say what factorization `factor_poly` actually returned.

`factor_poly` on a `Polynomial ℤ` hands back `factors.map HexPolyZMathlib.toPolynomial` over `Hex.DensePoly.ofCoeffs` literals. Nothing normalized that, so `cyclo.factors = [Φ₅, Φ₇]` was not `rfl` and `simp` stalled at `toPolynomial (ofCoeffs #[1, 1, 1, 1, 1])`; the closest a statement could get was that the returned factors multiply to the expected product. The new lemma sends a raw coefficient array to the ascending sum `∑ i ∈ Finset.range cs.size, C (cs.getD i 0) * X ^ i`, and is stated with `C _ * X ^ i` rather than `monomial i _` so a use site needs no `C_mul_X_pow_eq_monomial` rewrite of its own.

Reading the factorization off also needs the assembler `Hex.FactoredPoly.ofZ` unfolded, so it is tagged `simp` too, and a factorization becomes a statement of the answer:

```lean
example : cyclo.factors = [1+X+X^2+X^3+X^4, 1+X+X^2+X^3+X^4+X^5+X^6] := by
  simp [cyclo, Finset.sum_range_succ]
```

Unfolding is the only thing that reaches inside an emitted term. A projection lemma over `ofZ` cannot match one: its certificate slots hold `Eq.refl true`, which is type-correct only once `beqCoeffs` computes on the literals, so at the reducible transparency `rw` and `simp` match under, the application is ill-typed. Tagging a def `simp` is a blunt instrument in general, but `ofZ` is a purpose-built assembler appearing only in terms the elaborator emits for `Polynomial ℤ`, so the blast radius is that one constructor.

`Finset.sum_range_succ` remains because Mathlib does not expand range sums by simp. A Horner-shaped cons lemma removes it and reaches a bare `simp [cyclo]`, but leaves `1 + X * (1 + X * (1 + X * (1 + X))) = 1 + X + X ^ 2 + X ^ 3 + X ^ 4` for `ring`, and makes nested Horner the simp normal form for every coefficient literal.

Both `simp` registrations were checked rather than assumed. A full `lake build` (9754 jobs, including `HexManual`) finds exactly one downstream effect between them: a case in `HexNumberFieldTowerMathlib.NormCore.Basic` now closes by `simp` alone, so its redundant tail and two unused simp arguments go away.

🤖 Prepared with Claude Code