### PR TITLE
interval: prove meanings of reified goals

### DIFF
--- a/HexInterval/Experiment/GoalClosure.lean
+++ b/HexInterval/Experiment/GoalClosure.lean
@@ -1,0 +1,292 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.FrontendEncoder
+public import HexInterval.Experiment.GoalFrontend
+public import HexInterval.Experiment.OperationSemantics
+public import HexInterval.Experiment.TraceReplay
+
+@[expose] public section
+
+/-!
+# Kernel links for reified expression graphs
+
+Goal recognizers are untrusted elaborator code.  This module turns their plain
+graph result into a kernel-checked operation model by asking each aligned
+package for a proof of its own relation at every node.  The assembler has no
+case split on mathematical functions.
+-/
+
+namespace Hex.Interval.Experiment.GoalClosure
+
+open Lean Meta
+open Propagator SemanticReplay ChronologicalReplay
+open GoalFrontend FrontendEncoder OperationSemantics
+
+/-- Interpret a finite list of reified values as a total node valuation. -/
+def valuationOf (fallback : Value) (values : List Value) (node : NodeId) : Value :=
+  values[node.index]?.getD fallback
+
+/-- The proof-producing half of one syntax package.
+
+`model` is an expression denoting the package's `OperationSemantics.Model`;
+`aligned` proves that model names the same opaque operation. `prove` must
+return a term proving the model's relation for the supplied argument
+expressions and result expression. All are checked by the kernel when the
+assembled `Models` term is elaborated. -/
+structure Package where
+  operation : Operation
+  model : Expr
+  aligned : Expr
+  prove : List Expr → Expr → MetaM Expr
+
+/-- A reified valuation together with the kernel proof that it models the
+exact expression program. -/
+structure ModelProof where
+  valuation : Expr
+  proof : Expr
+
+/-- Reified kernel terms for the caller's exact base graph and canonical
+version-zero fact list. -/
+structure BaseProof where
+  input : Expr
+  program : Expr
+  facts : Expr
+  basePrefix : Expr
+  within : Expr
+  extension : Expr
+  sameOperations : Expr
+
+/-- Domain-specific proof hooks for caller assumptions.  The callback receives
+the graph expression, valuation, node, proposed fact, corresponding Lean term,
+and the original local proof.  Its result must typecheck as the semantic fact
+at that node. -/
+structure FactBridge (Fact : Type) where
+  runtime : FactDomain Fact
+  schema : Expr
+  proveAssumption : Expr → Expr → NodeId → Fact → Expr → Expr → MetaM Expr
+
+/-- Resolve the exact Lean expression assigned to a reified node. -/
+def termAt? (terms : Array TermRef) (node : NodeId) : Option Expr := do
+  let term ← terms.toList.find? fun term => term.node == node
+  pure term.expression
+
+/-- Package one checked model lookup and relation theorem as a node meaning. -/
+theorem meaningOf (models : Array (OperationSemantics.Model Value))
+    (valuation : NodeId → Value) (node : NodeId) (instruction : Node)
+    (model : OperationSemantics.Model Value)
+    (found : models[instruction.op.index]? = some model)
+    (related : model.relation (instruction.args.map valuation) (valuation node)) :
+    OperationSemantics.NodeMeaning models valuation node instruction :=
+  ⟨model, found, related⟩
+
+/-- Exact semantic facts in list order, used to emit the universal base-fact
+premise without generating a function by cases on node identifiers. -/
+def FactMeanings (semantics : Semantics Fact) (program : Program)
+    (valuation : NodeId → semantics.Value) : List (NodeFact Fact) → Prop
+  | [] => True
+  | fact :: rest =>
+      semantics.holds program valuation fact ∧
+        FactMeanings semantics program valuation rest
+
+theorem FactMeanings.all {semantics : Semantics Fact} {program : Program}
+    {valuation : NodeId → semantics.Value} (facts : List (NodeFact Fact))
+    (meanings : FactMeanings semantics program valuation facts) :
+    ∀ fact, fact ∈ facts → semantics.holds program valuation fact := by
+  intro fact member
+  induction facts with
+  | nil => simp at member
+  | cons head tail ih =>
+      rcases List.mem_cons.mp member with rfl | member
+      · exact meanings.1
+      · exact ih meanings.2 member
+
+/-- Project a successful transparent domain check by ordinary reduction. -/
+def checkedGet {α : Type} (result : Option α) (success : result.isSome = true) : α :=
+  result.get success
+
+/-- Combine the previous and proposed semantic facts through the domain's
+checked meet theorem. -/
+theorem holdsMeet {semantics : Semantics Fact} {program : Program}
+    {valuation : NodeId → semantics.Value} {node : NodeId}
+    {previous proposed installed : Fact}
+    (meet : Evidence
+      (∀ value, semantics.models program value →
+        (semantics.holds program value { node, fact := installed } ↔
+          semantics.holds program value { node, fact := previous } ∧
+            semantics.holds program value { node, fact := proposed })))
+    (model : semantics.models program valuation)
+    (previousProof : semantics.holds program valuation { node, fact := previous })
+    (proposedProof : semantics.holds program valuation { node, fact := proposed }) :
+    semantics.holds program valuation { node, fact := installed } :=
+  (meet.proof valuation model).mpr ⟨previousProof, proposedProof⟩
+
+def installFact (domain : FactDomain Fact) (nodeDomain : DomainId)
+    (current proposed : Fact) : Except String Fact :=
+  match domain.narrow nodeDomain current proposed with
+  | .noChange => pure current
+  | .improved installed | .contradiction installed => pure installed
+  | .malformed _ => throw "malformed caller interval fact"
+  | .resourceLimit _ => throw "caller interval fact exceeded its resource bound"
+
+/-- Prove the complete canonical base-fact premise from domain top and each
+caller's ordered seed recipe. -/
+def proveFacts [BEq Fact] (bridge : FactBridge Fact)
+    (encoder : FrontendEncoder.Encoder Fact) (result : GoalFrontend.Result Fact)
+    (base : BaseProof) (model : ModelProof) : MetaM Expr := do
+  unless result.seeds.size == result.input.baseProgram.nodes.size &&
+      result.baseFacts.length == result.input.baseProgram.nodes.size do
+    throwError "interval goal closure: seed table does not cover the base graph"
+  let mut proofs := []
+  for index in [0:result.input.baseProgram.nodes.size] do
+    let node : NodeId := { index }
+    let some instruction := result.input.baseProgram.nodes[index]?
+      | throwError "interval goal closure: fact node escaped its program"
+    let some expression := termAt? result.terms node
+      | throwError "interval goal closure: fact node has no Lean expression"
+    let some seed := result.seeds[index]?
+      | throwError "interval goal closure: fact node has no seed recipe"
+    let some finalFact := result.baseFacts[index]?
+      | throwError "interval goal closure: fact node has no canonical base fact"
+    unless finalFact.node == node do
+      throwError "interval goal closure: canonical base facts are out of order"
+    let nodeTerm ← encoder.nodeId node
+    let instructionTerm ← encoder.node instruction
+    let someInstruction ← mkAppM ``Option.some #[instructionTerm]
+    let found ← mkAppM ``Eq.refl #[someInstruction]
+    let mut current := bridge.runtime.top instruction.domain
+    let mut proof ←
+      mkAppM ``FactDomainSchema.topSound
+        #[bridge.schema, base.program, model.valuation, nodeTerm,
+          instructionTerm, found, model.proof]
+    for assumption in seed.assumptions do
+      let proposedProof ← bridge.proveAssumption base.program model.valuation
+        node assumption.fact expression assumption.proof
+      let installed ←
+        match installFact bridge.runtime instruction.domain current assumption.fact with
+        | .ok installed => pure installed
+        | .error message => throwError "interval goal closure: {message}"
+      let meetResult ←
+        mkAppM ``FactDomainSchema.proveMeet
+          #[bridge.schema, base.program, nodeTerm,
+            ← encoder.fact current, ← encoder.fact assumption.fact,
+            ← encoder.fact installed]
+      let success ← mkAppM ``Eq.refl #[mkConst ``Bool.true]
+      let meet ← mkAppM ``checkedGet #[meetResult, success]
+      proof ← mkAppM ``holdsMeet #[meet, model.proof, proof, proposedProof]
+      current := installed
+    unless current == finalFact.fact do
+      throwError "interval goal closure: seed recipe does not produce its base fact"
+    proofs := proofs.concat proof
+  let mut meanings := mkConst ``True.intro
+  for proof in proofs.reverse do
+    meanings ← mkAppM ``And.intro #[proof, meanings]
+  mkAppM ``FactMeanings.all #[base.facts, meanings]
+
+/-- Quote a checker input with the same fact encoder used for proof events. -/
+def inputExpr (factType : Expr) (encoder : FrontendEncoder.Encoder Fact)
+    (input : CheckerInput Fact) : MetaM Expr := do
+  let facts ← input.initialFacts.toList.mapM encoder.fact
+  mkAppM ``CheckerInput.mk
+    #[← encoder.program input.baseProgram,
+      ← arrayExpr factType facts,
+      ← encoder.nodeFact input.target]
+
+/-- Construct the generic reflexive proof context for a reified base graph. -/
+def proveBase (factType semantics : Expr)
+    (encoder : FrontendEncoder.Encoder Fact) (input : CheckerInput Fact) :
+    MetaM BaseProof := do
+  unless input.initialFacts.size == input.baseProgram.nodes.size do
+    throwError "interval goal closure: initial facts do not cover the base graph"
+  let inputTerm ← inputExpr factType encoder input
+  let program ← encoder.program input.baseProgram
+  let facts ← mkAppM ``TraceReplay.initialBase #[inputTerm]
+  let sizeEq ← mkAppM ``Eq.refl #[mkNatLit input.initialFacts.size]
+  let within ← mkAppM ``TraceReplay.initialBaseWithin #[inputTerm, sizeEq]
+  let basePrefix ← mkAppM ``ProgramPrefix.refl #[program]
+  let extension ← mkAppM ``ChronologicalReplay.extendRefl #[semantics, program]
+  let operations ← mkAppM ``Program.operations #[program]
+  let sameOperations ← mkAppM ``Eq.refl #[operations]
+  pure
+    { input := inputTerm
+      program
+      facts
+      basePrefix
+      within
+      extension
+      sameOperations }
+
+def relationProof (models valuation : Expr) (packages : Array Package)
+    (terms : Array TermRef) (node : NodeId) (instruction : Node) : MetaM Expr := do
+  let some package := packages[instruction.op.index]?
+    | throwError "interval goal closure: node operation has no meaning package"
+  let some output := termAt? terms node
+    | throwError "interval goal closure: reified node has no Lean expression"
+  let mut arguments := []
+  for argument in instruction.args do
+    let some expression := termAt? terms argument
+      | throwError "interval goal closure: instruction argument has no Lean expression"
+    arguments := arguments.concat expression
+  let relation ← package.prove arguments output
+  let someModel ← mkAppM ``Option.some #[package.model]
+  let found ← mkAppM ``Eq.refl #[someModel]
+  mkAppM ``meaningOf
+    #[models, valuation, ← nodeIdExpr node, ← nodeExpr instruction,
+      package.model, found, relation]
+
+/-- Construct a kernel proof for the semantic meaning of every reified node.
+
+Runtime equality first pins the meaning packages to the program's operation
+array.  The emitted equality and node-relation terms must then reduce and
+typecheck; a recognizer cannot establish either fact by returning `true`. -/
+def proveModel (valueType fallback : Expr) (packages : Array Package)
+    (encoder : FrontendEncoder.Encoder Fact) (result : GoalFrontend.Result Fact) :
+    MetaM ModelProof := do
+  unless result.input.baseProgram.check do
+    throwError "interval goal closure: reified program is not structurally valid"
+  unless packages.map (fun package => package.operation) ==
+      result.input.baseProgram.operations do
+    throwError "interval goal closure: syntax and meaning operations are not aligned"
+  unless result.terms.size == result.input.baseProgram.nodes.size do
+    throwError "interval goal closure: term table does not cover every graph node"
+  for index in [0:result.terms.size] do
+    let some term := result.terms[index]?
+      | throwError "interval goal closure: term index escaped its table"
+    unless term.node.index == index do
+      throwError "interval goal closure: term table is not in node order"
+    let some instruction := result.input.baseProgram.nodes[index]?
+      | throwError "interval goal closure: term index escaped its program"
+    unless term.domain == instruction.domain do
+      throwError "interval goal closure: term domain differs from its instruction"
+  let values := result.terms.toList.map (fun term => term.expression)
+  let valuesTerm := listExpr valueType values
+  let valuation ← mkAppM ``valuationOf #[fallback, valuesTerm]
+  let modelType ← mkAppM ``OperationSemantics.Model #[valueType]
+  let models ← arrayExpr modelType (packages.toList.map (fun package => package.model))
+  let program ← encoder.program result.input.baseProgram
+  let programOperations ← mkAppM ``Program.operations #[program]
+  let mut aligned := mkConst ``True.intro
+  for package in packages.toList.reverse do
+    aligned ← mkAppM ``And.intro #[package.aligned, aligned]
+  let operations ←
+    mkAppM ``OperationSemantics.operationsOfAligned
+      #[models, programOperations, aligned]
+  let mut meanings := mkConst ``True.intro
+  for offset in [0:result.input.baseProgram.nodes.size] do
+    let index := result.input.baseProgram.nodes.size - 1 - offset
+    let some instruction := result.input.baseProgram.nodes[index]?
+      | throwError "interval goal closure: node index escaped its program"
+    let nodeProof ← relationProof models valuation packages result.terms
+      { index } instruction
+    meanings ← mkAppM ``And.intro #[nodeProof, meanings]
+  let proof ←
+    mkAppM ``OperationSemantics.modelsOfMeanings
+      #[models, program, valuation, operations, meanings]
+  pure { valuation, proof }
+
+end Hex.Interval.Experiment.GoalClosure

--- a/HexInterval/Experiment/OperationSemantics.lean
+++ b/HexInterval/Experiment/OperationSemantics.lean
@@ -30,6 +30,33 @@ structure Model (Value : Type) where
   operation : Operation
   relation : List Value → Value → Prop
 
+/-- Pointwise alignment between semantic models and opaque operations. -/
+def Aligned : List (Model Value) → List Operation → Prop
+  | [], [] => True
+  | model :: models, operation :: operations =>
+      model.operation = operation ∧ Aligned models operations
+  | _, _ => False
+
+theorem Aligned.map {models : List (Model Value)} {operations : List Operation}
+    (aligned : Aligned models operations) :
+    models.map (fun model => model.operation) = operations := by
+  induction models generalizing operations with
+  | nil => cases operations <;> simp_all [Aligned]
+  | cons model models ih =>
+      cases operations with
+      | nil => simp [Aligned] at aligned
+      | cons operation operations =>
+          simp only [Aligned] at aligned
+          simp [aligned.1, ih aligned.2]
+
+/-- Exact array equality follows from package-by-package operation alignment. -/
+theorem operationsOfAligned (models : Array (Model Value))
+    (operations : Array Operation)
+    (aligned : Aligned models.toList operations.toList) :
+    operations = models.map (fun model => model.operation) := by
+  apply Array.toList_inj.mp
+  simpa using aligned.map.symm
+
 /-- Every operation and node in a program is interpreted by the aligned model
 array. The exact operation-array equality prevents a meaning from being paired
 with a different opaque operation signature. -/
@@ -40,6 +67,56 @@ def Models (models : Array (Model Value)) (program : Program)
       ∃ model,
         models[instruction.op.index]? = some model ∧
           model.relation (instruction.args.map valuation) (valuation node)
+
+/-- The meaning of one instruction at its exact SSA node. -/
+def NodeMeaning (models : Array (Model Value)) (valuation : NodeId → Value)
+    (node : NodeId) (instruction : Node) : Prop :=
+  ∃ model,
+    models[instruction.op.index]? = some model ∧
+      model.relation (instruction.args.map valuation) (valuation node)
+
+/-- Node meanings in exact program order.  This proposition is deliberately
+list-shaped so a tactic can emit one package-owned relation proof per reified
+node and combine them without a switch on operation keys. -/
+def Meanings (models : Array (Model Value)) (valuation : NodeId → Value) :
+    Nat → List Node → Prop
+  | _, [] => True
+  | index, instruction :: rest =>
+      NodeMeaning models valuation { index } instruction ∧
+        Meanings models valuation (index + 1) rest
+
+theorem Meanings.at {models : Array (Model Value)}
+    {valuation : NodeId → Value} {start : Nat} {nodes : List Node}
+    (meanings : Meanings models valuation start nodes) (offset : Nat)
+    {instruction : Node} (found : nodes[offset]? = some instruction) :
+    NodeMeaning models valuation { index := start + offset } instruction := by
+  induction nodes generalizing start offset with
+  | nil => simp at found
+  | cons head tail ih =>
+      cases offset with
+      | zero =>
+          simp at found
+          subst head
+          simpa [Meanings] using meanings.1
+      | succ offset =>
+          simp at found
+          have tailMeaning := ih meanings.2 offset found
+          have indices : (start + 1) + offset = start + (offset + 1) := by
+            omega
+          simpa [indices] using tailMeaning
+
+/-- Assemble the global program model from the exact operation alignment and
+one relation proof for every node. -/
+theorem modelsOfMeanings (models : Array (Model Value)) (program : Program)
+    (valuation : NodeId → Value)
+    (operations : program.operations = models.map (fun model => model.operation))
+    (meanings : Meanings models valuation 0 program.nodes.toList) :
+    Models models program valuation := by
+  refine ⟨operations, ?_⟩
+  intro node instruction found
+  have foundList : program.nodes.toList[node.index]? = some instruction := by
+    simpa [Program.node?] using found
+  simpa [NodeMeaning] using meanings.at node.index foundList
 
 /-- Node-local fact semantics over a package-composed operation model. -/
 def semantics (models : Array (Model Value))

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1392,8 +1392,9 @@ do not disable an otherwise applicable proof; later operation packages may
 also extend the registry after the target prefix. Removing that last prefix
 comparison requires package-compositional construction of the program
 semantics and generic proof emission for the recorded top/assumption seed
-recipes; it remains the next frontend experiment rather than an assumed
-capability.
+recipes. `GoalClosure` now supplies those two proof bridges; running compiled
+search on the resulting dynamic checker input remains the next frontend
+experiment rather than an assumed capability.
 
 The first package-composed semantics experiment removes a second fixed-graph
 assumption. An operation-meaning package supplies an opaque operation signature
@@ -1413,14 +1414,49 @@ instruction, the exponential package's current operation slot, and unary
 argument before proving the result. Key-resolved lookup replaces that
 canary-specific numeric slot before packages may be reordered. A
 three-node `exp (exp x)` canary obtains an ordinary theorem through that schema,
-while applying it to the source node fails closed. The remaining frontend gap
-is a kernel-checked link from each syntax recognizer to its operation relation,
-followed by generic discharge of the reifier's top and ordered-assumption seed
-recipes. A recognizer match alone is never treated as semantic evidence.
+while applying it to the source node fails closed. The `GoalClosure` experiment
+below supplies the kernel-checked link from syntax packages to their operation
+relations and generically discharges the reifier's top and ordered-assumption
+seed recipes. A recognizer match alone is never treated as semantic evidence.
 This first adapter uses one semantic value type for all domains. A later
 multi-domain adapter must choose and validate a tagged universal value or a
 domain-indexed valuation rather than pretending heterogeneous values have one
 untyped representation.
+
+The first kernel link from the goal graph to this semantics is also generic in
+the mathematical operations. Each goal-closure package carries its opaque
+operation, the corresponding semantic model term, a kernel proof that the two
+operations agree, and a callback which constructs the model's relation proof
+for concrete argument and result expressions. The assembler first requires
+the complete package operation array to equal the reified program's array. It
+then checks that the term table covers every node in exact SSA order, builds a
+total valuation from those terms, and emits one package-owned relation theorem
+per instruction. A recursive `Meanings` proof turns those node theorems and
+the package-by-package alignment proofs into `semantics.models` for the exact
+reified graph. Missing packages and a callback returning an unrelated proof
+both fail during elaboration. Recognizer success is not used as evidence.
+
+The same bridge constructs the caller-fact premise without arithmetic or
+function cases. Canonical version-zero facts begin at the domain schema's top
+theorem. Each recorded hypothesis must typecheck as its parsed semantic fact;
+the bridge reruns the runtime narrowing operation and the independent
+`proveMeet` schema in the recorded order until it reaches the exact installed
+base fact. It then supplies all base facts to the emitted replay theorem. The
+exponential canary now has an ordinary `interval_exp_model` theorem whose
+value assignment, complete operation model, and caller facts come from the
+actual reified goal. One variant closes from the live exponential replay; a
+second consumes a caller hypothesis through the ordered seed path. Neither
+uses `native_decide`.
+
+This experiment still uses the exponential canary's fixed compiled search
+trace when the target is not already a caller fact, so it presently requires
+the reified graph to be exactly that two-node target graph. The next step is to
+start the generic session from the reifier's `CheckerInput`, select the target
+node in that session, and feed its dynamically quoted trace to
+`ProofFrontend`. That removes the last exact-graph check and lets supported
+hypotheses append unrelated nodes without changing proof production. Key-
+resolved semantic model selection must land before operation packages may be
+reordered; array position is not a permanent package identity.
 
 The fixed canary also requires a live session with no dropped work and an exact
 proof history of one instance, one equality, three fact events, and the

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import HexIntervalMathlib.Experiment.ExpSign
 import HexInterval.Experiment.GoalFrontend
+import HexInterval.Experiment.GoalClosure
 import HexInterval.Experiment.ProofFrontend
 import Mathlib.Lean.Elab.Tactic.Meta
 
@@ -25,6 +26,7 @@ open Lean Elab Tactic Meta
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend ExpSign
+open GoalClosure
 
 /-! ## Extensible goal reification -/
 
@@ -76,6 +78,35 @@ private def claimParser : GoalFrontend.Parser Bound :=
           pure none
       else
         pure none }
+
+private theorem sourceAligned : sourceModel.operation = sourceOperation := rfl
+
+private theorem expAligned : expModel.operation = expOperation := rfl
+
+private def sourceMeaning : GoalClosure.Package :=
+  { operation := sourceOperation
+    model := mkConst ``sourceModel
+    aligned := mkConst ``sourceAligned
+    prove := fun arguments _ => do
+      unless arguments.isEmpty do
+        throwError "interval_exp: source meaning received arguments"
+      let empty := FrontendEncoder.listExpr (mkConst ``Real) []
+      mkAppM ``Eq.refl #[empty] }
+
+private def expMeaning : GoalClosure.Package :=
+  { operation := expOperation
+    model := mkConst ``expModel
+    aligned := mkConst ``expAligned
+    prove := fun arguments output => do
+      let [input] := arguments
+        | throwError "interval_exp: exponential meaning is not unary"
+      let expected ← mkAppM ``Real.exp #[input]
+      unless ← isDefEq output expected do
+        throwError "interval_exp: recognizer did not preserve exponential meaning"
+      mkAppM ``Eq.refl #[output] }
+
+private def meanings : Array GoalClosure.Package :=
+  #[sourceMeaning, expMeaning]
 
 private meta def reifyGoal (target : Expr) : MetaM (GoalFrontend.Result Bound) := do
   let registry ←
@@ -269,14 +300,28 @@ private def boundExpr : Bound → Expr
   | .nonnegative => mkConst ``Bound.nonnegative
   | .empty => mkConst ``Bound.empty
 
+private def boundEncoder : FrontendEncoder.Encoder Bound :=
+  FrontendEncoder.make (mkConst ``Bound) (fun fact => pure (boundExpr fact))
+
+private def factBridge : GoalClosure.FactBridge Bound :=
+  { runtime := factDomain
+    schema := mkConst ``boundSchema
+    proveAssumption := fun program valuation node fact _ proof => do
+      let nodeFact ← boundEncoder.nodeFact { node, fact }
+      let expected ←
+        mkAppM ``SemanticReplay.Semantics.holds
+          #[mkConst ``semantics, program, valuation, nodeFact]
+      unless ← isDefEq (← inferType proof) expected do
+        throwError "interval_exp: hypothesis does not prove its parsed fact"
+      pure proof }
+
 private def seedAssumed (graph : Program) (base : List (NodeFact Bound))
     (index : Nat) (fact : NodeFact Bound) (found : base[index]? = some fact) :
     Evidence (semantics.Entails graph base fact) :=
   ProofEmitter.assumedAt graph base index fact found
 
 private def frontendContext : ProofFrontend.Context Bound Name :=
-  { encoder := FrontendEncoder.make (mkConst ``Bound)
-      (fun fact => pure (boundExpr fact))
+  { encoder := boundEncoder
     resolveSchema := pure
     semantics := mkConst ``semantics
     domain := mkConst ``boundSchema
@@ -309,6 +354,76 @@ private meta def emitEvidence : MetaM Expr := do
 
 private def expTarget (x : ℝ) : Prop :=
   0 ≤ Real.exp x
+
+private meta def proveModeledExp (target : Expr) : MetaM Expr := do
+  let result ← reifyGoal target
+  unless result.input.baseProgram == ExpSign.program do
+    throwError "interval_exp model test: expected the exact target graph"
+  let some fallback := GoalClosure.termAt? result.terms { index := 0 }
+    | throwError "interval_exp model test: missing source expression"
+  if (← observing? <| GoalClosure.proveModel (mkConst ``Real) fallback
+      #[sourceMeaning] boundEncoder result).isSome then
+    throwError "interval_exp model test: missing meaning package was accepted"
+  let falseExp : GoalClosure.Package :=
+    { expMeaning with prove := fun _ _ => pure (mkConst ``True.intro) }
+  if (← observing? <| GoalClosure.proveModel (mkConst ``Real) fallback
+      #[sourceMeaning, falseExp] boundEncoder result).isSome then
+    throwError "interval_exp model test: false node link was accepted"
+  let model ← GoalClosure.proveModel (mkConst ``Real) fallback meanings
+    boundEncoder result
+  let base ← GoalClosure.proveBase (mkConst ``Bound) (mkConst ``semantics)
+    boundEncoder result.input
+  let facts ← GoalClosure.proveFacts factBridge boundEncoder result base model
+  let matching := result.baseFacts.zipIdx.find? fun item =>
+    item.1 == result.input.target
+  let evidence ←
+    match matching with
+    | some (fact, index) => do
+        let factTerm ← boundEncoder.nodeFact fact
+        let someFact ← mkAppM ``Option.some #[factTerm]
+        let found ← mkAppM ``Eq.refl #[someFact]
+        mkAppM ``seedAssumed
+          #[base.program, base.facts, mkNatLit index, factTerm, found]
+    | none =>
+        if result.baseFacts == ExpSign.baseFacts then
+          emitEvidence
+        else
+          throwError "interval_exp model test: fixed trace has different base facts"
+  let proof ←
+    mkAppM ``Evidence.proof #[evidence, model.valuation, model.proof, facts]
+  unless ← isDefEq (← inferType proof) target do
+    throwError "interval_exp model test: modeled replay has the wrong target"
+  pure (← instantiateMVars proof)
+
+syntax (name := intervalExpModelTac) "interval_exp_model" : tactic
+
+@[tactic intervalExpModelTac] meta def evalIntervalExpModel : Tactic := fun stx => do
+  match stx with
+  | `(tactic| interval_exp_model) =>
+      let goal ← getMainGoal
+      goal.withContext do
+        goal.assign (← proveModeledExp (← instantiateMVars (← goal.getType)))
+      replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+theorem tacticExpModeled (x : ℝ) : 0 ≤ Real.exp x := by
+  interval_exp_model
+
+/--
+info: 'Hex.IntervalMathlib.ExpSignConformance.tacticExpModeled' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms tacticExpModeled
+
+theorem tacticExpModeledSeed (x : ℝ) (_h : 0 ≤ Real.exp x) :
+    0 ≤ Real.exp x := by
+  interval_exp_model
+
+/--
+info: 'Hex.IntervalMathlib.ExpSignConformance.tacticExpModeledSeed' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms tacticExpModeledSeed
 
 private meta def proveExp (target : Expr) : MetaM Expr := do
   let reified ← reifyGoal target

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -316,6 +316,7 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.FrontendEncoder,
     `HexInterval.Experiment.ProofFrontend,
     `HexInterval.Experiment.GoalFrontend,
+    `HexInterval.Experiment.GoalClosure,
     `HexInterval.Experiment.TraceReplay,
     `HexInterval.Experiment.SineSign,
     `HexInterval.Experiment.ExpSign]

--- a/progress/20260811T133527Z.md
+++ b/progress/20260811T133527Z.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Added a function-independent kernel bridge from reified expression nodes to
+  package-composed operation semantics.
+- Required explicit package/model operation alignment and one checked
+  package-owned relation theorem for every graph node.
+- Added generic reconstruction of version-zero fact proofs from domain top and
+  ordered caller assumptions, rerunning the independent meet schema.
+- Added an ordinary `Real.exp` tactic theorem whose valuation, complete graph
+  model, and base-fact premise are constructed from the actual reified goal.
+- Added rejection checks for a missing meaning package and an unrelated node
+  proof.
+
+# Current frontier
+
+The goal graph is now connected to kernel semantics and caller assumptions.
+When the target is not already a caller fact, the conformance tactic still
+uses the fixed two-node exponential search trace.
+
+# Next step
+
+Start the policy session from the reifier's dynamic `CheckerInput`, select the
+actual target node, and feed that session's quote to the generic proof frontend.
+
+# Blockers
+
+None.

--- a/progress/20260811T164210Z.md
+++ b/progress/20260811T164210Z.md
@@ -1,0 +1,25 @@
+# Accomplished
+
+- Reconciled generic goal closure with the repaired operation-semantics and
+  arbitrary-function frontend stack.
+- Preserved complete operation-model construction, ordered caller-fact proof
+  assembly, selected-schema kernel checking, and the guarded sine theorem
+  axiom report.
+- Updated the proof-only Lake exemption to the exact reconciled registration
+  blob while retaining the current factorization-source exemptions.
+
+# Current frontier
+
+The frontend can construct semantic models and initial-fact proofs for an
+actual reified graph without operation cases. Search is still the next layer:
+dynamic policy execution must start from that exact checker input and return a
+target fact which the generic closure code can discharge.
+
+# Next step
+
+Finish focused and static checks, push this exact head for fresh review, then
+reconcile dynamic goal execution and target closure.
+
+# Blockers
+
+None.

--- a/progress/20260811T165749Z.md
+++ b/progress/20260811T165749Z.md
@@ -1,0 +1,23 @@
+# Accomplished
+
+- Added compile-checked axiom reports for both generic goal-closure tactic
+  canaries: the live replay path and the caller-seeded path.
+- Confirmed each generated theorem depends only on the expected standard
+  Mathlib axioms: `propext`, `Classical.choice`, and `Quot.sound`.
+- Rebuilt the focused goal-closure conformance target and reran the static
+  trust, DAG, phase, source-size, and copyright checks.
+
+# Current frontier
+
+The generic goal-closure bridge now has an explicit trust-surface regression
+gate for both ways it closes the exponential target. The implementation and
+SPEC remain unchanged by this repair.
+
+# Next step
+
+Push the repaired exact head, obtain a fresh isolated review, and require the
+new exact-head CI run to pass before descendants are reconciled.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -120,6 +120,12 @@
     "reason": "Additionally registers package-composed interval operation semantics only; the factorization service target and executable dependency graph are unchanged."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "f316525022094da9ec017e2268c929dcc1193816",
+    "reason": "Additionally registers the generic interval goal-closure proof bridge only; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",


### PR DESCRIPTION
Depends on #9211.

This adds the generic kernel bridge from an extensible goal graph to package-composed semantics. Each meaning package supplies an aligned semantic operation and a relation theorem for its own nodes; the assembler proves the full model without switching on mathematical functions. It also reconstructs version-zero caller facts from domain top plus ordered hypothesis meets.

The Real.exp conformance now contains an ordinary theorem whose valuation, graph model, and base-fact premise are built from the actual reified goal. Missing meaning packages and unrelated relation proofs fail closed.

No native_decide, axioms, or sorries. Focused 1,951-job build, structural checks, trust audit, and factor-data freshness pass locally.