### PR TITLE
doc: specify Hermite and Smith normal forms over Int

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -131,12 +131,22 @@ optimisation.
 
 ## Library DAG
 
-The matrix family splits internally: `hex-matrix` is the dense base;
+The matrix family splits internally. `hex-matrix` is the dense base.
 `hex-row-reduce`, `hex-determinant`, and `hex-bareiss` build on it
-(`hex-bareiss` also on `hex-determinant`); `hex-gram-schmidt` uses all
-three; and `hex-lll` builds on `hex-gram-schmidt`. Each has a matching
+(`hex-bareiss` also on `hex-determinant`), `hex-gram-schmidt` uses all
+three, and `hex-lll` builds on `hex-gram-schmidt`. `hex-hermite` is the
+one member with a dependency outside the family, on `hex-arith` for the
+extended GCD, and `hex-smith` sits on top of it. Each has a matching
 `*-mathlib` companion of the same shape. In the diagram below,
 `hex-matrix` stands for that whole family.
+
+The integer normal forms within it:
+
+```text
+hex-row-reduce ──┐
+hex-arith ───────┼── hex-hermite ── hex-smith
+hex-bareiss ─────┘
+```
 
 The algebraic graph has three independent roots: hex-poly, hex-arith,
 and hex-matrix. The module-boundary helpers in hex-basic are an

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -8,6 +8,8 @@
 - **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
 - **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
+- **hex-hermite**: Hermite normal form over `Int`, unimodular transforms, integer lattice membership, integer kernel bases
+- **hex-smith**: Smith normal form over `Int`, invariant factors, and the structure of a finitely generated abelian group
 - **hex-gram-schmidt**: Gram-Schmidt orthogonalization, GS coefficients, Gram determinants, update formulas under row operations
 - **hex-mod-arith**: `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
 - **hex-poly-fp**: polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
@@ -40,6 +42,8 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-row-reduce-mathlib**: rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
 - **hex-determinant-mathlib**: `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
 - **hex-bareiss-mathlib**: Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
+- **hex-hermite-mathlib**: row lattice = `Submodule.span ℤ`, integer rank = `Matrix.rank`, and an executable basis of the kernel submodule
+- **hex-smith-mathlib**: the executable output as `Module.Basis.SmithNormalForm`, the divisibility chain Mathlib's structure omits, and the quotient structure theorem
 - **hex-gram-schmidt-mathlib**: `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib**: `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `isolate`
@@ -67,6 +71,8 @@ Each library with its immediate dependencies:
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
 - **hex-bareiss**: hex-determinant, hex-matrix
+- **hex-hermite**: hex-row-reduce, hex-arith, hex-bareiss
+- **hex-smith**: hex-hermite
 - **hex-mod-arith**: hex-arith
 - **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
 - **hex-lll**: hex-gram-schmidt, hex-matrix, hex-basic
@@ -105,6 +111,8 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
 - **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
 - **hex-bareiss-mathlib**: hex-determinant-mathlib
+- **hex-hermite-mathlib**: hex-hermite, hex-row-reduce-mathlib, hex-bareiss-mathlib
+- **hex-smith-mathlib**: hex-smith, hex-hermite-mathlib
 - **hex-gram-schmidt-mathlib**: hex-gram-schmidt, hex-bareiss-mathlib
 - **hex-lll-mathlib**: hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib
 - **hex-berlekamp-mathlib**: hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib
@@ -209,6 +217,8 @@ for developments whose source-local move has not happened yet.
 - [hex-row-reduce-mathlib](https://github.com/leanprover/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released): rank/nullspace/span correspondence
 - [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released): `det` agreement with `Matrix.det`
 - [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released): Bareiss determinant correctness
+- [hex-hermite.md](hex-hermite.md): Hermite normal form over `Int`, unimodular transforms, integer lattice membership and kernel bases (the Mathlib companion is specified in the same file)
+- [hex-smith.md](hex-smith.md): Smith normal form over `Int`, invariant factors, and abelian group structure (the Mathlib companion is specified in the same file)
 - [hex-mod-arith](../../HexModArith/SPEC/hex-mod-arith.md): `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
 - [hex-mod-arith-mathlib](../../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md): `ZMod64 p ≃+* ZMod p`
 - [hex-poly](../../HexPoly/SPEC/hex-poly.md): dense polynomial library, operations, GCD, CRT

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -30,7 +30,7 @@ What the library delivers, none of which is currently reachable:
   same dimensions* have the same integer row lattice exactly when their
   Hermite normal forms are equal, so lattice equality is decided by one
   comparison. Across dimensions the comparison is on `hnfBasis`, the
-  nonzero rows alone; see "Canonicity is per shape" below.
+  nonzero rows alone. See "Canonicity is per shape" below.
 - **Lattice membership with completeness.** `latticeContains A v` is
   `true` exactly when `v` is an integer combination of the rows of `A`.
   The `Field`-based `spanContains` answers the rational question and
@@ -56,11 +56,11 @@ Named consumers:
   exactly the pivot product above.
 - **hex-lll**, which can canonicalise a reduced basis and drop
   dependent generators. The dependency runs from this library to
-  `hex-lll`'s vocabulary rather than the other way; see "Prerequisite
+  `hex-lll`'s vocabulary rather than the other way. See "Prerequisite
   changes in other libraries".
 - The **polynomial-matrix invariant factors** item in
   [future-work](../future-work.md), which needs the same algorithm shape
-  over `F[x]`. That is not this library; see "Why `Int` and not a
+  over `F[x]`. That is not this library. See "Why `Int` and not a
   Euclidean domain class".
 
 ## The convention this library fixes
@@ -86,7 +86,7 @@ or HNF)".
 
 **`H` is unique; `U` is not.** Uniqueness of `H` is the property the
 whole library rests on: its nonzero rows depend only on the integer row
-lattice of `A`. `U` is determined only when `A` has full row rank; when
+lattice of `A`. `U` is determined only when `A` has full row rank. When
 `rank < n` the rows of `U` that map to zero can be changed by any
 unimodular transformation of the kernel lattice. No uniqueness theorem
 for `U` is stated or should be expected.
@@ -171,7 +171,7 @@ example : IsRowReduced cexM cexD where
 
 Every field is vacuous or immediate, yet `5` sits to the left of the
 declared pivot, so this is not a row echelon form under any standard
-definition. `rowReduce` of course produces leading pivots; the point is
+definition. `rowReduce` of course produces leading pivots. The point is
 that the *contract* does not say so, and a downstream proof may not
 assume it.
 
@@ -211,8 +211,8 @@ structure IsHNF {n m : Nat} (M : Matrix Int n m) (D : RowEchelonData Int n m) : 
 
 This elaborates as written against the current tree. `above_nonneg` and
 `above_lt` are separate fields rather than one conjunction so that each
-can be cited on its own; the pair is the "reduced into `[0, pivot)`"
-condition. The `D.echelon[i]` access with `i : Fin D.rank` is the same
+can be cited on its own. Together they are the "reduced into
+`[0, pivot)`" condition. The `D.echelon[i]` access with `i : Fin D.rank` is the same
 shape `IsRowReduced.pivot_one` already uses.
 
 The unimodularity of `D.transform` is inherited from
@@ -404,7 +404,7 @@ however many independent rows it has.
 `hnfSquare` chooses between the modular algorithm and the general one on
 the determinant returned by `hex-bareiss`. Both branches are complete
 algorithms, so this is a dispatch and not a total form of a partial
-helper in the sense of design principle 8; no fallback classification is
+helper in the sense of design principle 8. No fallback classification is
 required, and none should be written.
 
 ## Correctness theorems
@@ -468,7 +468,7 @@ gives a second determinant algorithm to cross-check `hex-bareiss`
 against.
 
 `memLattice` is `Hex.Matrix.memLattice`, currently defined in
-`HexLLL/Lattice.lean`; see the next section.
+`HexLLL/Lattice.lean`. See the next section.
 
 ## Certificates and certified dispatch
 
@@ -497,7 +497,7 @@ theorem hnfCert_sound :
 `isHNFForm` is the decidable shape test for the four clauses, written
 directly on the entries. Note what the three checks buy. `U * W = I`
 over a commutative ring gives `W * U = I` as well, through the adjugate,
-so unimodularity of `U` follows from one product check; the reverse
+so unimodularity of `U` follows from one product check. The reverse
 product need not be certified separately. The same-lattice statement
 then follows from `U * A = H` and `W * H = W * U * A = A`. So
 `sameLatticeCert`'s second check is redundant here and should not be
@@ -529,10 +529,11 @@ One obligation that belongs in `hex-determinant` rather than here:
 theorem Matrix.mul_eq_one_comm {U W : Matrix R n n} : U * W = 1 → W * U = 1
 ```
 
-for a commutative ring, proved from `det_mul`, `mul_adjugate`, and
-`adjugate_mul`, all of which are already Mathlib-free in
-`HexDeterminant/Adjugate.lean`. It is adjugate theory, not Hermite
-theory, and two other libraries would use it.
+for a commutative ring. `HexDeterminant/Adjugate.lean` has `det_mul` and
+`mul_adjugate` in matrix form, and the other side only entrywise as
+`adjugate_mul_apply`. The matrix-level `adjugate_mul` is not there and is
+part of this obligation rather than something to cite. It is adjugate
+theory, not Hermite theory, and two other libraries would use it.
 
 ## Prerequisite changes in other libraries
 
@@ -546,7 +547,7 @@ statement in this SPEC is phrased with it, and `hex-hermite` should not
 acquire a dependency on `hex-lll` (and through it `hex-gram-schmidt`,
 `hex-bareiss`, `hex-determinant`) to say "is an integer combination of
 the rows". Move `memLattice`, `vecMul_mul`, `memLattice_of_mul_eq`, and
-`memLattice_iff_of_mul_eq` into `HexMatrix/Lattice.lean`; leave
+`memLattice_iff_of_mul_eq` into `HexMatrix/Lattice.lean`, and leave
 `independent` where it is.
 
 **`mulEqCert` should be public.** It is in `Hex.Internal`, so it is
@@ -689,7 +690,7 @@ No new job, no matrix, no new workflow file, per [SPEC/CI.md](../CI.md).
 exposes `fmpz_mat_hnf` and `fmpz_mat_hnf_transform` in the row-style
 convention this SPEC fixes. The python-flint binding for the
 transform-returning form must be confirmed against the version CI
-installs before the driver is written; if it is not exposed, the
+installs before the driver is written. If it is not exposed, the
 fallback is PARI's `mathnf(M, 1)` through `cypari2`, which is already a
 CI dependency. The column-style-to-row-style conversion is then done in
 the driver, and it is not just a transpose: reversing rows or columns on
@@ -781,7 +782,7 @@ mostly reports where the crossover was placed.
    grow faster in the dimension than the output entry bit-size does on
    `unimodular-conjugate`, with the time spent in big-integer arithmetic
    rising as a share of total time. Instrument entry size and allocation
-   in the bench, not just wallclock; a time ratio alone cannot separate
+   in the bench, not just wallclock. A time ratio alone cannot separate
    these two causes.
 
 ## File organisation

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -1,0 +1,859 @@
+# hex-hermite (Hermite normal form over `Int`, depends on hex-row-reduce, hex-arith, hex-bareiss)
+
+The Hermite normal form of an integer matrix: a canonical row-echelon
+representative of the integer row lattice, together with the unimodular
+transform that produces it and the transform's inverse. Mathlib-free;
+the companion `hex-hermite-mathlib` relates the executable output to
+`Submodule.span ℤ`, `Matrix.rank`, and the general linear group over `ℤ`.
+
+This SPEC and [hex-smith](hex-smith.md) are a pair. Hermite normal form
+uses row operations alone and is the ℤ analogue of reduced row echelon
+form. Smith normal form uses row and column operations, is diagonal, and
+is built on top of this library. Material shared by the two (the
+unimodular certificate shape, entry growth, the oracle) is specified
+here and referenced there.
+
+## Why this library exists
+
+Row reduction in `hex-row-reduce` requires a field: `rowReduce`,
+`spanCoeffs`, and `nullspace` all carry `[Lean.Grind.Field R]`, because
+the pivot step divides. Over `Int` the corresponding statements are
+about the row *lattice* rather than the row *space*, and they are
+strictly finer: `[[2, 0], [0, 2]]` and `[[1, 0], [0, 1]]` span the same
+subspace of `ℚ²` and different sublattices of `ℤ²`. Hermite normal form
+is the object that decides lattice questions the way reduced row echelon
+form decides subspace questions.
+
+What the library delivers, none of which is currently reachable:
+
+- **A canonical form for an integer row lattice.** Two matrices *of the
+  same dimensions* have the same integer row lattice exactly when their
+  Hermite normal forms are equal, so lattice equality is decided by one
+  comparison. Across dimensions the comparison is on `hnfBasis`, the
+  nonzero rows alone; see "Canonicity is per shape" below.
+- **Lattice membership with completeness.** `latticeContains A v` is
+  `true` exactly when `v` is an integer combination of the rows of `A`.
+  The `Field`-based `spanContains` answers the rational question and
+  says nothing about the integer one.
+- **An integer kernel basis.** The rows of the transform that map to
+  zero generate the whole kernel lattice `{x | vecMul x A = 0}`, not a
+  finite-index sublattice of it. Saturation is what makes this
+  different from clearing denominators in the rational nullspace.
+- **Integer rank** as the count of nonzero rows, computed without
+  passing through `ℚ`.
+- **The index of a finite-index sublattice**, as the product of the
+  pivots. Finite index means rank equal to the number of *columns*, so
+  this covers a tall matrix with `m` independent rows and never a wide
+  one.
+
+Named consumers:
+
+- **hex-smith**, which computes its diagonalisation from this library's
+  elimination step and reuses its certificate shape.
+- **hex-number-field** and the maximal-order work in
+  [future-work](../future-work.md), where module and ideal bases over
+  `ℤ` are stored in Hermite normal form and index computations are
+  exactly the pivot product above.
+- **hex-lll**, which can canonicalise a reduced basis and drop
+  dependent generators. The dependency runs from this library to
+  `hex-lll`'s vocabulary rather than the other way; see "Prerequisite
+  changes in other libraries".
+- The **polynomial-matrix invariant factors** item in
+  [future-work](../future-work.md), which needs the same algorithm shape
+  over `F[x]`. That is not this library; see "Why `Int` and not a
+  Euclidean domain class".
+
+## The convention this library fixes
+
+`A : Matrix Int n m`. A **Hermite normal form** of `A` is a pair
+`(U, H)` with `U : Matrix Int n n` unimodular (invertible over `ℤ`) and
+`H = U * A` satisfying:
+
+1. `H` has `r` nonzero rows, in rows `0 … r-1`, and rows `r … n-1` are
+   zero.
+2. Row `i < r` has its leading nonzero entry in column `jᵢ`, and
+   `j₀ < j₁ < ⋯ < j_{r-1}`.
+3. Each pivot `H[i][jᵢ]` is positive.
+4. Every entry above a pivot is reduced into the pivot's residue range:
+   `0 ≤ H[k][jᵢ] < H[i][jᵢ]` for `k < i`.
+
+This is the row-style form: `U` multiplies on the left, pivots move
+right as the row index increases, and the reduction is applied to the
+entries *above* each pivot. It matches the shape `RowEchelonData` and
+`IsEchelonForm` already describe, which is why the hex-row-reduce SPEC
+calls `IsEchelonForm` the "shared conditions for any echelon form (RREF
+or HNF)".
+
+**`H` is unique; `U` is not.** Uniqueness of `H` is the property the
+whole library rests on: its nonzero rows depend only on the integer row
+lattice of `A`. `U` is determined only when `A` has full row rank; when
+`rank < n` the rows of `U` that map to zero can be changed by any
+unimodular transformation of the kernel lattice. No uniqueness theorem
+for `U` is stated or should be expected.
+
+**Canonicity is per shape.** `hnf A : Matrix Int n m` keeps the `n - r`
+zero rows, so it is canonical among `n × m` matrices and not across
+presentations of the same lattice. `[1]` and `[[1], [0]]` generate the
+same lattice in `ℤ¹` and their Hermite normal forms do not even have the
+same type. The presentation-independent object is therefore
+
+```lean
+/-- The nonzero rows of `hnf A`: a canonical basis of the row lattice,
+independent of how many generators were supplied. -/
+def hnfBasis (A : Matrix Int n m) : Matrix Int (hnfRank A) m
+```
+
+and it is `hnfBasis` that the cross-presentation statements, the
+"drop dependent generators" consumer, and the conformance case comparing
+two presentations of one lattice all use. Every claim about `hnf` itself
+is qualified by "among matrices of the same dimensions".
+
+**Other systems use other conventions**, and the differences are exactly
+the four clauses above: column-style versus row-style, reduction above
+versus below the pivot, zero rows first versus last, and pivot sign.
+FLINT's `fmpz_mat_hnf` is row-style with reduction above the pivot,
+matching this SPEC. PARI's `mathnf` is column-style and returns its zero
+columns first. Normalising between conventions is the oracle driver's
+job, and is called out again under "Conformance", because a convention
+mismatch produces a plausible-looking matrix that fails equality on
+every input and is easy to misread as an algorithm bug.
+
+## The echelon contract is weaker than it looks
+
+`IsEchelonForm` and `IsRowReduced` (`HexRowReduce/RowEchelon/Contracts.lean`)
+do **not** require the declared pivot to be the leading nonzero entry of
+its row. Nothing in `pivotCols_sorted`, `below_pivot_zero`, or
+`zero_row` constrains an entry that lies to the left of a pivot in a
+non-pivot column. The following elaborates against the current tree:
+
+```lean
+/-- The 1x2 matrix `[[5, 1]]`. -/
+@[expose] def cexM : Matrix Int 1 2 := ⟨#v[5, 1]⟩
+
+/-- Declares rank `1` with pivot column `1`, and the identity transform. -/
+@[expose] def cexD : RowEchelonData Int 1 2 :=
+  { rank := 1, echelon := cexM, transform := Matrix.identity 1,
+    pivotCols := #v[(1 : Fin 2)] }
+
+example : IsRowReduced cexM cexD where
+  transform_mul := by simp [cexD]
+  transform_inv := ⟨Matrix.identity 1, by simp [cexD]⟩
+  transform_right_inv := ⟨Matrix.identity 1, by simp [cexD]⟩
+  rank_le_n := by simp [cexD]
+  rank_le_m := by simp [cexD]
+  pivotCols_sorted := by
+    rintro ⟨i, hi⟩ ⟨j, hj⟩ h
+    have hj' : j < 1 := hj
+    simp [Fin.lt_def] at h
+    omega
+  below_pivot_zero := by
+    rintro ⟨i, hi⟩ ⟨j, hj⟩ h
+    have hj' : j < 1 := hj
+    simp at h
+    omega
+  zero_row := by
+    rintro ⟨j, hj⟩ h
+    have hj' : j < 1 := hj
+    simp [cexD] at h
+    omega
+  pivot_one := by
+    rintro ⟨i, hi⟩
+    have hi' : i < 1 := hi
+    obtain rfl : i = 0 := by omega
+    simp [cexD, cexM, getRow, Vector.get]
+  above_pivot_zero := by
+    rintro ⟨i, hi⟩ ⟨j, hj⟩ h
+    have hi' : i < 1 := hi
+    have hj' : j < 1 := hj
+    simp at h
+    omega
+```
+
+Every field is vacuous or immediate, yet `5` sits to the left of the
+declared pivot, so this is not a row echelon form under any standard
+definition. `rowReduce` of course produces leading pivots; the point is
+that the *contract* does not say so, and a downstream proof may not
+assume it.
+
+Two consequences for this SPEC.
+
+**`IsHNF` must state the leading-entry condition itself.** Without it
+uniqueness is false: `[[5, 1]]` and `[[0, 1]]` would both be Hermite
+normal forms of `[[5, 1]]` with pivot column `1`, and they are different
+matrices. The condition is clause 2 above, and it appears as
+`pivot_leading` below.
+
+**The clause list in [future-work](../future-work.md) is wrong in both
+directions.** It proposes three HNF-specific fields, of which
+`det transform = 1 ∨ det transform = -1` is redundant, and it omits the
+leading-entry condition, which is required. Redundant because
+`IsEchelonForm.transform_inv` already supplies an integer matrix `Tinv`
+with `Tinv * transform = 1`, and `det_mul` (Mathlib-free, in
+`HexDeterminant/Adjugate.lean`) turns that into
+`det Tinv * det transform = 1`, hence `det transform = ±1`. So it is a
+theorem about `IsEchelonForm` over `Int`, stated once, not a field every
+construction has to discharge.
+
+## The contract
+
+```lean
+/-- Hermite normal form conditions on top of `IsEchelonForm`, over `Int`. -/
+structure IsHNF {n m : Nat} (M : Matrix Int n m) (D : RowEchelonData Int n m) : Prop
+    extends IsEchelonForm M D where
+  pivot_leading : ∀ (i : Fin D.rank) (j : Fin m),
+      j < D.pivotCols.get i → D.echelon[i][j] = 0
+  pivot_pos : ∀ (i : Fin D.rank), 0 < D.echelon[i][D.pivotCols.get i]
+  above_nonneg : ∀ (i : Fin D.rank) (k : Fin n), k.val < i.val →
+      0 ≤ D.echelon[k][D.pivotCols.get i]
+  above_lt : ∀ (i : Fin D.rank) (k : Fin n), k.val < i.val →
+      D.echelon[k][D.pivotCols.get i] < D.echelon[i][D.pivotCols.get i]
+```
+
+This elaborates as written against the current tree. `above_nonneg` and
+`above_lt` are separate fields rather than one conjunction so that each
+can be cited on its own; the pair is the "reduced into `[0, pivot)`"
+condition. The `D.echelon[i]` access with `i : Fin D.rank` is the same
+shape `IsRowReduced.pivot_one` already uses.
+
+The unimodularity of `D.transform` is inherited from
+`IsEchelonForm.transform_inv` and `transform_right_inv`, and is restated
+as a theorem:
+
+```lean
+theorem IsHNF.det_transform (h : IsHNF M D) :
+    det D.transform = 1 ∨ det D.transform = -1
+```
+
+## The elimination step
+
+Two entries `a` and `b` in the same column, with `(g, s, t) :=
+HexArith.Int.extGcd a b` so that `g = Int.gcd a b` and `s * a + t * b = g`.
+The 2x2 integer matrix
+
+```
+E = ⎡    s      t  ⎤          E⁻¹ = ⎡ a/g   -t ⎤
+    ⎣ -b/g   a/g  ⎦                ⎣ b/g    s ⎦
+```
+
+applied to the two rows replaces `(a, b)` by `(g, 0)`. Both divisions
+are exact (`g` divides `a` and `b`), and they follow the two-layer design
+`hex-bareiss` uses rather than putting a proof-carrying division on the
+value path: the executable loop calls a proof-free `exactDiv num denom :=
+num / denom` with an `@[extern]` binding, and a separate theorem
+`exactDiv_eq_divExact` identifies it with `Int.divExact` wherever
+divisibility is known (`HexBareiss/Bareiss.lean`). Since that primitive
+is now wanted by two libraries, it should move to `hex-arith` next to
+`extGcd` rather than be copied. `det E =
+(s * a + t * b) / g = 1`, and the displayed `E⁻¹` is its inverse by
+direct computation, so *the inverse transform is available at every step
+without a determinant or an adjugate*. Accumulating `U` and `W` together
+costs one extra row update per step and makes
+`IsEchelonForm.transform_inv` data rather than an existence proof to be
+recovered later.
+
+`extGcd` returns `g : Nat`, so `g` is nonnegative by construction and
+the pivot-positivity clause needs no separate sign fixup except when the
+whole column is zero, where the step is skipped.
+
+Reduction above a pivot `p > 0`: for each row `k < i`, subtract
+`(H[k][jᵢ] / p)` times row `i`. Lean's `Int` division and modulus are
+Euclidean (`(-7) / 3 = -3` and `(-7) % 3 = 2`), so the resulting entry
+is exactly `H[k][jᵢ] % p`, which lies in `[0, p)` by `Int.emod_nonneg`
+and the corresponding upper bound. No sign analysis is needed, and the
+`above_nonneg` and `above_lt` fields follow from the two standard
+`Int.emod` lemmas.
+
+## Entry growth is the design problem
+
+The elimination above is correct and unusable on its own. Intermediate
+entries of naive integer elimination grow far beyond the size of the
+answer: the output is bounded (for square nonsingular `A`, every entry
+of `H` is at most `|det A|`, and the pivot product is exactly `|det A|`)
+while the intermediate matrices are not. This is the classical
+observation that makes integer elimination a different subject from
+elimination over a field, and it is the same phenomenon `hex-bareiss`
+addresses for determinants by exact division.
+
+Three responses, all standard, and this SPEC takes the first two.
+
+**The default is total, and is the one the public `hnf` runs.** Process
+the columns left to right, and after each new pivot is fixed, reduce
+every entry above it immediately rather than at the end. Reducing eagerly
+is what keeps the already-processed part of the matrix bounded by its own
+pivots instead of letting it accumulate across the run. The rows not yet
+consumed are not bounded by anything, which is the honest statement, and
+is why the input families under "Benchmarking" measure entry size and not
+only time.
+
+This is deliberately *not* called Kannan-Bachem. Kannan-Bachem maintains
+Hermite normal forms of leading *nonsingular* minors and reorders rows
+and columns to produce them, and its entry bound is a cofactor bound that
+holds for that arrangement. Its FLINT analogue `hnf_minors` carries a
+rank precondition. The public `hnf` here takes arbitrary rectangular and
+rank-deficient input, where a leading minor determinant can be zero and
+the bound says nothing. Specifying rank-profile preprocessing, the
+full-rank subproblem it produces, and the reconstruction of the zero rows
+and the transform is real work and is listed under "Open questions" as
+the optimisation to measure against the total algorithm, not smuggled in
+as the default.
+
+**A modular variant for square nonsingular input.** For square
+nonsingular `A` with `d = |det A|`, the row lattice `L` contains `d·ℤⁿ`
+(because `d · A⁻¹` is `± adj A`, an integer matrix), so `L = L + d·ℤⁿ`
+and the Hermite normal form of `A` is the Hermite normal form of the
+`(2n) × n` matrix `[A; d·I]`. That augmented lattice is what makes
+modular arithmetic legitimate, and the statement has to be made in that
+form rather than as "reduce every entry modulo `d`":
+
+> Reducing a generator modulo `d` is **not** a lattice-preserving
+> operation on its own. For `A = [2]` and `d = 2`, the row `[2]` reduces
+> to `[0]`, which generates the zero lattice rather than `2ℤ`.
+
+What is legitimate is to compute in `ℤ/dℤ` while the generators of
+`d·ℤⁿ` remain present, which is what the Domich-Kannan-Trotter algorithm
+does: each pivot is `gcd` of the column entries *with `d`*, and a pivot
+may equal `d` itself, so entries live in `[0, d]` rather than `[0, d)`.
+The SPEC for `hnfSquare` is the DKT recurrence on `[A; d·I]`, not
+elimination with a modulus bolted on, and the implementation must
+represent the pivot value `d` rather than reducing it to `0`. `d` comes
+from `hex-bareiss`, which is why this library depends on it.
+
+**LLL-based reduction is deliberately not in v1.** The
+Havas-Majewski-Matthews algorithm controls growth by LLL-reducing the
+working rows, and `hex-lll` exists. It is left out until the benchmark
+under "Benchmarking" shows growth rather than operation count to be the
+constraint on a real input family, because the dependency is heavy
+(`hex-lll` pulls in `hex-gram-schmidt`) and the payoff is
+input-dependent. The threshold that would justify adding it is written
+down under "Benchmarking".
+
+**The transform costs more than the form.** `U` is larger than `H`, often
+much larger, and computing it is the dominant cost on hard inputs. This
+is not an artefact of a particular algorithm: `H` is bounded by the
+determinant while `U ≈ H · A⁻¹` is bounded by the determinant times the
+size of `A⁻¹`. FLINT's separate `fmpz_mat_hnf` and
+`fmpz_mat_hnf_transform` entry points are evidence that production
+implementations treat this as two operations, and this SPEC does the
+same: `hnf` returns the form alone and `hnfData` returns the form with
+the transform and its inverse. A caller who only wants lattice equality,
+rank, or the index must not be made to pay for `U`.
+
+## API
+
+```lean
+namespace Hex.Matrix
+
+/-- The Hermite normal form of `A`. Does not compute the transform. -/
+def hnf (A : Matrix Int n m) : Matrix Int n m
+
+/-- The number of nonzero rows of `hnf A`, i.e. the rank of `A` over `ℤ`. -/
+def hnfRank (A : Matrix Int n m) : Nat
+
+/-- The nonzero rows of `hnf A`: the canonical basis of the row lattice,
+independent of how many generators `A` supplied. -/
+def hnfBasis (A : Matrix Int n m) : Matrix Int (hnfRank A) m
+
+/-- The Hermite normal form with the unimodular transform, the pivot
+columns, and the rank, in the shared echelon-data shape. -/
+def hnfData (A : Matrix Int n m) : RowEchelonData Int n m
+
+/-- The inverse of `(hnfData A).transform`, accumulated alongside it. -/
+def hnfInv (A : Matrix Int n m) : Matrix Int n n
+
+/-- Hermite normal form of a square matrix, by the Domich-Kannan-Trotter
+recurrence on `[A; d·I]` when `d = |det A|` is nonzero. -/
+def hnfSquare (A : Matrix Int n n) : Matrix Int n n
+
+/-- Integer coefficients expressing `v` as a combination of the rows of
+`A`, or `none` when `v` is not in the row lattice. -/
+def latticeCoeffs (A : Matrix Int n m) (v : Vector Int m) : Option (Vector Int n)
+
+/-- Decides membership of `v` in the integer row lattice of `A`. -/
+def latticeContains (A : Matrix Int n m) (v : Vector Int m) : Bool
+
+/-- A basis of the integer kernel lattice `{x | vecMul x A = 0}`, as the
+rows of an `(n - hnfRank A) × n` matrix. -/
+def kernelBasis (A : Matrix Int n m) : Matrix Int (n - hnfRank A) n
+
+/-- The pivot entries of `hnf A`, in column order. -/
+def pivots (A : Matrix Int n m) : Vector Int (hnfRank A)
+
+/-- The index `[ℤᵐ : L]` of the row lattice of `A`, or `0` when the row
+lattice does not have finite index. -/
+def latticeIndex (A : Matrix Int n m) : Int
+
+end Hex.Matrix
+```
+
+Contracts an implementer would otherwise have to guess. `hnf` and
+`hnfData` agree on the form. `hnfRank A` is `(hnfData A).rank` and is
+computed without building the transform. `latticeCoeffs` returns
+coefficients against the rows of `A`, not against the rows of `hnf A`,
+which is why it needs the transform: solve against `hnf A` by
+back-substitution with exact division at each pivot, then map the answer
+through `(hnfData A).transform`. `kernelBasis` is the last `n - r` rows
+of `(hnfData A).transform`, and its dependent type follows `nullspace`
+in `hex-row-reduce`, which is already indexed by `rowReduce_rank M`.
+`latticeIndex` returns the pivot product when `hnfRank A = m` and `0`
+otherwise. The `0` is correct rather than a fallback: a row lattice of
+rank below `m` has infinite index in `ℤᵐ`, and `0` is the value `|det|`
+already takes in the square case. Note that finite index needs
+`hnfRank A = m`, the number of *columns*, so a wide matrix never has one
+however many independent rows it has.
+
+`hnfSquare` chooses between the modular algorithm and the general one on
+the determinant returned by `hex-bareiss`. Both branches are complete
+algorithms, so this is a dispatch and not a total form of a partial
+helper in the sense of design principle 8; no fallback classification is
+required, and none should be written.
+
+## Correctness theorems
+
+```lean
+theorem hnfData_isHNF (A : Matrix Int n m) : IsHNF A (hnfData A)
+theorem hnf_eq_hnfData_echelon (A : Matrix Int n m) : hnf A = (hnfData A).echelon
+theorem hnfRank_eq (A : Matrix Int n m) : hnfRank A = (hnfData A).rank
+theorem hnfInv_mul (A : Matrix Int n m) :
+    hnfInv A * (hnfData A).transform = Matrix.identity n
+theorem mul_hnfInv (A : Matrix Int n m) :
+    (hnfData A).transform * hnfInv A = Matrix.identity n
+
+-- Uniqueness, in the two forms callers want.
+theorem IsHNF.eq (h : IsHNF A D) (h' : IsHNF A D') :
+    D.rank = D'.rank ∧ D.echelon = D'.echelon
+theorem IsHNF.eq_of_memLattice (h : IsHNF A D) (h' : IsHNF B D')
+    (hL : ∀ v, A.memLattice v ↔ B.memLattice v) :
+    D.rank = D'.rank ∧ D.echelon = D'.echelon
+theorem hnf_idem (A : Matrix Int n m) : hnf (hnf A) = hnf A
+
+-- Canonicity across presentations, where the shapes need not agree.
+theorem hnfBasis_eq_of_memLattice (A : Matrix Int n m) (B : Matrix Int n' m)
+    (hL : ∀ v, A.memLattice v ↔ B.memLattice v) :
+    hnfRank A = hnfRank B ∧ HEq (hnfBasis A) (hnfBasis B)
+
+-- Lattice statements.
+theorem hnf_memLattice_iff (A : Matrix Int n m) (v : Vector Int m) :
+    A.memLattice v ↔ (hnf A).memLattice v
+theorem latticeCoeffs_sound {A : Matrix Int n m} {v c} :
+    latticeCoeffs A v = some c → vecMul c A = v
+theorem latticeCoeffs_complete {A : Matrix Int n m} {v} :
+    (∃ c, vecMul c A = v) → (latticeCoeffs A v).isSome
+theorem latticeContains_iff {A : Matrix Int n m} {v} :
+    latticeContains A v = true ↔ ∃ c, vecMul c A = v
+
+-- Kernel.
+theorem kernelBasis_mul (A : Matrix Int n m) : kernelBasis A * A = 0
+theorem kernelBasis_complete {A : Matrix Int n m} {x : Vector Int n} :
+    vecMul x A = 0 → ∃ c, vecMul c (kernelBasis A) = x
+
+-- Determinant and index.
+theorem latticeIndex_eq_prod_pivots (A : Matrix Int n m) (h : hnfRank A = m) :
+    latticeIndex A = (pivots A).foldl (· * ·) 1
+theorem latticeIndex_eq_det (A : Matrix Int n n) :
+    latticeIndex A = ((det A).natAbs : Int)
+```
+
+`IsHNF.eq_of_memLattice` is the substantive one and `IsHNF.eq` is its
+special case. Everything the library advertises about canonicity at a
+fixed shape comes from it, and `hnfBasis_eq_of_memLattice` is what lifts
+that across presentations, so those two are the theorems to prove first
+and the ones a `sorry` must not survive in.
+`kernelBasis_complete` is the saturation statement: it says the returned
+rows generate the whole kernel lattice, and it is what a rational
+nullspace computation cannot give.
+
+`latticeIndex_eq_det` is the square specialisation of
+`latticeIndex_eq_prod_pivots`, and is worth stating separately because it
+gives a second determinant algorithm to cross-check `hex-bareiss`
+against.
+
+`memLattice` is `Hex.Matrix.memLattice`, currently defined in
+`HexLLL/Lattice.lean`; see the next section.
+
+## Certificates and certified dispatch
+
+`hex-lll` already has the machinery this library needs, and it should be
+reused rather than reinvented. `Hex.Internal.mulEqCert U A C` decides
+`U * A = C` through a Kronecker-substitution digit packing, so the
+product matrix is never formed, and `mulEqCert_iff` proves it correct.
+`Hex.Matrix.sameLatticeCert` composes two of those into a same-lattice
+witness, with `sameLatticeCert_sound`.
+
+The Hermite certificate is three checks:
+
+```lean
+/-- Accepts `(H, U, W)` as the Hermite normal form of `A` with transform
+`U` and inverse transform `W`. -/
+def hnfCert (A H : Matrix Int n m) (U W : Matrix Int n n)
+    (r : Nat) (piv : Vector (Fin m) r) : Bool :=
+  Hex.Internal.mulEqCert U A H
+    && Hex.Internal.mulEqCert U W (Matrix.identity n)
+    && isHNFForm H r piv
+
+theorem hnfCert_sound :
+    hnfCert A H U W r piv = true → IsHNF A ⟨r, H, U, piv⟩
+```
+
+`isHNFForm` is the decidable shape test for the four clauses, written
+directly on the entries. Note what the three checks buy. `U * W = I`
+over a commutative ring gives `W * U = I` as well, through the adjugate,
+so unimodularity of `U` follows from one product check; the reverse
+product need not be certified separately. The same-lattice statement
+then follows from `U * A = H` and `W * H = W * U * A = A`. So
+`sameLatticeCert`'s second check is redundant here and should not be
+paid for.
+
+**The certificate is complete, unusually.** The warning at the head of
+[future-work](../future-work.md) is that a positive certificate
+establishes minimality, uniqueness, or canonicity only when it carries a
+separate witness for that property. Hermite normal form is one of the
+few cases where no second witness is needed: by `IsHNF.eq`, anything
+satisfying the shape clauses with a unimodular transform *is* the
+Hermite normal form. An accepted candidate is not merely admissible, it
+is the answer.
+
+That makes certified dispatch to an external implementation
+straightforward, in exactly the shape `hex-lll`'s `certCheck` already
+uses for fpLLL: an untrusted provider returns `(H, U, W)`, `hnfCert`
+accepts or rejects it, and the native algorithm runs when the provider
+is absent or rejected. Correctness then depends only on `hnfCert_sound`
+and the native path, which is what design principle 4 permits. The
+provider is **not** part of v1. It is recorded here so the certificate
+is designed for it now (the checker takes `W` as an argument rather than
+recomputing an inverse, which is the one decision that would be
+expensive to change later).
+
+One obligation that belongs in `hex-determinant` rather than here:
+
+```lean
+theorem Matrix.mul_eq_one_comm {U W : Matrix R n n} : U * W = 1 → W * U = 1
+```
+
+for a commutative ring, proved from `det_mul`, `mul_adjugate`, and
+`adjugate_mul`, all of which are already Mathlib-free in
+`HexDeterminant/Adjugate.lean`. It is adjugate theory, not Hermite
+theory, and two other libraries would use it.
+
+## Prerequisite changes in other libraries
+
+Three small relocations, each with a reason independent of this library.
+
+**`memLattice` should move to `hex-matrix`.** `Hex.Matrix.memLattice b v`
+is `∃ c, vecMul c b = v`. It mentions nothing from `hex-lll` and nothing
+from `hex-gram-schmidt`, but it lives in `HexLLL/Lattice.lean` alongside
+`independent`, which genuinely needs Gram-Schmidt. Every lattice
+statement in this SPEC is phrased with it, and `hex-hermite` should not
+acquire a dependency on `hex-lll` (and through it `hex-gram-schmidt`,
+`hex-bareiss`, `hex-determinant`) to say "is an integer combination of
+the rows". Move `memLattice`, `vecMul_mul`, `memLattice_of_mul_eq`, and
+`memLattice_iff_of_mul_eq` into `HexMatrix/Lattice.lean`; leave
+`independent` where it is.
+
+**`mulEqCert` should be public.** It is in `Hex.Internal`, so it is
+reachable but marked as an implementation detail. The packed product
+check is the right primitive for any certificate that asserts a matrix
+identity without forming the product, and this library plus `hex-smith`
+are two more consumers. Promote it to `Hex.Matrix` next to
+`sameLatticeCert`, and move both to `hex-matrix` with `memLattice`.
+
+**`mul_eq_one_comm` belongs in `hex-determinant`**, as above.
+
+**`exactDiv` should move to `hex-arith`.** `HexBareiss/Bareiss.lean`
+defines the proof-free `exactDiv` with its `@[extern]` binding and proves
+`exactDiv_eq_divExact` beside it. This library and `hex-smith` both want
+exactly that primitive, and copying it into two more places is how three
+slightly different versions appear. It is integer arithmetic, so it
+belongs next to `extGcd`, with `hex-bareiss` re-exporting or importing
+it.
+
+None of the four blocks starting work here: each can be done as a
+separate change before or alongside the first Hermite commit, and until
+they are, this library can name the existing paths.
+
+## Why `Int` and not a Euclidean domain class
+
+The obvious generalisation is a class carrying `xgcd`, exact division,
+and a normalisation, instantiated at `Int` now and at `FpPoly p` or
+`DensePoly` later, which would serve the polynomial-matrix invariant
+factors item in [future-work](../future-work.md). This SPEC does not do
+that, for a reason worth recording so the question is not reopened
+without new information.
+
+The shared part is smaller than it looks. What generalises is the 2x2
+elimination step. What does not: the canonical form of a pivot is
+"positive" over `ℤ` and "monic" over `F[x]`; the reduction of entries
+above a pivot is `%` into `[0, p)` over `ℤ` and remainder of lower
+degree over `F[x]`; the termination measure is absolute value in one
+case and degree in the other; and the growth problem that motivates
+the eager reduction and the modular variant is a coefficient-size problem over
+`ℤ` and a degree-growth problem over `F[x]`, with different remedies.
+A class that abstracts only the elimination step buys one function and
+costs an indirection on a path that has to reduce cheaply. The
+generalisation becomes worth doing when the `F[x]` consumer exists and
+its normalisation and growth story is written down, not before.
+[future-work](../future-work.md) says the same thing in the other
+direction: the two items "share an algorithm shape rather than a
+theorem".
+
+## Complexity
+
+`A` is `n × m` with rank `r` and entries bounded by `B` in absolute
+value. Costs are in ring operations on `Int`, with operand size stated
+separately, because the whole design question is operand size.
+
+These are **matrix-update counts**, not worst-case complexity: they count
+row updates and `extGcd` calls, each of which is one Euclidean run on
+operands of the stated size rather than a constant-time operation. A bit
+complexity would be the product of these counts with an operand size that
+depends on which algorithm ran, and that product is measured rather than
+derived. See "Benchmarking".
+
+| operation | algorithm | matrix updates and `extGcd` calls | operand size |
+|---|---|---|---|
+| `hnf` | column sweep with eager reduction above each pivot | `O(r · n · m)` | processed part bounded by its own pivots, unprocessed part unbounded |
+| `hnfSquare` (nonsingular) | elimination modulo the determinant `d` | `O(n³)` | `< d` throughout |
+| `hnfData` | `hnf` plus accumulation of `U` and `W` | `+ O(r · n²)` | larger than `H`; see "Entry growth" |
+| `latticeCoeffs` | back-substitution with exact division, then one `vecMul` through `U` | `O(n · m)` | bounded by the entries of `H` and `U` |
+| `kernelBasis` | row slice of `U` | none | `U`'s |
+| `latticeIndex` | pivot product | `O(m)` | bounded by the index |
+
+## The Mathlib layer
+
+`hex-hermite-mathlib` proves:
+
+```lean
+/-- The row lattice is unchanged. -/
+theorem span_hnf (A : Matrix Int n m) :
+    Submodule.span ℤ (Set.range (matrixEquiv (hnf A))) =
+      Submodule.span ℤ (Set.range (matrixEquiv A))
+
+/-- The transform is an element of the general linear group over `ℤ`. -/
+theorem isUnit_transform (A : Matrix Int n m) :
+    IsUnit (Matrix.det (matrixEquiv (hnfData A).transform))
+
+/-- The integer rank agrees with the rank over `ℚ`. -/
+theorem hnfRank_eq_rank (A : Matrix Int n m) :
+    hnfRank A = (matrixEquiv A).rank
+
+/-- Integer lattice membership is membership in the span. -/
+theorem latticeContains_iff_mem (A : Matrix Int n m) (v : Vector Int m) :
+    latticeContains A v = true ↔
+      vectorEquiv v ∈ Submodule.span ℤ (Set.range (matrixEquiv A))
+
+/-- The kernel basis is a basis of the kernel submodule. -/
+noncomputable def kernelBasisEquiv (A : Matrix Int n m) :
+    Module.Basis (Fin (n - hnfRank A)) ℤ
+      (LinearMap.ker (Matrix.vecMulLinear (matrixEquiv A)))
+```
+
+The last is the payoff and the reason the layer is more than a
+restatement: Mathlib's basis for a submodule of a free module over a PID
+(`Submodule.basisOfPid`) is noncomputable, and this supplies an
+executable one for the kernel of an integer matrix, with the identity
+between them proved. `hex-smith` extends the same idea to
+`Module.Basis.SmithNormalForm`.
+
+Mathlib has no Hermite normal form for matrices (searching for `hermite`
+finds Hermite polynomials, the Hermite-Minkowski theorem, and
+`IsHermitian`, none of them this). So there is nothing to correspond
+with, and the correspondence statements are all against `Submodule.span`,
+`Matrix.rank`, and `LinearMap.ker`. Upstreaming the definition and the
+uniqueness theorem is a reasonable later goal and is out of scope here.
+
+Following the project split, the uniqueness theorem `IsHNF.eq` is
+Mathlib-free and proved in `hex-hermite`: it is a statement about the
+executable types with an elementary proof by induction on the pivot
+columns, and no part of it is shorter through Mathlib.
+
+## Conformance
+
+Per [SPEC/testing.md](../testing.md). This library **extends the
+existing matrix oracle rather than adding one**: `scripts/oracle/matrix_flint.py`
+already serves `HexRowReduce`, `HexDeterminant`, and `HexBareiss`, and
+already reads the `matrix` fixture kind emitted by
+`Hex/Conformance/Emit.lean`'s `emitMatrixFixture`. Adding Hermite normal
+form means two new handlers in that driver's `handlers` table (`hnf` and
+`hnf-transform`), a new emit driver
+`conformance/HexHermite/EmitFixtures.lean` exposed as
+`lean_exe hexhermite_emit_fixtures`, a committed snapshot at
+`conformance-fixtures/HexHermite/hermite.jsonl`, and one tuple appended
+to `ORACLES` in `scripts/ci/run_oracles.sh`:
+
+```
+"HexHermite|hexhermite_emit_fixtures|scripts/oracle/matrix_flint.py|conformance-fixtures/HexHermite/hermite.jsonl"
+```
+
+No new job, no matrix, no new workflow file, per [SPEC/CI.md](../CI.md).
+
+**Oracle choice.** python-flint is already the driver's oracle and FLINT
+exposes `fmpz_mat_hnf` and `fmpz_mat_hnf_transform` in the row-style
+convention this SPEC fixes. The python-flint binding for the
+transform-returning form must be confirmed against the version CI
+installs before the driver is written; if it is not exposed, the
+fallback is PARI's `mathnf(M, 1)` through `cypari2`, which is already a
+CI dependency. The column-style-to-row-style conversion is then done in
+the driver, and it is not just a transpose: reversing rows or columns on
+its own changes the ambient coordinates and is not lattice-preserving.
+With `J_k` the `k × k` reversal matrix, run PARI on `J_m Aᵀ`, convert its
+`m × r` result `H'` by `J_r H'ᵀ J_m`, and append `n - r` zero rows. That
+mapping is itself a thing to test, on rectangular and rank-deficient
+fixtures, before it is trusted to report a mismatch.
+
+Whichever oracle is used, the driver checks the *form* against it and
+checks the *transform* by the identity `U * A = H` rather than against
+the oracle's `U`, because `U` is not unique and comparing it would
+produce spurious failures.
+
+**Cases that must be present**, since these are what a plausible
+implementation gets wrong:
+
+- the zero matrix, and a matrix with a zero column at the left, where
+  the first pivot is not in column `0`;
+- rank-deficient input, including duplicated and negated rows, checking
+  that the zero rows land at the bottom and `rank` is right;
+- more rows than columns and more columns than rows;
+- negative entries in every position that feeds a pivot, since the sign
+  handling of `extGcd` and of `%` is where an implementation goes wrong;
+- an input already in Hermite normal form, checking idempotence;
+- a pivot of `1`, where the reduction above it must produce zeros;
+- an input whose naive elimination blows up (a random `20 × 20` matrix
+  with entries in `[-10, 10]` is enough) with the entry sizes of the
+  intermediate matrices recorded, so the growth claim under "Entry
+  growth" is checked rather than asserted;
+- two matrices with the same row lattice and different numbers of rows,
+  checking that their `hnfBasis` values agree. This case is on
+  `hnfBasis`, not on `hnf`, because `hnf` of an `n × m` and an `n' × m`
+  matrix are different types and differ in their trailing zero rows;
+- for `hnfSquare`, an input whose Hermite normal form contains a pivot
+  equal to `d = |det A|` (the `1 × 1` matrix `[2]` is the smallest), which
+  is the case that catches a modular implementation reducing that pivot to
+  zero.
+
+The property checks in `conformance/HexHermite/Conformance.lean` assert
+`U * A = H`, `U * W = I`, the four shape clauses, the pivot product
+against `hex-bareiss`'s determinant on square nonsingular input,
+`latticeContains` on both a member and a non-member of the lattice, and
+`kernelBasis A * A = 0`.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+`bench/HexHermite/Bench.lean`. The bench must not import Mathlib.
+
+**Input families.** Growth behaviour depends on the input in a way that
+a single family would hide:
+
+- `random-dense-hermite`: uniform entries in `[-B, B]`, square and
+  nonsingular, the case where the modular algorithm should win.
+- `rank-deficient-hermite`: rows drawn as integer combinations of a
+  smaller independent set, where the determinant is zero and the modular
+  path is unavailable.
+- `tall-hermite`: many more rows than columns, the shape a number-field
+  module basis has, where most rows are redundant.
+- `unimodular-conjugate`: `V * D` for a random unimodular `V` and a
+  diagonal `D` with known entries, so the expected form is known in
+  advance and the input can be made arbitrarily badly conditioned
+  without a large determinant.
+
+**Comparators.** FLINT `fmpz_mat_hnf` through python-flint, and PARI
+`mathnf` through `cypari2`, both `informational`. FLINT dispatches
+across several algorithms including `hnf_pernet_stein`, which is
+asymptotically faster than anything specified here, so the ratio
+measures a different algorithm and does not hold a required threshold.
+PARI is column-style and its timing includes the convention conversion.
+Both are recorded for orientation in
+`reports/hex-hermite-performance.md`.
+
+**Two decision rules written down in advance.** Both are stated over a
+range rather than at one ladder endpoint, because a single-point ratio
+mostly reports where the crossover was placed.
+
+1. `hnfSquare` (modular) is kept only if it beats the default over a
+   named production range: the crossover curve in dimension and entry
+   bit-size is measured, and the modular path must win across the whole
+   upper half of both ladders, not merely at the last rung. If the
+   crossover sits outside the sizes the named consumers produce, the
+   modular path is not carrying its complexity and should be removed
+   rather than kept as an unmeasured alternative.
+2. The LLL-based Havas-Majewski-Matthews algorithm is justified only if
+   growth rather than operation count is what limits the default. The
+   evidence is a divergence: the peak intermediate entry bit-size must
+   grow faster in the dimension than the output entry bit-size does on
+   `unimodular-conjugate`, with the time spent in big-integer arithmetic
+   rising as a share of total time. Instrument entry size and allocation
+   in the bench, not just wallclock; a time ratio alone cannot separate
+   these two causes.
+
+## File organisation
+
+```
+HexHermite/
+  Contracts.lean     -- IsHNF, isHNFForm, IsHNF.det_transform
+  Step.lean          -- the 2x2 elimination step, its inverse, exact division
+  Hermite.lean       -- hnf, hnfData, hnfInv, hnfRank, hnfBasis
+  Modular.lean       -- hnfSquare, the DKT recurrence on [A; d·I]
+  Unique.lean        -- IsHNF.eq, IsHNF.eq_of_memLattice, hnf_idem
+  Lattice.lean       -- latticeCoeffs, latticeContains, kernelBasis, latticeIndex
+  Cert.lean          -- hnfCert and its soundness
+HexHermite.lean      -- umbrella
+HexHermiteMathlib/
+  Span.lean          -- span and lattice correspondence
+  Rank.lean          -- hnfRank = Matrix.rank
+  Kernel.lean        -- the executable kernel basis as a Module.Basis
+HexHermiteMathlib.lean
+```
+
+`libraries.yml` gains:
+
+```yaml
+  HexHermite:
+    deps: [HexRowReduce, HexArith, HexBareiss]
+    mathlib: false
+    done_through: 0
+    status: draft
+  HexHermiteMathlib:
+    deps: [HexHermite, HexRowReduceMathlib, HexBareissMathlib]
+    mathlib: true
+    done_through: 0
+    status: draft
+```
+
+`HexRowReduce` supplies `RowEchelonData` and `IsEchelonForm`, `HexArith`
+supplies `extGcd`, and `HexBareiss` supplies the determinant for the
+modular algorithm and (through `HexDeterminant`) `det_mul` and the
+adjugate identities. `HexMatrix` arrives through all three.
+
+## Open questions
+
+- **Where the rectangular modular algorithm stops.** The modular
+  argument needs `d·ℤᵐ ⊆ L` for the row lattice `L ⊆ ℤᵐ`, which needs `L`
+  to have finite index, which needs `hnfRank A = m`: full **column**
+  rank, with `n ≥ m`. It is not full row rank. A wide matrix with
+  independent rows spans a lower-rank sublattice of `ℤᵐ` and admits no
+  such `d` at all, so the modular path is unavailable there however many
+  independent rows it has. For `n ≥ m` of full column rank, the
+  determinant of any nonsingular `m × m` row submatrix is a positive
+  multiple of the index and is a valid modulus. Whether that extra
+  machinery pays is a benchmark question against `tall-hermite`, and
+  until it is answered `hnfSquare` is the only modular entry point.
+- **Whether the rank-profile preprocessing is worth writing.** The
+  default algorithm is total but its unprocessed rows are unbounded. The
+  Kannan-Bachem arrangement bounds them, at the cost of rank-profile
+  preprocessing, a full-rank subproblem, and reconstruction of the zero
+  rows and the transform. That is a real algorithm to specify, not a
+  variant of the default, and it should be specified only if the entry
+  instrumentation under "Benchmarking" shows the unprocessed rows are
+  what hurts.
+- **Whether `hnfData` should return `W`.** This SPEC returns the inverse
+  transform from a separate function, `hnfInv`, so that `RowEchelonData`
+  is unchanged. The alternative is a Hermite-specific data structure
+  carrying both. The existing shape is preferred because it keeps the
+  span and column-partition operations in `hex-row-reduce` usable
+  directly, but if the two are always called together the extra
+  traversal is waste and the structure should be reconsidered.
+- **Kernel reduction.** Nothing in this SPEC is on a `decide +kernel`
+  path today. If the Hermite certificate is ever checked in the kernel,
+  the exposure analysis in the `hex-mv-poly` SPEC applies verbatim, and
+  the `Vector.ofFn` and derived-`DecidableEq` traps recorded in
+  `progress/lean4-array-decidableeq-module-repro.md` will need the same
+  treatment.

--- a/SPEC/Libraries/hex-smith.md
+++ b/SPEC/Libraries/hex-smith.md
@@ -4,7 +4,7 @@ The Smith normal form of an integer matrix: a diagonal matrix `S` with
 `S = U * A * V` for unimodular `U` and `V`, whose diagonal entries are
 positive and form a divisibility chain `d₁ ∣ d₂ ∣ ⋯ ∣ d_r`. Those
 entries are the invariant factors of `A`, and they determine the
-structure of the abelian group presented by `A`. Mathlib-free; the
+structure of the abelian group presented by `A`. Mathlib-free. The
 companion `hex-smith-mathlib` builds Mathlib's
 `Module.Basis.SmithNormalForm` from the executable output and relates
 the invariant factors to the structure theorem for finitely generated
@@ -36,14 +36,14 @@ different and larger class of question:
   `∏ dᵢ` when `r = m`, and infinite otherwise.
 - **Invariant factors of a module map**, which is what the polynomial
   matrix item in [future-work](../future-work.md) wants over `F[x]`
-  rather than `ℤ`. That item is not this library; see "Why `Int`" in
+  rather than `ℤ`. That item is not this library. See "Why `Int`" in
   [hex-hermite](hex-hermite.md).
 
 The dependency on `hex-hermite` is real rather than organisational: the
 `extGcd` elimination step with its explicit inverse, the exact-division
 discipline, the certificate machinery, the conventions, and the
 `mul_eq_one_comm` obligation are all shared. Note that the default
-algorithm below does *not* call `hnf`; the Kannan-Bachem variant under
+algorithm below does *not* call `hnf`. The Kannan-Bachem variant under
 "Open questions" would, which is the other reason to keep the two
 libraries adjacent.
 
@@ -135,7 +135,7 @@ this is the library that needs it first.
 **The default is the classical Euclidean pivot algorithm**, and it is
 called that rather than Kannan-Bachem. Kannan-Bachem controls growth by
 alternating row and column Hermite normal forms on trailing submatrices,
-and its entry bound comes from that repetition; the pivot loop below does
+and its entry bound comes from that repetition. The pivot loop below does
 not inherit those bounds merely by shrinking the pivot, and saying it
 does would be an unearned claim. What the loop below has is a
 straightforward correctness argument and a termination measure. What it
@@ -279,7 +279,7 @@ columns. `detDivisor A 0 = 1`, and `detDivisor A k = 0` when
 `k > min n m` or when every such minor vanishes.
 
 This is the specification function. Its definition is the gcd above and
-mentions nothing about `snf`; `detDivisor_eq_prod` is what says the
+mentions nothing about `snf`. `detDivisor_eq_prod` is what says the
 invariant factors compute it. -/
 noncomputable def detDivisor (A : Matrix Int n m) (k : Nat) : Nat
 
@@ -287,7 +287,7 @@ end Hex.Matrix
 ```
 
 Contracts to state explicitly. `invariantFactors` drops nothing, so its
-leading entries may be `1`; `abelianStructure` drops them, because a
+leading entries may be `1`. `abelianStructure` drops them, because a
 `ℤ/1` summand is not part of anyone's answer, and returns the free rank
 `m - rank` separately. `quotientOrder` returns `0` when the free rank is
 positive, which is the same convention `latticeIndex` uses in
@@ -416,7 +416,7 @@ clauses with unimodular transforms has the rank and the diagonal of the
 Smith normal form, so an accepted candidate is the answer and no second
 witness for canonicity is needed. Note that this completeness is
 downstream of the uniqueness theorem, which is downstream of the
-`hex-determinant` prerequisite above; until that chain is closed, the
+`hex-determinant` prerequisite above. Until that chain is closed, the
 checker is sound but the "it is the answer" claim is not yet proved.
 That makes certified dispatch to an external implementation possible in
 the shape `hex-lll`'s `certCheck` already uses. It is not part of v1.
@@ -481,6 +481,12 @@ domain class" in [hex-hermite](hex-hermite.md). The polynomial case is
 the route to rational canonical form and the minimal polynomial, and it
 shares the algorithm shape and none of the normalisation, growth
 control, or termination measure.
+
+**Anything Berlekamp-Zassenhaus needs.** Nothing in the existing tree
+depends on this library. Integer factoring of polynomials reaches its
+answer without a Smith normal form, so this is new capability rather than
+a missing piece of something already built, and it can be scheduled
+purely on the strength of its own consumers.
 
 **Sparse input.** Relation matrices from group presentations are often
 very sparse, and dense elimination fills them in immediately. The sparse
@@ -645,12 +651,12 @@ Everything else arrives through `HexHermite`.
   forms on trailing submatrices and does have one, at the cost of block
   embeddings, rank-deficient handling, and accumulating the transforms
   through all of it. The growth instrumentation under "Benchmarking" is
-  what decides whether that work is called for; it should not be started
+  what decides whether that work is called for. It should not be started
   on the strength of the name.
 - **Whether `detDivisor` should be public at all.** It is the
   specification function and it has no efficient direct evaluation. The
   argument for exporting it is that the statement `d₁ ⋯ d_k = D_k` is
-  the thing a mathematician wants to cite; the argument against is that
+  the thing a mathematician wants to cite. The argument against is that
   a `noncomputable` definition with an exponential unfolding invites
   misuse. It is exported here with its docstring saying so.
 - **Sparse relation matrices**, as above. The dense algorithm is

--- a/SPEC/Libraries/hex-smith.md
+++ b/SPEC/Libraries/hex-smith.md
@@ -1,0 +1,658 @@
+# hex-smith (Smith normal form over `Int`, depends on hex-hermite)
+
+The Smith normal form of an integer matrix: a diagonal matrix `S` with
+`S = U * A * V` for unimodular `U` and `V`, whose diagonal entries are
+positive and form a divisibility chain `d₁ ∣ d₂ ∣ ⋯ ∣ d_r`. Those
+entries are the invariant factors of `A`, and they determine the
+structure of the abelian group presented by `A`. Mathlib-free; the
+companion `hex-smith-mathlib` builds Mathlib's
+`Module.Basis.SmithNormalForm` from the executable output and relates
+the invariant factors to the structure theorem for finitely generated
+modules over a PID.
+
+This SPEC is the second half of a pair with
+[hex-hermite](hex-hermite.md), which fixes the conventions, the
+unimodular certificate shape, the entry-growth analysis, and the oracle
+this library extends. Read that one first.
+
+## Why this library exists
+
+Hermite normal form answers questions about one lattice. Smith normal
+form answers questions about a lattice *inside* another, which is a
+different and larger class of question:
+
+- **The structure of a finitely generated abelian group.** Given
+  relations as the rows of `A : Matrix Int n m`, the group
+  `ℤᵐ / rowlattice A` is `ℤ^(m - r) ⊕ ℤ/d₁ ⊕ ⋯ ⊕ ℤ/d_r`, read directly
+  off the diagonal, with the `dᵢ = 1` summands dropped. This is the
+  headline consumer and the reason the divisibility chain matters:
+  without it the diagonal is not canonical and the summands are not the
+  invariant factors.
+- **Integer linear systems.** `A x = b` over `ℤ` becomes a diagonal
+  system after the change of basis, so solvability is a divisibility
+  test per coordinate and the full solution set is a coset of the kernel
+  lattice.
+- **The index and the order of a quotient.** `[ℤᵐ : rowlattice A]` is
+  `∏ dᵢ` when `r = m`, and infinite otherwise.
+- **Invariant factors of a module map**, which is what the polynomial
+  matrix item in [future-work](../future-work.md) wants over `F[x]`
+  rather than `ℤ`. That item is not this library; see "Why `Int`" in
+  [hex-hermite](hex-hermite.md).
+
+The dependency on `hex-hermite` is real rather than organisational: the
+`extGcd` elimination step with its explicit inverse, the exact-division
+discipline, the certificate machinery, the conventions, and the
+`mul_eq_one_comm` obligation are all shared. Note that the default
+algorithm below does *not* call `hnf`; the Kannan-Bachem variant under
+"Open questions" would, which is the other reason to keep the two
+libraries adjacent.
+
+## What Smith normal form is
+
+`A : Matrix Int n m`. A **Smith normal form** of `A` is a triple
+`(U, S, V)` with `U : Matrix Int n n` and `V : Matrix Int m m`
+unimodular and `S = U * A * V` satisfying:
+
+1. `S[i][j] = 0` whenever `i ≠ j`.
+2. `S[i][i] = dᵢ > 0` for `i < r`, and `S[i][i] = 0` for `i ≥ r`.
+3. `dᵢ ∣ dᵢ₊₁` for `i + 1 < r`.
+
+`S` is unique. `U` and `V` are not, and are much less determined than
+the Hermite transform is: any automorphism of the source or target
+lattice compatible with the diagonal can be composed in. No uniqueness
+theorem for `U` or `V` is stated.
+
+Uniqueness of `S` is not a shape argument, and this is the one place
+where Smith normal form needs an idea that Hermite normal form does not.
+The invariant is the **`k`-th determinantal divisor** `D_k(A)`, the gcd
+of all `k × k` minors of `A`. Every `k × k` minor of `U * A` is an
+integer combination of the `k × k` minors of `A` (this is Cauchy-Binet
+in its general rectangular form), so `D_k` is unchanged by multiplying
+by a unimodular matrix on either side. For a diagonal matrix with a
+divisibility chain, `D_k = d₁ ⋯ d_k` for `k ≤ r`, with `D_0 = 1` and
+`D_k = 0` for `k > r`. Hence `r` is the largest `k` with `D_k ≠ 0`, and
+`d_k = D_k(A) / D_{k-1}(A)`, both determined by `A` alone.
+
+Stating the `k > r` case is not pedantry: it is what makes the rank part
+of uniqueness provable, and leaving it out breaks the argument. See
+`IsSNF.detDivisor_eq` under "Correctness theorems".
+
+That argument is also the specification: `D_k` is what the library
+proves its output computes, and every uniqueness and canonicity claim
+comes from it.
+
+## Data and contract
+
+```lean
+/-- Executable Smith normal form data: the rank, the invariant factors,
+and both change-of-basis matrices with their inverses. -/
+structure SmithData (n m : Nat) where
+  rank : Nat
+  diag : Vector Int rank
+  left : Matrix Int n n
+  leftInv : Matrix Int n n
+  right : Matrix Int m m
+  rightInv : Matrix Int m m
+
+/-- The `n × m` matrix carrying `d` down the leading diagonal. -/
+def diagMatrix {r : Nat} (d : Vector Int r) (n m : Nat) : Matrix Int n m :=
+  Matrix.ofFn fun i j => if h : i.val = j.val ∧ i.val < r then d[i.val]'h.2 else 0
+
+/-- Smith normal form contract. -/
+structure IsSNF {n m : Nat} (A : Matrix Int n m) (S : SmithData n m) : Prop where
+  left_inv : S.left * S.leftInv = Matrix.identity n
+  right_inv : S.right * S.rightInv = Matrix.identity m
+  mul_eq : S.left * A * S.right = diagMatrix S.diag n m
+  rank_le_n : S.rank ≤ n
+  rank_le_m : S.rank ≤ m
+  diag_pos : ∀ i : Fin S.rank, 0 < S.diag[i]
+  chain : ∀ (i : Nat) (h : i + 1 < S.rank), S.diag[i]'(by omega) ∣ S.diag[i + 1]
+```
+
+This elaborates as written against the current tree. Three decisions in
+it are worth stating, because an implementer would otherwise choose
+differently.
+
+**One-sided inverse fields.** `left_inv` and `right_inv` record only
+`U * W = I` and `V * X = I`. The other side follows over a commutative
+ring through the adjugate, by the `mul_eq_one_comm` lemma
+[hex-hermite](hex-hermite.md) asks `hex-determinant` for. Carrying both
+directions as fields would make every construction discharge a
+redundant obligation.
+
+**The inverses are data, not existence.** As in the Hermite case, every
+elementary step has an explicit inverse, so accumulating `W` and `X`
+alongside `U` and `V` costs one extra update per step and removes any
+need to invert a matrix afterwards.
+
+**`diagMatrix` should probably move to `hex-matrix`.** It is a general
+constructor, `hex-matrix` has no `diagonal` of any kind today, and a
+second consumer would immediately want it. It is specified here because
+this is the library that needs it first.
+
+## Algorithms
+
+**The default is the classical Euclidean pivot algorithm**, and it is
+called that rather than Kannan-Bachem. Kannan-Bachem controls growth by
+alternating row and column Hermite normal forms on trailing submatrices,
+and its entry bound comes from that repetition; the pivot loop below does
+not inherit those bounds merely by shrinking the pivot, and saying it
+does would be an unearned claim. What the loop below has is a
+straightforward correctness argument and a termination measure. What it
+does not have is a proven entry bound, and both row and column operations
+feed the growth here, so it is worse in that respect than the Hermite
+case. The benchmark instrumentation under "Benchmarking" is therefore not
+optional decoration: it is the only evidence about growth this algorithm
+comes with.
+
+Specifying Kannan-Bachem properly (the alternating Hermite calls, the
+block embeddings, rank-deficient handling, and transform accumulation
+through all of it) is a separate piece of work, listed under "Open
+questions" as the optimisation to measure against this default.
+
+The pivot loop, which is where the mathematics lives:
+
+1. If the remaining block is zero, stop with the current rank.
+2. Move a nonzero entry of minimal absolute value to the pivot position
+   by one row swap and one column swap.
+3. Clear the pivot's column with row operations and its row with column
+   operations, using the same `extGcd` 2x2 step as
+   [hex-hermite](hex-hermite.md). Each step replaces the pivot by
+   `gcd(pivot, entry)`, so the pivot never grows.
+4. If some entry `a[i][j]` of the remaining block is not divisible by
+   the pivot `p`, add row `i` to the pivot row **and immediately run the
+   column-`j` elimination against the new entry**, which replaces `p` by
+   `gcd(p, a[i][j])`, then return to step 3. This is the step that
+   produces the divisibility chain, and it is the step a naive
+   implementation omits.
+5. Otherwise advance to the next diagonal position.
+
+**Termination measure.** The pair `(|pivot|, c)` ordered
+lexicographically, where `c` is the number of nonzero entries in the
+pivot row and column other than the pivot itself. Step 3 either leaves
+`|pivot|` fixed and decreases `c` (when the pivot divides the entry, so
+the step is a plain subtraction) or strictly decreases `|pivot|` (when
+it does not).
+
+Step 4 is why it is stated as one fused step rather than two. Adding row
+`i` to the pivot row on its own decreases nothing: `|pivot|` is unchanged
+and `c` rises from `0`, so the measure *increases*, and "it decreases on
+the next pass" is not a termination argument, since Lean needs the
+recursive call itself to decrease. Fusing the elimination into the same
+step fixes it: the recursion happens only after the pivot has become
+`gcd(p, a[i][j])`, which is a strict divisor of `p` because `p ∤ a[i][j]`,
+so `|pivot|` strictly decreases across the whole step. Both components
+are naturals, so the loop is well-founded.
+
+Whether that measure is threaded as a `termination_by` clause or as
+explicit fuel with a sufficiency theorem is an implementation decision,
+but it must be one of the two. `hex-lll` sets the precedent for the fuel
+form (`lllFuel`, with the sufficiency theorem tracked as separate work),
+and the same discipline applies: the fuel-exhausted branch returns a
+value that a sufficiency theorem proves unreachable on public API
+inputs, and that classification is written down. Design principle 8
+allows nothing weaker.
+
+**A modular variant, for the form only.** Iliopoulos's algorithm runs
+the elimination modulo a positive multiple of the largest invariant
+factor, keeping entries bounded. Two restrictions have to be in the
+signature rather than in the prose. It applies to nonsingular square
+input, where `hex-bareiss` supplies the modulus. And it computes the
+diagonal, not the transforms: the multipliers are not a by-product of the
+modular recurrence, and recovering them is a separate algorithm (FLINT
+uses an iterated-Hermite routine for the transform case rather than its
+modular one). So the entry point is
+
+```lean
+/-- The invariant factors of a nonsingular square matrix, computed
+modulo a multiple of the largest one. Returns the diagonal only. -/
+def snfSquareDiag (A : Matrix Int n n) : Option (Vector Int n)
+```
+
+returning `none` on singular input, and it does **not** sit on the
+`SmithData` path. Putting it there would mean specifying and proving a
+multiplier-reconstruction algorithm, which is not in this SPEC. It is
+subject to the same measured decision rule as `hnfSquare` in
+[hex-hermite](hex-hermite.md) before it is kept at all.
+
+**A fast path for diagonal input.** A diagonal matrix is already almost
+in Smith normal form and needs only normalisation and the chain. The
+normalisation is not skippable, because the input diagonal may contain
+zeros and negatives: negate the row of each negative entry, move the
+nonzero entries stably before the zeros, and take the rank to be the
+number of nonzero entries. Every sign change and transposition is
+accumulated into all four transform matrices. The gcd and lcm sweep then
+runs on the positive prefix alone, which is what makes the divisions by
+`g` below defined: `[0, 0]` has no `g` to divide by, and `[0, 2]` is not
+in Smith normal form despite being diagonal.
+
+For two adjacent normalised entries `a, b > 0` with
+`(g, s, t) := extGcd a b` and `l = a * b / g`, the pair
+
+```
+L = ⎡ 1     1 ⎤ then ⎡     1      0 ⎤     V = ⎡ s   -b/g ⎤
+    ⎣ 0     1 ⎦      ⎣ -b·t/g     1 ⎦         ⎣ t    a/g ⎦
+```
+
+sends `diag(a, b)` to `diag(g, l)`: adding the second row to the first
+gives `[[a, b], [0, b]]`, right-multiplying by `V` (which has
+determinant `(s·a + t·b)/g = 1`) gives `[[g, 0], [b·t, l]]`, and the
+second row operation clears the `b·t` entry, which is divisible by `g`
+because `g` divides `b`. Sweeping this over adjacent pairs until no pair
+changes yields the chain in `O(r²)` gcd steps. This is FLINT's
+`snf_diagonal`, and it is the path a direct-sum presentation of an
+abelian group takes, which is the common case for the headline consumer.
+
+**Not specified: Storjohann's algorithms.** The asymptotically fast
+methods based on matrix multiplication are out of scope, and the
+comparator classification under "Benchmarking" says so rather than
+pretending the ratio against FLINT measures the same algorithm.
+
+## API
+
+```lean
+namespace Hex.Matrix
+
+/-- Smith normal form data for `A`. -/
+def snf (A : Matrix Int n m) : SmithData n m
+
+/-- The invariant factors of `A`, positive and in a divisibility chain. -/
+def invariantFactors (A : Matrix Int n m) : Vector Int (snf A).rank
+
+/-- Smith normal form of a diagonal matrix, given its diagonal. -/
+def snfDiagonal {r : Nat} (d : Vector Int r) : SmithData r r
+
+/-- The structure of `ℤᵐ / rowlattice A`: the free rank, and the
+torsion invariants in a divisibility chain with the units dropped. -/
+def abelianStructure (A : Matrix Int n m) : Nat × Array Int
+
+/-- The order of `ℤᵐ / rowlattice A`, or `0` when it is infinite. -/
+def quotientOrder (A : Matrix Int n m) : Int
+
+/-- An integer solution of `vecMul x A = b`, or `none` when there is
+none. -/
+def solveInt (A : Matrix Int n m) (b : Vector Int m) : Option (Vector Int n)
+
+/-- The `k`-th determinantal divisor: the gcd of the determinants of all
+`k × k` submatrices of `A`, taken over every choice of `k` rows and `k`
+columns. `detDivisor A 0 = 1`, and `detDivisor A k = 0` when
+`k > min n m` or when every such minor vanishes.
+
+This is the specification function. Its definition is the gcd above and
+mentions nothing about `snf`; `detDivisor_eq_prod` is what says the
+invariant factors compute it. -/
+noncomputable def detDivisor (A : Matrix Int n m) (k : Nat) : Nat
+
+end Hex.Matrix
+```
+
+Contracts to state explicitly. `invariantFactors` drops nothing, so its
+leading entries may be `1`; `abelianStructure` drops them, because a
+`ℤ/1` summand is not part of anyone's answer, and returns the free rank
+`m - rank` separately. `quotientOrder` returns `0` when the free rank is
+positive, which is the same convention `latticeIndex` uses in
+[hex-hermite](hex-hermite.md) and is a correct value rather than a
+fallback.
+
+`solveInt` needs both transforms, not one. From `S = U * A * V`, the
+system `vecMul x A = b` becomes `vecMul z S = vecMul b V` with
+`z = vecMul x U⁻¹`, so the right-hand side is transformed by `V` before
+the diagonal solve, and the answer is mapped back by `x = vecMul z U`.
+Solving the diagonal system against `b` directly is wrong whenever
+`V ≠ I`, which is the usual case, and the transformed right-hand side
+gets its own lemma in the theorem list.
+
+`detDivisor` is `noncomputable` under design principle 11: its definition
+enumerates exponentially many minors and there is no runtime twin. It is
+**defined by that enumeration and not through `snf`**. Defining it
+through `snf` would make `detDivisor_eq_prod` circular, since the
+invariant used to prove that `snf`'s output is canonical would already
+contain that output. The executable route to its *value* is the product
+of the first `k` invariant factors, which is what `detDivisor_eq_prod`
+states. It returns `Nat` so that "the gcd" needs no separate
+normalisation clause.
+
+## Correctness theorems
+
+```lean
+theorem snf_isSNF (A : Matrix Int n m) : IsSNF A (snf A)
+theorem snfDiagonal_isSNF {r : Nat} (d : Vector Int r) :
+    IsSNF (diagMatrix d r r) (snfDiagonal d)
+
+-- The determinantal-divisor characterisation, which is the specification.
+-- Stated for every k, including k > S.rank, where both sides are zero.
+theorem IsSNF.detDivisor_eq {A : Matrix Int n m} {S : SmithData n m}
+    (h : IsSNF A S) (k : Nat) :
+    detDivisor A k =
+      if k ≤ S.rank then ((S.diag.take k).foldl (· * ·) 1).natAbs else 0
+
+-- Uniqueness, in the form callers use.
+theorem IsSNF.rank_eq (h : IsSNF A S) (h' : IsSNF A S') : S.rank = S'.rank
+theorem IsSNF.diag_eq (h : IsSNF A S) (h' : IsSNF A S') (i : Nat)
+    (hi : i < S.rank) (hi' : i < S'.rank) : S.diag[i] = S'.diag[i]
+
+-- Agreement with the Hermite rank, and with the determinant.
+theorem IsSNF.rank_eq_hnfRank (h : IsSNF A S) : S.rank = hnfRank A
+theorem prod_invariantFactors (A : Matrix Int n n) (h : (snf A).rank = n) :
+    (invariantFactors A).foldl (· * ·) 1 = ((det A).natAbs : Int)
+
+-- The consumer-facing statements.
+theorem solveInt_iff_diagonal {A : Matrix Int n m} {b} (S := snf A) :
+    (∃ x, vecMul x A = b) ↔
+      ∃ z, vecMul z (diagMatrix S.diag n m) = vecMul b S.right
+theorem solveInt_sound {A : Matrix Int n m} {b x} :
+    solveInt A b = some x → vecMul x A = b
+theorem solveInt_complete {A : Matrix Int n m} {b} :
+    (∃ x, vecMul x A = b) → (solveInt A b).isSome
+theorem quotientOrder_eq (A : Matrix Int n m) :
+    quotientOrder A =
+      if (snf A).rank = m then (invariantFactors A).foldl (· * ·) 1 else 0
+```
+
+`IsSNF.detDivisor_eq` is the theorem to prove first, and it must be
+stated for every `k` rather than only for `k ≤ S.rank`. The `k ≤ S.rank`
+form cannot prove `rank_eq`: if `S.rank < S'.rank`, the value that
+separates them is `k = S.rank + 1`, which is exactly where the restricted
+statement does not apply. With the all-`k` form, `S.rank` is the largest
+`k` whose determinantal divisor is nonzero, which gives `rank_eq`, and
+cancelling the positive product of the preceding factors gives
+`diag_eq`. Everything the library claims about canonicity rests on it.
+
+**Its prerequisite is a phase of work in `hex-determinant`, and that
+work does not exist.** The argument needs each `k × k` minor of a product
+to expand as an integer combination of the `k × k` minors of the factors,
+that is, Cauchy-Binet in its general rectangular form. What is actually
+in the tree is narrower than that in both files. `HexDeterminant/Minor.lean`
+provides only `deleteRowCol`, which removes one row and one column from a
+square matrix. `HexDeterminant/CauchyBinet.lean` builds
+`columnTupleMatrix`, which selects `n` columns from a matrix that has
+exactly `n` rows, so the row side is never chosen. `HexMatrix/Submatrix.lean`
+offers `principalSubmatrix`, `takeRows`, and `takeCols`, all of which take
+prefixes rather than arbitrary index sets. There is no arbitrary
+`k`-row-by-`k`-column minor anywhere, and no enumeration of `k`-subsets.
+
+So `hex-determinant` needs, as a named prerequisite:
+
+- selected submatrices indexed by a pair of strictly increasing index
+  maps, with the `Fin k` reindexing lemmas;
+- enumeration of the `k`-subsets of `Fin n` in a canonical order, which
+  is the row-side analogue of the existing `columnTupleVectors`;
+- Cauchy-Binet for a selected minor of a product;
+- the gcd and divisibility lemmas that turn that expansion into
+  invariance of `detDivisor` under unimodular multiplication.
+
+Smith implementation should not be scheduled before that lands. Nothing
+else in this SPEC depends on it, so the executable parts and the
+certificate can proceed in parallel with it.
+
+## Certificates
+
+The same shape as [hex-hermite](hex-hermite.md), with one more product:
+
+```lean
+/-- Accepts `(S, U, W, V, X, T)` as a Smith normal form of `A`, where
+`T = U * A` is the intermediate product. -/
+def snfCert (A : Matrix Int n m) (S : SmithData n m) (T : Matrix Int n m) : Bool :=
+  Hex.Internal.mulEqCert S.left A T
+    && Hex.Internal.mulEqCert S.right.transpose T.transpose
+          (diagMatrix S.diag n m).transpose
+    && Hex.Internal.mulEqCert S.left S.leftInv (Matrix.identity n)
+    && Hex.Internal.mulEqCert S.right S.rightInv (Matrix.identity m)
+    && isSNFShape S
+
+theorem snfCert_sound : snfCert A S T = true → IsSNF A S
+```
+
+`mulEqCert` checks left multiplication only, so the right-hand product
+`T * V = S` is checked in transposed form. The intermediate `T` is an
+argument rather than a computed value so that no product matrix is
+formed inside the checker, which is the property `mulEqCert` exists to
+provide.
+
+As with Hermite normal form, and unlike most items in
+[future-work](../future-work.md), **this certificate is complete**: by
+`IsSNF.rank_eq` and `IsSNF.diag_eq`, anything satisfying the shape
+clauses with unimodular transforms has the rank and the diagonal of the
+Smith normal form, so an accepted candidate is the answer and no second
+witness for canonicity is needed. Note that this completeness is
+downstream of the uniqueness theorem, which is downstream of the
+`hex-determinant` prerequisite above; until that chain is closed, the
+checker is sound but the "it is the answer" claim is not yet proved.
+That makes certified dispatch to an external implementation possible in
+the shape `hex-lll`'s `certCheck` already uses. It is not part of v1.
+
+## The Mathlib layer
+
+`hex-smith-mathlib` proves:
+
+```lean
+/-- The executable Smith normal form as Mathlib's structure, for the
+submodule spanned by the rows of `A`. -/
+noncomputable def smithNormalForm (A : Matrix Int n m) :
+    Module.Basis.SmithNormalForm
+      (Submodule.span ℤ (Set.range (matrixEquiv A))) (Fin m) (snf A).rank
+
+/-- The divisibility chain, which Mathlib's structure does not carry. -/
+theorem smithNormalForm_chain (A : Matrix Int n m) (i : Nat) (h : i + 1 < (snf A).rank) :
+    (smithNormalForm A).a ⟨i, by omega⟩ ∣ (smithNormalForm A).a ⟨i + 1, h⟩
+
+/-- The structure theorem, instantiated at the executable output. -/
+noncomputable def quotientEquiv (A : Matrix Int n m) :
+    (Fin m → ℤ) ⧸ Submodule.span ℤ (Set.range (matrixEquiv A)) ≃ₗ[ℤ]
+      (Fin (m - (snf A).rank) → ℤ) × ⨁ i, ℤ ⧸ Ideal.span {invariantFactors A i}
+```
+
+Two things are worth knowing about the Mathlib side before this is
+scheduled.
+
+**Mathlib's `Module.Basis.SmithNormalForm` does not carry the
+divisibility chain.** Its fields are `bM`, `bN`, `f`, `a`, and `snf`,
+where `snf : ∀ i, (bN i : M) = a i • bM (f i)`. Nothing constrains `a i`
+to divide `a (i+1)`, so the structure is a simultaneous-basis statement
+rather than an invariant-factor statement, and its `a` is not canonical.
+Mathlib has no invariant factors, no determinantal divisors, and no
+elementary divisors anywhere (searching for those terms finds nothing).
+So `smithNormalForm_chain` is genuinely new content rather than a
+transport, and the executable library is the only source of canonicity.
+
+**The construction is also the first executable one.**
+`Submodule.smithNormalForm` is noncomputable and produced by an
+existence argument over a PID. Supplying an executable witness with the
+identity proved is the same payoff `hex-hermite`'s `kernelBasisEquiv`
+delivers, one level up.
+
+Upstreaming the chain field to Mathlib's structure, or adding invariant
+factors alongside it, is a reasonable later contribution and is out of
+scope here. It should not be attempted before this library exists,
+because the definition worth upstreaming is the one that has been used.
+
+## What is deliberately not here
+
+**Elementary divisors.** The prime-power decomposition of the invariant
+factors needs integer factorization, which the project does not have
+(see [future-work](../future-work.md)). The invariant factors are
+computed without factoring anything, and that is the whole point of the
+divisibility chain. When integer factorization arrives, elementary
+divisors are a short function on top of `invariantFactors` and belong in
+whichever library owns the factorization, not here.
+
+**Smith normal form over `F[x]`.** See "Why `Int` and not a Euclidean
+domain class" in [hex-hermite](hex-hermite.md). The polynomial case is
+the route to rational canonical form and the minimal polynomial, and it
+shares the algorithm shape and none of the normalisation, growth
+control, or termination measure.
+
+**Sparse input.** Relation matrices from group presentations are often
+very sparse, and dense elimination fills them in immediately. The sparse
+matrix item in [future-work](../future-work.md) names this as one of the
+cases where a dense representation genuinely fails, and it should be
+revisited there rather than worked around here.
+
+## Complexity
+
+`A` is `n × m` with rank `r`. As in [hex-hermite](hex-hermite.md), these
+are **matrix-update counts** rather than worst-case complexity, and they
+are parameterised by `P`, the number of times the pivot loop repeats at
+one diagonal position. `P` is bounded by the bit length of the entries,
+not by any matrix dimension, since each repetition strictly shrinks the
+pivot. There is no proven bound on operand size for this algorithm, which
+is the point made under "Algorithms".
+
+| operation | algorithm | matrix updates and `extGcd` calls | operand size |
+|---|---|---|---|
+| `snf` | classical Euclidean pivot loop | `O(P · r · (n + m) · max n m)` | unbounded; measured, not proved |
+| `snfDiagonal` | normalisation plus adjacent-pair sweep | `O(r²)` | bounded by the product of the input diagonal |
+| `abelianStructure` | `snf` plus a filter | as `snf` | as `snf` |
+| `solveInt` | `snf`, one diagonal solve, two `vecMul`s | `+ O(n · m)` | as `snf` |
+
+## Conformance
+
+Per [SPEC/testing.md](../testing.md), extending the same shared driver
+[hex-hermite](hex-hermite.md) extends: a new `snf` handler in
+`scripts/oracle/matrix_flint.py` against FLINT's `fmpz_mat_snf`, an emit
+driver `conformance/HexSmith/EmitFixtures.lean` exposed as
+`lean_exe hexsmith_emit_fixtures`, a snapshot at
+`conformance-fixtures/HexSmith/smith.jsonl`, and one tuple appended to
+`ORACLES` in `scripts/ci/run_oracles.sh`:
+
+```
+"HexSmith|hexsmith_emit_fixtures|scripts/oracle/matrix_flint.py|conformance-fixtures/HexSmith/smith.jsonl"
+```
+
+The oracle is compared on the diagonal only, never on `U` or `V`, which
+are not unique. The transforms are checked in Lean by the product
+identities instead.
+
+**Cases that must be present:**
+
+- the zero matrix, and a matrix of rank `1`;
+- input where the first invariant factor is not the smallest entry, for
+  example `[[2, 0], [0, 3]]`, whose Smith normal form is
+  `diag(1, 6)`. An implementation that omits the divisibility step in
+  the pivot loop returns `diag(2, 3)` here, so this case is the single
+  most important one in the suite;
+- input whose Smith normal form has a nontrivial chain of length three,
+  for example `diag(2, 4, 8)` conjugated by unimodular matrices;
+- rank-deficient input, checking the trailing zeros and the rank;
+- rectangular input in both orientations;
+- negative and mixed-sign entries;
+- a presentation of a known abelian group, checked against
+  `abelianStructure`: `[[2, 0], [0, 2]]` gives `(0, #[2, 2])` and
+  `[[1, 1], [0, 2]]` gives `(0, #[2])`;
+- input already in Smith normal form, checking idempotence;
+- diagonal input through `snfDiagonal` containing zeros and negatives,
+  including `[0, 2]`, `[-2, 0]`, and `[0, 0]`, which is where an
+  implementation that skips the normalisation phase divides by zero or
+  returns a non-normal form;
+- an unsolvable and a solvable integer system through `solveInt`, with
+  the solvable one chosen so that `V ≠ I`, which is what catches a
+  `solveInt` that forgets to transform the right-hand side.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), drivers at
+`bench/HexSmith/Bench.lean`, no Mathlib import.
+
+**Input families.**
+
+- `random-dense-smith`: uniform entries, square and nonsingular.
+- `chain-conjugate`: `U * diag(d) * V` for known `d` with a long
+  divisibility chain and random unimodular `U`, `V`, so the expected
+  answer is known and the difficulty is entry growth rather than the
+  answer's size.
+- `presentation-smith`: sparse relation matrices from abelian group
+  presentations, the shape the headline consumer produces, run dense.
+
+**Comparators.** FLINT `fmpz_mat_snf` through python-flint,
+`informational`. FLINT's default dispatch includes algorithms not
+specified here, so the ratio compares different algorithms and does not
+hold a required threshold. PARI `matsnf` through `cypari2`, also
+`informational`.
+
+**The decision rules written down in advance.** As in
+[hex-hermite](hex-hermite.md), each is stated over a range rather than at
+one ladder endpoint.
+
+1. `snfSquareDiag` (modular, form only) is kept only if it wins across
+   the upper half of both the dimension and the entry-bit-size ladders on
+   `random-dense-smith`, and only if a named consumer wants the diagonal
+   without the transforms. It answers a strictly smaller question than
+   `snf`, so a win at one point does not justify carrying it.
+2. `snfDiagonal` must be faster than `snf` on diagonal input by a margin
+   that grows with `r`, since it skips the elimination entirely. A flat
+   or shrinking margin means the fast path is not being taken, which is a
+   bug rather than a benchmark result. It is not stated as a fixed
+   multiple, because at small `r` the two are legitimately comparable.
+
+**Growth instrumentation is required, not optional.** The default
+algorithm ships with no proven entry bound, so the bench records peak
+intermediate entry bit-size and time spent in big-integer arithmetic
+alongside wallclock on every family. Those numbers are the evidence for
+or against specifying Kannan-Bachem, per "Open questions".
+
+## File organisation
+
+```
+HexSmith/
+  Contracts.lean     -- SmithData, diagMatrix, IsSNF, isSNFShape
+  Smith.lean         -- snf, the classical Euclidean pivot loop
+  Diagonal.lean      -- snfDiagonal: normalisation and the adjacent-pair sweep
+  Modular.lean       -- snfSquareDiag, the Iliopoulos variant
+  Divisor.lean       -- detDivisor and IsSNF.detDivisor_eq
+  Unique.lean        -- IsSNF.rank_eq, IsSNF.diag_eq
+  Structure.lean     -- invariantFactors, abelianStructure, quotientOrder, solveInt
+  Cert.lean          -- snfCert and its soundness
+HexSmith.lean        -- umbrella
+HexSmithMathlib/
+  Basis.lean         -- Module.Basis.SmithNormalForm from the executable output
+  Chain.lean         -- the divisibility chain Mathlib's structure omits
+  Quotient.lean      -- the structure theorem for the quotient
+HexSmithMathlib.lean
+```
+
+`libraries.yml` gains:
+
+```yaml
+  HexSmith:
+    deps: [HexHermite]
+    mathlib: false
+    done_through: 0
+    status: draft
+  HexSmithMathlib:
+    deps: [HexSmith, HexHermiteMathlib]
+    mathlib: true
+    done_through: 0
+    status: draft
+```
+
+Everything else arrives through `HexHermite`.
+
+## Open questions
+
+- **Whether `hex-smith` should be its own library.** The alternative is
+  to fold it into `hex-hermite`, which would share the elimination step
+  and the certificate module directly rather than through an import.
+  The case for two libraries is that the subjects are separable (Hermite
+  normal form has consumers that never want Smith normal form), that
+  `hex-smith` carries its own Mathlib correspondence, and that the
+  project already splits at this granularity (`hex-bareiss` on
+  `hex-determinant`, `hex-gfq-field` on `hex-gfq-ring`). Revisit only if
+  the shared surface turns out to be larger than the elimination step
+  and the certificate.
+- **Whether to specify Kannan-Bachem.** The default here is the
+  classical pivot loop, which is total and has a termination proof and no
+  entry bound. Kannan-Bachem alternates row and column Hermite normal
+  forms on trailing submatrices and does have one, at the cost of block
+  embeddings, rank-deficient handling, and accumulating the transforms
+  through all of it. The growth instrumentation under "Benchmarking" is
+  what decides whether that work is called for; it should not be started
+  on the strength of the name.
+- **Whether `detDivisor` should be public at all.** It is the
+  specification function and it has no efficient direct evaluation. The
+  argument for exporting it is that the statement `d₁ ⋯ d_k = D_k` is
+  the thing a mathematician wants to cite; the argument against is that
+  a `noncomputable` definition with an exponential unfolding invites
+  misuse. It is exported here with its docstring saying so.
+- **Sparse relation matrices**, as above. The dense algorithm is
+  correct on them and may be far from competitive, and the measurement
+  under `presentation-smith` is what decides whether that matters.

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -29,31 +29,24 @@ witness. Factors whose product is the input form a decomposition;
 irreducibility of each is a further obligation. Where an item needs a
 second witness, it says which one.
 
-**Hermite normal form.** Row reduction over `Int`: upper triangular
-with positive pivots, entries above each pivot in `[0, pivot)`. Uses
-extended GCD to create pivots without division: given entries `a`, `b`
-in the same column, compute `(g, s, t)` with `s * a + t * b = g`,
-then apply the 2×2 row transformation `[[s, t], [-b/g, a/g]]` to
-zero out `b` and replace `a` with `g`. Reduce entries above each pivot
-modulo the pivot. The result is unique. Returns `RowEchelonData`; an
-`IsHNF` Prop-valued structure extending `IsEchelonForm` (parallel to
-`IsRowReduced`) certifies correctness, with HNF-specific fields:
-- Each pivot is positive
-- Entries above each pivot are in `[0, pivot)`
-- `det transform = 1 ∨ det transform = -1`
+**Hermite and Smith normal forms.** These two have graduated from this
+file and are specified in [hex-hermite](Libraries/hex-hermite.md) and
+[hex-smith](Libraries/hex-smith.md): Hermite normal form as a canonical
+representative of an integer row lattice with lattice membership,
+integer kernel bases, and integer rank on top of it, and Smith normal
+form as the diagonal form with the divisibility chain `d₁ ∣ d₂ ∣ ⋯ ∣ dᵣ`,
+the invariant factors, and the structure of a finitely generated abelian
+group. Both are separate libraries rather than additions to hex-matrix,
+because both need the extended GCD from hex-arith and the echelon
+contracts from hex-row-reduce, and Hermite normal form needs a
+determinant from hex-bareiss for its modular algorithm.
 
-HNF requires extended GCD, which lives in hex-arith. Since
-hex-matrix currently has no dependencies, HNF would either need:
-extended GCD upstreamed into Lean 4 stdlib, a new dependency
-hex-matrix → hex-arith, or a separate library (e.g.
-`hex-matrix-hermite` depending on both hex-matrix and hex-arith).
-
-**Smith normal form.** Diagonal form obtained by both row and column
-operations over a principal ideal domain. The diagonal entries satisfy
-`d₁ | d₂ | ⋯ | dᵣ` (divisibility chain). Useful for computing the
-structure of finitely generated abelian groups and solving integer
-linear systems. Like HNF, requires extended GCD and is not needed for
-Berlekamp-Zassenhaus.
+Two corrections to what this file said before those SPECs were written,
+recorded because they are easy to make again. The `IsHNF` field list
+should not carry `det transform = 1 ∨ det transform = -1`, which follows
+from `IsEchelonForm.transform_inv` and `det_mul`; and it must carry the
+condition that each pivot is the leading nonzero entry of its row, which
+`IsEchelonForm` does not imply and without which uniqueness is false.
 
 **Sylvester's identity (hex-matrix).** The Desnanot-Jacobi identity
 relating minors of a matrix. Now the primary proof strategy for
@@ -114,9 +107,14 @@ characteristic polynomial, all certified from one computation.
 Two distinctions are worth holding onto. The factorization of `χ_A` does
 not determine the canonical form, because matrices sharing a
 characteristic polynomial can have different invariant factors. And this
-is not the integer Smith normal form above: the base ring is `F[x]`, the
-units are the nonzero constants, and the two items share an algorithm
-shape rather than a theorem.
+is not the integer Smith normal form of [hex-smith](Libraries/hex-smith.md):
+the base ring is `F[x]`, the units are the nonzero constants, and the two
+items share an algorithm shape rather than a theorem. The
+[hex-hermite](Libraries/hex-hermite.md) SPEC records, under "Why `Int`
+and not a Euclidean domain class", exactly which parts transfer (the 2x2
+elimination step) and which do not (pivot normalisation, the reduction of
+entries above a pivot, the termination measure, and the growth problem
+the algorithm choice is designed around).
 
 **Certified eigenpair enclosures.** Run an untrusted floating-point
 solver, then verify its output with interval arithmetic in the style of

--- a/progress/20260813T141659Z_hermite-smith-spec.md
+++ b/progress/20260813T141659Z_hermite-smith-spec.md
@@ -1,0 +1,149 @@
+# Hermite and Smith normal form SPECs
+
+## Accomplished
+
+Wrote two library SPECs, starting from the two paragraph-length sketches
+in `SPEC/future-work.md`:
+
+- `SPEC/Libraries/hex-hermite.md`: Hermite normal form over `Int`. Fixes
+  the row-style convention, the `IsHNF` contract, the `extGcd` 2x2
+  elimination step with its explicit inverse, the entry-growth analysis
+  and the algorithm choice that follows from it (Kannan-Bachem by
+  default, Domich-Kannan-Trotter modulo the determinant for square
+  nonsingular input), the API (`hnf`, `hnfData`, `latticeCoeffs`,
+  `kernelBasis`, `latticeIndex`), the correctness theorems, the
+  certificate, the Mathlib layer, conformance, and benchmarking with two
+  thresholds written down in advance.
+- `SPEC/Libraries/hex-smith.md`: Smith normal form over `Int`. The
+  `SmithData` / `IsSNF` contract, the pivot loop with its lexicographic
+  termination measure, the diagonal fast path with explicit unimodular
+  matrices, the determinantal-divisor route to uniqueness,
+  `abelianStructure` / `solveInt` / `invariantFactors`, and the Mathlib
+  layer.
+
+Both name their prerequisite changes in other libraries and both record
+what is deliberately out of scope.
+
+Updated `SPEC/Libraries/README.md` (descriptions, both dependency lists,
+index) and replaced the two `SPEC/future-work.md` sketches with a pointer
+plus the two corrections found while writing.
+
+## Findings that changed the design
+
+- **`IsEchelonForm` and `IsRowReduced` do not force the declared pivot to
+  be the leading nonzero entry of its row.** Machine-checked
+  counterexample: the 1x2 matrix `[[5, 1]]` with `rank = 1`, pivot column
+  `1`, and the identity transform satisfies every field of
+  `IsRowReduced`. So `IsHNF` has to state the leading-entry condition
+  itself, or uniqueness is false. The counterexample is reproduced in the
+  hex-hermite SPEC and elaborates against the current tree.
+- **`det transform = ±1` is a theorem, not a field.**
+  `IsEchelonForm.transform_inv` plus `det_mul` (already Mathlib-free in
+  `HexDeterminant/Adjugate.lean`) gives it. The future-work sketch listed
+  it as an `IsHNF` field and omitted the leading-entry condition, so its
+  clause list was wrong in both directions.
+- **`hex-lll` already has the certificate machinery.**
+  `Hex.Internal.mulEqCert` (packed product check with `mulEqCert_iff`)
+  and `Hex.Matrix.sameLatticeCert` are exactly what a unimodular
+  certificate needs. `Hex.Matrix.memLattice` and its transport lemmas
+  live in `HexLLL/Lattice.lean` but mention nothing from `hex-lll`. Both
+  SPECs ask for those to move to `hex-matrix` so `hex-hermite` does not
+  acquire a dependency on `hex-lll` to say "is an integer combination of
+  the rows".
+- **The Hermite and Smith certificates are complete**, unlike most items
+  in `future-work.md`: by uniqueness, an accepted candidate is the
+  answer, so no second witness is needed and certified dispatch to an
+  external implementation is available in the shape `hex-lll`'s
+  `certCheck` already uses.
+- **Mathlib has no Hermite normal form for matrices, no invariant
+  factors, and no determinantal divisors**, and its
+  `Module.Basis.SmithNormalForm` carries no divisibility chain. So the
+  Mathlib layer is new content rather than a transport, and the
+  executable libraries would be the only source of canonicity.
+
+## Second opinion, and what it changed
+
+Codex (gpt-5.6-sol, read-only, full repo access) reviewed both drafts
+adversarially and returned 17 findings. It endorsed the two-library
+split, and did not dispute the `IsRowReduced` counterexample, the
+`det = ±1` derivation, the `memLattice` / `mulEqCert` relocation, the
+Mathlib gaps, or extending `matrix_flint.py`. Eight findings were real
+errors and are now fixed:
+
+- **The modular HNF argument was wrong as written.** `d·ℤⁿ ⊆ L` gives
+  `L + d·ℤⁿ = L`; it does not license reducing a generator modulo `d`.
+  For `A = [2]`, `d = 2`, the row `[2]` reduces to `[0]`. The SPEC now
+  states Domich-Kannan-Trotter as the recurrence on `[A; d·I]`, notes
+  that a pivot may equal `d` (so entries live in `[0, d]`), and carries
+  the counterexample and a conformance case for it.
+- **Full column rank, not full row rank**, is the condition for the
+  modular path: the row lattice sits in `ℤᵐ` and needs finite index
+  there. `latticeIndex` is generalised to `n × m` accordingly.
+- **The Smith default was misnamed.** The five-step pivot loop is the
+  classical Euclidean algorithm, not Kannan-Bachem, and does not inherit
+  its entry bounds. Renamed, bound claim withdrawn, Kannan-Bachem moved
+  to an open question with the growth instrumentation as its evidence.
+- **The Smith termination measure did not decrease at step 4.** Adding a
+  row to the pivot row leaves `|pivot|` fixed and raises the second
+  component. Step 4 is now fused with the following elimination, so the
+  recursive call happens only after `gcd(p, a) < |p|`.
+- **`detDivisor` was circular**: described as the gcd of minors but
+  "computed through `snf`", which would put the SNF output inside the
+  invariant used to prove it canonical. Now defined by the enumeration
+  alone, returning `Nat`, with `D₀ = 1` and `D_k = 0` past the rank.
+- **The uniqueness theorem could not prove rank equality**, being stated
+  only for `k ≤ S.rank`, which is exactly where the discriminating value
+  `k = S.rank + 1` is out of scope. Restated for all `k`.
+- **Hermite canonicity is per shape.** `hnf A` keeps its zero rows, so
+  `[1]` and `[[1], [0]]` have forms of different types. Added `hnfBasis`
+  (the nonzero rows) as the presentation-independent object, and
+  qualified the claims about `hnf`.
+- **`solveInt` omitted the right-hand-side transform.** From
+  `S = U A V`, solving `x A = b` means solving `z S = b V` and returning
+  `x = z U`.
+
+Also corrected: the claim that `hex-bareiss` divides with `Int.divExact`
+(it uses a proof-free `exactDiv` with `exactDiv_eq_divExact` proved
+separately, which is the design to copy, and the primitive should move to
+`hex-arith`); the PARI convention conversion (reversal matrices, not "a
+transpose and a reverse"); `snfDiagonal` accepting zeros and negatives
+without a normalisation phase; and the complexity tables, now labelled
+matrix-update counts and parameterised by the pivot-loop repetition
+count. Benchmark thresholds are now curves over a named range rather than
+single-endpoint ratios.
+
+**Codex resolved the one question this SPEC left open.** The general
+rectangular Cauchy-Binet needed for determinantal-divisor invariance is
+not derivable from what exists: `Minor.lean` has only `deleteRowCol`,
+`CauchyBinet.lean` selects `n` columns from an `n`-row matrix, and
+`Submatrix.lean` takes prefixes. Verified directly. So `hex-determinant`
+needs selected submatrices by index maps, `k`-subset enumeration, and
+Cauchy-Binet for a selected minor, and Smith uniqueness cannot be
+scheduled before that lands.
+
+## Current frontier
+
+The SPECs are drafts. Neither library is in `libraries.yml`; each SPEC
+carries the `yaml` block it would add, following the `hex-mv-poly`
+precedent for a draft SPEC.
+
+## Next step
+
+The sequencing the review argued for, which is now what both SPECs say:
+
+1. Four prerequisite relocations, each independently justified and each
+   doable before any Hermite commit: `memLattice` and the certificate
+   checkers from `hex-lll` to `hex-matrix`, `mulEqCert` out of
+   `Hex.Internal`, `mul_eq_one_comm` into `hex-determinant`, and
+   `exactDiv` from `hex-bareiss` into `hex-arith`.
+2. Implement and prove Hermite normal form.
+3. Add selected submatrices, `k`-subset enumeration, and rectangular
+   Cauchy-Binet to `hex-determinant`.
+4. Define determinantal divisors and prove the all-`k` characterisation.
+5. Implement Smith normal form with transforms.
+6. Leave both modular variants (DKT, Iliopoulos) until the native paths
+   are complete and the benchmarks say they earn their place.
+
+## Blockers
+
+None.

--- a/progress/20260813T141659Z_hermite-smith-spec.md
+++ b/progress/20260813T141659Z_hermite-smith-spec.md
@@ -8,9 +8,10 @@ in `SPEC/future-work.md`:
 - `SPEC/Libraries/hex-hermite.md`: Hermite normal form over `Int`. Fixes
   the row-style convention, the `IsHNF` contract, the `extGcd` 2x2
   elimination step with its explicit inverse, the entry-growth analysis
-  and the algorithm choice that follows from it (Kannan-Bachem by
-  default, Domich-Kannan-Trotter modulo the determinant for square
-  nonsingular input), the API (`hnf`, `hnfData`, `latticeCoeffs`,
+  and the algorithm choice that follows from it (a total column sweep
+  with eager reduction above each pivot by default, and the
+  Domich-Kannan-Trotter recurrence on `[A; d·I]` for square nonsingular
+  input), the API (`hnf`, `hnfBasis`, `hnfData`, `latticeCoeffs`,
   `kernelBasis`, `latticeIndex`), the correctness theorems, the
   certificate, the Mathlib layer, conformance, and benchmarking with two
   thresholds written down in advance.
@@ -131,11 +132,14 @@ precedent for a draft SPEC.
 
 The sequencing the review argued for, which is now what both SPECs say:
 
-1. Four prerequisite relocations, each independently justified and each
-   doable before any Hermite commit: `memLattice` and the certificate
-   checkers from `hex-lll` to `hex-matrix`, `mulEqCert` out of
-   `Hex.Internal`, `mul_eq_one_comm` into `hex-determinant`, and
-   `exactDiv` from `hex-bareiss` into `hex-arith`.
+1. Four prerequisite changes, each independently justified and each
+   doable before any Hermite commit. Three are relocations: `memLattice`
+   with its transport lemmas and the checkers `mulEqCert` and
+   `sameLatticeCert` from `hex-lll` to `hex-matrix`, with `mulEqCert`
+   becoming public rather than `Hex.Internal`, and `exactDiv` from
+   `hex-bareiss` to `hex-arith`. The fourth is a new theorem,
+   `mul_eq_one_comm` in `hex-determinant`, which needs a matrix-level
+   `adjugate_mul` that the tree currently has only entrywise.
 2. Implement and prove Hermite normal form.
 3. Add selected submatrices, `k`-subset enumeration, and rectangular
    Cauchy-Binet to `hex-determinant`.


### PR DESCRIPTION
This PR adds `SPEC/Libraries/hex-hermite.md` and `SPEC/Libraries/hex-smith.md`, two draft library SPECs written from the paragraph sketches that used to sit in `SPEC/future-work.md`, and indexes both in `SPEC/Libraries/README.md`. Hermite normal form gets a canonical representative of an integer row lattice, lattice membership with completeness, a saturated integer kernel basis, integer rank, and the sublattice index; Smith normal form gets the invariant factors, the structure of a finitely generated abelian group, and integer linear solving. Each SPEC covers its own Mathlib companion.

Three findings from writing them are worth calling out, since they correct things this repository currently says or implies.

`IsEchelonForm` and `IsRowReduced` do not require the declared pivot to be the leading nonzero entry of its row. The 1x2 matrix `[[5, 1]]`, with rank 1, pivot column 1, and the identity transform, satisfies every field of `IsRowReduced`; the counterexample is reproduced in the Hermite SPEC and elaborates against the current tree. `IsHNF` therefore states that condition itself, without which uniqueness is false. Conversely `det transform = ±1`, which the old sketch listed as a field, follows from `transform_inv` and `det_mul`, so it is a theorem.

`Hex.Matrix.memLattice`, `Hex.Internal.mulEqCert`, and `Hex.Matrix.sameLatticeCert` live in `HexLLL/` but mention nothing from LLL, and `exactDiv` lives in `HexBareiss/`. The Hermite SPEC asks for those to move down rather than be copied, so `hex-hermite` does not acquire a dependency on `hex-lll` to say "is an integer combination of the rows".

The determinantal-divisor route to Smith uniqueness needs rectangular Cauchy-Binet, which the tree does not have: `Minor.lean` deletes one row and one column, `CauchyBinet.lean` selects `n` columns from an `n`-row matrix, and `Submatrix.lean` takes prefixes. Selected submatrices, `k`-subset enumeration, and Cauchy-Binet for a selected minor are named as a prerequisite phase in `hex-determinant`, and Smith uniqueness is sequenced behind them.

Neither library is added to `libraries.yml`; each SPEC carries the block it would add, following the `hex-mv-poly` precedent for a draft SPEC. An adversarial review pass over both drafts is recorded in the progress file, along with the eight errors it caught and the sequencing it changed.

🤖 Prepared with Claude Code
