### PR TITLE
feat(interval): compose mixed function instantiation

### DIFF
--- a/HexInterval/Experiment/MixedInstantiation.lean
+++ b/HexInterval/Experiment/MixedInstantiation.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.MixedFunctions
+public import HexInterval.Experiment.SemanticReplay
+
+@[expose] public section
+
+/-!
+# A mixed-function instantiation canary
+
+This experiment starts from `exp (sin (-x))`. Direct sine propagation is
+disabled when the sine input is a negation node. A structural matcher instead
+adds `sin x` and `-(sin x)`, then records the oddness equality. Independent
+sine and negation propagators establish the shared unit-range fact, equality
+transport returns it to `sin (-x)`, and exponential propagation consumes it.
+-/
+
+namespace Hex.Interval.Experiment.MixedInstantiation
+
+open Propagator PayloadArena
+
+abbrev Bound := MixedFunctions.Bound
+
+def factDomain : FactDomain Bound := MixedFunctions.factDomain
+
+def real : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "mixed-instantiation.source" }
+def negationKey : OpKey := { name := "mixed-instantiation.negation" }
+def sineKey : OpKey := { name := "mixed-instantiation.sine" }
+def expKey : OpKey := { name := "mixed-instantiation.exp" }
+
+def negationRuleKey : RuleKey := { name := "mixed-instantiation.negation.unit" }
+def sineRuleKey : RuleKey := { name := "mixed-instantiation.sine.unit" }
+def oddnessRuleKey : RuleKey := { name := "mixed-instantiation.sine.oddness" }
+def expRuleKey : RuleKey := { name := "mixed-instantiation.exp.at-most-three" }
+
+def sourceOperation : Operation :=
+  { key := sourceKey, inputs := [], output := real }
+
+def negationOperation : Operation :=
+  { key := negationKey, inputs := [real], output := real }
+
+def sineOperation : Operation :=
+  { key := sineKey, inputs := [real], output := real }
+
+def expOperation : Operation :=
+  { key := expKey, inputs := [real], output := real }
+
+def operations : Array Operation :=
+  #[sourceOperation, negationOperation, sineOperation, expOperation]
+
+def node (index : Nat) : NodeId := { index }
+def payload (index : Nat) : PayloadId := { index }
+
+def sourceInstruction : Node :=
+  { domain := real, op := { index := 0 }, args := [] }
+
+def negatedSourceInstruction : Node :=
+  { domain := real, op := { index := 1 }, args := [node 0] }
+
+def sineNegatedSourceInstruction : Node :=
+  { domain := real, op := { index := 2 }, args := [node 1] }
+
+def expSineInstruction : Node :=
+  { domain := real, op := { index := 3 }, args := [node 2] }
+
+def baseProgram : Program :=
+  { operations
+    nodes :=
+      #[sourceInstruction, negatedSourceInstruction,
+        sineNegatedSourceInstruction, expSineInstruction] }
+
+/-- The caller-visible graph and target before structural instantiation. -/
+def checkerInput : SemanticReplay.CheckerInput Bound :=
+  { baseProgram
+    initialFacts := #[.all, .all, .all, .all]
+    target := { node := node 3, fact := .atMostThree } }
+
+def sineSourceInstruction : Node :=
+  { domain := real, op := { index := 2 }, args := [node 0] }
+
+def negatedSineInstruction : Node :=
+  { domain := real, op := { index := 1 }, args := [node 4] }
+
+def extendedProgram : Program :=
+  { operations
+    nodes := baseProgram.nodes ++ #[sineSourceInstruction, negatedSineInstruction] }
+
+def negationRule : Registration :=
+  { key := negationRuleKey
+    head := negationKey
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def sineRule : Registration :=
+  { key := sineRuleKey
+    head := sineKey
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def oddnessRule : Registration :=
+  { key := oddnessRuleKey
+    head := sineKey
+    kind := .instantiate
+    watches := []
+    writes := []
+    binding := .global
+    watchesProgram := true
+    matchWatch := .network }
+
+def expRule : Registration :=
+  { key := expRuleKey
+    head := expKey
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def factFormat : ReplayFormat :=
+  { role := .fact
+    schema := 1
+    validateBody := fun body =>
+      match body with
+      | [code] => (MixedFunctions.Bound.ofCode? code).isSome
+      | _ => false }
+
+def instanceFormat : ReplayFormat :=
+  { role := .instance
+    schema := 1
+    validateBody := fun body => body == [1] }
+
+def equalityFormat : ReplayFormat :=
+  { role := .equality
+    schema := 1
+    validateBody := fun body => body == [1] }
+
+def factPlan (fact : Bound) (label : PayloadId)
+    (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs, request.writes with
+  | [_], [target] =>
+      { outcome :=
+          .success [{ node := target, fact, payload := label }] [] {}
+        drafts :=
+          [{ label, role := .fact, schema := 1,
+             body := [MixedFunctions.Bound.code fact] }] }
+  | _, _ => { outcome := .failed 1, drafts := [] }
+
+/-- Unit range is preserved by negation. -/
+def negationPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if input.fact == .unit then factPlan .unit (payload 20) request
+      else { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 2, drafts := [] }
+
+/-- Sine proves its unit range except at the deliberately blocked `sin (-_)`
+shape. The matcher must expose the equivalent positive-shape expression. -/
+def sinePlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if request.program.operationKey? input.node == some negationKey then
+        { outcome := .noChange {}, drafts := [] }
+      else
+        factPlan .unit (payload 21) request
+  | _ => { outcome := .failed 3, drafts := [] }
+
+def expPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if input.fact == .unit then factPlan .atMostThree (payload 24) request
+      else { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 4, drafts := [] }
+
+def oddness? (view : ProgramView) (input : StructuralInput) :
+    Option InstantiationRequest := do
+  let .node anchor := input.key | none
+  if view.operationKey? anchor != some sineKey then none else pure ()
+  let expression ← view.node? anchor
+  let [negated] := expression.args | none
+  if view.operationKey? negated != some negationKey then none else pure ()
+  let negation ← view.node? negated
+  let [argument] := negation.args | none
+  let (sineId, _) ← view.findOp? sineKey
+  let (negationId, _) ← view.findOp? negationKey
+  pure
+    { key := 1
+      nodes :=
+        [{ domain := real, op := sineId, args := [.existing argument] },
+          { domain := real, op := negationId, args := [.proposed 0] }]
+      equalities :=
+        [{ left := .existing anchor
+           right := .proposed 1
+           payload := payload 23 }]
+      payload := payload 22 }
+
+def oddnessPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.action.structuralInputs.findSome? (oddness? request.program) with
+  | none => { outcome := .noChange {}, drafts := [] }
+  | some proposal =>
+      { outcome := .success [] [.instantiate proposal] {}
+        drafts :=
+          [{ label := payload 22, role := .instance, schema := 1, body := [1] },
+           { label := payload 23, role := .equality, schema := 1, body := [1] }] }
+
+def sourcePackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[sourceOperation], handlers := #[] }
+
+def negationPackage : Package Bound :=
+  { Cache := Unit
+    cache := ()
+    operations := #[negationOperation]
+    handlers := #[Handler.statelessPlanned negationRule negationPlan #[factFormat]] }
+
+def sinePackage : Package Bound :=
+  { Cache := Unit
+    cache := ()
+    operations := #[sineOperation]
+    requiredOperations := #[negationOperation]
+    handlers :=
+      #[Handler.statelessPlanned sineRule sinePlan #[factFormat],
+        Handler.statelessPlanned oddnessRule oddnessPlan
+          #[instanceFormat, equalityFormat]] }
+
+def expPackage : Package Bound :=
+  { Cache := Unit
+    cache := ()
+    operations := #[expOperation]
+    handlers := #[Handler.statelessPlanned expRule expPlan #[factFormat]] }
+
+def packages : Array (Package Bound) :=
+  #[sourcePackage, negationPackage, sinePackage, expPackage]
+
+def engineLimits : Propagator.Limits :=
+  { maxOperations := 4
+    maxNodes := 6
+    maxRules := 4
+    maxRegistryEntries := 20
+    maxReplayFormats := 6
+    maxArity := 1
+    maxScopeNodes := 1
+    maxApplications := 10
+    maxQueueEntries := 32
+    maxActions := 24
+    maxMatcherVisits := 16
+    matcherBatchSize := 8
+    maxAcceptedFacts := 12
+    maxRetainedSuggestions := 2
+    maxEffort := 1
+    maxObservationValue := 20
+    maxDiagnosticValue := 300
+    maxOutcomeCandidates := 1
+    maxOutcomeSuggestions := 1
+    maxProposalItems := 4
+    maxInstances := 1
+    maxGeneration := 1
+    maxNodeDepth := 4
+    maxEqualities := 1
+    splitEndpointLimit :=
+      { maxEndpointHeight := 8, maxAlignmentShift := 4 } }
+
+def policyLimits : Propagator.Policy.Limits :=
+  { maxDecisions := 32, maxTraversal := 384, maxLiveOffers := 32 }
+
+def arenaLimits : PayloadArena.Limits :=
+  { maxEntries := 20
+    maxBodyCells := 40
+    maxDrafts := 10
+    maxDraftCells := 10
+    maxAtom := 32
+    maxSchema := 1
+    maxUses := 10 }
+
+def limits : PolicySession.Limits :=
+  { engine := engineLimits, policy := policyLimits, arena := arenaLimits }
+
+end Hex.Interval.Experiment.MixedInstantiation

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1811,7 +1811,9 @@ the instance event comes first; independent sine and negation packages derive
 the unit-range fact on the two new nodes; generic equality transport installs
 that exact fact, with its retained version, on the original `sin (-x)` node;
 and only then does the independent exponential package derive the target.
-Removing or reordering any of those dependencies makes replay fail closed.
+The dependent-typed emitter requires every exact predecessor proof to be
+available at its retained version, so a missing or reordered dependency cannot
+produce a type-correct replay term.
 
 The goal reifier, target driver, policy session, chronology quotation,
 `ProofFrontend`, and final semantic closure have no sine, negation, or

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1819,14 +1819,16 @@ The goal reifier, target driver, policy session, chronology quotation,
 `ProofFrontend`, and final semantic closure have no sine, negation, or
 exponential branch. Each operation supplies its own syntax recognition,
 planning, mathematical relation, and replay schema. They cooperate through
-one shared fact domain and value semantics, as required by the package
-boundary above. The final theorem is an ordinary kernel theorem, and its
+one shared fact domain and value semantics, while the sine matcher declares
+the negation operation through the ordinary `requiredOperations` package
+contract. The final theorem is an ordinary kernel theorem, and its
 guarded axiom report contains only Lean's standard propositional extensionality,
 choice, and quotient axioms. This vertical adds no rational backend and uses
 neither `native_decide` nor an unchecked proof shortcut.
 
 This is a deliberately exact canary, not yet the production abstraction. Its
-replay schemas validate the particular base and extended programs, and its
+replay schemas validate the particular base and extended programs, the tactic
+rejects other graph shapes rather than generalizing them, and its
 semantic model array still couples each operation to a numeric position.
 Consequently it demonstrates that dynamic expression instantiation composes
 with arbitrary downstream function propagation, but not yet that packages can

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1800,6 +1800,39 @@ later mixed-function acceptance case should use the existing instantiation
 protocol to introduce an auxiliary expression whose package then participates
 in the same dependent chain.
 
+That acceptance case is now executable for
+`Real.exp (Real.sin (-x)) ≤ 3`. The caller graph contains only `x`, `-x`,
+`sin (-x)`, and the outer exponential. The sine forward rule deliberately
+declines an input whose instruction is negation, so direct propagation cannot
+close the target. A sine-owned network matcher recognizes the oddness shape
+and adds `sin x`, `-(sin x)`, and an equality between the latter expression
+and `sin (-x)`. The resulting successful chronology is fixed by a live guard:
+the instance event comes first; independent sine and negation packages derive
+the unit-range fact on the two new nodes; generic equality transport installs
+that exact fact, with its retained version, on the original `sin (-x)` node;
+and only then does the independent exponential package derive the target.
+Removing or reordering any of those dependencies makes replay fail closed.
+
+The goal reifier, target driver, policy session, chronology quotation,
+`ProofFrontend`, and final semantic closure have no sine, negation, or
+exponential branch. Each operation supplies its own syntax recognition,
+planning, mathematical relation, and replay schema. They cooperate through
+one shared fact domain and value semantics, as required by the package
+boundary above. The final theorem is an ordinary kernel theorem, and its
+guarded axiom report contains only Lean's standard propositional extensionality,
+choice, and quotient axioms. This vertical adds no rational backend and uses
+neither `native_decide` nor an unchecked proof shortcut.
+
+This is a deliberately exact canary, not yet the production abstraction. Its
+replay schemas validate the particular base and extended programs, and its
+semantic model array still couples each operation to a numeric position.
+Consequently it demonstrates that dynamic expression instantiation composes
+with arbitrary downstream function propagation, but not yet that packages can
+be reordered or instantiated under arbitrary surrounding graphs. The next
+generalization should resolve operation meanings and replay obligations by
+stable package keys, construct the extension proof for the actual appended
+graph, and preserve this same guarded chronology as a regression test.
+
 The first goal-reification experiment now derives the exponential canary's
 base program, version-zero fact array, and target fact from the actual Lean
 goal before running its compiled fixture. Expression packages contribute an

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1804,7 +1804,9 @@ That acceptance case is now executable for
 `Real.exp (Real.sin (-x)) ≤ 3`. The caller graph contains only `x`, `-x`,
 `sin (-x)`, and the outer exponential. The sine forward rule deliberately
 declines an input whose instruction is negation, so direct propagation cannot
-close the target. A sine-owned network matcher recognizes the oddness shape
+close the target. This is a search-side canary restriction that forces the
+matcher path, not a mathematical limitation of the sine replay schema. A
+sine-owned network matcher recognizes the oddness shape
 and adds `sin x`, `-(sin x)`, and an equality between the latter expression
 and `sin (-x)`. The resulting successful chronology is fixed by a live guard:
 the instance event comes first; independent sine and negation packages derive

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1829,9 +1829,10 @@ choice, and quotient axioms. This vertical adds no rational backend and uses
 neither `native_decide` nor an unchecked proof shortcut.
 
 This is a deliberately exact canary, not yet the production abstraction. Its
-replay schemas validate the particular base and extended programs, the tactic
-rejects other graph shapes rather than generalizing them, and its
-semantic model array still couples each operation to a numeric position.
+instantiation and equality replay schemas validate the particular base and
+extended programs, while its fact schemas and semantic model array still
+resolve each operation by numeric position. The tactic rejects other graph
+shapes rather than generalizing them.
 Consequently it demonstrates that dynamic expression instantiation composes
 with arbitrary downstream function propagation, but not yet that packages can
 be reordered or instantiated under arbitrary surrounding graphs. The next

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1815,7 +1815,9 @@ that exact fact, with its retained version, on the original `sin (-x)` node;
 and only then does the independent exponential package derive the target.
 The guard pins the complete initial matcher batch and engine-issued action,
 every instance output and generation field, and the frozen quote entry's
-origin, role, schema, and body.
+origin, role, schema, and body. It also pins each narrowing event's program
+version, predecessor slot/version and concrete previous fact, ordered
+assumptions, and installed fact/version.
 The dependent-typed emitter requires every exact predecessor proof to be
 available at its retained version, so a missing or reordered dependency cannot
 produce a type-correct replay term.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1813,6 +1813,9 @@ the instance event comes first; independent sine and negation packages derive
 the unit-range fact on the two new nodes; generic equality transport installs
 that exact fact, with its retained version, on the original `sin (-x)` node;
 and only then does the independent exponential package derive the target.
+The guard pins the complete initial matcher batch and engine-issued action,
+every instance output and generation field, and the frozen quote entry's
+origin, role, schema, and body.
 The dependent-typed emitter requires every exact predecessor proof to be
 available at its retained version, so a missing or reordered dependency cannot
 produce a type-correct replay term.

--- a/HexIntervalMathlib/Experiment/MixedInstantiation.lean
+++ b/HexIntervalMathlib/Experiment/MixedInstantiation.lean
@@ -1,0 +1,468 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib.Analysis.Complex.ExponentialBounds
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+public import HexInterval.Experiment.MixedInstantiation
+public import HexIntervalMathlib.Experiment.MixedFunctions
+public import HexInterval.Experiment.ProofRegistry
+public import HexInterval.Experiment.OperationSemantics
+
+@[expose] public section
+
+/-!
+# Real semantics for mixed-function instantiation
+-/
+
+namespace Hex.Interval.Experiment.MixedInstantiation
+
+open Propagator SemanticReplay ChronologicalReplay ProofEmitter ProofRegistry
+open GenericInstanceReconstruction OperationSemantics
+
+def Contains : Bound → ℝ → Prop := MixedFunctions.Contains
+
+def sourceModel : OperationSemantics.Model ℝ :=
+  { operation := sourceOperation
+    relation := fun inputs _ => inputs = [] }
+
+def negationModel : OperationSemantics.Model ℝ :=
+  { operation := negationOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [input] => output = -input
+      | _ => False }
+
+def sineModel : OperationSemantics.Model ℝ :=
+  { operation := sineOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [input] => output = Real.sin input
+      | _ => False }
+
+def expModel : OperationSemantics.Model ℝ :=
+  { operation := expOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [input] => output = Real.exp input
+      | _ => False }
+
+def operationModels : Array (OperationSemantics.Model ℝ) :=
+  #[sourceModel, negationModel, sineModel, expModel]
+
+def semantics : Semantics Bound :=
+  OperationSemantics.semantics operationModels Contains
+
+theorem containsMeet (left right : Bound) (x : ℝ) :
+    Contains (MixedFunctions.Bound.meet left right) x ↔
+      Contains left x ∧ Contains right x := by
+  exact MixedFunctions.containsMeet left right x
+
+def boundSchema : FactDomainSchema semantics :=
+  { top := fun _ => .all
+    topSound := by
+      intro _ _ _ _ _ _
+      trivial
+    proveMeet := fun _ _ previous proposed installed =>
+      if exact : installed = MixedFunctions.Bound.meet previous proposed then
+        some
+          { proof := by
+              subst installed
+              intro valuation _
+              exact containsMeet previous proposed (valuation _) }
+      else
+        none }
+
+def laws : Laws semantics :=
+  { holdsEq := by
+      intro _ valuation left right fact _ _ values
+      change Contains fact (valuation left) ↔ Contains fact (valuation right)
+      rw [values] }
+
+def stableLaw : StableLaw semantics :=
+  OperationSemantics.stableLaw operationModels Contains
+
+theorem sineEntails (graph : Program) (assumptions : List (NodeFact Bound))
+    (output : NodeId) (instruction : Node) (input : NodeId)
+    (found : graph.node? output = some instruction)
+    (operation : instruction.op = ({ index := 2 } : OpId))
+    (arguments : instruction.args = [input]) :
+    semantics.Entails graph assumptions { node := output, fact := .unit } := by
+  intro valuation model _
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 output instruction found
+  simp [operationModels, operation] at meaningAt
+  subst meaning
+  have outputEq : valuation output = Real.sin (valuation input) := by
+    simpa [sineModel, arguments, List.map] using related
+  change -1 ≤ valuation output ∧ valuation output ≤ 1
+  rw [outputEq]
+  exact ⟨Real.neg_one_le_sin _, Real.sin_le_one _⟩
+
+theorem negationEntails (graph : Program) (assumptions : List (NodeFact Bound))
+    (output : NodeId) (instruction : Node) (input : NodeId)
+    (found : graph.node? output = some instruction)
+    (operation : instruction.op = ({ index := 1 } : OpId))
+    (arguments : instruction.args = [input])
+    (exactAssumptions : assumptions = [{ node := input, fact := .unit }]) :
+    semantics.Entails graph assumptions { node := output, fact := .unit } := by
+  intro valuation model holds
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 output instruction found
+  simp [operationModels, operation] at meaningAt
+  subst meaning
+  have outputEq : valuation output = -valuation input := by
+    simpa [negationModel, arguments, List.map] using related
+  have inputRange : Contains .unit (valuation input) :=
+    holds { node := input, fact := .unit } (by simp [exactAssumptions])
+  change -1 ≤ valuation output ∧ valuation output ≤ 1
+  rw [outputEq]
+  exact ⟨neg_le_neg inputRange.2, neg_le.mp inputRange.1⟩
+
+theorem expEntails (graph : Program) (assumptions : List (NodeFact Bound))
+    (output : NodeId) (instruction : Node) (input : NodeId)
+    (found : graph.node? output = some instruction)
+    (operation : instruction.op = ({ index := 3 } : OpId))
+    (arguments : instruction.args = [input])
+    (exactAssumptions : assumptions = [{ node := input, fact := .unit }]) :
+    semantics.Entails graph assumptions
+      { node := output, fact := .atMostThree } := by
+  intro valuation model holds
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 output instruction found
+  simp [operationModels, operation] at meaningAt
+  subst meaning
+  have outputEq : valuation output = Real.exp (valuation input) := by
+    simpa [expModel, arguments, List.map] using related
+  have inputRange : Contains .unit (valuation input) :=
+    holds { node := input, fact := .unit } (by simp [exactAssumptions])
+  change valuation output ≤ 3
+  rw [outputEq]
+  exact (Real.exp_le_exp.mpr inputRange.2).trans Real.exp_one_lt_three.le
+
+theorem programPrefix : ProgramPrefix baseProgram extendedProgram := by
+  refine
+    { operationSize := by simp [baseProgram, extendedProgram]
+      nodeSize := by simp [baseProgram, extendedProgram]
+      operationAt := ?_
+      nodeAt := ?_ }
+  · intro index within
+    simp [baseProgram, extendedProgram]
+  · intro index within
+    cases index with
+    | zero => rfl
+    | succ index =>
+        cases index with
+        | zero => rfl
+        | succ index =>
+            cases index with
+            | zero => rfl
+            | succ index =>
+                cases index with
+                | zero => rfl
+                | succ index =>
+                    have lower : 4 ≤ index + 1 + 1 + 1 + 1 :=
+                      Nat.le_add_left 4 index
+                    exact False.elim (Nat.not_lt_of_ge lower (by
+                      simpa [baseProgram] using within))
+
+theorem sameOperations : baseProgram.operations = extendedProgram.operations := rfl
+
+noncomputable def extendValuation (valuation : NodeId → ℝ) : NodeId → ℝ :=
+  fun observed =>
+    if observed = node 4 then Real.sin (valuation (node 0))
+    else if observed = node 5 then -Real.sin (valuation (node 0))
+    else valuation observed
+
+theorem extension : semantics.Extends baseProgram extendedProgram := by
+  intro valuation model
+  obtain ⟨oldMeaning0, oldAt0, oldRelated0⟩ :=
+    model.2 (node 0) sourceInstruction (by rfl)
+  obtain ⟨oldMeaning1, oldAt1, oldRelated1⟩ :=
+    model.2 (node 1) negatedSourceInstruction (by rfl)
+  obtain ⟨oldMeaning2, oldAt2, oldRelated2⟩ :=
+    model.2 (node 2) sineNegatedSourceInstruction (by rfl)
+  obtain ⟨oldMeaning3, oldAt3, oldRelated3⟩ :=
+    model.2 (node 3) expSineInstruction (by rfl)
+  simp [operationModels, sourceInstruction] at oldAt0
+  simp [operationModels, negatedSourceInstruction] at oldAt1
+  simp [operationModels, sineNegatedSourceInstruction] at oldAt2
+  simp [operationModels, expSineInstruction] at oldAt3
+  subst oldMeaning0
+  subst oldMeaning1
+  subst oldMeaning2
+  subst oldMeaning3
+  refine ⟨extendValuation valuation, ?_, ?_⟩
+  · refine ⟨?_, ?_⟩
+    · simpa [baseProgram, extendedProgram] using model.1
+    · intro observed instruction found
+      rcases observed with ⟨index⟩
+      cases index with
+      | zero =>
+          simp [extendedProgram, baseProgram, Program.node?] at found
+          subst instruction
+          refine ⟨sourceModel, by rfl, ?_⟩
+          simp [sourceModel, sourceInstruction, extendValuation, node] at oldRelated0 ⊢
+      | succ index =>
+          cases index with
+          | zero =>
+              simp [extendedProgram, baseProgram, Program.node?] at found
+              subst instruction
+              refine ⟨negationModel, by rfl, ?_⟩
+              simpa [negationModel, negatedSourceInstruction, extendValuation, node,
+                List.map] using oldRelated1
+          | succ index =>
+              cases index with
+              | zero =>
+                  simp [extendedProgram, baseProgram, Program.node?] at found
+                  subst instruction
+                  refine ⟨sineModel, by rfl, ?_⟩
+                  simpa [sineModel, sineNegatedSourceInstruction, extendValuation, node,
+                    List.map] using oldRelated2
+              | succ index =>
+                  cases index with
+                  | zero =>
+                      simp [extendedProgram, baseProgram, Program.node?] at found
+                      subst instruction
+                      refine ⟨expModel, by rfl, ?_⟩
+                      simpa [expModel, expSineInstruction, extendValuation, node,
+                        List.map] using oldRelated3
+                  | succ index =>
+                      cases index with
+                      | zero =>
+                          simp [extendedProgram, baseProgram, Program.node?] at found
+                          subst instruction
+                          refine ⟨sineModel, by rfl, ?_⟩
+                          simp [sineModel, sineSourceInstruction, extendValuation, node,
+                            List.map]
+                      | succ index =>
+                          cases index with
+                          | zero =>
+                              simp [extendedProgram, baseProgram, Program.node?] at found
+                              subst instruction
+                              refine ⟨negationModel, by rfl, ?_⟩
+                              simp [negationModel, negatedSineInstruction,
+                                extendValuation, node, List.map]
+                          | succ index =>
+                              simp [extendedProgram, baseProgram, Program.node?] at found
+  · intro observed within
+    have notFour : observed ≠ node 4 := by
+      intro equal
+      subst observed
+      simp [baseProgram, node] at within
+    have notFive : observed ≠ node 5 := by
+      intro equal
+      subst observed
+      simp [baseProgram, node] at within
+    simp [extendValuation, notFour, notFive]
+
+def stable : StableStep semantics baseProgram extendedProgram :=
+  stableLaw.stable (by rfl) (by rfl) programPrefix sameOperations
+
+theorem targetWithin : (node 3).index < baseProgram.nodes.size := by
+  decide
+
+/-- Pull a proof over the instantiated graph back to the exact caller graph. -/
+def closeEvidence {base : List (NodeFact Bound)}
+    (baseWithin : FactsWithin baseProgram base)
+    (extensionEvidence : Evidence (semantics.Extends baseProgram extendedProgram))
+    (final : Evidence (semantics.Entails extendedProgram base checkerInput.target)) :
+    Evidence (semantics.Entails baseProgram base checkerInput.target) :=
+  closeBase (input := checkerInput) stable baseWithin targetWithin
+    extensionEvidence final
+
+theorem oddnessEntails :
+    semantics.EntailsEq extendedProgram [] (node 2) (node 5) := by
+  intro valuation model _
+  change NodeId → ℝ at valuation
+  obtain ⟨negMeaning, negAt, negRelated⟩ :=
+    model.2 (node 1) negatedSourceInstruction (by rfl)
+  obtain ⟨oldSinMeaning, oldSinAt, oldSinRelated⟩ :=
+    model.2 (node 2) sineNegatedSourceInstruction (by rfl)
+  obtain ⟨sinMeaning, sinAt, sinRelated⟩ :=
+    model.2 (node 4) sineSourceInstruction (by rfl)
+  obtain ⟨newNegMeaning, newNegAt, newNegRelated⟩ :=
+    model.2 (node 5) negatedSineInstruction (by rfl)
+  simp [operationModels, negatedSourceInstruction] at negAt
+  simp [operationModels, sineNegatedSourceInstruction] at oldSinAt
+  simp [operationModels, sineSourceInstruction] at sinAt
+  simp [operationModels, negatedSineInstruction] at newNegAt
+  subst negMeaning
+  subst oldSinMeaning
+  subst sinMeaning
+  subst newNegMeaning
+  have negated : valuation (node 1) = -valuation (node 0) := by
+    simpa [negationModel, negatedSourceInstruction, List.map] using negRelated
+  have oldSine : valuation (node 2) = Real.sin (valuation (node 1)) := by
+    simpa [sineModel, sineNegatedSourceInstruction, List.map] using oldSinRelated
+  have sine : valuation (node 4) = Real.sin (valuation (node 0)) := by
+    simpa [sineModel, sineSourceInstruction, List.map] using sinRelated
+  have newNegated : valuation (node 5) = -valuation (node 4) := by
+    simpa [negationModel, negatedSineInstruction, List.map] using newNegRelated
+  calc
+    valuation (node 2) = Real.sin (valuation (node 1)) := oldSine
+    _ = Real.sin (-valuation (node 0)) := congrArg Real.sin negated
+    _ = -Real.sin (valuation (node 0)) := Real.sin_neg _
+    _ = -valuation (node 4) := congrArg Neg.neg sine.symm
+    _ = valuation (node 5) := newNegated.symm
+
+private theorem factWith (fact : NodeFact Bound) {value : Bound}
+    (equal : fact.fact = value) :
+    fact = { node := fact.node, fact := value } := by
+  cases fact
+  simp_all
+
+def sineFactSchema : PackedFactSchema semantics where
+  rule := sineRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body =>
+    if body == [MixedFunctions.Bound.unit.code] then some () else none
+  replay := fun _ _ context _ =>
+    if programEq : context.program = extendedProgram then
+      if proposedFact : context.proposed.fact = .unit then
+        match found : context.program.node? context.proposed.node with
+        | some instruction =>
+            if operation : instruction.op = ({ index := 2 } : OpId) then
+              match arguments : instruction.args with
+              | [input] =>
+                  some
+                    { proof := by
+                        rw [factWith context.proposed proposedFact]
+                        exact sineEntails context.program context.assumptions
+                          context.proposed.node instruction input found operation arguments }
+              | _ => none
+            else none
+        | none => none
+      else none
+    else none
+
+def negationFactSchema : PackedFactSchema semantics where
+  rule := negationRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body =>
+    if body == [MixedFunctions.Bound.unit.code] then some () else none
+  replay := fun _ _ context _ =>
+    if programEq : context.program = extendedProgram then
+      if proposedFact : context.proposed.fact = .unit then
+        match found : context.program.node? context.proposed.node with
+        | some instruction =>
+            if operation : instruction.op = ({ index := 1 } : OpId) then
+              match arguments : instruction.args with
+              | [input] =>
+                  if exactAssumptions :
+                      context.assumptions = [{ node := input, fact := .unit }] then
+                    some
+                      { proof := by
+                          rw [factWith context.proposed proposedFact]
+                          exact negationEntails context.program context.assumptions
+                            context.proposed.node instruction input found operation
+                            arguments exactAssumptions }
+                  else none
+              | _ => none
+            else none
+        | none => none
+      else none
+    else none
+
+def expFactSchema : PackedFactSchema semantics where
+  rule := expRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body =>
+    if body == [MixedFunctions.Bound.atMostThree.code] then some () else none
+  replay := fun _ _ context _ =>
+    if programEq : context.program = extendedProgram then
+      if proposedFact : context.proposed.fact = .atMostThree then
+        match found : context.program.node? context.proposed.node with
+        | some instruction =>
+            if operation : instruction.op = ({ index := 3 } : OpId) then
+              match arguments : instruction.args with
+              | [input] =>
+                  if exactAssumptions :
+                      context.assumptions = [{ node := input, fact := .unit }] then
+                    some
+                      { proof := by
+                          rw [factWith context.proposed proposedFact]
+                          exact expEntails context.program context.assumptions
+                            context.proposed.node instruction input found operation
+                            arguments exactAssumptions }
+                  else none
+              | _ => none
+            else none
+        | none => none
+      else none
+    else none
+
+def oddnessInstanceSchema : PackedInstanceSchema semantics where
+  rule := oddnessRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [1] then some () else none
+  replay := fun _ _ context _ =>
+    if beforeEq : context.before = baseProgram then
+      if afterEq : context.after = extendedProgram then
+        some
+          { proof := by
+              simpa only [beforeEq, afterEq] using extension }
+      else none
+    else none
+
+def oddnessEqualitySchema : PackedEqualitySchema semantics where
+  rule := oddnessRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [1] then some () else none
+  replay := fun _ _ context _ =>
+    if programEq : context.program = extendedProgram then
+      if assumptionsEq : context.assumptions = [] then
+        if leftEq : context.edge.left = node 2 then
+          if rightEq : context.edge.right = node 5 then
+            some
+              { proof := by
+                  simpa only [programEq, assumptionsEq, leftEq, rightEq] using
+                    oddnessEntails }
+          else none
+        else none
+      else none
+    else none
+
+def sourceProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[] }
+    emit := { schemas := [] } }
+
+def negationProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[negationFactSchema] }
+    emit :=
+      { schemas :=
+          [{ key := negationFactSchema.key, handle := ``negationFactSchema }] } }
+
+def sineProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic :=
+      { factSchemas := #[sineFactSchema]
+        instanceSchemas := #[oddnessInstanceSchema]
+        equalitySchemas := #[oddnessEqualitySchema] }
+    emit :=
+      { schemas :=
+          [{ key := sineFactSchema.key, handle := ``sineFactSchema },
+           { key := oddnessInstanceSchema.key, handle := ``oddnessInstanceSchema },
+           { key := oddnessEqualitySchema.key, handle := ``oddnessEqualitySchema }] } }
+
+def expProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[expFactSchema] }
+    emit :=
+      { schemas :=
+          [{ key := expFactSchema.key, handle := ``expFactSchema }] } }
+
+def proofPackages : Array (ProofRegistry.Package semantics Lean.Name) :=
+  #[sourceProof, negationProof, sineProof, expProof]
+
+end Hex.Interval.Experiment.MixedInstantiation

--- a/HexIntervalMathlib/Experiment/MixedInstantiation.lean
+++ b/HexIntervalMathlib/Experiment/MixedInstantiation.lean
@@ -326,22 +326,20 @@ def sineFactSchema : PackedFactSchema semantics where
   decode := fun body =>
     if body == [MixedFunctions.Bound.unit.code] then some () else none
   replay := fun _ _ context _ =>
-    if programEq : context.program = extendedProgram then
-      if proposedFact : context.proposed.fact = .unit then
-        match found : context.program.node? context.proposed.node with
-        | some instruction =>
-            if operation : instruction.op = ({ index := 2 } : OpId) then
-              match arguments : instruction.args with
-              | [input] =>
-                  some
-                    { proof := by
-                        rw [factWith context.proposed proposedFact]
-                        exact sineEntails context.program context.assumptions
-                          context.proposed.node instruction input found operation arguments }
-              | _ => none
-            else none
-        | none => none
-      else none
+    if proposedFact : context.proposed.fact = .unit then
+      match found : context.program.node? context.proposed.node with
+      | some instruction =>
+          if operation : instruction.op = ({ index := 2 } : OpId) then
+            match arguments : instruction.args with
+            | [input] =>
+                some
+                  { proof := by
+                      rw [factWith context.proposed proposedFact]
+                      exact sineEntails context.program context.assumptions
+                        context.proposed.node instruction input found operation arguments }
+            | _ => none
+          else none
+      | none => none
     else none
 
 def negationFactSchema : PackedFactSchema semantics where
@@ -351,26 +349,24 @@ def negationFactSchema : PackedFactSchema semantics where
   decode := fun body =>
     if body == [MixedFunctions.Bound.unit.code] then some () else none
   replay := fun _ _ context _ =>
-    if programEq : context.program = extendedProgram then
-      if proposedFact : context.proposed.fact = .unit then
-        match found : context.program.node? context.proposed.node with
-        | some instruction =>
-            if operation : instruction.op = ({ index := 1 } : OpId) then
-              match arguments : instruction.args with
-              | [input] =>
-                  if exactAssumptions :
-                      context.assumptions = [{ node := input, fact := .unit }] then
-                    some
-                      { proof := by
-                          rw [factWith context.proposed proposedFact]
-                          exact negationEntails context.program context.assumptions
-                            context.proposed.node instruction input found operation
-                            arguments exactAssumptions }
-                  else none
-              | _ => none
-            else none
-        | none => none
-      else none
+    if proposedFact : context.proposed.fact = .unit then
+      match found : context.program.node? context.proposed.node with
+      | some instruction =>
+          if operation : instruction.op = ({ index := 1 } : OpId) then
+            match arguments : instruction.args with
+            | [input] =>
+                if exactAssumptions :
+                    context.assumptions = [{ node := input, fact := .unit }] then
+                  some
+                    { proof := by
+                        rw [factWith context.proposed proposedFact]
+                        exact negationEntails context.program context.assumptions
+                          context.proposed.node instruction input found operation
+                          arguments exactAssumptions }
+                else none
+            | _ => none
+          else none
+      | none => none
     else none
 
 def expFactSchema : PackedFactSchema semantics where
@@ -380,26 +376,24 @@ def expFactSchema : PackedFactSchema semantics where
   decode := fun body =>
     if body == [MixedFunctions.Bound.atMostThree.code] then some () else none
   replay := fun _ _ context _ =>
-    if programEq : context.program = extendedProgram then
-      if proposedFact : context.proposed.fact = .atMostThree then
-        match found : context.program.node? context.proposed.node with
-        | some instruction =>
-            if operation : instruction.op = ({ index := 3 } : OpId) then
-              match arguments : instruction.args with
-              | [input] =>
-                  if exactAssumptions :
-                      context.assumptions = [{ node := input, fact := .unit }] then
-                    some
-                      { proof := by
-                          rw [factWith context.proposed proposedFact]
-                          exact expEntails context.program context.assumptions
-                            context.proposed.node instruction input found operation
-                            arguments exactAssumptions }
-                  else none
-              | _ => none
-            else none
-        | none => none
-      else none
+    if proposedFact : context.proposed.fact = .atMostThree then
+      match found : context.program.node? context.proposed.node with
+      | some instruction =>
+          if operation : instruction.op = ({ index := 3 } : OpId) then
+            match arguments : instruction.args with
+            | [input] =>
+                if exactAssumptions :
+                    context.assumptions = [{ node := input, fact := .unit }] then
+                  some
+                    { proof := by
+                        rw [factWith context.proposed proposedFact]
+                        exact expEntails context.program context.assumptions
+                          context.proposed.node instruction input found operation
+                          arguments exactAssumptions }
+                else none
+            | _ => none
+          else none
+      | none => none
     else none
 
 def oddnessInstanceSchema : PackedInstanceSchema semantics where

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -169,33 +169,37 @@ private def firstOffer : TargetRun.Controller Bound Unit :=
       | some offer => .select offer state
       | none => .stop state }
 
-private structure Fixture where
+private structure Run where
   result : TargetRun.Result Bound Unit
   reached : TargetRun.Reached Bound
-  registry : ProofRegistry.Registry semantics Name
 
-private def runInput? (input : CheckerInput Bound) : Option Fixture := do
+private def runSession? (input : CheckerInput Bound) : Option Run := do
   let .ok session := PolicySession.Session.start factDomain input.baseProgram
       packages input.initialFacts limits
     | none
   let result := TargetRun.drive factDomain input.target.node input.target.fact
     firstOffer limits.policy.maxDecisions session ()
   let .target reached := result.stop | none
-  let .ok registry := ProofRegistry.build result.session.registry proofPackages
+  some { result, reached }
+
+private structure Fixture where
+  result : TargetRun.Result Bound Unit
+  reached : TargetRun.Reached Bound
+  registry : ProofRegistry.Registry semantics Name
+
+private def runInput? (input : CheckerInput Bound) : Option Fixture := do
+  let some run := runSession? input | none
+  let .ok registry := ProofRegistry.build run.result.session.registry proofPackages
     | none
-  some { result, reached, registry }
+  some { result := run.result, reached := run.reached, registry }
 
 private def fixedInput : CheckerInput Bound :=
   checkerInput
 
-private def liveTrace? : Option (Frontend.Trace Bound) := do
-  let .ok session := PolicySession.Session.start factDomain fixedInput.baseProgram
-      packages fixedInput.initialFacts limits
-    | none
-  let result := TargetRun.drive factDomain fixedInput.target.node fixedInput.target.fact
-    firstOffer limits.policy.maxDecisions session ()
-  let .target _ := result.stop | none
-  Frontend.trace? result.session.state.engine result.session.arena
+private def liveTrace? : Option (Frontend.Trace Bound) :=
+  match runSession? fixedInput with
+  | some run => Frontend.trace? run.result.session.state.engine run.result.session.arena
+  | none => none
 
 private def exactRuleInput (step : RuleStep Bound) (expected : SeenVersion) : Bool :=
   match step.event.cause with
@@ -339,9 +343,10 @@ mixed-function goal through the generic proof frontend. -/
 theorem mixedSinNegExp (x : ℝ) : Real.exp (Real.sin (-x)) ≤ 3 := by
   interval_mixed_instance
 
+/-- error: interval_mixed_instance: reifier produced an unexpected input -/
+#guard_msgs in
 example (x : ℝ) : Real.exp (Real.sin x) ≤ 3 := by
-  fail_if_success interval_mixed_instance
-  simpa using mixedSinNegExp (-x)
+  interval_mixed_instance
 
 /--
 info: 'Hex.IntervalMathlib.MixedInstantiationConformance.mixedSinNegExp' depends on axioms: [propext,
@@ -350,9 +355,5 @@ info: 'Hex.IntervalMathlib.MixedInstantiationConformance.mixedSinNegExp' depends
 -/
 #guard_msgs in
 #print axioms mixedSinNegExp
-
-example (_x : ℝ) : True := by
-  fail_if_success interval_mixed_instance
-  trivial
 
 end Hex.IntervalMathlib.MixedInstantiationConformance

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -264,25 +264,42 @@ private def oddnessAction : Action :=
             instantiation.entry.schema == 1 &&
             instantiation.entry.body == [1] &&
             sine.entry.replayKey == sineFactSchema.key &&
+            sine.event.programVersion == 1 &&
             sine.event.node == node 4 &&
+            sine.event.previous == ({ node := node 4, version := 0 } : SeenVersion) &&
             sine.event.version == 1 &&
             sine.event.fact == .unit &&
+            sine.previous == .all &&
+            sine.assumptions == [{ node := node 0, fact := .all }] &&
             exactRuleInput sine { node := node 0, version := 0 } &&
             negation.entry.replayKey == negationFactSchema.key &&
+            negation.event.programVersion == 1 &&
             negation.event.node == node 5 &&
+            negation.event.previous == ({ node := node 5, version := 0 } : SeenVersion) &&
             negation.event.version == 1 &&
             negation.event.fact == .unit &&
+            negation.previous == .all &&
+            negation.assumptions == [{ node := node 4, fact := .unit }] &&
             exactRuleInput negation { node := node 4, version := 1 } &&
             transport.entry.replayKey == oddnessEqualitySchema.key &&
+            transport.event.programVersion == 1 &&
             transport.event.node == node 2 &&
+            transport.event.previous == ({ node := node 2, version := 0 } : SeenVersion) &&
             transport.event.version == 1 &&
             transport.event.fact == .unit &&
+            transport.previous == .all &&
+            transport.sourceFact == .unit &&
+            transport.assumptions == [] &&
             exactTransportInput transport { index := 0 }
               { node := node 5, version := 1 } &&
             exp.entry.replayKey == expFactSchema.key &&
+            exp.event.programVersion == 1 &&
             exp.event.node == node 3 &&
+            exp.event.previous == ({ node := node 3, version := 0 } : SeenVersion) &&
             exp.event.version == 1 &&
             exp.event.fact == .atMostThree &&
+            exp.previous == .all &&
+            exp.assumptions == [{ node := node 2, fact := .unit }] &&
             exactRuleInput exp { node := node 2, version := 1 }
       | _ => false
 

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Experiment.MixedInstantiation
+import HexInterval.Experiment.GoalFrontend
+import HexInterval.Experiment.GoalClosure
+import HexInterval.Experiment.ProofFrontend
+import HexInterval.Experiment.TargetRun
+import Mathlib.Lean.Elab.Tactic.Meta
+
+/-!
+# Mixed-function dynamic-instantiation conformance
+
+The actual goal reifier initially discovers only `x`, `-x`, `sin (-x)`, and
+`exp (sin (-x))`. Search cannot propagate sine on the negative-shape node.
+The sine package's matcher adds `sin x` and `-(sin x)`; independent sine and
+negation rules establish their unit range; generic equality transport carries
+that fact back to `sin (-x)`; and the exponential package consumes it.
+-/
+
+namespace Hex.IntervalMathlib.MixedInstantiationConformance
+
+open Lean Elab Tactic Meta
+open Hex.Interval.Experiment
+open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
+open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend GoalClosure
+open MixedInstantiation
+
+private def sourceSyntax : GoalFrontend.Package :=
+  { operation := sourceOperation
+    recognize := fun expression => do
+      let type ← inferType expression
+      pure <|
+        if expression.isFVar && type == mkConst ``Real then some [] else none }
+
+private def negationSyntax : GoalFrontend.Package :=
+  { operation := negationOperation
+    recognize := fun expression =>
+      let arguments := expression.getAppArgs
+      pure <|
+        if expression.getAppFn.constName? == some ``Neg.neg &&
+            !arguments.isEmpty then
+          some [arguments[arguments.size - 1]!]
+        else none }
+
+private def sineSyntax : GoalFrontend.Package :=
+  { operation := sineOperation
+    recognize := fun expression =>
+      let arguments := expression.getAppArgs
+      pure <|
+        if expression.getAppFn.constName? == some ``Real.sin &&
+            arguments.size == 1 then
+          some [arguments[0]!]
+        else none }
+
+private def expSyntax : GoalFrontend.Package :=
+  { operation := expOperation
+    recognize := fun expression =>
+      let arguments := expression.getAppArgs
+      pure <|
+        if expression.getAppFn.constName? == some ``Real.exp &&
+            arguments.size == 1 then
+          some [arguments[0]!]
+        else none }
+
+private def goalRegistry? : Except String GoalFrontend.Registry :=
+  GoalFrontend.Registry.build
+    { maxPackages := 5, maxNodes := 16, maxDepth := 8 }
+    #[sourceSyntax, negationSyntax, sineSyntax, expSyntax]
+
+private def isThree (expression : Expr) : Bool :=
+  let arguments := expression.getAppArgs
+  expression.getAppFn.constName? == some ``OfNat.ofNat &&
+    arguments.size == 3 &&
+      match arguments[1]! with
+      | .lit (.natVal 3) => true
+      | _ => false
+
+private def claimParser : GoalFrontend.Parser Bound :=
+  { parse := fun proposition => do
+      let arguments := proposition.getAppArgs
+      if proposition.getAppFn.constName? == some ``LE.le &&
+          arguments.size ≥ 2 then
+        let left := arguments[arguments.size - 2]!
+        let right := arguments[arguments.size - 1]!
+        let leftType ← inferType left
+        if isThree right && leftType == mkConst ``Real then
+          pure <| some
+            { expression := left
+              domain := real
+              fact := .atMostThree }
+        else pure none
+      else pure none }
+
+private theorem sourceAligned : sourceModel.operation = sourceOperation := rfl
+private theorem negationAligned : negationModel.operation = negationOperation := rfl
+private theorem sineAligned : sineModel.operation = sineOperation := rfl
+private theorem expAligned : expModel.operation = expOperation := rfl
+
+private def sourceMeaning : GoalClosure.Package :=
+  { operation := sourceOperation
+    model := mkConst ``sourceModel
+    aligned := mkConst ``sourceAligned
+    prove := fun arguments _ => do
+      unless arguments.isEmpty do
+        throwError "interval_mixed_instance: source meaning received arguments"
+      mkAppM ``Eq.refl #[FrontendEncoder.listExpr (mkConst ``Real) []] }
+
+private def negationMeaning : GoalClosure.Package :=
+  { operation := negationOperation
+    model := mkConst ``negationModel
+    aligned := mkConst ``negationAligned
+    prove := fun arguments output => do
+      let [input] := arguments
+        | throwError "interval_mixed_instance: negation meaning is not unary"
+      let expected ← mkAppM ``Neg.neg #[input]
+      unless ← isDefEq output expected do
+        throwError "interval_mixed_instance: negation recognizer changed the expression"
+      mkAppM ``Eq.refl #[output] }
+
+private def sineMeaning : GoalClosure.Package :=
+  { operation := sineOperation
+    model := mkConst ``sineModel
+    aligned := mkConst ``sineAligned
+    prove := fun arguments output => do
+      let [input] := arguments
+        | throwError "interval_mixed_instance: sine meaning is not unary"
+      let expected ← mkAppM ``Real.sin #[input]
+      unless ← isDefEq output expected do
+        throwError "interval_mixed_instance: sine recognizer changed the expression"
+      mkAppM ``Eq.refl #[output] }
+
+private def expMeaning : GoalClosure.Package :=
+  { operation := expOperation
+    model := mkConst ``expModel
+    aligned := mkConst ``expAligned
+    prove := fun arguments output => do
+      let [input] := arguments
+        | throwError "interval_mixed_instance: exponential meaning is not unary"
+      let expected ← mkAppM ``Real.exp #[input]
+      unless ← isDefEq output expected do
+        throwError "interval_mixed_instance: exponential recognizer changed the expression"
+      mkAppM ``Eq.refl #[output] }
+
+private def meanings : Array GoalClosure.Package :=
+  #[sourceMeaning, negationMeaning, sineMeaning, expMeaning]
+
+private meta def reifyGoal (target : Expr) : MetaM (GoalFrontend.Result Bound) := do
+  let registry ←
+    match goalRegistry? with
+    | .ok registry => pure registry
+    | .error message =>
+        throwError "interval_mixed_instance: invalid registry: {message}"
+  let context ← getLCtx
+  let mut hypotheses := []
+  for declaration in context do
+    unless declaration.isImplementationDetail do
+      hypotheses := hypotheses.concat
+        (← instantiateMVars declaration.type, mkFVar declaration.fvarId)
+  GoalFrontend.reify registry factDomain claimParser hypotheses target
+
+private def firstOffer : TargetRun.Controller Bound Unit :=
+  { update := fun state _ => state
+    choose := fun state view =>
+      match view.offers[0]? with
+      | some offer => .select offer state
+      | none => .stop state }
+
+private structure Fixture where
+  result : TargetRun.Result Bound Unit
+  reached : TargetRun.Reached Bound
+  registry : ProofRegistry.Registry semantics Name
+
+private def runInput? (input : CheckerInput Bound) : Option Fixture := do
+  let .ok session := PolicySession.Session.start factDomain input.baseProgram
+      packages input.initialFacts limits
+    | none
+  let result := TargetRun.drive factDomain input.target.node input.target.fact
+    firstOffer limits.policy.maxDecisions session ()
+  let .target reached := result.stop | none
+  let .ok registry := ProofRegistry.build result.session.registry proofPackages
+    | none
+  some { result, reached, registry }
+
+private def fixedInput : CheckerInput Bound :=
+  checkerInput
+
+private def liveTrace? : Option (Frontend.Trace Bound) := do
+  let .ok session := PolicySession.Session.start factDomain fixedInput.baseProgram
+      packages fixedInput.initialFacts limits
+    | none
+  let result := TargetRun.drive factDomain fixedInput.target.node fixedInput.target.fact
+    firstOffer limits.policy.maxDecisions session ()
+  let .target _ := result.stop | none
+  Frontend.trace? result.session.state.engine result.session.arena
+
+private def exactRuleInput (step : RuleStep Bound) (expected : SeenVersion) : Bool :=
+  match step.event.cause with
+  | .rule action _ _ => action.inputs == [expected]
+  | .transport _ _ => false
+
+private def exactTransportInput (step : TransportStep Bound)
+    (expectedEquality : EqualityId) (expectedSource : SeenVersion) : Bool :=
+  match step.event.cause with
+  | .rule _ _ _ => false
+  | .transport equality source =>
+      equality == expectedEquality && source == expectedSource
+
+#guard
+  liveTrace?.any fun trace =>
+    trace.program == extendedProgram &&
+      match trace.events with
+      | [.instantiation instantiation, .rule sine, .rule negation,
+          .transport transport, .rule exp] =>
+          instantiation.entry.replayKey == oddnessInstanceSchema.key &&
+            instantiation.event.newNodes == [node 4, node 5] &&
+            sine.entry.replayKey == sineFactSchema.key &&
+            sine.event.node == node 4 &&
+            exactRuleInput sine { node := node 0, version := 0 } &&
+            negation.entry.replayKey == negationFactSchema.key &&
+            negation.event.node == node 5 &&
+            exactRuleInput negation { node := node 4, version := 1 } &&
+            transport.entry.replayKey == oddnessEqualitySchema.key &&
+            transport.event.node == node 2 &&
+            exactTransportInput transport { index := 0 }
+              { node := node 5, version := 1 } &&
+            exp.entry.replayKey == expFactSchema.key &&
+            exp.event.node == node 3 &&
+            exactRuleInput exp { node := node 2, version := 1 }
+      | _ => false
+
+private def boundExpr : Bound → Expr
+  | .all => mkConst ``MixedFunctions.Bound.all
+  | .unit => mkConst ``MixedFunctions.Bound.unit
+  | .atMostThree => mkConst ``MixedFunctions.Bound.atMostThree
+  | .empty => mkConst ``MixedFunctions.Bound.empty
+
+private def boundEncoder : FrontendEncoder.Encoder Bound :=
+  FrontendEncoder.make (mkConst ``MixedFunctions.Bound)
+    (fun fact => pure (boundExpr fact))
+
+private def factBridge : GoalClosure.FactBridge Bound :=
+  { runtime := factDomain
+    schema := mkConst ``boundSchema
+    proveAssumption := fun program valuation factNode fact _ proof => do
+      let expected ←
+        mkAppM ``SemanticReplay.Semantics.holds
+          #[mkConst ``semantics, program, valuation,
+            ← boundEncoder.nodeFact { node := factNode, fact }]
+      unless ← isDefEq (← inferType proof) expected do
+        throwError "interval_mixed_instance: hypothesis does not prove its parsed fact"
+      pure proof }
+
+private def seedAssumed (graph : Program) (base : List (NodeFact Bound))
+    (index : Nat) (fact : NodeFact Bound) (found : base[index]? = some fact) :
+    Evidence (semantics.Entails graph base fact) :=
+  ProofEmitter.assumedAt graph base index fact found
+
+private def inputContext (result : GoalFrontend.Result Bound)
+    (base : GoalClosure.BaseProof) : ProofFrontend.Context Bound Name :=
+  { encoder := boundEncoder
+    resolveSchema := pure
+    semantics := mkConst ``semantics
+    domain := mkConst ``boundSchema
+    laws := mkConst ``laws
+    stableLaw := mkConst ``stableLaw
+    input := base.input
+    assumed := ``seedAssumed
+    baseFacts := result.baseFacts
+    baseFactsTerm := base.facts
+    baseProgram := result.input.baseProgram
+    baseProgramTerm := base.program
+    basePrefix := base.basePrefix
+    baseWithin := base.within
+    initialExtension := base.extension
+    finalPrefix := mkConst ``programPrefix
+    sameOperations := mkConst ``sameOperations
+    top := boundSchema.top }
+
+private meta def emitInput (result : GoalFrontend.Result Bound)
+    (base : GoalClosure.BaseProof) : MetaM Expr := do
+  let some fixture := runInput? result.input
+    | throwError "interval_mixed_instance: search or proof registry failed"
+  let some trace := Frontend.trace? fixture.result.session.state.engine
+      fixture.result.session.arena
+    | throwError "interval_mixed_instance: chronology quotation failed"
+  unless trace.program == extendedProgram do
+    throwError "interval_mixed_instance: matcher produced an unexpected final graph"
+  let context := inputContext result base
+  let state ← ProofFrontend.emitTrace context trace.program trace.events
+    fixture.registry.emit
+  let final ← ProofFrontend.closeTarget context state fixture.reached.seen
+    fixture.reached.fact result.input.target
+  mkAppM ``closeEvidence #[base.within, state.extension, final]
+
+private meta def proveMixedInstantiation (target : Expr) : MetaM Expr := do
+  let result ← reifyGoal target
+  unless result.input.baseProgram == baseProgram &&
+      result.input.target == fixedInput.target &&
+      result.input.initialFacts == fixedInput.initialFacts do
+    throwError "interval_mixed_instance: reifier produced an unexpected input"
+  let some fallback := GoalClosure.termAt? result.terms (node 0)
+    | throwError "interval_mixed_instance: source expression is missing"
+  let model ← GoalClosure.proveModel (mkConst ``Real) fallback meanings
+    boundEncoder result
+  let base ← GoalClosure.proveBase (mkConst ``MixedFunctions.Bound)
+    (mkConst ``semantics) boundEncoder result.input
+  let facts ← GoalClosure.proveFacts factBridge boundEncoder result base model
+  let evidence ← emitInput result base
+  let proof ← mkAppM ``Evidence.proof #[evidence, model.valuation, model.proof, facts]
+  unless ← isDefEq (← inferType proof) target do
+    throwError "interval_mixed_instance: emitted proof has the wrong target"
+  pure (← instantiateMVars proof)
+
+syntax (name := intervalMixedInstantiationTac) "interval_mixed_instance" : tactic
+
+@[tactic intervalMixedInstantiationTac] meta def evalIntervalMixedInstantiation :
+    Tactic := fun stx => do
+  match stx with
+  | `(tactic| interval_mixed_instance) =>
+      let goal ← getMainGoal
+      goal.withContext do
+        goal.assign
+          (← proveMixedInstantiation (← instantiateMVars (← goal.getType)))
+      replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+/-- Dynamic expression growth and four independent packages close the actual
+mixed-function goal through the generic proof frontend. -/
+theorem mixedSinNegExp (x : ℝ) : Real.exp (Real.sin (-x)) ≤ 3 := by
+  interval_mixed_instance
+
+/--
+info: 'Hex.IntervalMathlib.MixedInstantiationConformance.mixedSinNegExp' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound]
+-/
+#guard_msgs in
+#print axioms mixedSinNegExp
+
+example (_x : ℝ) : True := by
+  fail_if_success interval_mixed_instance
+  trivial
+
+end Hex.IntervalMathlib.MixedInstantiationConformance

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -221,17 +221,26 @@ private def exactTransportInput (step : TransportStep Bound)
           .transport transport, .rule exp] =>
           instantiation.entry.replayKey == oddnessInstanceSchema.key &&
             instantiation.event.programVersion == 1 &&
+            instantiation.event.family == 1 &&
+            instantiation.event.substitution == [node 2] &&
+            instantiation.event.products == [node 4, node 5] &&
             instantiation.event.newNodes == [node 4, node 5] &&
+            instantiation.event.equalities == [{ index := 0 }] &&
+            instantiation.event.newEqualities == [{ index := 0 }] &&
+            instantiation.event.payload == instantiation.payload &&
             sine.entry.replayKey == sineFactSchema.key &&
             sine.event.node == node 4 &&
+            sine.event.version == 1 &&
             sine.event.fact == .unit &&
             exactRuleInput sine { node := node 0, version := 0 } &&
             negation.entry.replayKey == negationFactSchema.key &&
             negation.event.node == node 5 &&
+            negation.event.version == 1 &&
             negation.event.fact == .unit &&
             exactRuleInput negation { node := node 4, version := 1 } &&
             transport.entry.replayKey == oddnessEqualitySchema.key &&
             transport.event.node == node 2 &&
+            transport.event.version == 1 &&
             transport.event.fact == .unit &&
             exactTransportInput transport { index := 0 }
               { node := node 5, version := 1 } &&

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -213,6 +213,31 @@ private def exactTransportInput (step : TransportStep Bound)
   | .transport equality source =>
       equality == expectedEquality && source == expectedSource
 
+private def initialMatcherBatch : List StructuralInput :=
+  [{ key := .node (node 0), generation := 0 },
+   { key := .node (node 1), generation := 0 },
+   { key := .node (node 2), generation := 0 },
+   { key := .node (node 3), generation := 0 },
+   { key := .application { index := 0 }, generation := 0 },
+   { key := .application { index := 1 }, generation := 0 },
+   { key := .application { index := 2 }, generation := 0 },
+   { key := .application { index := 3 }, generation := 0 }]
+
+private def oddnessAction : Action :=
+  { serial := 2
+    programVersion := 0
+    application := { index := 2 }
+    rule := { index := 2 }
+    key := oddnessRuleKey
+    node := node 2
+    kind := .instantiate
+    effort := 0
+    generation := 0
+    inputs := []
+    writes := []
+    structuralInputs := initialMatcherBatch
+    matcherEpoch := some 0 }
+
 #guard
   liveTrace?.any fun trace =>
     trace.program == extendedProgram &&
@@ -221,13 +246,23 @@ private def exactTransportInput (step : TransportStep Bound)
           .transport transport, .rule exp] =>
           instantiation.entry.replayKey == oddnessInstanceSchema.key &&
             instantiation.event.programVersion == 1 &&
+            instantiation.event.origin == oddnessAction &&
             instantiation.event.family == 1 &&
             instantiation.event.substitution == [node 2] &&
             instantiation.event.products == [node 4, node 5] &&
             instantiation.event.newNodes == [node 4, node 5] &&
+            instantiation.event.bindings == [] &&
+            instantiation.event.newBindings == [] &&
+            instantiation.event.applications == [] &&
+            instantiation.event.newApplications == [] &&
+            instantiation.event.generation == 1 &&
             instantiation.event.equalities == [{ index := 0 }] &&
             instantiation.event.newEqualities == [{ index := 0 }] &&
             instantiation.event.payload == instantiation.payload &&
+            instantiation.entry.origin == instantiation.event.origin &&
+            instantiation.entry.role == .instance &&
+            instantiation.entry.schema == 1 &&
+            instantiation.entry.body == [1] &&
             sine.entry.replayKey == sineFactSchema.key &&
             sine.event.node == node 4 &&
             sine.event.version == 1 &&

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -216,6 +216,7 @@ private def exactTransportInput (step : TransportStep Bound)
       | [.instantiation instantiation, .rule sine, .rule negation,
           .transport transport, .rule exp] =>
           instantiation.entry.replayKey == oddnessInstanceSchema.key &&
+            instantiation.event.programVersion == 1 &&
             instantiation.event.newNodes == [node 4, node 5] &&
             sine.entry.replayKey == sineFactSchema.key &&
             sine.event.node == node 4 &&
@@ -232,6 +233,7 @@ private def exactTransportInput (step : TransportStep Bound)
               { node := node 5, version := 1 } &&
             exp.entry.replayKey == expFactSchema.key &&
             exp.event.node == node 3 &&
+            exp.event.version == 1 &&
             exp.event.fact == .atMostThree &&
             exactRuleInput exp { node := node 2, version := 1 }
       | _ => false
@@ -336,6 +338,10 @@ syntax (name := intervalMixedInstantiationTac) "interval_mixed_instance" : tacti
 mixed-function goal through the generic proof frontend. -/
 theorem mixedSinNegExp (x : ℝ) : Real.exp (Real.sin (-x)) ≤ 3 := by
   interval_mixed_instance
+
+example (x : ℝ) : Real.exp (Real.sin x) ≤ 3 := by
+  fail_if_success interval_mixed_instance
+  simpa using mixedSinNegExp (-x)
 
 /--
 info: 'Hex.IntervalMathlib.MixedInstantiationConformance.mixedSinNegExp' depends on axioms: [propext,

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -42,7 +42,7 @@ private def negationSyntax : GoalFrontend.Package :=
       let arguments := expression.getAppArgs
       pure <|
         if expression.getAppFn.constName? == some ``Neg.neg &&
-            !arguments.isEmpty then
+            arguments.size == 3 then
           some [arguments[arguments.size - 1]!]
         else none }
 
@@ -219,16 +219,20 @@ private def exactTransportInput (step : TransportStep Bound)
             instantiation.event.newNodes == [node 4, node 5] &&
             sine.entry.replayKey == sineFactSchema.key &&
             sine.event.node == node 4 &&
+            sine.event.fact == .unit &&
             exactRuleInput sine { node := node 0, version := 0 } &&
             negation.entry.replayKey == negationFactSchema.key &&
             negation.event.node == node 5 &&
+            negation.event.fact == .unit &&
             exactRuleInput negation { node := node 4, version := 1 } &&
             transport.entry.replayKey == oddnessEqualitySchema.key &&
             transport.event.node == node 2 &&
+            transport.event.fact == .unit &&
             exactTransportInput transport { index := 0 }
               { node := node 5, version := 1 } &&
             exp.entry.replayKey == expFactSchema.key &&
             exp.event.node == node 3 &&
+            exp.event.fact == .atMostThree &&
             exactRuleInput exp { node := node 2, version := 1 }
       | _ => false
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -370,7 +370,8 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.PntBKLNWPow,
     `HexInterval.Experiment.SinTen,
     `HexInterval.Experiment.SinTenInterval,
-    `HexInterval.Experiment.MixedFunctions].map Glob.one
+    `HexInterval.Experiment.MixedFunctions,
+    `HexInterval.Experiment.MixedInstantiation].map Glob.one
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Arithmetic,
@@ -409,7 +410,8 @@ lean_lib HexIntervalMathlibExperiment where
     `HexIntervalAlgebraic.Experiment.PolynomialDispatchProof,
     `HexIntervalMathlib.Experiment.SinTen,
     `HexIntervalMathlib.Experiment.SinTenInterval,
-    `HexIntervalMathlib.Experiment.MixedFunctions].map Glob.one
+    `HexIntervalMathlib.Experiment.MixedFunctions,
+    `HexIntervalMathlib.Experiment.MixedInstantiation].map Glob.one
 
 @[default_target]
 lean_lib HexIntervalMathlib where
@@ -511,6 +513,7 @@ lean_lib HexConformance where
     ++ #[`HexInterval.PolicyFeatureConformance,
       `HexInterval.FeaturePolicyConformance,
       `HexIntervalMathlib.MixedFunctionsConformance,
+      `HexIntervalMathlib.MixedInstantiationConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one
 
 -- The expensive complete-family Mathlib proofs are owned only by this

--- a/progress/20260811T210945Z.md
+++ b/progress/20260811T210945Z.md
@@ -1,0 +1,34 @@
+# Accomplished
+
+- Added a Mathlib-free mixed-function instantiation experiment for a caller
+  graph representing `exp (sin (-x))`.
+- Made direct sine propagation decline the negative-shaped input, then used a
+  sine-owned structural matcher to append `sin x`, `-(sin x)`, and their
+  oddness equality to the network.
+- Added independent sine, negation, and exponential proof packages over the
+  shared mixed-function fact domain and real operation semantics.
+- Added an end-to-end tactic theorem whose guarded live trace requires the
+  exact instance, sine, negation, equality-transport, and exponential event
+  sequence. Its guarded axiom report contains no `sorryAx`.
+- Documented both the achieved arbitrary-function composition and the current
+  exact-graph and numeric operation-position limitations in the interval SPEC.
+- Built the focused runtime, proof, and conformance modules and the complete
+  `HexConformance` target. DAG, trust-surface, line-count, benchmark-freshness,
+  JSON, and diff checks all pass.
+
+# Current frontier
+
+Dynamic expression instantiation now feeds a transported fact to an unrelated
+downstream function package through the generic scheduler and proof frontend.
+The canary's proof schemas still validate one exact graph, and its semantic
+operation models remain aligned by array position.
+
+# Next step
+
+Resolve operation models and replay obligations by stable package keys and
+construct conservative-extension evidence for arbitrary appended graphs,
+while retaining this exact chronology as a regression test.
+
+# Blockers
+
+None.

--- a/progress/20260812T052900Z.md
+++ b/progress/20260812T052900Z.md
@@ -1,0 +1,22 @@
+# Accomplished
+
+- Tightened the mixed-instantiation negation recognizer to the exact
+  three-argument `Neg.neg` application shape.
+- Strengthened the live chronology guard to pin every installed fact as well
+  as the event keys, nodes, versions, and dependencies.
+- Clarified that missing or reordered dependency rejection follows from the
+  dependent-typed proof-emission boundary.
+
+# Current frontier
+
+The mixed-function instantiation vertical now has exact positive chronology
+coverage for both dependency structure and installed fact values.
+
+# Next step
+
+Generalize matching beyond one result per batch and reuse equivalent existing
+nodes before appending new instructions.
+
+# Blockers
+
+None.

--- a/progress/20260812T054300Z.md
+++ b/progress/20260812T054300Z.md
@@ -8,6 +8,9 @@
   otherwise-provable mixed graph.
 - Documented the matcher package's required-operation dependency and the
   canary's exact-graph rejection boundary.
+- Factored the shared session-driving prefix used by the tactic and chronology
+  guard, and made all three fact schemas replay against any checked program
+  prefix rather than only the final extended graph.
 
 # Current frontier
 

--- a/progress/20260812T054300Z.md
+++ b/progress/20260812T054300Z.md
@@ -1,0 +1,24 @@
+# Accomplished
+
+- Kept the live chronology guard aligned with the tactic runner's exact
+  session, controller, limits, and input while retaining its smaller
+  proof-registry-free result type.
+- Pinned the instantiation program version and final fact version.
+- Added a negative control showing that the tactic rejects a different
+  otherwise-provable mixed graph.
+- Documented the matcher package's required-operation dependency and the
+  canary's exact-graph rejection boundary.
+
+# Current frontier
+
+The live positive guard and negative graph-shape control now pin the tactic's
+session-driving contract and exact accepted graph separately.
+
+# Next step
+
+Factor the repeated unary schema and client tactic glue before adding another
+mixed-function vertical.
+
+# Blockers
+
+None.

--- a/progress/20260812T054300Z.md
+++ b/progress/20260812T054300Z.md
@@ -8,10 +8,6 @@
   otherwise-provable mixed graph.
 - Documented the matcher package's required-operation dependency and the
   canary's exact-graph rejection boundary.
-- Factored the shared session-driving prefix used by the tactic and chronology
-  guard, and made all three fact schemas replay against any checked program
-  prefix rather than only the final extended graph.
-
 # Current frontier
 
 The live positive guard and negative graph-shape control now pin the tactic's

--- a/progress/20260814T094910Z.md
+++ b/progress/20260814T094910Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Factored the mixed-instantiation tactic and chronology guard through one
+  shared session-driving definition while keeping proof-registry construction
+  outside the reducible guard path.
+- Generalized the sine, negation, and exponential fact schemas from the one
+  final extended program to any checked program prefix containing the exact
+  operation, node, arguments, fact, and assumptions.
+- Replaced failure-agnostic negative controls with a diagnostic-pinned rejection
+  of a different, otherwise true mixed-function graph.
+- Clarified that declining direct sine propagation is a deliberate search-side
+  canary restriction rather than a mathematical limitation.
+
+# Current frontier
+
+The mixed-instantiation vertical now pins one shared live run and no longer
+builds a final-program restriction into otherwise program-generic rule replay.
+
+# Next step
+
+Resolve operation meanings and schema selection by stable package keys and
+construct conservative extensions for arbitrary appended graphs.
+
+# Blockers
+
+None.

--- a/progress/20260815T001901Z.md
+++ b/progress/20260815T001901Z.md
@@ -1,0 +1,31 @@
+# Accomplished
+
+- Replayed the mixed-function instantiation series onto exact local #9238 head
+  `80561376a5eef782c2974b009ec98d04277f5806`, preserving the earlier mixed,
+  policy, raster, Table 12, and PNT stack.
+- Audited the live path from the initial `exp (sin (-x))` graph through the
+  sine-owned instantiation of `sin x` and `-(sin x)`, oddness equality,
+  sine and negation facts, equality transport, and exponential closure.
+- Confirmed exact node, fact, version, dependency, and chronology guards; the
+  proof emitter consumes checked instance, equality, and predecessor evidence.
+- Preserved the documented limitations that extension/equality replay target
+  this exact graph and fact schemas still identify operation positions, while
+  the generic scheduler, reifier, runner, frontend, and closure remain free of
+  function-specific cases.
+- Reconciled Lake registrations, refreshed the narrow proof-only exemption,
+  built all three feature targets, and passed structural, trust, freshness,
+  PNT inventory, and banned-mechanism checks.
+
+# Current frontier
+
+Dynamic expression instantiation now introduces an auxiliary arbitrary-function
+chain whose transported fact is load-bearing for a different function package.
+
+# Next step
+
+After #9238 lands, rebase this local feature series onto its exact merge commit,
+recompute the Lake exemption, and run the final PR review and CI cycle.
+
+# Blockers
+
+None.

--- a/progress/20260815T024737Z.md
+++ b/progress/20260815T024737Z.md
@@ -1,0 +1,50 @@
+# Accomplished
+
+- Reconciled the #9240 dynamic mixed-function instantiation series onto exact
+  local #9238 candidate `b9c87b83b7132584c14a9819a5eb8a66e8af9717`,
+  preserving the separate #9235 branch and current registrations.
+- Audited the sine-owned network matcher. From the exact `sin (-x)` anchor it
+  proposes `sin x`, `-(sin x)`, and the oddness equality relating the latter
+  node to the original anchor, using the declared negation-operation dependency.
+- Confirmed the live graph grows from four to six exact nodes and one equality.
+  Strengthened the chronology guard to pin matcher family `1`, substitution
+  `[node 2]`, products/new nodes `[node 4, node 5]`, equality output/fresh suffix
+  `[0]`, and the frozen instance payload identity.
+- Pinned the successful chronology and every installed fact version:
+  instantiation, sine at node 4/version 1, negation at node 5/version 1,
+  equality transport from node 5/version 1 to node 2/version 1, and exponential
+  closure from node 2/version 1.
+- Audited prefix replay. The instance schema proves the exact base-to-extended
+  conservative extension, the equality schema proves the exact oddness edge,
+  and the generic dependent fold resolves each predecessor only after it enters
+  the checked prefix. Final evidence is restricted back to the caller graph.
+- Confirmed the reifier, scheduler, target driver, chronology quotation,
+  `ProofFrontend`, and final closure contain no function-specific branch; all
+  sine, negation, exponential, instantiation, and equality logic is supplied by
+  packages in this vertical.
+- Rechecked non-vacuity and trust. Goal closure constructs meanings for every
+  base node, the extension theorem supplies an extended model, and the ordinary
+  theorem's guarded axiom report is exactly `propext`, `Classical.choice`, and
+  `Quot.sound`.
+- Preserved the SPEC's exact limitations: one shared fact/value model, numeric
+  operation slots in fact replay, and exact base/extended graphs in instance
+  and equality replay. Package reordering and arbitrary surrounding graphs
+  remain future work.
+- Built the focused mixed-instantiation targets and preserved interval/PNT
+  targets, then passed structural, trust-surface, freshness, PNT inventory,
+  release, Mathlib-free bench, and static checks.
+
+# Current frontier
+
+Dynamic instantiation now creates a load-bearing auxiliary function chain and
+equality whose transported fact closes a different function package's target.
+Key-resolved schemas and arbitrary conservative extensions remain future work.
+
+# Next step
+
+After #9238 lands, rebase this local candidate onto its exact merge commit,
+refresh the Lake exemption, and perform the final review and CI cycle.
+
+# Blockers
+
+None.

--- a/progress/20260815T074702Z.md
+++ b/progress/20260815T074702Z.md
@@ -1,0 +1,23 @@
+# Accomplished
+
+- Recovered the audited dynamic mixed-instantiation stack as `#9240` on exact prepared `#9238` head `0273c61646cd57c2899411b8848a0a1389da3cbf`, preserving every earlier preparation ref and a source ref for the historical audited stack.
+- Audited the sine-owned network matcher from the exact `sin (-x)` anchor through resolved `sin x`, `-(sin x)`, and the oddness equality, growing the graph from four to six nodes with one fresh equality.
+- Strengthened the live guard to pin the complete engine-issued oddness action and eight-item matcher batch, every instance output and generation field, and the frozen quote entry's origin, role, schema, and body.
+- Confirmed the exact chronology and predecessors: instantiation, sine at node 4/version 1 from node 0/version 0, negation at node 5/version 1 from node 4/version 1, equality transport to node 2/version 1 from node 5/version 1, then exponential closure from node 2/version 1.
+- Audited prefix replay: the instance schema proves the exact base-to-extended conservative extension, the equality schema proves the exact generated edge, and the dependent replay fold cannot consume a fact or equality before its checked predecessor exists.
+- Confirmed goal closure constructs a model for the base program, the extension theorem constructs the extended model, and final target evidence is restricted back to the original caller graph. The ordinary theorem has the guarded axiom report `[propext, Classical.choice, Quot.sound]`.
+- Confirmed the scheduler, recursive goal reifier, target runner, chronology quotation, and `ProofFrontend` remain generic and unchanged. The SPEC honestly retains numeric operation slots and exact base/extended graph schemas as canary limitations.
+- Recomputed the exact Lake freshness exemption for blob `4f674f1f40c82a55f5e81b255b394f8326c7afba`.
+- Passed the focused mixed-instantiation and experiment builds, complete PNT conformance set, static/DAG/phase checks, trust-surface and release-manifest checks, source-pinned PNT inventory checks, unit tests, and factor-sweep freshness.
+
+# Current frontier
+
+`#9240` is a clean local-only dynamic mixed-instantiation candidate on branch `codex/9240-prepare-current`, reconciled with the preceding policy and mixed-function stack and all current public arithmetic and PNT registrations.
+
+# Next step
+
+Retain the branch for the directed landing sequence; rebase and repeat exact-head review/CI only when explicitly requested.
+
+# Blockers
+
+None.

--- a/progress/20260815T132920Z.md
+++ b/progress/20260815T132920Z.md
@@ -1,0 +1,39 @@
+# Accomplished
+
+- Replayed the dynamic mixed-function instantiation edge directly onto exact
+  #9238 head `af38bfa921460cef9fc1c8dda433576ad09d0a85`, preserving all earlier
+  controller and raster fork refs.
+- Confirmed the sine-owned matcher receives the complete initial structural
+  batch and exact engine-issued action, then grows the exact four-node caller
+  graph to the six-node graph with the one oddness equality.
+- Strengthened the live chronology guard to pin every narrowing event's
+  program version, predecessor node/version and concrete previous fact,
+  ordered assumptions, installed fact/version, and exact rule or transport
+  input.
+- Re-audited the full instance, sine, negation, equality-transport, exponential
+  chronology; exact program-prefix and equality replay; construction of the
+  extended model; and restriction of final evidence back to the caller graph.
+- Confirmed the goal reifier, runner, quotation layer, and `ProofFrontend`
+  remain unchanged and function-generic. The ordinary theorem's guarded axiom
+  report remains exactly `propext`, `Classical.choice`, and `Quot.sound`.
+- Kept the canary limits explicit: fact schemas still resolve numeric operation
+  slots, and instance/equality schemas accept only the exact base and extended
+  graphs rather than arbitrary surrounding programs.
+- Refreshed the exact Lake registration exemption, built the 2289-job focused
+  controller/public/PNT closure, and passed structural, trust, inventory,
+  release, freshness, and banned-mechanism checks.
+
+# Current frontier
+
+The local stack now demonstrates dynamic graph extension, package-owned
+extension and equality proofs, versioned dependent replay, and downstream
+arbitrary-function closure in one ordinary theorem.
+
+# Next step
+
+Retain the prepared boundaries for the directed landing sequence. Generalize
+numeric operation slots and exact-graph schemas only as a separate later edge.
+
+# Blockers
+
+None.

--- a/progress/20260816T021538Z.md
+++ b/progress/20260816T021538Z.md
@@ -1,0 +1,28 @@
+# Prepare dynamic mixed instantiation after sine-exp
+
+## Accomplished
+
+- Replayed the audited dynamic mixed-instantiation edge directly onto exact
+  #9238 candidate `933a6a58c9dc54abbc77972c6550ebe6eae1d7d0`, excluding
+  raster #9235.
+- Preserved the sine-owned matcher, exact four-to-six-node graph extension and
+  equality, and the instance-to-sine-to-negation-to-transport-to-exp chronology
+  with versions, predecessors, facts, assumptions, and sources pinned.
+- Preserved base-to-extended prefix and equality replay, closeEvidence, the
+  unchanged generic runner, reifier, quotation and ProofFrontend, and the honest
+  numeric-slot and exact-graph limitations.
+- Preserved all current registrations and refreshed the exact Lake exemption.
+
+## Current frontier
+
+The local branch contains only dynamic mixed instantiation above #9238. Raster
+#9235 remains independent and unchanged.
+
+## Next step
+
+After #9238 merges, replay this prepared edge onto its literal merge commit and
+publish PR #9240 as a direct-main branch.
+
+## Blockers
+
+None.

--- a/progress/20260816T023428Z.md
+++ b/progress/20260816T023428Z.md
@@ -1,0 +1,26 @@
+# Restack dynamic instantiation onto merged sine-exp path
+
+## Accomplished
+
+- Replayed the prepared dynamic mixed-instantiation edge onto literal #9238
+  merge commit `ebab89d508f5f87c5c8360fab7fa9c306348a54c`, excluding
+  raster #9235.
+- Preserved the merged mixed sine-exp path, feature policies, adaptive policy,
+  exact-branch proof, subtraction replay, staged policy, complete source-pinned
+  LogTables providers and inventory, PNT examples, and public registrations.
+- Confirmed that the exact combined Lake blob and narrow proof-only runtime
+  exemption remain unchanged by the merge-parent restack.
+
+## Current frontier
+
+PR #9240 is a direct-main dynamic-instantiation edge. The local generated build
+cache is cold and requires a fresh focused rebuild before publication.
+
+## Next step
+
+Rebuild the focused dynamic-instantiation, frontend, controller and PNT closure;
+run trust, freshness, inventory and diff gates; then publish and monitor CI.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -248,7 +248,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "8b2d6935591884d4f8990b7b54f08d26f1785caa",
+    "current_blob": "4f674f1f40c82a55f5e81b255b394f8326c7afba",
     "reason": "Additionally registers the mixed-function dynamic-instantiation interval experiment, its proof-only real-semantics companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -248,8 +248,8 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "f0056f49222570d26691f2ba570fc93539fd97db",
-    "reason": "Additionally registers the mixed-function dynamic-instantiation interval experiment, its proof-only real-semantics companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
+    "current_blob": "87e1aeeb6973b1010da9e6bf27400050ef262900",
+    "reason": "Additionally registers the mixed-function dynamic-instantiation interval experiment, its proof-only real-semantics companion, and conformance module on top of the retained mixed sine-exp path, feature policies, exact-branch proof, subtraction replay, staged policy, complete LogTables, PNT, and public interval registrations; none enters the factorization service target or changes its executable dependency graph."
   },
   {
     "path": "HexBerlekamp/FactorTacticTests.lean",

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -248,7 +248,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "4f674f1f40c82a55f5e81b255b394f8326c7afba",
+    "current_blob": "f0056f49222570d26691f2ba570fc93539fd97db",
     "reason": "Additionally registers the mixed-function dynamic-instantiation interval experiment, its proof-only real-semantics companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -246,6 +246,12 @@
     "reason": "Additionally registers the isolated mixed-function interval experiment, its proof-only real-semantics companion, and conformance module on top of the retained feature policies, exact-branch proof, subtraction replay, staged policy, complete LogTables, PNT, and public interval registrations; none enters the factorization service target or changes its executable dependency graph."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "8b2d6935591884d4f8990b7b54f08d26f1785caa",
+    "reason": "Additionally registers the mixed-function dynamic-instantiation interval experiment, its proof-only real-semantics companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",


### PR DESCRIPTION
## Summary

- prove the mixed arbitrary-function target Real.exp (Real.sin (-x)) ≤ 3
- use a sine-owned structural matcher to extend the exact four-node graph to six nodes with sin x, -(sin x), and the oddness equality
- authenticate the live chronology: instance → sine → negation → equality transport → exponential, including every version, predecessor, fact, assumption, and source
- replay the base-to-extended prefix and equality transport through the unchanged generic runner, reifier, quotation, proof frontend, and closure
- preserve separate source, negation, sine, and exponential packages over shared fact/value semantics

## Validation

- cold focused build: 2,288 jobs
- trust-surface and factor-freshness checks
- PNT inventory tests and inventory validation
- exact main ancestry, Lake blob, source-inventory, diff, and banned-construct checks
- prepared-to-direct-main range-diff: all ten feature commits patch-identical

## Scope

This is an acceptance experiment for structural discovery and dynamic instantiation across independently registered functions. The current matcher still uses fixed numeric slots and recognizes one exact graph shape; stable-key arbitrary graph discovery and package-independent generalization remain future work.