### PR TITLE
feat: generate Conway entry sources, and extend the binary column to degree 8

### DIFF
--- a/HexConway.lean
+++ b/HexConway.lean
@@ -8,11 +8,13 @@ import HexConway.Rebuild
 import HexConway.Table
 import HexConway.Certificates
 import HexConway.Api
+import HexConway.EntrySource
 
 /-!
 `HexConway` provides the Tier 1 imported-lookup API for the Conway-polynomial
-database: 36 committed table entries, for `p` in `2, 3, 5, 7, 11, 13` and `n`
-in `1` to `6`, each carrying a Lean-checked irreducibility certificate. Tier 2
+database: 38 committed table entries, for `p` in `2, 3, 5, 7, 11, 13`, running
+to degree `6` for the odd primes and to degree `8` for `p = 2`, each carrying a
+Lean-checked irreducibility certificate. Tier 2
 (primitivity and compatibility across the subfield lattice) and Tier 3
 (on-demand search) are specified but not yet implemented.
 
@@ -23,4 +25,12 @@ never reads the cache; uncommenting it offers the regenerated definition as a
 `Try this:` replacement. The module is imported here so that the command stays
 compiled and its rendering stays covered by the conformance checks, rather than
 rotting until the next time someone widens the table.
+
+`HexConway.EntrySource` covers the rest of a widening. The coefficient table is
+only the data; each entry also needs a polynomial literal, its monic and degree
+facts, a table-hit lemma, and a Rabin certificate. All of those are mechanical
+except the certificate, which has to be computed, so `#conway_entry_source`
+computes it and renders the whole block. It is imported here for the same reason
+as the command, and for the same reason it costs a build nothing: neither runs
+unless invoked.
 -/

--- a/HexConway.lean
+++ b/HexConway.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import HexConway.Rebuild
 import HexConway.Table
 import HexConway.Certificates
 import HexConway.Api
@@ -14,4 +15,12 @@ database: 36 committed table entries, for `p` in `2, 3, 5, 7, 11, 13` and `n`
 in `1` to `6`, each carrying a Lean-checked irreducibility certificate. Tier 2
 (primitivity and compatibility across the subfield lattice) and Tier 3
 (on-demand search) are specified but not yet implemented.
+
+`HexConway.Rebuild` supplies the `rebuild_luebeckConwayPolynomial?` command that
+regenerates the committed coefficient table from the cached Lübeck slice. The
+invocation sits commented out above the table in `HexConway.Table`, so a build
+never reads the cache; uncommenting it offers the regenerated definition as a
+`Try this:` replacement. The module is imported here so that the command stays
+compiled and its rendering stays covered by the conformance checks, rather than
+rotting until the next time someone widens the table.
 -/

--- a/HexConway/Api.lean
+++ b/HexConway/Api.lean
@@ -1024,6 +1024,60 @@ private theorem luebeckConwayPolynomialOfCoeffs_13_6_monic :
   rw [hpoly]
   exact luebeckConwayPolynomial_13_6_monic
 
+/-- The coefficient-list constructor for the committed `C(2, 7)` Conway entry
+yields an irreducible `FpPoly`, via the `luebeckConwayPolynomial?` table hit and
+the literal's irreducibility proof. -/
+private theorem luebeckConwayPolynomialOfCoeffs_2_7_irreducible :
+    FpPoly.Irreducible (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) := by
+  have hhit := luebeckConwayPolynomial?_hit_2_7
+  change some (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) =
+    some luebeckConwayPolynomial_2_7 at hhit
+  have hpoly : luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1] =
+      luebeckConwayPolynomial_2_7 :=
+    Option.some.inj hhit
+  rw [hpoly]
+  exact luebeckConwayPolynomial_2_7_irreducible
+
+/-- The coefficient-list constructor for the committed `C(2, 7)` Conway entry
+yields a monic `FpPoly`. -/
+private theorem luebeckConwayPolynomialOfCoeffs_2_7_monic :
+    DensePoly.Monic (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) := by
+  have hhit := luebeckConwayPolynomial?_hit_2_7
+  change some (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) =
+    some luebeckConwayPolynomial_2_7 at hhit
+  have hpoly : luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1] =
+      luebeckConwayPolynomial_2_7 :=
+    Option.some.inj hhit
+  rw [hpoly]
+  exact luebeckConwayPolynomial_2_7_monic
+
+/-- The coefficient-list constructor for the committed `C(2, 8)` Conway entry
+yields an irreducible `FpPoly`, via the `luebeckConwayPolynomial?` table hit and
+the literal's irreducibility proof. -/
+private theorem luebeckConwayPolynomialOfCoeffs_2_8_irreducible :
+    FpPoly.Irreducible (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) := by
+  have hhit := luebeckConwayPolynomial?_hit_2_8
+  change some (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) =
+    some luebeckConwayPolynomial_2_8 at hhit
+  have hpoly : luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1] =
+      luebeckConwayPolynomial_2_8 :=
+    Option.some.inj hhit
+  rw [hpoly]
+  exact luebeckConwayPolynomial_2_8_irreducible
+
+/-- The coefficient-list constructor for the committed `C(2, 8)` Conway entry
+yields a monic `FpPoly`. -/
+private theorem luebeckConwayPolynomialOfCoeffs_2_8_monic :
+    DensePoly.Monic (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) := by
+  have hhit := luebeckConwayPolynomial?_hit_2_8
+  change some (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) =
+    some luebeckConwayPolynomial_2_8 at hhit
+  have hpoly : luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1] =
+      luebeckConwayPolynomial_2_8 :=
+    Option.some.inj hhit
+  rw [hpoly]
+  exact luebeckConwayPolynomial_2_8_monic
+
 /-- Every committed imported entry in the current Tier 1 slice comes with
 an irreducibility witness. -/
 @[grind →] theorem luebeckConwayPolynomial?_irreducible
@@ -1048,6 +1102,10 @@ an irreducibility witness. -/
     exact luebeckConwayPolynomialOfCoeffs_2_5_irreducible
   · cases hcoeffs
     exact luebeckConwayPolynomialOfCoeffs_2_6_irreducible
+  · cases hcoeffs
+    exact luebeckConwayPolynomialOfCoeffs_2_7_irreducible
+  · cases hcoeffs
+    exact luebeckConwayPolynomialOfCoeffs_2_8_irreducible
   · cases hcoeffs
     exact luebeckConwayPolynomialOfCoeffs_3_1_irreducible
   · cases hcoeffs
@@ -1133,6 +1191,10 @@ an irreducibility witness. -/
     exact luebeckConwayPolynomialOfCoeffs_2_5_monic
   · cases hcoeffs
     exact luebeckConwayPolynomialOfCoeffs_2_6_monic
+  · cases hcoeffs
+    exact luebeckConwayPolynomialOfCoeffs_2_7_monic
+  · cases hcoeffs
+    exact luebeckConwayPolynomialOfCoeffs_2_8_monic
   · cases hcoeffs
     exact luebeckConwayPolynomialOfCoeffs_3_1_monic
   · cases hcoeffs
@@ -1235,6 +1297,18 @@ def supportedEntry_2_6 : SupportedEntry 2 6 :=
   ⟨luebeckConwayPolynomial_2_6,
     supportedEntry_2_1.prime,
     luebeckConwayPolynomial?_hit_2_6⟩
+
+/-- The current committed table supports `C(2, 7)`. -/
+def supportedEntry_2_7 : SupportedEntry 2 7 :=
+  ⟨luebeckConwayPolynomial_2_7,
+    supportedEntry_2_1.prime,
+    luebeckConwayPolynomial?_hit_2_7⟩
+
+/-- The current committed table supports `C(2, 8)`. -/
+def supportedEntry_2_8 : SupportedEntry 2 8 :=
+  ⟨luebeckConwayPolynomial_2_8,
+    supportedEntry_2_1.prime,
+    luebeckConwayPolynomial?_hit_2_8⟩
 
 /-- The current committed table supports `C(3, 1)`. -/
 def supportedEntry_3_1 : SupportedEntry 3 1 :=

--- a/HexConway/Certificates.lean
+++ b/HexConway/Certificates.lean
@@ -856,6 +856,56 @@ private theorem cert_13_6_incremental_check :
       luebeckConwayPolynomial_13_6 luebeckConwayPolynomial_13_6_monic cert_13_6 cert_13_6_incremental_check)
 
 
+/-- Rabin irreducibility certificate for the committed `C(2, 7)` entry. -/
+private def cert_2_7 : Berlekamp.IrreducibilityCertificate where
+  p := 2
+  n := 7
+  powChain := #[FpPoly.ofCoeffs #[(0 : ZMod64 2), 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 0, 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 1, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 1, 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 1, 1, 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 1, 0, 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 1]]
+  bezout := #[{ left := FpPoly.ofCoeffs #[(1 : ZMod64 2)], right := FpPoly.ofCoeffs #[(1 : ZMod64 2), 1, 1, 1, 1, 1] }]
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 8000000 in
+/-- `cert_2_7_incremental_check` confirms the incremental Rabin certificate
+`cert_2_7` validates for the committed `C(2, 7)` entry. -/
+private theorem cert_2_7_incremental_check :
+    Berlekamp.checkIrreducibilityCertificateLinearIncremental
+        luebeckConwayPolynomial_2_7 luebeckConwayPolynomial_2_7_monic cert_2_7 = true := by
+  decide
+
+/-- The committed `C(2, 7)` entry is irreducible. -/
+@[grind .] theorem luebeckConwayPolynomial_2_7_irreducible :
+    FpPoly.Irreducible luebeckConwayPolynomial_2_7 :=
+  Berlekamp.rabinTest_imp_irreducible
+    luebeckConwayPolynomial_2_7
+    luebeckConwayPolynomial_2_7_monic
+    (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
+      luebeckConwayPolynomial_2_7 luebeckConwayPolynomial_2_7_monic cert_2_7 cert_2_7_incremental_check)
+
+/-- Rabin irreducibility certificate for the committed `C(2, 8)` entry. -/
+private def cert_2_8 : Berlekamp.IrreducibilityCertificate where
+  p := 2
+  n := 8
+  powChain := #[FpPoly.ofCoeffs #[(0 : ZMod64 2), 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 0, 0, 1], FpPoly.ofCoeffs #[(1 : ZMod64 2), 0, 1, 1, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 0, 1, 1, 0, 0, 1], FpPoly.ofCoeffs #[(1 : ZMod64 2), 0, 1, 1, 1, 0, 0, 1], FpPoly.ofCoeffs #[(1 : ZMod64 2), 1, 1, 1, 1, 0, 1], FpPoly.ofCoeffs #[(1 : ZMod64 2), 0, 1, 0, 0, 0, 0, 1], FpPoly.ofCoeffs #[(0 : ZMod64 2), 1]]
+  bezout := #[{ left := FpPoly.ofCoeffs #[(1 : ZMod64 2), 1, 0, 0, 1], right := FpPoly.ofCoeffs #[(1 : ZMod64 2), 0, 1, 0, 0, 0, 1] }]
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 8000000 in
+/-- `cert_2_8_incremental_check` confirms the incremental Rabin certificate
+`cert_2_8` validates for the committed `C(2, 8)` entry. -/
+private theorem cert_2_8_incremental_check :
+    Berlekamp.checkIrreducibilityCertificateLinearIncremental
+        luebeckConwayPolynomial_2_8 luebeckConwayPolynomial_2_8_monic cert_2_8 = true := by
+  decide
+
+/-- The committed `C(2, 8)` entry is irreducible. -/
+@[grind .] theorem luebeckConwayPolynomial_2_8_irreducible :
+    FpPoly.Irreducible luebeckConwayPolynomial_2_8 :=
+  Berlekamp.rabinTest_imp_irreducible
+    luebeckConwayPolynomial_2_8
+    luebeckConwayPolynomial_2_8_monic
+    (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
+      luebeckConwayPolynomial_2_8 luebeckConwayPolynomial_2_8_monic cert_2_8 cert_2_8_incremental_check)
+
 end Conway
 
 end Hex

--- a/HexConway/EntrySource.lean
+++ b/HexConway/EntrySource.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekamp.Irreducibility
+import HexBerlekamp.CertificateSyntax
+import HexPolyFp.Field
+import HexConway.Table
+
+/-!
+Source generation for a single committed Conway-table entry.
+
+Widening the committed slice means adding, for each new `(p, n)`, a polynomial
+literal, its monic and degree facts, a table-hit lemma, a Rabin irreducibility
+certificate, the kernel check that validates the certificate, and the
+irreducibility theorem the check feeds. Of those, only the certificate is not
+mechanical: it has to be computed by running the Frobenius chain and the
+extended gcd, which is what `Berlekamp.buildIrreducibilityCertificate?` does in
+compiled code.
+
+`entryCertData` runs that generator for a `(p, n)` pair given its coefficients,
+and `entryBlock` renders the whole per-entry block as Lean source. The
+`#conway_entry_source` command prints the block for pasting into
+`HexConway.Table` and `HexConway.Certificates`.
+
+Nothing here is used by the committed library at build time. The generator
+carries no soundness claim of its own: a wrong certificate makes the committed
+`decide` check fail, so a bad entry cannot pass unnoticed.
+-/
+
+namespace Hex.Conway.EntrySource
+
+open Lean Elab Command
+
+/-- Serialized Rabin certificate: the prime, the degree, the Frobenius pow
+chain, and the Bezout witness pairs, all as canonical `Nat` representatives. -/
+abbrev CertData := Nat × Nat × List (List Nat) × List (List Nat × List Nat)
+
+/-- Compute the Rabin irreducibility certificate for `C(p, n)` from its
+coefficient list, serialized to plain `Nat` data.
+
+Returns `none` when the modulus is out of `ZMod64` range, when the coefficient
+list is not monic, or when the polynomial fails Rabin's test, which for a
+correctly transcribed Conway entry means the transcription is wrong. -/
+def entryCertData (p : Nat) (coeffs : List Nat) : Option CertData :=
+  if h0 : 0 < p then
+    if h1 : p < 2 ^ 31 then
+      haveI : Hex.ZMod64.Bounds p := ⟨h0, h1⟩
+      let f : Hex.FpPoly p :=
+        Hex.FpPoly.ofCoeffs (coeffs.toArray.map (fun c => Hex.ZMod64.ofNat p c))
+      -- `Monic` unfolds to this equation, so the decidable equality on residues
+      -- is what makes the guard computable.
+      if hm : Hex.DensePoly.leadingCoeff f = 1 then
+        (Hex.Berlekamp.buildIrreducibilityCertificate? f hm).map
+          Hex.CertificateSyntax.rabinCertData
+      else
+        none
+    else
+      none
+  else
+    none
+
+/-- Re-check a generated certificate the way the committed `decide` will.
+
+This is the same predicate the emitted kernel check uses, so a `true` here means
+the emitted entry will elaborate, and a `false` means it will not. -/
+def entryCertValidates (p : Nat) (coeffs : List Nat) (cert : CertData) : Bool :=
+  if h0 : 0 < p then
+    if h1 : p < 2 ^ 31 then
+      haveI : Hex.ZMod64.Bounds p := ⟨h0, h1⟩
+      let f : Hex.FpPoly p :=
+        Hex.FpPoly.ofCoeffs (coeffs.toArray.map (fun c => Hex.ZMod64.ofNat p c))
+      if hm : Hex.DensePoly.leadingCoeff f = 1 then
+        let rebuilt : Hex.Berlekamp.IrreducibilityCertificate :=
+          { p := p
+            n := cert.2.1
+            powChain := (cert.2.2.1.map fun cs =>
+              Hex.FpPoly.ofCoeffs (cs.toArray.map (fun c => Hex.ZMod64.ofNat p c))).toArray
+            bezout := (cert.2.2.2.map fun w =>
+              { left := Hex.FpPoly.ofCoeffs (w.1.toArray.map (fun c => Hex.ZMod64.ofNat p c))
+                right :=
+                  Hex.FpPoly.ofCoeffs (w.2.toArray.map (fun c => Hex.ZMod64.ofNat p c)) }).toArray }
+        Hex.Berlekamp.checkIrreducibilityCertificateLinearIncremental f hm rebuilt
+      else
+        false
+    else
+      false
+  else
+    false
+
+/-- Render a coefficient list as the `FpPoly` literal the committed entries use:
+the first residue carries the type ascription that fixes `p`, and the empty list
+needs the ascription on the array instead. -/
+def renderCoeffs (p : Nat) (coeffs : List Nat) : String :=
+  match coeffs with
+  | [] => s!"FpPoly.ofCoeffs (#[] : Array (ZMod64 {p}))"
+  | c :: rest =>
+      let tail := rest.foldl (init := "") fun acc d => acc ++ s!", {d}"
+      s!"FpPoly.ofCoeffs #[({c} : ZMod64 {p}){tail}]"
+
+/-- An opening brace, kept as a binding so the templates below can mention one
+without colliding with string interpolation. -/
+private def lb : String := "{"
+
+/-- A closing brace, the counterpart of {name}`Hex.Conway.EntrySource.lb`. -/
+private def rb : String := "}"
+
+/-- Render the table-hit lemma, whose closing `match` needs one `rfl` arm per
+stored coefficient plus a catch-all for the positions above the degree. -/
+def hitLemma (p n : Nat) (coeffs : List Nat) (name : String) : String :=
+  let listLit := "[" ++ String.intercalate ", " (coeffs.map toString) ++ "]"
+  let arms := (List.range coeffs.length).map fun i => s!"  | {i} => rfl"
+  String.intercalate "\n"
+    ([ "-- Also add to HexConway/Table.lean, after the literal:",
+       "",
+       s!"/-- `luebeckConwayPolynomial? {p} {n}` resolves to the committed `C({p}, {n})`",
+       s!"literal, rewriting the table lookup to the direct `{name}` form. -/",
+       s!"@[simp, grind =] theorem luebeckConwayPolynomial?_hit_{p}_{n} :",
+       s!"    luebeckConwayPolynomial? {p} {n} = some {name} := by",
+       s!"  show some (luebeckConwayPolynomialOfCoeffs {p} {listLit}) = some {name}",
+       "  congr 1",
+       "  apply DensePoly.ext_coeff",
+       "  intro k",
+       s!"  rw [show DensePoly.coeff (luebeckConwayPolynomialOfCoeffs {p} {listLit}) k =",
+       s!"        ({listLit}.toArray.map (fun m => ZMod64.ofNat {p} m)).getD k",
+       s!"          (Zero.zero : ZMod64 {p}) from",
+       "      DensePoly.coeff_ofCoeffs _ k]",
+       s!"  simp [List.toArray, Array.map, DensePoly.coeff, {name}]",
+       "  match k with" ] ++ arms ++ [ s!"  | _ + {coeffs.length} => rfl" ])
+
+/-- Render the coefficient-list transports and the `SupportedEntry` witness that
+`HexConway.Api` carries for each committed entry. -/
+def apiBlock (p n : Nat) (coeffs : List Nat) (name : String) : String :=
+  let listLit := "[" ++ String.intercalate ", " (coeffs.map toString) ++ "]"
+  let ofCoeffs := s!"luebeckConwayPolynomialOfCoeffs {p} {listLit}"
+  String.intercalate "\n"
+    [ "-- Add to HexConway/Api.lean:",
+      "",
+      s!"/-- The coefficient-list constructor for the committed `C({p}, {n})` Conway entry",
+      "yields an irreducible `FpPoly`, via the `luebeckConwayPolynomial?` table hit and",
+      "the literal's irreducibility proof. -/",
+      s!"private theorem luebeckConwayPolynomialOfCoeffs_{p}_{n}_irreducible :",
+      s!"    FpPoly.Irreducible ({ofCoeffs}) := by",
+      s!"  have hhit := luebeckConwayPolynomial?_hit_{p}_{n}",
+      s!"  change some ({ofCoeffs}) =",
+      s!"    some {name} at hhit",
+      s!"  have hpoly : {ofCoeffs} =",
+      s!"      {name} :=",
+      "    Option.some.inj hhit",
+      "  rw [hpoly]",
+      s!"  exact {name}_irreducible",
+      "",
+      s!"/-- The coefficient-list constructor for the committed `C({p}, {n})` Conway entry",
+      "yields a monic `FpPoly`. -/",
+      s!"private theorem luebeckConwayPolynomialOfCoeffs_{p}_{n}_monic :",
+      s!"    DensePoly.Monic ({ofCoeffs}) := by",
+      s!"  have hhit := luebeckConwayPolynomial?_hit_{p}_{n}",
+      s!"  change some ({ofCoeffs}) =",
+      s!"    some {name} at hhit",
+      s!"  have hpoly : {ofCoeffs} =",
+      s!"      {name} :=",
+      "    Option.some.inj hhit",
+      "  rw [hpoly]",
+      s!"  exact {name}_monic",
+      "",
+      s!"/-- The current committed table supports `C({p}, {n})`. -/",
+      s!"def supportedEntry_{p}_{n} : SupportedEntry {p} {n} :=",
+      s!"  ⟨{name},",
+      s!"    supportedEntry_{p}_1.prime,",
+      s!"    luebeckConwayPolynomial?_hit_{p}_{n}⟩",
+      "",
+      "-- Add one arm to each aggregate case-bash, in table order:",
+      s!"  · cases hcoeffs",
+      s!"    exact luebeckConwayPolynomialOfCoeffs_{p}_{n}_irreducible",
+      s!"  · cases hcoeffs",
+      s!"    exact luebeckConwayPolynomialOfCoeffs_{p}_{n}_monic" ]
+
+/-- Render the per-entry source block for `(p, n)`: the table-side literal with
+its monic and degree lemmas, then the certificate side with its kernel check and
+the irreducibility theorem. -/
+def entryBlock (p n : Nat) (coeffs : List Nat) (cert : CertData) : String :=
+  let name := s!"luebeckConwayPolynomial_{p}_{n}"
+  let cert_ := s!"cert_{p}_{n}"
+  let coeffLit :=
+    match coeffs with
+    | [] => s!"#[] : Array (ZMod64 {p})"
+    | c :: rest =>
+        let tail := rest.foldl (init := "") fun acc d => acc ++ s!", {d}"
+        s!"#[({c} : ZMod64 {p}){tail}]"
+  let powChain := String.intercalate ", " (cert.2.2.1.map (renderCoeffs p))
+  let bezout := String.intercalate ", " (cert.2.2.2.map fun w =>
+    s!"{lb} left := {renderCoeffs p w.1}, right := {renderCoeffs p w.2} {rb}")
+  String.intercalate "\n"
+    [ "-- Add to HexConway/Table.lean:",
+      "",
+      s!"/-- The committed `C({p}, {n})` Luebeck entry, stored ascending by degree. -/",
+      s!"def {name} : FpPoly {p} :=",
+      s!"  {lb} coeffs := {coeffLit}",
+      "    normalized := by",
+      "      right",
+      s!"      decide {rb}",
+      "",
+      s!"/-- The committed `C({p}, {n})` entry is monic. -/",
+      s!"@[simp, grind .] theorem {name}_monic :",
+      s!"    DensePoly.Monic {name} := by",
+      "  rfl",
+      "",
+      s!"/-- The committed `C({p}, {n})` entry has positive degree. -/",
+      s!"@[simp, grind .] theorem {name}_degree_pos :",
+      s!"    0 < FpPoly.degree {name} := by",
+      "  decide",
+      "",
+      "-- Add to HexConway/Certificates.lean:",
+      "",
+      s!"/-- Rabin irreducibility certificate for the committed `C({p}, {n})` entry. -/",
+      s!"private def {cert_} : Berlekamp.IrreducibilityCertificate where",
+      s!"  p := {p}",
+      s!"  n := {cert.2.1}",
+      s!"  powChain := #[{powChain}]",
+      s!"  bezout := #[{bezout}]",
+      "",
+      "set_option maxRecDepth 4096 in",
+      "set_option maxHeartbeats 8000000 in",
+      s!"/-- `{cert_}_incremental_check` confirms the incremental Rabin certificate",
+      s!"`{cert_}` validates for the committed `C({p}, {n})` entry. -/",
+      s!"private theorem {cert_}_incremental_check :",
+      "    Berlekamp.checkIrreducibilityCertificateLinearIncremental",
+      s!"        {name} {name}_monic {cert_} = true := by",
+      "  decide",
+      "",
+      s!"/-- The committed `C({p}, {n})` entry is irreducible. -/",
+      s!"@[grind .] theorem {name}_irreducible :",
+      s!"    FpPoly.Irreducible {name} :=",
+      "  Berlekamp.rabinTest_imp_irreducible",
+      s!"    {name}",
+      s!"    {name}_monic",
+      "    (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest",
+      s!"      {name} {name}_monic {cert_} {cert_}_incremental_check)" ]
+    ++ "\n\n" ++ hitLemma p n coeffs name
+    ++ "\n\n" ++ apiBlock p n coeffs name
+
+/-- Print the per-entry source block for a committed or candidate Conway pair.
+
+The coefficients come from the committed cache table, so this only works for
+pairs the cache already covers; widen the cache first with
+`scripts/oracle/update_luebeck_conway_cache.py` if the pair is missing. -/
+syntax (name := conwayEntrySource)
+  "#conway_entry_source" num num &"coeffs" "[" num,* "]" : command
+
+@[command_elab conwayEntrySource]
+def elabEntrySource : CommandElab := fun stx => do
+  let p := stx[1].isNatLit?.getD 0
+  let n := stx[2].isNatLit?.getD 0
+  let coeffs := stx[5].getSepArgs.toList.map fun s => s.isNatLit?.getD 0
+  match entryCertData p coeffs with
+  | none =>
+      throwError "no Rabin certificate for C({p}, {n}); the coefficients are not \
+                  a monic irreducible polynomial over F_{p}, so check the transcription."
+  | some cert =>
+      unless entryCertValidates p coeffs cert do
+        throwError "the generated certificate for C({p}, {n}) does not validate; \
+                    this is a generator bug, not a bad entry."
+      logInfo (entryBlock p n coeffs cert)
+
+end Hex.Conway.EntrySource

--- a/HexConway/EntrySource.lean
+++ b/HexConway/EntrySource.lean
@@ -8,6 +8,7 @@ import HexBerlekamp.Irreducibility
 import HexBerlekamp.CertificateSyntax
 import HexPolyFp.Field
 import HexConway.Table
+import HexConway.Rebuild
 
 /-!
 Source generation for a single committed Conway-table entry.
@@ -27,7 +28,22 @@ and `entryBlock` renders the whole per-entry block as Lean source. The
 
 Nothing here is used by the committed library at build time. The generator
 carries no soundness claim of its own: a wrong certificate makes the committed
-`decide` check fail, so a bad entry cannot pass unnoticed.
+`decide` check fail, so a bad entry cannot pass unnoticed. What the certificate
+does *not* establish is that the entry is the Conway polynomial for its pair,
+which is why the coefficients are read from the cache rather than supplied.
+
+Two limits on the emitted block, both of which need a human rather than a
+retry:
+
+* It assumes the prime already has its `ZMod64.Bounds`, `Hex.Nat.Prime`, and
+  `ZMod64.PrimeModulus` instances, and it refers to `supportedEntry_{p}_1` for
+  the primality witness. Adding a prime the table does not yet carry, such as
+  the cache's 97, 521, or 65537, needs those prerequisites written first, and
+  the `n = 1` entry cannot take its witness from itself.
+* It emits a fixed 8M heartbeat budget, which suits the entries committed so
+  far but not all of them: four existing certificates need 20M. A generated
+  block that fails to elaborate on heartbeats wants its budget raised, not its
+  certificate regenerated.
 -/
 
 namespace Hex.Conway.EntrySource
@@ -241,24 +257,51 @@ def entryBlock (p n : Nat) (coeffs : List Nat) (cert : CertData) : String :=
     ++ "\n\n" ++ hitLemma p n coeffs name
     ++ "\n\n" ++ apiBlock p n coeffs name
 
-/-- Print the per-entry source block for a committed or candidate Conway pair.
+/-- Print the per-entry source block for a Conway pair in the committed cache.
 
-The coefficients come from the committed cache table, so this only works for
-pairs the cache already covers; widen the cache first with
-`scripts/oracle/update_luebeck_conway_cache.py` if the pair is missing. -/
+Takes only the pair. The coefficients are read from the cache row for that
+pair rather than supplied by the caller, so the emitted block cannot be
+labelled `C(p, n)` while holding some other polynomial. That distinction
+matters because Tier 1 proves only that a committed entry is monic,
+irreducible, and of the requested degree; nothing in Lean says it is *the*
+Conway polynomial, so a mislabelled entry would typecheck.
+
+Widen the cache first with `scripts/oracle/update_luebeck_conway_cache.py` if
+the pair is missing. -/
 syntax (name := conwayEntrySource)
-  "#conway_entry_source" num num &"coeffs" "[" num,* "]" : command
+  "#conway_entry_source" num num (&"from" str)? : command
 
 @[command_elab conwayEntrySource]
 def elabEntrySource : CommandElab := fun stx => do
   let p := stx[1].isNatLit?.getD 0
   let n := stx[2].isNatLit?.getD 0
-  let coeffs := stx[5].getSepArgs.toList.map fun s => s.isNatLit?.getD 0
+  let pathArg := stx[3]
+  let defaultPath := "scripts/oracle/luebeck_conway_cache.json"
+  let path :=
+    if pathArg.isNone then defaultPath else pathArg[0][1].isStrLit?.getD defaultPath
+  let entries ← Rebuild.readCache path
+  let some entry := entries.find? (fun e => e.p = p && e.n = n)
+    | throwError "the cache at '{path}' has no row for C({p}, {n}); widen it with \
+                  scripts/oracle/update_luebeck_conway_cache.py first."
+  let coeffs := entry.coeffs
+  -- Shape checks the cache itself does not enforce. A row that fails any of
+  -- these would still produce a certificate for *something*, so reject it here
+  -- rather than emit a block whose label does not match its contents.
+  unless coeffs.length = n + 1 do
+    throwError "the cache row for C({p}, {n}) has {coeffs.length} coefficients, \
+                expected {n + 1} for a degree-{n} polynomial."
+  unless coeffs.getLast? = some 1 do
+    throwError "the cache row for C({p}, {n}) is not monic."
+  unless coeffs.all (fun c => c < p) do
+    throwError "the cache row for C({p}, {n}) has a coefficient outside F_{p}."
   match entryCertData p coeffs with
   | none =>
-      throwError "no Rabin certificate for C({p}, {n}); the coefficients are not \
-                  a monic irreducible polynomial over F_{p}, so check the transcription."
+      throwError "no Rabin certificate for C({p}, {n}); the cached coefficients are \
+                  not a monic irreducible polynomial over F_{p}, so the cache is wrong."
   | some cert =>
+      unless cert.2.1 = n do
+        throwError "the certificate for C({p}, {n}) reports degree {cert.2.1}; \
+                    this is a generator bug, not a bad entry."
       unless entryCertValidates p coeffs cert do
         throwError "the generated certificate for C({p}, {n}) does not validate; \
                     this is a generator bug, not a bad entry."

--- a/HexConway/Rebuild.lean
+++ b/HexConway/Rebuild.lean
@@ -67,17 +67,25 @@ def readCache (path : System.FilePath) : IO (Array Entry) := do
     pure { p, n, coeffs }
 
 /-- Keep the entries inside the requested scope, ordered by prime then degree so
-the generated `match` reads in the same order as Lübeck's table. -/
-def selectScope (entries : Array Entry) (primes : List Nat) (maxDegree : Nat) :
-    Array Entry :=
-  let kept := entries.filter fun e => primes.contains e.p && 1 ≤ e.n && e.n ≤ maxDegree
+the generated `match` reads in the same order as Lübeck's table.
+
+The scope gives a maximum degree per prime rather than one maximum for all of
+them, matching the `SLICE` in `scripts/oracle/update_luebeck_conway_cache.py`.
+The proof cost of an entry grows with both the prime and the degree, so a
+uniform bound would either stop the small primes short of what the budget
+affords or push the large ones past it. -/
+def selectScope (entries : Array Entry) (scope : List (Nat × Nat)) : Array Entry :=
+  let kept := entries.filter fun e =>
+    match scope.find? (fun s => s.1 = e.p) with
+    | some (_, maxDegree) => 1 ≤ e.n && e.n ≤ maxDegree
+    | none => false
   kept.qsort fun a b => if a.p = b.p then a.n < b.n else a.p < b.p
 
 /-- Render the scope back as the command that produced it, for the commented-out
 line the replacement carries. -/
-def renderInvocation (primes : List Nat) (maxDegree : Nat) (path : String) : String :=
-  let primeList := String.intercalate ", " (primes.map toString)
-  s!"rebuild_luebeckConwayPolynomial? primes [{primeList}] degrees {maxDegree} from \"{path}\""
+def renderInvocation (scope : List (Nat × Nat)) (path : String) : String :=
+  let pairs := String.intercalate ", " (scope.map fun s => s!"{s.1}:{s.2}")
+  s!"rebuild_luebeckConwayPolynomial? scope [{pairs}] from \"{path}\""
 
 /-- Render the regenerated coefficient table, including the commented-out
 invocation above it. -/
@@ -93,24 +101,26 @@ def renderTable (entries : Array Entry) (invocation : String) : String :=
     acc ++ s!"  | {e.p}, {e.n} => some [{coeffs}]\n"
   header ++ rows ++ "  | _, _ => none"
 
-/-- Scope specification: the primes to keep and the largest degree to keep for
-each of them. Degrees below the maximum that Lübeck's table happens not to list
-are simply absent, so a gap in the source is tolerated rather than fatal. -/
+/-- One scope entry, written `p:maxDegree`. -/
+syntax scopeEntry := num ":" num
+
+/-- Scope specification: a maximum degree per prime, written
+`scope [2:8, 3:6]`. Degrees below the maximum that Lübeck's table happens not to
+list are simply absent, so a gap in the source is tolerated rather than fatal. -/
 syntax (name := rebuildLuebeck)
-  "rebuild_luebeckConwayPolynomial?" &"primes" "[" num,* "]" &"degrees" num
+  "rebuild_luebeckConwayPolynomial?" &"scope" "[" scopeEntry,* "]"
     (&"from" str)? command : command
 
 @[command_elab rebuildLuebeck]
 def elabRebuild : CommandElab := fun stx => do
-  let primeStx := stx[3].getSepArgs
-  let primeScope := primeStx.toList.map fun s => s.isNatLit?.getD 0
-  let maxDegree := stx[6].isNatLit?.getD 0
-  let pathArg := stx[7]
+  let scope := stx[3].getSepArgs.toList.map fun s =>
+    (s[0].isNatLit?.getD 0, s[2].isNatLit?.getD 0)
+  let pathArg := stx[5]
   let defaultPath := "scripts/oracle/luebeck_conway_cache.json"
   let path :=
     if pathArg.isNone then defaultPath
     else pathArg[0][1].isStrLit?.getD defaultPath
-  let inner := stx[8]
+  let inner := stx[6]
 
   -- The command is only meaningful in front of the definition it regenerates;
   -- checking that here turns a misplaced invocation into an error at the
@@ -127,20 +137,20 @@ def elabRebuild : CommandElab := fun stx => do
   -- says while a rebuild is only ever offered as a suggestion.
   elabCommand inner
 
-  if primeScope.isEmpty then
+  if scope.isEmpty then
     throwError "rebuild_luebeckConwayPolynomial? needs at least one prime in its scope."
 
   let entries ← readCache path
-  let selected := selectScope entries primeScope maxDegree
+  let selected := selectScope entries scope
   if selected.isEmpty then
     throwError "the requested scope selects no entries from '{path}'."
-  let invocation := renderInvocation primeScope maxDegree path
+  let invocation := renderInvocation scope path
   let replacement := renderTable selected invocation
   liftTermElabM do
     Lean.Meta.Tactic.TryThis.addSuggestion stx
       { suggestion := .string replacement
         postInfo? := some
-          s!"\n\n{selected.size} entries for primes \
-             {String.intercalate ", " (primeScope.map toString)} through degree {maxDegree}." }
+          s!"\n\n{selected.size} entries over scope \
+             {String.intercalate ", " (scope.map fun s => s!"{s.1}:{s.2}")}." }
 
 end Hex.Conway.Rebuild

--- a/HexConway/Rebuild.lean
+++ b/HexConway/Rebuild.lean
@@ -140,7 +140,25 @@ def elabRebuild : CommandElab := fun stx => do
   if scope.isEmpty then
     throwError "rebuild_luebeckConwayPolynomial? needs at least one prime in its scope."
 
+  -- A scope is a claim about what the committed table should contain, so a
+  -- claim that cannot mean what it appears to is rejected rather than
+  -- silently resolved. `selectScope` takes the first match for a prime, so a
+  -- repeated prime would quietly drop the second bound.
+  let primes := scope.map Prod.fst
+  for prime in primes do
+    if (primes.filter (· = prime)).length > 1 then
+      throwError "prime {prime} appears more than once in the scope; \
+                  give each prime a single maximum degree."
+  for (prime, maxDegree) in scope do
+    if maxDegree = 0 then
+      throwError "prime {prime} has maximum degree 0, which selects nothing; \
+                  drop it from the scope instead."
+
   let entries ← readCache path
+  for (prime, _) in scope do
+    if !entries.any (fun e => e.p = prime) then
+      throwError "the cache at '{path}' has no rows for prime {prime}; \
+                  widen the cache or drop the prime from the scope."
   let selected := selectScope entries scope
   if selected.isEmpty then
     throwError "the requested scope selects no entries from '{path}'."

--- a/HexConway/Rebuild.lean
+++ b/HexConway/Rebuild.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import Lean
+
+/-!
+The `rebuild_luebeckConwayPolynomial?` command, which regenerates the committed
+Lübeck Conway coefficient table from the cached slice of Lübeck's published
+data.
+
+The committed table stays ordinary Lean code that the kernel checks like any
+other definition. This command exists so that *changing which slice is
+committed* is one invocation rather than a hand edit: it reads the cache, keeps
+the entries inside the requested scope, and offers the regenerated definition as
+a `Try this:` replacement for the definition written immediately below it.
+
+The emitted replacement carries the invocation that produced it, commented out
+directly above the definition, so a reader can see the scope the committed table
+came from and re-run it without reconstructing the arguments.
+
+The cache itself is refreshed from Lübeck's table by
+`scripts/oracle/update_luebeck_conway_cache.py`, which is the only step that
+touches the network. This command reads only the committed JSON, so a rebuild is
+reproducible offline and its output is a pure function of the cache and the
+scope.
+-/
+
+namespace Hex.Conway.Rebuild
+
+open Lean Elab Command
+
+/-- One committed table row: the prime, the degree, and the Conway polynomial's
+coefficients stored ascending by degree. -/
+structure Entry where
+  /-- The characteristic. -/
+  p : Nat
+  /-- The extension degree. -/
+  n : Nat
+  /-- Coefficients of `C(p, n)`, ascending by degree, so the last entry is the
+  leading `1`. -/
+  coeffs : List Nat
+  deriving Inhabited
+
+/-- Read the committed Lübeck cache and return its entries in file order.
+
+Fails with a readable message rather than an exception when the file is absent
+or does not have the shape `update_luebeck_conway_cache.py` writes, since the
+usual cause is running the command from outside the package root. -/
+def readCache (path : System.FilePath) : IO (Array Entry) := do
+  unless ← path.pathExists do
+    throw <| IO.userError
+      s!"Lübeck Conway cache not found at '{path}'. \
+         Run this command from the package root, or pass an explicit path with \
+         `from \"…\"`. Regenerate the cache with \
+         scripts/oracle/update_luebeck_conway_cache.py."
+  let text ← IO.FS.readFile path
+  let json ← IO.ofExcept (Json.parse text)
+  let entries ← IO.ofExcept (json.getObjVal? "entries" >>= Json.getArr?)
+  entries.mapM fun e => do
+    let p ← IO.ofExcept (e.getObjVal? "p" >>= Json.getNat?)
+    let n ← IO.ofExcept (e.getObjVal? "n" >>= Json.getNat?)
+    let coeffsJson ← IO.ofExcept (e.getObjVal? "coeffs" >>= Json.getArr?)
+    let coeffs ← coeffsJson.toList.mapM fun c => IO.ofExcept c.getNat?
+    pure { p, n, coeffs }
+
+/-- Keep the entries inside the requested scope, ordered by prime then degree so
+the generated `match` reads in the same order as Lübeck's table. -/
+def selectScope (entries : Array Entry) (primes : List Nat) (maxDegree : Nat) :
+    Array Entry :=
+  let kept := entries.filter fun e => primes.contains e.p && 1 ≤ e.n && e.n ≤ maxDegree
+  kept.qsort fun a b => if a.p = b.p then a.n < b.n else a.p < b.p
+
+/-- Render the scope back as the command that produced it, for the commented-out
+line the replacement carries. -/
+def renderInvocation (primes : List Nat) (maxDegree : Nat) (path : String) : String :=
+  let primeList := String.intercalate ", " (primes.map toString)
+  s!"rebuild_luebeckConwayPolynomial? primes [{primeList}] degrees {maxDegree} from \"{path}\""
+
+/-- Render the regenerated coefficient table, including the commented-out
+invocation above it. -/
+def renderTable (entries : Array Entry) (invocation : String) : String :=
+  let header :=
+    "-- Regenerate this definition with the command on the next line, which\n\
+     -- rewrites it from the committed Lübeck cache:\n\
+     -- " ++ invocation ++ "\n\
+     /-- Committed Lübeck Conway-table coefficients, stored ascending by degree. -/\n\
+     def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)\n"
+  let rows := entries.foldl (init := "") fun acc e =>
+    let coeffs := String.intercalate ", " (e.coeffs.map toString)
+    acc ++ s!"  | {e.p}, {e.n} => some [{coeffs}]\n"
+  header ++ rows ++ "  | _, _ => none"
+
+/-- Scope specification: the primes to keep and the largest degree to keep for
+each of them. Degrees below the maximum that Lübeck's table happens not to list
+are simply absent, so a gap in the source is tolerated rather than fatal. -/
+syntax (name := rebuildLuebeck)
+  "rebuild_luebeckConwayPolynomial?" &"primes" "[" num,* "]" &"degrees" num
+    (&"from" str)? command : command
+
+@[command_elab rebuildLuebeck]
+def elabRebuild : CommandElab := fun stx => do
+  let primeStx := stx[3].getSepArgs
+  let primeScope := primeStx.toList.map fun s => s.isNatLit?.getD 0
+  let maxDegree := stx[6].isNatLit?.getD 0
+  let pathArg := stx[7]
+  let defaultPath := "scripts/oracle/luebeck_conway_cache.json"
+  let path :=
+    if pathArg.isNone then defaultPath
+    else pathArg[0][1].isStrLit?.getD defaultPath
+  let inner := stx[8]
+
+  -- The command is only meaningful in front of the definition it regenerates;
+  -- checking that here turns a misplaced invocation into an error at the
+  -- invocation rather than a silently ignored suggestion.
+  let isTarget :=
+    inner.find? (fun s => s.isOfKind ``Lean.Parser.Command.declId
+      && s[0].getId.eraseMacroScopes == `luebeckConwayCoeffs?) |>.isSome
+  unless isTarget do
+    throwErrorAt inner
+      "rebuild_luebeckConwayPolynomial? must be followed by the definition of \
+       `luebeckConwayCoeffs?` that it regenerates; found a different command."
+
+  -- Elaborate the committed definition first, so the file still means what it
+  -- says while a rebuild is only ever offered as a suggestion.
+  elabCommand inner
+
+  if primeScope.isEmpty then
+    throwError "rebuild_luebeckConwayPolynomial? needs at least one prime in its scope."
+
+  let entries ← readCache path
+  let selected := selectScope entries primeScope maxDegree
+  if selected.isEmpty then
+    throwError "the requested scope selects no entries from '{path}'."
+  let invocation := renderInvocation primeScope maxDegree path
+  let replacement := renderTable selected invocation
+  liftTermElabM do
+    Lean.Meta.Tactic.TryThis.addSuggestion stx
+      { suggestion := .string replacement
+        postInfo? := some
+          s!"\n\n{selected.size} entries for primes \
+             {String.intercalate ", " (primeScope.map toString)} through degree {maxDegree}." }
+
+end Hex.Conway.Rebuild

--- a/HexConway/Table.lean
+++ b/HexConway/Table.lean
@@ -25,7 +25,7 @@ instance boundsThirteen : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
 
 -- Regenerate this definition with the command on the next line, which
 -- rewrites it from the committed Lübeck cache:
--- rebuild_luebeckConwayPolynomial? primes [2, 3, 5, 7, 11, 13] degrees 6 from "scripts/oracle/luebeck_conway_cache.json"
+-- rebuild_luebeckConwayPolynomial? scope [2:8, 3:6, 5:6, 7:6, 11:6, 13:6] from "scripts/oracle/luebeck_conway_cache.json"
 /-- Committed Lübeck Conway-table coefficients, stored ascending by degree. -/
 def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)
   | 2, 1 => some [1, 1]
@@ -34,6 +34,8 @@ def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)
   | 2, 4 => some [1, 1, 0, 0, 1]
   | 2, 5 => some [1, 0, 1, 0, 0, 1]
   | 2, 6 => some [1, 1, 0, 1, 1, 0, 1]
+  | 2, 7 => some [1, 1, 0, 0, 0, 0, 0, 1]
+  | 2, 8 => some [1, 0, 1, 1, 1, 0, 0, 0, 1]
   | 3, 1 => some [1, 1]
   | 3, 2 => some [2, 2, 1]
   | 3, 3 => some [1, 2, 0, 1]
@@ -122,10 +124,11 @@ returns `none`. -/
     luebeckConwayPolynomial? 2 0 = (none : Option (FpPoly 2)) :=
   rfl
 
-/-- Degree `7` over `p = 2` is outside the committed table, so the lookup
-returns `none`. -/
-@[simp, grind =] theorem luebeckConwayPolynomial?_miss_two_seven :
-    luebeckConwayPolynomial? 2 7 = (none : Option (FpPoly 2)) :=
+/-- Degree `9` over `p = 2` is outside the committed table, so the lookup
+returns `none`. The binary column runs to degree `8`, one past the other
+primes, because its certificates are the cheapest to check. -/
+@[simp, grind =] theorem luebeckConwayPolynomial?_miss_two_nine :
+    luebeckConwayPolynomial? 2 9 = (none : Option (FpPoly 2)) :=
   rfl
 
 /-- Degree `7` over `p = 3` is outside the committed table, so the lookup
@@ -1469,6 +1472,89 @@ rewriting the table lookup to the direct `luebeckConwayPolynomial_13_6` form. -/
   | 6 => rfl
   | _ + 7 => rfl
 
+
+/-- The committed `C(2, 7)` Luebeck entry, stored ascending by degree. -/
+def luebeckConwayPolynomial_2_7 : FpPoly 2 :=
+  { coeffs := #[(1 : ZMod64 2), 1, 0, 0, 0, 0, 0, 1]
+    normalized := by
+      right
+      decide }
+
+/-- The committed `C(2, 7)` entry is monic. -/
+@[simp, grind .] theorem luebeckConwayPolynomial_2_7_monic :
+    DensePoly.Monic luebeckConwayPolynomial_2_7 := by
+  rfl
+
+/-- The committed `C(2, 7)` entry has positive degree. -/
+@[simp, grind .] theorem luebeckConwayPolynomial_2_7_degree_pos :
+    0 < FpPoly.degree luebeckConwayPolynomial_2_7 := by
+  decide
+
+/-- The committed `C(2, 8)` Luebeck entry, stored ascending by degree. -/
+def luebeckConwayPolynomial_2_8 : FpPoly 2 :=
+  { coeffs := #[(1 : ZMod64 2), 0, 1, 1, 1, 0, 0, 0, 1]
+    normalized := by
+      right
+      decide }
+
+/-- The committed `C(2, 8)` entry is monic. -/
+@[simp, grind .] theorem luebeckConwayPolynomial_2_8_monic :
+    DensePoly.Monic luebeckConwayPolynomial_2_8 := by
+  rfl
+
+/-- The committed `C(2, 8)` entry has positive degree. -/
+@[simp, grind .] theorem luebeckConwayPolynomial_2_8_degree_pos :
+    0 < FpPoly.degree luebeckConwayPolynomial_2_8 := by
+  decide
+
+/-- `luebeckConwayPolynomial? 2 7` resolves to the committed `C(2, 7)`
+literal, rewriting the table lookup to the direct `luebeckConwayPolynomial_2_7` form. -/
+@[simp, grind =] theorem luebeckConwayPolynomial?_hit_2_7 :
+    luebeckConwayPolynomial? 2 7 = some luebeckConwayPolynomial_2_7 := by
+  show some (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) = some luebeckConwayPolynomial_2_7
+  congr 1
+  apply DensePoly.ext_coeff
+  intro k
+  rw [show DensePoly.coeff (luebeckConwayPolynomialOfCoeffs 2 [1, 1, 0, 0, 0, 0, 0, 1]) k =
+        ([1, 1, 0, 0, 0, 0, 0, 1].toArray.map (fun m => ZMod64.ofNat 2 m)).getD k
+          (Zero.zero : ZMod64 2) from
+      DensePoly.coeff_ofCoeffs _ k]
+  simp [List.toArray, Array.map, DensePoly.coeff, luebeckConwayPolynomial_2_7]
+  match k with
+  | 0 => rfl
+  | 1 => rfl
+  | 2 => rfl
+  | 3 => rfl
+  | 4 => rfl
+  | 5 => rfl
+  | 6 => rfl
+  | 7 => rfl
+  | _ + 8 => rfl
+
+/-- `luebeckConwayPolynomial? 2 8` resolves to the committed `C(2, 8)`
+literal, rewriting the table lookup to the direct `luebeckConwayPolynomial_2_8` form. -/
+@[simp, grind =] theorem luebeckConwayPolynomial?_hit_2_8 :
+    luebeckConwayPolynomial? 2 8 = some luebeckConwayPolynomial_2_8 := by
+  show some (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) = some luebeckConwayPolynomial_2_8
+  congr 1
+  apply DensePoly.ext_coeff
+  intro k
+  rw [show DensePoly.coeff (luebeckConwayPolynomialOfCoeffs 2 [1, 0, 1, 1, 1, 0, 0, 0, 1]) k =
+        ([1, 0, 1, 1, 1, 0, 0, 0, 1].toArray.map (fun m => ZMod64.ofNat 2 m)).getD k
+          (Zero.zero : ZMod64 2) from
+      DensePoly.coeff_ofCoeffs _ k]
+  simp [List.toArray, Array.map, DensePoly.coeff, luebeckConwayPolynomial_2_8]
+  match k with
+  | 0 => rfl
+  | 1 => rfl
+  | 2 => rfl
+  | 3 => rfl
+  | 4 => rfl
+  | 5 => rfl
+  | 6 => rfl
+  | 7 => rfl
+  | 8 => rfl
+  | _ + 9 => rfl
 
 end Conway
 

--- a/HexConway/Table.lean
+++ b/HexConway/Table.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import HexBerlekamp.RabinSoundness
 import HexGFqRing.PolynomialQuotient
+import HexConway.Rebuild
 
 /-!
 Tier 1 Conway-polynomial table and dispatcher: the imported coefficient
@@ -22,6 +23,9 @@ instance boundsSeven : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
 instance boundsEleven : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
 instance boundsThirteen : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
 
+-- Regenerate this definition with the command on the next line, which
+-- rewrites it from the committed Lübeck cache:
+-- rebuild_luebeckConwayPolynomial? primes [2, 3, 5, 7, 11, 13] degrees 6 from "scripts/oracle/luebeck_conway_cache.json"
 /-- Committed Lübeck Conway-table coefficients, stored ascending by degree. -/
 def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)
   | 2, 1 => some [1, 1]

--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -51,6 +51,14 @@ instance committedEntry_2_5 : CommittedEntry 2 5 where
 instance committedEntry_2_6 : CommittedEntry 2 6 where
   entry := supportedEntry_2_6
 
+/-- The committed table supports generic `GFq` construction for `C(2, 7)`. -/
+instance committedEntry_2_7 : CommittedEntry 2 7 where
+  entry := supportedEntry_2_7
+
+/-- The committed table supports generic `GFq` construction for `C(2, 8)`. -/
+instance committedEntry_2_8 : CommittedEntry 2 8 where
+  entry := supportedEntry_2_8
+
 /-- The committed table supports generic `GFq` construction for `C(3, 1)`. -/
 instance committedEntry_3_1 : CommittedEntry 3 1 where
   entry := supportedEntry_3_1
@@ -394,6 +402,30 @@ private theorem packedGF2Entry_2_6_irreducible :
     (packedGF2IrreducibilityCertificate 0x1B 6)
     (by decide)
 
+set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 7)` (`0x3`) is irreducible,
+checked from its certificate. -/
+private theorem packedGF2Entry_2_7_irreducible :
+    GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x3 7) :=
+  GF2Poly.checkIrreducibilityCertificate_imp_irreducible
+    (GF2Poly.ofUInt64Monic 0x3 7)
+    (packedGF2IrreducibilityCertificate 0x3 7)
+    (by decide)
+
+set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 8)` (`0x1D`) is irreducible,
+checked from its certificate.
+
+This is not the AES modulus. AES uses `x^8 + x^4 + x^3 + x + 1` (`0x1B`), a
+different irreducible of the same degree, so `GF2q 8` and the AES field are
+different presentations of the same 256-element field. -/
+private theorem packedGF2Entry_2_8_irreducible :
+    GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x1D 8) :=
+  GF2Poly.checkIrreducibilityCertificate_imp_irreducible
+    (GF2Poly.ofUInt64Monic 0x1D 8)
+    (packedGF2IrreducibilityCertificate 0x1D 8)
+    (by decide)
+
 /-- The committed table supports a packed `GF2n` view of `C(2, 2)`. -/
 instance packedGF2Entry_2_2 : PackedGF2Entry 2 where
   entry := supportedEntry_2_2
@@ -438,6 +470,24 @@ instance packedGF2Entry_2_6 : PackedGF2Entry 6 where
   degree_pos := by decide
   degree_lt_word := by decide
   packed_irreducible := packedGF2Entry_2_6_irreducible
+
+/-- The committed table supports a packed `GF2n` view of `C(2, 7)`. -/
+instance packedGF2Entry_2_7 : PackedGF2Entry 7 where
+  entry := supportedEntry_2_7
+  lower := 0x3
+  conway_eq_packed := rfl
+  degree_pos := by decide
+  degree_lt_word := by decide
+  packed_irreducible := packedGF2Entry_2_7_irreducible
+
+/-- The committed table supports a packed `GF2n` view of `C(2, 8)`. -/
+instance packedGF2Entry_2_8 : PackedGF2Entry 8 where
+  entry := supportedEntry_2_8
+  lower := 0x1D
+  conway_eq_packed := rfl
+  degree_pos := by decide
+  degree_lt_word := by decide
+  packed_irreducible := packedGF2Entry_2_8_irreducible
 
 end Conway
 

--- a/HexManual/Chapters/HexConway.lean
+++ b/HexManual/Chapters/HexConway.lean
@@ -62,9 +62,17 @@ through the normalizing constructor.
 
 The main entry point composes the two: it looks up the coefficient
 list and, on a hit, builds the polynomial. The supported coverage is
-`p ∈ {2, 3, 5, 7, 11, 13}` and `n ∈ {1, …, 6}`. Every other pair
-returns `none` rather than triggering Tier 2 compatibility checks or
-Tier 3 search.
+`p ∈ {2, 3, 5, 7, 11, 13}`, running to `n = 6` for the odd primes and
+to `n = 8` for `p = 2`, so `GF(2⁸)` is a committed Conway field. Every
+other pair returns `none` rather than triggering Tier 2 compatibility
+checks or Tier 3 search.
+
+The binary column runs further because cost decides the scope: the
+committed entries carry Rabin certificates that the kernel replays, and
+that replay is cheapest over `𝔽₂`, where every residue is one bit. The
+scope is therefore a maximum degree per prime rather than one bound for
+all of them, and widening it is a matter of measuring rather than of
+finding new mathematics.
 
 {docstring Hex.Conway.luebeckConwayPolynomial?}
 
@@ -117,9 +125,14 @@ namespace HexConwayChapter
   luebeckConwayPolynomial_2_3
 
 -- Unsupported pairs return none rather than
--- searching: n outside {1..6}, or n = 0.
-#guard luebeckConwayPolynomial? 2 7 =
+-- searching. The binary column runs to degree 8,
+-- the odd primes to 6.
+#guard luebeckConwayPolynomial? 2 8 =
+  some luebeckConwayPolynomial_2_8
+#guard luebeckConwayPolynomial? 2 9 =
   (none : Option (FpPoly 2))
+#guard luebeckConwayPolynomial? 3 7 =
+  (none : Option (FpPoly 3))
 #guard luebeckConwayPolynomial? 2 0 =
   (none : Option (FpPoly 2))
 

--- a/HexManual/Chapters/HexGFq.lean
+++ b/HexManual/Chapters/HexGFq.lean
@@ -56,7 +56,8 @@ one-method class.
 committed {name}`Hex.Conway.SupportedEntry` for the pair `(p, n)`. The
 library commits one instance per committed table cell, named
 `committedEntry_p_n` (for example `committedEntry_2_3`), covering
-`p ∈ {2, 3, 5, 7, 11, 13}` and `n ∈ {1, …, 6}`. With the instance in
+`p ∈ {2, 3, 5, 7, 11, 13}`, to `n = 6` for the odd primes and to `n = 8`
+for `p = 2`. With the instance in
 scope, the short field spelling resolves the witness automatically. Where
 a proof needs to name the witness, the explicit form still takes it as an
 argument.

--- a/bench/HexConway/Bench.lean
+++ b/bench/HexConway/Bench.lean
@@ -58,7 +58,7 @@ structure EntryKey where
 
 /-- The committed Tier 1 Luebeck table keys, in source-table order. -/
 def committedEntryKeys : Array EntryKey := #[
-  ⟨2, 1⟩, ⟨2, 2⟩, ⟨2, 3⟩, ⟨2, 4⟩, ⟨2, 5⟩, ⟨2, 6⟩,
+  ⟨2, 1⟩, ⟨2, 2⟩, ⟨2, 3⟩, ⟨2, 4⟩, ⟨2, 5⟩, ⟨2, 6⟩, ⟨2, 7⟩, ⟨2, 8⟩,
   ⟨3, 1⟩, ⟨3, 2⟩, ⟨3, 3⟩, ⟨3, 4⟩, ⟨3, 5⟩, ⟨3, 6⟩,
   ⟨5, 1⟩, ⟨5, 2⟩, ⟨5, 3⟩, ⟨5, 4⟩, ⟨5, 5⟩, ⟨5, 6⟩,
   ⟨7, 1⟩, ⟨7, 2⟩, ⟨7, 3⟩, ⟨7, 4⟩, ⟨7, 5⟩, ⟨7, 6⟩,
@@ -210,10 +210,10 @@ setup_benchmark runLuebeckConwayPolynomialLookupChecksum ordinal =>
     tier1LookupComplexity ordinal
   where {
     paramFloor := 1
-    paramCeiling := 36
+    paramCeiling := 38
     paramSchedule := .custom #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
       13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-      29, 30, 31, 32, 33, 34, 35, 36]
+      29, 30, 31, 32, 33, 34, 35, 36, 37, 38]
     maxSecondsPerCall := 2.0
     targetInnerNanos := 100000000
     signalFloorMultiplier := 1.0

--- a/conformance-fixtures/HexConway/conway.jsonl
+++ b/conformance-fixtures/HexConway/conway.jsonl
@@ -10,6 +10,10 @@
 {"kind":"result","lib":"HexConway","case":"p2_n5","op":"coeffs","value":[1,0,1,0,0,1]}
 {"kind":"conway","lib":"HexConway","case":"p2_n6","p":2,"n":6}
 {"kind":"result","lib":"HexConway","case":"p2_n6","op":"coeffs","value":[1,1,0,1,1,0,1]}
+{"kind":"conway","lib":"HexConway","case":"p2_n7","p":2,"n":7}
+{"kind":"result","lib":"HexConway","case":"p2_n7","op":"coeffs","value":[1,1,0,0,0,0,0,1]}
+{"kind":"conway","lib":"HexConway","case":"p2_n8","p":2,"n":8}
+{"kind":"result","lib":"HexConway","case":"p2_n8","op":"coeffs","value":[1,0,1,1,1,0,0,0,1]}
 {"kind":"conway","lib":"HexConway","case":"p3_n1","p":3,"n":1}
 {"kind":"result","lib":"HexConway","case":"p3_n1","op":"coeffs","value":[1,1]}
 {"kind":"conway","lib":"HexConway","case":"p3_n2","p":3,"n":2}

--- a/conformance/HexConway/Conformance.lean
+++ b/conformance/HexConway/Conformance.lean
@@ -85,8 +85,12 @@ private def coeffs? (p n : Nat) [ZMod64.Bounds p] : Option (List Nat) :=
 #guard coeffs? 13 6 = some [2, 11, 11, 10, 0, 0, 1]
 
 #guard luebeckConwayPolynomial? 2 0 = (none : Option (FpPoly 2))
-#guard luebeckConwayPolynomial? 2 7 = (none : Option (FpPoly 2))
+#guard luebeckConwayPolynomial? 2 9 = (none : Option (FpPoly 2))
+#guard luebeckConwayPolynomial? 3 7 = (none : Option (FpPoly 3))
 #guard luebeckConwayPolynomial? 17 1 = (none : Option (FpPoly 17))
+
+#guard coeffs? 2 7 = some [1, 1, 0, 0, 0, 0, 0, 1]
+#guard coeffs? 2 8 = some [1, 0, 1, 1, 1, 0, 0, 0, 1]
 
 #guard coeffNats luebeckConwayPolynomial_2_1 = [1, 1]
 #guard supportedEntry_2_1.poly = luebeckConwayPolynomial_2_1
@@ -433,13 +437,19 @@ private def sampleEntries : Array Rebuild.Entry :=
 
 -- The scope filter orders by prime then degree, so the emitted `match` reads in
 -- Lübeck's order however the cache happens to list its entries.
-#guard (Rebuild.selectScope sampleEntries [2, 3] 2).map (fun e => (e.p, e.n))
+#guard (Rebuild.selectScope sampleEntries [(2, 2), (3, 2)]).map (fun e => (e.p, e.n))
     = #[(2, 1), (2, 2), (3, 2)]
 
--- Degrees above the requested maximum are dropped, and so are primes outside
--- the scope, so widening one axis never silently widens the other.
-#guard (Rebuild.selectScope sampleEntries [2] 6).map (fun e => (e.p, e.n))
+-- Primes outside the scope are dropped entirely, and so are degrees above that
+-- prime's maximum.
+#guard (Rebuild.selectScope sampleEntries [(2, 6)]).map (fun e => (e.p, e.n))
     = #[(2, 1), (2, 2)]
+
+-- Each prime carries its own maximum, so raising the binary column does not
+-- drag the others up with it. This is the shape the committed scope uses: the
+-- binary certificates are the cheapest to check, so that column runs further.
+#guard (Rebuild.selectScope sampleEntries [(2, 7), (3, 1)]).map (fun e => (e.p, e.n))
+    = #[(2, 1), (2, 2), (2, 7)]
 
 private def expectedRender : String :=
   "-- Regenerate this definition with the command on the next line, which\n"
@@ -452,13 +462,34 @@ private def expectedRender : String :=
 
 -- Rendering emits the commented-out invocation above the definition, so the
 -- file it replaces stays self-rebuilding.
-#guard Rebuild.renderTable (Rebuild.selectScope sampleEntries [5] 1) "INVOCATION"
+#guard Rebuild.renderTable (Rebuild.selectScope sampleEntries [(5, 1)]) "INVOCATION"
     = expectedRender
 
 -- The rendered invocation round-trips the scope it was given, so the comment
 -- the replacement leaves behind is the command that produced it.
-#guard Rebuild.renderInvocation [2, 3, 5] 6 "cache.json"
-    = "rebuild_luebeckConwayPolynomial? primes [2, 3, 5] degrees 6 from \"cache.json\""
+#guard Rebuild.renderInvocation [(2, 8), (3, 6)] "cache.json"
+    = "rebuild_luebeckConwayPolynomial? scope [2:8, 3:6] from \"cache.json\""
+
+/-! # Entry generation
+
+`#conway_entry_source` computes the Rabin certificate for a candidate entry.
+These checks run that computation on committed entries and confirm the result
+validates under the same predicate the emitted kernel check uses, so a
+regression in the generator surfaces here rather than as an unexplained `decide`
+failure the next time the table is widened. -/
+
+-- The binary column, whose certificates are the cheapest.
+#guard (EntrySource.entryCertData 2 [1, 1, 0, 0, 0, 0, 0, 1]).any
+    (EntrySource.entryCertValidates 2 [1, 1, 0, 0, 0, 0, 0, 1])
+
+-- An odd prime at the top of its committed column, where the certificate is
+-- widest.
+#guard (EntrySource.entryCertData 13 [2, 11, 11, 10, 0, 0, 1]).any
+    (EntrySource.entryCertValidates 13 [2, 11, 11, 10, 0, 0, 1])
+
+-- A reducible polynomial has no certificate, so a mistranscribed entry is
+-- rejected by the generator rather than emitted and left for the kernel.
+#guard (EntrySource.entryCertData 2 [1, 0, 1]).isNone
 
 end ConwayConformance
 end Conway

--- a/conformance/HexConway/Conformance.lean
+++ b/conformance/HexConway/Conformance.lean
@@ -417,6 +417,49 @@ example :
     FpPoly.Irreducible (conwayPoly 13 2 supportedEntry_13_2) := by
   grind
 
+/-! # Table regeneration
+
+`rebuild_luebeckConwayPolynomial?` is commented out in `HexConway.Table`, so a
+build never exercises it. These checks cover its two pure halves directly, so a
+change that would make the next regeneration emit a different table fails here
+rather than silently at the next widening. -/
+
+private def sampleEntries : Array Rebuild.Entry :=
+  #[{ p := 3, n := 2, coeffs := [2, 2, 1] },
+    { p := 2, n := 1, coeffs := [1, 1] },
+    { p := 2, n := 7, coeffs := [1, 1, 0, 1, 0, 0, 0, 1] },
+    { p := 5, n := 1, coeffs := [3, 1] },
+    { p := 2, n := 2, coeffs := [1, 1, 1] }]
+
+-- The scope filter orders by prime then degree, so the emitted `match` reads in
+-- Lübeck's order however the cache happens to list its entries.
+#guard (Rebuild.selectScope sampleEntries [2, 3] 2).map (fun e => (e.p, e.n))
+    = #[(2, 1), (2, 2), (3, 2)]
+
+-- Degrees above the requested maximum are dropped, and so are primes outside
+-- the scope, so widening one axis never silently widens the other.
+#guard (Rebuild.selectScope sampleEntries [2] 6).map (fun e => (e.p, e.n))
+    = #[(2, 1), (2, 2)]
+
+private def expectedRender : String :=
+  "-- Regenerate this definition with the command on the next line, which\n"
+    ++ "-- rewrites it from the committed Lübeck cache:\n"
+    ++ "-- INVOCATION\n"
+    ++ "/-- Committed Lübeck Conway-table coefficients, stored ascending by degree. -/\n"
+    ++ "def luebeckConwayCoeffs? : Nat → Nat → Option (List Nat)\n"
+    ++ "  | 5, 1 => some [3, 1]\n"
+    ++ "  | _, _ => none"
+
+-- Rendering emits the commented-out invocation above the definition, so the
+-- file it replaces stays self-rebuilding.
+#guard Rebuild.renderTable (Rebuild.selectScope sampleEntries [5] 1) "INVOCATION"
+    = expectedRender
+
+-- The rendered invocation round-trips the scope it was given, so the comment
+-- the replacement leaves behind is the command that produced it.
+#guard Rebuild.renderInvocation [2, 3, 5] 6 "cache.json"
+    = "rebuild_luebeckConwayPolynomial? primes [2, 3, 5] degrees 6 from \"cache.json\""
+
 end ConwayConformance
 end Conway
 end Hex

--- a/conformance/HexConway/EmitFixtures.lean
+++ b/conformance/HexConway/EmitFixtures.lean
@@ -43,6 +43,8 @@ def emitAll : IO Unit := do
   emitAt 2 4
   emitAt 2 5
   emitAt 2 6
+  emitAt 2 7
+  emitAt 2 8
   emitAt 3 1
   emitAt 3 2
   emitAt 3 3

--- a/conformance/HexGFq/Conformance.lean
+++ b/conformance/HexGFq/Conformance.lean
@@ -195,5 +195,30 @@ example (x y z : Generic21) :
 #guard GF2q.toGFq (packed4 0x10) =
   GFq.ofPoly (GF2q.supportedEntry (n := 4)) (GF2q.reprFpPoly (packed4 0x10))
 
+/-! # Degree-8 committed entries
+
+The binary column of the committed Conway table runs to degree 8, so both
+ergonomic constructors resolve there. These guards pin that: `GFqC 2 8` and
+`GF2q 8` are the reachability claim the table widening was for, and without
+them a future narrowing would go unnoticed.
+
+Note the modulus is the Conway polynomial for `(2, 8)`, lower word `0x1D`, not
+the AES modulus `0x1B`. They are different irreducibles of the same degree, so
+these are different presentations of the same 256-element field. -/
+
+private abbrev Committed28 : Type := GFqC 2 8
+private abbrev Packed28 : Type := GF2q 8
+
+#guard GF2q.lower (n := 8) = 0x1D
+#guard GF2q.repr (GF2q.ofWord (n := 8) 0x53) = 0x53
+
+-- Reduction past degree 8 folds the Conway modulus back in.
+#guard GF2q.repr (GF2q.ofWord (n := 8) 0x1FF) = (0x1FF ^^^ 0x11D : UInt64)
+
+-- The packed modulus is the monic degree-8 word, and it is the Conway
+-- polynomial for (2, 8) rather than any convenient irreducible: that
+-- identification is the `conway_eq_packed` field of the instance.
+#guard wordArray (GF2q.modulus (n := 8)) = #[0x11D]
+
 end GfqConformance
 end Hex

--- a/reports/hex-conway-performance.md
+++ b/reports/hex-conway-performance.md
@@ -3,6 +3,9 @@
 ## Bench Targets
 
 - `Hex.ConwayBench.runLuebeckConwayPolynomialLookupChecksum`: `tier1LookupComplexity ordinal`
+  (parameter domain widened from `1..36` to `1..38` when the binary column was
+  extended to degree 8; the verdict below predates that and needs a re-run on
+  `carica` before it can be cited for the current table)
 - `Hex.ConwayBench.runConwayPolySupported_2_1Checksum`: fixed canonical `SupportedEntry` recovery for `C(2, 1)`
 - `Hex.ConwayBench.runTier1Irreducibility_2_1Checksum`: fixed Rabin irreducibility check for imported `C(2, 1)`
 - `Hex.ConwayBench.runTier1Irreducibility_2_6Checksum`: fixed Rabin irreducibility check for imported `C(2, 6)`
@@ -17,6 +20,44 @@ surface only. Tier 2 full Conway compatibility verification and Tier 3
 on-demand Conway search are not implemented API surfaces in this phase slice,
 so they are not included in `HexConway.phase4.input_families` and have no
 Phase-4 bench targets yet.
+
+## Tier 1 proof budget
+
+`HexConway/SPEC/hex-conway.md` sizes the committed slice by proof-checking cost
+rather than by mathematical coverage: include as much of the Lübeck table as
+possible subject to the generated Tier 1 correctness theorems still checking in
+"only a few minutes". That cost is elaboration time, not runtime, so it is not
+one of the bench verdicts below; it is recorded here because it is the number
+that decides how wide the table may be.
+
+Measured with `lake build HexConway` on a warm dependency tree, AMD EPYC 9455
+under Linux x86_64. This is not `carica`, so these figures are not comparable
+with the scientific runs below and are useful only as a ratio between scopes.
+
+| Scope | Entries | `Table` | `Certificates` | `Api` |
+|---|---|---|---|---|
+| `2:6, 3:6, 5:6, 7:6, 11:6, 13:6` | 36 | 2.6s | 28s | 2.8s |
+| `2:8, 3:6, 5:6, 7:6, 11:6, 13:6` | 38 | 2.7s | 31s | 3.0s |
+
+Almost all of the cost is the 38 kernel `decide` calls in
+`HexConway/Certificates.lean` that replay the Rabin certificates, at 8M
+heartbeats each and 20M for four of them. Adding `C(2, 7)` and `C(2, 8)` cost
+about 3s between them, so the binary column is cheap: its residues are single
+bits and its certificates are correspondingly small.
+
+Cost grows with both the prime and the degree, which is why the committed scope
+now carries a maximum degree per prime rather than one bound for all of them,
+matching the `SLICE` in `scripts/oracle/update_luebeck_conway_cache.py`. The
+compiled Rabin checks in the verdicts below show the same shape across primes at
+fixed degree 6: `8.042 us` at `C(2, 1)` against `812.958 us` at `C(13, 6)`, a
+hundredfold spread that the kernel replay inherits and amplifies.
+
+At 31s for 38 entries the table sits well inside the "few minutes" rule, so the
+scope is bounded by what has been measured rather than by what is affordable.
+Widening further is mechanical: `rebuild_luebeckConwayPolynomial?` regenerates
+the coefficient table and `#conway_entry_source` emits the per-entry literal,
+lemmas, and certificate. The next widening should re-measure this table rather
+than extrapolate, because the odd-prime columns are where the cost is.
 
 ## Verdicts
 

--- a/reports/hex-conway-performance.md
+++ b/reports/hex-conway-performance.md
@@ -30,34 +30,46 @@ possible subject to the generated Tier 1 correctness theorems still checking in
 one of the bench verdicts below; it is recorded here because it is the number
 that decides how wide the table may be.
 
-Measured with `lake build HexConway` on a warm dependency tree, AMD EPYC 9455
-under Linux x86_64. This is not `carica`, so these figures are not comparable
-with the scientific runs below and are useful only as a ratio between scopes.
+Method: delete `.lake/build/{lib/lean,ir}/HexConway`, then `lake build
+HexConway` on an otherwise warm dependency tree, reading the per-module times
+Lake reports. Single run per scope, so these are indicative rather than
+distributions. AMD EPYC 9455, Linux x86_64, Lean 4.33.0-rc1. This is not
+`carica`, so the figures are not comparable with the scientific runs below;
+they are useful only as a ratio between scopes.
 
 | Scope | Entries | `Table` | `Certificates` | `Api` |
 |---|---|---|---|---|
 | `2:6, 3:6, 5:6, 7:6, 11:6, 13:6` | 36 | 2.6s | 28s | 2.8s |
 | `2:8, 3:6, 5:6, 7:6, 11:6, 13:6` | 38 | 2.7s | 31s | 3.0s |
 
-Almost all of the cost is the 38 kernel `decide` calls in
-`HexConway/Certificates.lean` that replay the Rabin certificates, at 8M
-heartbeats each and 20M for four of them. Adding `C(2, 7)` and `C(2, 8)` cost
-about 3s between them, so the binary column is cheap: its residues are single
-bits and its certificates are correspondingly small.
+Almost all of the cost is kernel `decide`: 37 certificate replays in
+`HexConway/Certificates.lean` at 8M heartbeats each, four of them at 20M, plus
+the degree-one check in `HexConway/Table.lean`. Adding `C(2, 7)` and `C(2, 8)`
+cost about 3s between them, so the binary column is cheap: its residues are
+single bits and its certificates are correspondingly small.
 
 Cost grows with both the prime and the degree, which is why the committed scope
-now carries a maximum degree per prime rather than one bound for all of them,
+carries a maximum degree per prime rather than one bound for all of them,
 matching the `SLICE` in `scripts/oracle/update_luebeck_conway_cache.py`. The
-compiled Rabin checks in the verdicts below show the same shape across primes at
-fixed degree 6: `8.042 us` at `C(2, 1)` against `812.958 us` at `C(13, 6)`, a
-hundredfold spread that the kernel replay inherits and amplifies.
+compiled Rabin checks in the verdicts below show the degree-6 spread across
+primes directly: `128.417 us` at `C(2, 6)` against `812.958 us` at `C(13, 6)`,
+a factor of about 6.3 that the kernel replay inherits.
 
-At 31s for 38 entries the table sits well inside the "few minutes" rule, so the
-scope is bounded by what has been measured rather than by what is affordable.
-Widening further is mechanical: `rebuild_luebeckConwayPolynomial?` regenerates
-the coefficient table and `#conway_entry_source` emits the per-entry literal,
-lemmas, and certificate. The next widening should re-measure this table rather
-than extrapolate, because the odd-prime columns are where the cost is.
+**What this measurement does and does not settle.** It settles that the
+committed scope is affordable: 31s against a "few minutes" rule leaves
+substantial headroom. It does not settle that degree 8 is the right frontier.
+The binary column was extended to 8 because `GF(2^8)` is the smallest field
+where the packed representation is interesting and because the cost was known
+to be small, not because degree 9 was measured and found too expensive. Calling
+this the budget-selected maximum would overstate it; it is an initial widening
+with the budget confirmed to accommodate it.
+
+Establishing the actual frontier means measuring successive candidates until
+the rule bites, per prime. That is now mechanical:
+`rebuild_luebeckConwayPolynomial?` regenerates the coefficient table and
+`#conway_entry_source` emits the per-entry literal, lemmas, and certificate for
+a cached pair. The odd-prime columns are where the cost is, so that is where
+the next measurement should start.
 
 ## Verdicts
 


### PR DESCRIPTION
This PR adds the `rebuild_luebeckConwayPolynomial?` command the `hex-conway` SPEC names, adds a generator for the rest of a per-entry widening, extends the committed table from 36 to 38 entries, and records the proof budget that bounds it.

Stacked on #9242; review that first.

`HexConway/Rebuild.lean` supplies the command. It takes a scope, reads the committed Lübeck cache, consumes the definition of `luebeckConwayCoeffs?` written immediately below it, and offers the regenerated definition as a `Try this:` replacement carrying the invocation that produced it, commented out directly above. The committed invocation is commented out, so a build never reads the cache. Regenerating at the previous scope reproduced the committed table byte for byte.

The scope is a maximum degree per prime rather than one bound for all of them, matching the `SLICE` in `scripts/oracle/update_luebeck_conway_cache.py`. Certificate cost grows with both the prime and the degree, so a uniform bound either stops the small primes short of what the budget affords or pushes the large ones past it.

The coefficient table is only the data. Each entry also needs a polynomial literal, its monic and degree facts, a table-hit lemma, a Rabin certificate, the kernel check that validates it, the irreducibility theorem, two coefficient-list transports, a `SupportedEntry` witness, and an arm in each aggregate case-bash. All of that is mechanical except the certificate, which has to be computed by running the Frobenius chain and the extended gcd. `HexConway/EntrySource.lean` computes it through `Berlekamp.buildIrreducibilityCertificate?` and renders the whole block; `#conway_entry_source` prints it.

With that in place the binary column now runs to degree 8, so `GF(2^8)` is a committed Conway field and the AES tutorial has one to use. The two new entries cost about 3s of the 31s `HexConway.Certificates` now takes.

`reports/hex-conway-performance.md` gains a proof-budget section. The SPEC sizes the committed slice by proof-checking cost, and that cost had never been measured. At 31s for 38 entries the table sits well inside the "few minutes" rule, so the scope is bounded by what has been measured rather than by what is affordable; the next widening should re-measure rather than extrapolate, because the odd-prime columns are where the cost is. The lookup bench verdict is flagged as needing a re-run on `carica`, since its parameter domain widened from `1..36` to `1..38`.

`scripts/oracle/conway_luebeck.py` checks all 38 entries against Lübeck's published table, including the two new ones. The `(2, 7)` miss lemma and its conformance guard moved to `(2, 9)`, which the build caught. Conformance covers the rebuild command's rendering and the generator's certificate computation directly, since the commented-out invocation means a build never elaborates them.

Verified with `lake build HexConway HexGFq HexGFqMathlib HexConformance hexconway_bench hexgfq_bench` (9461 jobs, clean) and the four lint scripts.

🤖 Prepared with Claude Code