### PR TITLE
feat(interval): replay exact subtraction arithmetic

### DIFF
--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -140,11 +140,14 @@ def preflightSubtraction (limit : EndpointLimit) (left right : Dyadic) :
   if !comparison.allowed limit then throw (.comparison comparison)
 
 def subtractionChecked (limit : EndpointLimit) (left right : Dyadic) :
-    Except WorkCost Dyadic := do
-  preflightSubtraction limit left right
-  let result := left - right
-  endpointChecked limit result
-  pure result
+    Except WorkCost Dyadic :=
+  match preflightSubtraction limit left right with
+  | .error cost => .error cost
+  | .ok _ =>
+      let result := left - right
+      match endpointChecked limit result with
+      | .error cost => .error cost
+      | .ok _ => .ok result
 
 def multiplicationAllowed (limit : EndpointLimit) (left right : Dyadic) : Bool :=
   let leftCost := EndpointCost.ofDyadic left

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1563,6 +1563,19 @@ band is weakened to `[0,1/4]`, and its ordinary theorem confirms that the
 watched output premise is load-bearing. Richer packages may add retries,
 instantiators, and split suggestions without changing this interface.
 
+The exact arithmetic package contributes its first replay schema through this
+same boundary. The forward subtraction callback remains Mathlib-free and
+computes over the complete canonical dyadic cut language; its companion schema
+recomputes the successful proposal and proves the pointwise real subtraction
+law from the exact ordered pair of input facts. The live conformance case uses
+`x ∈ (1,+∞)` and `y ∈ (-∞,3]` to derive `x - y ∈ (-2,+∞)`, so both
+strictness and independent unboundedness are load-bearing. The generic proof
+emitter contains no arithmetic case. Weakening the left premise or adding a
+trailing schema-zero payload cell is rejected, and the accepted quote yields
+the ordinary theorem `1 < x → y ≤ 3 → -2 < x - y`. Further arithmetic
+schemas extend this package-owned pattern without introducing a
+rational-normalization dependency into propagation replay.
+
 The prefix resolver returns an exact fact together with its theorem for a
 requested `(node, version)`, and builds the rule's ordered input list by
 traversing the immutable `Action.inputs`. The rule transition consumes this

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1564,10 +1564,13 @@ watched output premise is load-bearing. Richer packages may add retries,
 instantiators, and split suggestions without changing this interface.
 
 The exact arithmetic package contributes its first replay schema through this
-same boundary. The forward subtraction callback remains Mathlib-free and
-computes over the complete canonical dyadic cut language; its companion schema
-recomputes the successful proposal and proves the pointwise real subtraction
-law from the exact ordered pair of input facts. The live conformance case uses
+same boundary. This is package-callback replay over
+`Experiment.DyadicInterval.Fact`, not a second supported interval-arithmetic
+API; the public resource-checked operation remains `Hex.Interval.subWithin`.
+The forward subtraction callback remains Mathlib-free and computes over the
+complete experimental dyadic cut language; its companion schema recomputes the
+successful proposal and proves the pointwise real subtraction law from the
+exact ordered pair of input facts. The live conformance case uses
 `x ∈ (1,+∞)` and `y ∈ (-∞,3]` to derive `x - y ∈ (-2,+∞)`, so both
 strictness and independent unboundedness are load-bearing. The generic proof
 emitter contains no arithmetic case. Weakening the left premise or adding a

--- a/HexIntervalMathlib/Experiment/Arithmetic.lean
+++ b/HexIntervalMathlib/Experiment/Arithmetic.lean
@@ -17,7 +17,9 @@ public import HexInterval.Experiment.DyadicRules
 This companion supplies the first package-owned arithmetic replay schema for
 the Mathlib-free dyadic registry. The generic proof emitter remains unaware of
 subtraction: it checks the rule address and event links, then invokes the
-schema below on the exact ordered input facts.
+schema below on the exact ordered input facts. This experiment is a package
+callback/proof adapter, not another public interval subtraction API; the
+supported resource-checked operation is `Hex.Interval.subWithin`.
 -/
 
 namespace Hex.Interval.Experiment.Arithmetic

--- a/HexIntervalMathlib/Experiment/Arithmetic.lean
+++ b/HexIntervalMathlib/Experiment/Arithmetic.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Experiment.DyadicInterval
+public import HexInterval.Experiment.DyadicRules
+
+@[expose] public section
+
+/-!
+# Real semantics for exact arithmetic propagators
+
+This companion supplies the first package-owned arithmetic replay schema for
+the Mathlib-free dyadic registry. The generic proof emitter remains unaware of
+subtraction: it checks the rule address and event links, then invokes the
+schema below on the exact ordered input facts.
+-/
+
+namespace Hex.Interval.Experiment.Arithmetic
+
+open Propagator SemanticReplay
+open DyadicInterval DyadicRules
+
+/-- Real meaning contributed by the arithmetic package for subtraction nodes.
+Other operation keys remain available for independent semantic packages. -/
+def Models (program : Program) (valuation : NodeId → ℝ) : Prop :=
+  ∀ output instruction,
+    program.node? output = some instruction →
+    ∀ operation,
+      program.operation? instruction.op = some operation →
+      operation.key = subOp →
+      ∃ left right, instruction.args = [left, right] ∧
+        valuation output = valuation left - valuation right
+
+/-- Exact dyadic facts interpreted over the arithmetic package's real model. -/
+def semantics : Semantics DyadicInterval.Fact :=
+  DyadicInterval.realSemantics Models
+
+/-- Shared exact fact-domain laws at the replay budget selected by the caller. -/
+def domain (limit : EndpointLimit) : FactDomainSchema semantics :=
+  DyadicInterval.factSchema limit Models
+
+/-- Semantic theorem behind every successful executable forward-subtraction
+proposal, with no restriction to bounded or closed facts. -/
+theorem subEntails (limit : EndpointLimit) (program : Program)
+    (assumptions : List (NodeFact DyadicInterval.Fact))
+    (output : NodeId) (instruction : Node) (operation : Operation)
+    (left right : NodeFact DyadicInterval.Fact)
+    (result : DyadicInterval.Fact)
+    (found : program.node? output = some instruction)
+    (operationFound : program.operation? instruction.op = some operation)
+    (key : operation.key = subOp)
+    (arguments : instruction.args = [left.node, right.node])
+    (exactAssumptions : assumptions = [left, right])
+    (computed : DyadicInterval.sub limit left.fact right.fact = .ready result) :
+    semantics.Entails program assumptions { node := output, fact := result } := by
+  intro valuation model assumptionHolds
+  change Models program valuation at model
+  obtain ⟨actualLeft, actualRight, actualArguments, outputEq⟩ :=
+    model output instruction found operation operationFound key
+  have sameArguments : [actualLeft, actualRight] = [left.node, right.node] := by
+    rw [← actualArguments, arguments]
+  injection sameArguments with leftEq tailEq
+  injection tailEq with rightEq
+  subst actualLeft
+  subst actualRight
+  have leftContains := assumptionHolds left (by simp [exactAssumptions])
+  have rightContains := assumptionHolds right (by simp [exactAssumptions])
+  change result.Contains (valuation output)
+  rw [outputEq]
+  exact DyadicInterval.contains_sub computed leftContains rightContains
+
+/-- Package-owned transparent schema for schema-zero subtraction payloads.
+It recomputes the exact checked interval result and accepts every canonical cut
+shape supported by the Mathlib-free operation. -/
+def subFactSchema (limit : EndpointLimit) : PackedFactSchema semantics where
+  rule := subForwardKey
+  schema := 0
+  Certificate := Unit
+  decode := fun body => if body.isEmpty then some () else none
+  replay := fun _ _ context _ =>
+    match context.assumptions with
+    | [left, right] =>
+        match found : context.program.node? context.proposed.node with
+        | some instruction =>
+            match operationFound : context.program.operation? instruction.op with
+            | some operation =>
+                if key : operation.key = subOp then
+                  if arguments : instruction.args = [left.node, right.node] then
+                    if computed : DyadicInterval.sub limit left.fact right.fact =
+                        .ready context.proposed.fact then
+                      some
+                        { proof := by
+                            exact subEntails limit context.program
+                              [left, right] context.proposed.node instruction operation
+                              left right context.proposed.fact found operationFound key
+                              arguments rfl computed }
+                    else none
+                  else none
+                else none
+            | none => none
+        | none => none
+    | _ => none
+
+end Hex.Interval.Experiment.Arithmetic

--- a/HexIntervalMathlib/Experiment/DyadicInterval.lean
+++ b/HexIntervalMathlib/Experiment/DyadicInterval.lean
@@ -50,6 +50,11 @@ theorem toReal_inj {left right : Dyadic} :
     exact Rat.cast_injective equal
   · exact fun equal => congrArg toReal equal
 
+@[simp]
+theorem toReal_sub (left right : Dyadic) :
+    toReal (left - right) = toReal left - toReal right := by
+  simp [toReal, Dyadic.toRat_sub]
+
 /-- Meaning of a lower interval cut. -/
 def lowerContains : Lower → ℝ → Prop
   | .unbounded, _ => True
@@ -400,6 +405,136 @@ theorem contains_intersect {limit : EndpointLimit} {left right result : Fact}
                             rw [lowerContains_intersect lowerChecked,
                               upperContains_intersect upperChecked]
                             aesop
+
+private theorem subtractionChecked_toReal {limit : EndpointLimit}
+    {left right result : Dyadic}
+    (checked : subtractionChecked limit left right = .ok result) :
+    toReal result = toReal left - toReal right := by
+  unfold subtractionChecked at checked
+  cases preflight : preflightSubtraction limit left right with
+  | error cost =>
+      simp only [preflight] at checked
+      contradiction
+  | ok _ =>
+      simp only [preflight] at checked
+      cases endpoint : endpointChecked limit (left - right) with
+      | error cost =>
+          rw [endpoint] at checked
+          contradiction
+      | ok _ =>
+          rw [endpoint] at checked
+          injection checked with same
+          subst result
+          exact toReal_sub left right
+
+private theorem lowerContains_subtract {limit : EndpointLimit}
+    {left : Lower} {right : Upper} {result : Lower} {x y : ℝ}
+    (checked : subtractLower limit left right = .ok result)
+    (leftContains : lowerContains left x)
+    (rightContains : upperContains right y) :
+    lowerContains result (x - y) := by
+  cases left with
+  | unbounded =>
+      change Except.ok .unbounded = Except.ok result at checked
+      injection checked with same
+      subst result
+      trivial
+  | finite left leftStrict =>
+      cases right with
+      | unbounded =>
+          change Except.ok .unbounded = Except.ok result at checked
+          injection checked with same
+          subst result
+          trivial
+      | finite right rightStrict =>
+          simp only [subtractLower] at checked
+          cases subtraction : subtractionChecked limit left right with
+          | error cost => simp [subtraction] at checked
+          | ok difference =>
+              simp [subtraction] at checked
+              subst result
+              have value := subtractionChecked_toReal subtraction
+              cases leftStrict <;> cases rightStrict <;>
+                simp_all [lowerContains, upperContains] <;> linarith
+
+private theorem upperContains_subtract {limit : EndpointLimit}
+    {left : Upper} {right : Lower} {result : Upper} {x y : ℝ}
+    (checked : subtractUpper limit left right = .ok result)
+    (leftContains : upperContains left x)
+    (rightContains : lowerContains right y) :
+    upperContains result (x - y) := by
+  cases left with
+  | unbounded =>
+      change Except.ok .unbounded = Except.ok result at checked
+      injection checked with same
+      subst result
+      trivial
+  | finite left leftStrict =>
+      cases right with
+      | unbounded =>
+          change Except.ok .unbounded = Except.ok result at checked
+          injection checked with same
+          subst result
+          trivial
+      | finite right rightStrict =>
+          simp only [subtractUpper] at checked
+          cases subtraction : subtractionChecked limit left right with
+          | error cost => simp [subtraction] at checked
+          | ok difference =>
+              simp [subtraction] at checked
+              subst result
+              have value := subtractionChecked_toReal subtraction
+              cases leftStrict <;> cases rightStrict <;>
+                simp_all [lowerContains, upperContains] <;> linarith
+
+/-- Every successful exact subtraction proposal contains the pointwise real
+difference of members of its two input facts. This covers the complete checked
+cut language, including open and independently unbounded ends. -/
+theorem contains_sub {limit : EndpointLimit} {left right result : Fact}
+    {x y : ℝ} (checked : sub limit left right = .ready result)
+    (leftContains : left.Contains x) (rightContains : right.Contains y) :
+    result.Contains (x - y) := by
+  cases left with
+  | mk leftRaw leftConsistent =>
+      cases right with
+      | mk rightRaw rightConsistent =>
+          cases leftRaw with
+          | empty => simp [Fact.Contains, rawContains] at leftContains
+          | bounds leftLower leftUpper =>
+              cases rightRaw with
+              | empty => simp [Fact.Contains, rawContains] at rightContains
+              | bounds rightLower rightUpper =>
+                  simp only [sub] at checked
+                  cases preflight : (do
+                      preflightLowerSubtraction limit leftLower rightUpper
+                      preflightUpperSubtraction limit leftUpper rightLower) with
+                  | error cost => simp [preflight] at checked
+                  | ok _ =>
+                      cases lowerChecked : subtractLower limit leftLower rightUpper with
+                      | error cost => simp [preflight, lowerChecked] at checked
+                      | ok lower =>
+                          cases upperChecked : subtractUpper limit leftUpper rightLower with
+                          | error cost =>
+                              simp [preflight, lowerChecked, upperChecked] at checked
+                          | ok upper =>
+                              simp [preflight, lowerChecked, upperChecked, normalize] at checked
+                              split at checked
+                              · contradiction
+                              · injection checked with installed
+                                subst result
+                                change rawContains
+                                  (Raw.normalizeUnchecked (.bounds lower upper)) (x - y)
+                                rw [rawContains_normalize]
+                                change lowerContains lower (x - y) ∧
+                                  upperContains upper (x - y)
+                                change lowerContains leftLower x ∧
+                                  upperContains leftUpper x at leftContains
+                                change lowerContains rightLower y ∧
+                                  upperContains rightUpper y at rightContains
+                                exact ⟨lowerContains_subtract lowerChecked
+                                    leftContains.1 rightContains.2,
+                                  upperContains_subtract upperChecked
+                                    leftContains.2 rightContains.1⟩
 
 /-- Attach exact interval facts to any operation semantics over real-valued
 program nodes. -/

--- a/conformance/HexIntervalMathlib/ArithmeticConformance.lean
+++ b/conformance/HexIntervalMathlib/ArithmeticConformance.lean
@@ -246,6 +246,24 @@ private def assumptionRejected :=
 
 #guard assumptionRejected.isNone
 
+private def swappedAssumptions : RuleStep DyadicInterval.Fact :=
+  { step with assumptions :=
+      [{ node := node 1, fact := rightRange }, { node := node 0, fact := leftRange }] }
+
+private def swappedInputs : Evidence
+    (InputsSound Arithmetic.semantics program base swappedAssumptions.assumptions) := by
+  simpa [swappedAssumptions, step, event] using
+    (EntailsList.cons rightSound
+      (EntailsList.cons leftSound EntailsList.nil)).sound
+
+private def swappedRejected :=
+  ProofEmitter.replayRule (Arithmetic.subFactSchema endpointLimit)
+    (Arithmetic.domain endpointLimit) checkerInput program
+    (ProgramPrefix.refl program) base swappedAssumptions
+    (by simpa [swappedAssumptions, step, event] using previousSound) swappedInputs
+
+#guard swappedRejected.isNone
+
 private def trailingPayload : RuleStep DyadicInterval.Fact :=
   { step with entry := { entry with body := [0] } }
 

--- a/conformance/HexIntervalMathlib/ArithmeticConformance.lean
+++ b/conformance/HexIntervalMathlib/ArithmeticConformance.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import Mathlib.Tactic.NormNum
+import HexIntervalMathlib.Experiment.Arithmetic
+import HexInterval.Experiment.PayloadSession
+import HexInterval.Experiment.ProofEmitter
+
+/-!
+# Exact arithmetic replay conformance
+
+The live rule subtracts an upper-bounded interval from an open lower half-line.
+Its exact result is again open and unbounded, so the proof exercises cut
+strictness and missing endpoints rather than a closed bounded special case.
+-/
+
+namespace Hex.IntervalMathlib.ArithmeticConformance
+
+open Hex.Interval Hex.Interval.Experiment
+open Propagator PayloadArena PayloadSession SemanticReplay ChronologicalReplay ProofEmitter
+open DyadicInterval DyadicRules Arithmetic
+
+private def real : DomainId := { index := 0 }
+private def sourceKey : OpKey := { name := "arithmetic-conformance.source" }
+
+private def endpointLimit : EndpointLimit :=
+  { maxEndpointHeight := 64, maxAlignmentShift := 64 }
+
+private def config : Config :=
+  { endpointLimit
+    reciprocalBasePrecision := 2
+    maxReciprocalEffort := 0 }
+
+private def operations : Array Operation :=
+  (arithmeticOperations real).push
+    { key := sourceKey, inputs := [], output := real }
+
+private def node (index : Nat) : NodeId := { index }
+private def payload (index : Nat) : PayloadId := { index }
+
+private def sourceInstruction : Node :=
+  { domain := real, op := { index := 6 }, args := [] }
+
+private def subtractionInstruction : Node :=
+  { domain := real, op := { index := 2 }, args := [node 0, node 1] }
+
+private def program : Program :=
+  { operations
+    nodes := #[sourceInstruction, sourceInstruction, subtractionInstruction] }
+
+private def leftRange : DyadicInterval.Fact :=
+  ⟨.bounds (.finite 1 true) .unbounded, by decide⟩
+
+private def rightRange : DyadicInterval.Fact :=
+  ⟨.bounds .unbounded (.finite 3 false), by decide⟩
+
+private def differenceRange : DyadicInterval.Fact :=
+  ⟨.bounds (.finite (-2) true) .unbounded, by decide⟩
+
+@[simp] private theorem toReal_intCast (value : Int) :
+    DyadicInterval.toReal (value : Dyadic) = value := by
+  rw [DyadicInterval.toReal, Dyadic.toRat_intCast]
+  norm_num
+
+@[simp] private theorem toReal_one : DyadicInterval.toReal 1 = (1 : ℝ) := by
+  rw [show (1 : Dyadic) = ((1 : Int) : Dyadic) from rfl, toReal_intCast]
+  norm_num
+
+@[simp] private theorem toReal_three : DyadicInterval.toReal 3 = (3 : ℝ) := by
+  rw [show (3 : Dyadic) = ((3 : Int) : Dyadic) from rfl, toReal_intCast]
+  norm_num
+
+@[simp] private theorem toReal_negTwo : DyadicInterval.toReal (-2) = (-2 : ℝ) := by
+  rw [show (-2 : Dyadic) = ((-2 : Int) : Dyadic) from rfl, toReal_intCast]
+  norm_num
+
+private def limits : Propagator.Limits :=
+  { maxOperations := 8
+    maxNodes := 4
+    maxRules := 16
+    maxRegistryEntries := 32
+    maxReplayFormats := 16
+    maxArity := 2
+    maxApplications := 8
+    maxQueueEntries := 16
+    maxActions := 8
+    maxAcceptedFacts := 4
+    maxRetainedSuggestions := 0
+    maxEffort := 0
+    maxObservationValue := 16
+    maxDiagnosticValue := 300
+    maxOutcomeCandidates := 1
+    maxOutcomeSuggestions := 0
+    maxProposalItems := 0
+    maxInstances := 0
+    maxGeneration := 0
+    maxNodeDepth := 1
+    maxEqualities := 0
+    splitEndpointLimit := endpointLimit }
+
+private def arenaLimits : PayloadArena.Limits :=
+  { maxEntries := limits.maxActions
+    maxBodyCells := 0
+    maxDrafts := limits.maxActions
+    maxDraftCells := 0
+    maxAtom := 0
+    maxSchema := 0
+    maxUses := limits.maxActions }
+
+private def session? : Option (PayloadSession.Session DyadicInterval.Fact) :=
+  match PayloadSession.Session.start
+      (DyadicInterval.factDomain endpointLimit) program
+      #[arithmeticPackage config real] #[leftRange, rightRange, .whole]
+      limits arenaLimits with
+  | .ok session => some session
+  | .error _ => none
+
+private def run? : Option (PayloadSession.Run DyadicInterval.Fact) := do
+  let session ← session?
+  pure (session.drive 8)
+
+private def action : Action :=
+  { serial := 0
+    programVersion := 0
+    application := { index := 0 }
+    rule := { index := 3 }
+    key := subForwardKey
+    node := node 2
+    kind := .forward
+    effort := 0
+    generation := 0
+    inputs := [{ node := node 0, version := 0 }, { node := node 1, version := 0 }]
+    writes := [node 2] }
+
+private def event : FactEvent DyadicInterval.Fact :=
+  { programVersion := 0
+    node := node 2
+    previous := { node := node 2, version := 0 }
+    fact := differenceRange
+    version := 1
+    cause := .rule action differenceRange (payload 0) }
+
+private def entry : Entry :=
+  { origin := action, role := .fact, schema := 0, body := [] }
+
+private def step : RuleStep DyadicInterval.Fact :=
+  { event
+    payload := payload 0
+    entry
+    assumptions :=
+      [{ node := node 0, fact := leftRange }, { node := node 1, fact := rightRange }]
+    previous := .whole }
+
+private def sameEntry (left right : Entry) : Bool :=
+  left.origin == right.origin && left.role == right.role &&
+    left.schema == right.schema && left.body == right.body
+
+private def sameEvent (left right : FactEvent DyadicInterval.Fact) : Bool :=
+  left.programVersion == right.programVersion && left.node == right.node &&
+    left.previous == right.previous && left.fact == right.fact &&
+    left.version == right.version &&
+      match left.cause, right.cause with
+      | .rule leftAction leftFact leftPayload,
+          .rule rightAction rightFact rightPayload =>
+          leftAction == rightAction && leftFact == rightFact &&
+            leftPayload == rightPayload
+      | _, _ => false
+
+private def quoteMatchesLive : Bool :=
+  match run? with
+  | some run =>
+      run.stop == .saturated && run.session.engine.history.size == 1 &&
+        run.session.engine.factAt? { node := node 2, version := 1 } ==
+          some differenceRange &&
+        match run.session.engine.history[0]?,
+            run.session.arena.entry? (payload 0) .fact with
+        | some actualEvent, some actualEntry =>
+            sameEvent actualEvent event && sameEntry actualEntry entry
+        | _, _ => false
+  | none => false
+
+#guard quoteMatchesLive
+
+private def checkerInput : CheckerInput DyadicInterval.Fact :=
+  { baseProgram := program
+    initialFacts := #[leftRange, rightRange, .whole]
+    target := { node := node 2, fact := differenceRange } }
+
+private def base : List (NodeFact DyadicInterval.Fact) :=
+  [{ node := node 0, fact := leftRange },
+    { node := node 1, fact := rightRange },
+    { node := node 2, fact := .whole }]
+
+private def leftSound : Evidence
+    (Arithmetic.semantics.Entails program base
+      { node := node 0, fact := leftRange }) :=
+  ProofEmitter.assumed (by simp [base])
+
+private def rightSound : Evidence
+    (Arithmetic.semantics.Entails program base
+      { node := node 1, fact := rightRange }) :=
+  ProofEmitter.assumed (by simp [base])
+
+private def previousSound : Evidence
+    (Arithmetic.semantics.Entails program base
+      { node := node 2, fact := step.previous }) := by
+  apply ProofEmitter.assumed
+  simp [step, base]
+
+private def assumptionsSound : Evidence
+    (InputsSound Arithmetic.semantics program base step.assumptions) := by
+  simpa [step, event] using
+    (EntailsList.cons leftSound (EntailsList.cons rightSound EntailsList.nil)).sound
+
+private def replayed :=
+  ProofEmitter.replayRule (Arithmetic.subFactSchema endpointLimit)
+    (Arithmetic.domain endpointLimit) checkerInput program
+    (ProgramPrefix.refl program) base step previousSound assumptionsSound
+
+#guard replayed.isSome
+
+private def weakenedLeft : Evidence
+    (Arithmetic.semantics.Entails program base
+      { node := node 0, fact := DyadicInterval.Fact.whole }) :=
+  (ProofEmitter.closeFact (Arithmetic.domain endpointLimit) program base
+    (node 0) leftRange .whole leftSound).get (by rfl)
+
+private def wrongAssumption : RuleStep DyadicInterval.Fact :=
+  { step with assumptions :=
+      [{ node := node 0, fact := .whole }, { node := node 1, fact := rightRange }] }
+
+private def wrongInputs : Evidence
+    (InputsSound Arithmetic.semantics program base wrongAssumption.assumptions) := by
+  simpa [wrongAssumption, step, event] using
+    (EntailsList.cons weakenedLeft
+      (EntailsList.cons rightSound EntailsList.nil)).sound
+
+private def assumptionRejected :=
+  ProofEmitter.replayRule (Arithmetic.subFactSchema endpointLimit)
+    (Arithmetic.domain endpointLimit) checkerInput program
+    (ProgramPrefix.refl program) base wrongAssumption
+    (by simpa [wrongAssumption, step, event] using previousSound) wrongInputs
+
+#guard assumptionRejected.isNone
+
+private def trailingPayload : RuleStep DyadicInterval.Fact :=
+  { step with entry := { entry with body := [0] } }
+
+private def payloadRejected :=
+  ProofEmitter.replayRule (Arithmetic.subFactSchema endpointLimit)
+    (Arithmetic.domain endpointLimit) checkerInput program
+    (ProgramPrefix.refl program) base trailingPayload
+    (by simpa [trailingPayload, step, event] using previousSound)
+    (by simpa [trailingPayload, step, event] using assumptionsSound)
+
+#guard payloadRejected.isNone
+
+/-- The live Mathlib-free subtraction event becomes an ordinary theorem via
+the arithmetic package schema and the operation-agnostic proof emitter. -/
+theorem emittedSubtraction :
+    Arithmetic.semantics.Entails program base checkerInput.target :=
+  ProofEmitter.proofOfReplay replayed (by rfl)
+
+private noncomputable def valuation (x y : ℝ) : NodeId → ℝ
+  | ⟨0⟩ => x
+  | ⟨1⟩ => y
+  | ⟨2⟩ => x - y
+  | _ => 0
+
+private theorem models (x y : ℝ) : Arithmetic.Models program (valuation x y) := by
+  intro output instruction found operation operationFound key
+  rcases output with ⟨index⟩
+  cases index with
+  | zero =>
+      simp [Program.node?, program, sourceInstruction] at found
+      subst instruction
+      simp [Program.operation?, program, operations, arithmeticOperations,
+        sourceKey, subOp] at operationFound
+      subst operation
+      simp [subOp] at key
+  | succ index =>
+      cases index with
+      | zero =>
+          simp [Program.node?, program, sourceInstruction] at found
+          subst instruction
+          simp [Program.operation?, program, operations, arithmeticOperations,
+            sourceKey, subOp] at operationFound
+          subst operation
+          simp [subOp] at key
+      | succ index =>
+          cases index with
+          | zero =>
+              simp [Program.node?, program, subtractionInstruction] at found
+              subst instruction
+              refine ⟨node 0, node 1, rfl, ?_⟩
+              simp [node, valuation]
+          | succ index => simp [Program.node?, program] at found
+
+/-- Open and independently unbounded input facts are preserved through exact
+semantic replay: `x > 1` and `y ≤ 3` imply `x - y > -2`. -/
+theorem tacticSubtraction (x y : ℝ) (left : 1 < x) (right : y ≤ 3) :
+    -2 < x - y := by
+  have result := emittedSubtraction (valuation x y) (models x y) (by
+    intro assumption member
+    simp only [base, List.mem_cons, List.not_mem_nil, or_false] at member
+    rcases member with rfl | rfl | rfl
+    · change leftRange.Contains (valuation x y (node 0))
+      simpa [leftRange, DyadicInterval.Fact.Contains, rawContains, lowerContains,
+        upperContains, node, valuation] using left
+    · change rightRange.Contains (valuation x y (node 1))
+      simpa [rightRange, DyadicInterval.Fact.Contains, rawContains, lowerContains,
+        upperContains, node, valuation] using right
+    · change DyadicInterval.Fact.whole.Contains (valuation x y (node 2))
+      simp [DyadicInterval.Fact.Contains, DyadicInterval.Fact.whole, rawContains,
+        lowerContains, upperContains])
+  change differenceRange.Contains (valuation x y (node 2)) at result
+  simpa [differenceRange, DyadicInterval.Fact.Contains, rawContains, lowerContains,
+    upperContains, node, valuation] using result
+
+/--
+info: 'Hex.IntervalMathlib.ArithmeticConformance.tacticSubtraction' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms tacticSubtraction
+
+end Hex.IntervalMathlib.ArithmeticConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -369,7 +369,8 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.SinTenInterval].map Glob.one
 
 lean_lib HexIntervalMathlibExperiment where
-  globs := #[`HexIntervalMathlib.Experiment.Center,
+  globs := #[`HexIntervalMathlib.Experiment.Arithmetic,
+    `HexIntervalMathlib.Experiment.Center,
     `HexIntervalMathlib.Experiment.Centered,
     `HexIntervalMathlib.Experiment.DyadicInterval,
     `HexIntervalMathlib.Experiment.SineSign,
@@ -496,6 +497,8 @@ lean_lib HexConformance where
       `HexIntervalMathlib.PntTable10ExactConformance].map Glob.one
 
     ++ #[`HexInterval.StagedPolicyConformance].map Glob.one
+
+    ++ #[`HexIntervalMathlib.ArithmeticConformance].map Glob.one
 
     ++ #[`HexInterval.MinMaxConformance,
       `HexIntervalMathlib.MinMaxConformance].map Glob.one

--- a/progress/20260811T192252Z.md
+++ b/progress/20260811T192252Z.md
@@ -1,0 +1,34 @@
+# Exact subtraction arithmetic replay
+
+## Accomplished
+
+- Audited the exact `DyadicInterval` domain and its existing Mathlib-free
+  `DyadicRules` forward subtraction path.
+- Added an exact-real soundness theorem for successful interval subtraction,
+  including empty, open or closed, and independently unbounded cuts.
+- Added a package-owned subtraction fact schema that validates the operation
+  node, ordered assumptions, exact rule key, schema-zero body, and the
+  recomputed Mathlib-free interval result before emitting a generic proof.
+- Added live payload-session conformance, an ordinary theorem, and negative
+  mutations for a weakened assumption and trailing payload data.
+- Documented the arithmetic replay vertical and registered the new experiment
+  and conformance modules in `lakefile.lean`.
+- Verified the focused interval/conformance targets and a full `lake build`
+  (9754 jobs) without `sorry`, `axiom`, or `native_decide` in the changed Lean
+  sources.
+
+## Current frontier
+
+The interval package now has one function-agnostic arithmetic vertical:
+forward subtraction composes through the generic proof emitter over the full
+exact cut language, rather than depending on rational normalization.
+
+## Next step
+
+Review and integrate this subtraction schema. Extend the same small
+package-owned pattern to another arithmetic direction only when a concrete
+consumer needs it; keep rational normalization as a separate concern.
+
+## Blockers
+
+None.

--- a/progress/20260811T192558Z.md
+++ b/progress/20260811T192558Z.md
@@ -1,0 +1,24 @@
+# Accomplished
+
+- Reconciled the exact subtraction arithmetic experiment onto the staged-policy
+  head without changing either source worktree.
+- Preserved both conformance targets in the combined Lake registration and
+  added the exact proof-only factor-freshness exemption for that combined
+  Lakefile.
+- Re-ran the focused arithmetic build and the repository copyright,
+  line-count, DAG, trust-surface, Phase 4, conformance-registration,
+  factor-freshness, and diff checks successfully.
+
+# Current frontier
+
+The arithmetic branch contains the staged policy plus the exact-real forward
+subtraction propagator and its generic proof replay.
+
+# Next step
+
+Review and integrate the arithmetic pull request, then exercise this
+propagator in a branch-dependent proof.
+
+# Blockers
+
+None.

--- a/progress/20260814T234636Z.md
+++ b/progress/20260814T234636Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Replayed the exact subtraction arithmetic feature onto exact local #9231
+  boundary `425f1b3a5fc72fd77b65bcb539e363705aaf1721` while preserving the
+  complete PNT, Table 12, centered-function, branch, and staged-policy stack.
+- Audited the universal successful-subtraction theorem over empty, open,
+  closed, bounded, and independently unbounded canonical dyadic cuts.
+- Verified that schema replay binds the rule key, schema body, proposed node,
+  operation, noncommutative argument order, exact assumptions, and recomputed
+  Mathlib-free result before producing evidence.
+- Added a swapped-input rejection canary so the ordered subtraction premises
+  are explicitly load-bearing alongside the weakened-premise and malformed-
+  payload guards.
+- Resolved Lake registration overlap without dropping inherited targets and
+  refreshed the exact proof-only freshness exemption.
+- Passed the focused 2,233-job build and structural, trust, Phase 4, PNT
+  inventory, factor-freshness, diff, and banned-proof checks.
+
+# Current frontier
+
+The local #9232 candidate adds one exact arithmetic schema through the generic
+proof-emitter boundary. Runtime propagation remains Mathlib-free; only the
+companion semantics and ordinary theorem import Mathlib.
+
+# Next step
+
+After #9231 lands, rebase this candidate once onto its final merged lineage,
+refresh the Lake exemption, then push and obtain exact-head review and CI.
+
+# Blockers
+
+None.

--- a/progress/20260815T021108Z.md
+++ b/progress/20260815T021108Z.md
@@ -1,0 +1,44 @@
+# Local #9232 subtraction-replay preparation
+
+## Accomplished
+
+- Replayed the #9232 exact subtraction schema and its swapped-input rejection
+  canary onto exact prepared #9231 head
+  `aeab4b71ab4d425171f9a4a1f1bec3b03c1803d0`.
+- Preserved the current experiment and conformance registrations while adding
+  only the arithmetic semantics and arithmetic conformance roots. Refreshed
+  the narrow exact-blob proof-only freshness exemption for the combined Lake
+  file.
+- Confirmed all four changed Lean source files are byte-for-byte identical to
+  the previously audited repaired #9232 versions.
+- Audited semantic direction and non-vacuity. The executable lower endpoint is
+  `left.lower - right.upper`, the upper endpoint is
+  `left.upper - right.lower`, and openness is retained when either contributing
+  endpoint is open. The companion theorem proves that every successful checked
+  result contains `x - y` from exact ordered membership premises.
+- Verified the replay schema is pinned to the subtraction rule, exact ordered
+  assumptions, empty schema-zero payload, operation arguments, and recomputed
+  result. The live quote is matched before replay; weakened, swapped, and
+  trailing-payload mutations fail. The emitted ordinary theorem makes both
+  caller inequalities load-bearing and has only the permitted standard axioms.
+- Built `HexIntervalMathlibExperiment` and
+  `HexIntervalMathlib.ArithmeticConformance` (8706 jobs), then rebuilt the
+  centered, large-cosine, precision-log, and full PNT conformance set.
+- Passed file, copyright, DAG, trust-surface, conformance-target, PNT inventory,
+  factor-freshness, release-manifest, manual-split, release-sync, Phase 4, and
+  Mathlib-free bench checks. The explicit banned-mechanism scan is clean.
+
+## Current frontier
+
+- The local #9232 candidate is clean on top of the prepared #9231 boundary.
+  Existing PNT/log/cos registrations and sources are unchanged.
+
+## Next step
+
+- After the preceding stack edges land, rebase this feature boundary onto its
+  final parent, refresh the exact Lake exemption, then push for exact-head
+  review and CI.
+
+## Blockers
+
+- None. Remote PR and CI state were intentionally left untouched.

--- a/progress/20260815T125348Z.md
+++ b/progress/20260815T125348Z.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+- Restacked the experimental exact-subtraction replay slice onto the staged
+  policy candidate while preserving the supported public interval operations
+  and current PNT registrations.
+- Kept the schema tied to the exact ordered pair of input facts, recomputed
+  checked result, empty schema-zero body, live rule event, and payload entry.
+- Preserved rejection guards for a weakened input fact, swapped operands, and
+  a trailing payload cell.
+- Clarified that this is package-callback proof replay over experimental facts,
+  not a second public subtraction API; `Hex.Interval.subWithin` remains the
+  supported resource-checked operation.
+- Rebuilt arithmetic replay, staged-policy, branch, centered, public interval,
+  and PNT targets and ran the repository formatting, DAG, trust, registration,
+  PNT, and freshness checks.
+
+# Current frontier
+
+The local arithmetic package now turns one live Mathlib-free subtraction quote
+into an ordinary real theorem through the generic proof emitter. Its semantic
+premises and operand order are load-bearing.
+
+# Next step
+
+Complete the normal remote review and CI cycle after the preceding controller
+stack edges land.
+
+# Blockers
+
+None.

--- a/progress/20260815T225326Z.md
+++ b/progress/20260815T225326Z.md
@@ -1,0 +1,25 @@
+# Subtraction replay direct-main preparation
+
+## Accomplished
+
+- Replayed the audited exact-subtraction callback and proof-replay edge onto
+  the final staged-policy candidate without disturbing the later local stack.
+- Preserved the distinction between the supported public `subWithin` operation
+  and this experimental package callback replay.
+- Added the exact proof-only Lake freshness exemption for the arithmetic
+  experiment and its conformance module.
+
+## Current frontier
+
+The local candidate is clean and ready for one final rebase onto the #9231
+merge commit. Exact arguments, source versions, body, result, chronology, and
+ordinary theorem mutations remain load-bearing.
+
+## Next step
+
+After #9231 merges, rebase these commits onto that exact main, rerun the focused
+gates, and publish #9232 direct-main.
+
+## Blockers
+
+Awaiting the exact #9231 merge commit only.

--- a/progress/20260815T234601Z.md
+++ b/progress/20260815T234601Z.md
@@ -1,0 +1,24 @@
+# Restack subtraction replay after complete LogTables
+
+## Accomplished
+
+- Replayed the audited subtraction callback-replay edge onto exact main
+  `73ab76da6aff67e3b7c3ec2e677c3f3d8741fd90`.
+- Preserved the complete source-pinned LogTables provider registrations,
+  inventory, specifications, and the merged staged policy.
+- Reconciled the proof-only runtime exemption additively for the exact combined
+  Lake blob without changing the executable factor dependency graph.
+
+## Current frontier
+
+The branch contains only the experimental subtraction replay edge above the
+complete LogTables and staged-policy main tree.
+
+## Next step
+
+Run the focused subtraction, controller, LogTables/PNT, trust, freshness, and
+diff gates, then publish the exact direct-main PR head.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -210,6 +210,12 @@
     "reason": "Additionally registers the isolated Mathlib-free HexInterval staged-policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "ed9fdd5da05cce896320919abe72bcf2ba1c2cb0",
+    "reason": "Additionally registers the proof-only exact subtraction semantics and conformance module alongside the isolated HexInterval staged-policy experiment; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -424,5 +424,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "8ac991a3185fb38f5617a272fbaf771db4fc6367",
     "reason": "Additionally registers the complete bounded source-pinned PNT+ LogTables provider stack, its ordinary-kernel companions, and conformance modules on top of the retained staged-policy, small-prime, and controller registrations; these acceptance-only modules do not enter the factorization service target or its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "d10f93b76ec5ee321d15b400c9bdb2c554744352",
+    "reason": "Additionally registers the Mathlib-free exact subtraction callback-replay experiment and its proof-only conformance module on top of the complete LogTables, staged-policy, PNT, and interval registrations; neither enters the factorization service target or changes its executable dependency graph."
   }
 ]


### PR DESCRIPTION
## Summary
- prove exact-real soundness for successful interval subtraction over open, closed, empty, and unbounded cuts
- add a package-owned forward subtraction fact schema with generic proof replay
- exercise the live payload session and reject swapped inputs, weakened assumptions, and malformed payloads
- document this as experimental package callback replay, distinct from the supported public `subWithin` API

## Validation
- `lake build +HexIntervalMathlib.ArithmeticConformance:olean +HexInterval.StagedPolicyConformance:olean +HexInterval.NestedBranchConformance:olean`
- trust-surface, factor freshness, PNT inventory, diff, and banned-proof checks