### PR TITLE
refactor: name the last anonymous Bounds instances

### DIFF
--- a/HexBerlekampZassenhaus/Classical/Obstruction.lean
+++ b/HexBerlekampZassenhaus/Classical/Obstruction.lean
@@ -39,7 +39,7 @@ have been performed anyway, and small enough that its trial-division primality
 proof is cheap to check in the kernel. -/
 def obstructionPrime : Nat := 67108859
 
-instance : ZMod64.Bounds obstructionPrime where
+instance boundsObstructionPrime : ZMod64.Bounds obstructionPrime where
   pPos := by decide
   pLtR := by decide
 

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -89,7 +89,7 @@ end RingEquiv
 
 namespace GF2Poly
 
-instance : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -35,7 +35,7 @@ end TypeEquiv
 
 namespace GF2n
 
-instance : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem prime_two : Hex.Nat.Prime 2 := by
   constructor
@@ -418,7 +418,7 @@ end GF2n
 
 namespace GF2nPoly
 
-instance : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem prime_two : Hex.Nat.Prime 2 := by
   constructor

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -19,7 +19,7 @@ namespace GF2q
 
 variable {n : Nat} [h : Conway.PackedGF2Entry n]
 
-instance : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem cast_symm_cast {α β : Type u} (h : α = β) (x : α) :
     cast h.symm (cast h x) = x := by

--- a/bench/HexStrassen/Compare.lean
+++ b/bench/HexStrassen/Compare.lean
@@ -23,9 +23,9 @@ abbrev tinyPrime : Nat := 5
 abbrev smallPrime : Nat := 65537
 abbrev upperPrime : Nat := 2147483647
 
-instance : ZMod64.Bounds tinyPrime := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds smallPrime := ⟨by decide, by decide⟩
-instance : ZMod64.Bounds upperPrime := ⟨by decide, by decide⟩
+instance boundsTiny : ZMod64.Bounds tinyPrime := ⟨by decide, by decide⟩
+instance boundsSmall : ZMod64.Bounds smallPrime := ⟨by decide, by decide⟩
+instance boundsUpper : ZMod64.Bounds upperPrime := ⟨by decide, by decide⟩
 
 def tinyCtx : Hex.BarrettCtx tinyPrime := Hex.BarrettCtx.ofModulus (by decide) (by decide)
 def smallCtx : Hex.BarrettCtx smallPrime := Hex.BarrettCtx.ofModulus (by decide) (by decide)

--- a/progress/20260811T050939Z_name-remaining-bounds.md
+++ b/progress/20260811T050939Z_name-remaining-bounds.md
@@ -1,0 +1,44 @@
+# Naming the last anonymous Bounds instances
+
+## Accomplished
+
+Completes the audit begun on `refactor/name-bounds-instances`. Eight
+anonymous `ZMod64.Bounds` instances are now named:
+
+- `HexGF2Mathlib/Basic.lean`, and two in `HexGF2Mathlib/Field.lean`
+  (`GF2n` and `GF2nPoly`, so both can be `boundsTwo`);
+- `HexGFqMathlib/GF2q.lean`;
+- `HexBerlekampZassenhaus/Classical/Obstruction.lean`, over the named
+  constant `obstructionPrime` rather than a numeral;
+- three in `bench/HexStrassen/Compare.lean`.
+
+Visibility is unchanged throughout, as on the previous pass.
+
+Three anonymous instances are deliberately left, in
+`HexManual/Chapters/{HexGFqField,HexGFqRing,HexPolyFp}.lean`. They sit
+inside ```lean blocks that the published manual renders, so naming them
+would add noise to a worked example for no reader benefit, and they are
+`private`, so they cannot be captured from another module.
+
+Verified against `ci.yml`'s `HEX_LIB_TARGETS`, plus `HexGF2Mathlib`,
+`HexGFqMathlib` and `hexstrassen_compare`, which the CI list does not
+cover: 9673 jobs, green.
+
+## Current frontier
+
+`refactor/name-remaining-bounds`.
+
+## Next step
+
+The duplication this makes legible is now the whole of what is left.
+Public `Bounds 2` witnesses exist in `HexBerlekamp.Irreducibility`,
+`HexConway.Table`, `HexGF2Mathlib.Basic`, `HexGF2Mathlib.Field` twice, and
+`HexGFqMathlib.GF2q`. Any module importing more than one sees several
+equal-priority candidates. The fix is one canonical witness per modulus in a
+low-level `ZMod64` module, registered locally or by an opt-in scope at each
+consumer, which means migrating every consumer and so wants to be its own
+piece of work.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -64,5 +64,11 @@
     "baseline_blob": "ebc42b9f71233e1c470ac885c43fd012bd9116db",
     "current_blob": "d3abc2673a4968020241b5891630a42086637bd3",
     "reason": "Renames the public ZMod64.Bounds 2 proof instance without changing its body, priority, scope or declaration position. Elaboration may now refer to the new declaration name, but Bounds is a Prop and its instance arguments are erased, so generated factorization code and runtime behaviour are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/Classical/Obstruction.lean",
+    "baseline_blob": "c6503f384a5e97defd593b440430b5dcc1d6b19b",
+    "current_blob": "a10f8bfb2b9ceef8eb49029c10ffd3c4aa2670ac",
+    "reason": "Names the public ZMod64.Bounds obstructionPrime proof instance without changing its body, priority, scope or declaration position. Elaboration may now refer to the new declaration name, but Bounds is a Prop and its instance arguments are erased, so generated factorization code and runtime behaviour are unchanged."
   }
 ]


### PR DESCRIPTION
Completes the audit begun in https://github.com/kim-em/hex-dev/pull/9190, which named the instances in two modules and listed the rest.

Eight anonymous `ZMod64.Bounds` instances are now named, so no library or bench instance carries an auto-generated `instBoundsOfNatNat_*` name:

- `HexGF2Mathlib/Basic.lean`, and two in `HexGF2Mathlib/Field.lean` (in `GF2n` and `GF2nPoly`, so both can be `boundsTwo`)
- `HexGFqMathlib/GF2q.lean`
- `HexBerlekampZassenhaus/Classical/Obstruction.lean`, over the named constant `obstructionPrime` rather than a numeral
- three in `bench/HexStrassen/Compare.lean`

Visibility is unchanged throughout, as in 9190.

Three anonymous instances are deliberately left, in `HexManual/Chapters/{HexGFqField,HexGFqRing,HexPolyFp}.lean`. They sit inside ```lean blocks that the published manual renders, so naming them would add noise to a worked example for no reader benefit, and they are `private`, so they cannot be captured from another module.

`HexBerlekampZassenhaus/` is a tracked freshness prefix, so a blob-pinned proof-only exemption is recorded on the same erasure grounds as 9190: `Bounds` is a `Prop` and its instance arguments are erased, so generated code is unchanged.

Verified against `ci.yml`'s `HEX_LIB_TARGETS` plus `HexGF2Mathlib`, `HexGFqMathlib` and `hexstrassen_compare`, none of which the CI library list covers: 9673 jobs, green.

What this does not fix, now fully visible: public `Bounds 2` witnesses exist in `HexBerlekamp.Irreducibility`, `HexConway.Table`, `HexGF2Mathlib.Basic`, `HexGF2Mathlib.Field` twice, and `HexGFqMathlib.GF2q`, so any module importing several sees several equal-priority candidates. One canonical witness per modulus in a low-level `ZMod64` module, registered by opt-in scope at each consumer, is the fix, and it means migrating every consumer.

🤖 Prepared with Claude Code