### PR TITLE
refactor: one canonical Bounds 2, and fix the bug it uncovered

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -1245,6 +1245,37 @@ restructure around the reported line first; it is usually a cheap `omega` or
   `omega` and defeq checks whnf that term — avoid binding the matrix; write it
   out or `clear_value` only when the value is genuinely unneeded downstream.
 
+## `private instance` does not hide an instance; `local instance` does
+
+Instance search in an importing module still finds a `private instance` from
+an imported module, but the emitted term cannot legally name it. When the
+`factor_poly` / `irreducibility` elaborators pick one up, the result is
+
+```
+Unknown constant `_private.HexPolyFp.SquareFree.0.Hex.FpPoly.squareFreeGuardBoundsTwo`
+Note: A private declaration ... exists but would need to be public to access here.
+```
+
+in whatever module invoked the tactic, which is nowhere near the declaration.
+This has bitten twice: once from a test module's anonymous instances, and once
+from `HexPolyFp.SquareFree`'s `private` guards, the latter masked for a while
+because a public duplicate happened to be declared later and win.
+
+So, for a `ZMod64.Bounds` witness at a concrete modulus:
+
+- `local instance` if only this file needs it. This is the default. Note it
+  scopes the *attribute*, not the name: the declaration stays referenceable.
+  To hide both, write `private theorem foo : ...` followed by
+  `attribute [local instance] foo`.
+- a plain public `instance` if downstream modules genuinely need it, and only
+  where no other module already provides one. `Hex.ZMod64.boundsTwo` in
+  `HexModArith/Residue.lean` is the canonical `Bounds 2`; do not re-declare it.
+- never `private instance`: it keeps the hazard and only hides the name.
+
+`Bounds p` is a `Prop`, so duplicate witnesses are never a coherence problem;
+they are an ambiguity and diagnosability problem, which is why one canonical
+public witness plus `local` everywhere else is the shape to aim for.
+
 ## Verifying executable-layer changes: build the module, not the target
 
 `lake build HexBerlekampZassenhaus` (the whole target) drags in

--- a/HexBerlekamp/FactorTacticTests.lean
+++ b/HexBerlekamp/FactorTacticTests.lean
@@ -20,7 +20,6 @@ open Hex
 namespace HexBerlekamp.FactorTacticTests
 
 local instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
-local instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 def z (n : Nat) : ZMod64 5 := ZMod64.ofNat 5 n
 

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -22,13 +22,6 @@ namespace Hex
 
 namespace Berlekamp
 
-/-- `Bounds 2` for the `FpPoly 2`-specialized pow-chain witness checkers below.
-Previously this was supplied implicitly by a private instance in
-`HexPolyFp.SquareFree` that leaked through typeclass resolution under the
-pre-module import semantics; the module system hides private instances, so the
-`p = 2` checkers declare it in this module. -/
-instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
-
 variable {p : Nat} [ZMod64.Bounds p]
 
 /-- `X^(p^k) - X` reduced modulo `f`. -/

--- a/HexConway/Table.lean
+++ b/HexConway/Table.lean
@@ -16,7 +16,6 @@ per-entry polynomial literals with their monic/degree/table-hit lemmas.
 namespace Hex
 
 namespace Conway
-instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 instance boundsThree : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
 instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
 instance boundsSeven : ZMod64.Bounds 7 := ⟨by decide, by decide⟩

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -89,7 +89,6 @@ end RingEquiv
 
 namespace GF2Poly
 
-instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -35,8 +35,6 @@ end TypeEquiv
 
 namespace GF2n
 
-instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
-
 private theorem prime_two : Hex.Nat.Prime 2 := by
   constructor
   · decide
@@ -417,8 +415,6 @@ theorem fintype_card :
 end GF2n
 
 namespace GF2nPoly
-
-instance boundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem prime_two : Hex.Nat.Prime 2 := by
   constructor

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -19,7 +19,6 @@ namespace GF2q
 
 variable {n : Nat} [h : Conway.PackedGF2Entry n]
 
-instance boundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem cast_symm_cast {α β : Type u} (h : α = β) (x : α) :
     cast h.symm (cast h x) = x := by

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -128,6 +128,8 @@ Over a prime field, the result has the analogous
 ```lean
 open Hex
 
+local instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+
 def fp : FpPoly 5 := #p[4, 0, 1]
 
 def fpFactors : FpPoly.Factored fp :=

--- a/HexManual/Chapters/HexBerlekamp.lean
+++ b/HexManual/Chapters/HexBerlekamp.lean
@@ -75,6 +75,8 @@ data in an irreducibility certificate.
 ```lean
 open Hex
 
+local instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+
 def f : FpPoly 5 := #p[1, 0, 1]
 
 #check Berlekamp.berlekampFactor

--- a/HexManual/Chapters/HexGFqField.lean
+++ b/HexManual/Chapters/HexGFqField.lean
@@ -139,7 +139,7 @@ open Hex Hex.GFqField
 
 namespace HexGFqFieldChapterExample
 
-private instance : ZMod64.Bounds 5 :=
+local instance boundsFive : ZMod64.Bounds 5 :=
   ⟨by decide, by decide⟩
 
 private theorem prime_five : Hex.Nat.Prime 5 := by

--- a/HexManual/Chapters/HexGFqRing.lean
+++ b/HexManual/Chapters/HexGFqRing.lean
@@ -122,7 +122,7 @@ open Hex Hex.GFqRing
 
 namespace HexGFqRingChapterExample
 
-private instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+local instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
 
 private theorem prime_five : Hex.Nat.Prime 5 := by
   constructor

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -143,7 +143,7 @@ open Hex Hex.FpPoly
 
 namespace HexPolyFpChapterExample
 
-private instance : ZMod64.Bounds 5 :=
+local instance boundsFive : ZMod64.Bounds 5 :=
   ⟨by decide, by decide⟩
 
 private theorem prime_five : Hex.Nat.Prime 5 := by

--- a/HexModArith/Residue.lean
+++ b/HexModArith/Residue.lean
@@ -44,6 +44,26 @@ residue fit in a `UInt64`. Derived from the `p < 2^31` bound. -/
 theorem Bounds.pLtWord (p : Nat) [Bounds p] : p < UInt64.word :=
   Nat.lt_trans (Bounds.pLtR (p := p)) (by decide)
 
+/-- The canonical `Bounds 2`, for the whole project.
+
+`Bounds` has no general instance: the two conditions are decidable for a
+literal, but instance search cannot run `decide` on the goal, so every modulus
+needs its own witness. `p = 2` is wanted almost everywhere (`GF(2)`, the
+`FpPoly 2` pow-chain checkers, the Conway table), and it used to be re-declared
+in each place: six public copies across five files, in `HexBerlekamp`,
+`HexConway`, `HexGF2Mathlib` (three) and `HexGFqMathlib`. Any module importing
+several saw that many equal-priority candidates, and further copies in test and
+guard modules were captured into emitted proof terms, producing errors naming
+constants nobody had written.
+
+Declaring it here, alongside the class, gives every consumer one candidate
+reachable by the import they already have. A module needing some other modulus
+should use `local instance`, or a `private theorem` plus
+`attribute [local instance]` to keep the name unexported too. Never
+`private instance`: that leaves the instance visible to search in importing
+modules while making its name unreferenceable there. -/
+instance boundsTwo : Bounds 2 := ⟨by decide, by decide⟩
+
 end ZMod64
 
 /-- Residues mod `p` stored in a single machine word, with a proof of reduction. -/

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -247,7 +247,8 @@ theorem squareFreeDecomposition_pairwise_coprime (hp : Hex.Nat.Prime p) (f : FpP
       (fun a b => (normalizeMonic (DensePoly.gcd a.factor b.factor)).2 = 1) :=
   squareFree_pairwise_coprime hp f
 
-private instance squareFreeGuardBoundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+private theorem squareFreeGuardBoundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+attribute [local instance] squareFreeGuardBoundsFive
 
 private theorem prime_five_squareFree_guard : Hex.Nat.Prime 5 := by
   constructor
@@ -286,8 +287,6 @@ private def coeffNatsSquareFreeGuard (f : FpPoly 5) : List Nat :=
   let d := squareFreeDecomposition prime_five_squareFree_guard f
   coeffNatsSquareFreeGuard (weightedProduct d.factors) ==
     coeffNatsSquareFreeGuard f
-
-private instance squareFreeGuardBoundsTwo : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem prime_two_squareFree_guard : Hex.Nat.Prime 2 := by
   constructor

--- a/progress/20260811T072937Z_canonical-bounds-two.md
+++ b/progress/20260811T072937Z_canonical-bounds-two.md
@@ -1,0 +1,59 @@
+# One canonical `Bounds 2`, and the bug the duplicates were hiding
+
+## Accomplished
+
+`Hex.ZMod64.boundsTwo` in `HexModArith/Residue.lean`, beside the class it
+witnesses, is now the project's single `Bounds 2`. The five public copies
+are gone: `HexBerlekamp/Irreducibility.lean`, `HexConway/Table.lean`,
+`HexGF2Mathlib/Basic.lean`, `HexGF2Mathlib/Field.lean` twice, and
+`HexGFqMathlib/GF2q.lean`. No consumer needed migrating, since anything
+using `ZMod64` already imports the module that defines it.
+
+That is a smaller change than the opt-in-scope scheme sketched previously,
+and it is enough: `Bounds p` is a `Prop`, so several witnesses were never a
+coherence risk, only ambiguity and unreadable diagnostics. One reachable
+candidate settles both.
+
+Removing the duplicates then exposed a real bug they had been masking.
+`HexPolyFp/SquareFree.lean` declared `private instance
+squareFreeGuardBoundsTwo`. **`private` hides the name but leaves the
+instance in the table for importing modules**, so with the public copies
+gone, instance search in `HexBerlekampZassenhausMathlib/FactorPolyTests.lean`
+selected it and emitted a term naming
+`_private.HexPolyFp.SquareFree.0.Hex.FpPoly.squareFreeGuardBoundsTwo`, which
+cannot legally be referenced there. This is the same failure shape as the
+original leak, from a different source, and it was one instance-ordering
+change away from firing on its own. Both guards are now `local instance`.
+
+`local` is therefore the right marker for an instance you do not want
+exported, and `private` is actively wrong: it keeps the hazard and only
+hides the name. Written up in the `hex-lean-mathlib-boundary` skill, since
+this has now caused two separate failures.
+
+Two manual chapters, `HexBerlekamp` and `FactorTactics`, turned out to have
+no `Bounds 5` witness of their own: their displayed examples compiled only
+because the `SquareFree` guard was leaking into them. Both now declare
+`local instance boundsFive`. The three chapters that already had one showed
+`private instance`, the form the skill now says never to use, so they are
+converted too; a manual should display the idiom it recommends.
+
+Verified against `ci.yml`'s `HEX_LIB_TARGETS` plus `HexGF2Mathlib`,
+`HexGFqMathlib` and `hexstrassen_compare` (9673 jobs), and separately
+against `HexManual` (9717 jobs), which `ci.yml` builds as its own step and
+which an earlier round of this change missed.
+
+## Current frontier
+
+`refactor/canonical-bounds-two`.
+
+## Next step
+
+`Bounds` witnesses at other moduli are all single-declaration or scoped, so
+none of them is ambiguous. The remaining `private instance` occurrences live
+in conformance, bench, manual chapters and `reports/scratch`, none of which
+any module imports, so they cannot leak; converting them to `local` would be
+tidiness rather than a fix.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -112,5 +112,29 @@
     "baseline_blob": "80f9ea2b180066079f41d912b8f9137074a8676a",
     "current_blob": "23dc012088d8513f1d8c1748c5367c9a33f4120c",
     "reason": "Adds the DirectPrimeProbe.Trial proposition and the retained-probe theorems, and rederives directPrimePlan?_selected_p_le_500 from the all-probes version. Trial is Prop-valued and nothing on the ZPoly.factorize path mentions it; no executable definition changes."
+  },
+  {
+    "path": "HexBerlekamp/FactorTacticTests.lean",
+    "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
+    "current_blob": "84ee69d7ff6520879b20dbf8644b0e27b8c4b3e5",
+    "reason": "Removes a test module's now-redundant local Bounds 2 fixture. Test module only; nothing in the benchmarked executable graph changes."
+  },
+  {
+    "path": "HexBerlekamp/Irreducibility.lean",
+    "baseline_blob": "ebc42b9f71233e1c470ac885c43fd012bd9116db",
+    "current_blob": "377a37b6fdfb7c94f3a18a455edfbb5f50829b6a",
+    "reason": "Removes the duplicate ZMod64.Bounds 2 instance, now supplied canonically by HexModArith. Bounds proofs are erased before code generation and the elaborators do not branch on the witness expression, so the benchmarked executable is unchanged."
+  },
+  {
+    "path": "HexModArith/Residue.lean",
+    "baseline_blob": "c1e80e762e66f1ff6000217dd09ac9b746ecccd9",
+    "current_blob": "91a08cda3853a3dd24432e2124fc24e48a189484",
+    "reason": "Adds the canonical ZMod64.Bounds 2 instance beside the class. Bounds proofs are erased before code generation, and the factorization and irreducibility elaborators transport the witness through types and constructor applications without branching on its identity, so which witness is selected cannot reach the benchmarked executable."
+  },
+  {
+    "path": "HexPolyFp/SquareFree.lean",
+    "baseline_blob": "9bf2c14fba5223b110dbe95f1b8834fd15294c3c",
+    "current_blob": "f2fc2e74288a630fc49490e9bea3602e8e165ebb",
+    "reason": "Scopes the square-free guard witnesses so importing modules stop selecting an instance they cannot legally name: the Bounds 2 guard is dropped in favour of the canonical instance, and the Bounds 5 guard becomes a private theorem with a local instance attribute. Definitions, their bodies and their declaration positions are unchanged, Bounds proofs are erased before code generation, and the elaborators do not branch on the witness expression."
   }
 ]


### PR DESCRIPTION
This PR make `Hex.ZMod64.boundsTwo`, declared in `HexModArith/Residue.lean` beside the class it witnesses, the project's single `ZMod64.Bounds 2`, and remove the six public duplicates across `HexBerlekamp/Irreducibility.lean`, `HexConway/Table.lean`, `HexGF2Mathlib/Basic.lean`, `HexGF2Mathlib/Field.lean` (two) and `HexGFqMathlib/GF2q.lean`. No consumer changes: anything using `ZMod64` already imports the module that defines it. `Bounds p` is a `Prop`, so several witnesses were never a coherence risk, only ambiguity and unreadable diagnostics, and one reachable candidate settles both.

It also fix an instance-capture defect in `HexPolyFp/SquareFree.lean`, which declared `private instance squareFreeGuardBoundsTwo : Bounds 2`. `private` hides the name but leaves the instance in the table for importing modules, so instance search elsewhere can select a witness whose name cannot legally be referenced there, and the `factor_poly` elaborator then emits `_private.HexPolyFp.SquareFree.0.…` into the proof term. The `Bounds 2` guard is dropped in favour of the canonical instance, and the `Bounds 5` guard becomes a `private theorem` with `attribute [local instance]`, which scopes the instance and keeps the name unexported. `HexPolyFp/SquareFree.lean` was the only library module carrying this hazard; the remaining `private instance` occurrences are in conformance, bench and `reports/scratch`, none of which any module imports.

Two manual chapters, `HexBerlekamp` and `FactorTactics`, declared `FpPoly 5` values with no `Bounds 5` witness of their own; their displayed examples compiled only because the `SquareFree` guard reached them. Both now declare `local instance boundsFive`. The three chapters that already carried a witness used `private instance`, so they are converted to the same form: a manual should display the idiom it recommends.

The six removed declarations were anonymous until earlier today, so no caller can have referenced them by name; they are treated as unstable rather than given deprecated aliases.

The `hex-lean-mathlib-boundary` skill records the rule: `local instance` for a witness only one file needs, `private theorem` plus `attribute [local instance]` to hide the name as well, a plain public instance only where downstream modules need one and none exists, and never `private instance`.

Four blob-pinned proof-only exemptions accompany the change: `Bounds` proofs are erased before code generation, and the factorization and irreducibility elaborators transport the witness through types and constructor applications without branching on its identity, so witness selection cannot reach the benchmarked executable.

🤖 Prepared with Claude Code