### PR TITLE
feat(release): list announcement links on the aggregate README

### DIFF
--- a/SPEC/readme.md
+++ b/SPEC/readme.md
@@ -67,6 +67,12 @@ edit, provided its manifest entry carries a `component:` label naming the row
 manifest. `*-mathlib` companions take no label; they appear in the row of the
 computational library they bridge.
 
+A library that has been announced somewhere carries an `announcements:` map
+from venue (`blog`, `zulip`, `linkedin`) to https URL, and those render as an
+Announcements section below the table, one line per library. That keeps the
+table clean: only a couple of libraries are ever announced, so a fourth column
+would be empty for almost every row.
+
 The five required headings above do not apply to the aggregate: it documents
 the collection, not a library.
 

--- a/progress/20260811T011352Z_announcement-links.md
+++ b/progress/20260811T011352Z_announcement-links.md
@@ -27,8 +27,7 @@ README.md` and nothing else.
 
 ## Next step
 
-LinkedIn URLs for both libraries are not recorded yet; the field is
-optional, so they drop in as a one-line manifest edit each.
+Nothing outstanding. All three venues are recorded for both libraries.
 
 ## Blockers
 

--- a/progress/20260811T011352Z_announcement-links.md
+++ b/progress/20260811T011352Z_announcement-links.md
@@ -1,0 +1,35 @@
+# Announcement links on the aggregate README
+
+## Accomplished
+
+The aggregate README now lists where each library was announced, generated
+from the manifest like everything else it contains.
+
+- `released.yml` entries take an optional `announcements:` map from venue
+  (`blog`, `zulip`, `linkedin`) to https URL. Filled in for `hex-lll` and
+  `hex-berlekamp-zassenhaus`.
+- `aggregate_readme.render_announcements` renders one line per library that
+  has any, naming the component and linking the library, into a new
+  marker region in `scripts/release/hex-README.md`. Venue order is fixed by
+  `VENUES`, not by the manifest's key order, so the output is stable.
+- `check_released_manifest.py` rejects announcements on a non-aggregated
+  entry, an empty map, an unknown venue, and a non-https URL. Each rejection
+  was exercised by hand against a mutated manifest.
+
+Deliberately a section rather than a fourth table column: only a couple of
+libraries are ever announced, so a column would be empty for 17 of 19 rows
+and would get worse as the table grows.
+
+## Current frontier
+
+`feat/announcement-links`. A `--dry-run --only hex` sync reports `M
+README.md` and nothing else.
+
+## Next step
+
+LinkedIn URLs for both libraries are not recorded yet; the field is
+optional, so they drop in as a one-line manifest edit each.
+
+## Blockers
+
+None.

--- a/scripts/release/aggregate_readme.py
+++ b/scripts/release/aggregate_readme.py
@@ -20,6 +20,10 @@ HERE = Path(__file__).resolve().parent
 TEMPLATE = HERE / "hex-README.md"
 BEGIN = "<!-- LIBRARIES:BEGIN"
 END = "<!-- LIBRARIES:END -->"
+ANNOUNCE_BEGIN = "<!-- ANNOUNCEMENTS:BEGIN"
+ANNOUNCE_END = "<!-- ANNOUNCEMENTS:END -->"
+# Rendered in this order, whichever of them a library has.
+VENUES = (("blog", "blog post"), ("zulip", "Zulip"), ("linkedin", "LinkedIn"))
 NO_LAYER = "n/a"
 # Replaces the template's own editor note in the published file: the released
 # repo's reader needs to know the file is generated and where to edit it, not
@@ -81,17 +85,42 @@ def render_table(manifest: dict) -> str:
     return "\n".join(rows)
 
 
+def render_announcements(manifest: dict) -> str:
+    """Where each library was announced, one line per library that has any.
+
+    Kept out of the table: only a couple of libraries are ever announced, and a
+    column would be empty for almost every row.
+    """
+    lines = []
+    for entry in table_entries(manifest):
+        announcements = entry.get("announcements") or {}
+        links = [f"[{label}]({announcements[key]})"
+                 for key, label in VENUES if announcements.get(key)]
+        if links:
+            lines.append(f"- {entry['component']} ({_link(entry)}): "
+                         + ", ".join(links))
+    return "\n".join(lines)
+
+
+def _splice(text: str, begin: str, end: str, body: str, what: str) -> str:
+    """Replace the region between two markers, keeping the marker lines."""
+    start, stop = text.find(begin), text.find(end)
+    if start < 0 or stop < 0 or stop < start:
+        raise ValueError(f"template is missing its {what} markers")
+    return text[:text.index("\n", start) + 1] + body + "\n" + text[stop:]
+
+
 def render(manifest: dict, template: Path = TEMPLATE) -> str:
     """The full README text for the aggregate."""
     text = template.read_text(encoding="utf-8")
     if text.startswith("<!--"):
         text = NOTICE + text[text.index("-->\n") + len("-->\n"):]
-    start = text.find(BEGIN)
-    end = text.find(END)
-    if start < 0 or end < 0 or end < start:
-        raise ValueError(f"{template} is missing its LIBRARIES markers")
-    head = text[:text.index("\n", start) + 1]
-    return head + render_table(manifest) + "\n" + text[end:]
+    try:
+        text = _splice(text, BEGIN, END, render_table(manifest), "LIBRARIES")
+        return _splice(text, ANNOUNCE_BEGIN, ANNOUNCE_END,
+                       render_announcements(manifest), "ANNOUNCEMENTS")
+    except ValueError as exc:
+        raise ValueError(f"{template}: {exc}") from None
 
 
 if __name__ == "__main__":

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -234,6 +234,23 @@ def main() -> int:
                 fail(f"{repo}: aggregated library must declare a component label")
         elif component is not None:
             fail(f"{repo}: component labels belong only on aggregated libraries")
+    venues = {key for key, _label in aggregate_readme.VENUES}
+    for entry in entries:
+        announcements = entry.get("announcements")
+        if announcements is None:
+            continue
+        repo = entry["repo"]
+        if repo not in labelled:
+            fail(f"{repo}: announcements belong only on aggregated libraries")
+        if not isinstance(announcements, dict) or not announcements:
+            fail(f"{repo}: announcements must be a non-empty venue map")
+        unknown = sorted(set(announcements) - venues)
+        if unknown:
+            fail(f"{repo}: unknown announcement venues {unknown}; "
+                 f"known are {sorted(venues)}")
+        for venue, url in announcements.items():
+            if not isinstance(url, str) or not url.startswith("https://"):
+                fail(f"{repo}: {venue} announcement must be an https URL")
     try:
         aggregate_readme.render(document, REPO_ROOT / template)
     except ValueError as exc:

--- a/scripts/release/hex-README.md
+++ b/scripts/release/hex-README.md
@@ -61,5 +61,10 @@ library.
 <!-- LIBRARIES:BEGIN (generated from released.yml; do not edit by hand) -->
 <!-- LIBRARIES:END -->
 
+# Announcements
+
+<!-- ANNOUNCEMENTS:BEGIN (generated from released.yml; do not edit by hand) -->
+<!-- ANNOUNCEMENTS:END -->
+
 Development of the full project (including unreleased libraries) happens in the
 [`hex-dev`](https://github.com/kim-em/hex-dev) monorepo.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -431,6 +431,7 @@ repos:
     announcements:
       blog: https://kim-em.github.io/blog/2026-7-7-lattice-basis-reduction-using-the-hex-lean-library/
       zulip: https://leanprover.zulipchat.com/#narrow/channel/579630-Project-announcements/topic/Hex%3A.20a.20computational.20algebra.20library/near/608173688
+      linkedin: https://www.linkedin.com/posts/kim-morrison-219962b_lattice-basis-reduction-using-the-hex-lean-share-7480672935360266241-WF7o/
     lib: HexLLL
     executables: {hexlll_external_reduction: HexLLL.ExternalReduction}
     umbrella: true
@@ -458,6 +459,7 @@ repos:
     announcements:
       blog: https://kim-em.github.io/blog/2026-8-10-certified-integer-polynomial-factorization-in-lean/
       zulip: https://leanprover.zulipchat.com/#narrow/channel/579630-Project-announcements/topic/Hex%3A.20integer.20polynomial.20factorization/near/615747356
+      linkedin: https://www.linkedin.com/feed/update/urn:li:activity:7492744920349192193
     lib: HexBerlekampZassenhaus
     test_modules: [HexBerlekampZassenhaus.FactorTacticTests]
     build_modules: [HexBerlekampZassenhaus.All]

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -37,6 +37,11 @@
 # root module. The sync refuses to publish when the skeleton is stale.
 # `pins` lists the upstream repos whose git rev is rewritten in this repo's root
 # lakefile (matched by their github URL); `lakefile` is that file's format.
+# `announcements` maps a venue (`blog`, `zulip`, `linkedin`) to the https URL
+# where this library was announced; it renders as one line per library in the
+# aggregate README's Announcements section. Deliberately not a table column:
+# only a couple of libraries are ever announced, so a column would be empty for
+# almost every row.
 # `component` is the human label this library gets in the aggregate README's
 # table (see `readme_template` below). Required on every aggregated
 # computational library, so releasing one cannot silently skip the table; the
@@ -423,6 +428,9 @@ repos:
 
   - repo: leanprover/hex-lll
     component: LLL lattice reduction
+    announcements:
+      blog: https://kim-em.github.io/blog/2026-7-7-lattice-basis-reduction-using-the-hex-lean-library/
+      zulip: https://leanprover.zulipchat.com/#narrow/channel/579630-Project-announcements/topic/Hex%3A.20a.20computational.20algebra.20library/near/608173688
     lib: HexLLL
     executables: {hexlll_external_reduction: HexLLL.ExternalReduction}
     umbrella: true
@@ -447,6 +455,9 @@ repos:
 
   - repo: leanprover/hex-berlekamp-zassenhaus
     component: Integer polynomial factorization
+    announcements:
+      blog: https://kim-em.github.io/blog/2026-8-10-certified-integer-polynomial-factorization-in-lean/
+      zulip: https://leanprover.zulipchat.com/#narrow/channel/579630-Project-announcements/topic/Hex%3A.20integer.20polynomial.20factorization/near/615747356
     lib: HexBerlekampZassenhaus
     test_modules: [HexBerlekampZassenhaus.FactorTacticTests]
     build_modules: [HexBerlekampZassenhaus.All]

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -380,6 +380,9 @@ class AggregateReadmeTests(unittest.TestCase):
             "<!-- LIBRARIES:BEGIN (generated) -->\n"
             "| Component | stale | rows |\n"
             "<!-- LIBRARIES:END -->\n\n"
+            "<!-- ANNOUNCEMENTS:BEGIN (generated) -->\n"
+            "- stale announcement\n"
+            "<!-- ANNOUNCEMENTS:END -->\n\n"
             "trailer\n",
             encoding="utf-8",
         )
@@ -407,6 +410,38 @@ class AggregateReadmeTests(unittest.TestCase):
             f"| {aggregate_readme.NO_LAYER} |",
             text,
         )
+
+    def test_announcements_render_per_library(self) -> None:
+        manifest = {"repos": [
+            {"repo": "leanprover/hex-lll", "lib": "HexLLL",
+             "component": "LLL lattice reduction",
+             "announcements": {"zulip": "https://z.example/t",
+                               "blog": "https://b.example/p"}},
+            {"repo": "leanprover/hex-matrix", "lib": "HexMatrix",
+             "component": "Matrices"},
+            {"repo": "leanprover/hex", "pins_only": True},
+        ]}
+        rendered = aggregate_readme.render_announcements(manifest)
+        # venue order is fixed by VENUES, not by the manifest's key order
+        self.assertEqual(
+            rendered,
+            "- LLL lattice reduction ([HexLLL](https://github.com/leanprover/hex-lll)): "
+            "[blog post](https://b.example/p), [Zulip](https://z.example/t)")
+        # a library with no announcements contributes no line
+        self.assertNotIn("Matrices", rendered)
+
+    def test_announcement_region_is_replaced(self) -> None:
+        text = aggregate_readme.render(self.MANIFEST, self.template)
+        self.assertNotIn("stale announcement", text)
+        self.assertTrue(text.endswith("trailer\n"))
+
+    def test_template_without_announcement_markers_is_an_error(self) -> None:
+        partial = Path(self.temporary.name) / "partial.md"
+        partial.write_text(
+            "# hex\n<!-- LIBRARIES:BEGIN -->\n<!-- LIBRARIES:END -->\n",
+            encoding="utf-8")
+        with self.assertRaises(ValueError):
+            aggregate_readme.render(self.MANIFEST, partial)
 
     def test_missing_component_label_is_an_error(self) -> None:
         manifest = {"repos": [{"repo": "leanprover/hex-matrix", "lib": "HexMatrix"}]}


### PR DESCRIPTION
Where a library was announced was recorded nowhere, so the aggregate README gave a reader no route to the blog post or Zulip thread explaining what a library is for.

Entries in `released.yml` now take an optional `announcements:` map from venue (`blog`, `zulip`, `linkedin`) to https URL, and the aggregate README grows an Announcements section rendered from it, one line per library, naming the component and linking the library:

```
- LLL lattice reduction ([HexLLL](https://github.com/leanprover/hex-lll)): [blog post](…), [Zulip](…)
- Integer polynomial factorization ([HexBerlekampZassenhaus](…)): [blog post](…), [Zulip](…)
```

A section rather than a fourth table column: only a couple of libraries are ever announced, so a column would be empty for 17 of the 19 rows, and worse as the table grows. Venue order is fixed by `VENUES` rather than by the manifest's key order, so the rendered output is stable.

LinkedIn is left out for now because those URLs do not exist yet; the field is optional per venue, so each drops in as a one-line manifest edit.

`check_released_manifest.py` rejects announcements on a non-aggregated entry, an empty map, an unknown venue, and a non-https URL. Each rejection was exercised against a deliberately mutated manifest, which caught one of my own test mistakes: inserting a duplicate `blog:` key does not test the URL check, since YAML keeps the later value.

`--dry-run --only hex` reports `M README.md` and nothing else.

🤖 Prepared with Claude Code