### PR TITLE
feat(interval): add a staged search policy

### DIFF
--- a/HexInterval/Experiment/StagedPolicy.lean
+++ b/HexInterval/Experiment/StagedPolicy.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.TargetRun
+
+@[expose] public section
+
+/-!
+# A replaceable staged interval-search policy
+
+This first policy candidate is deliberately representation- and
+function-independent. It ranks only engine-owned offer classes, action kinds,
+ages, and bounded effort. Package keys and facts remain opaque.
+
+The policy is an experiment, not a soundness boundary. Every selection is
+still validated by `PolicySession`, and proof replay remains independent of
+the order chosen here.
+-/
+
+namespace Hex.Interval.Experiment.StagedPolicy
+
+open Propagator Propagator.Policy TargetRun
+
+/-- Replaceable feature gates for the staged baseline. -/
+structure Config where
+  allowInstantiation : Bool := true
+  allowRetries : Bool := true
+  allowSplits : Bool := true
+  maxRetryEffort : Nat := 4
+  deriving DecidableEq, Repr
+
+/-- Policy-private observations. These counters affect diagnostics and future
+policy upgrades, never the validity of an installed fact. -/
+structure Metrics where
+  ruleRuns : Nat := 0
+  equalityRuns : Nat := 0
+  improvements : Nat := 0
+  noChanges : Nat := 0
+  inapplicable : Nat := 0
+  failures : Nat := 0
+  extensions : Nat := 0
+  dismissals : Nat := 0
+  rejections : Nat := 0
+  deriving DecidableEq, Repr
+
+structure State where
+  config : Config
+  metrics : Metrics := {}
+  deriving DecidableEq, Repr
+
+def State.initial (config : Config := {}) : State := { config }
+
+def splitReasonRank : SplitReason -> Nat
+  | .singularity => 0
+  | .totalityBoundary => 1
+  | .kink => 2
+  | .criticalPoint => 3
+  | .contractor => 4
+  | .smallLandmark => 5
+  | .midpoint => 6
+  | .custom code => 7 + code
+
+/-- Coarse replaceable stages. Lower values run first. An invocation which
+discovers an instantiation or split precedes the resulting semantic offer. -/
+def rank : OfferView -> Nat
+  | { key := .equality _, .. } => 0
+  | { key := .invoke invocation, .. } =>
+      match invocation.kind with
+      | .forward | .backward | .rewrite => 0
+      | .instantiate => 10
+      | .improve | .shave | .regularize => 20
+      | .split => 30
+  | { key := .instantiate _ _, .. } => 11
+  | { key := .retry _ _, .. } => 21
+  | { key := .split _ _ _ reason, .. } => 40 + splitReasonRank reason
+
+def allowed (config : Config) (offer : OfferView) : Bool :=
+  match offer.key with
+  | .retry _ effort => config.allowRetries && effort <= config.maxRetryEffort
+  | .instantiate _ _ => config.allowInstantiation
+  | .split _ _ _ _ => config.allowSplits
+  | .invoke invocation =>
+      match invocation.kind with
+      | .instantiate => config.allowInstantiation
+      | .split => config.allowSplits
+      | .forward | .backward | .improve | .shave | .rewrite | .regularize => true
+  | .equality _ => true
+
+def better (candidate current : OfferView) : Bool :=
+  rank candidate < rank current ||
+    (rank candidate == rank current && current.age < candidate.age)
+
+/-- Select the oldest offer in the earliest enabled stage. Array order is the
+final deterministic tie-breaker. -/
+def choose? (config : Config) (offers : Array OfferView) : Option OfferView :=
+  offers.foldl (fun best candidate =>
+    if !allowed config candidate then best
+    else
+      match best with
+      | none => some candidate
+      | some current => if better candidate current then some candidate else best) none
+
+def recordRule (metrics : Metrics) (observation : RuleObservation Fact) : Metrics :=
+  let improved := observation.changes.size
+  { metrics with
+    ruleRuns := metrics.ruleRuns + 1
+    improvements := metrics.improvements + improved
+    noChanges := metrics.noChanges + if observation.outcome == .noChange then 1 else 0
+    inapplicable := metrics.inapplicable +
+      if observation.outcome == .inapplicable then 1 else 0
+    failures := metrics.failures +
+      if observation.outcome matches .failed _ | .resourceLimit _ then 1 else 0 }
+
+def recordEquality (metrics : Metrics)
+    (observation : EqualityObservation Fact) : Metrics :=
+  { metrics with
+    equalityRuns := metrics.equalityRuns + 1
+    improvements := metrics.improvements + observation.changes.size
+    noChanges := metrics.noChanges +
+      if observation.outcome == .noChange then 1 else 0
+    failures := metrics.failures +
+      if observation.outcome matches .engineResource _ | .factResource _ | .invalid _
+      then 1 else 0 }
+
+def update : State -> Event Fact -> State
+  | state, .rule observation =>
+      { state with metrics := recordRule state.metrics observation }
+  | state, .equality observation =>
+      { state with metrics := recordEquality state.metrics observation }
+  | state, .instance completion =>
+      match completion with
+      | .instanceAdmitted _ =>
+          { state with
+            metrics := { state.metrics with extensions := state.metrics.extensions + 1 } }
+      | .instanceDuplicate | .instanceRejected _ => state
+      | .dismissed =>
+          { state with
+            metrics := { state.metrics with dismissals := state.metrics.dismissals + 1 } }
+  | state, .dismissed =>
+      { state with
+        metrics := { state.metrics with dismissals := state.metrics.dismissals + 1 } }
+  | state, .rejected _ =>
+      { state with
+        metrics := { state.metrics with rejections := state.metrics.rejections + 1 } }
+  | state, .invalidPayload _ | state, .rejectedPayload _ =>
+      { state with
+        metrics := { state.metrics with failures := state.metrics.failures + 1 } }
+
+/-- Generic target-run controller for the staged baseline. -/
+def controller : TargetRun.Controller Fact State where
+  update := update
+  choose := fun state view =>
+    match choose? state.config view.offers with
+    | some offer => .select offer state
+    | none => .stop state
+
+end Hex.Interval.Experiment.StagedPolicy

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3336,6 +3336,25 @@ uses four stages.
 4. If no candidate has adequate predicted gain, choose a solver split and
    repeat in both children.
 
+The first executable staged baseline now implements this ordering without
+inspecting facts, operation keys, or package identities. It ranks engine-owned
+equality and forward/backward/rewrite offers first, then structural
+instantiation discovery and admission, then improve/shave/regularize and
+bounded retry offers, then split probes and their retained split plans.
+Configuration independently disables instantiation, retries, or splits and
+bounds retry effort; the oldest offer wins within a stage and stable view order
+is the final tie-breaker. Policy-private counters record rule and equality
+runs, actual fact-version changes, no-change and inapplicable outcomes,
+extensions, failures, dismissals, and rejected selections. These counters are
+diagnostic inputs for later scoring, not evidence.
+
+A live Mathlib-free arbitrary-function canary presents two exponential
+forward contractors and one source split rule in the same frontier. The policy
+selects both fact improvements, then invokes the split probe, then returns its
+split plan; it contains no reference to any of those rule keys. This establishes
+the replaceable staging seam. It does not yet claim that fixed stage order is
+the best policy, nor does it implement width- or goal-sensitive scoring.
+
 The prototype computes a goal-directed potential rather than summing raw widths.
 Nodes on the backwards dependency slice from the desired comparison or current
 contradiction receive greater weight. A node's uncertainty records:

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3343,8 +3343,11 @@ instantiation discovery and admission, then improve/shave/regularize and
 bounded retry offers, then split probes and their retained split plans.
 Configuration independently disables instantiation, retries, or splits and
 bounds retry effort; the oldest offer wins within a stage and stable view order
-is the final tie-breaker. Policy-private counters record rule and equality
-runs, actual fact-version changes, no-change and inapplicable outcomes,
+is the final tie-breaker. If enabled semantic work finishes while only
+disabled offers remain, the target driver stops with `policyStop` and retains
+the live-offer count; it does not dismiss or execute those offers.
+Policy-private counters record rule and equality runs, actual fact-version
+changes, no-change and inapplicable outcomes,
 extensions, failures, dismissals, and rejected selections. These counters are
 diagnostic inputs for later scoring, not evidence.
 

--- a/conformance/HexInterval/StagedPolicyConformance.lean
+++ b/conformance/HexInterval/StagedPolicyConformance.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.StagedPolicy
+import HexInterval.Experiment.ExpSign
+import HexInterval.Experiment.SemanticReplay
+
+/-!
+# Staged policy conformance
+
+The controller below knows no rule keys. On a live arbitrary-function graph it
+drains two forward contractors before invoking a split probe and selecting the
+resulting solver split.
+-/
+
+namespace Hex.Interval.StagedPolicyConformance
+
+open Experiment
+open Propagator PolicySession SemanticReplay TargetRun
+open ExpSign StagedPolicy
+
+private def program : Program :=
+  { operations
+    nodes := #[sourceInstruction, expInstruction, expInstruction] }
+
+private def input : CheckerInput Bound :=
+  { baseProgram := program
+    initialFacts := #[.all, .all, .all]
+    target := { node := node 2, fact := .empty } }
+
+private def session? : Option (PolicySession.Session Bound) :=
+  match PolicySession.Session.start factDomain program splitPackages
+      input.initialFacts limits { index := 0 } with
+  | .ok session => some session
+  | .error _ => none
+
+private def result? : Option (TargetRun.Result Bound StagedPolicy.State) := do
+  let session ← session?
+  pure (TargetRun.drive factDomain input.target.node input.target.fact
+    StagedPolicy.controller 16 session StagedPolicy.State.initial)
+
+private def expectedMetrics : StagedPolicy.Metrics :=
+  { ruleRuns := 3, improvements := 2 }
+
+/- Cheap forward work reaches a fixed point before the split probe and its
+resulting semantic split offer. -/
+#guard
+  result?.any fun result =>
+    result.events.size == 3 &&
+      result.session.state.engine.history.size == 2 &&
+      result.session.state.engine.facts == #[.all, .nonnegative, .nonnegative] &&
+      result.policyState.metrics == expectedMetrics &&
+      match result.events[0]?, result.events[1]?, result.events[2]?, result.stop with
+      | some (TargetRun.Event.rule first), some (TargetRun.Event.rule second),
+          some (TargetRun.Event.rule probe), TargetRun.Stop.split plan =>
+          first.invocation.kind == .forward && first.invocation.anchor == node 1 &&
+            first.changes.size == 1 &&
+            second.invocation.kind == .forward && second.invocation.anchor == node 2 &&
+            second.changes.size == 1 &&
+            probe.invocation.kind == .split && probe.invocation.anchor == node 0 &&
+            probe.changes.isEmpty && probe.emittedSuggestions.size == 1 &&
+            plan.node == node 0 && plan.point == 0 && plan.reason == .smallLandmark
+      | _, _, _, _ => false
+
+private def invocation (index : Nat) (kind : ActionKind) : Policy.InvocationKey :=
+  { scope := { index := 0 }
+    programVersion := 0
+    application := { index }
+    rule := { name := "staged-policy.synthetic" }
+    anchor := node index
+    kind
+    effort := 0
+    inputs := [] }
+
+private def offer (index age : Nat) (key : Policy.OfferKey) : Policy.OfferView :=
+  { id := .suggestion { index }, key, offerClass := key.offerClass, age }
+
+private def forwardOffer : Policy.OfferView :=
+  offer 0 1 (.invoke (invocation 0 .forward))
+
+private def olderForward : Policy.OfferView :=
+  offer 1 5 (.invoke (invocation 1 .forward))
+
+private def instanceOffer : Policy.OfferView :=
+  offer 2 9 (.invoke (invocation 2 .instantiate))
+
+private def retryOffer : Policy.OfferView :=
+  offer 3 9 (.retry (invocation 3 .improve) 2)
+
+private def splitOffer : Policy.OfferView :=
+  offer 4 9 (.split (invocation 4 .split)
+    { node := node 0, version := 0 } 0 .midpoint)
+
+#guard
+  (StagedPolicy.choose? {} #[splitOffer, retryOffer, instanceOffer, forwardOffer]).map
+      (fun selected => selected.key) == some forwardOffer.key
+
+#guard
+  (StagedPolicy.choose? {} #[forwardOffer, olderForward]).map
+      (fun selected => selected.key) == some olderForward.key
+
+#guard
+  (StagedPolicy.choose?
+      { allowInstantiation := false, allowRetries := false, allowSplits := false }
+      #[splitOffer, retryOffer, instanceOffer]).isNone
+
+end Hex.Interval.StagedPolicyConformance

--- a/conformance/HexInterval/StagedPolicyConformance.lean
+++ b/conformance/HexInterval/StagedPolicyConformance.lean
@@ -84,18 +84,26 @@ private def forwardOffer : Policy.OfferView :=
 private def olderForward : Policy.OfferView :=
   offer 1 5 (.invoke (invocation 1 .forward))
 
-private def instanceOffer : Policy.OfferView :=
+private def instanceProbe : Policy.OfferView :=
   offer 2 9 (.invoke (invocation 2 .instantiate))
 
+private def instanceOffer : Policy.OfferView :=
+  offer 3 9 (.instantiate (invocation 3 .instantiate)
+    { family := 0, generation := 0, nodes := [], equalities := [], scopes := [] })
+
 private def retryOffer : Policy.OfferView :=
-  offer 3 9 (.retry (invocation 3 .improve) 2)
+  offer 4 9 (.retry (invocation 4 .improve) 2)
+
+private def splitProbe : Policy.OfferView :=
+  offer 5 9 (.invoke (invocation 5 .split))
 
 private def splitOffer : Policy.OfferView :=
-  offer 4 9 (.split (invocation 4 .split)
+  offer 6 9 (.split (invocation 6 .split)
     { node := node 0, version := 0 } 0 .midpoint)
 
 #guard
-  (StagedPolicy.choose? {} #[splitOffer, retryOffer, instanceOffer, forwardOffer]).map
+  (StagedPolicy.choose? {}
+      #[splitOffer, retryOffer, instanceOffer, instanceProbe, forwardOffer]).map
       (fun selected => selected.key) == some forwardOffer.key
 
 #guard
@@ -103,8 +111,17 @@ private def splitOffer : Policy.OfferView :=
       (fun selected => selected.key) == some olderForward.key
 
 #guard
-  (StagedPolicy.choose?
-      { allowInstantiation := false, allowRetries := false, allowSplits := false }
-      #[splitOffer, retryOffer, instanceOffer]).isNone
+  (StagedPolicy.choose? { allowInstantiation := false }
+      #[instanceProbe, instanceOffer]).isNone
+
+#guard
+  (StagedPolicy.choose? { allowRetries := false } #[retryOffer]).isNone
+
+#guard
+  (StagedPolicy.choose? { maxRetryEffort := 1 } #[retryOffer]).isNone
+
+#guard
+  (StagedPolicy.choose? { allowSplits := false }
+      #[splitProbe, splitOffer]).isNone
 
 end Hex.Interval.StagedPolicyConformance

--- a/conformance/HexInterval/StagedPolicyConformance.lean
+++ b/conformance/HexInterval/StagedPolicyConformance.lean
@@ -65,6 +65,27 @@ resulting semantic split offer. -/
             plan.node == node 0 && plan.point == 0 && plan.reason == .smallLandmark
       | _, _, _, _ => false
 
+private def disabledResult? : Option (TargetRun.Result Bound StagedPolicy.State) := do
+  let session ← session?
+  pure (TargetRun.drive factDomain input.target.node input.target.fact
+    StagedPolicy.controller 16 session
+      (StagedPolicy.State.initial
+        { allowInstantiation := false
+          allowRetries := false
+          allowSplits := false }))
+
+-- Enabled semantic work still passes through the ordinary session boundary.
+-- Once only the disabled split-discovery offer remains, the controller stops
+-- honestly with that live offer retained rather than selecting it.
+#guard
+  disabledResult?.any fun result =>
+    result.events.size == 2 &&
+      result.session.state.engine.history.size == 2 &&
+      result.session.state.engine.facts == #[.all, .nonnegative, .nonnegative] &&
+      match result.stop with
+      | .policyStop liveOffers => liveOffers == 1
+      | _ => false
+
 private def invocation (index : Nat) (kind : ActionKind) : Policy.InvocationKey :=
   { scope := { index := 0 }
     programVersion := 0

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -474,6 +474,8 @@ lean_lib HexConformance where
       `HexIntervalMathlib.PntTable10A2Conformance,
       `HexIntervalMathlib.PntTable10ExactConformance].map Glob.one
 
+    ++ #[`HexInterval.StagedPolicyConformance].map Glob.one
+
     ++ #[`HexInterval.MinMaxConformance,
       `HexIntervalMathlib.MinMaxConformance].map Glob.one
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -307,6 +307,7 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.PayloadSession,
     `HexInterval.Experiment.PolicySession,
     `HexInterval.Experiment.TargetRun,
+    `HexInterval.Experiment.StagedPolicy,
     `HexInterval.Experiment.BranchStart,
     `HexInterval.Experiment.BranchTree,
     `HexInterval.Experiment.BranchProof,

--- a/progress/20260811T185238Z.md
+++ b/progress/20260811T185238Z.md
@@ -1,0 +1,31 @@
+# Accomplished
+
+- Added a Mathlib-free, function- and fact-independent staged policy
+  controller over engine-owned offer metadata.
+- Made instantiation, retries, and solver splits independently configurable,
+  bounded retry effort, and used oldest-first fairness within each stage.
+- Recorded policy-private productivity, no-change, inapplicability, failure,
+  extension, dismissal, and rejection metrics without making them evidence.
+- Added a live arbitrary-function conformance graph on which two forward facts
+  are installed before the split probe and final split plan are selected.
+- Added isolated ordering, age-fairness, and feature-disable guards.
+- Documented the delivered baseline and its deliberate lack of width- or
+  goal-sensitive scoring in the SPEC.
+- Passed focused builds and the structural, trust, Phase 4, registration,
+  diff, and banned-proof checks.
+
+# Current frontier
+
+The engine now has a concrete replaceable baseline for deciding when to drain
+propagation, admit structural work, try stronger actions, and subdivide. Its
+metrics are ready for comparative policy experiments rather than hard-coded
+function logic.
+
+# Next step
+
+Obtain an independent review, then compare this staged baseline with a
+contraction-aware candidate on an exact-domain useful split example.
+
+# Blockers
+
+None.

--- a/progress/20260814T234206Z.md
+++ b/progress/20260814T234206Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Replayed the staged search-policy feature onto exact local #9230 boundary
+  `515788c75e3ff4c7637cc515deb329d21c078745` without changing the public
+  controller API.
+- Resolved the Lake registration overlap by preserving the complete current
+  PNT, Table 12, interval, and centered-function target set.
+- Audited stage ordering, age fairness, configuration gates, retry effort,
+  private metrics, and the live arbitrary-function execution trace.
+- Strengthened conformance so instantiation discovery and admission, retries,
+  retry effort, split discovery and retained split offers are gated explicitly.
+- Refreshed the narrow proof-only Lake freshness exemption to the reconciled
+  file blob.
+- Built the focused staged-policy and inherited interval targets and passed the
+  structural, trust, Phase 4, PNT inventory, freshness, diff, and banned-proof
+  checks.
+
+# Current frontier
+
+The local #9231 candidate is a clean policy-only successor to #9230. The live
+canary exercises the intended forward-forward-split ordering, while synthetic
+guards pin fairness and every delivered configuration boundary.
+
+# Next step
+
+After #9229 and #9230 land, rebase this candidate once onto their final merged
+lineage, recompute the exact Lake exemption, then push and obtain exact-head
+review and CI.
+
+# Blockers
+
+None.

--- a/progress/20260815T020725Z.md
+++ b/progress/20260815T020725Z.md
@@ -1,0 +1,39 @@
+# Local #9231 staged-policy preparation
+
+## Accomplished
+
+- Replayed the #9231 staged search-policy feature and its strengthened gate
+  canaries onto exact prepared #9230 head
+  `a9bea490fdfd8de9e962733d54fa2f74f793114a`.
+- Preserved the current Lake target lists while adding only
+  `HexInterval.Experiment.StagedPolicy` and
+  `HexInterval.StagedPolicyConformance`; refreshed the narrow exact-blob
+  proof-only freshness exemption for that combined Lake file.
+- Confirmed the policy and conformance sources are byte-for-byte identical to
+  the previously audited repaired #9231 versions.
+- Audited the limits and stopping premise. The policy sees only engine-owned
+  offer kind/class/age, gates instantiation and split probes together with
+  their semantic offers, bounds retry offers, and returns an explicit
+  `policyStop` if every live offer is disabled. `PolicySession` still validates
+  every selection, and policy metrics remain diagnostic rather than evidence.
+- Built the staged policy conformance and the complete `HexIntervalExperiment`
+  root. Rebuilt the centered, large-cosine, precision-log, and full PNT
+  conformance set.
+- Passed file, copyright, DAG, trust-surface, conformance-target, PNT inventory,
+  factor-freshness, release-manifest, manual-split, release-sync, Phase 4, and
+  Mathlib-free bench checks. The explicit banned-mechanism scan is clean.
+
+## Current frontier
+
+- The local #9231 candidate is clean on top of the prepared #9230 boundary.
+  Existing PNT/log/cos registrations and sources are unchanged.
+
+## Next step
+
+- After the preceding stack edges land, rebase this feature boundary once onto
+  the final parent, refresh its exact Lake exemption, then push for exact-head
+  review and CI.
+
+## Blockers
+
+- None. Remote PR and CI state were intentionally left untouched.

--- a/progress/20260815T115212Z.md
+++ b/progress/20260815T115212Z.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+- Restacked the staged policy experiment onto the authenticated branch-proof
+  and centered-contractor candidates while preserving current public interval
+  and PNT registrations.
+- Retained independent gates for instantiation discovery/admission, retry
+  effort, and split discovery/selection.
+- Added a live all-disabled configuration canary: enabled forward facts still
+  run through the ordinary session boundary, then the driver reports
+  `policyStop` when only a disabled split probe remains.
+- Kept the policy independent of fact values, operation and rule keys,
+  mathematical functions, widths, and goals.
+- Rebuilt staged-policy, branch, centered, public interval, and PNT targets and
+  ran the repository formatting, DAG, trust, registration, PNT, and freshness
+  checks.
+
+# Current frontier
+
+The local policy is a replaceable fixed-stage baseline over engine-owned offer
+class, action kind, age, and bounded retry effort. Exact selection identity is
+still revalidated by `PolicySession`; policy metrics do not enter evidence.
+
+# Next step
+
+Complete the normal remote review and CI cycle after the preceding stack edges
+land.
+
+# Blockers
+
+None.

--- a/progress/20260815T220705Z.md
+++ b/progress/20260815T220705Z.md
@@ -1,0 +1,24 @@
+# Staged policy direct-main reconciliation
+
+## Accomplished
+
+- Replayed the staged search-policy edge onto the merged post-run split base.
+- Preserved the whole-record split-plan authentication and its point/version
+  mutation guards.
+- Registered the exact proof-only Lake freshness exemption for the staged
+  policy experiment and conformance target.
+
+## Current frontier
+
+The staged policy remains a replaceable experimental ordering policy. Its
+configuration gates and stop behavior are covered without granting proof
+authority or freezing a default policy.
+
+## Next step
+
+Review and merge this edge before replaying the next prepared controller
+dependency.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -204,6 +204,12 @@
     "reason": "Additionally registers the proof-only centered-function real-semantics companion and its conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "af5d1c8d63d2d61a1d6866f8bb60a6ec80df0ee2",
+    "reason": "Additionally registers the isolated Mathlib-free HexInterval staged-policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -412,5 +412,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "9375f2f3431d2369497b7ce6aed343aa96ad7504",
     "reason": "Additionally registers the proof-only bounded PNT+ small-prime logarithm theorem family and its conformance module on top of the complete FKS2 and Table 10 registrations; these acceptance-only modules do not enter the factorization service target or its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "d3ac044f73ebc00b2b86ca89a658495091d350e6",
+    "reason": "Additionally registers the bounded Mathlib-free staged-policy experiment and its conformance module on top of the current PNT and interval registrations; neither enters the factorization service target or changes its executable dependency graph."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -206,7 +206,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "af5d1c8d63d2d61a1d6866f8bb60a6ec80df0ee2",
+    "current_blob": "cc0579df444cae1a2fcc9a900c8f9c53c452943a",
     "reason": "Additionally registers the isolated Mathlib-free HexInterval staged-policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {


### PR DESCRIPTION
## Summary
- add a fact- and function-independent staged controller over engine-owned offers
- make instantiation, retries, and solver splits independently configurable and retain productivity metrics
- demonstrate live ordering: two arbitrary-function forward improvements, then split probe, then split plan
- document this as a replaceable baseline rather than a finalized score

## Validation
- `lake build +HexInterval.StagedPolicyConformance:olean +HexInterval.NestedBranchConformance:olean +HexIntervalMathlib.ExpSignConformance:olean`
- trust-surface, factor freshness, PNT inventory, diff, and banned-proof checks