### PR TITLE
refactor: name the remaining anonymous Bounds instances

### DIFF
--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -26,8 +26,8 @@ namespace Berlekamp
 Previously this was supplied implicitly by a private instance in
 `HexPolyFp.SquareFree` that leaked through typeclass resolution under the
 pre-module import semantics; the module system hides private instances, so the
-`p = 2` checkers declare it locally. -/
-instance : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+`p = 2` checkers declare it in this module. -/
+instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 variable {p : Nat} [ZMod64.Bounds p]
 

--- a/HexConway/Table.lean
+++ b/HexConway/Table.lean
@@ -16,12 +16,12 @@ per-entry polynomial literals with their monic/degree/table-hit lemmas.
 namespace Hex
 
 namespace Conway
-instance : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
+instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+instance boundsThree : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
+instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+instance boundsSeven : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
+instance boundsEleven : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
+instance boundsThirteen : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
 
 /-- Committed Lübeck Conway-table coefficients, stored ascending by degree. -/
 def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)

--- a/progress/2026-07-03T05-04-24Z.md
+++ b/progress/2026-07-03T05-04-24Z.md
@@ -1,0 +1,28 @@
+# Coppersmith tutorial plan review
+
+## Accomplished
+
+Reviewed the proposed Tutorial 4 plan against `SPEC/tutorials.md`,
+`PLAN/Phase7.md`, `HexManual.lean`, and the current `HexLLL` manual/API
+surface. Checked that the manual is import/include driven and that
+`lllNative` plus the unchecked short-vector helpers are available for pure
+Lean evaluated examples.
+
+## Current frontier
+
+The plan is broadly viable, but it needs tighter wording and implementation
+hedges around the minimal Coppersmith lattice: determinant-scale bounds,
+candidate-row selection, coefficient de-scaling divisibility, and numeric
+parameter choice.
+
+## Next step
+
+When implementing, first validate a concrete instance in a small throwaway
+module, then make the tutorial recover the root by scanning reduced candidate
+rows and checking the modular/root conditions rather than assuming a specific
+first-row polynomial.
+
+## Blockers
+
+None for the review. The implementation still needs concrete parameters that
+leave enough margin below the `N^(1/6)` regime after LLL's constant factors.

--- a/progress/2026-07-04T03-04-12Z.md
+++ b/progress/2026-07-04T03-04-12Z.md
@@ -1,0 +1,15 @@
+# Cleanup plan review
+
+**Accomplished**
+- Reviewed the proposed HexBerlekampZassenhaus factor-path cleanup plan against `HexBerlekampZassenhaus/Basic.lean`, `HexBerlekampZassenhausMathlib/`, conformance, bench, `scripts/bench/factor_sweep.py`, and the BZ SPEC.
+- Verified the high-level production path claim: `factor = factorHybrid`, with classical-first dispatch, lattice fallback, and trial backstop.
+- Identified review concerns around hidden rename/delete touchpoints, Mathlib proof-cluster deletion risk, SPEC rewrite gaps, and sequencing.
+
+**Current frontier**
+- No source changes were made. The review is ready to report.
+
+**Next step**
+- Incorporate the review findings into the cleanup plan before filing worker issues, especially by broadening grep scopes and splitting Mathlib deletion/renaming work where needed.
+
+**Blockers**
+- None.

--- a/progress/2026-07-04T03-43-38Z.md
+++ b/progress/2026-07-04T03-43-38Z.md
@@ -1,0 +1,15 @@
+# Real roots SPEC review
+
+**Accomplished**
+- Reviewed the three SPEC files on `spec/real-roots-and-rcf` directly from git: `hex-real-roots.md`, `hex-real-roots-mathlib.md`, and `hex-rcf.md`.
+- Cross-checked them against the existing roots SPEC style and `SPEC/writing-style.md`.
+- Identified review findings around low-degree separation definitions, executable type holes, RCF bounded-cell classification, root-cell sign certificates, and a few wording/style issues.
+
+**Current frontier**
+- No source changes were made beyond this progress note. The review is ready to report.
+
+**Next step**
+- Patch the SPEC files to define the low-degree and zero-polynomial cases explicitly, add the missing executable structures/checker fields, and make the RCF bounded-cell and gcd-certificate contracts precise.
+
+**Blockers**
+- None.

--- a/progress/2026-07-22T17-31-01Z.md
+++ b/progress/2026-07-22T17-31-01Z.md
@@ -1,0 +1,23 @@
+# Review of the HexRoots manual chapter
+
+## Accomplished
+
+Reviewed `HexManual/Chapters/HexRoots.lean` against the executable definitions,
+the Mathlib soundness/completeness theorems, the HexRoots SPEC, and the Pisot
+example. Identified inaccuracies concerning Pellet-region containment, cluster
+and `isolate` edge-case semantics, the strategy used by `isolate_pisot`, the
+formal scope and wording of the Pisot claim, and exact-certificate prose.
+
+## Current frontier
+
+The review is complete. No source or documentation files were changed.
+
+## Next step
+
+Apply the suggested prose corrections, especially replacing claims that a
+Pellet atom's stored square contains its root with the actual circumscribed-disc
+contract.
+
+## Blockers
+
+None.

--- a/progress/2026-07-24T06-05-46Z.md
+++ b/progress/2026-07-24T06-05-46Z.md
@@ -1,0 +1,28 @@
+# Review of the factor-tactics manual chapter
+
+## Accomplished
+
+- Reviewed the proposed `HexManual/Chapters/FactorTactics.lean` chapter
+  against the plain finite-field and integer providers, both Mathlib bridge
+  providers, the bang elaborators, certificate checkers, and the existing
+  factor-tactic test suites.
+- Confirmed that the displayed Lean examples and their stated factor counts,
+  scalars, certificate handoffs, and axiom output agree with the existing
+  tests and implementations.
+- Identified documentation precision issues around the actual replay-budget
+  predicate, the bridge parsers' accepted grammar, bounded integer witness
+  searches, the bang fallback's incomplete coverage, and a few trust-model
+  descriptions.
+
+## Current frontier
+
+The review is complete. No library or manual source was modified.
+
+## Next step
+
+Revise the chapter's coverage and trust-model prose to match the concrete
+provider limits and bang fallback caveats before merging.
+
+## Blockers
+
+None.

--- a/progress/2026-07-27T02-47-26Z.md
+++ b/progress/2026-07-27T02-47-26Z.md
@@ -1,0 +1,37 @@
+# Planned-library implementation readiness audit
+
+## Accomplished
+
+- Audited the unimplemented centralized library specifications against
+  `SPEC/Libraries/README.md`, `libraries.yml`, the phase dependency rules, the
+  current source tree, and open GitHub issues and pull requests.
+- Identified `HexResultant` and `HexRCF` as the two libraries whose declared
+  dependencies are sufficiently advanced to begin Phase 1 now.
+- Verified the direct prerequisite targets for both candidates with
+  `lake build HexPoly HexRealRoots HexRealRootsMathlib HexPolyZ
+  HexPolyZMathlib`; the build completed successfully.
+- Confirmed that no open issue or pull request currently names resultant,
+  number-field, real-closed-field, or RCF work.
+
+## Current frontier
+
+- `HexResultant`, `HexResultantMathlib`, `HexNumberField`,
+  `HexNumberFieldMathlib`, and `HexRCF` remain `status: planned`, so the
+  orchestrator does not dispatch them despite their finished specifications.
+- `HexNumberFieldTower` and `HexNumberFieldTowerMathlib` have centralized
+  specifications but are not yet represented in `libraries.yml`.
+
+## Next step
+
+- Activate `HexResultant` and/or `HexRCF` when implementation should begin.
+  Resultant is the dependency-critical first choice; RCF is independent and
+  can proceed in parallel.
+- Advance the remaining planned libraries in dependency order, and register
+  the tower pair before attempting to activate it.
+
+## Blockers
+
+- Dispatch is blocked only by the deliberate `planned` status for the two
+  immediately ready candidates.
+- The remaining unimplemented libraries have unimplemented or insufficiently
+  phased dependencies; the tower pair also lacks registry entries.

--- a/progress/2026-07-27T02-53-22Z.md
+++ b/progress/2026-07-27T02-53-22Z.md
@@ -1,0 +1,31 @@
+# Clarified the HexResultant boundary
+
+## Accomplished
+
+- Traced resultant, discriminant, and pseudo-remainder usage through
+  `HexRealRoots`, `HexRealRootsMathlib`, `HexRoots`, and
+  `HexPolyZMathlib`.
+- Confirmed that real-root isolation uses a specialized `ZPoly` Sturm chain
+  whose primitive-part normalization retains root/sign information but
+  discards the scale factors needed to recover an exact resultant value.
+- Confirmed that the separation proofs use Mathlib's abstract
+  `Polynomial.resultant` API to establish discriminant facts, while the
+  executable precision calculation uses only the proved lower bound
+  `|discr p| >= 1` and never computes a discriminant or resultant.
+
+## Current frontier
+
+- `HexResultant` remains a genuine missing library: it must provide a generic
+  executable subresultant PRS, exact resultant/discriminant values, bivariate
+  specialization, and the scale/sign bookkeeping needed by number-field
+  consumers.
+
+## Next step
+
+- If `HexResultant` is activated, decide during scaffolding whether any generic
+  pseudo-division helper can be shared with the specialized real-roots chain
+  without changing the latter's positive-scaling Sturm invariant.
+
+## Blockers
+
+- None for this clarification.

--- a/progress/2026-07-27T02-54-48Z.md
+++ b/progress/2026-07-27T02-54-48Z.md
@@ -1,0 +1,34 @@
+# Planned-library DAG and workstream split
+
+## Accomplished
+
+- Mapped the planned resultant, number-field, and RCF libraries onto their
+  immediate computational and Mathlib dependencies.
+- Confirmed that the RCF branch is independent of the resultant/number-field
+  branch and can proceed concurrently.
+- Identified the internal fork after `HexResultant`: computational
+  `HexNumberField` does not depend on `HexResultantMathlib`, while
+  `HexNumberFieldMathlib` depends on both branches.
+
+## Current frontier
+
+- A safe serial ownership lane is `HexResultant`,
+  `HexResultantMathlib`, `HexNumberField`, then
+  `HexNumberFieldMathlib`, but this serializes number-field computation behind
+  the substantial Stage 2 resultant correspondence unnecessarily.
+- `HexBerlekampZassenhaus` and `HexRootsMathlib` remain additional phase-level
+  prerequisites for the number-field pair.
+
+## Next step
+
+- Represent the two lanes as narrow, dependency-linked issues: one independent
+  `HexRCF` sequence and one resultant/number-field sequence. After executable
+  resultant scaffolding stabilizes, consider splitting the latter into
+  concurrent resultant-companion and computational-number-field issues.
+
+## Blockers
+
+- All planned libraries must be activated before orchestration will dispatch
+  their Phase work.
+- Parallel Phase 1 PRs will touch shared registry/build files and may require a
+  small rebase, but there is no semantic cross-branch dependency.

--- a/progress/2026-07-27T06-07-14Z.md
+++ b/progress/2026-07-27T06-07-14Z.md
@@ -1,0 +1,52 @@
+# Release-readiness PR and merge
+
+## Accomplished
+
+- Scoped the release-readiness implementation into a dedicated branch while
+  excluding unrelated worktree metadata and older untracked progress files.
+- Obtained an independent pre-merge review and verified every finding against
+  the source. Restored HexBerlekamp's two FLINT comparators as gating, kept the
+  library at Phase 3, removed the frozen-evidence budget checker, corrected the
+  factorization theorem namespaces and clauses in user-facing documentation,
+  and restored the outstanding HexLLL evidence requirement.
+- Expanded the trust scan from the six release-facing packages to all 356 Lean
+  files managed by the publication manifest, restricted DAG exemptions to
+  named build-only targets, corrected stale links and examples, and added
+  strategy-generic `isolate_disjoint` and `isolate!_disjoint` theorems.
+- Rebased the branch over the concurrent RCF, Berlekamp, and interval-spec
+  changes, preserving their new modules, regression benchmark, and testing
+  contracts. The conflict resolutions were rebuilt and rechecked locally.
+- Opened PR #8900, verified that it had no review comments or unresolved
+  threads, and observed a green current-head CI run. The single job completed
+  in 15m59s with all builds, installed FLINT/PARI/Conway benchmark registrations,
+  required oracles, and fail-closed BZ gates passing.
+- Squash-merged PR #8900 as `ce3ff80879fc473265f46a885543c441e5512c35`.
+
+## Current frontier
+
+- The release-readiness implementation is on `main` and the PR is closed as
+  merged.
+- Releases 3--5 remain intentionally not ready: their integration examples
+  build, but the transitive Phase 7 predicates still report unfinished
+  dependencies.
+- The remote topic branch remains present; no unrelated untracked files were
+  staged, committed, deleted, or otherwise changed.
+
+## Next step
+
+- Close HexBerlekamp's gating Rabin and distinct-degree performance gaps before
+  advancing it beyond Phase 3.
+- Complete the remaining bridge-library audits and the
+  Berlekamp--Zassenhaus scientific performance work in dependency order.
+- Bootstrap and dry-run the split-repository publication flow only after every
+  transitive dependency of the corresponding release reaches Phase 7.
+
+## Blockers
+
+- HexBerlekamp's committed scientific evidence is approximately 1700x slower
+  than FLINT for Rabin irreducibility and 2900x slower for distinct-degree
+  factorization at the largest eligible rungs.
+- Berlekamp--Zassenhaus retains inconclusive scientific verdicts, the fallback
+  probe regression, and incomplete large-`r` evidence.
+- Several Mathlib bridges remain below Phase 7 and need their outstanding
+  documentation, benchmark/report, and final release-review phases.

--- a/progress/20260703T075809Z_docgen-plan-review.md
+++ b/progress/20260703T075809Z_docgen-plan-review.md
@@ -1,0 +1,26 @@
+# docgen plan review
+
+## Accomplished
+
+Reviewed the proposed `leanprover/hex` doc-gen4 API documentation plan
+against the current `docgen-action` README/source, `lean-action` docs, and
+the inspection clone at `/tmp/hex-inspect`. Verified that the released
+aggregate uses `lakefile.toml`, has `defaultTargets = ["HexAll"]`, and
+already uses an explicit Mathlib cache rebuild guard in CI.
+
+## Current frontier
+
+The plan is broadly viable, but the workflow needs corrections around
+`workflow_dispatch`, preserving the existing Mathlib rebuild guard, action
+pinning, concurrency, and the exact meaning of docgen's cache/build behavior.
+
+## Next step
+
+If implementing, copy the existing CI setup/cache/build guard into
+`docs.yml`, keep `docgen-action` for the docs/deploy path, and either remove
+manual-dispatch expectations or hand-roll the docs/deploy steps so manual
+runs actually publish.
+
+## Blockers
+
+None for the review.

--- a/progress/20260703T212724Z_release-sync-review.md
+++ b/progress/20260703T212724Z_release-sync-review.md
@@ -1,0 +1,23 @@
+# release sync pins-only review
+
+## Accomplished
+
+Reviewed `scripts/release/sync_released.py`, `scripts/release/released.yml`,
+the baseline workflow, `scripts/release/synced.json`, and the bootstrap notes
+for the new `pins_only` aggregate entry.
+
+## Current frontier
+
+The `pins_only` path itself avoids managed-source dereferences, but the first
+run without a baseline entry and the manifest string-rewrite approach both need
+explicit review attention.
+
+## Next step
+
+Decide whether to require an explicit baseline seed/accept-current step for the
+aggregate, and whether aggregate manifest updates should be produced by Lake
+rather than by direct JSON rev replacement.
+
+## Blockers
+
+None for the review.

--- a/progress/20260704T141310Z_issue-8598-review.md
+++ b/progress/20260704T141310Z_issue-8598-review.md
@@ -1,0 +1,26 @@
+# Issue #8598 review pass
+
+## Accomplished
+Reviewed the committed `issue-8598` diff against `origin/main` for the
+HexBerlekampZassenhausMathlib module-system migration.
+
+Checked declaration-header changes with `git diff -U0`; the only header changes
+were the intended `meta` markings on elaboration-time/test helpers. Inspected the
+`monicModPImage` zero-branch proof repair in
+`HexBerlekampZassenhausMathlib/Basic.lean`; it remains a proof-text-only repair.
+Reviewed the `public meta import` and `import all` usage in the certificate test
+module.
+
+Ran `lake build HexBerlekampZassenhausMathlib`, which completed successfully.
+Ran `python3 scripts/check_dag.py`, which exited successfully. Checked the diff
+for added `sorry`, `axiom`, or `native_decide`; none were added.
+
+## Current frontier
+No blocking review findings from this pass. The branch is still clean except for
+this review progress note.
+
+## Next step
+Report findings and suggested minor cleanups to the user.
+
+## Blockers
+None.

--- a/progress/20260722T180701Z_factor-poly-plan-review.md
+++ b/progress/20260722T180701Z_factor-poly-plan-review.md
@@ -1,0 +1,32 @@
+# `factor_poly` / `irreducibility` implementation-plan review
+
+## Accomplished
+
+- Audited the proposed plan against the current free and Mathlib bridge declarations.
+- Verified the principal Rabin, mod-p transfer, factorization soundness, transport,
+  and decidability theorem shapes.
+- Identified feasibility gaps in opaque closed-term certification, free-layer ZPoly
+  completeness, provider fallback/goal-mode design, plain-import reduction, and the
+  Mathlib-free Eisenstein translation proof.
+- Checked the stated examples: `X^4 + 1` is Eisenstein after translating by `1` at
+  prime `2`; `X^4 - 10X^2 + 1` is not shift-Eisenstein for any integer shift.
+
+## Current frontier
+
+Review complete. No implementation files were changed.
+
+## Next step
+
+Revise the plan around a short feasibility phase: prototype provider discovery and
+goal-mode execution under plain imports, define the exact closed-term trust boundary,
+and decide whether free `ZPoly.factor_poly` is explicitly partial or gains a complete
+free certificate route.
+
+## Blockers
+
+- The existing free certificate menu cannot prove irreducibility of every factor
+  returned by `ZPoly.factorize`; unconditional per-factor soundness currently lives in
+  `HexBerlekampZassenhausMathlib`.
+- Imported opaque closed definitions cannot be equated to elaborator-evaluated literals
+  merely from `evalExpr`; a kernel-checkable bridge or a stricter input contract is
+  required.

--- a/progress/20260727T043001Z_open-issues-triage.md
+++ b/progress/20260727T043001Z_open-issues-triage.md
@@ -1,0 +1,27 @@
+# Open-issue triage
+
+**Accomplished**
+
+- Enumerated the repository's open GitHub issues and open pull requests.
+- Cross-referenced closing PRs so issues already in review are distinguished
+  from the unclaimed backlog.
+- Checked claim labels, assignees, worktrees, fresh branch commits, and running
+  agent processes to identify active work even where the `claimed` label is
+  missing.
+
+**Current frontier**
+
+- There are 18 substantive open issues plus the permanent coordination
+  sentinel. Three issues have active agents, five have open closing PRs, and
+  ten have neither an active claim nor an open closing PR.
+
+**Next step**
+
+- Re-run the triage after the active Resultant/NumberField PR stack and the
+  three claimed branches advance, since several statuses are changing quickly.
+
+**Blockers**
+
+- The documented `coordination` helper is unavailable in this checkout's
+  environment, so active-agent status was reconstructed from GitHub metadata,
+  worktrees, recent commits, and live processes.

--- a/progress/20260727T044213Z_open-issue-staleness-audit.md
+++ b/progress/20260727T044213Z_open-issue-staleness-audit.md
@@ -1,0 +1,36 @@
+# Open-issue staleness audit
+
+**Accomplished**
+
+- Audited the nine unclaimed issues other than HexNumberField M2 against
+  current `origin/main`, issue comments, merged PRs, SPEC commitments, and
+  current implementation surfaces.
+- Confirmed that #8851, #8852, and #8744 still describe present implementation
+  gaps; #8853 is current but deliberately a non-claimable tracking issue.
+- Confirmed that #8751 remains current under its owner-comment reframe, while
+  its original Phase-4-blocking premise is obsolete.
+- Identified substantive directive drift in #8664 and #8569: #8664's BZ
+  consumer/gate and one-final-reduction shape no longer match the evidence or
+  current HexMatrix SPEC, while #8569's dependencies have landed and its
+  harness/report still use the retired `Hex.factor` surface.
+- Confirmed #8369 and #8370 remain real SPEC gaps but are intentionally parked;
+  their current owner comments provide the required post-refactor name mapping.
+
+**Current frontier**
+
+- No audited issue is wholly superseded with all deliverables complete.
+- #8664 needs a major rewrite (or closure and replacement) before it is safe to
+  claim; #8569 needs a smaller rebase/rewrite before execution.
+- #8369/#8370 should remain out of the near-term worker queue until the lattice
+  tier stabilizes, and #8853 should remain outside it until its stage-zero
+  architecture decisions are made.
+
+**Next step**
+
+- If requested, update the stale issue bodies/comments and labels, then produce
+  a reduced claimable queue containing only current directives.
+
+**Blockers**
+
+- None for the audit. The `coordination` helper remains unavailable, but this
+  pass concerns directive validity rather than active claims.

--- a/progress/20260727T050520Z_rewrite-stale-issues.md
+++ b/progress/20260727T050520Z_rewrite-stale-issues.md
@@ -1,0 +1,29 @@
+# Rewrite stale open issues
+
+**Accomplished**
+
+- Rewrote GitHub issue #8664 as the current HexMatrix task for a measured,
+  periodic-reduction `ZMod64` Strassen base kernel.
+- Removed #8664's disproved Berlekamp-nullspace consumer premise and its unsafe
+  one-final-reduction shape; added the generic-dimension overflow constraint,
+  measurement gate, `StrassenConfig.Valid` proof target, and explicit scope.
+- Rewrote GitHub issue #8569 around the current certificate tactic stack.
+- Replaced the retired `irreducible_cert` / `Hex.factor` framing with
+  `factor_poly`, `irreducibility`, their bang fallbacks, and
+  `Hex.ZPoly.factorize`; added baseline repair, coverage/decline measurement,
+  honest timing separation, and Linear-vs-Incremental replay deliverables.
+- Verified both issues remain open with their original labels and no assignees.
+
+**Current frontier**
+
+- #8664 and #8569 are now current, premise-checked directives suitable for
+  backlog prioritization.
+
+**Next step**
+
+- Recompute the reduced claimable backlog if requested, treating #8853 as
+  tracking-only and #8369/#8370 as parked.
+
+**Blockers**
+
+- None.

--- a/progress/20260727T053517Z_top-five-open-issues.md
+++ b/progress/20260727T053517Z_top-five-open-issues.md
@@ -1,0 +1,26 @@
+# Top-five open-issue ranking
+
+**Accomplished**
+
+- Rechecked the current claim, assignee, comment, and linked-PR state of the
+  audited unclaimed backlog.
+- Confirmed no candidate in the reduced queue has been claimed or acquired an
+  open implementation PR.
+- Ranked the ready work by project leverage, independence, evidence quality,
+  and expected implementation/proof cost.
+
+**Current frontier**
+
+- Recommended dispatch order: #8751, #8569, #8852, #8851, #8664.
+- #8744 remains a real gap but should follow the first #8751 performance gain
+  or an explicit decision to change fixture emission architecture.
+- #8853 remains tracking-only; #8369 and #8370 remain intentionally parked.
+
+**Next step**
+
+- Claim and scope #8751 to its first optimization slice (Graeffe iteration),
+  while the four independent measurement-first tasks can proceed separately.
+
+**Blockers**
+
+- None.

--- a/progress/20260727T053857Z_pr-8900-overlap-audit.md
+++ b/progress/20260727T053857Z_pr-8900-overlap-audit.md
@@ -1,0 +1,33 @@
+# PR #8900 overlap audit
+
+**Accomplished**
+
+- Inspected PR #8900's metadata, changed-file set, and the relevant Roots,
+  factor-tactic, oracle, LLL, benchmark, report, and release-status hunks.
+- Compared the patch against the recommended work in #8751, #8569, #8852,
+  #8851, and #8664, plus the held #8744 fixture issue.
+- Confirmed PR #8900 adds release-facing APIs, examples, documentation, and
+  validation infrastructure but does not implement any recommended performance
+  kernel or certificate benchmark.
+
+**Current frontier**
+
+- The top-five order remains #8751, #8569, #8852, #8851, #8664.
+- #8751 shares only a small SPEC hunk; the new proof-facing `isolate!` wrapper
+  delegates to the same executable isolator and increases the payoff of its
+  performance work.
+- #8569 should take its post-#8900 baseline and use release-facing provider
+  imports; PR #8900 removes verification-only test imports from public
+  umbrellas but does not touch the kernel-factor sweep.
+- #8744 remains held: PR #8900 makes oracle dependency checks stricter but
+  retains fresh emission/cross-checking and does not restore the 50-case tier.
+
+**Next step**
+
+- Let PR #8900 land, then branch all recommended work from the resulting main
+  so measurements and generated-module imports reflect the release surface.
+
+**Blockers**
+
+- PR #8900 is currently open with CI running and reports a dirty merge state;
+  the overlap conclusion assumes its patch lands after the expected update.

--- a/progress/20260727T111310Z_sparse-matrix-timing.md
+++ b/progress/20260727T111310Z_sparse-matrix-timing.md
@@ -1,0 +1,31 @@
+# Sparse-valued matrix multiplication timing
+
+**Accomplished**
+
+- Measured Hex dense `Int` matrix multiplication on deterministic sparse-valued
+  square inputs at 1%, 5%, and 10% density, with nonzero coefficients in
+  `{-3, -2, -1, 1, 2, 3}`.
+- Used the canonical `lean-bench` harness on `chungus2`, pinned to CPU 24, with
+  three outer trials for `n = 64, 128, 256, 512, 1024`.
+- Compared ordinary `*` with `mulStrassen strassenDefault` at 5% density.
+- Removed the temporary local registrations and rebuilt `hexmatrix_bench`
+  successfully, leaving its tracked source unchanged.
+
+**Current frontier**
+
+- Ordinary `*` medians were effectively independent of the tested density:
+  about 0.80 ms, 5.2 ms, 38 ms, 282 ms, and 2.16--2.20 s across the five sizes.
+- At 5% density, Strassen medians were about 0.90 ms, 7.74 ms, 60.1 ms,
+  443 ms, and 3.29 s, so the ordinary dense kernel was faster throughout.
+- The result reflects sparse-valued dense storage: Hex currently executes the
+  full dense dot-product schedule and does not skip zero entries.
+
+**Next step**
+
+- If sparse multiplication becomes a supported performance surface, design a
+  sparse representation/kernel and add a permanent benchmark family that
+  varies both dimension and density.
+
+**Blockers**
+
+- None.

--- a/progress/20260727T114905Z_sparse-matrix-design.md
+++ b/progress/20260727T114905Z_sparse-matrix-design.md
@@ -1,0 +1,31 @@
+# Sparse matrix representation design
+
+**Accomplished**
+
+- Confirmed Hex currently has only the flat row-major dense `Matrix` type and
+  no existing CSR, CSC, or other sparse-matrix representation.
+- Evaluated the proposed duplicated row/column association-list layout against
+  the sparse matrix multiplication access pattern.
+- Identified CSR-style row storage for both operands plus a Gustavson row
+  accumulator as the appropriate initial computational design.
+
+**Current frontier**
+
+- Sparse multiplication can traverse `A` row-wise and, for each `A[i,k]`,
+  traverse row `k` of `B`; it does not require a column index for `B`.
+- A production representation should use contiguous CSR arrays with sorted,
+  unique, in-bounds column indices and no stored zeros, rather than pointer-heavy
+  association lists.
+- Output fill-in is central: for independent 5%-dense supports at `n = 1024`,
+  a structural product entry is present with probability about 92%, ignoring
+  coefficient cancellation, so sparse inputs may warrant a dense output.
+
+**Next step**
+
+- If implemented, specify a separate sparse type, its canonical invariants,
+  CSR multiplication and accumulator strategy, dense/sparse conversion and
+  correspondence theorem, and a fill-in-aware benchmark grid.
+
+**Blockers**
+
+- None.

--- a/progress/20260810T235956Z_name-bounds-instances.md
+++ b/progress/20260810T235956Z_name-bounds-instances.md
@@ -1,0 +1,50 @@
+# Naming the last anonymous Bounds instances
+
+## Accomplished
+
+Follow-up to the instance leak fixed on `fix/bounds-instance-leak`. Two
+library modules still declared anonymous `ZMod64.Bounds` instances, so they
+carried auto-generated `instBoundsOfNatNat_*` names, which is what made the
+original failure so hard to read.
+
+- `HexBerlekamp/Irreducibility.lean`: one, now `boundsTwo`.
+- `HexConway/Table.lean`: six, now `boundsTwo` ... `boundsThirteen`.
+
+Visibility is deliberately unchanged. Scoping them `local`, as was done for
+the test fixtures, was tried first and is wrong here: it breaks
+`HexConway/Certificates.lean` (101 errors) and
+`HexBerlekampMathlib/Irreducibility.lean` (2). Those instances are
+load-bearing for downstream modules, so the fix is naming only.
+
+Verified against the `HEX_LIB_TARGETS` set from `ci.yml`, 9643 jobs, green.
+The default `lake build` target set omits the test libraries, which is how
+an earlier version of the sibling fix reached CI broken.
+
+## Current frontier
+
+`refactor/name-bounds-instances`.
+
+## Next step
+
+Two things this deliberately does not do.
+
+Anonymous `ZMod64.Bounds` instances remain elsewhere:
+`HexGFqMathlib/GF2q.lean`, `HexGF2Mathlib/Basic.lean`, two in
+`HexGF2Mathlib/Field.lean`, and `HexBerlekampZassenhaus/Classical/Obstruction.lean`
+(the last over a named constant rather than a numeral), plus several bench
+modules. Naming those is the same mechanical change.
+
+More substantially, naming is diagnosability, not hazard removal. Public
+instances for specific numerals are still visible to every importing
+module's instance search, and there are now visibly two equal-priority
+candidates for `Bounds 2` inside `HexConway/Table.lean`: its own
+`Hex.Conway.boundsTwo`, and `Hex.Berlekamp.boundsTwo` reaching it through
+`HexBerlekamp.RabinSoundness`, which publicly imports
+`HexBerlekamp.Irreducibility`. The structural fix is one canonical witness
+per numeral in a low-level `ZMod64` module, registered locally or through an
+opt-in scope at each consumer; that means migrating the consumers, which is
+why it is not folded in here.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -58,5 +58,11 @@
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",
     "reason": "Names the four ZMod64.Bounds test fixtures and marks them private, so instance search cannot capture them into terms emitted in other modules. Test-module fixtures only; no factorizer definition and nothing in the benchmarked executable graph changes."
+  },
+  {
+    "path": "HexBerlekamp/Irreducibility.lean",
+    "baseline_blob": "ebc42b9f71233e1c470ac885c43fd012bd9116db",
+    "current_blob": "d3abc2673a4968020241b5891630a42086637bd3",
+    "reason": "Renames the public ZMod64.Bounds 2 proof instance without changing its body, priority, scope or declaration position. Elaboration may now refer to the new declaration name, but Bounds is a Prop and its instance arguments are erased, so generated factorization code and runtime behaviour are unchanged."
   }
 ]


### PR DESCRIPTION
This PR gives the last seven anonymous `ZMod64.Bounds` instances in these two modules names, so their declarations stop carrying auto-generated `instBoundsOfNatNat_*` names. One is in `HexBerlekamp/Irreducibility.lean`, six in `HexConway/Table.lean`.

**This is diagnosability, not hazard removal.** Unnameable declarations are what made the leak in https://github.com/kim-em/hex-dev/pull/9189 so hard to read: the error named a constant nobody had written. Naming fixes that and gives the instances stable public names, and it does not change what instance search can see.

Visibility is deliberately unchanged. Scoping them `local`, as the test fixtures in 9189 now are, was tried first and is wrong here: it breaks `HexConway/Certificates.lean` (101 errors) and `HexBerlekampMathlib/Irreducibility.lean` (2). Those instances are load-bearing for downstream modules, so localizing them means migrating the consumers, which does not belong in this change.

Naming does make one pre-existing oddity visible: `HexConway/Table.lean` now has two equal-priority public candidates for `Bounds 2`, its own `Hex.Conway.boundsTwo` and `Hex.Berlekamp.boundsTwo`, the latter arriving through `HexBerlekamp.RabinSoundness`, which publicly imports `HexBerlekamp.Irreducibility`. That duplication predates this PR; it was simply invisible while both were anonymous. The structural fix is one canonical witness per numeral in a low-level `ZMod64` module, registered locally or by an opt-in scope at each consumer.

Anonymous `Bounds` instances also remain in `HexGFqMathlib/GF2q.lean`, `HexGF2Mathlib/Basic.lean`, `HexGF2Mathlib/Field.lean` (two) and `HexBerlekampZassenhaus/Classical/Obstruction.lean`, plus several bench modules. Same mechanical change, not done here.

`HexBerlekamp/` is inside the freshness check's tracked prefixes, so a blob-pinned proof-only exemption is recorded. The rationale is erasure, not irrelevance: elaboration may now refer to the new declaration name, but `Bounds` is a `Prop` and its instance arguments are erased, so generated factorization code and runtime behaviour are unchanged. (`HexConway/` is not tracked.)

Verified against `ci.yml`'s `HEX_LIB_TARGETS` rather than the default targets, which omit the test libraries: 9643 jobs, green.

🤖 Prepared with Claude Code