### PR TITLE
fix(interval): bind splits to post-run snapshots

### DIFF
--- a/HexInterval/Experiment/BranchProof.lean
+++ b/HexInterval/Experiment/BranchProof.lean
@@ -69,11 +69,7 @@ def sameParent [DecidableEq Fact] (source : BranchTree.Leaf Fact PolicyState)
     parent.target == source.input.target
 
 def samePlan [DecidableEq Fact] (left right : Propagator.Policy.SplitPlan Fact) : Bool :=
-  left.scope == right.scope && left.suggestion == right.suggestion &&
-    left.origin == right.origin && left.node == right.node &&
-    left.version == right.version && left.fact == right.fact &&
-    left.point == right.point && left.reason == right.reason &&
-    left.source == right.source
+  left == right
 
 def sameChild [DecidableEq Fact]
     (scope : Propagator.Policy.ScopeId) (depth : Nat)

--- a/HexInterval/Experiment/BranchProof.lean
+++ b/HexInterval/Experiment/BranchProof.lean
@@ -59,6 +59,22 @@ def sameInput [DecidableEq Fact]
   left.baseProgram == right.baseProgram &&
     left.initialFacts == right.initialFacts && left.target == right.target
 
+/-- The split parent is the completed run's current snapshot, not necessarily
+its starting input: propagation and instantiation may precede subdivision. -/
+def sameParent [DecidableEq Fact] (source : BranchTree.Leaf Fact PolicyState)
+    (run : TargetRun.Result Fact PolicyState)
+    (parent : SemanticReplay.CheckerInput Fact) : Bool :=
+  parent.baseProgram == run.session.state.engine.program &&
+    parent.initialFacts == run.session.state.engine.facts &&
+    parent.target == source.input.target
+
+def samePlan [DecidableEq Fact] (left right : Propagator.Policy.SplitPlan Fact) : Bool :=
+  left.scope == right.scope && left.suggestion == right.suggestion &&
+    left.origin == right.origin && left.node == right.node &&
+    left.version == right.version && left.fact == right.fact &&
+    left.point == right.point && left.reason == right.reason &&
+    left.source == right.source
+
 def sameChild [DecidableEq Fact]
     (scope : Propagator.Policy.ScopeId) (depth : Nat)
     (input : SemanticReplay.CheckerInput Fact)
@@ -98,8 +114,14 @@ partial def emitAt [DecidableEq Fact]
       let rightOutput ← emitAt limits emitter tree (depth + 1) right
       unless BranchStart.sameInput source.scope source.input run do
         throwError "interval branch proof: split input does not match its run"
-      unless sameInput source.input children.parent do
-        throwError "interval branch proof: split parent input changed"
+      unless sameParent source run children.parent do
+        throwError "interval branch proof: split parent is not the run's current state"
+      match run.stop with
+      | .split plan =>
+          unless samePlan plan children.plan do
+            throwError "interval branch proof: split plan changed"
+      | _ =>
+          throwError "interval branch proof: retained split did not stop at a split"
       unless sameChild children.leftScope children.depth children.left
           leftOutput.source do
         throwError "interval branch proof: left child input changed"

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -575,6 +575,7 @@ structure SplitPlan (Fact : Type) where
   point : Dyadic
   reason : SplitReason
   source : InvocationKey
+  deriving DecidableEq
 
 inductive Completed where
   | instanceAdmitted (newNodes : List NodeId)

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2129,17 +2129,17 @@ A retained runtime result is not by itself a proof of closure: the leaf
 callback must turn it into the corresponding kernel-checked evidence before
 the bottom-up join can accept it.
 
- A Mathlib-free live canary first propagates an unrelated exponential node,
- then splits a source, and finally closes both children on a second exponential
- target. Its split parent contains the propagated fact and therefore differs
- from the starting input; the generic fold accepts the exact post-run snapshot,
- but rejects replacing it with the stale start snapshot or changing the stored
- split point. The package callback remains responsible for replaying any
- pre-split improvements needed by the eventual parent theorem.
+A Mathlib-free live canary first propagates an unrelated exponential node,
+then splits a source, and finally closes both children on a second exponential
+target. Its split parent contains the propagated fact and therefore differs
+from the starting input; the generic fold accepts the exact post-run snapshot,
+but rejects replacing it with the stale start snapshot or changing the stored
+split point. The package callback remains responsible for replaying any
+pre-split improvements needed by the eventual parent theorem.
 
- The distinct-assumption ReLU canary now runs through this generic path. Its
- retained root has two exact live target children; the leaf callback invokes the
- unchanged generic chronology emitter with the side-specific proof registry, and the
+The distinct-assumption ReLU canary now runs through this generic path. Its
+retained root has two exact live target children; the leaf callback invokes the
+unchanged generic chronology emitter with the side-specific proof registry, and the
 split callback applies `replaySplit`. The resulting expression is assigned to
 an ordinary declaration and its axiom report is compile-checked. Separate
 negative tests reject the delivered step-limited partial tree, a fork whose

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2109,9 +2109,14 @@ subdivision benchmark.
 
 This runtime tree contains no proof evidence. The separate generic
 `BranchProof` frontend now folds a settled retained tree bottom-up. It first
-binds every leaf and split result back to its exact scope, base program, and
-initial fact array. Each child is checked against the exact child input stored
-by its parent, including that input's target. Pending, blocked, failed,
+binds every leaf and split run back to its exact starting scope, base program,
+and initial fact array. A split's parent snapshot is instead checked against
+the completed run's current program and fact array, while retaining the
+starting request's target. This distinction permits narrowing and expression
+instantiation before subdivision without mistaking the post-run facts for
+caller assumptions. Each child is checked against the exact child input
+stored by its parent, including that input's target, and the stored split plan
+must equal the plan which stopped the run. Pending, blocked, failed,
 dangling, shared, cyclic, and unreachable nodes are rejected. Client callbacks
 then replay each closed leaf and apply each package-owned split join; the final
 emitted expression must have the requested Lean target type. A callback can
@@ -2124,9 +2129,17 @@ A retained runtime result is not by itself a proof of closure: the leaf
 callback must turn it into the corresponding kernel-checked evidence before
 the bottom-up join can accept it.
 
-The distinct-assumption ReLU canary now runs through this generic path. Its
-retained root has two exact live target children; the leaf callback invokes the
-unchanged generic chronology emitter with the side-specific proof registry, and the
+ A Mathlib-free live canary first propagates an unrelated exponential node,
+ then splits a source, and finally closes both children on a second exponential
+ target. Its split parent contains the propagated fact and therefore differs
+ from the starting input; the generic fold accepts the exact post-run snapshot,
+ but rejects replacing it with the stale start snapshot or changing the stored
+ split point. The package callback remains responsible for replaying any
+ pre-split improvements needed by the eventual parent theorem.
+
+ The distinct-assumption ReLU canary now runs through this generic path. Its
+ retained root has two exact live target children; the leaf callback invokes the
+ unchanged generic chronology emitter with the side-specific proof registry, and the
 split callback applies `replaySplit`. The resulting expression is assigned to
 an ordinary declaration and its axiom report is compile-checked. Separate
 negative tests reject the delivered step-limited partial tree, a fork whose

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexInterval.Experiment.BranchTree
+import HexInterval.Experiment.BranchProof
 import HexInterval.Experiment.ExpSign
+import Lean.Elab.Tactic.Basic
 
 /-!
 # Nested branch scheduling conformance
@@ -18,9 +19,10 @@ frontiers differ on live pending work.
 
 namespace Hex.Interval.NestedBranchConformance
 
+open Lean Elab Tactic Meta
 open Experiment
 open Propagator PolicySession SemanticReplay TargetRun BranchStart BranchTree
-open ExpSign
+open BranchProof ExpSign
 
 private def program : Program :=
   { operations
@@ -160,5 +162,122 @@ private def leafReached? (entry : Node Bound Route) : Bool :=
     state.settled && state.steps == 5 && state.splits == 2 &&
       state.leaves == 3 && state.nodes.size == 5 &&
       state.nodes.toList.countP leafReached? == 3
+
+/-! ## Propagate before splitting -/
+
+private def postProgram : Program :=
+  { operations
+    nodes := #[sourceInstruction, expInstruction, expInstruction] }
+
+private def postTarget : NodeFact Bound :=
+  { node := node 2, fact := .nonnegative }
+
+private def postInput : CheckerInput Bound :=
+  { baseProgram := postProgram
+    initialFacts := #[.all, .all, .all]
+    target := postTarget }
+
+private inductive PostRoute where
+  | improve
+  | split
+  | close
+  deriving DecidableEq, Repr
+
+private def postController : Controller Bound PostRoute :=
+  { update := fun state event =>
+      match state, event with
+      | .improve, .rule _ => .split
+      | state, _ => state
+    choose := fun state view =>
+      let selected :=
+        match state with
+        | .improve => expAt (node 1) view
+        | .split => splitAt (node 0) view
+        | .close => expAt (node 2) view
+      match selected with
+      | some offer => .select offer state
+      | none => .stop state }
+
+private def postFork (_ : PostRoute) (_ : Side) : PostRoute := .close
+
+private def postResources : BranchTree.Limits :=
+  { branch := { maxDepth := 1, maxScopes := 3 }
+    maxSteps := 3
+    maxSplits := 1
+    maxLeaves := 2
+    leafFuel := limits.policy.maxDecisions }
+
+private def postConfig : Config Bound PostRoute :=
+  { factDomain
+    packages := splitPackages
+    sessionLimits := limits
+    controller := postController
+    splitter
+    forkPolicy := postFork
+    order := .depthFirst
+    limits := postResources }
+
+private def postTree? : Option (State Bound PostRoute) := do
+  let .ok state := BranchTree.start postConfig { index := 0 } postInput .improve
+    | none
+  let .ok state := BranchTree.run postConfig state | none
+  some state
+
+/- The split parent is the exact post-propagation snapshot. It intentionally
+differs from the run's starting input at the unrelated exponential node. -/
+#guard
+  postTree?.any fun tree =>
+    tree.settled && tree.nodes.size == 3 &&
+      match tree.nodes[0]? with
+      | some (BranchTree.Node.split source result children _ _) =>
+          !BranchProof.sameInput source.input children.parent &&
+            BranchProof.sameParent source result children.parent &&
+            children.parent.initialFacts == #[.all, .nonnegative, .all] &&
+            match result.stop with
+            | .split plan => BranchProof.samePlan plan children.plan
+            | _ => false
+      | _ => false
+
+private def trueEmitter : BranchProof.Emitter Bound PostRoute :=
+  { leaf := fun _ _ => pure (mkConst ``True.intro)
+    split := fun _ _ _ _ _ => pure (mkConst ``True.intro) }
+
+private def postProofLimits : BranchProof.Limits :=
+  { maxNodes := 3, maxDepth := 1 }
+
+/-- The generic fold accepts a live tree whose parent performed a fact
+improvement before subdividing. -/
+example : True := by
+  run_tac
+    let some tree := postTree?
+      | throwError "interval post-run split: runtime tree failed"
+    let goal ← getMainGoal
+    goal.assign (← BranchProof.emit postProofLimits trueEmitter tree
+      (← goal.getType))
+
+example : True := by
+  run_tac
+    let some tree := postTree?
+      | throwError "interval post-run split mutation: runtime tree failed"
+    let some root := tree.nodes[0]?
+      | throwError "interval post-run split mutation: root missing"
+    let BranchTree.Node.split source result children left right := root
+      | throwError "interval post-run split mutation: root is not split"
+    let staleChildren := { children with parent := source.input }
+    let stale :=
+      { tree with
+        nodes := tree.nodes.set! 0 (.split source result staleChildren left right) }
+    if (← observing? <| BranchProof.emit postProofLimits trueEmitter stale
+        (mkConst ``True)).isSome then
+      throwError "interval post-run split mutation: stale parent was accepted"
+    let wrongPlan := { children.plan with point := 1 }
+    let changedChildren := { children with plan := wrongPlan }
+    let changed :=
+      { tree with
+        nodes := tree.nodes.set! 0 (.split source result changedChildren left right) }
+    if (← observing? <| BranchProof.emit postProofLimits trueEmitter changed
+        (mkConst ``True)).isSome then
+      throwError "interval post-run split mutation: changed plan was accepted"
+  trivial
 
 end Hex.Interval.NestedBranchConformance

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -278,6 +278,15 @@ example : True := by
     if (← observing? <| BranchProof.emit postProofLimits trueEmitter changed
         (mkConst ``True)).isSome then
       throwError "interval post-run split mutation: changed plan was accepted"
+    let wrongVersion := { children.plan with version := children.plan.version + 1 }
+    let changedVersionChildren := { children with plan := wrongVersion }
+    let changedVersion :=
+      { tree with
+        nodes := tree.nodes.set! 0
+          (.split source result changedVersionChildren left right) }
+    if (← observing? <| BranchProof.emit postProofLimits trueEmitter changedVersion
+        (mkConst ``True)).isSome then
+      throwError "interval post-run split mutation: changed plan version was accepted"
   trivial
 
 end Hex.Interval.NestedBranchConformance

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -11,7 +11,6 @@ import HexInterval.Experiment.ProofFrontend
 import HexInterval.Experiment.TargetRun
 import HexInterval.Experiment.BranchStart
 import HexInterval.Experiment.BranchTree
-import HexInterval.Experiment.BranchProof
 import Mathlib.Lean.Elab.Tactic.Meta
 
 /-!

--- a/progress/20260811T184409Z.md
+++ b/progress/20260811T184409Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Corrected the generic branch-proof fold so a split parent is bound to the
+  completed run's current program and facts, rather than incorrectly requiring
+  the run's starting snapshot.
+- Preserved the starting target, exact child inputs, and exact stopping split
+  plan as independent checks.
+- Added a live Mathlib-free tree which propagates one exponential node, then
+  splits a source, then closes both children on another exponential target.
+- Confirmed that the post-propagation parent differs from the starting input,
+  is accepted by the proof fold, and that stale-parent and changed-plan
+  mutations are rejected.
+- Removed an unused branch-proof import from the exponential conformance
+  module and updated the SPEC's propagation-before-subdivision contract.
+- Passed focused builds and the structural, trust, Phase 4, freshness, diff,
+  and banned-proof checks.
+
+# Current frontier
+
+Retained proof trees now permit the policy sequence needed by a practical
+interval solver: propagate or instantiate, retain the improved snapshot, then
+subdivide it.
+
+# Next step
+
+Review this repair, then connect the exact dyadic domain and arbitrary
+function contractors to a useful post-contraction split rather than the
+structural exponential canary.
+
+# Blockers
+
+None.

--- a/progress/20260814T233647Z.md
+++ b/progress/20260814T233647Z.md
@@ -1,0 +1,36 @@
+# PR #9230 local reconciliation
+
+## Accomplished
+
+- Preserved exact local #9229 boundary
+  `947b6072a9a81ae2c77635c744ec072298a40489` and replayed only the original
+  #9230 post-run split-binding tip on a separate local branch.
+- Resolved the interval SPEC overlap by retaining current PNT/Table12 and the
+  distinct-assumption ReLU wording alongside the post-run split contract.
+- Audited `sameParent` against `BranchStart.prepare`: split parents now bind
+  the completed engine program and fact array while retaining the starting
+  target, rather than incorrectly requiring the stale starting facts.
+- Audited `samePlan` against `SplitPlan`; all nine fields are compared, and a
+  retained split whose run did not actually stop with that exact plan is
+  rejected before the package split callback.
+- Verified the live Mathlib-free canary first propagates an unrelated fact,
+  then splits and closes both children; its post-run parent differs from the
+  starting input, while stale-parent and changed-plan mutations are rejected.
+- Built BranchProof, nested-branch, ExpSign, ReLU, centered, and PNT Table12
+  targets successfully in a 2,236-job focused build.
+- Passed copyright, file-line, DAG, trust-surface, Phase 4, factor-freshness,
+  PNT-inventory, diff, and banned-mechanism checks.
+
+## Current frontier
+
+- The clean local #9230 stack is ready for one final rebase after Table12 full
+  and #9229 land; no remote PR metadata or CI has been touched.
+
+## Next step
+
+- Rebase the preserved #9229/#9230 lineage onto the eventual exact `main`,
+  then push and review the two edges in dependency order.
+
+## Blockers
+
+- None.

--- a/progress/20260815T020103Z.md
+++ b/progress/20260815T020103Z.md
@@ -1,0 +1,38 @@
+# Local #9230 post-run split preparation
+
+## Accomplished
+
+- Replayed the #9230 post-run split-snapshot feature and its previously audited
+  SPEC reconciliation onto exact prepared #9229 head
+  `c8924bd251e6c244aaeee0d882107564c58bbb88`.
+- Confirmed that the executable diffs in `BranchProof`, the live nested-branch
+  conformance, and the Mathlib exponential conformance import are byte-for-byte
+  identical to the earlier audited feature patch.
+- Audited the premise against `BranchTree.step` and `BranchStart.prepare`: an
+  accepted split is prepared from the completed run's current engine program
+  and fact array, retains the starting target, and stores the exact plan that
+  stopped the run. The proof fold now checks those same values and rejects a
+  stale starting snapshot or a changed plan.
+- Built `HexInterval.NestedBranchConformance` and
+  `HexIntervalMathlib.ExpSignConformance`, including the live pre-split
+  propagation canary and both mutation guards.
+- Rebuilt the centered, large-cosine, precision-log, and full PNT conformance
+  set. Ran repository static, trust-surface, PNT inventory, factor-freshness,
+  release-manifest, manual-split, Phase 4, and Mathlib-free bench gates. The
+  explicit banned-mechanism scan is clean.
+
+## Current frontier
+
+- The local #9230 candidate is ready on top of the prepared #9229 boundary.
+  It changes no Lake registration, fixture, oracle, or current PNT/log/cos
+  source file.
+
+## Next step
+
+- After #9229 lands on the eventual current main, rebase this local feature
+  boundary once, refresh any exact freshness metadata only if the base requires
+  it, then push and obtain exact-head review and CI.
+
+## Blockers
+
+- None. Remote PR state was intentionally left untouched.

--- a/progress/20260815T114816Z.md
+++ b/progress/20260815T114816Z.md
@@ -1,0 +1,28 @@
+# Accomplished
+
+- Restacked post-run split authentication directly onto the centered backward
+  contractor candidate.
+- Bound each retained split parent to the completed run's current program and
+  fact array while retaining the starting target.
+- Bound the stored split plan to every field of the exact plan which stopped
+  the run.
+- Preserved negative guards rejecting a stale starting snapshot and a changed
+  split point, alongside the live propagate-then-split tree.
+- Rebuilt nested-branch, ExpSign, centered, public interval, and PNT targets
+  and ran the repository formatting, DAG, trust, registration, PNT, and
+  freshness checks.
+
+# Current frontier
+
+The local branch-proof fold now authenticates the run's starting input, its
+post-run split snapshot, and its exact stopping plan before invoking the
+client's kernel-facing split callback.
+
+# Next step
+
+Complete the normal remote review and CI cycle for this stack edge after the
+centered backward contractor lands.
+
+# Blockers
+
+None.

--- a/progress/20260815T212901Z.md
+++ b/progress/20260815T212901Z.md
@@ -1,0 +1,23 @@
+# Post-run split plan authentication
+
+## Accomplished
+
+- Made split plans structurally decidable and reduced proof-side plan
+  authentication to whole-record equality.
+- Added a non-point plan-version mutation beside the existing point mutation,
+  so future fields cannot escape authentication through a hand-maintained
+  projection.
+
+## Current frontier
+
+The post-run parent snapshot and complete stopping split plan are both exact
+inputs to branch proof emission.
+
+## Next step
+
+Review and merge the direct-main post-run split edge before replaying the next
+prepared controller dependency.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary
- bind retained split parents to the completed run current program/facts instead of the stale starting snapshot
- retain exact starting target, child-input, and stopping-plan checks
- add a live propagate-then-split-then-close Mathlib-free tree and reject stale-parent/changed-plan mutations
- document the propagation-before-subdivision proof boundary

## Validation
- `lake build +HexInterval.NestedBranchConformance:olean +HexIntervalMathlib.ExpSignConformance:olean`
- trust-surface, factor freshness, PNT inventory, diff, and banned-proof checks