### PR TITLE
spec(interval): add numerical acceptance roadmap

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2774,9 +2774,157 @@ a proof.
 
 ## Applications
 
-The tactic is the first client, not the only one. Two downstream applications
-constrain the framework without requiring either application to be implemented
-in the first release.
+The tactic is the first client, not the only one. The numerical acceptance
+programs and two downstream applications below constrain the framework without
+requiring all of them to be implemented in the first release.
+
+### Example-driven numerical roadmap
+
+The small propagation canaries above are architectural tests, not the intended
+ceiling of the numerical system. Development after the generic proof frontend
+is driven by the following executable acceptance programs. A generic mechanism
+is justified when one of these programs needs it; passing a synthetic rule test
+alone is not completion.
+
+#### Large-argument elementary functions
+
+The first range-reduction targets are:
+
+- prove `Real.sin 10 < 0` from a certified enclosure of `sin 10`; and
+- produce exact dyadic `lo` and `hi` with `0 < lo`,
+  `Real.cos (10 ^ 10) ∈ [lo, hi]`, and `hi - lo ≤ 2 ^ (-80)`.
+
+These examples must not reduce a floating-point approximation and then ask the
+kernel to trust it. A function package combines a checked constant enclosure,
+an exact integer or quadrant reduction, a small residual interval, and a local
+enclosure theorem. The large reduction integer, the selected quadrant, and the
+residual are explicit replay data. An off-by-one reduction candidate must be
+rejected. The `cos (10 ^ 10)` example is deliberately large enough that a
+low-precision approximation to pi cannot accidentally select the right
+quadrant.
+
+Range reduction depends on a pluggable constant service rather than a pi
+literal wired into the sine package. Its first serious provider uses the
+Chudnovsky series to return a certified pi interval at a requested precision.
+The certificate checks the term recurrence, finite sum, and tail bound. A
+second, slower formula such as a Machin identity is a conformance provider so
+that registry selection, fallback, and agreement of independently produced
+enclosures are load-bearing. The acceptance target is a 1,000-bit pi enclosure;
+the engine may cache and share it across every trigonometric node in a run.
+
+#### Series as package-owned numerical algorithms
+
+A registered function may supply a power or Taylor series without teaching the
+engine that function. The generic series interface carries a center, exact
+coefficient recipe or recurrence, an admissible input region, a truncation
+degree, and a theorem bounding the remainder. Replay proves the finite
+polynomial enclosure and adds the remainder interval. Different formulas for
+one function are ordinary competing providers selected by policy and checked
+by their own theorems.
+
+The first precision canary computes `Real.exp (1 / 8)` in an interval of width
+at most `2 ^ (-100)` using the usual exponential series. It is followed by a
+formula whose coefficients are not built into the interval library, proving
+that the interface is genuinely package-owned. Increasing requested precision
+must extend or refine cached series work rather than restart an unrelated
+generic expression search.
+
+#### Certified logarithm tables
+
+The table-building acceptance program constructs enclosures for
+
+`Real.log (1 + i / 256)`, for every `0 ≤ i ≤ 256`,
+
+with width at most `2 ^ (-128)`. The table certificate binds the exact index,
+exact rational argument, chosen range reduction, series data, and final
+interval. It additionally proves monotonic ordering of adjacent entries. A
+later `log` propagator may use the table for argument reduction, but every
+lookup remains an ordinary replayable dependency rather than trusted generated
+code.
+
+Table construction is a first-class batch client: common constants,
+coefficients, and remainder proofs are shared. The benchmark records total
+integer work, proof size, cache reuse, and incremental cost when the requested
+precision grows. Producing one correct entry 257 times independently does not
+satisfy the table acceptance target.
+
+#### Certified integral bounds
+
+The first quadrature target proves the strict rational enclosure
+
+`7468 / 10000 < ∫ x in 0..1, Real.exp (-(x ^ 2))`
+
+and
+
+`∫ x in 0..1, Real.exp (-(x ^ 2)) < 7469 / 10000`.
+
+The executable planner may choose a partition and a quadrature or Taylor rule.
+The proof package checks each local enclosure and its remainder theorem, then
+adds the subinterval bounds exactly. Adaptive subdivision is driven by the
+same policy observations as other refinement, but an integral certificate has
+its own compositional theorem; sampling values is never evidence for an
+integral bound. Polynomial integrands should use exact antiderivative or
+polynomial-integration providers when available instead of being forced
+through generic quadrature.
+
+#### Specialized algebraic solvers before generic propagation
+
+The generic interval engine is a coordinator and fallback, not a mandate to
+solve every recognizable fragment by branch-and-contract. Hex already has
+certified real and complex polynomial root-isolation engines. A provider may
+recognize a closed polynomial fragment, reify it into the existing `Hex.ZPoly`
+representation, invoke the specialized executable solver, and replay its
+existing certificate into interval facts, disjoint cases, root counts, or
+refutations.
+
+The initial integration targets are:
+
+- use `HexRealRoots` to isolate the unique real root of `x ^ 5 - x - 1` and
+  feed its isolating interval into the surrounding interval problem;
+- use `HexRoots` to return a complete family of disjoint certified complex
+  regions for `z ^ 5 - z + 1`; and
+- solve a mixed problem in which real-root isolation supplies finitely many
+  algebraic candidate intervals and arbitrary-function propagators, such as a
+  sine or logarithm package, eliminate or refine those candidates.
+
+For a purely polynomial goal, the acceptance trace uses the specialized
+provider and does not reproduce Sturm, Descartes, Pellet, Newton, or complex
+argument-principle search as generic expression steps. Generic interval
+propagation remains available around polynomial islands and as a bounded
+fallback when the specialized provider declines. Provider choice cannot affect
+soundness: every imported isolation is tied to the exact reified polynomial
+and checked through the existing `HexRealRootsMathlib` or `HexRootsMathlib`
+theorems.
+
+The same dispatch principle extends to other Hex libraries. Exact polynomial
+factorization, real-closed-field procedures, and future specialized linear or
+algebraic solvers should be preferred when their recognized fragment and
+certificate language fit the goal. The interval engine composes their results;
+it does not hide a slower duplicate implementation behind a uniform API.
+
+#### Required provider boundaries
+
+These examples require several independently registered numerical roles:
+
+- constant providers, such as Chudnovsky pi;
+- range-reduction providers for periodic and scale-reduced functions;
+- local function enclosures, including Taylor or other convergent formulas;
+- reusable certified table providers;
+- quadrature and integral-remainder providers; and
+- specialized algebraic solvers that return checked facts or branch families.
+
+All providers are versioned, resource-bounded at their public boundary, and
+replaceable. Their executable output is untrusted candidate data. Only exact
+data checked by package-owned theorems enters `Evidence`. Expensive provider
+internals may be native Lean, or an optional external program may propose the
+same candidate, but rejection and absence fall back without changing theorem
+statements.
+
+The roadmap order is example-driven: large-argument sine and pluggable pi;
+generic series and the high-precision log table; certified quadrature; real
+and complex root-isolator dispatch; then mixed workloads combining several of
+these providers. Verified raster and ODE clients below consume the same
+capabilities rather than introducing private numerical engines.
 
 ### Verified raster graphs
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2790,7 +2790,7 @@ alone is not completion.
 
 The first range-reduction targets are:
 
-- prove `Real.sin 10 < 0` from a certified enclosure of `sin 10`; and
+- prove `Real.sin 10 < 0` from a certified enclosure of `Real.sin 10`; and
 - produce exact dyadic `lo` and `hi` with `0 < lo`,
   `Real.cos (10 ^ 10) ∈ [lo, hi]`, and `hi - lo ≤ 2 ^ (-80)`.
 
@@ -2799,9 +2799,10 @@ kernel to trust it. A function package combines a checked constant enclosure,
 an exact integer or quadrant reduction, a small residual interval, and a local
 enclosure theorem. The large reduction integer, the selected quadrant, and the
 residual are explicit replay data. An off-by-one reduction candidate must be
-rejected. The `cos (10 ^ 10)` example is deliberately large enough that a
-low-precision approximation to pi cannot accidentally select the right
-quadrant.
+rejected. The reduced argument of `cos (10 ^ 10)` is not especially close to
+a quadrant boundary. Its purpose is the `2 ^ (-80)` output width: multiplying
+the pi error by a reduction integer near `10 ^ 10` forces a substantially
+higher-precision constant enclosure than quadrant selection alone.
 
 Range reduction depends on a pluggable constant service rather than a pi
 literal wired into the sine package. Its first serious provider uses the
@@ -2833,7 +2834,7 @@ generic expression search.
 
 The table-building acceptance program constructs enclosures for
 
-`Real.log (1 + i / 256)`, for every `0 ≤ i ≤ 256`,
+`Real.log (1 + (i : ℝ) / 256)`, for every `i : ℕ` with `i ≤ 256`,
 
 with width at most `2 ^ (-128)`. The table certificate binds the exact index,
 exact rational argument, chosen range reduction, series data, and final
@@ -2893,8 +2894,15 @@ argument-principle search as generic expression steps. Generic interval
 propagation remains available around polynomial islands and as a bounded
 fallback when the specialized provider declines. Provider choice cannot affect
 soundness: every imported isolation is tied to the exact reified polynomial
-and checked through the existing `HexRealRootsMathlib` or `HexRootsMathlib`
-theorems.
+and a checked squarefree or simple-root certificate, then replayed through the
+existing `HexRealRootsMathlib` or `HexRootsMathlib` theorems.
+
+The root-isolation adapter does not live in `HexInterval` or
+`HexIntervalMathlib`: those libraries retain their present dependency order.
+A separate integration library depends on the interval and root-isolation
+libraries, registers the specialized providers, and translates their results
+to interval facts and proof branches. This also prevents a generic interval
+import from pulling in polynomial isolation machinery.
 
 The same dispatch principle extends to other Hex libraries. Exact polynomial
 factorization, real-closed-field procedures, and future specialized linear or
@@ -2916,15 +2924,26 @@ These examples require several independently registered numerical roles:
 All providers are versioned, resource-bounded at their public boundary, and
 replaceable. Their executable output is untrusted candidate data. Only exact
 data checked by package-owned theorems enters `Evidence`. Expensive provider
-internals may be native Lean, or an optional external program may propose the
-same candidate, but rejection and absence fall back without changing theorem
-statements.
+internals may use compiled Lean search code. An optional external program may
+propose the same candidate only under the untrusted-dispatch contract in
+Scope; this SPEC still approves no `@[extern]` planner hook. Rejection and
+absence fall back without changing theorem statements.
 
 The roadmap order is example-driven: large-argument sine and pluggable pi;
 generic series and the high-precision log table; certified quadrature; real
 and complex root-isolator dispatch; then mixed workloads combining several of
 these providers. Verified raster and ODE clients below consume the same
 capabilities rather than introducing private numerical engines.
+
+In the companion development order, large-argument sine and the constant
+provider refine D5-D7; the series and log-table programs are D7-D8; the
+selected PNT+ point, sum, and generated-table workloads are D8-D9; adaptive
+quadrature and affine covers refine D9-D10; and root-isolator dispatch is a
+separate integration provider after the root libraries. Surveyed PNT+
+certified-bound and integral dependencies become milestone work only when a
+migration workload selects them. This mapping keeps the dependency order
+authoritative while the examples determine what each milestone must
+demonstrate.
 
 ### Verified raster graphs
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2805,13 +2805,15 @@ the pi error by a reduction integer near `10 ^ 10` forces a substantially
 higher-precision constant enclosure than quadrant selection alone.
 
 Range reduction depends on a pluggable constant service rather than a pi
-literal wired into the sine package. Its first serious provider uses the
-Chudnovsky series to return a certified pi interval at a requested precision.
-The certificate checks the term recurrence, finite sum, and tail bound. A
-second, slower formula such as a Machin identity is a conformance provider so
-that registry selection, fallback, and agreement of independently produced
-enclosures are load-bearing. The acceptance target is a 1,000-bit pi enclosure;
-the engine may cache and share it across every trigonometric node in a run.
+literal wired into the sine package. Its first serious provider uses a Machin-
+style arctangent identity whose identity and alternating-series remainder can
+be proved from elementary Mathlib analysis. A faster Chudnovsky provider
+follows once the Ramanujan-type identity connecting its series to `Real.pi` is
+formalized; checking only its term recurrence, finite sum, and tail would not
+establish that identity. Registry selection, fallback, and agreement of these
+independently produced enclosures are load-bearing. The acceptance target is a
+1,000-bit pi enclosure; the engine may cache and share it across every
+trigonometric node in a run.
 
 #### Series as package-owned numerical algorithms
 
@@ -2873,10 +2875,13 @@ through generic quadrature.
 The generic interval engine is a coordinator and fallback, not a mandate to
 solve every recognizable fragment by branch-and-contract. Hex already has
 certified real and complex polynomial root-isolation engines. A provider may
-recognize a closed polynomial fragment, reify it into the existing `Hex.ZPoly`
-representation, invoke the specialized executable solver, and replay its
-existing certificate into interval facts, disjoint cases, root counts, or
-refutations.
+recognize a closed univariate polynomial fragment with integer coefficients,
+or rational coefficients that can be cleared with a proved nonzero scale,
+reify it into the existing `Hex.ZPoly` representation, invoke the specialized
+executable solver, and replay its existing certificate into interval facts,
+disjoint cases, root counts, or refutations. Irrational, symbolic-coefficient,
+and multivariate fragments decline this provider and remain with generic or
+other specialized methods.
 
 The initial integration targets are:
 
@@ -2888,21 +2893,28 @@ The initial integration targets are:
   algebraic candidate intervals and arbitrary-function propagators, such as a
   sine or logarithm package, eliminate or refine those candidates.
 
-For a purely polynomial goal, the acceptance trace uses the specialized
+For root counting, isolation, or a sign partition determined by the roots of a
+supported univariate polynomial, the acceptance trace uses the specialized
 provider and does not reproduce Sturm, Descartes, Pellet, Newton, or complex
-argument-principle search as generic expression steps. Generic interval
-propagation remains available around polynomial islands and as a bounded
-fallback when the specialized provider declines. Provider choice cannot affect
-soundness: every imported isolation is tied to the exact reified polynomial
-and a checked squarefree or simple-root certificate, then replayed through the
-existing `HexRealRootsMathlib` or `HexRootsMathlib` theorems.
+argument-principle search as generic expression steps. A complete univariate
+real-closed-field sentence goes first to `hex-rcf`, which already owns that
+end-to-end decision problem and may use real-root isolation internally. Direct
+root-region results use this adapter. Polynomial range bounds on boxes use the
+generic Bernstein, centered, or Taylor-model portfolio unless they reduce to
+one of those exact decision problems. Generic interval propagation remains
+available around polynomial islands and as a bounded fallback when a
+specialized provider declines. Provider choice cannot affect soundness: every
+imported isolation is tied to the exact reified polynomial and a checked
+squarefree or simple-root certificate, then replayed through the existing
+`HexRealRootsMathlib` or `HexRootsMathlib` theorems.
 
 The root-isolation adapter does not live in `HexInterval` or
 `HexIntervalMathlib`: those libraries retain their present dependency order.
-A separate integration library depends on the interval and root-isolation
-libraries, registers the specialized providers, and translates their results
-to interval facts and proof branches. This also prevents a generic interval
-import from pulling in polynomial isolation machinery.
+The planned Mathlib-facing `hex-interval-algebraic` integration library depends
+on `hex-interval-mathlib`, `hex-real-roots-mathlib`, and
+`hex-roots-mathlib`, registers the specialized providers, and translates their
+results to interval facts and proof branches. This also prevents a generic
+interval import from pulling in polynomial isolation machinery.
 
 The same dispatch principle extends to other Hex libraries. Exact polynomial
 factorization, real-closed-field procedures, and future specialized linear or
@@ -2914,7 +2926,7 @@ it does not hide a slower duplicate implementation behind a uniform API.
 
 These examples require several independently registered numerical roles:
 
-- constant providers, such as Chudnovsky pi;
+- constant providers, such as Machin and Chudnovsky pi enclosures;
 - range-reduction providers for periodic and scale-reduced functions;
 - local function enclosures, including Taylor or other convergent formulas;
 - reusable certified table providers;
@@ -2923,8 +2935,9 @@ These examples require several independently registered numerical roles:
 
 All providers are versioned, resource-bounded at their public boundary, and
 replaceable. Their executable output is untrusted candidate data. Only exact
-data checked by package-owned theorems enters `Evidence`. Expensive provider
-internals may use compiled Lean search code. An optional external program may
+candidate data becomes a fact through a package-owned theorem, and `Evidence`
+stores the resulting proof. Expensive provider internals may use compiled Lean
+search code. An optional external program may
 propose the same candidate only under the untrusted-dispatch contract in
 Scope; this SPEC still approves no `@[extern]` planner hook. Rejection and
 absence fall back without changing theorem statements.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2870,6 +2870,11 @@ integral bound. Polynomial integrands should use exact antiderivative or
 polynomial-integration providers when available instead of being forced
 through generic quadrature.
 
+The first quadrature proof package lives in `HexIntervalMathlib`, which already
+owns real-function semantics and imports Mathlib; it does not add a dependency
+to Mathlib-free `HexInterval`. A general certified integrator with reusable
+partition APIs remains a later downstream library with its own SPEC.
+
 #### Specialized algebraic solvers before generic propagation
 
 The generic interval engine is a coordinator and fallback, not a mandate to
@@ -2897,11 +2902,13 @@ For root counting, isolation, or a sign partition determined by the roots of a
 supported univariate polynomial, the acceptance trace uses the specialized
 provider and does not reproduce Sturm, Descartes, Pellet, Newton, or complex
 argument-principle search as generic expression steps. A complete univariate
-real-closed-field sentence goes first to `hex-rcf`, which already owns that
-end-to-end decision problem and may use real-root isolation internally. Direct
-root-region results use this adapter. Polynomial range bounds on boxes use the
-generic Bernstein, centered, or Taylor-model portfolio unless they reduce to
-one of those exact decision problems. Generic interval propagation remains
+real-closed-field sentence should be sent by the caller to `hex-rcf`, which
+already owns that end-to-end decision problem and may use real-root isolation
+internally; this is usage precedence, not a dependency or dispatch edge from
+the adapter. The adapter instead serves root-region fragments embedded in a
+larger interval problem. Polynomial range bounds on boxes use the generic
+Bernstein, centered, or Taylor-model portfolio unless they reduce to one of
+those exact decision problems. Generic interval propagation remains
 available around polynomial islands and as a bounded fallback when a
 specialized provider declines. Provider choice cannot affect soundness: every
 imported isolation is tied to the exact reified polynomial and a checked
@@ -2949,7 +2956,8 @@ these providers. Verified raster and ODE clients below consume the same
 capabilities rather than introducing private numerical engines.
 
 In the companion development order, large-argument sine and the constant
-provider refine D5-D7; the series and log-table programs are D7-D8; the
+provider refine D5-D7, with Chudnovsky a later stretch provider; the series and
+log-table programs are D7-D8; the
 selected PNT+ point, sum, and generated-table workloads are D8-D9; adaptive
 quadrature and affine covers refine D9-D10; and root-isolator dispatch is a
 separate integration provider after the root libraries. Surveyed PNT+

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2811,9 +2811,10 @@ be proved from elementary Mathlib analysis. A faster Chudnovsky provider
 follows once the Ramanujan-type identity connecting its series to `Real.pi` is
 formalized; checking only its term recurrence, finite sum, and tail would not
 establish that identity. Registry selection, fallback, and agreement of these
-independently produced enclosures are load-bearing. The acceptance target is a
-1,000-bit pi enclosure; the engine may cache and share it across every
-trigonometric node in a run.
+independently produced enclosures are load-bearing. Before Chudnovsky is
+available, conformance compares two independently proved Machin-style
+identities. The acceptance target is a 1,000-bit pi enclosure; the engine may
+cache and share it across every trigonometric node in a run.
 
 #### Series as package-owned numerical algorithms
 

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -174,11 +174,9 @@ The computational interval pair is independent. Its planned algebraic adapter
 joins the Mathlib-facing interval layer to the existing root-isolation graph:
 
 ```text
-hex-interval ── hex-interval-mathlib
-                         │
-                         └── hex-interval-algebraic
-                              ├── hex-real-roots-mathlib
-                              └── hex-roots-mathlib
+hex-interval ── hex-interval-mathlib ──┐
+hex-real-roots-mathlib ────────────────┼── hex-interval-algebraic
+hex-roots-mathlib ─────────────────────┘
 ```
 
 Multivariate polynomials extend the univariate polynomial library and

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -170,10 +170,15 @@ hex-berlekamp-zassenhaus ────┤
 hex-row-reduce ──────────────┘
 ```
 
-Interval arithmetic is an independent library pair:
+The computational interval pair is independent. Its planned algebraic adapter
+joins the Mathlib-facing interval layer to the existing root-isolation graph:
 
 ```text
 hex-interval ── hex-interval-mathlib
+                         │
+                         └── hex-interval-algebraic
+                              ├── hex-real-roots-mathlib
+                              └── hex-roots-mathlib
 ```
 
 Multivariate polynomials extend the univariate polynomial library and

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -16,6 +16,7 @@
 - **hex-roots**: certified complex root isolation for `Z[x]` via dyadic squares, Pellet tests, and speculative Newton iteration
 - **hex-real-roots**: certified real root isolation for `Z[x]`: Sturm-count witnesses, a Descartes bisection search with a proven-complete Sturm fallback
 - **hex-interval**: exact open, closed, empty, and unbounded dyadic intervals; a shared expression program; and a budgeted scheduler for propagation, refinement, and subdivision
+- **hex-interval-algebraic**: planned Mathlib-facing integration of interval facts with certified real and complex polynomial root isolation; `mathlib: true`
 - **hex-rcf**: the `rcf` tactic, a complete decision procedure for univariate real-closed-field sentences (Boolean combinations of polynomial inequalities under one `∀`/`∃` over `ℝ`); `mathlib: true`, soundness theorem in the same library
 - **hex-resultant**: polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - **hex-number-field**: fixed fields `QAdjoin p x`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and roots of polynomials with algebraic coefficients
@@ -74,6 +75,7 @@ Each library with its immediate dependencies:
 - **hex-roots**: hex-poly-z
 - **hex-real-roots**: hex-poly-z
 - **hex-interval**: (none)
+- **hex-interval-algebraic**: hex-interval-mathlib, hex-real-roots-mathlib, hex-roots-mathlib (mathlib: true)
 - **hex-rcf**: hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant**: hex-poly
 - **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
@@ -221,6 +223,7 @@ for developments whose source-local move has not happened yet.
 - [hex-real-roots-mathlib.md](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `isolate?`
 - [hex-interval.md](../../HexInterval/SPEC/hex-interval.md): exact interval data, shared programs, and budgeted propagation search
 - [hex-interval-mathlib.md](hex-interval-mathlib.md): real semantics, verified propagators, proof replay, and the `interval` tactic
+- **hex-interval-algebraic** (planned): Mathlib-facing interval providers backed by certified real and complex polynomial root isolation; its provider contract is specified in [hex-interval.md](../../HexInterval/SPEC/hex-interval.md#specialized-algebraic-solvers-before-generic-propagation)
 - [hex-rcf.md](hex-rcf.md): the `rcf` tactic for univariate real-closed-field sentences
 - [hex-resultant](../../HexResultant/SPEC/hex-resultant.md): polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - [hex-resultant-mathlib](../../HexResultantMathlib/SPEC/hex-resultant-mathlib.md): executable resultant agreement, specialization, root-product, and discriminant theorems

--- a/SPEC/Libraries/hex-interval-algebraic.md
+++ b/SPEC/Libraries/hex-interval-algebraic.md
@@ -1,0 +1,10 @@
+# Hex interval algebraic integration
+
+`hex-interval-algebraic` is a planned Mathlib-facing integration library. It
+registers interval providers backed by the certified real and complex
+polynomial root-isolation libraries without adding those dependencies to
+`hex-interval` or `hex-interval-mathlib`.
+
+Its initial provider contract, supported coefficient fragment, solver
+precedence, and acceptance programs are specified in
+[the interval SPEC](../../HexInterval/SPEC/hex-interval.md#specialized-algebraic-solvers-before-generic-propagation).

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -992,7 +992,7 @@ limitations to current LeanCert.
   `Lean.trustCompiler`, and generated
   `<decl>._native.native_decide.ax_*` dependencies from claimed kernel-only
   results, together with `sorryAx` and every project-local axiom forbidden by
-  the Axiom contract below.
+  the Axiom contract above.
 - `IntervalRat` represents only nonempty finite closed intervals. This library
   represents empty, open, half-open, and unbounded intervals.
 - The current LeanCert pin has a semantic router. Hex's distinct requirement is
@@ -1118,7 +1118,7 @@ feature-for-feature LeanCert parity.
 The migration claim is earned when that port reproduces or strengthens the
 selected mathematical statements with ordinary kernel-checked proofs and the
 performance comparison below. The transitive axiom set of every claimed ported
-theorem satisfies the full Axiom contract below: it excludes `sorryAx`, every
+theorem satisfies the full Axiom contract above: it excludes `sorryAx`, every
 project-local axiom, `Lean.ofReduceBool`, `Lean.trustCompiler`, and generated
 `*.native_decide.ax_*` declarations. A retained dependency that reintroduces
 one of them is recorded as explicit trust residue and prevents that theorem
@@ -1383,7 +1383,7 @@ These are `D7` fixtures unless marked otherwise.
 - `[D7]` an enclosure of `Real.exp (1 / 8)` of width at most
   `2 ^ (-100)` from a package-owned series and remainder theorem;
 - `[D7]` a 1,000-bit Machin-style pi enclosure, plus provider fallback and
-  agreement checks against a second elementary identity;
+  agreement checks against a second independently proved Machin-style identity;
 - `[D7]` a registered series with coefficients supplied entirely by its
   function package rather than the interval library;
 - `[D8]` the ordered 257-entry table of
@@ -1434,12 +1434,12 @@ release requirements:
   `7468 / 10000 < ∫ x in 0..1, Real.exp (-(x ^ 2))` and
   `∫ x in 0..1, Real.exp (-(x ^ 2)) < 7469 / 10000`, obtained from a checked
   adaptive quadrature or Taylor partition rather than samples;
-- `[hex-interval-algebraic]` isolate the unique real root of
+- `[D10 cross-library: hex-interval-algebraic]` isolate the unique real root of
   `x ^ 5 - x - 1` with `hex-real-roots`, then consume its certified interval
   in an interval goal;
-- `[hex-interval-algebraic]` return disjoint certified complex regions for all
+- `[D10 cross-library: hex-interval-algebraic]` return disjoint certified complex regions for all
   roots of `z ^ 5 - z + 1` with `hex-roots`; and
-- `[hex-interval-algebraic]` a mixed case in which exact algebraic candidate
+- `[D10 cross-library: hex-interval-algebraic]` a mixed case in which exact algebraic candidate
   intervals are refined or eliminated by independently registered sine or
   logarithm packages.
 

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -956,13 +956,20 @@ identifier order.
 
 The inspected LeanCert snapshot is
 [`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d).
-The inspected PNT+ snapshot is
-[`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f).
+The current PNT+ audit snapshot is
+[`21998bb`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/21998bb6196b56789f72a52656a781a75e134eb0).
 Its
-[lakefile](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/lakefile.toml)
-pins LeanCert `v4.32.1` at commit `87a21d7`. The differences from the inspected
-LeanCert main snapshot do not change the interval representation or trust
-findings below.
+[lakefile](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/lakefile.toml)
+pins LeanCert `v4.32.2.2` at commit
+[`58edbea`](https://github.com/alerad/leancert/tree/58edbea59458e9b010262238eaca27b6e0240dae).
+The earlier detailed source audit used PNT+ snapshot
+[`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f)
+and its LeanCert `v4.32.1` pin. The PNT+ `interval_decide` corpus is unchanged
+between those snapshots: the current tree still has 290 textual occurrences
+across the same 15 files. The newer LeanCert pin itself has substantial new
+router, integration, root-finding, algebraic, and trust-mode APIs. Those APIs
+are not silently claimed as PNT+ requirements here; replacing LeanCert beyond
+the API actually exercised by PNT+ requires a separate refreshed audit.
 
 The useful LeanCert ideas are a small semantic expression language, a golden
 soundness theorem, exact rational and dyadic evaluators, affine arithmetic,
@@ -996,17 +1003,88 @@ provide regression expectations for the trust boundary.
 
 PNT+ supplies the principal real-world corpus:
 
-At the pinned snapshot it contains about 280 actual `interval_decide`
-invocations across 15 files. Compatibility must therefore be tested by
+At the current pinned snapshot it contains exactly 280 actual `interval_decide`
+invocations, and 290 textual occurrences including ten explanatory prose or
+comment mentions, across 15 files. Compatibility must therefore be tested by
 maintaining source-pinned copies of representative statements and expression
 definitions with their LeanCert calls replaced. Merely importing an upstream
 declaration whose existing proof already used compiler trust does not test the
 replacement. A few translated README examples are also insufficient.
 
-- [LogTables.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/LogTables.lean)
+The replacement claim has a stronger full-corpus gate than the representative
+per-PR fixtures. A checked manifest records the PNT+ commit, LeanCert pin, every
+source occurrence's file and classification, the enclosing declaration of
+every actual invocation, and the generated batch families that one source
+occurrence expands into. Refreshing either upstream
+pin must regenerate and review that manifest. The release/local profile must
+then compile a source-pinned translation of every actual call site with the Hex
+tactic, or classify it explicitly as a redundant call or a known false target
+with an expected-failure enclosure. No entry may be discharged by importing a
+PNT+ theorem whose original proof already used LeanCert. The inventory must
+cover, at minimum:
+
+- all 141 `LogTables.lean` textual occurrences, of which 136 are actual tactic
+  invocations, including nested logarithms, large exponential arguments,
+  square roots, pi, and tails down to `10^-100`;
+- all 132 BKLNW textual occurrences across nine files, of which 128 are actual
+  tactic invocations, including the generated Table 10 and roughly 135-check
+  Table 12 batches rather than merely their outer tactic call sites; and
+- all 17 remaining textual occurrences, of which 16 are actual tactic
+  invocations, in `Dusart.lean`, `FKS2.lean`, `FKS2Cor23Cor14Tail.lean`,
+  `FKS2Floor/Cor22Floor.lean`, and `Goldbach.lean`.
+
+The complete 13,590-cell FKS2 stream is a generated workload in addition to
+this source-occurrence inventory. Passing all 290 textual sites while omitting
+that generated stream is not PNT+ compatibility. Conversely, importing the
+already-proved FKS2 result does not exercise the replacement. A drift check
+fails when the pinned PNT+ commit, LeanCert pin, occurrence inventory, or batch
+sizes change without an explicit SPEC and fixture refresh.
+
+`interval_decide` is not the complete PNT+ dependency surface. The same pinned
+tree has 60 actual `interval_auto` calls in `TMEEMT.lean` and
+`RosserSchoenfeld/RSPrimeLower.lean`. It also has sixteen direct LeanCert import
+statements covering these six public modules:
+
+- `LeanCert.Tactic.IntervalAuto`;
+- `LeanCert.CertifiedBounds.Li2`;
+- `LeanCert.CertifiedBounds.Chebyshev`;
+- `LeanCert.CertifiedBounds.BKLNW`;
+- `LeanCert.ANT`; and
+- `LeanCert.Validity.AffineCover`.
+
+The certified-bound imports are load-bearing theorem dependencies, not merely
+convenient tactic imports. PNT+ uses the Li(2) integrand, positivity, boundedness,
+value, and upper/lower integral results; Chebyshev and BKLNW certified bounds;
+the ANT expression evaluator and whole-interval checker behind the extended
+FKS2 table; and an affine-cover certificate for its small-`x` floor. Some of
+these current PNT+ glue proofs evaluate LeanCert checkers with `native_decide`.
+They therefore belong to the migration and trust audit even though they do not
+spell `interval_decide`.
+
+The compatibility manifest records every `interval_auto` invocation, every
+direct LeanCert import, every referenced LeanCert declaration, and every use of
+compiled evaluation to establish a LeanCert checker result. A replacement may
+classify a finite natural-number `interval_auto` call as ordinary arithmetic
+automation rather than route it through the real interval engine, but the
+translated source must no longer need the LeanCert import. Certified-bound and
+checker uses must be replaced by an ordinary Hex theorem whose full certificate
+is replayed in the kernel; copying only LeanCert's lightweight public interface
+while leaving its heavy verification outside the build is insufficient.
+
+Accordingly, the PNT+ replacement gate is a source-level build of the pinned
+PNT+ compatibility tree with the LeanCert dependency removed. All 280
+`interval_decide` calls, all 60 `interval_auto` calls, all six directly imported
+API modules, the generated table workloads, and the exact public theorem
+dependencies PNT+ consumes must be replaced or explicitly classified. This
+gate covers all LeanCert functionality PNT+ actually uses at the pinned
+commit. It does not
+claim to replace the many newer LeanCert algebraic, integration, optimization,
+or root-finding APIs that PNT+ does not import.
+
+- [LogTables.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/LogTables.lean)
   contains hundreds of `exp` and `log` point bounds, nested logs, large
   arguments, and errors down to about `10^-100`.
-- [BKLNW_a2_bounds.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_a2_bounds.lean)
+- [BKLNW_a2_bounds.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_a2_bounds.lean)
   contains finite sums whose certified upper limits reach 433.
 - BKLNW Table 10 contains sums of exponentials with small margins. PNT+ PR
   [#1510](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/pull/1510)
@@ -1018,12 +1096,12 @@ replacement. A few translated README examples are also insufficient.
   rows, at `b = log(5e10)`, `25`, `log(3.2e13)`, and `32`; at least one
   original row remains an expected-failure regression. These cases motivate
   certified normalization, batch replay, and useful failure bounds.
-- [Table4ExtCore.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4ExtCore.lean)
+- [Table4ExtCore.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4ExtCore.lean)
   defines the generic cell checker and its transport theorem. The 13,590 cells
   live in
-  [fourteen `Table4ExtData_*` shards](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables),
+  [fourteen `Table4ExtData_*` shards](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/FKS2Tables),
   thirteen of size 1,000 and one of size 590, and
-  [Table4Ext.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4Ext.lean)
+  [Table4Ext.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4Ext.lean)
   assembles them. Their manual exponential range-reduction rewrite motivates
   shared certificates, local effort, arbitrary partitions, and bounded object
   size. PNT+ PR
@@ -1284,7 +1362,7 @@ The committed compatibility subset is `D8` unless marked `D9`:
   shard in per-PR `ci`, and all 13,590 cells in the `local`/release profile;
 - mutated Taylor, range-reduction, fold, and split certificates, all rejected.
 
-The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/scripts/gen_log_tables.py)
+The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/scripts/gen_log_tables.py)
 is a model for optional untrusted candidate generation. The committed tests
 still exercise the native Lean planner and replay path.
 
@@ -1915,7 +1993,9 @@ shortcut, and no additional workflow or CI job is introduced.
 - Sicun Gao, Jeremy Avigad, and Edmund Clarke,
   [Delta-complete decision procedures for satisfiability over the reals](https://arxiv.org/abs/1204.3513).
 - [IntervalArithmetic.jl documentation](https://juliaintervals.github.io/IntervalArithmetic.jl/stable/).
-- LeanCert at
-  [`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d)
+- LeanCert at the original detailed-audit snapshot
+  [`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d),
+  the current PNT+ LeanCert pin
+  [`58edbea`](https://github.com/alerad/leancert/tree/58edbea59458e9b010262238eaca27b6e0240dae),
   and PNT+ at
-  [`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f).
+  [`21998bb`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/21998bb6196b56789f72a52656a781a75e134eb0).

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -777,14 +777,14 @@ array equality reduction across module boundaries.
 The BKLNW sums with upper limits 29, 37, 63, 145, 289, and 433 are the scaling
 ladder. Their index set is `Icc 3 N`, so they contain `N - 2` summands. The
 13,590-cell FKS2 corpus is the full `local` acceptance test used by the
-replacement and release gates. Per-PR
+migration and release criteria. Per-PR
 `core` uses a small deterministic sample, while per-PR `ci` uses a measured
 medium shard. The complete data is streamed from split JSONL fixtures; it is
 not generated as one enormous Lean source file. JSONL is only data transport:
 the runner turns each measured chunk into the same proof/checker invocation,
 elaborates it, kernel-replays it, and includes the resulting theorems in the
 axiom audit. A compiled pass over all cells without those proof obligations
-does not satisfy the replacement criterion.
+does not satisfy the migration criterion.
 
 ### Failure during replay
 
@@ -975,20 +975,29 @@ the API actually exercised by PNT+ requires a separate refreshed audit.
 The useful LeanCert ideas are a small semantic expression language, a golden
 soundness theorem, exact rational and dyadic evaluators, affine arithmetic,
 derivative-sign pruning, and untrusted discovery followed by checked
-evaluation. The replacement keeps those ideas.
+evaluation. The migration keeps those ideas.
 
-The following limitations become explicit requirements here.
+The following comparison originally described the `31579b5` snapshot. The
+current `58edbea` baseline adds a semantic router and explicit
+[`kernel`, `native`, and `auto` verification modes](https://github.com/alerad/leancert/blob/58edbea59458e9b010262238eaca27b6e0240dae/docs/architecture/trust-model.md).
+Comparative runs must use the exact PNT+ pin: its kernel mode is the
+trust-equivalent baseline, while its default native mode is reported separately
+as a compiler-trusting performance reference. The requirements below record
+the remaining design differences rather than attributing superseded
+limitations to current LeanCert.
 
-- Practical LeanCert tactics usually close checks with `native_decide`. The
-  pinned audit shows `Lean.ofReduceBool` plus a fresh generated declaration
-  matching `<decl>._native.native_decide.ax_*`; reliance on compiled
-  evaluation is the trust issue, while `Lean.trustCompiler` is not listed as a
-  direct dependency of those audited theorems. This library excludes all of
-  these paths.
+- At the older audit snapshot practical tactics usually closed checks with
+  `native_decide`. The current pin can instead require kernel reduction and
+  never fall back. Hex likewise excludes `Lean.ofReduceBool`,
+  `Lean.trustCompiler`, and generated
+  `<decl>._native.native_decide.ax_*` dependencies from claimed kernel-only
+  results.
 - `IntervalRat` represents only nonempty finite closed intervals. This library
   represents empty, open, half-open, and unbounded intervals.
-- Backend choice is mostly static. This library measures rule outcomes and can
-  escalate precision, form, rewriting, propagation, or subdivision.
+- The current LeanCert pin has a semantic router. Hex's distinct requirement is
+  independently registered package methods whose measured outcomes can drive
+  escalation among precision, form, rewriting, propagation, and subdivision;
+  comparative measurements include LeanCert's current router.
 - Raw-expression reification has bespoke cases and proof-tree growth for large
   sums. This library uses a shared program and generic fold certificates.
 - Manual rewrites and fixed midpoint depths are common downstream. This
@@ -1043,6 +1052,18 @@ drift check fails when the pinned PNT+ commit, LeanCert pin, toolchain, Mathlib
 revision, occurrence inventory, or batch sizes change without an explicit
 SPEC and fixture refresh.
 
+The committed inventory lives at
+`conformance-fixtures/HexIntervalMathlib/pnt-inventory.jsonl` and is generated
+by `scripts/interval/pnt_inventory.py`. The generator tokenizes pinned Lean
+sources, counts tactic identifiers outside comments and string literals,
+records their enclosing declarations, separately records raw textual matches,
+and expands the named generated-data families. Per-PR CI validates the
+committed manifest without network access. The `local`/release refresh command
+checks out the recorded upstream revisions, regenerates it, and requires a
+reviewed diff when any count, classification, toolchain, or batch size changes.
+These artifacts are D8 deliverables; the paths name the required interface and
+do not imply that they exist before that milestone.
+
 `interval_decide` is not the complete PNT+ dependency surface. The same pinned
 tree has 60 actual `interval_auto` calls in `TMEEMT.lean` and
 `RosserSchoenfeld/RSPrimeLower.lean`. It also has sixteen direct LeanCert import
@@ -1083,20 +1104,26 @@ change imports, consolidate repeated calls into shared lemmas, reorganize
 generated tables, and adjust proof statements through explicit equivalences.
 Its selected numerical corpus must include the logarithm and exponential tail
 families, the large BKLNW sums and recorded false targets, Table 10, Table 12,
-and the complete 13,590-cell FKS2 stream. Additional Li(2), integration,
-Chebyshev, affine-cover, or ANT cases are added when they support a claimed Hex
-workload; surveying them does not commit `HexInterval` to feature-for-feature
-LeanCert parity.
+and the complete 13,590-cell FKS2 stream. The selected BKLNW and FKS2 results
+must also replace the load-bearing roles of the old BKLNW certified bounds and
+ANT whole-interval checker, either by porting those results or by proving the
+same required statements through a different Hex route. This is an obligation
+on the resulting proof, not a requirement to clone either API. Additional
+Li(2), integration, Chebyshev, or affine-cover cases are added when they support
+a claimed Hex workload; surveying them does not commit `HexInterval` to
+feature-for-feature LeanCert parity.
 
 The migration claim is earned when that port reproduces or strengthens the
-selected mathematical statements with ordinary kernel-checked proofs, no
-`native_decide`, competitive total time and artifact size, and a simpler
-package/provider interface. A migrated result may not be discharged merely by
-importing an upstream theorem whose original proof already used compiler
-trust. PNT+ is allowed to adapt to Hex; Hex is not advertised as a drop-in
-LeanCert replacement. Newer LeanCert algebraic, integration, optimization,
-root-finding, and routing APIs remain outside the claim unless a later workload
-explicitly selects them.
+selected mathematical statements with ordinary kernel-checked proofs and the
+performance comparison below. The transitive axiom set of every claimed ported
+theorem excludes `Lean.ofReduceBool`, `Lean.trustCompiler`, and generated
+`*.native_decide.ax_*` declarations. A retained dependency that reintroduces
+one of them is recorded as explicit trust residue and prevents that theorem
+from satisfying the kernel-only migration claim; it cannot be hidden behind a
+textually `native_decide`-free wrapper. PNT+ is allowed to adapt to Hex; Hex is
+not advertised as a drop-in LeanCert replacement. Newer LeanCert algebraic,
+integration, optimization, root-finding, and routing APIs remain outside the
+claim unless a later workload explicitly selects them.
 
 - [LogTables.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/LogTables.lean)
   contains hundreds of `exp` and `log` point bounds, nested logs, large
@@ -1345,8 +1372,18 @@ These are `D7` fixtures unless marked otherwise.
 - `[D5]` `|sin x| ≤ 1` on an unbounded input;
 - a narrow sine interval crossing a critical point;
 - a large-argument sine that uses periodic reduction;
+- `[D7]` `Real.sin 10 < 0` through certified periodic reduction;
+- `[D7]` exact dyadic `0 < lo ≤ Real.cos (10 ^ 10) ≤ hi` with
+  `hi - lo ≤ 2 ^ (-80)`, including rejection of an off-by-one reduction;
 - exact `sin π = 0` through a symbolic rewrite;
 - `exp x ≥ 1 + x` on `[0,+∞)` through derivative monotonicity;
+- `[D7]` an enclosure of `Real.exp (1 / 8)` of width at most
+  `2 ^ (-100)` from a package-owned series and remainder theorem;
+- `[D7]` a 1,000-bit Machin-style pi enclosure and `[D8]` a Chudnovsky
+  enclosure at the same precision after its series identity is formalized;
+- `[D8]` the ordered 257-entry table of
+  `Real.log (1 + (i : ℝ) / 256)` for `i ≤ 256`, each entry of width at most
+  `2 ^ (-128)`, with shared coefficients and remainder proofs;
 - `x < 1 + x^3` on `[-1,+∞)`, matching the
   [pinned CoqInterval example](https://gitlab.inria.fr/coqinterval/interval/-/blob/dcdffc06d31e8e3646829b948c137ff140756b80/README.md#L334);
 - `sin x ≤ 0` on `[3.2,6.2]`;
@@ -1382,6 +1419,23 @@ The committed compatibility subset is `D8` unless marked `D9`:
 The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/scripts/gen_log_tables.py)
 is a model for optional untrusted candidate generation. The committed tests
 still exercise the compiled Lean planner and kernel replay path.
+
+### Integration and algebraic-provider clients
+
+These are later Mathlib-facing or cross-library fixtures rather than first
+release requirements:
+
+- `[D10]` the strict rational bounds
+  `7468 / 10000 < ∫ x in 0..1, Real.exp (-(x ^ 2))` and
+  `∫ x in 0..1, Real.exp (-(x ^ 2)) < 7469 / 10000`, obtained from a checked
+  adaptive quadrature or Taylor partition rather than samples;
+- `[D10 integration]` isolate the unique real root of `x ^ 5 - x - 1` with
+  `hex-real-roots`, then consume its certified interval in an interval goal;
+- `[D10 integration]` return disjoint certified complex regions for all roots
+  of `z ^ 5 - z + 1` with `hex-roots`; and
+- `[D10 integration]` a mixed case in which exact algebraic candidate intervals
+  are refined or eliminated by independently registered sine or logarithm
+  packages.
 
 ### Zulip and downstream challenge sets
 
@@ -1792,12 +1846,14 @@ validation, are:
 - the complete 13,590-cell FKS2 `local` run as a migration criterion,
   with the same per-cell metrics and a reported total wall-clock time.
 
-The LeanCert version pinned by PNT+ is a migration baseline. Hex is not called
-an obviously better choice for the selected PNT+ numerical workload until the
-source-pinned port above passes the stricter axiom audit and improves either
-total time or artifact size on every large tier without a serious regression
-on the other measure. This is a mathematical-workload and engineering claim,
-not source compatibility or feature-for-feature parity.
+The LeanCert version pinned by PNT+ is the migration baseline. The claim is
+factual: Hex reproduces or strengthens the selected PNT+ mathematical corpus
+with the transitive kernel-only trust set above, and on every large tier
+improves either total time or artifact size without a serious regression on the
+other measure. Both LeanCert's current kernel route and its default native
+route are reported, so the trust improvement and the performance comparison
+remain distinct. This is a mathematical-workload and engineering claim, not
+source compatibility or feature-for-feature parity.
 
 ## Development order
 
@@ -1860,14 +1916,13 @@ wide answers that masquerade as the intended algorithm.
 
 `D1`–`D10` is a dependency order, not ten uniform release milestones. The first
 public release target is D1–D8 plus the basic arbitrary/function-suggested
-split path and small per-PR D9 samples. Claiming that Hex is the better choice
-for PNT+'s selected numerical workload additionally requires the source-pinned
-migration profile above, including the complete FKS2 stream and whichever D9
-contractor prototypes those cases actually need. It does not require
-exact-source compatibility or replacement of every LeanCert feature PNT+
-currently imports. D10 is comparative follow-on work and does not block the
-claim unless the measured migration corpus demonstrates that one of its
-methods is necessary.
+split path and small per-PR D9 samples. The PNT+ migration claim additionally
+requires the source-pinned profile and comparison above, including the complete
+FKS2 stream and whichever D9 contractor prototypes those cases actually need.
+It does not require exact-source compatibility or replacement of every
+LeanCert feature PNT+ currently imports. D10 is comparative follow-on work and
+does not block the claim unless the measured migration corpus demonstrates
+that one of its methods is necessary.
 
 Verified raster graphing begins only after the `interval_bound` and batch APIs
 are stable; certified ODE integration is a later client of D6/D10 machinery.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -964,10 +964,11 @@ pins LeanCert `v4.32.2.2` at commit
 [`58edbea`](https://github.com/alerad/leancert/tree/58edbea59458e9b010262238eaca27b6e0240dae).
 The earlier detailed source audit used PNT+ snapshot
 [`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f)
-and its LeanCert `v4.32.1` pin. The PNT+ `interval_decide` corpus is unchanged
-between those snapshots: the current tree still has 290 textual occurrences
-across the same 15 files. The newer LeanCert pin itself has substantial new
-router, integration, root-finding, algebraic, and trust-mode APIs. Those APIs
+and its LeanCert `v4.32.1` pin. The audited `interval_decide` totals and file
+set are unchanged between those snapshots: the current tree still has 290
+textual occurrences across the same 15 files. The newer LeanCert pin has
+substantial new router, integration, root-finding, algebraic, and trust-mode
+APIs. Those APIs
 are not silently claimed as PNT+ requirements here; replacing LeanCert beyond
 the API actually exercised by PNT+ requires a separate refreshed audit.
 
@@ -1005,23 +1006,24 @@ PNT+ supplies the principal real-world corpus:
 
 At the current pinned snapshot it contains exactly 280 actual `interval_decide`
 invocations, and 290 textual occurrences including ten explanatory prose or
-comment mentions, across 15 files. Compatibility must therefore be tested by
-maintaining source-pinned copies of representative statements and expression
-definitions with their LeanCert calls replaced. Merely importing an upstream
-declaration whose existing proof already used compiler trust does not test the
-replacement. A few translated README examples are also insufficient.
+comment mentions, across 15 files. These counts define the audit surface, not a
+promise to clone every LeanCert API or preserve PNT+ source syntax. A checked
+manifest records the PNT+ commit, LeanCert pin, Lean toolchain and Mathlib
+revision, every source occurrence's file and enclosing declaration, and the
+generated batch families that one source occurrence expands into. Every entry
+is classified as one of:
 
-The replacement claim has a stronger full-corpus gate than the representative
-per-PR fixtures. A checked manifest records the PNT+ commit, LeanCert pin, every
-source occurrence's file and classification, the enclosing declaration of
-every actual invocation, and the generated batch families that one source
-occurrence expands into. Refreshing either upstream
-pin must regenerate and review that manifest. The release/local profile must
-then compile a source-pinned translation of every actual call site with the Hex
-tactic, or classify it explicitly as a redundant call or a known false target
-with an expected-failure enclosure. No entry may be discharged by importing a
-PNT+ theorem whose original proof already used LeanCert. The inventory must
-cover, at minimum:
+- accepted unchanged by a Hex frontend;
+- accepted after a documented PNT+ source rewrite or proof reorganization;
+- replaced by a stronger shared Hex theorem or numerical provider;
+- unrelated to the interval migration and retained through another dependency;
+  or
+- redundant, malformed, or a known false target with an expected-failure
+  enclosure.
+
+Refreshing an upstream pin must regenerate and review the manifest. The
+inventory prevents blind spots; it does not make exact-source compatibility a
+release criterion. It must cover, at minimum:
 
 - all 141 `LogTables.lean` textual occurrences, of which 136 are actual tactic
   invocations, including nested logarithms, large exponential arguments,
@@ -1034,11 +1036,12 @@ cover, at minimum:
   `FKS2Floor/Cor22Floor.lean`, and `Goldbach.lean`.
 
 The complete 13,590-cell FKS2 stream is a generated workload in addition to
-this source-occurrence inventory. Passing all 290 textual sites while omitting
-that generated stream is not PNT+ compatibility. Conversely, importing the
-already-proved FKS2 result does not exercise the replacement. A drift check
-fails when the pinned PNT+ commit, LeanCert pin, occurrence inventory, or batch
-sizes change without an explicit SPEC and fixture refresh.
+this source-occurrence inventory. Counting the 280 actual tactic invocations
+while omitting that generated stream misses the main batch workload.
+Conversely, importing the already-proved FKS2 result does not exercise Hex. A
+drift check fails when the pinned PNT+ commit, LeanCert pin, toolchain, Mathlib
+revision, occurrence inventory, or batch sizes change without an explicit
+SPEC and fixture refresh.
 
 `interval_decide` is not the complete PNT+ dependency surface. The same pinned
 tree has 60 actual `interval_auto` calls in `TMEEMT.lean` and
@@ -1058,28 +1061,42 @@ value, and upper/lower integral results; Chebyshev and BKLNW certified bounds;
 the ANT expression evaluator and whole-interval checker behind the extended
 FKS2 table; and an affine-cover certificate for its small-`x` floor. Some of
 these current PNT+ glue proofs evaluate LeanCert checkers with `native_decide`.
-They therefore belong to the migration and trust audit even though they do not
-spell `interval_decide`.
+They therefore belong to the audit even though they do not spell
+`interval_decide`. `LeanCert.Tactic.IntervalAuto` re-exports both
+`interval_decide` and `interval_auto`, so the six-module import list covers the
+tactic entry points as well as the certified-bound interfaces.
 
 The compatibility manifest records every `interval_auto` invocation, every
 direct LeanCert import, every referenced LeanCert declaration, and every use of
-compiled evaluation to establish a LeanCert checker result. A replacement may
+compiled evaluation to establish a LeanCert checker result. A migration may
 classify a finite natural-number `interval_auto` call as ordinary arithmetic
-automation rather than route it through the real interval engine, but the
-translated source must no longer need the LeanCert import. Certified-bound and
-checker uses must be replaced by an ordinary Hex theorem whose full certificate
-is replayed in the kernel; copying only LeanCert's lightweight public interface
-while leaving its heavy verification outside the build is insufficient.
+automation rather than route it through the real interval engine. A direct
+certified-bound dependency may remain outside the interval migration or be
+replaced by a differently stated shared theorem. When a migrated PNT+ theorem
+mentions a LeanCert-specific definition, the port must either restate the
+theorem in PNT+ vocabulary or prove the required equivalence or implication;
+Hex need not mimic the old API.
 
-Accordingly, the PNT+ replacement gate is a source-level build of the pinned
-PNT+ compatibility tree with the LeanCert dependency removed. All 280
-`interval_decide` calls, all 60 `interval_auto` calls, all six directly imported
-API modules, the generated table workloads, and the exact public theorem
-dependencies PNT+ consumes must be replaced or explicitly classified. This
-gate covers all LeanCert functionality PNT+ actually uses at the pinned
-commit. It does not
-claim to replace the many newer LeanCert algebraic, integration, optimization,
-or root-finding APIs that PNT+ does not import.
+The PNT+ migration criterion is therefore a source-pinned port, not a build of
+the upstream source with tactic names mechanically substituted. The port may
+change imports, consolidate repeated calls into shared lemmas, reorganize
+generated tables, and adjust proof statements through explicit equivalences.
+Its selected numerical corpus must include the logarithm and exponential tail
+families, the large BKLNW sums and recorded false targets, Table 10, Table 12,
+and the complete 13,590-cell FKS2 stream. Additional Li(2), integration,
+Chebyshev, affine-cover, or ANT cases are added when they support a claimed Hex
+workload; surveying them does not commit `HexInterval` to feature-for-feature
+LeanCert parity.
+
+The migration claim is earned when that port reproduces or strengthens the
+selected mathematical statements with ordinary kernel-checked proofs, no
+`native_decide`, competitive total time and artifact size, and a simpler
+package/provider interface. A migrated result may not be discharged merely by
+importing an upstream theorem whose original proof already used compiler
+trust. PNT+ is allowed to adapt to Hex; Hex is not advertised as a drop-in
+LeanCert replacement. Newer LeanCert algebraic, integration, optimization,
+root-finding, and routing APIs remain outside the claim unless a later workload
+explicitly selects them.
 
 - [LogTables.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/PrimeNumberTheoremAnd/IEANTN/LogTables.lean)
   contains hundreds of `exp` and `log` point bounds, nested logs, large
@@ -1364,7 +1381,7 @@ The committed compatibility subset is `D8` unless marked `D9`:
 
 The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/21998bb6196b56789f72a52656a781a75e134eb0/scripts/gen_log_tables.py)
 is a model for optional untrusted candidate generation. The committed tests
-still exercise the native Lean planner and replay path.
+still exercise the compiled Lean planner and kernel replay path.
 
 ### Zulip and downstream challenge sets
 
@@ -1772,13 +1789,15 @@ validation, are:
 - the per-PR FKS2 shard: bounded per-cell certificate size, shared static data,
   and no theorem or object-file blowup proportional to duplicated
   transcendental tables;
-- the complete 13,590-cell FKS2 `local` run as a replacement/release criterion,
+- the complete 13,590-cell FKS2 `local` run as a migration criterion,
   with the same per-cell metrics and a reported total wall-clock time.
 
-The LeanCert version pinned by PNT+ is a migration baseline. The new tactic is
-not declared a replacement until it proves the selected downstream corpus,
-passes the stricter axiom audit, and improves either total time or artifact
-size on every large tier without a serious regression on the other measure.
+The LeanCert version pinned by PNT+ is a migration baseline. Hex is not called
+an obviously better choice for the selected PNT+ numerical workload until the
+source-pinned port above passes the stricter axiom audit and improves either
+total time or artifact size on every large tier without a serious regression
+on the other measure. This is a mathematical-workload and engineering claim,
+not source compatibility or feature-for-feature parity.
 
 ## Development order
 
@@ -1818,15 +1837,16 @@ size on every large tier without a serious regression on the other measure.
 7. **D7 — elementary portfolio.** Add `π`, `exp`, `log`, square root, `atan`,
    positive-base real powers, certified range reduction, and symbolic special
    values.
-8. **D8 — large certificates.** Add production chunked folds and the PNT+
-   point and sum corpus. Remove every need for a `native_decide` proof path in
-   the selected compatibility files.
+8. **D8 — large certificates.** Add production chunked folds and the selected
+   PNT+ point and sum migration corpus. Remove every need for a
+   `native_decide` proof path in the ported files, without requiring unchanged
+   PNT+ tactic syntax or unrelated LeanCert APIs.
 9. **D9 — branch search.** Add arbitrary and function-suggested subdivision,
    plus the Table 10, Table 12, and tiered FKS2 tests. Compare split variable,
    point, and node-order strategies rather than coupling them. Local shaving,
    interval Newton, the complete IMO partition, the full FKS2 run, and small
    translated RealPaver benchmarks are separately labeled prototype or
-   replacement-acceptance subtargets within this milestone.
+   migration-acceptance subtargets within this milestone.
 10. **D10 — advanced dependency control.** Compare Bernstein,
     second-order, affine, and Taylor-model methods, plus gain-adaptive ACID-like
     contractor scheduling, on the challenge corpus before selecting further
@@ -1838,18 +1858,20 @@ Every stage has real executable definitions and tests for its advertised
 surface. Unimplemented methods remain absent rather than returning ceremonial
 wide answers that masquerade as the intended algorithm.
 
-`D1`–`D10` is a dependency order, not ten uniform release gates. The first
+`D1`–`D10` is a dependency order, not ten uniform release milestones. The first
 public release target is D1–D8 plus the basic arbitrary/function-suggested
-split path and small per-PR D9 samples. Claiming that the tactic replaces
-LeanCert additionally requires the selected full PNT+ local profile, including
-the complete FKS2 stream and whichever D9 contractor prototypes those cases
-actually need. D10 is comparative follow-on work and does not block either
-claim unless the measured replacement corpus demonstrates that one of its
+split path and small per-PR D9 samples. Claiming that Hex is the better choice
+for PNT+'s selected numerical workload additionally requires the source-pinned
+migration profile above, including the complete FKS2 stream and whichever D9
+contractor prototypes those cases actually need. It does not require
+exact-source compatibility or replacement of every LeanCert feature PNT+
+currently imports. D10 is comparative follow-on work and does not block the
+claim unless the measured migration corpus demonstrates that one of its
 methods is necessary.
 
 Verified raster graphing begins only after the `interval_bound` and batch APIs
 are stable; certified ODE integration is a later client of D6/D10 machinery.
-Neither application is a release or replacement gate above.
+Neither application is a release or migration criterion above.
 
 ## Open design questions
 

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -954,7 +954,7 @@ identifier order.
 
 ### LeanCert and PNT+
 
-The inspected LeanCert snapshot is
+The originally inspected LeanCert snapshot is
 [`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d).
 The current PNT+ audit snapshot is
 [`21998bb`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/21998bb6196b56789f72a52656a781a75e134eb0).
@@ -991,7 +991,8 @@ limitations to current LeanCert.
   never fall back. Hex likewise excludes `Lean.ofReduceBool`,
   `Lean.trustCompiler`, and generated
   `<decl>._native.native_decide.ax_*` dependencies from claimed kernel-only
-  results.
+  results, together with `sorryAx` and every project-local axiom forbidden by
+  the Axiom contract below.
 - `IntervalRat` represents only nonempty finite closed intervals. This library
   represents empty, open, half-open, and unbounded intervals.
 - The current LeanCert pin has a semantic router. Hex's distinct requirement is
@@ -1054,15 +1055,16 @@ SPEC and fixture refresh.
 
 The committed inventory lives at
 `conformance-fixtures/HexIntervalMathlib/pnt-inventory.jsonl` and is generated
-by `scripts/interval/pnt_inventory.py`. The generator tokenizes pinned Lean
+by `scripts/maintenance/pnt_inventory.py`. The generator tokenizes pinned Lean
 sources, counts tactic identifiers outside comments and string literals,
 records their enclosing declarations, separately records raw textual matches,
-and expands the named generated-data families. Per-PR CI validates the
-committed manifest without network access. The `local`/release refresh command
-checks out the recorded upstream revisions, regenerates it, and requires a
-reviewed diff when any count, classification, toolchain, or batch size changes.
-These artifacts are D8 deliverables; the paths name the required interface and
-do not imply that they exist before that milestone.
+and expands the named generated-data families. Per-PR CI and the mandatory
+release profile validate the committed manifest without network access. A
+separate maintainer refresh command checks out the recorded upstream revisions,
+regenerates it, and requires a reviewed diff when any count, classification,
+toolchain, or batch size changes. These artifacts are D8 deliverables; the
+paths name the required interface and do not imply that they exist before that
+milestone.
 
 `interval_decide` is not the complete PNT+ dependency surface. The same pinned
 tree has 60 actual `interval_auto` calls in `TMEEMT.lean` and
@@ -1116,11 +1118,12 @@ feature-for-feature LeanCert parity.
 The migration claim is earned when that port reproduces or strengthens the
 selected mathematical statements with ordinary kernel-checked proofs and the
 performance comparison below. The transitive axiom set of every claimed ported
-theorem excludes `Lean.ofReduceBool`, `Lean.trustCompiler`, and generated
+theorem satisfies the full Axiom contract below: it excludes `sorryAx`, every
+project-local axiom, `Lean.ofReduceBool`, `Lean.trustCompiler`, and generated
 `*.native_decide.ax_*` declarations. A retained dependency that reintroduces
 one of them is recorded as explicit trust residue and prevents that theorem
 from satisfying the kernel-only migration claim; it cannot be hidden behind a
-textually `native_decide`-free wrapper. PNT+ is allowed to adapt to Hex; Hex is
+textually clean wrapper. PNT+ is allowed to adapt to Hex; Hex is
 not advertised as a drop-in LeanCert replacement. Newer LeanCert algebraic,
 integration, optimization, root-finding, and routing APIs remain outside the
 claim unless a later workload explicitly selects them.
@@ -1379,8 +1382,10 @@ These are `D7` fixtures unless marked otherwise.
 - `exp x ≥ 1 + x` on `[0,+∞)` through derivative monotonicity;
 - `[D7]` an enclosure of `Real.exp (1 / 8)` of width at most
   `2 ^ (-100)` from a package-owned series and remainder theorem;
-- `[D7]` a 1,000-bit Machin-style pi enclosure and `[D8]` a Chudnovsky
-  enclosure at the same precision after its series identity is formalized;
+- `[D7]` a 1,000-bit Machin-style pi enclosure, plus provider fallback and
+  agreement checks against a second elementary identity;
+- `[D7]` a registered series with coefficients supplied entirely by its
+  function package rather than the interval library;
 - `[D8]` the ordered 257-entry table of
   `Real.log (1 + (i : ℝ) / 256)` for `i ≤ 256`, each entry of width at most
   `2 ^ (-128)`, with shared coefficients and remainder proofs;
@@ -1420,7 +1425,7 @@ The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberThe
 is a model for optional untrusted candidate generation. The committed tests
 still exercise the compiled Lean planner and kernel replay path.
 
-### Integration and algebraic-provider clients
+### Quadrature and algebraic-provider clients
 
 These are later Mathlib-facing or cross-library fixtures rather than first
 release requirements:
@@ -1429,13 +1434,14 @@ release requirements:
   `7468 / 10000 < ∫ x in 0..1, Real.exp (-(x ^ 2))` and
   `∫ x in 0..1, Real.exp (-(x ^ 2)) < 7469 / 10000`, obtained from a checked
   adaptive quadrature or Taylor partition rather than samples;
-- `[D10 integration]` isolate the unique real root of `x ^ 5 - x - 1` with
-  `hex-real-roots`, then consume its certified interval in an interval goal;
-- `[D10 integration]` return disjoint certified complex regions for all roots
-  of `z ^ 5 - z + 1` with `hex-roots`; and
-- `[D10 integration]` a mixed case in which exact algebraic candidate intervals
-  are refined or eliminated by independently registered sine or logarithm
-  packages.
+- `[hex-interval-algebraic]` isolate the unique real root of
+  `x ^ 5 - x - 1` with `hex-real-roots`, then consume its certified interval
+  in an interval goal;
+- `[hex-interval-algebraic]` return disjoint certified complex regions for all
+  roots of `z ^ 5 - z + 1` with `hex-roots`; and
+- `[hex-interval-algebraic]` a mixed case in which exact algebraic candidate
+  intervals are refined or eliminated by independently registered sine or
+  logarithm packages.
 
 ### Zulip and downstream challenge sets
 
@@ -1472,6 +1478,8 @@ outward regularization, and certification of a local maximum.
 The following specialized computations are stretch tests, not baseline
 requirements for a general rule:
 
+- a Chudnovsky pi enclosure after the Ramanujan-type identity connecting its
+  series to `Real.pi` has been formalized;
 - exact-`π` rational approximations following the
   [`exact-pi` interface](https://hackage.haskell.org/package/exact-pi-0.5.0.2/docs/Data-ExactPi.html#v:rationalApproximations);
 - `log 2` at 30,000 and one million decimal digits, using binary splitting and
@@ -1824,8 +1832,9 @@ The test harness records four times separately:
 4. incremental rebuild of a file importing the finished theorem.
 
 It also records allocations, program nodes, accepted actions, rule calls,
-splits, leaves, maximum endpoint heights, certificate bytes, proof nodes, and
-object-file size.
+splits, leaves, maximum endpoint heights, certificate bytes, proof nodes,
+object-file size, cache hits and reused terms, and incremental work when an
+existing series or table is extended to higher precision.
 
 Initial targets, to be confirmed on the reference host during performance
 validation, are:
@@ -1850,10 +1859,12 @@ The LeanCert version pinned by PNT+ is the migration baseline. The claim is
 factual: Hex reproduces or strengthens the selected PNT+ mathematical corpus
 with the transitive kernel-only trust set above, and on every large tier
 improves either total time or artifact size without a serious regression on the
-other measure. Both LeanCert's current kernel route and its default native
-route are reported, so the trust improvement and the performance comparison
-remain distinct. This is a mathematical-workload and engineering claim, not
-source compatibility or feature-for-feature parity.
+other measure, compared with LeanCert's trust-equivalent kernel route. A
+campaign fixes the permitted regression threshold before measuring results;
+the initial threshold is 20 percent. LeanCert's default native-route figures
+are reported as context, not used as the pass/fail baseline, so trust and
+performance remain distinct. This is a mathematical-workload and engineering
+claim, not source compatibility or feature-for-feature parity.
 
 ## Development order
 
@@ -1894,9 +1905,9 @@ source compatibility or feature-for-feature parity.
    positive-base real powers, certified range reduction, and symbolic special
    values.
 8. **D8 — large certificates.** Add production chunked folds and the selected
-   PNT+ point and sum migration corpus. Remove every need for a
-   `native_decide` proof path in the ported files, without requiring unchanged
-   PNT+ tactic syntax or unrelated LeanCert APIs.
+   PNT+ point and sum migration corpus. Ensure every claimed ported theorem's
+   transitive axiom set excludes everything forbidden by the Axiom contract,
+   without requiring unchanged PNT+ tactic syntax or unrelated LeanCert APIs.
 9. **D9 — branch search.** Add arbitrary and function-suggested subdivision,
    plus the Table 10, Table 12, and tiered FKS2 tests. Compare split variable,
    point, and node-order strategies rather than coupling them. Local shaving,

--- a/libraries.yml
+++ b/libraries.yml
@@ -555,6 +555,11 @@ libraries:
     done_through: 0
     status: planned
     proof_probes: [bench/HexIntervalMathlib]
+  HexIntervalAlgebraic:
+    deps: [HexIntervalMathlib, HexRealRootsMathlib, HexRootsMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned
   HexResultantMathlib:
     deps: [HexResultant, HexPolyMathlib]
     mathlib: true

--- a/progress/20260812T020310Z.md
+++ b/progress/20260812T020310Z.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Added an example-driven numerical roadmap to the interval SPEC on current
+  `main`, independently of the experimental function-instantiation stack.
+- Made large-argument trigonometric range reduction, pluggable certified
+  constants, package-owned series, high-accuracy logarithm tables, certified
+  integral bounds, and specialized root-isolator dispatch explicit acceptance
+  programs.
+- Required purely polynomial fragments to prefer the existing Hex real and
+  complex root-isolation engines instead of duplicating their algorithms as
+  generic interval propagation.
+
+# Current frontier
+
+The SPEC now treats the generic interval engine as a coordinator for
+replaceable numerical and algebraic providers. The constant, series,
+quadrature, table, and root-isolator adapters remain to be implemented.
+
+# Next step
+
+Land the SPEC-only PR, then drive the next numerical vertical from
+`Real.sin 10 < 0`: a replaceable certified pi provider, exact periodic range
+reduction, and a package-owned local sine enclosure.
+
+# Blockers
+
+None for the roadmap change.

--- a/progress/20260812T020310Z.md
+++ b/progress/20260812T020310Z.md
@@ -9,12 +9,21 @@
 - Required purely polynomial fragments to prefer the existing Hex real and
   complex root-isolation engines instead of duplicating their algorithms as
   generic interval propagation.
+- Refreshed the PNT+/LeanCert usage audit to the current PNT+ snapshot and
+  strengthened compatibility to a source-pinned full-call-site and generated-
+  batch migration manifest.
+- Expanded that gate beyond `interval_decide` to PNT+'s `interval_auto` calls,
+  six directly imported LeanCert API modules, certified-bound theorem uses,
+  and compiled checker evaluation.
 
 # Current frontier
 
 The SPEC now treats the generic interval engine as a coordinator for
 replaceable numerical and algebraic providers. The constant, series,
 quadrature, table, and root-isolator adapters remain to be implemented.
+PNT+ replacement is explicitly gated on every current call site plus the full
+generated FKS2 stream and direct theorem dependency, not only a representative
+sample.
 
 # Next step
 

--- a/progress/20260812T020310Z.md
+++ b/progress/20260812T020310Z.md
@@ -10,20 +10,20 @@
   complex root-isolation engines instead of duplicating their algorithms as
   generic interval propagation.
 - Refreshed the PNT+/LeanCert usage audit to the current PNT+ snapshot and
-  strengthened compatibility to a source-pinned full-call-site and generated-
-  batch migration manifest.
-- Expanded that gate beyond `interval_decide` to PNT+'s `interval_auto` calls,
-  six directly imported LeanCert API modules, certified-bound theorem uses,
-  and compiled checker evaluation.
+  defined a source-pinned migration inventory covering call sites, imports,
+  theorem dependencies, and generated batches without requiring API parity.
+- Distinguished complete dependency classification from the selected hard
+  numerical workloads that support an "obviously better" migration claim.
 
 # Current frontier
 
 The SPEC now treats the generic interval engine as a coordinator for
 replaceable numerical and algebraic providers. The constant, series,
 quadrature, table, and root-isolator adapters remain to be implemented.
-PNT+ replacement is explicitly gated on every current call site plus the full
-generated FKS2 stream and direct theorem dependency, not only a representative
-sample.
+PNT+ may reorganize its proofs, consolidate repeated checks, and retain
+unrelated dependencies. The migration claim requires ordinary kernel proofs,
+the complete FKS2 stream and other selected hard workloads, and competitive
+time/artifact size rather than exact-source LeanCert compatibility.
 
 # Next step
 

--- a/progress/20260812T020310Z.md
+++ b/progress/20260812T020310Z.md
@@ -13,7 +13,7 @@
   defined a source-pinned migration inventory covering call sites, imports,
   theorem dependencies, and generated batches without requiring API parity.
 - Distinguished complete dependency classification from the selected hard
-  numerical workloads that support an "obviously better" migration claim.
+  numerical workloads that support a measurable trust and performance claim.
 
 # Current frontier
 

--- a/progress/20260812T024909Z.md
+++ b/progress/20260812T024909Z.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Reframed the PNT+/LeanCert survey as a complete dependency inventory plus a
+  selected hard migration corpus, rather than source-compatible API parity.
+- Required transitive kernel-only trust for claimed migrated theorems and tied
+  the mandatory BKLNW and FKS2 workloads to their load-bearing checker roles.
+- Updated the comparison baseline for LeanCert's current router and explicit
+  kernel/native/auto modes.
+- Put Machin before Chudnovsky, narrowed root-isolator dispatch to its actual
+  univariate coefficient domain, named the planned algebraic integration
+  library, and added the roadmap examples to the companion fixture corpus.
+
+# Current frontier
+
+The numerical roadmap and PNT+ migration criterion are internally aligned. The
+PR remains SPEC-only; the inventory generator, fixtures, providers, and
+integration library are milestone deliverables rather than implementations in
+this change.
+
+# Next step
+
+Finish exact-head review and CI, then merge the roadmap PR. Implementation
+should begin with the Machin-backed large-argument `Real.sin 10` vertical.
+
+# Blockers
+
+None in the SPEC text.

--- a/progress/20260812T024909Z.md
+++ b/progress/20260812T024909Z.md
@@ -9,6 +9,9 @@
 - Put Machin before Chudnovsky, narrowed root-isolator dispatch to its actual
   univariate coefficient domain, named the planned algebraic integration
   library, and added the roadmap examples to the companion fixture corpus.
+- Added `hex-interval-algebraic` to the machine-readable library graph, made
+  Chudnovsky a post-release stretch target, and made the PNT+ trust and
+  performance comparisons fully transitive and route-specific.
 
 # Current frontier
 


### PR DESCRIPTION
## Summary

- make large-argument `Real.sin 10` and `Real.cos (10^10)` explicit range-reduction acceptance programs
- specify replaceable certified constant providers, beginning with an elementary Machin-style pi proof and adding Chudnovsky after its series identity is formalized
- add package-owned series, high-accuracy log tables, and certified integral-bound targets
- require supported root problems to dispatch to the existing Hex real/complex isolators through the planned `hex-interval-algebraic` integration library, while `hex-rcf` keeps complete univariate real-closed-field sentences
- refresh the PNT+/LeanCert audit to PNT+ `21998bb` and LeanCert pin `58edbea`, including its current router and kernel/native/auto trust modes
- inventory all 280 `interval_decide` calls, 60 `interval_auto` calls, six directly imported LeanCert API modules, theorem dependencies, and generated table workloads so migration gaps remain visible
- define a workload-driven PNT+ migration criterion: PNT+ may rewrite and reorganize proofs, consolidate repeated checks, and retain unrelated dependencies; Hex must handle the selected hard numerical corpus, including the complete 13,590-cell FKS2 stream, with transitively kernel-only proofs and a measured trust/performance advantage
- explicitly reject source-compatible or feature-for-feature LeanCert parity as a requirement
- define the common untrusted-candidate / kernel-checked provider boundary

## Validation

- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/release/check_trust_surface.py`
- `python3 scripts/check_phase4.py`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `git diff --check`

This is SPEC-only and targets current `main`, independent of the experimental interval PR stack.
