### PR TITLE
feat: add the Grind ring tower and mapCoeffs to HexMvPoly

### DIFF
--- a/HexMvPoly.lean
+++ b/HexMvPoly.lean
@@ -13,6 +13,7 @@ public import HexMvPoly.Query
 public import HexMvPoly.Eval
 public import HexMvPoly.Structural
 public import HexMvPoly.Recursive
+public import HexMvPoly.Ring
 
 public section
 

--- a/HexMvPoly/Ring.lean
+++ b/HexMvPoly/Ring.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvPoly.Operations
+
+@[expose] public section
+
+/-!
+The Mathlib-free multivariate polynomial ring instance.
+
+`HexMvPoly.Operations` proves the ring laws as standalone lemmas so the
+arithmetic does not impose an algebra hierarchy. Consumers that recurse into
+polynomial coefficient rings need those laws packaged, so this file supplies
+the numeral and scalar-multiplication operations and assembles the existing
+lemmas into `Lean.Grind.CommRing`.
+
+The consumer that forces this is `HexResultant`: its subresultant chain runs
+over any coefficient type with `Div` and `ExactDivLaws`, but every one of its
+correctness theorems takes `[Lean.Grind.CommRing S]`. Without the instance
+below the chain computes over `MvPoly n R cmp` and none of its theorems apply.
+`HexResultant.ExactDiv` builds the same tower for `DensePoly`.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [BEq R] [LawfulBEq R]
+
+attribute [local instance] Lean.Grind.Semiring.natCast Lean.Grind.Ring.intCast
+
+/-- Natural number numerals, as constant polynomials. -/
+instance instNatCast [Lean.Grind.CommRing R] [DecidableEq R] :
+    NatCast (MvPoly n R cmp) :=
+  ⟨fun k =>
+    match k with
+    | 0 => Zero.zero
+    | 1 => One.one
+    | k + 2 => C (Nat.cast (k + 2))⟩
+
+instance instOfNat [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat) :
+    OfNat (MvPoly n R cmp) k :=
+  ⟨match k with
+    | 0 => Zero.zero
+    | 1 => One.one
+    | k + 2 => C (OfNat.ofNat (k + 2))⟩
+
+instance instNSMul [Lean.Grind.CommRing R] [DecidableEq R] :
+    SMul Nat (MvPoly n R cmp) :=
+  ⟨fun k p => (Nat.cast k : MvPoly n R cmp) * p⟩
+
+instance instIntCast [Lean.Grind.CommRing R] [DecidableEq R] :
+    IntCast (MvPoly n R cmp) :=
+  ⟨fun i =>
+    match i with
+    | .ofNat k => (Nat.cast k : MvPoly n R cmp)
+    | .negSucc k => -(Nat.cast (k + 1) : MvPoly n R cmp)⟩
+
+instance instZSMul [Lean.Grind.CommRing R] [DecidableEq R] :
+    SMul Int (MvPoly n R cmp) :=
+  ⟨fun i p =>
+    match i with
+    | .ofNat k => k • p
+    | .negSucc k => -((k + 1) • p)⟩
+
+/-- Numerals are constant polynomials. -/
+@[simp]
+theorem coeff_ofNat [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat)
+    (m : Mono n) :
+    coeff m (OfNat.ofNat (α := MvPoly n R cmp) k) =
+      if m = Mono.zero then OfNat.ofNat (α := R) k else 0 := by
+  match k with
+  | 0 =>
+      change coeff m (0 : MvPoly n R cmp) = if m = Mono.zero then (0 : R) else 0
+      rw [coeff_zero]
+      by_cases hm : m = Mono.zero <;> simp only [hm, if_true, if_false]
+  | 1 =>
+      change coeff m (1 : MvPoly n R cmp) = if m = Mono.zero then (1 : R) else 0
+      exact coeff_one m
+  | k + 2 =>
+      change coeff m (C (OfNat.ofNat (α := R) (k + 2))) = _
+      exact coeff_C m _
+
+/-- The canonical map from the natural numbers lands in the constants. -/
+@[simp]
+theorem coeff_natCast [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat)
+    (m : Mono n) :
+    coeff m (Nat.cast k : MvPoly n R cmp) =
+      if m = Mono.zero then (Nat.cast k : R) else 0 := by
+  match k with
+  | 0 =>
+      change coeff m (0 : MvPoly n R cmp) = _
+      rw [coeff_zero, Lean.Grind.Semiring.natCast_zero]
+      by_cases hm : m = Mono.zero <;> simp only [hm, if_true, if_false]
+  | 1 =>
+      change coeff m (1 : MvPoly n R cmp) = _
+      rw [coeff_one, Lean.Grind.Semiring.natCast_one]
+  | k + 2 =>
+      change coeff m (C ((Nat.cast (k + 2) : R))) = _
+      exact coeff_C m _
+
+/-- The zeroth power is one.
+
+`npowBySq` is defined by well-founded recursion, so it is `@[irreducible]` and
+`rfl` does not see through it; the equation lemma does. -/
+theorem pow_zero [Lean.Grind.CommRing R] [DecidableEq R]
+    (p : MvPoly n R cmp) : p ^ 0 = 1 := by
+  change npowBySq p 0 = 1
+  simp [npowBySq]
+
+/-- Negating zero gives zero. -/
+@[simp]
+theorem neg_zero [Lean.Grind.CommRing R] [DecidableEq R] :
+    -(0 : MvPoly n R cmp) = 0 := by
+  apply ext
+  intro m
+  rw [coeff_neg, coeff_zero]
+  grind
+
+/-- Negation is an involution. -/
+@[simp]
+theorem neg_neg [Lean.Grind.CommRing R] [DecidableEq R]
+    (p : MvPoly n R cmp) : -(-p) = p := by
+  apply ext
+  intro m
+  rw [coeff_neg, coeff_neg]
+  grind
+
+/-- Negation is the left inverse of addition. -/
+theorem neg_add_cancel [Lean.Grind.CommRing R] [DecidableEq R]
+    (p : MvPoly n R cmp) : -p + p = 0 := by
+  apply ext
+  intro m
+  rw [coeff_add, coeff_neg, coeff_zero]
+  grind
+
+/-- Subtraction is addition of the negation. -/
+theorem sub_eq_add_neg [Lean.Grind.CommRing R] [DecidableEq R]
+    (p q : MvPoly n R cmp) : p - q = p + -q := rfl
+
+/-- Multiplying by a natural numeral is scalar multiplication. -/
+theorem nsmul_eq_natCast_mul [Lean.Grind.CommRing R] [DecidableEq R]
+    (k : Nat) (p : MvPoly n R cmp) :
+    k • p = (Nat.cast k : MvPoly n R cmp) * p := rfl
+
+/-- Successor numerals add one. -/
+theorem ofNat_succ [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat) :
+    (OfNat.ofNat (α := MvPoly n R cmp) (k + 1)) =
+      OfNat.ofNat (α := MvPoly n R cmp) k + 1 := by
+  apply ext
+  intro m
+  rw [coeff_add, coeff_ofNat, coeff_ofNat, coeff_one]
+  by_cases hm : m = Mono.zero
+  · simpa only [hm, if_true] using (Lean.Grind.Semiring.ofNat_succ (α := R) k)
+  · simp only [hm, if_false]
+    grind
+
+/-- Numerals agree with the canonical map from the natural numbers. -/
+theorem ofNat_eq_natCast [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat) :
+    (OfNat.ofNat (α := MvPoly n R cmp) k) = (Nat.cast k : MvPoly n R cmp) := by
+  apply ext
+  intro m
+  rw [coeff_ofNat, coeff_natCast]
+  by_cases hm : m = Mono.zero
+  · simpa only [hm, if_true] using (Lean.Grind.Semiring.ofNat_eq_natCast (α := R) k)
+  · simp only [hm, if_false]
+
+/-- Multivariate polynomials over a lightweight commutative ring form a
+lightweight semiring. -/
+instance instGrindSemiring [Lean.Grind.CommRing R] [DecidableEq R] :
+    Lean.Grind.Semiring (MvPoly n R cmp) := by
+  refine Lean.Grind.Semiring.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  · exact add_zero
+  · exact add_comm
+  · exact add_assoc
+  · exact mul_assoc
+  · exact mul_one
+  · exact one_mul
+  · exact mul_add
+  · exact add_mul
+  · exact zero_mul
+  · exact mul_zero
+  · exact pow_zero
+  · exact pow_succ
+  · exact ofNat_succ
+  · exact ofNat_eq_natCast
+  · exact nsmul_eq_natCast_mul
+
+/-- Multivariate polynomials over a lightweight commutative ring form a
+lightweight ring. -/
+instance instGrindRing [Lean.Grind.CommRing R] [DecidableEq R] :
+    Lean.Grind.Ring (MvPoly n R cmp) := by
+  refine Lean.Grind.Ring.mk ?_ ?_ ?_ ?_ ?_ ?_
+  · exact neg_add_cancel
+  · exact sub_eq_add_neg
+  · intro i p
+    cases i with
+    | ofNat k =>
+        cases k with
+        | zero =>
+            show (0 : Nat) • p = -((0 : Nat) • p)
+            change (Nat.cast 0 : MvPoly n R cmp) * p =
+              -((Nat.cast 0 : MvPoly n R cmp) * p)
+            rw [show (Nat.cast 0 : MvPoly n R cmp) = 0 from rfl, zero_mul,
+              neg_zero]
+        | succ k => rfl
+    | negSucc k =>
+        show (k + 1 : Nat) • p = -(-((k + 1 : Nat) • p))
+        rw [neg_neg]
+  · intro k p
+    rfl
+  · intro k
+    show (Nat.cast k : MvPoly n R cmp) = OfNat.ofNat k
+    exact (ofNat_eq_natCast k).symm
+  · intro i
+    cases i with
+    | ofNat k =>
+        cases k with
+        | zero =>
+            show (Nat.cast 0 : MvPoly n R cmp) = -(Nat.cast 0 : MvPoly n R cmp)
+            rw [show (Nat.cast 0 : MvPoly n R cmp) = 0 from rfl, neg_zero]
+        | succ k => rfl
+    | negSucc k =>
+        show (Nat.cast (k + 1) : MvPoly n R cmp) =
+          -(-(Nat.cast (k + 1) : MvPoly n R cmp))
+        rw [neg_neg]
+
+/-- Multivariate polynomial multiplication is commutative when coefficient
+multiplication is. -/
+instance instGrindCommRing [Lean.Grind.CommRing R] [DecidableEq R] :
+    Lean.Grind.CommRing (MvPoly n R cmp) := by
+  refine Lean.Grind.CommRing.mk ?_
+  exact mul_comm
+
+end Hex.MvPoly

--- a/HexMvPoly/Structural.lean
+++ b/HexMvPoly/Structural.lean
@@ -573,4 +573,129 @@ theorem partialEval_eq_subst [Lean.Grind.Semiring R] [DecidableEq R]
         (fun q => acc + (monomial Mono.zero c : MvPoly n R cmp) * q)
         hprod.symm
 
+/-! Coefficient maps.
+
+`bind` already changes the coefficient type, so `mapCoeffs φ` agrees with
+`bind φ X`, though no agreement lemma is proved here: `bind` has no
+coefficient characterisation to prove one against. It is a separate operation
+for two reasons.
+
+Cost: `bind` folds `acc + C (φ c) * Mono.prod g m` over the terms, so it pays
+one polynomial addition and one monomial product per term, quadratic in the
+term count where a map over the backing values is linear. Reduction of an
+integer polynomial modulo a prime is the inner loop of every modular algorithm
+built on this type, so the linear form is the one to have.
+
+Laws: the homomorphism lemmas below take their hypotheses on `φ` explicitly
+rather than through a bundled homomorphism record, because nothing else in
+this library needs such a record and a caller can bundle as it likes. -/
+
+section MapCoeffs
+
+variable [Zero R] [Zero S] [BEq S] [LawfulBEq S]
+
+/-- Map `φ` over the coefficients, dropping every term it sends to zero.
+
+Terms are never merged, since the monomials are untouched, so this is the
+one member of the substitution family that cannot create a collision. -/
+def mapCoeffs (φ : R → S) (p : MvPoly n R cmp) : MvPoly n S cmp :=
+  letI : DecidableEq S := instDecidableEqOfLawfulBEq
+  { termsInternal := p.termsInternal.filterMap fun _ c =>
+      let c' := φ c
+      if c' = 0 then none else some c'
+    nonzeroInternal := by
+      intro m
+      rw [Std.ExtTreeMap.getElem?_filterMap']
+      cases hcoeff : p.termsInternal[m]? with
+      | none => simp
+      | some c =>
+          simp only [Option.bind_some]
+          split <;> simp_all }
+
+/-- Coefficients of a coefficient map, for a `φ` that fixes zero. -/
+@[simp]
+theorem coeff_mapCoeffs {φ : R → S} (hzero : φ 0 = 0) (m : Mono n)
+    (p : MvPoly n R cmp) :
+    coeff m (mapCoeffs φ p) = φ (coeff m p) := by
+  letI : DecidableEq S := instDecidableEqOfLawfulBEq
+  change ((mapCoeffs φ p).termsInternal[m]?).getD 0 = φ ((p.termsInternal[m]?).getD 0)
+  change ((p.termsInternal.filterMap fun _ c =>
+    let c' := φ c
+    if c' = 0 then none else some c')[m]?).getD 0 = _
+  rw [Std.ExtTreeMap.getElem?_filterMap']
+  cases hcoeff : p.termsInternal[m]? with
+  | none => simp [hzero]
+  | some c =>
+      simp only [Option.bind_some]
+      split <;> simp_all
+
+end MapCoeffs
+
+section MapCoeffsLaws
+
+variable [Lean.Grind.Semiring R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Lean.Grind.Semiring S] [DecidableEq S] [BEq S] [LawfulBEq S]
+
+omit [DecidableEq R] [BEq R] [LawfulBEq R] [DecidableEq S] in
+/-- A coefficient map fixing zero sends the zero polynomial to zero. -/
+theorem mapCoeffs_zero {φ : R → S} (hzero : φ 0 = 0) :
+    mapCoeffs (cmp := cmp) (n := n) φ 0 = 0 := by
+  apply ext
+  intro m
+  rw [coeff_mapCoeffs hzero, coeff_zero, coeff_zero, hzero]
+
+/-- A coefficient map fixing zero and one sends one to one. -/
+theorem mapCoeffs_one {φ : R → S} (hzero : φ 0 = 0) (hone : φ 1 = 1) :
+    mapCoeffs (cmp := cmp) (n := n) φ 1 = 1 := by
+  apply ext
+  intro m
+  rw [coeff_mapCoeffs hzero, coeff_one, coeff_one]
+  by_cases hm : m = Mono.zero
+  · simp only [hm, if_true]; exact hone
+  · simp only [hm, if_false]; exact hzero
+
+/-- An additive coefficient map commutes with polynomial addition. -/
+theorem mapCoeffs_add {φ : R → S} (hzero : φ 0 = 0)
+    (hadd : ∀ a b : R, φ (a + b) = φ a + φ b) (p q : MvPoly n R cmp) :
+    mapCoeffs (cmp := cmp) φ (p + q) =
+      mapCoeffs φ p + mapCoeffs φ q := by
+  apply ext
+  intro m
+  rw [coeff_mapCoeffs hzero, coeff_add, coeff_add, hadd,
+    coeff_mapCoeffs hzero, coeff_mapCoeffs hzero]
+
+omit [DecidableEq R] [BEq R] [LawfulBEq R] [DecidableEq S] in
+/-- Pushing a ring map through the convolution fold that computes a product
+coefficient. The accumulator is generalised so the induction goes through. -/
+private theorem foldl_map_convolution {φ : R → S} (hzero : φ 0 = 0)
+    (hadd : ∀ a b : R, φ (a + b) = φ a + φ b)
+    (hmul : ∀ a b : R, φ (a * b) = φ a * φ b) (p q : MvPoly n R cmp) :
+    ∀ (L : List (Mono n × Mono n)) (acc : R),
+      φ (L.foldl (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) acc) =
+        L.foldl
+          (fun acc ab =>
+            acc + coeff ab.1 (mapCoeffs φ p) * coeff ab.2 (mapCoeffs φ q))
+          (φ acc) := by
+  intro L
+  induction L with
+  | nil => intro acc; rfl
+  | cons ab rest ih =>
+      intro acc
+      rw [List.foldl_cons, List.foldl_cons, ih]
+      congr 1
+      rw [hadd, hmul, coeff_mapCoeffs hzero, coeff_mapCoeffs hzero]
+
+/-- A ring map on coefficients commutes with polynomial multiplication. -/
+theorem mapCoeffs_mul {φ : R → S} (hzero : φ 0 = 0)
+    (hadd : ∀ a b : R, φ (a + b) = φ a + φ b)
+    (hmul : ∀ a b : R, φ (a * b) = φ a * φ b) (p q : MvPoly n R cmp) :
+    mapCoeffs (cmp := cmp) φ (p * q) =
+      mapCoeffs φ p * mapCoeffs φ q := by
+  apply ext
+  intro m
+  rw [coeff_mapCoeffs hzero, coeff_mul, coeff_mul,
+    foldl_map_convolution hzero hadd hmul p q (Mono.splits m) 0, hzero]
+
+end MapCoeffsLaws
+
 end Hex.MvPoly

--- a/progress/20260814T004500Z_mvpoly-gcd-prereqs.md
+++ b/progress/20260814T004500Z_mvpoly-gcd-prereqs.md
@@ -1,0 +1,108 @@
+# HexMvPoly additions for hex-mv-gcd
+
+## Accomplished
+
+Two of the three additions `SPEC/Libraries/hex-mv-gcd.md` asks of
+`HexMvPoly` are implemented and proved. Both were checked against the source
+rather than the SPEC text, and one SPEC claim did not survive that check.
+
+**The `Lean.Grind` ring tower** (`HexMvPoly/Ring.lean`, new). `NatCast`,
+`OfNat`, `SMul Nat`, `IntCast`, `SMul Int`, then
+`Lean.Grind.Semiring`, `Lean.Grind.Ring`, and `Lean.Grind.CommRing` on
+`MvPoly n R cmp`. This is the addition that matters outside this library:
+every `HexResultant` correctness theorem takes `[Lean.Grind.CommRing S]`
+(`HexResultant/Subresultant.lean:152` and following), so without it the
+subresultant chain computes over multivariate coefficients and none of its
+theorems apply. `HexResultant/ExactDiv.lean:255-434` is the `DensePoly`
+tower this mirrors.
+
+Almost all of it is packaging: `HexMvPoly/Operations.lean` already proves
+`add_zero`, `add_comm`, `add_assoc`, `mul_assoc`, `mul_one`, `one_mul`,
+`mul_add`, `add_mul`, `zero_mul`, `mul_zero`, `mul_comm`, and `pow_succ`.
+What was missing and is added here: `neg_zero`, `neg_neg`, `neg_add_cancel`,
+`pow_zero`, `ofNat_succ`, `ofNat_eq_natCast`, `coeff_ofNat`, `coeff_natCast`.
+
+One trap worth recording. `pow_zero` is not `rfl`: `npowBySq` is defined by
+well-founded recursion, so it is `@[irreducible]` and `rfl` does not see
+through it. The equation lemma (`simp [npowBySq]`) does.
+
+Unlike `DensePoly`, no separate `natPow` was needed. `MvPoly` already has a
+`Pow _ Nat` instance and a proved `pow_succ` for it, so the `Semiring.npow`
+field uses the existing operation rather than introducing a second one.
+
+**`mapCoeffs` and its homomorphism laws** (`HexMvPoly/Structural.lean`).
+`mapCoeffs φ p` maps `φ` over the backing values and drops the terms it sends
+to zero, with `coeff_mapCoeffs`, `mapCoeffs_zero`, `mapCoeffs_one`,
+`mapCoeffs_add`, and `mapCoeffs_mul`.
+
+The SPEC claimed hex-mv-poly had no coefficient map at all. That is wrong:
+`Structural.bind` takes `f : R → S` alongside the variable map, so
+`bind φ X` already is one. The real gaps are cost and laws. `bind` folds
+`acc + C (f c) * Mono.prod g m` over the terms, one polynomial addition and
+one monomial product each, so a pure coefficient map through it is quadratic
+in the term count where a map over the values is linear, and reduction modulo
+a prime is on the inner loop of every modular algorithm hex-mv-gcd specifies.
+And `bind` carries no homomorphism laws, which is what the certificate needs.
+
+The laws take their hypotheses on `φ` explicitly rather than through a
+bundled homomorphism record, because nothing else in this library needs such
+a record and a caller can bundle as it likes.
+
+Not proved: `mapCoeffs_bind`, the agreement between `mapCoeffs φ` and
+`bind φ X`. `bind` has no coefficient characterisation to prove it against,
+so it would mean first proving `coeff_bind`, which is work about `bind`
+rather than about this addition.
+
+**`monoContent` came off the list.** `Mono.gcd` already exists and the fold
+over `support` is three lines that belong with the content operations in
+hex-mv-gcd, not here.
+
+## Current frontier
+
+The arity-preserving recursive view is **not** in this PR. The design is
+settled and one SPEC decision is now known to be wrong.
+
+The SPEC proposed a `Without i R cmp` subtype so that "the coefficients do
+not involve `xᵢ`" holds in the type. That is the wrong trade: anything
+downstream has to compute with those coefficients, so the subtype would need
+the entire `HexMvPoly.Ring` tower above rebuilt on it, where plain
+`MvPoly n R cmp` coefficients already have it. The view should therefore
+return `DensePoly (MvPoly n R cmp)` and carry the invariant as a theorem.
+
+The shape that was drafted (kept at `/tmp/slice-wip.lean`, not committed):
+
+- `setAt i e m` replacing the `xᵢ` exponent, with `degreeOf_setAt`,
+  `setAt_degreeOf`, `setAt_setAt`, and `setAt_zero_of_degreeOf_eq_zero`;
+- `coeffIn i e p`, the `xᵢ`-degree-`e` slice with the exponent cleared,
+  defined as a `foldTerms` in the style of `derivative`;
+- `coeff_coeffIn`, characterising it as
+  `if degreeOf i m = 0 then coeff (setAt i e m) p else 0`;
+- `degreeIn?`, `leadingCoeffIn`, then `coeffsIn` / `ofCoeffsIn` and the
+  round trips.
+
+Two things make it larger than it looks, and are why it is not here. The
+`coeff_rename` / `coeff_derivative` idiom (an `aux` induction turning the
+`addMonomial` fold into a fold of conditional coefficient adds, then a `step`
+lemma identifying the selected terms) is reusable but has to be redone for
+each operation. And the existing arity-dropping development in
+`HexMvPoly/Recursive.lean` is 436 lines with three private fold lemmas and
+four round-trip theorems; the arity-preserving one parallels it.
+
+It also deserves a premise check before it is built: `Recursive.lean`
+already proves `toUnivariate_coeff`, `ofUnivariate_coeff`, and both round
+trips, so the alternative is for hex-mv-gcd to use the arity-dropping view
+and pay the reindexing, rather than have hex-mv-poly grow a second
+development. That is a SPEC decision, not an implementation one.
+
+## Next step
+
+Decide the view question above, then implement whichever wins. Nothing else
+in hex-mv-gcd's milestone 1 is blocked: exact division, the `Div` and
+`ExactDivLaws` instances, `monoContent`, `contentIn`, and `primPartIn` all
+live in hex-mv-gcd and need only the ring tower landed here.
+
+## Blockers
+
+None. Both landed additions build clean with no new warnings, and
+`#print axioms` on `instGrindCommRing`, `mapCoeffs_mul`, and
+`coeff_mapCoeffs` reports only `[propext, Classical.choice, Quot.sound]`.


### PR DESCRIPTION
This PR adds two of the three `HexMvPoly` additions that [hex-mv-gcd](https://github.com/kim-em/hex-dev/blob/main/SPEC/Libraries/hex-mv-gcd.md) needs.

`HexMvPoly/Ring.lean` supplies `NatCast`, `OfNat`, `SMul Nat`, `IntCast`, and `SMul Int` on `MvPoly n R cmp`, then assembles `Lean.Grind.Semiring`, `Lean.Grind.Ring`, and `Lean.Grind.CommRing` from the ring laws `Operations.lean` already proves. This is the addition that matters outside the library: every `HexResultant` correctness theorem takes `[Lean.Grind.CommRing S]` (`HexResultant/Subresultant.lean:152` and following), so without it the subresultant chain computes over multivariate coefficients and none of its theorems apply. `HexResultant/ExactDiv.lean:255-434` is the `DensePoly` tower this mirrors. Unlike that one it needs no separate `natPow`: `MvPoly` already has a `Pow _ Nat` instance with a proved `pow_succ`, so the `Semiring.npow` field uses the existing operation. `pow_zero` is not `rfl`, because `npowBySq` is defined by well-founded recursion and is therefore `@[irreducible]`; the equation lemma discharges it.

`HexMvPoly/Structural.lean` gains `mapCoeffs`, mapping a function over the backing coefficients and dropping the terms it sends to zero, with `coeff_mapCoeffs`, `mapCoeffs_zero`, `mapCoeffs_one`, `mapCoeffs_add`, and `mapCoeffs_mul`. `Structural.bind` already changes the coefficient type, so `bind φ X` is a coefficient map, but it folds `acc + C (f c) * Mono.prod g m` over the terms, one polynomial addition and one monomial product each, making a pure coefficient map quadratic in the term count where a map over the values is linear. Reduction modulo a prime is on the inner loop of every modular algorithm hex-mv-gcd specifies. `bind` also carries no homomorphism laws, which is what the certificate checking needs. The laws take their hypotheses on the map explicitly rather than through a bundled homomorphism record, since nothing else here needs such a record.

Two things the SPEC asked for are deliberately absent. `monoContent` is not needed here: `Mono.gcd` exists and the fold over `support` belongs with the content operations in hex-mv-gcd. The arity-preserving recursive view is not in this PR, and implementing it showed the SPEC's `Without` subtype is the wrong trade, since downstream code has to compute with those coefficients and the subtype would need this whole ring tower rebuilt on it. The progress note records the drafted shape, the reason it is larger than it looks, and the prior question of whether hex-mv-gcd should just use the existing arity-dropping `toUnivariate` instead.

`lake build HexMvPoly HexMvPolyMathlib` completes clean with no new warnings, and `#print axioms` on `instGrindCommRing`, `mapCoeffs_mul`, and `coeff_mapCoeffs` reports only `[propext, Classical.choice, Quot.sound]`.

🤖 Prepared with Claude Code