### PR TITLE
feat(interval): replay a backward function contractor

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1550,9 +1550,18 @@ and quoted replay produces the ordinary real theorem
 `0 ≤ x → x ≤ 1 → 0 ≤ f(x) ∧ f(x) ≤ 1/4`. Replacing the quoted `[0,1]`
 assumption by the whole line is rejected, so the function theorem's premise is
 load-bearing rather than decorative. This is the minimal arbitrary-function
-vertical against the exact interval domain; richer packages may add backward
-contractors, retries, instantiators, and split suggestions without changing
-the generic transition.
+vertical against the exact interval domain.
+
+A second, independently assembled package attaches a backward registration to
+that same opaque operation without redefining it. From the exact output band
+`f(x) ∈ [3/16,1/4]`, its runtime contractor narrows a whole-line input to
+`[1/4,3/4]`; its own schema derives that inverse image from the centered
+operation model. The live registry therefore contains two packages which own
+different directions for one function, while both proof steps use the same
+generic rule transition. The backward quote is rejected if its precise output
+band is weakened to `[0,1/4]`, and its ordinary theorem confirms that the
+watched output premise is load-bearing. Richer packages may add retries,
+instantiators, and split suggestions without changing this interface.
 
 The prefix resolver returns an exact fact together with its theorem for a
 requested `(node, version)`, and builds the rule's ordered input list by

--- a/HexIntervalMathlib/Experiment/Centered.lean
+++ b/HexIntervalMathlib/Experiment/Centered.lean
@@ -35,6 +35,18 @@ def unitRange : DyadicInterval.Fact :=
 def quarterRange : DyadicInterval.Fact :=
   ⟨.bounds (.finite 0 false) (.finite quarter false), by decide⟩
 
+def threeSixteenths : Dyadic := Dyadic.ofIntWithPrec 3 4
+
+def threeQuarters : Dyadic := Dyadic.ofIntWithPrec 3 2
+
+/-- Output band which forces the input into the middle half of the domain. -/
+def highRange : DyadicInterval.Fact :=
+  ⟨.bounds (.finite threeSixteenths false) (.finite quarter false), by decide⟩
+
+/-- Backward image of `highRange` under the centered function. -/
+def middleRange : DyadicInterval.Fact :=
+  ⟨.bounds (.finite quarter false) (.finite threeQuarters false), by decide⟩
+
 @[simp]
 theorem toReal_half : DyadicInterval.toReal half = (1 / 2 : ℝ) := by
   norm_num [DyadicInterval.toReal, half,
@@ -50,6 +62,18 @@ theorem toReal_one : DyadicInterval.toReal 1 = (1 : ℝ) := by
 @[simp]
 theorem toReal_quarter : DyadicInterval.toReal quarter = (1 / 4 : ℝ) := by
   norm_num [DyadicInterval.toReal, quarter,
+    Dyadic.toRat_ofIntWithPrec_eq_mul_two_pow]
+
+@[simp]
+theorem toReal_threeSixteenths :
+    DyadicInterval.toReal threeSixteenths = (3 / 16 : ℝ) := by
+  norm_num [threeSixteenths, DyadicInterval.toReal,
+    Dyadic.toRat_ofIntWithPrec_eq_mul_two_pow]
+
+@[simp]
+theorem toReal_threeQuarters :
+    DyadicInterval.toReal threeQuarters = (3 / 4 : ℝ) := by
+  norm_num [threeQuarters, DyadicInterval.toReal,
     Dyadic.toRat_ofIntWithPrec_eq_mul_two_pow]
 
 /-- Function-package contribution to a program model. Other operations remain
@@ -106,6 +130,35 @@ theorem centeredEntails (program : Program)
   rw [outputEq]
   constructor <;> nlinarith [sq_nonneg (valuation input - (1 / 2 : ℝ))]
 
+theorem backwardEntails (program : Program)
+    (assumptions : List (NodeFact DyadicInterval.Fact))
+    (input output : NodeId) (instruction : Node) (operation : Operation)
+    (found : program.node? output = some instruction)
+    (operationFound : program.operation? instruction.op = some operation)
+    (key : operation.key = centeredOp)
+    (arguments : instruction.args = [input])
+    (exactAssumptions : assumptions = [{ node := output, fact := highRange }]) :
+    semantics.Entails program assumptions { node := input, fact := middleRange } := by
+  intro valuation model assumptionHolds
+  change NodeId → ℝ at valuation
+  change Models program valuation at model
+  obtain ⟨actualInput, actualArguments, outputEq⟩ :=
+    model output instruction found operation operationFound key
+  have sameInput : actualInput = input := by
+    simpa [arguments] using actualArguments.symm
+  subst actualInput
+  have outputRange := assumptionHolds { node := output, fact := highRange } (by
+    simp [exactAssumptions])
+  change highRange.Contains (valuation output) at outputRange
+  change middleRange.Contains (valuation input)
+  simp only [highRange, middleRange, DyadicInterval.Fact.Contains, rawContains,
+    lowerContains, upperContains, toReal_threeSixteenths, toReal_quarter,
+    toReal_threeQuarters] at outputRange ⊢
+  rw [outputEq] at outputRange
+  constructor <;>
+    nlinarith [sq_nonneg (valuation input - (1 / 4 : ℝ)),
+      sq_nonneg (valuation input - (3 / 4 : ℝ))]
+
 private theorem factWith (fact : NodeFact DyadicInterval.Fact)
     {value : DyadicInterval.Fact}
     (equal : fact.fact = value) :
@@ -149,6 +202,43 @@ def centeredFactSchema : PackedFactSchema semantics where
               else none
           | none => none
       | none => none
+    else none
+
+/-- Package-owned backward contractor. The exact output band is part of the
+schema, while the generic replay layer remains unaware of the function. -/
+def backwardFactSchema (backwardKey : RuleKey) : PackedFactSchema semantics where
+  rule := backwardKey
+  schema := 0
+  Certificate := Unit
+  decode := fun body => if body.isEmpty then some () else none
+  replay := fun _ _ context _ =>
+    if proposedFact : context.proposed.fact = middleRange then
+      match context.assumptions with
+      | [{ node := output, fact := outputFact }] =>
+          if outputExact : outputFact = highRange then
+            match found : context.program.node? output with
+            | some instruction =>
+                match operationFound : context.program.operation? instruction.op with
+                | some operation =>
+                    if key : operation.key = centeredOp then
+                      match arguments : instruction.args with
+                      | [input] =>
+                          if inputExact : input = context.proposed.node then
+                            some
+                              { proof := by
+                                  rw [factWith context.proposed proposedFact]
+                                  have result := backwardEntails context.program
+                                    [{ node := output, fact := outputFact }]
+                                    input output instruction operation found
+                                    operationFound key arguments (by simp [outputExact])
+                                  simpa only [inputExact] using result }
+                          else none
+                      | _ => none
+                    else none
+                | none => none
+            | none => none
+          else none
+      | _ => none
     else none
 
 end Hex.Interval.Experiment.Centered

--- a/conformance/HexIntervalMathlib/CenteredConformance.lean
+++ b/conformance/HexIntervalMathlib/CenteredConformance.lean
@@ -269,4 +269,195 @@ info: 'Hex.IntervalMathlib.CenteredConformance.tacticCentered' depends on axioms
 #guard_msgs in
 #print axioms tacticCentered
 
+/-! ## Independent backward contractor -/
+
+private def backwardKey : RuleKey :=
+  { name := "real.centered-product.backward-high" }
+
+private def backwardRule : Registration :=
+  { key := backwardKey
+    head := centeredOp
+    kind := .backward
+    watches := [.result]
+    writes := [.argument 0] }
+
+private def backwardPlan (request : RuleRequest DyadicInterval.Fact) :
+    Plan DyadicInterval.Fact :=
+  match request.inputs, request.writes with
+  | [output], [target] =>
+      if output.fact == highRange then
+        planOfResult target 1 2 [] (.ready middleRange)
+      else
+        withoutPayloads .inapplicable
+  | _, _ => withoutPayloads (.failed 72)
+
+/-- A separately assembled package can attach another propagation direction
+to the centered operation without owning or redefining that operation. -/
+private def backwardPackage : Package DyadicInterval.Fact :=
+  { Cache := Unit
+    cache := ()
+    operations := #[]
+    requiredOperations := centeredOperations real
+    handlers := #[factHandler backwardRule backwardPlan]
+    acceptsLimits := fun _ _ _ => true }
+
+private def backwardSession? :
+    Option (PayloadSession.Session DyadicInterval.Fact) :=
+  match PayloadSession.Session.start
+      (DyadicInterval.factDomain Centered.endpointLimit) program
+      #[centeredPackage config real, backwardPackage] #[.whole, highRange]
+      limits arenaLimits with
+  | .ok session => some session
+  | .error _ => none
+
+private def backwardRun? : Option (PayloadSession.Run DyadicInterval.Fact) := do
+  let session ← backwardSession?
+  pure (session.drive 12)
+
+private def backwardAction : Action :=
+  { serial := 2
+    programVersion := 0
+    application := { index := 2 }
+    rule := { index := 3 }
+    key := backwardKey
+    node := node 1
+    kind := .backward
+    effort := 0
+    generation := 0
+    inputs := [{ node := node 1, version := 0 }]
+    writes := [node 0] }
+
+private def backwardEvent : FactEvent DyadicInterval.Fact :=
+  { programVersion := 0
+    node := node 0
+    previous := { node := node 0, version := 0 }
+    fact := middleRange
+    version := 1
+    cause := .rule backwardAction middleRange (payload 1) }
+
+private def backwardEntry : Entry :=
+  { origin := backwardAction
+    role := .fact
+    schema := 0
+    body := [] }
+
+private def backwardStep : RuleStep DyadicInterval.Fact :=
+  { event := backwardEvent
+    payload := payload 1
+    entry := backwardEntry
+    assumptions := [{ node := node 1, fact := highRange }]
+    previous := .whole }
+
+private def backwardMatchesLive : Bool :=
+  match backwardRun? with
+  | some run =>
+      run.stop == .saturated && run.session.complete &&
+        run.session.engine.history.size == 1 &&
+        run.session.arena.entries.size == 3 &&
+        run.session.arena.bodyCells == 0 &&
+        run.session.engine.factAt? { node := node 0, version := 1 } ==
+          some middleRange &&
+        match run.session.engine.history[0]?,
+            run.session.arena.entry? (payload 1) .fact with
+        | some actualEvent, some actualEntry =>
+            sameEvent actualEvent backwardEvent &&
+              sameEntry actualEntry backwardEntry
+        | _, _ => false
+  | none => false
+
+#guard backwardMatchesLive
+
+private def backwardInput : CheckerInput DyadicInterval.Fact :=
+  { baseProgram := program
+    initialFacts := #[.whole, highRange]
+    target := { node := node 0, fact := middleRange } }
+
+private def backwardBase : List (NodeFact DyadicInterval.Fact) :=
+  [{ node := node 0, fact := .whole }, { node := node 1, fact := highRange }]
+
+private def backwardPrevious : Evidence
+    (Centered.semantics.Entails program backwardBase
+      { node := node 0, fact := backwardStep.previous }) := by
+  apply ProofEmitter.assumed
+  simp [backwardStep, backwardBase]
+
+private def backwardAssumption : Evidence
+    (Centered.semantics.Entails program backwardBase
+      { node := node 1, fact := highRange }) :=
+  ProofEmitter.assumed (by simp [backwardBase])
+
+private def backwardInputs : Evidence
+    (InputsSound Centered.semantics program backwardBase
+      backwardStep.assumptions) := by
+  simpa [backwardStep, backwardEvent] using
+    (EntailsList.singleton backwardAssumption)
+
+private def backwardReplayed :=
+  ProofEmitter.replayRule (Centered.backwardFactSchema backwardKey)
+    Centered.domain backwardInput program (ProgramPrefix.refl program)
+    backwardBase backwardStep backwardPrevious backwardInputs
+
+#guard backwardReplayed.isSome
+
+private def weakenedOutput : Evidence
+    (Centered.semantics.Entails program backwardBase
+      { node := node 1, fact := quarterRange }) :=
+  (ProofEmitter.closeFact Centered.domain program backwardBase (node 1)
+    highRange quarterRange backwardAssumption).get (by rfl)
+
+private def malformedBackward : RuleStep DyadicInterval.Fact :=
+  { backwardStep with
+    assumptions := [{ node := node 1, fact := quarterRange }] }
+
+private def malformedBackwardInputs : Evidence
+    (InputsSound Centered.semantics program backwardBase
+      malformedBackward.assumptions) := by
+  simpa [malformedBackward, backwardStep, backwardEvent] using
+    (EntailsList.singleton weakenedOutput)
+
+private def backwardRejected :=
+  ProofEmitter.replayRule (Centered.backwardFactSchema backwardKey)
+    Centered.domain backwardInput program (ProgramPrefix.refl program)
+    backwardBase malformedBackward
+    (by simpa [malformedBackward, backwardStep, backwardEvent] using backwardPrevious)
+    malformedBackwardInputs
+
+#guard backwardRejected.isNone
+
+theorem emittedBackward :
+    Centered.semantics.Entails program backwardBase backwardInput.target :=
+  ProofEmitter.proofOfReplay backwardReplayed (by rfl)
+
+/-- A backward arbitrary-function contractor narrows the input from a fact
+about the output, through the same generic replay transition as the forward
+contractor. -/
+theorem tacticCenteredBackward (x : ℝ)
+    (lower : 3 / 16 ≤ (1 / 4 : ℝ) - (x - (1 / 2 : ℝ)) ^ 2)
+    (upper : (1 / 4 : ℝ) - (x - (1 / 2 : ℝ)) ^ 2 ≤ 1 / 4) :
+    1 / 4 ≤ x ∧ x ≤ (3 / 4 : ℝ) := by
+  have result := emittedBackward (valuation x) (models x) (by
+    intro assumption member
+    simp only [backwardBase, List.mem_cons, List.not_mem_nil, or_false] at member
+    rcases member with rfl | rfl
+    · change DyadicInterval.Fact.whole.Contains (valuation x (node 0))
+      simp [DyadicInterval.Fact.Contains, DyadicInterval.Fact.whole,
+        rawContains, lowerContains, upperContains]
+    · change highRange.Contains (valuation x (node 1))
+      simpa only [highRange, DyadicInterval.Fact.Contains, rawContains,
+        lowerContains, upperContains, Centered.toReal_threeSixteenths,
+        Centered.toReal_quarter, node, valuation, and_true] using
+          And.intro lower upper)
+  change middleRange.Contains (valuation x (node 0)) at result
+  simpa only [middleRange, DyadicInterval.Fact.Contains, rawContains,
+    lowerContains, upperContains, Centered.toReal_quarter,
+    Centered.toReal_threeQuarters, node, valuation, and_true] using result
+
+/--
+info: 'Hex.IntervalMathlib.CenteredConformance.tacticCenteredBackward' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound]
+-/
+#guard_msgs in
+#print axioms tacticCenteredBackward
+
 end Hex.IntervalMathlib.CenteredConformance

--- a/progress/20260811T183909Z.md
+++ b/progress/20260811T183909Z.md
@@ -1,0 +1,33 @@
+# Accomplished
+
+- Added the exact output interval `[3/16,1/4]` and its centered-function
+  inverse image `[1/4,3/4]` to the package's real semantics companion.
+- Proved the backward semantic rule from the centered operation model and
+  exposed it as a package-owned transparent fact schema.
+- Assembled a separate runtime package which contributes no operation but
+  attaches a backward propagator to the existing opaque centered operation.
+- Ran the forward and backward packages together, checked the exact live
+  backward action, payload entry, installed input fact, and completed session,
+  then replayed the event into an ordinary inverse-image theorem.
+- Added a negative replay case showing that weakening the watched output from
+  `[3/16,1/4]` to `[0,1/4]` is rejected.
+- Added a guarded axiom report and updated the SPEC's arbitrary-propagator
+  design with the independently assembled forward/backward composition.
+- Passed focused builds and the structural, trust, Phase 4, freshness, diff,
+  and banned-proof checks.
+
+# Current frontier
+
+One opaque function now has independently assembled forward and backward
+propagator packages, each with its own exact theorem, both replayed by the same
+function-agnostic transition.
+
+# Next step
+
+Review this vertical, then repair the retained-tree post-propagation split
+binding identified during review and use it to combine contraction with
+subdivision.
+
+# Blockers
+
+None.

--- a/progress/20260815T015716Z.md
+++ b/progress/20260815T015716Z.md
@@ -1,0 +1,31 @@
+# Backward centered contractor preparation
+
+## Accomplished
+
+- Replayed the previously audited backward-centered contractor feature onto
+  exact main `56f56fc4e420a3289ccdec85cd7b56277ae967e0` without changing its Lean
+  source or conformance patch.
+- Rechecked the theorem premise: the output band `[3/16,1/4]` forces the input
+  into `[1/4,3/4]`, while weakening the watched output to `[0,1/4]` is rejected.
+- Preserved the current PNT Table 12, logarithm-provider, and huge-cosine
+  experiments and their Lake registrations. The feature changes no Lake file,
+  so no proof-only freshness exemption is needed.
+- Built the centered Mathlib companion and conformance target, then rebuilt the
+  current PNT, logarithm, and huge-cosine conformance targets successfully.
+- Passed source line-count, copyright, DAG, release-manifest, manual-split,
+  phase-4, trust-surface, conformance-matrix, Mathlib-free bench, PNT inventory,
+  and factor-freshness checks.
+
+## Current frontier
+
+The local branch contains a clean candidate for #9229 on exact current main.
+It has not been pushed, retargeted, reviewed, or submitted to CI.
+
+## Next step
+
+After the pending main movement is final, rebase this candidate if necessary,
+then push and obtain a fresh exact-head review and CI run.
+
+## Blockers
+
+None.

--- a/progress/20260815T070326Z.md
+++ b/progress/20260815T070326Z.md
@@ -1,0 +1,31 @@
+# Backward centered contractor current-main preparation
+
+## Accomplished
+
+- Rebased the preserved two-commit backward-centered contractor patch onto
+  exact main `1bea02b5ffeb65eeffb5562c488b35c84353c3ff`.
+- Confirmed with `git range-diff` that the feature and earlier preparation
+  patches are byte-identical to their preserved forms.
+- Rechecked the semantic premise: the exact output band `[3/16,1/4]` implies
+  the input band `[1/4,3/4]`, while replay rejects the weakened watched output
+  fact `[0,1/4]`.
+- Preserved the current public interval/arithmetic surface and every PNT+
+  registration. The patch changes neither `lakefile.lean` nor the proof-only
+  freshness exemptions.
+- Built `HexIntervalMathlib.CenteredConformance` and the complete current PNT+
+  acceptance target set, and passed the structural, trust, inventory,
+  pinned-source, freshness, and banned-proof checks.
+
+## Current frontier
+
+The local branch contains a clean #9229 candidate on exact current main. It is
+local-only and has not been pushed, retargeted, reviewed, or submitted to CI.
+
+## Next step
+
+When landing is sequenced, rebase only if main has advanced, then run the
+fresh exact-head review and CI cycle.
+
+## Blockers
+
+None.

--- a/progress/20260815T114625Z.md
+++ b/progress/20260815T114625Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Restacked the centered backward-propagation slice as a direct child of the
+  merged public interval arithmetic and natural-power surface.
+- Preserved the exact live backward event and payload quote, its generic proof
+  replay, and rejection when the watched output band is weakened.
+- Confirmed the centered runtime/proof modules remain compatible with the
+  current public interval APIs and PNT registrations.
+- Rebuilt the centered, public interval, and PNT conformance targets and ran
+  the repository formatting, DAG, trust, registration, PNT, and freshness
+  checks.
+
+# Current frontier
+
+The local candidate adds one independently assembled backward package for the
+existing opaque centered operation. Its schema narrows the whole input to
+`[1/4, 3/4]` only from the exact output band `[3/16, 1/4]`.
+
+# Next step
+
+Complete the normal remote review and CI cycle for this first controller/proof
+stack edge before restacking its descendants.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary
- prove the centered function inverse-image rule `[3/16,1/4] -> [1/4,3/4]`
- attach a backward propagator from a separate package to the existing opaque operation
- check the live event and replay it through the same generic fact transition
- reject a quote whose watched output premise is weakened, and pin the ordinary theorem axiom report
- reconcile the feature directly onto current upstream `main`, preserving the public interval and PNT registrations

## Validation
- `lake build HexInterval.Conformance HexIntervalMathlib.PntBKLNWPowConformance HexIntervalMathlib.MixedInstantiationConformance HexIntervalMathlib.ExactBranchConformance` (2256 jobs, green on the reconciled lineage)
- trust-surface, PNT inventory, factor freshness, diff, and banned-proof checks are retained for exact CI

Base: upstream `main` at `505a91875c3409781d34999d023d04b1a8833b1b`.