### PR TITLE
feat: a one-sided matrix inverse is two-sided over a commutative ring

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -232,6 +232,21 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     have hji : j ≠ i := fun h => hij h.symm
     rw [if_neg hji]
 
+/-- The adjugate identity `adjugate M * M = det M • identity`.
+
+The left-hand companion to `mul_adjugate`. Having both sides in matrix form is
+what lets a one-sided inverse be turned into a two-sided one; see
+`mul_eq_one_comm`. -/
+theorem adjugate_mul {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) :
+    adjugate M * M = det M • Matrix.identity (n + 1) := by
+  apply ext_getElem
+  intro i j
+  rw [adjugate_mul_apply, Matrix.smul_getElem, getElem_identity]
+  by_cases h : i = j
+  · rw [if_pos h, if_pos h]; show det M = det M * 1; grind
+  · rw [if_neg h, if_neg h]; show (0 : R) = det M * 0; grind
+
 /-- Column-`0` view of `M * adjugate M`. -/
 theorem mul_adjugate_apply_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (i : Fin (n + 1)) :
@@ -670,6 +685,43 @@ theorem det_setRow_setRow_mul_det
     det_setRow_eq_cofactorRowPairing M b u]
   exact cofactorRowPairing_setRow_plucker M a b hab u v
 
+
+/-- A square matrix with a right inverse over a commutative ring has that same
+matrix as a left inverse.
+
+Over a field this is linear algebra. Over a general commutative ring it needs
+the adjugate, because the inverse is only available as `adjugate M` scaled by
+`det M`, and `det M` is a unit exactly when `M` is invertible. The certificate
+checkers in the integer normal-form libraries rely on this: they verify one
+product `U * W = 1` and read unimodularity of `U` off it. -/
+theorem mul_eq_one_comm {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
+    W * U = Matrix.identity n := by
+  cases n with
+  | zero =>
+    apply ext_getElem
+    intro i _
+    exact absurd i.isLt (by omega)
+  | succ n =>
+    have hdet : det U * det W = 1 := by
+      rw [← det_mul, h, det_identity]
+    have hadj : adjugate U = det U • W := by
+      calc adjugate U
+          = adjugate U * Matrix.identity (n + 1) := (mul_identity _).symm
+        _ = adjugate U * (U * W) := by rw [h]
+        _ = adjugate U * U * W := (mul_assoc _ _ _).symm
+        _ = (det U • Matrix.identity (n + 1)) * W := by rw [adjugate_mul]
+        _ = det U • (Matrix.identity (n + 1) * W) := by rw [smul_mul]
+        _ = det U • W := by rw [identity_mul]
+    have hkey : det U • (W * U) = det U • Matrix.identity (n + 1) := by
+      rw [← smul_mul, ← hadj, adjugate_mul]
+    apply ext_getElem
+    intro i j
+    have hentry := congrArg (fun X : Matrix R (n + 1) (n + 1) => X[i][j]) hkey
+    simp only [Matrix.smul_getElem] at hentry
+    have hmul : det U * (W * U)[i][j]
+        = det U * (Matrix.identity (R := R) (n + 1))[i][j] := hentry
+    grind
 
 end Matrix
 end Hex

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -691,9 +691,13 @@ matrix as a left inverse.
 
 Over a field this is linear algebra. Over a general commutative ring it needs
 the adjugate, because the inverse is only available as `adjugate M` scaled by
-`det M`, and `det M` is a unit exactly when `M` is invertible. The certificate
-checkers in the integer normal-form libraries rely on this: they verify one
-product `U * W = 1` and read unimodularity of `U` off it. -/
+`det M`, and `det M` is a unit exactly when `M` is invertible. The proof applies
+`adjugate_mul` twice: once to rewrite `adjugate U` as `det U • W`, and once to
+recognise `det U • (W * U)` as `det U • 1`.
+
+The intended consumer is a certificate checker that verifies a single product
+`U * W = 1` and reads unimodularity of `U` off it, rather than checking both
+directions or computing a determinant. -/
 theorem mul_eq_one_comm {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
     W * U = Matrix.identity n := by

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -25,7 +25,7 @@ tracking and by `hex-bareiss` for composing row swaps into a permutation sign.
 - `mul_eq_one_comm : U * W = 1 → W * U = 1` for a square matrix over a
   commutative ring, proved through the adjugate. A one-sided inverse is
   therefore enough to witness invertibility, which is what the integer
-  normal-form certificate checkers need.
+  normal-form certificate checkers are specified to rely on.
 
 **Mathlib-free vs. Mathlib-bridge proof surface.** Theorems connecting `Hex.det`
 to Mathlib's `Matrix.det` (e.g. `det_eq : Hex.det M = Matrix.det (matrixEquiv M)`)

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -20,8 +20,12 @@ tracking and by `hex-bareiss` for composing row swaps into a permutation sign.
 - `det_rowScale : det (rowScale M i c) = c * det M`
 - `det_rowAdd : i ≠ j → det (rowAdd M i j c) = det M`
 - column linearity, Laplace cofactor expansion, the Cauchy-Binet column-tuple
-  product formula, the adjugate identity, and the Plücker / Desnanot-Jacobi
-  two-row identities
+  product formula, the adjugate identity on both sides (`mul_adjugate` and
+  `adjugate_mul`), and the Plücker / Desnanot-Jacobi two-row identities
+- `mul_eq_one_comm : U * W = 1 → W * U = 1` for a square matrix over a
+  commutative ring, proved through the adjugate. A one-sided inverse is
+  therefore enough to witness invertibility, which is what the integer
+  normal-form certificate checkers need.
 
 **Mathlib-free vs. Mathlib-bridge proof surface.** Theorems connecting `Hex.det`
 to Mathlib's `Matrix.det` (e.g. `det_eq : Hex.det M = Matrix.det (matrixEquiv M)`)

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -304,6 +304,29 @@ theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R
   rw [getElem_sub, getElem_mul, getElem_mul, getElem_mul, col_sub,
     Vector.dotProduct_sub_right]
 
+/-- Row `i` of a scalar multiple is the scalar multiple of row `i`. -/
+@[simp, grind =] theorem row_smul {S : Type v} [SMul S R] (c : S)
+    (M : Matrix R n m) (i : Fin n) :
+    row (c • M) i = c • row M i := by
+  apply Vector.ext
+  intro j hj
+  simp only [Vector.getElem_smul]
+  show (row (c • M) i)[(⟨j, hj⟩ : Fin m)] = c • (row M i)[(⟨j, hj⟩ : Fin m)]
+  rw [getElem_row, getElem_row, smul_getElem]
+
+/-- Scalar multiplication commutes with matrix multiplication on the left.
+
+Together with `mul_adjugate` and `adjugate_mul` this is what turns a one-sided
+matrix inverse into a two-sided one; see `HexDeterminant.mul_eq_one_comm`. -/
+@[grind =] theorem smul_mul [Lean.Grind.CommRing R] (c : R)
+    (A : Matrix R n m) (B : Matrix R m k) :
+    (c • A) * B = c • (A * B) := by
+  apply ext_getElem
+  intro i j
+  rw [smul_getElem, getElem_mul, getElem_mul, row_smul,
+    Vector.dotProduct_smul_left]
+  rfl
+
 end Matrix
 
 end Hex

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -318,7 +318,7 @@ theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R
 
 Together with `mul_adjugate` and `adjugate_mul` this is what turns a one-sided
 matrix inverse into a two-sided one; see `HexDeterminant.mul_eq_one_comm`. -/
-@[grind =] theorem smul_mul [Lean.Grind.CommRing R] (c : R)
+@[grind =] theorem smul_mul [Lean.Grind.Ring R] (c : R)
     (A : Matrix R n m) (B : Matrix R m k) :
     (c • A) * B = c • (A * B) := by
   apply ext_getElem

--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -84,6 +84,7 @@ to change one column.
 - `transpose` is involutive
 - `gramMatrix M = M * Mᵀ`
 - elementary-operation multiplicative and inverse-preservation lemmas
+- `smul_mul : (c • A) * B = c • (A * B)`, with `row_smul` underneath it
 
 The determinant of a row operation (`det_rowSwap`, `det_rowScale`,
 `det_rowAdd`) is stated in `hex-determinant`, where `det` is defined.

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -523,17 +523,16 @@ is designed for it now (the checker takes `W` as an argument rather than
 recomputing an inverse, which is the one decision that would be
 expensive to change later).
 
-One obligation that belongs in `hex-determinant` rather than here:
+The lemma this rests on is `Hex.Matrix.mul_eq_one_comm` in
+`HexDeterminant/Adjugate.lean`:
 
 ```lean
-theorem Matrix.mul_eq_one_comm {U W : Matrix R n n} : U * W = 1 → W * U = 1
+theorem mul_eq_one_comm {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
+    W * U = Matrix.identity n
 ```
 
-for a commutative ring. `HexDeterminant/Adjugate.lean` has `det_mul` and
-`mul_adjugate` in matrix form, and the other side only entrywise as
-`adjugate_mul_apply`. The matrix-level `adjugate_mul` is not there and is
-part of this obligation rather than something to cite. It is adjugate
-theory, not Hermite theory, and two other libraries would use it.
+for a commutative ring, proved through `adjugate_mul` and `mul_adjugate`. It
+is adjugate theory rather than Hermite theory, which is why it lives there.
 
 ## Prerequisite changes in other libraries
 
@@ -557,7 +556,9 @@ identity without forming the product, and this library plus `hex-smith`
 are two more consumers. Promote it to `Hex.Matrix` next to
 `sameLatticeCert`, and move both to `hex-matrix` with `memLattice`.
 
-**`mul_eq_one_comm` belongs in `hex-determinant`**, as above.
+**`mul_eq_one_comm`** is done: it and the matrix-level `adjugate_mul` are in
+`HexDeterminant/Adjugate.lean`, with `smul_mul` added to `hex-matrix`
+underneath them.
 
 **`exactDiv` should move to `hex-arith`.** `HexBareiss/Bareiss.lean`
 defines the proof-free `exactDiv` with its `@[extern]` binding and proves

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -531,7 +531,7 @@ theorem mul_eq_one_comm {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
     W * U = Matrix.identity n
 ```
 
-for a commutative ring, proved through `adjugate_mul` and `mul_adjugate`. It
+for a commutative ring, proved by applying `adjugate_mul` twice. It
 is adjugate theory rather than Hermite theory, which is why it lives there.
 
 ## Prerequisite changes in other libraries

--- a/SPEC/Libraries/hex-smith.md
+++ b/SPEC/Libraries/hex-smith.md
@@ -41,8 +41,8 @@ different and larger class of question:
 
 The dependency on `hex-hermite` is real rather than organisational: the
 `extGcd` elimination step with its explicit inverse, the exact-division
-discipline, the certificate machinery, the conventions, and the
-`mul_eq_one_comm` obligation are all shared. Note that the default
+discipline, the certificate machinery, the conventions, and the reliance on
+`mul_eq_one_comm` are all shared. Note that the default
 algorithm below does *not* call `hnf`. The Kannan-Bachem variant under
 "Open questions" would, which is the other reason to keep the two
 libraries adjacent.
@@ -115,8 +115,8 @@ differently.
 
 **One-sided inverse fields.** `left_inv` and `right_inv` record only
 `U * W = I` and `V * X = I`. The other side follows over a commutative
-ring through the adjugate, by the `mul_eq_one_comm` lemma
-[hex-hermite](hex-hermite.md) asks `hex-determinant` for. Carrying both
+ring through the adjugate, by `Hex.Matrix.mul_eq_one_comm` in
+`HexDeterminant/Adjugate.lean`. Carrying both
 directions as fields would make every construction discharge a
 redundant obligation.
 

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -176,7 +176,7 @@
   {
     "path": "HexMatrix/MatrixAlgebra.lean",
     "baseline_blob": "a203c0a4f7aa5a096774bdac2092ad43b35b92b2",
-    "current_blob": "bc7b2802eae9726731134b3ef84f935acf72e9c0",
+    "current_blob": "461006d810f79d065f6e179497407449788d895a",
     "reason": "Adds the theorems row_smul and smul_mul only; no definition, attribute, or existing declaration on the compiled factorization path changes."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -172,5 +172,11 @@
     "baseline_blob": "9bf2c14fba5223b110dbe95f1b8834fd15294c3c",
     "current_blob": "f2fc2e74288a630fc49490e9bea3602e8e165ebb",
     "reason": "Scopes the square-free guard witnesses so importing modules stop selecting an instance they cannot legally name: the Bounds 2 guard is dropped in favour of the canonical instance, and the Bounds 5 guard becomes a private theorem with a local instance attribute. Definitions, their bodies and their declaration positions are unchanged, Bounds proofs are erased before code generation, and the elaborators do not branch on the witness expression."
+  },
+  {
+    "path": "HexMatrix/MatrixAlgebra.lean",
+    "baseline_blob": "a203c0a4f7aa5a096774bdac2092ad43b35b92b2",
+    "current_blob": "bc7b2802eae9726731134b3ef84f935acf72e9c0",
+    "reason": "Adds the theorems row_smul and smul_mul only; no definition, attribute, or existing declaration on the compiled factorization path changes."
   }
 ]


### PR DESCRIPTION
This PR adds `Hex.Matrix.mul_eq_one_comm`, which turns `U * W = 1` into `W * U = 1` for a square matrix over a commutative ring, together with the two lemmas it needs: the matrix-level `adjugate_mul` in `hex-determinant`, the companion to the existing `mul_adjugate`, and `smul_mul` in `hex-matrix`, with `row_smul` underneath it.

Over a field this is ordinary linear algebra. Over a general commutative ring it goes through the adjugate: from `U * W = 1`, multiplying `adjugate U * U = det U • 1` on the right by `W` gives `adjugate U = det U • W`, so `det U • (W * U) = det U • 1`, and `det U` is a unit because `det U * det W = 1`. The tree had `mul_adjugate` in matrix form and the other side only entrywise as `adjugate_mul_apply`, so the matrix-level `adjugate_mul` is proved here from the entrywise version.

The consumer is the certificate checker specified for the integer normal forms in `SPEC/Libraries/hex-hermite.md`, which verifies a single product `U * W = 1` and reads unimodularity of `U` off it rather than checking both directions or computing a determinant. That SPEC listed this lemma as a prerequisite; the prerequisite section is updated to record it as done.

No executable surface changes, so no conformance or benchmark target is affected.

🤖 Prepared with Claude Code