### PR TITLE
feat(interval): score bounded package features

### DIFF
--- a/HexInterval/Experiment/FeaturePolicy.lean
+++ b/HexInterval/Experiment/FeaturePolicy.lean
@@ -20,8 +20,8 @@ versioned feature addresses and signed integer weights.  It contains no cases
 for facts, functions, operations, or package families.
 
 Compatible feature data changes ordering only.  A decorator/scorer limit
-mismatch or oversized learned score fails closed with no selection.  A
-For a view returned by the decorator, a successful choice is the exact
+mismatch or oversized learned score fails closed with no selection.  For a
+view returned by the decorator, a successful choice is the exact
 engine-owned `OfferView` which that decorator retained.  The public view type
 also admits hand-built test data; scoring it does not authenticate feature
 provenance or its base view.  In either case the ordinary policy session

--- a/HexInterval/Experiment/FeaturePolicy.lean
+++ b/HexInterval/Experiment/FeaturePolicy.lean
@@ -21,9 +21,11 @@ for facts, functions, operations, or package families.
 
 Compatible feature data changes ordering only.  A decorator/scorer limit
 mismatch or oversized learned score fails closed with no selection.  A
-successful choice is the exact engine-owned `OfferView` retained by the
-decorator, so the ordinary policy session remains the authority for freshness
-and transition validity.
+For a view returned by the decorator, a successful choice is the exact
+engine-owned `OfferView` which that decorator retained.  The public view type
+also admits hand-built test data; scoring it does not authenticate feature
+provenance or its base view.  In either case the ordinary policy session
+remains the authority for freshness and transition validity.
 -/
 
 namespace Hex.Interval.Experiment.FeaturePolicy
@@ -197,8 +199,10 @@ def better (candidate current : Ranked) : Bool :=
       (current.score < candidate.score ||
         (current.score == candidate.score && current.offer.age < candidate.offer.age)))
 
-/-- Rank a successfully decorated view.  The returned value is always the
-exact `FeaturedOffer.base`; ordinary engine revalidation remains authoritative.
+/-- Rank a bounded, aligned featured view.  Only `PolicyFeature.decorate`
+authenticates provider provenance; this function deliberately also accepts
+hand-built experiment data.  The returned value is always the exact
+`FeaturedOffer.base`, and ordinary engine revalidation remains authoritative.
 Unknown and missing configured features contribute zero. -/
 def choose? (limits : Limits) (state : AdaptivePolicy.State) (plan : Plan)
     (view : PolicyFeature.View Fact) : Except Error (Option OfferView) := do

--- a/HexInterval/Experiment/FeaturePolicy.lean
+++ b/HexInterval/Experiment/FeaturePolicy.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.AdaptivePolicy
+public import HexInterval.Experiment.PolicyFeature
+
+@[expose] public section
+
+/-!
+# Bounded package-feature scoring
+
+This adapter combines the package-opaque feedback score from `AdaptivePolicy`
+with explicitly configured package features.  The scheduler understands only
+versioned feature addresses and signed integer weights.  It contains no cases
+for facts, functions, operations, or package families.
+
+Compatible feature data changes ordering only.  A decorator/scorer limit
+mismatch or oversized learned score fails closed with no selection.  A
+successful choice is the exact engine-owned `OfferView` retained by the
+decorator, so the ordinary policy session remains the authority for freshness
+and transition validity.
+-/
+
+namespace Hex.Interval.Experiment.FeaturePolicy
+
+open Propagator Propagator.Policy PolicyFeature
+
+/-- Globally unambiguous configured feature address. -/
+structure Address where
+  provider : ProviderKey
+  key : Nat
+  deriving DecidableEq, Repr
+
+/-- One signed linear scoring term.  Negative weights and feature values are
+both meaningful. -/
+structure Term where
+  address : Address
+  weight : Int
+  deriving DecidableEq, Repr
+
+/-- Every configuration or traversal dimension owned by this adapter has an
+independent explicit bound.  `maxPairChecks` bounds feature/term comparisons,
+not provider callback work performed before decoration returns. -/
+structure Limits where
+  maxTerms : Nat
+  maxProviderComponent : Nat
+  maxFeatureKey : Nat
+  maxWeight : Nat
+  maxOffers : Nat
+  maxFeaturesPerOffer : Nat
+  maxPairChecks : Nat
+  maxFeatureValue : Nat
+  maxScore : Nat
+  deriving DecidableEq, Repr
+
+/-- Transactional configuration rejection. -/
+inductive BuildError where
+  | termLimit
+  | providerComponentLimit (address : Address)
+  | featureKeyLimit (address : Address)
+  | weightLimit (address : Address) (weight : Int)
+  | duplicateAddress (address : Address)
+  deriving DecidableEq, Repr
+
+/-- Immutable validated scoring configuration. -/
+structure Plan where
+  private mk ::
+  terms : Array Term
+
+private def makePlan (terms : Array Term) : Plan := { terms }
+
+private def duplicateAddress? (terms : List Term) : Option Address :=
+  match terms with
+  | [] => none
+  | term :: rest =>
+      if rest.any (fun other => other.address == term.address) then
+        some term.address
+      else
+        duplicateAddress? rest
+
+/-- Validate a complete scoring configuration before making any part of it
+available to selection.  Caller order is retained as the deterministic
+saturating-add order. -/
+opaque Plan.buildWithin (limits : Limits) (terms : Array Term) :
+    Except BuildError Plan :=
+  if limits.maxTerms < terms.size then
+    .error .termLimit
+  else
+    match terms.find? fun term =>
+        limits.maxProviderComponent < term.address.provider.family ||
+          limits.maxProviderComponent < term.address.provider.version with
+    | some term => .error (.providerComponentLimit term.address)
+    | none =>
+        match terms.find? fun term => limits.maxFeatureKey < term.address.key with
+        | some term => .error (.featureKeyLimit term.address)
+        | none =>
+            match terms.find? fun term => limits.maxWeight < term.weight.natAbs with
+            | some term => .error (.weightLimit term.address term.weight)
+            | none =>
+                match duplicateAddress? terms.toList with
+                | some address => .error (.duplicateAddress address)
+                | none => .ok (makePlan terms)
+
+/-- Runtime rejection is also transactional: no selection is returned. -/
+inductive Error where
+  | plan (error : BuildError)
+  | offerAlignment
+  | offerLimit
+  | offerFeatureLimit (offer : OfferId)
+  | pairCheckLimit
+  | providerComponentLimit (offer : OfferId) (address : Address)
+  | featureKeyLimit (offer : OfferId) (address : Address)
+  | featureValueLimit (offer : OfferId) (address : Address) (value : Int)
+  | learnedScoreLimit (offer : OfferId) (score : Nat)
+  deriving DecidableEq, Repr
+
+def clamp (limit : Nat) (value : Int) : Int :=
+  let bound := Int.ofNat limit
+  if value < -bound then -bound else if bound < value then bound else value
+
+def addSat (limit : Nat) (left right : Int) : Int :=
+  clamp limit (left + right)
+
+def contribution (limits : Limits) (offer : FeaturedOffer)
+    (term : Term) : Except Error Int :=
+  match offer.feature? term.address.provider term.address.key with
+  | none => .ok 0
+  | some value =>
+      if limits.maxFeatureValue < value.natAbs then
+        .error (.featureValueLimit offer.base.id term.address value)
+      else
+        .ok (clamp limits.maxScore (term.weight * value))
+
+/-- Conservative upper bound on feature/term comparisons made by linear
+lookup.  Sizes are checked before this multiplication is performed. -/
+def pairChecks (plan : Plan) (offers : Array FeaturedOffer) : Nat :=
+  offers.foldl (fun total offer => total + plan.terms.size * offer.features.size) 0
+
+def preflight (limits : Limits) (plan : Plan)
+    (view : PolicyFeature.View Fact) : Except Error Unit := do
+  match Plan.buildWithin limits plan.terms with
+  | .error error => throw (.plan error)
+  | .ok _ => pure ()
+  if limits.maxOffers < view.base.offers.size ||
+      limits.maxOffers < view.offers.size then
+    throw .offerLimit
+  if view.offers.map (fun offer => offer.base) ≠ view.base.offers then
+    throw Error.offerAlignment
+  for offer in view.offers do
+    if limits.maxFeaturesPerOffer < offer.features.size then
+      throw (.offerFeatureLimit offer.base.id)
+    for feature in offer.features do
+      let address : Address := { provider := feature.provider, key := feature.key }
+      if limits.maxProviderComponent < feature.provider.family ||
+          limits.maxProviderComponent < feature.provider.version then
+        throw (.providerComponentLimit offer.base.id address)
+      if limits.maxFeatureKey < feature.key then
+        throw (.featureKeyLimit offer.base.id address)
+      if limits.maxFeatureValue < feature.value.natAbs then
+        throw (.featureValueLimit offer.base.id address feature.value)
+  if limits.maxPairChecks < pairChecks plan view.offers then throw .pairCheckLimit
+
+def featureScore (limits : Limits) (plan : Plan)
+    (offer : FeaturedOffer) : Except Error Int := do
+  let mut score := 0
+  for term in plan.terms do
+    score := addSat limits.maxScore score (<- contribution limits offer term)
+  pure score
+
+structure Ranked where
+  offer : OfferView
+  fair : Bool
+  stage : Nat
+  score : Int
+
+def rank (limits : Limits) (state : AdaptivePolicy.State) (plan : Plan)
+    (offer : FeaturedOffer) : Except Error Ranked := do
+  let base := AdaptivePolicy.rankOffer state offer.base
+  if limits.maxScore < base.score then
+    throw (.learnedScoreLimit offer.base.id base.score)
+  let learned := Int.ofNat base.score
+  let score := addSat limits.maxScore learned (<- featureScore limits plan offer)
+  pure { offer := offer.base, fair := base.fair, stage := base.stage, score }
+
+/-- Preserve adaptive fairness and staged semantic tiers.  Configured feature
+score participates only where learned score did: after fairness and stage, and
+before age and stable decorated-view order. -/
+def better (candidate current : Ranked) : Bool :=
+  (candidate.fair && !current.fair) ||
+    (candidate.fair == current.fair && candidate.stage < current.stage) ||
+    (candidate.fair == current.fair && candidate.stage == current.stage &&
+      (current.score < candidate.score ||
+        (current.score == candidate.score && current.offer.age < candidate.offer.age)))
+
+/-- Rank a successfully decorated view.  The returned value is always the
+exact `FeaturedOffer.base`; ordinary engine revalidation remains authoritative.
+Unknown and missing configured features contribute zero. -/
+def choose? (limits : Limits) (state : AdaptivePolicy.State) (plan : Plan)
+    (view : PolicyFeature.View Fact) : Except Error (Option OfferView) := do
+  preflight limits plan view
+  let mut best : Option Ranked := none
+  for offer in view.offers do
+    if StagedPolicy.allowed state.config.staged offer.base then
+      let candidate <- rank limits state plan offer
+      best := match best with
+        | none => some candidate
+        | some current => if better candidate current then some candidate else best
+  pure (best.map fun ranked => ranked.offer)
+
+end Hex.Interval.Experiment.FeaturePolicy

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -152,6 +152,7 @@ structure OfferView where
   key : OfferKey
   offerClass : OfferClass
   age : Nat
+  deriving DecidableEq
 
 /-! # Engine-owned frontier state -/
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3446,6 +3446,50 @@ allocation inside a callback. Production providers therefore need either a
 restricted bounded builder or an auditable
 declared-work protocol in addition to these output bounds.
 
+The first consumer of this interface is a generic bounded scoring adapter over
+the feedback-guided policy. Its immutable plan is an ordered array of
+`(provider family, provider version, local key, signed weight)` terms. Plan
+construction transactionally rejects duplicate addresses and separately bounds
+the term count, provider components, local keys, and absolute weights. Selection
+revalidates that plan against its own limits, so a plan built under a more
+generous configuration cannot bypass a stricter caller. It also requires the
+base and decorated offer counts to fit before traversing them, then requires
+the decorated offers to match the exact base view in order and field-for-field.
+It subsequently bounds features per offer and the conservative
+feature/term comparison count before scoring. Every decorated feature address
+and value is rechecked against independent component, key, and absolute-value
+limits before lookup or multiplication.
+Consequently the adapter's own configuration sizes and traversal counts are
+bounded. Equality of authentic offer keys may still traverse their engine-
+bounded nested structural lists; hostile hand-built keys need a separately
+bounded representation. The earlier limitation on work performed inside a
+provider callback remains.
+The decorator and scorer limits are independently valid configurations, so a
+caller must choose compatible bounds. A decorated view which exceeds a scorer
+bound fails closed with no selection. An adaptive learned score above the
+configured score bound is likewise rejected rather than silently clamped and
+allowed to flatten two different priorities.
+
+Scores use exact `Int` multiplication followed by explicit symmetric
+saturation, and saturating addition is applied in configured term order.
+Unknown emitted features and configured addresses missing from an offer are
+inert. Signed feature values and signed weights are both supported. Feature
+score is combined with the bounded adaptive learned score only after the
+fairness tier and staged semantic class have been fixed; it therefore cannot
+move a fresh action ahead of a fairness action or move a split ahead of cheap
+propagation. Age and stable decorated-view order remain the final tie-breakers.
+The chosen result is the exact aligned base `OfferView`, not a reconstruction,
+so ordinary engine revalidation remains authoritative. Conformance uses two
+unrelated providers to make width and goal/split data reverse otherwise-tied
+choices, and covers missing, unknown, negative, saturated, duplicate,
+oversized, and runtime-resource cases.
+
+Only `PolicyFeature.decorate` authenticates provider origin and uniqueness.
+The public featured-view structure remains useful for scoring experiments, but
+a hand-built view may fabricate or duplicate feature identities; those values
+can influence ordering after passing the explicit bounds, yet cannot alter the
+aligned base offer, authorize a transition, or enter proof evidence.
+
 A live Mathlib-free arbitrary-function canary presents two exponential
 forward contractors and one source split rule in the same frontier. The policy
 selects both fact improvements, then invokes the split probe, then returns its

--- a/conformance/HexInterval/FeaturePolicyConformance.lean
+++ b/conformance/HexInterval/FeaturePolicyConformance.lean
@@ -244,13 +244,15 @@ private def scoredView (first second : OfferView) (firstScore secondScore : Int)
     metrics := { providerChecks := 0, emittedFeatures := 2 } }
 
 /- With no configured feature terms and learned scores inside the explicit
-bound, adaptive ordering is preserved exactly. -/
+bound, the result equals the wrapped adaptive policy's result exactly. -/
 #guard
   match do
     let plan <- planOrError emptyPlan?
-    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
-      (scoredView (invokeOffer 0) { invokeOffer 1 with age := 1 } 20 (-20)) with
-  | .ok (some selected) => selected.id == (invokeOffer 1).id
+    let state := AdaptivePolicy.State.initial {}
+    let featured := scoredView (invokeOffer 0) { invokeOffer 1 with age := 1 } 20 (-20)
+    let selected <- FeaturePolicy.choose? scoreLimits state plan featured
+    pure (selected, AdaptivePolicy.choose? state featured.base.offers) with
+  | .ok (selected, adaptive) => selected == adaptive
   | _ => false
 
 /- Feature score cannot cross the adaptive fairness tier. -/
@@ -341,6 +343,20 @@ private def misaligned : PolicyFeature.View Nat :=
   match do
     let plan <- planOrError widthPlan?
     FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan misaligned with
+  | .error .offerAlignment => true
+  | _ => false
+
+/- Alignment compares every field of each retained offer, not only its engine
+identity or array position. -/
+private def changedOffer : PolicyFeature.View Nat :=
+  { base := view #[invokeOffer 0]
+    offers := #[{ base := { invokeOffer 0 with age := 1 }, features := #[] }]
+    metrics := { providerChecks := 0, emittedFeatures := 0 } }
+
+#guard
+  match do
+    let plan <- planOrError emptyPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan changedOffer with
   | .error .offerAlignment => true
   | _ => false
 

--- a/conformance/HexInterval/FeaturePolicyConformance.lean
+++ b/conformance/HexInterval/FeaturePolicyConformance.lean
@@ -1,0 +1,412 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.FeaturePolicy
+
+/-!
+# Bounded package-feature policy conformance
+
+Two unrelated providers change otherwise-tied width and goal/split choices.
+The policy sees only configured addresses and signed integers.
+-/
+
+namespace Hex.Interval.FeaturePolicyConformance
+
+open Experiment Propagator Propagator.Policy PolicyFeature FeaturePolicy
+
+private def node (index : Nat) : NodeId := { index }
+
+private def invocation (index : Nat) (kind : ActionKind := .forward) : InvocationKey :=
+  { scope := { index := 0 }
+    programVersion := 3
+    application := { index }
+    rule := { name := "feature-policy.test", schema := 1 }
+    anchor := node index
+    kind
+    effort := 0
+    inputs := [] }
+
+private def invokeOffer (index : Nat) : OfferView :=
+  { id := .application { index }
+    key := .invoke (invocation index)
+    offerClass := .invoke
+    age := 0 }
+
+private def splitOffer (index : Nat) : OfferView :=
+  { id := .suggestion { index }
+    key := .split (invocation index .split) { node := node index, version := 1 }
+      index .midpoint
+    offerClass := .split
+    age := 0 }
+
+private def view (offers : Array OfferView) : Policy.View Nat :=
+  { scope := { index := 0 }
+    serial := 2
+    programVersion := 3
+    offers
+    facts := { facts := #[8, 3], versions := #[1, 1], contradictory := false }
+    remaining :=
+      { actions := 20
+        matcherVisits := 20
+        acceptedFacts := 20
+        nodes := 20
+        applications := 20
+        equalities := 20
+        retainedSuggestions := 20
+        instances := 20
+        queueEntries := 20
+        generation := 20 }
+    incomplete := false }
+
+private def widthProviderKey : ProviderKey := { family := 10, version := 1 }
+private def goalProviderKey : ProviderKey := { family := 20, version := 4 }
+
+/-- A fact-domain companion publishes negative width, so a narrower interval
+has a larger score.  The policy does not know what the `Nat` means. -/
+private def widthProvider : Provider Nat :=
+  { key := widthProviderKey
+    features := fun request =>
+      match request.offer.key with
+      | .invoke invocation =>
+          match request.facts.fact? invocation.anchor with
+          | some width => #[{ key := 0, value := -(Int.ofNat width) }]
+          | none => #[]
+      | _ => #[] }
+
+/-- An independent frontend companion publishes split closing potential. -/
+private def goalProvider : Provider Nat :=
+  { key := goalProviderKey
+    features := fun request =>
+      match request.offer.key with
+      | .split _ target _ _ =>
+          #[{ key := 2, value := if target.node == node 1 then 9 else 2 },
+            { key := 9, value := 7 }]
+      | _ => #[] }
+
+private def featureLimits : PolicyFeature.Limits :=
+  { maxProviders := 2
+    maxProviderChecks := 8
+    maxFeaturesPerProvider := 2
+    maxFeaturesPerOffer := 2
+    maxTotalFeatures := 8
+    maxFeatureKey := 10
+    maxFeatureValue := 20 }
+
+private def scoreLimits : FeaturePolicy.Limits :=
+  { maxTerms := 4
+    maxProviderComponent := 100
+    maxFeatureKey := 10
+    maxWeight := 20
+    maxOffers := 4
+    maxFeaturesPerOffer := 4
+    maxPairChecks := 16
+    maxFeatureValue := 20
+    maxScore := 100 }
+
+private def registry? : Option (PolicyFeature.Registry Nat) :=
+  (PolicyFeature.Registry.buildWithin featureLimits #[widthProvider, goalProvider]).toOption
+
+private def address (provider : ProviderKey) (key : Nat) : Address := { provider, key }
+
+private def widthPlan? : Option Plan :=
+  (Plan.buildWithin scoreLimits
+    #[{ address := address widthProviderKey 0, weight := 1 }]).toOption
+
+private def goalPlan? : Option Plan :=
+  (Plan.buildWithin scoreLimits
+    #[{ address := address goalProviderKey 2, weight := 1 }]).toOption
+
+private def reverseGoalPlan? : Option Plan :=
+  (Plan.buildWithin scoreLimits
+    #[{ address := address goalProviderKey 2, weight := -1 }]).toOption
+
+private def emptyPlan? : Option Plan :=
+  (Plan.buildWithin scoreLimits #[]).toOption
+
+private def planOrError (plan : Option Plan) : Except FeaturePolicy.Error Plan :=
+  match plan with
+  | none => .error .offerLimit
+  | some plan => .ok plan
+
+private def choose (offers : Array OfferView) (plan : Plan) :
+    Except FeaturePolicy.Error (Option OfferView) := do
+  let registry <- match registry? with
+    | none => .error .offerLimit
+    | some registry => .ok registry
+  let featured <- (decorate featureLimits registry (view offers)).mapError fun _ => .offerLimit
+  FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan featured
+
+/- Width changes a tie: stable base order is wide then narrow, but the second
+offer has the larger negative-width score. -/
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    let selected <- choose #[invokeOffer 0, invokeOffer 1] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (invokeOffer 1).id
+  | _ => false
+
+/- The unrelated goal provider changes a tied split choice. -/
+#guard
+  match do
+    let plan <- planOrError goalPlan?
+    let selected <- choose #[splitOffer 0, splitOffer 1] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (splitOffer 1).id
+  | _ => false
+
+/- Signed weights are accepted.  Reversing the goal weight reverses the
+otherwise-tied choice even when the newly preferred offer comes second. -/
+#guard
+  match do
+    let plan <- planOrError reverseGoalPlan?
+    let selected <- choose #[splitOffer 1, splitOffer 0] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (splitOffer 0).id
+  | _ => false
+
+/- Missing configured data and emitted unknown keys are inert; stable base
+order remains the final tie-break. -/
+private def missingPlan? : Option Plan :=
+  (Plan.buildWithin scoreLimits
+    #[{ address := address goalProviderKey 8, weight := 7 }]).toOption
+
+#guard
+  match do
+    let plan <- planOrError missingPlan?
+    let selected <- choose #[invokeOffer 0, invokeOffer 1] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (invokeOffer 0).id
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    let selected <- choose #[splitOffer 0, splitOffer 1] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (splitOffer 0).id
+  | _ => false
+
+/- Negative feature values are used as signed values, not absolute values. -/
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    let selected <- choose #[invokeOffer 1, invokeOffer 0] plan
+    pure selected with
+  | .ok (some selected) => selected.id == (invokeOffer 1).id
+  | _ => false
+
+/- Saturation is applied after every configured term in caller order.  Here
+`20 * 20` reaches `10`, then `-7` lowers it to `3`; the competing score `4`
+wins.  Saturating only the final mathematical sum would choose the first. -/
+private def overflowProviderKey : ProviderKey := { family := 30, version := 1 }
+
+private def overflowView : PolicyFeature.View Nat :=
+  { base := view #[invokeOffer 0, invokeOffer 1]
+    offers :=
+      #[{ base := invokeOffer 0
+          features :=
+            #[{ provider := overflowProviderKey, key := 0, value := 20 },
+              { provider := overflowProviderKey, key := 1, value := -7 }] },
+        { base := invokeOffer 1
+          features := #[{ provider := overflowProviderKey, key := 0, value := 0 },
+            { provider := overflowProviderKey, key := 1, value := 4 }] }]
+    metrics := { providerChecks := 0, emittedFeatures := 4 } }
+
+private def overflowLimits : FeaturePolicy.Limits :=
+  { scoreLimits with maxScore := 10, maxWeight := 20 }
+
+private def overflowPlan? : Option Plan :=
+  (Plan.buildWithin overflowLimits
+    #[{ address := address overflowProviderKey 0, weight := 20 },
+      { address := address overflowProviderKey 1, weight := 1 }]).toOption
+
+#guard
+  match do
+    let plan <- planOrError overflowPlan?
+    let selected <- FeaturePolicy.choose? overflowLimits
+      (AdaptivePolicy.State.initial { optimism := 0 }) plan overflowView
+    pure selected with
+  | .ok (some selected) => selected.id == (invokeOffer 1).id
+  | _ => false
+
+private def scoredView (first second : OfferView) (firstScore secondScore : Int) :
+    PolicyFeature.View Nat :=
+  { base := view #[first, second]
+    offers :=
+      #[{ base := first
+          features := #[{ provider := goalProviderKey, key := 2, value := firstScore }] },
+        { base := second
+          features := #[{ provider := goalProviderKey, key := 2, value := secondScore }] }]
+    metrics := { providerChecks := 0, emittedFeatures := 2 } }
+
+/- With no configured feature terms and learned scores inside the explicit
+bound, adaptive ordering is preserved exactly. -/
+#guard
+  match do
+    let plan <- planOrError emptyPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
+      (scoredView (invokeOffer 0) { invokeOffer 1 with age := 1 } 20 (-20)) with
+  | .ok (some selected) => selected.id == (invokeOffer 1).id
+  | _ => false
+
+/- Feature score cannot cross the adaptive fairness tier. -/
+#guard
+  match do
+    let plan <- planOrError goalPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
+      (scoredView { invokeOffer 0 with age := 20 } (invokeOffer 1) (-20) 20) with
+  | .ok (some selected) => selected.id == (invokeOffer 0).id
+  | _ => false
+
+/- Nor can it cross the staged semantic tier. -/
+#guard
+  match do
+    let plan <- planOrError goalPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
+      (scoredView (invokeOffer 0) (splitOffer 1) (-20) 20) with
+  | .ok (some selected) => selected.id == (invokeOffer 0).id
+  | _ => false
+
+/- Duplicate and oversized plans are rejected before a plan exists. -/
+private def widthTerm : Term := { address := address widthProviderKey 0, weight := 1 }
+
+#guard
+  match Plan.buildWithin scoreLimits #[widthTerm, widthTerm] with
+  | .error (.duplicateAddress found) => found == widthTerm.address
+  | _ => false
+
+#guard
+  match Plan.buildWithin { scoreLimits with maxTerms := 0 } #[widthTerm] with
+  | .error .termLimit => true
+  | _ => false
+
+#guard
+  match Plan.buildWithin { scoreLimits with maxWeight := 0 } #[widthTerm] with
+  | .error (.weightLimit found weight) => found == widthTerm.address && weight == 1
+  | _ => false
+
+#guard
+  match Plan.buildWithin { scoreLimits with maxProviderComponent := 5 } #[widthTerm] with
+  | .error (.providerComponentLimit found) => found == widthTerm.address
+  | _ => false
+
+#guard
+  match Plan.buildWithin { scoreLimits with maxFeatureKey := 0 }
+      #[{ address := address widthProviderKey 1, weight := 0 }] with
+  | .error (.featureKeyLimit found) => found == address widthProviderKey 1
+  | _ => false
+
+/- Runtime work bounds reject transactionally, and a configured feature value
+outside the scoring limit is rejected before multiplication. -/
+private def oneFeatured (features : Array Feature) : PolicyFeature.View Nat :=
+  { base := view #[invokeOffer 0]
+    offers := #[{ base := invokeOffer 0, features }]
+    metrics := { providerChecks := 0, emittedFeatures := features.size } }
+
+/- Oversized adaptive scores fail closed rather than being clamped and
+silently flattened. -/
+#guard
+  match do
+    let plan <- planOrError emptyPlan?
+    FeaturePolicy.choose? { scoreLimits with maxScore := 100 }
+      (AdaptivePolicy.State.initial { optimism := 101 }) plan (oneFeatured #[]) with
+  | .error (.learnedScoreLimit offer score) =>
+      offer == (invokeOffer 0).id && score == 101
+  | _ => false
+
+/- A plan built under generous limits is revalidated against the limits used
+for selection. -/
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxTerms := 0 }
+      (AdaptivePolicy.State.initial {}) plan (oneFeatured #[]) with
+  | .error (.plan .termLimit) => true
+  | _ => false
+
+/- Even a publicly constructed featured view cannot substitute or reorder the
+engine-owned offers retained in its base view. -/
+private def misaligned : PolicyFeature.View Nat :=
+  { base := view #[invokeOffer 0, invokeOffer 1]
+    offers :=
+      #[{ base := invokeOffer 1, features := #[] },
+        { base := invokeOffer 0, features := #[] }]
+    metrics := { providerChecks := 0, emittedFeatures := 0 } }
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan misaligned with
+  | .error .offerAlignment => true
+  | _ => false
+
+/- Offer-count rejection precedes alignment traversal, even for a malformed
+oversized view. -/
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxOffers := 0 }
+      (AdaptivePolicy.State.initial {}) plan misaligned with
+  | .error .offerLimit => true
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxOffers := 0 }
+      (AdaptivePolicy.State.initial {}) plan (oneFeatured #[]) with
+  | .error .offerLimit => true
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxFeaturesPerOffer := 0 }
+      (AdaptivePolicy.State.initial {}) plan
+      (oneFeatured #[{ provider := widthProviderKey, key := 0, value := 1 }]) with
+  | .error (.offerFeatureLimit offer) => offer == (invokeOffer 0).id
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxPairChecks := 0 }
+      (AdaptivePolicy.State.initial {}) plan
+      (oneFeatured #[{ provider := widthProviderKey, key := 0, value := 1 }]) with
+  | .error .pairCheckLimit => true
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
+      (oneFeatured
+        #[{ provider := { family := 101, version := 1 }, key := 0, value := 0 }]) with
+  | .error (.providerComponentLimit offer found) =>
+      offer == (invokeOffer 0).id && found.provider.family == 101
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? scoreLimits (AdaptivePolicy.State.initial {}) plan
+      (oneFeatured #[{ provider := widthProviderKey, key := 11, value := 0 }]) with
+  | .error (.featureKeyLimit offer found) =>
+      offer == (invokeOffer 0).id && found == address widthProviderKey 11
+  | _ => false
+
+#guard
+  match do
+    let plan <- planOrError widthPlan?
+    FeaturePolicy.choose? { scoreLimits with maxFeatureValue := 2 }
+      (AdaptivePolicy.State.initial {}) plan
+      (oneFeatured #[{ provider := widthProviderKey, key := 0, value := -3 }]) with
+  | .error (.featureValueLimit offer address value) =>
+      offer == (invokeOffer 0).id && address == widthTerm.address && value == -3
+  | _ => false
+
+end Hex.Interval.FeaturePolicyConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -310,6 +310,7 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.StagedPolicy,
     `HexInterval.Experiment.AdaptivePolicy,
     `HexInterval.Experiment.PolicyFeature,
+    `HexInterval.Experiment.FeaturePolicy,
     `HexInterval.Experiment.BranchStart,
     `HexInterval.Experiment.BranchTree,
     `HexInterval.Experiment.BranchProof,
@@ -506,6 +507,7 @@ lean_lib HexConformance where
       `HexIntervalMathlib.MinMaxConformance].map Glob.one
 
     ++ #[`HexInterval.PolicyFeatureConformance,
+      `HexInterval.FeaturePolicyConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one
 
 -- The expensive complete-family Mathlib proofs are owned only by this

--- a/progress/20260811T201814Z.md
+++ b/progress/20260811T201814Z.md
@@ -1,0 +1,34 @@
+# Bounded package-feature scoring
+
+## Accomplished
+
+- Added a generic policy adapter which combines adaptive feedback with
+  explicitly configured, versioned package-feature addresses and signed
+  weights.
+- Bounded plan assembly, decorated-view traversal, value magnitudes, pair
+  checks, multiplication, and accumulated score; all configuration and runtime
+  failures are transactional.
+- Preserved adaptive fairness and staged semantic tiers, and returned the exact
+  retained engine offer for ordinary revalidation.
+- Added conformance for two unrelated width and goal/split providers, signed
+  values and weights, missing and unknown features, ordered saturation,
+  duplicate and oversized plans, and runtime resource failures.
+- Updated the interval SPEC and registered the experiment and conformance
+  modules. Focused builds and repository trust/static checks pass.
+
+## Current frontier
+
+Package-owned potential can now affect selection without adding fact,
+function, operation, or package cases to the generic scheduler.
+
+## Next step
+
+Integrate this adapter with the live target-run controller and benchmark
+candidate width, goal-distance, and split-potential vocabularies.
+
+## Blockers
+
+The existing provider API returns an allocated array after arbitrary callback
+work. This adapter bounds all of its own work and revalidates provider output,
+but it cannot preempt excessive computation or allocation inside a provider;
+the SPEC retains the restricted-builder or declared-work follow-up.

--- a/progress/20260815T001141Z.md
+++ b/progress/20260815T001141Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Replayed the bounded feature-scoring adapter onto exact local #9236 head
+  `8562cf2c5a6e7d0cde11a5277c600649e046d2bb`, preserving the package-feature,
+  verified-raster, Table 12, and PNT stack.
+- Audited scorer/decorator limit compatibility, plan revalidation, oversized
+  learned-score rejection, full aligned-offer equality, stable tie-breaking,
+  signed ordered saturation, and the conservative pair-check bound.
+- Confirmed that the implementation and SPEC distinguish bounded adapter-owned
+  traversal from provider callback work and authentic nested-key equality cost;
+  fabricated featured views remain scheduling input rather than proof evidence.
+- Refreshed the narrow proof-only Lake registration exemption to the combined
+  local stack and built the scoring adapter and conformance target.
+- Ran repository structural, trust-surface, PNT inventory, freshness, and
+  banned-mechanism checks successfully.
+
+# Current frontier
+
+Bounded package features can influence ordering beneath fairness and semantic
+stage tiers while returning an exact engine-owned offer for later revalidation.
+The concrete feature vocabulary and weights remain experimental.
+
+# Next step
+
+After #9236 lands, rebase this local feature onto its exact merge commit,
+recompute the Lake exemption, and run the final PR review and CI cycle.
+
+# Blockers
+
+None. The first focused build attempt exhausted the full shared filesystem
+while writing an artifact; after removing one clean superseded worktree from
+this review lineage, the exact build completed without a Lean diagnostic.

--- a/progress/20260815T023523Z.md
+++ b/progress/20260815T023523Z.md
@@ -1,0 +1,39 @@
+# Accomplished
+
+- Reconciled the #9237 bounded feature-scoring adapter onto exact local #9236
+  candidate `cc5379ed6d647a9c9d4494da27a95fcf61a3e39c`, preserving the separate
+  #9235 verified-raster branch and current PNT/Table 12 registrations.
+- Audited transactional plan construction and selection-time revalidation,
+  full field-for-field base-offer alignment, every scorer-owned count and value
+  bound, signed ordered saturation, and oversized learned-score rejection.
+- Confirmed that an empty scoring plan agrees exactly with the wrapped adaptive
+  policy while configured features remain subordinate to the unchanged
+  fairness and staged-semantic tiers.
+- Strengthened conformance so the empty plan is compared directly with
+  `AdaptivePolicy.choose?` and a same-position, same-identity offer with changed
+  age is rejected, making whole-offer equality load-bearing.
+- Clarified the public API documentation: only `PolicyFeature.decorate`
+  authenticates provider provenance; accepting bounded hand-built experiment
+  views never authenticates their features or base view, and engine
+  revalidation remains authoritative.
+- Confirmed the bounded-traversal claims are scoped honestly. Pair checks and
+  adapter-owned arrays are bounded, while nested engine-key equality and
+  provider callback work retain their explicit SPEC caveats.
+- Built the focused feature-policy targets and preserved interval/PNT targets,
+  then passed structural, trust-surface, freshness, PNT inventory, release,
+  Mathlib-free bench, and static checks.
+
+# Current frontier
+
+The adapter can combine authenticated package features with adaptive scores
+without crossing fairness or semantic-stage boundaries. Concrete feature
+vocabularies and weights remain experimental and do not influence proofs.
+
+# Next step
+
+After #9236 lands, rebase this local candidate onto its exact merge commit,
+refresh the Lake exemption, and perform the final review and CI cycle.
+
+# Blockers
+
+None.

--- a/progress/20260815T073926Z.md
+++ b/progress/20260815T073926Z.md
@@ -1,0 +1,21 @@
+# Accomplished
+
+- Recovered the audited FeaturePolicy experiment as `#9237` on exact prepared `#9236` head `066f1025d6f1f4fe36209b16e67dfdae5b774a9c`, while preserving the independent `#9234`, `#9235`, and `#9236` refs and a source ref for the historical audited patch.
+- Audited selection-time revalidation of the complete plan against the exact caller limits, structural equality of every field in each decorated/base `OfferView`, and fail-closed handling of limit mismatches and oversized learned scores.
+- Confirmed the same-ID, same-position age mutation is rejected, and that empty-plan selection agrees with `AdaptivePolicy` whenever learned scores satisfy the explicit bound.
+- Confirmed configured scores cannot cross adaptive fairness or staged semantic tiers, and that successful selection returns the exact aligned engine offer without entering proof evidence or authorizing a transition.
+- Confirmed the pair-check bound covers feature/term comparisons while provider callback work remains separately bounded only by PolicyFeature preflight/output limits and cannot currently be preempted inside a callback.
+- Corrected a module-docstring typo and recomputed the exact Lake freshness exemption for blob `05026d60972019c6462cfcda5dd502d03d1fc40c`.
+- Passed the focused FeaturePolicy build, complete PNT conformance set, static/DAG/phase checks, trust-surface and release-manifest checks, source-pinned PNT inventory checks, unit tests, and factor-sweep freshness.
+
+# Current frontier
+
+`#9237` is a clean local-only FeaturePolicy candidate on branch `codex/9237-prepare-current`, with its experimental scorer reconciled with the current PolicyFeature, public arithmetic, and PNT registrations.
+
+# Next step
+
+Retain the branch for the directed landing sequence; rebase and repeat exact-head review/CI only when explicitly requested.
+
+# Blockers
+
+None.

--- a/progress/20260815T131949Z.md
+++ b/progress/20260815T131949Z.md
@@ -1,0 +1,36 @@
+# Accomplished
+
+- Replayed the bounded `FeaturePolicy` adapter directly onto exact #9236 head
+  `1ce0771f7c3e860d394827f7d1ae27ebfbbe8936`, preserving the independent
+  #9234, #9235, and #9236 refs.
+- Confirmed that selection revalidates the complete private plan under the
+  exact caller limits and fails closed on plan, decorated-view, provider,
+  feature, traversal, and learned-score mismatches.
+- Confirmed field-for-field decorated/base `OfferView` alignment, including a
+  load-bearing same-identity age mutation, and exact return of the retained
+  base offer.
+- Confirmed ordered signed saturation, stable view-order ties, exact empty-plan
+  agreement with the wrapped adaptive selector on accepted inputs, and that
+  feature scores remain subordinate to fairness and semantic stages.
+- Kept resource and trust boundaries explicit: adapter-owned counts are
+  bounded, provider callbacks and nested-key equality have their stated cost
+  caveats, and scoring data never authorizes transitions or enters proof
+  evidence.
+- Refreshed the exact Lake registration exemption, built the 2283-job focused
+  controller/public/PNT target closure, and passed structural, trust,
+  inventory, release, freshness, and banned-mechanism checks.
+
+# Current frontier
+
+The local #9237 fork can rank aligned engine offers using bounded,
+package-addressed features without weakening the engine or proof boundary.
+Concrete provider vocabularies and weights remain experimental.
+
+# Next step
+
+Retain this fork for the directed landing sequence and rebase onto the eventual
+exact predecessor merge before any remote review or CI cycle.
+
+# Blockers
+
+None.

--- a/progress/20260816T011343Z.md
+++ b/progress/20260816T011343Z.md
@@ -1,0 +1,28 @@
+# Prepare feature scoring after package policy features
+
+## Accomplished
+
+- Replayed the audited FeaturePolicy edge directly onto exact #9236 candidate
+  `0facd239165d0ed57f45cadb1bb7dbb04dd88d24`, excluding raster #9235.
+- Preserved exact-limit plan revalidation, whole OfferView alignment including
+  same-identity age mutation, fail-closed mismatches and oversized scores,
+  stable ties and saturation, empty-plan adaptive equivalence, and stage and
+  fairness invariance.
+- Preserved callback and nested-key equality work caveats, exact retained-base
+  return, proof independence, and all current registrations.
+- Kept the merged reciprocal progress record at its original timestamp and
+  moved the historical FeaturePolicy record one second to avoid collision.
+
+## Current frontier
+
+The local branch contains only FeaturePolicy above #9236. Raster #9235 and the
+mixed-function #9238 and #9240 refs remain unchanged.
+
+## Next step
+
+After #9236 merges, replay this prepared edge onto its literal merge commit and
+publish PR #9237 as a direct-main branch.
+
+## Blockers
+
+None.

--- a/progress/20260816T012739Z.md
+++ b/progress/20260816T012739Z.md
@@ -1,0 +1,25 @@
+# Restack feature scoring onto merged package policy features
+
+## Accomplished
+
+- Replayed the prepared FeaturePolicy edge onto literal #9236 merge commit
+  `ffe5dbab5cebd3bc522d35f8ab472a4b7f604628`, excluding raster #9235.
+- Preserved merged PolicyFeature, adaptive policy, exact-branch proof,
+  subtraction replay, staged policy, complete source-pinned LogTables providers
+  and inventory, PNT examples, and current public interval registrations.
+- Confirmed that the exact combined Lake blob and narrow proof-only runtime
+  exemption remain unchanged by the merge-parent restack.
+
+## Current frontier
+
+PR #9237 is a direct-main FeaturePolicy edge. Raster #9235 and mixed-function
+#9238 and #9240 refs remain independent and unchanged.
+
+## Next step
+
+Run focused policy, controller, inventory, trust, freshness, and diff gates;
+then publish the direct-main PR head and monitor automatic CI.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -236,7 +236,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "05026d60972019c6462cfcda5dd502d03d1fc40c",
+    "current_blob": "95a55634a8b10cd0c7bb08d4b30f333f23ce2f16",
     "reason": "Additionally registers the isolated Mathlib-free bounded feature-scoring policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -236,8 +236,8 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "95a55634a8b10cd0c7bb08d4b30f333f23ce2f16",
-    "reason": "Additionally registers the isolated Mathlib-free bounded feature-scoring policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
+    "current_blob": "6f4ad627fd141e71916da6a287d0743d93c30197",
+    "reason": "Additionally registers the isolated Mathlib-free bounded feature-scoring policy experiment and its conformance module on top of the retained PolicyFeature, adaptive policy, exact-branch proof, subtraction replay, staged policy, complete LogTables, PNT, and public interval registrations; neither enters the factorization service target or changes its executable dependency graph."
   },
   {
     "path": "HexBerlekamp/FactorTacticTests.lean",

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -236,7 +236,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "0b9892f3618ff9cbb1b2a38e1976501b891bac5c",
+    "current_blob": "05026d60972019c6462cfcda5dd502d03d1fc40c",
     "reason": "Additionally registers the isolated Mathlib-free bounded feature-scoring policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -234,6 +234,12 @@
     "reason": "Additionally registers the isolated Mathlib-free package policy-feature experiment and its conformance module on top of the retained adaptive policy, exact-branch proof, subtraction replay, staged policy, complete LogTables, PNT, and public interval registrations; neither enters the factorization service target or changes its executable dependency graph."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "0b9892f3618ff9cbb1b2a38e1976501b891bac5c",
+    "reason": "Additionally registers the isolated Mathlib-free bounded feature-scoring policy experiment and its conformance module; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",


### PR DESCRIPTION
## Summary

- add a generic weighted scoring adapter over adaptive policy and decorated package features
- validate and revalidate ordered `(provider, key, weight)` plans under the exact caller limits
- require whole OfferView structural alignment, including fields outside stable identity, and return the exact retained base offer
- preserve fairness and semantic stages above feature scores, stable view-order ties, and explicit signed saturation
- reject provider, plan, decorated-view, traversal, and oversized learned-score mismatches transactionally

## Trust and resource boundary

Scores affect ordering only and never become proof evidence or authorize transitions. Adapter-owned counts and arithmetic are bounded; provider callbacks and nested-key equality retain their explicit non-preemptibility/work caveats.

## Validation

- focused FeaturePolicy, PolicyFeature, adaptive/staged-policy, exact-branch, subtraction, nested-branch, and complete LogTables conformance build
- trust surface, factor freshness, PNT source inventory, diff, and banned-proof checks