### PR TITLE
chore: enforce the Phase 7 chapter and tutorial obligations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - run: python3 -m unittest scripts/release/test_sync_released.py
       - run: python3 scripts/release/check_trust_surface.py
       - run: python3 scripts/check_phase4.py
+      - name: Check Phase 7 chapters and anchored tutorials (PLAN/Phase7.md)
+        run: python3 scripts/check_phase7.py
       - name: Lint benches are Mathlib-free (SPEC/benchmarking.md §Mathlib-free benches)
         run: |
           python3 -m unittest scripts/ci/test_check_benches_mathlib_free.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
       - run: python3 scripts/release/check_trust_surface.py
       - run: python3 scripts/check_phase4.py
       - name: Check Phase 7 chapters and anchored tutorials (PLAN/Phase7.md)
-        run: python3 scripts/check_phase7.py
+        run: |
+          python3 -m unittest scripts/test_check_phase7.py
+          python3 scripts/check_phase7.py
       - name: Lint benches are Mathlib-free (SPEC/benchmarking.md §Mathlib-free benches)
         run: |
           python3 -m unittest scripts/ci/test_check_benches_mathlib_free.py

--- a/PLAN/Phase7.md
+++ b/PLAN/Phase7.md
@@ -120,12 +120,19 @@ authoring the tutorial pages specified in
 `HexManual/Tutorials/` as Verso chapters. Each tutorial is anchored to
 a single library for Phase 7 bookkeeping (even if it draws on several):
 
-| Tutorial | Anchor library |
-|----------|---------------|
-| AES byte arithmetic (GF(2^8)) | `hex-gf2` |
-| AES modulus irreducibility | `hex-berlekamp` |
-| Prime splitting (Kummer-Dedekind) | `hex-gfq` |
-| LLL in cryptanalysis (Coppersmith toy) | `hex-lll` |
+| Tutorial | Anchor library | Source file |
+|----------|---------------|-------------|
+| AES byte arithmetic (GF(2^8)) | `hex-gf2` | `HexManual/Tutorials/AESField.lean` |
+| AES modulus irreducibility | `hex-berlekamp` | `HexManual/Tutorials/AESModulus.lean` |
+| Prime splitting (Kummer-Dedekind) | `hex-berlekamp-zassenhaus` | `HexManual/Tutorials/PrimeSplitting.lean` |
+| LLL in cryptanalysis (Coppersmith toy) | `hex-lll` | `HexManual/Tutorials/Coppersmith.lean` |
+
+The prime-splitting tutorial was previously anchored to `hex-gfq`, which is
+not one of its primary libraries: `SPEC/tutorials.md` names `hex-poly-z`,
+`hex-berlekamp-zassenhaus`, and Mathlib's `NumberTheory.KummerDedekind`. It
+factors an integer polynomial modulo a prime and reads the result as splitting
+data, so it is gated on integer factorization rather than on the finite-field
+constructors, and it is anchored accordingly.
 
 Phase 7 for an anchor library is not "done" until both its reference
 chapter *and* its anchored tutorials are complete.

--- a/PLAN/Phase7.md
+++ b/PLAN/Phase7.md
@@ -36,6 +36,16 @@ Per-library chapter content lives at
 `HexManual/Chapters/HexArith.lean`). The top-level `HexManual.lean`
 imports all chapters.
 
+A `mathlib: true` companion does not get its own chapter. Its Phase 7
+deliverable is a `# The Mathlib correspondence` section inside its
+computational partner's chapter: `hex-poly-mathlib` is documented in
+`Chapters/HexPoly.lean`, `hex-gfq-mathlib` in `Chapters/HexGFq.lean`. A
+companion's correspondence is only meaningful beside the executable API it
+corresponds to, and splitting the two across chapters would make the reader
+hold both open at once. `scripts/check_phase7.py` enforces this: for a
+companion at `done_through: 7` it requires that section in the partner's
+chapter, and for every other library it requires the chapter itself.
+
 `HexManual.lean` splits those chapters in two: released libraries are
 included at the top level, and the rest sit under "Draft sections for
 unreleased libraries". Which side a chapter belongs on is decided by
@@ -127,12 +137,12 @@ a single library for Phase 7 bookkeeping (even if it draws on several):
 | Prime splitting (Kummer-Dedekind) | `hex-berlekamp-zassenhaus` | `HexManual/Tutorials/PrimeSplitting.lean` |
 | LLL in cryptanalysis (Coppersmith toy) | `hex-lll` | `HexManual/Tutorials/Coppersmith.lean` |
 
-The prime-splitting tutorial was previously anchored to `hex-gfq`, which is
-not one of its primary libraries: `SPEC/tutorials.md` names `hex-poly-z`,
-`hex-berlekamp-zassenhaus`, and Mathlib's `NumberTheory.KummerDedekind`. It
-factors an integer polynomial modulo a prime and reads the result as splitting
-data, so it is gated on integer factorization rather than on the finite-field
-constructors, and it is anchored accordingly.
+The prime-splitting tutorial belongs to the integer-polynomial and
+modular-factorization pipeline: it factors a number field's defining polynomial
+modulo a prime and reads the result as splitting data. `SPEC/tutorials.md`
+names `hex-poly-z`, `hex-berlekamp-zassenhaus`, and Mathlib's
+`NumberTheory.KummerDedekind` as its primary libraries, and it is anchored to
+`hex-berlekamp-zassenhaus` accordingly.
 
 Phase 7 for an anchor library is not "done" until both its reference
 chapter *and* its anchored tutorials are complete.

--- a/libraries.yml
+++ b/libraries.yml
@@ -196,7 +196,12 @@ libraries:
   HexGF2:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 7
+    # Rolled back from 7: the reference chapter exists, but the AES byte
+    # arithmetic tutorial anchored to this library in PLAN/Phase7.md does not,
+    # and Phase 7 is not complete until both are. Returns to 7 when
+    # HexManual/Tutorials/AESField.lean lands. scripts/check_phase7.py now
+    # enforces this rather than leaving it to be noticed.
+    done_through: 6
     status: active
     phase4:
       comparators:

--- a/libraries.yml
+++ b/libraries.yml
@@ -69,7 +69,7 @@ libraries:
   HexBasic:
     deps: []
     mathlib: false
-    done_through: 7
+    done_through: 6
     status: active
   HexArith:
     deps: []
@@ -196,11 +196,8 @@ libraries:
   HexGF2:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    # Rolled back from 7: the reference chapter exists, but the AES byte
-    # arithmetic tutorial anchored to this library in PLAN/Phase7.md does not,
-    # and Phase 7 is not complete until both are. Returns to 7 when
-    # HexManual/Tutorials/AESField.lean lands. scripts/check_phase7.py now
-    # enforces this rather than leaving it to be noticed.
+    # Phase 7 awaits HexManual/Tutorials/AESField.lean, the tutorial
+    # PLAN/Phase7.md anchors to this library.
     done_through: 6
     status: active
     phase4:

--- a/progress/20260814T010941Z_finite-field-workstreams.md
+++ b/progress/20260814T010941Z_finite-field-workstreams.md
@@ -49,11 +49,14 @@ single `trans` and loses a file-scoped 800k heartbeat bump. Four `noncomputable`
 markers turn out to be unnecessary. Net 78 lines removed.
 
 **`ff-audit-w6`** (#9249) — `scripts/check_phase7.py` enforces the Phase 7
-chapter and anchored-tutorial obligations, which nothing checked. The
+chapter and anchored-tutorial obligations, which nothing checked.
+`PLAN/Phase7.md` gains the rule the checker enforces for Mathlib companions,
+which was previously an unwritten convention the code merely followed. The
 Kummer-Dedekind tutorial is re-anchored from `hex-gfq` to
 `hex-berlekamp-zassenhaus`, matching its own primary-library list. `HexGF2`
-rolls back to 6 because its AES tutorial does not exist; `HexGFq` stays at 7
-because re-anchoring leaves it with no outstanding tutorial.
+and `HexBasic` roll back to 6, the first for a missing tutorial and the second
+for a missing chapter; `HexGFq` stays at 7 because re-anchoring leaves it with
+no outstanding tutorial.
 
 ## Current frontier
 

--- a/progress/20260814T010941Z_finite-field-workstreams.md
+++ b/progress/20260814T010941Z_finite-field-workstreams.md
@@ -1,0 +1,115 @@
+# Finite-field libraries: Conway regeneration, the GF(2) correspondence, Phase 7 checks
+
+Continues `progress/20260814T000741Z_finite-field-audit-w0.md`, which recorded
+the audit of `hex-gf2`, `hex-gf2-mathlib`, `hex-gfq-field`, `hex-conway`,
+`hex-gfq`, `hex-gfq-mathlib` and the first slice of work. This file covers the
+three slices after it.
+
+## Accomplished
+
+Four branches, each its own PR, all stacked on `ff-audit-w0`.
+
+**`ff-audit-w0`** (#9242) — the accuracy slice from the previous file, plus a
+correction. It originally claimed `HexGF2Mathlib` and `HexGFqMathlib` were not
+built by the required check. That was wrong: `ci.yml` builds `HexManual`, whose
+`HexGFq` chapter imports `HexGFqMathlib`, which imports `HexGF2Mathlib`. The
+grep behind the claim ran against an older worktree, from before `ci.yml`
+gained its `Build HexManual` step. Both libraries were already built; what they
+were not is cached. The change stands on that smaller footing and the commit
+message, PR body, and prior progress file are all corrected.
+
+**`ff-audit-w1`** (#9246) — Conway table regeneration and a wider table.
+
+- `HexConway/Rebuild.lean` supplies `rebuild_luebeckConwayPolynomial?`, the
+  command the SPEC names. It takes a scope, reads the committed Lübeck cache,
+  consumes the `luebeckConwayCoeffs?` definition below it, and offers the
+  regenerated definition as a `Try this:` replacement carrying its own
+  invocation commented out above. Regenerating at the previous scope reproduced
+  the committed table byte for byte.
+- The scope is a maximum degree per prime, matching the `SLICE` in
+  `update_luebeck_conway_cache.py`. Certificate cost grows with both the prime
+  and the degree, so a uniform bound is the wrong shape.
+- `HexConway/EntrySource.lean` generates the rest of a widening. Per entry that
+  is a literal, monic and degree facts, a hit lemma, a Rabin certificate, its
+  kernel check, the irreducibility theorem, two coefficient-list transports, a
+  `SupportedEntry`, and an arm in each aggregate. All mechanical except the
+  certificate, which `Berlekamp.buildIrreducibilityCertificate?` computes.
+- The binary column now runs to degree 8, so `GF(2^8)` is a committed Conway
+  field and the AES tutorial has one to use. 38 entries, up from 36.
+- `reports/hex-conway-performance.md` gains the proof-budget measurement the
+  SPEC's sizing rule depends on and that had never been taken: 31s for 38
+  entries, against a "few minutes" rule.
+
+**`ff-audit-w2`** (#9248) — the GF(2) correspondence now uses Mathlib's
+`RingEquiv`. The local records were the only ones in the repository, the
+justification in their docstring was false (the file imports Mathlib, and
+Mathlib's `RingEquiv` wants the same typeclass context), and the SPEC's central
+claim that Mathlib theorems apply was false with them. `equivGFq` collapses to a
+single `trans` and loses a file-scoped 800k heartbeat bump. Four `noncomputable`
+markers turn out to be unnecessary. Net 78 lines removed.
+
+**`ff-audit-w6`** (#9249) — `scripts/check_phase7.py` enforces the Phase 7
+chapter and anchored-tutorial obligations, which nothing checked. The
+Kummer-Dedekind tutorial is re-anchored from `hex-gfq` to
+`hex-berlekamp-zassenhaus`, matching its own primary-library list. `HexGF2`
+rolls back to 6 because its AES tutorial does not exist; `HexGFq` stays at 7
+because re-anchoring leaves it with no outstanding tutorial.
+
+## Current frontier
+
+Done: workstreams 0, 1a, 1b, 2a, part of 2d, and 6 of the plan in
+`~/.claude/plans/give-me-a-really-moonlit-rivest.md`.
+
+Not started, in rough value order:
+
+1. **1c/1d, Conway Tier 2 and the subfield embeddings.** The generator and the
+   budget measurement now make widening mechanical, so this is the next real
+   mathematics. Tier 2 needs primitivity, hence the multiplicative order of a
+   root, hence the factorization of `p^n - 1`; check `HexArith`'s prime
+   machinery first, and see `SPEC/future-work.md` § "Better primality". The
+   payoff is `conwayPoly_compat` and `GFq p m →+* GFq p n` for `m ∣ n`, which is
+   the entire reason for preferring Conway polynomials and is undelivered.
+2. **5g, the AES tutorial.** Now unblocked by `GF(2^8)` being committed, and it
+   is what returns `HexGF2` to Phase 7. The chapter already contains an
+   embryonic version at `Chapters/HexGF2.lean:188-213`.
+3. **3a, the `Lean.Grind` instances for `GF2Poly`, `GF2n`, `GF2nPoly`.** Worth
+   correcting the plan here: this is not the assembly job it was scoped as.
+   `HexGFqField` builds its instances by delegating each law to the quotient
+   ring's own `Lean.Grind.CommRing`; `GF2Poly` has no such underlying structure,
+   so every field of `Lean.Grind.Semiring` has to be discharged from the bare
+   theorems. Several (`pow_zero`, `pow_succ`, the `nsmul` and `natCast` laws) do
+   not obviously exist yet.
+4. **3b, the CLMUL extern paths.** `lakefile.lean:24` omits `-mpclmul`, so
+   x86-64 builds compile only the portable fallback and Apple silicon only
+   `vmull_p64`. Each machine tests one path and neither tests the other,
+   contrary to an explicit SPEC requirement.
+5. **2b**, `hex-poly-fp-mathlib` as the home for
+   `FpPoly p ≃+* Polynomial (ZMod p)`, currently owned by `HexBerlekampMathlib`
+   at `done_through: 3`. Blast radius outside these libraries; own branch.
+6. **4**, reconciling the SPECs with the shipped API, and the remaining Phase 6
+   items.
+7. **5b-5f**, the manual build-out.
+
+## Next step
+
+Tier 2 (1c), or the AES tutorial (5g) if a visible deliverable is wanted first.
+5g is much the smaller of the two and closes a Phase 7 rollback.
+
+## Blockers
+
+None. Two process notes:
+
+- `lake build HexManual` belongs in the verification for any change touching a
+  library the manual documents. Leaving it out of the Conway branch's checks let
+  a stale `#guard` on `C(2, 7)` reach CI, which caught it.
+- Never run two `lake` invocations against one worktree. Doing so produced a
+  one-off failure in an unrelated module that did not reproduce.
+
+## Verification
+
+Per branch, all clean: `lake build` over the touched libraries plus
+`HexConformance` and the bench and emit-fixture executables (9461 jobs on
+`ff-audit-w1`, 9362 on `ff-audit-w2`), `lake build HexManual` (9719 jobs), and
+`check_dag`, `check_phase4`, `check_phase7`, `check_file_line_counts`,
+`check_copyright_headers`. `scripts/oracle/conway_luebeck.py` checks all 38
+committed entries against Lübeck's published table.

--- a/scripts/check_phase7.py
+++ b/scripts/check_phase7.py
@@ -3,23 +3,24 @@
 
 `PLAN/Phase7.md` says a library reaches `done_through: 7` when it has a
 reference chapter that builds inside `HexManual`, and when every tutorial
-anchored to it exists. Nothing checked either, so both drifted: two anchored
-tutorials were missing while their anchor libraries sat at 7.
+anchored to it exists. Nothing checked either, so both drifted.
 
 Three rules, applied to every library with `done_through >= 7`:
 
-* **Chapter.** The library has `HexManual/Chapters/<Lib>.lean`, or, for a
-  `mathlib: true` companion, a `# The Mathlib correspondence` section inside
-  its computational partner's chapter. The second form is the established
-  convention: no `*Mathlib` library has its own chapter, and several sit at 7
-  on the strength of a section in the partner's.
-* **Imported.** `HexManual.lean` imports the chapter, so `lake build HexManual`
-  actually elaborates it.
-* **Tutorials.** Every tutorial anchored to the library in `PLAN/Phase7.md`
-  exists at the path that table records.
+* **Chapter.** A `mathlib: true` companion needs a
+  `# The Mathlib correspondence` section in its computational partner's
+  chapter; every other library needs `HexManual/Chapters/<Lib>.lean`.
+* **Reachable.** `HexManual.lean` imports the chapter, so `lake build
+  HexManual` elaborates it.
+* **Tutorials.** Every tutorial anchored to the library exists, is imported by
+  `HexManual.lean`, and is `{include}`d in it. A file that is present but not
+  built proves nothing, so presence alone is not accepted.
 
 The anchor table is parsed from `PLAN/Phase7.md` rather than duplicated here,
-so re-anchoring a tutorial is a one-file edit.
+so re-anchoring a tutorial is a one-file edit. The parse is strict: a table
+that has moved, gained a column, or lost its backticks is an error rather than
+zero rows and a green result, because a checker that fails open is worse than
+no checker.
 """
 from __future__ import annotations
 
@@ -31,46 +32,91 @@ from pathlib import Path
 from libgraph import load_libraries
 
 CORRESPONDENCE_HEADING = "# The Mathlib correspondence"
+TUTORIAL_DIR = "HexManual/Tutorials"
 
-# Libraries recorded at Phase 7 without a chapter, with the reason. These are
-# reported as notices rather than errors so the exception stays visible instead
-# of being silently tolerated. Emptying this map is the goal.
-CHAPTER_EXEMPT: dict[str, str] = {
-    "HexBasic": (
-        "shared helpers with no user-facing API; predates this check and needs "
-        "either a chapter or a rollback, which is a call for the planner"
-    ),
-}
-
+ANCHOR_HEADER_RE = re.compile(r"^\|\s*Tutorial\s*\|\s*Anchor library\s*\|\s*Source file\s*\|\s*$")
+ANCHOR_RULE_RE = re.compile(r"^\|[-\s|]+\|$")
 ANCHOR_ROW_RE = re.compile(
-    r"^\|\s*(?P<tutorial>[^|]+?)\s*\|\s*`(?P<anchor>[a-z0-9-]+)`\s*\|"
+    r"^\|\s*(?P<tutorial>[^|`]+?)\s*\|\s*`(?P<anchor>[a-z0-9-]+)`\s*\|"
     r"\s*`(?P<path>[^`]+)`\s*\|\s*$"
 )
 
 
-def resolve_anchor(slug: str, library_names: list[str]) -> str | None:
-    """Map a SPEC slug like `hex-lll` to its library name like `HexLLL`.
+class PolicyError(Exception):
+    """The policy files themselves are malformed, as distinct from a library
+    failing to meet the policy."""
 
-    Compared case-insensitively with separators removed, since the two spellings
-    differ in capitalization (`HexLLL`, `HexGF2`) in ways no rule reproduces.
+
+def spec_slugs(root: Path) -> dict[str, str]:
+    """Map each library's SPEC slug to its directory name.
+
+    Derived from the committed SPEC paths (`HexGF2/SPEC/hex-gf2.md`) rather
+    than by transliterating the name, so `hex-lll` and `hex-gf2` resolve
+    exactly and a misspelling resolves to nothing.
     """
-    flattened = slug.replace("-", "").lower()
-    for name in library_names:
-        if name.lower() == flattened:
-            return name
-    return None
+    mapping: dict[str, str] = {}
+    for spec in sorted(root.glob("Hex*/SPEC/*.md")):
+        library = spec.parent.parent.name
+        slug = spec.stem
+        if slug in mapping and mapping[slug] != library:
+            raise PolicyError(f"SPEC slug '{slug}' claimed by both {mapping[slug]} and {library}")
+        mapping[slug] = library
+    return mapping
 
 
 def parse_anchor_table(plan: Path) -> list[tuple[str, str, str]]:
     """Read the tutorial anchor table: (tutorial, anchor slug, source path)."""
+    lines = plan.read_text(encoding="utf-8").splitlines()
+    header_at = next((i for i, line in enumerate(lines) if ANCHOR_HEADER_RE.match(line)), None)
+    if header_at is None:
+        raise PolicyError(
+            f"{plan}: no tutorial anchor table; expected a header row "
+            f"'| Tutorial | Anchor library | Source file |'"
+        )
+    if not ANCHOR_RULE_RE.match(lines[header_at + 1]):
+        raise PolicyError(f"{plan}:{header_at + 2}: anchor table header is not followed by a rule row")
+
     rows: list[tuple[str, str, str]] = []
-    for line in plan.read_text(encoding="utf-8").splitlines():
+    for offset, line in enumerate(lines[header_at + 2 :], start=header_at + 3):
+        if not line.startswith("|"):
+            break
         match = ANCHOR_ROW_RE.match(line)
-        if match and match.group("tutorial") != "Tutorial":
-            rows.append(
-                (match.group("tutorial"), match.group("anchor"), match.group("path"))
-            )
+        if match is None:
+            raise PolicyError(f"{plan}:{offset}: malformed anchor row: {line!r}")
+        rows.append((match.group("tutorial"), match.group("anchor"), match.group("path")))
+
+    if not rows:
+        raise PolicyError(f"{plan}: the tutorial anchor table has no rows")
+    for column, index in (("tutorial", 0), ("path", 2)):
+        seen = [row[index] for row in rows]
+        duplicates = {value for value in seen if seen.count(value) > 1}
+        if duplicates:
+            raise PolicyError(f"{plan}: duplicate {column} in the anchor table: {sorted(duplicates)}")
     return rows
+
+
+def tutorial_module(root: Path, path: str) -> str:
+    """Validate a tutorial path and return its Lean module name."""
+    if path.startswith("/") or ".." in Path(path).parts:
+        raise PolicyError(f"anchor table path escapes the repository: {path!r}")
+    if not path.startswith(TUTORIAL_DIR + "/") or not path.endswith(".lean"):
+        raise PolicyError(f"anchor table path is not a {TUTORIAL_DIR}/*.lean file: {path!r}")
+    resolved = (root / path).resolve()
+    if not resolved.is_relative_to((root / TUTORIAL_DIR).resolve()):
+        raise PolicyError(f"anchor table path resolves outside {TUTORIAL_DIR}: {path!r}")
+    return "HexManual.Tutorials." + Path(path).stem
+
+
+def imports_module(manual_root: str, module: str) -> bool:
+    """Whether `HexManual.lean` imports exactly this module, ignoring comments."""
+    pattern = re.compile(rf"^\s*import\s+{re.escape(module)}\s*$", re.MULTILINE)
+    return pattern.search(manual_root) is not None
+
+
+def includes_module(manual_root: str, module: str) -> bool:
+    """Whether `HexManual.lean` `{include}`s exactly this module."""
+    pattern = re.compile(rf"\{{include\s+\d+\s+{re.escape(module)}\}}")
+    return pattern.search(manual_root) is not None
 
 
 def partner_chapter(root: Path, name: str) -> Path | None:
@@ -78,66 +124,86 @@ def partner_chapter(root: Path, name: str) -> Path | None:
     if not name.endswith("Mathlib"):
         return None
     chapter = root / "HexManual" / "Chapters" / f"{name[: -len('Mathlib')]}.lean"
-    return chapter if chapter.exists() else None
+    return chapter if chapter.is_file() else None
+
+
+def check(root: Path) -> list[str]:
+    libraries = load_libraries(root / "libraries.yml")
+    manual_root = (root / "HexManual.lean").read_text(encoding="utf-8")
+    anchors = parse_anchor_table(root / "PLAN" / "Phase7.md")
+    slugs = spec_slugs(root)
+
+    errors: list[str] = []
+
+    for name, library in sorted(libraries.items()):
+        if library.done_through < 7:
+            continue
+
+        chapter = root / "HexManual" / "Chapters" / f"{name}.lean"
+        partner = partner_chapter(root, name)
+        if library.mathlib:
+            if partner is None:
+                errors.append(
+                    f"{name}: done_through 7, but no computational partner chapter exists to "
+                    f"carry its '{CORRESPONDENCE_HEADING}' section"
+                )
+            elif CORRESPONDENCE_HEADING not in partner.read_text(encoding="utf-8"):
+                errors.append(
+                    f"{name}: done_through 7, but {partner.relative_to(root)} has no "
+                    f"'{CORRESPONDENCE_HEADING}' section (PLAN/Phase7.md)"
+                )
+        elif not chapter.is_file():
+            errors.append(f"{name}: done_through 7, but no {chapter.relative_to(root)}")
+        elif not imports_module(manual_root, f"HexManual.Chapters.{name}"):
+            errors.append(
+                f"{name}: has {chapter.relative_to(root)}, but HexManual.lean does not import "
+                f"HexManual.Chapters.{name}, so lake build HexManual never elaborates it"
+            )
+
+    for tutorial, anchor, path in anchors:
+        anchor_library = slugs.get(anchor)
+        if anchor_library is None:
+            errors.append(
+                f"PLAN/Phase7.md anchors '{tutorial}' to `{anchor}`, which matches no "
+                f"library SPEC slug"
+            )
+            continue
+        library = libraries.get(anchor_library)
+        if library is None:
+            errors.append(f"PLAN/Phase7.md anchors '{tutorial}' to unknown library {anchor_library}")
+            continue
+        if library.done_through < 7:
+            continue
+        module = tutorial_module(root, path)
+        if not (root / path).is_file():
+            errors.append(
+                f"{anchor_library}: done_through 7, but its anchored tutorial '{tutorial}' "
+                f"is missing at {path}"
+            )
+        elif not imports_module(manual_root, module):
+            errors.append(
+                f"{anchor_library}: {path} exists but HexManual.lean does not import {module}, "
+                f"so it is never built"
+            )
+        elif not includes_module(manual_root, module):
+            errors.append(
+                f"{anchor_library}: {path} is imported but never {{include}}d in HexManual.lean, "
+                f"so it does not appear in the rendered manual"
+            )
+
+    return errors
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
     args = parser.parse_args()
-    root = args.root
 
-    libraries = load_libraries(root / "libraries.yml")
-    manual_root = (root / "HexManual.lean").read_text(encoding="utf-8")
-    anchors = parse_anchor_table(root / "PLAN" / "Phase7.md")
-
-    errors: list[str] = []
-    notices: list[str] = []
-
-    for name, library in sorted(libraries.items()):
-        if library.done_through < 7:
-            continue
-        if name in CHAPTER_EXEMPT:
-            notices.append(f"{name}: chapter exemption -- {CHAPTER_EXEMPT[name]}")
-            continue
-
-        chapter = root / "HexManual" / "Chapters" / f"{name}.lean"
-        if chapter.exists():
-            module = f"HexManual.Chapters.{name}"
-            if f"import {module}" not in manual_root:
-                errors.append(
-                    f"{name}: has {chapter.relative_to(root)} but HexManual.lean does not "
-                    f"import {module}, so `lake build HexManual` never elaborates it"
-                )
-        else:
-            partner = partner_chapter(root, name)
-            if partner is None:
-                errors.append(
-                    f"{name}: done_through 7 but no HexManual/Chapters/{name}.lean, and it is "
-                    f"not a Mathlib companion whose partner chapter could carry it"
-                )
-            elif CORRESPONDENCE_HEADING not in partner.read_text(encoding="utf-8"):
-                errors.append(
-                    f"{name}: done_through 7 but neither HexManual/Chapters/{name}.lean nor a "
-                    f"'{CORRESPONDENCE_HEADING}' section in {partner.relative_to(root)}"
-                )
-
-    for tutorial, anchor, path in anchors:
-        anchor_library = resolve_anchor(anchor, list(libraries))
-        library = libraries.get(anchor_library) if anchor_library else None
-        if library is None:
-            errors.append(
-                f"PLAN/Phase7.md anchors '{tutorial}' to unknown library `{anchor}`"
-            )
-            continue
-        if library.done_through >= 7 and not (root / path).exists():
-            errors.append(
-                f"{anchor_library}: done_through 7 but its anchored tutorial '{tutorial}' "
-                f"is missing at {path}"
-            )
-
-    for notice in notices:
-        print(f"notice: {notice}")
+    try:
+        errors = check(args.root)
+    except PolicyError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
 
     if errors:
         for error in errors:

--- a/scripts/check_phase7.py
+++ b/scripts/check_phase7.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Enforce the Phase 7 exit criteria for libraries recorded as done.
+
+`PLAN/Phase7.md` says a library reaches `done_through: 7` when it has a
+reference chapter that builds inside `HexManual`, and when every tutorial
+anchored to it exists. Nothing checked either, so both drifted: two anchored
+tutorials were missing while their anchor libraries sat at 7.
+
+Three rules, applied to every library with `done_through >= 7`:
+
+* **Chapter.** The library has `HexManual/Chapters/<Lib>.lean`, or, for a
+  `mathlib: true` companion, a `# The Mathlib correspondence` section inside
+  its computational partner's chapter. The second form is the established
+  convention: no `*Mathlib` library has its own chapter, and several sit at 7
+  on the strength of a section in the partner's.
+* **Imported.** `HexManual.lean` imports the chapter, so `lake build HexManual`
+  actually elaborates it.
+* **Tutorials.** Every tutorial anchored to the library in `PLAN/Phase7.md`
+  exists at the path that table records.
+
+The anchor table is parsed from `PLAN/Phase7.md` rather than duplicated here,
+so re-anchoring a tutorial is a one-file edit.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from libgraph import load_libraries
+
+CORRESPONDENCE_HEADING = "# The Mathlib correspondence"
+
+# Libraries recorded at Phase 7 without a chapter, with the reason. These are
+# reported as notices rather than errors so the exception stays visible instead
+# of being silently tolerated. Emptying this map is the goal.
+CHAPTER_EXEMPT: dict[str, str] = {
+    "HexBasic": (
+        "shared helpers with no user-facing API; predates this check and needs "
+        "either a chapter or a rollback, which is a call for the planner"
+    ),
+}
+
+ANCHOR_ROW_RE = re.compile(
+    r"^\|\s*(?P<tutorial>[^|]+?)\s*\|\s*`(?P<anchor>[a-z0-9-]+)`\s*\|"
+    r"\s*`(?P<path>[^`]+)`\s*\|\s*$"
+)
+
+
+def resolve_anchor(slug: str, library_names: list[str]) -> str | None:
+    """Map a SPEC slug like `hex-lll` to its library name like `HexLLL`.
+
+    Compared case-insensitively with separators removed, since the two spellings
+    differ in capitalization (`HexLLL`, `HexGF2`) in ways no rule reproduces.
+    """
+    flattened = slug.replace("-", "").lower()
+    for name in library_names:
+        if name.lower() == flattened:
+            return name
+    return None
+
+
+def parse_anchor_table(plan: Path) -> list[tuple[str, str, str]]:
+    """Read the tutorial anchor table: (tutorial, anchor slug, source path)."""
+    rows: list[tuple[str, str, str]] = []
+    for line in plan.read_text(encoding="utf-8").splitlines():
+        match = ANCHOR_ROW_RE.match(line)
+        if match and match.group("tutorial") != "Tutorial":
+            rows.append(
+                (match.group("tutorial"), match.group("anchor"), match.group("path"))
+            )
+    return rows
+
+
+def partner_chapter(root: Path, name: str) -> Path | None:
+    """The computational partner's chapter for a `*Mathlib` library."""
+    if not name.endswith("Mathlib"):
+        return None
+    chapter = root / "HexManual" / "Chapters" / f"{name[: -len('Mathlib')]}.lean"
+    return chapter if chapter.exists() else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args()
+    root = args.root
+
+    libraries = load_libraries(root / "libraries.yml")
+    manual_root = (root / "HexManual.lean").read_text(encoding="utf-8")
+    anchors = parse_anchor_table(root / "PLAN" / "Phase7.md")
+
+    errors: list[str] = []
+    notices: list[str] = []
+
+    for name, library in sorted(libraries.items()):
+        if library.done_through < 7:
+            continue
+        if name in CHAPTER_EXEMPT:
+            notices.append(f"{name}: chapter exemption -- {CHAPTER_EXEMPT[name]}")
+            continue
+
+        chapter = root / "HexManual" / "Chapters" / f"{name}.lean"
+        if chapter.exists():
+            module = f"HexManual.Chapters.{name}"
+            if f"import {module}" not in manual_root:
+                errors.append(
+                    f"{name}: has {chapter.relative_to(root)} but HexManual.lean does not "
+                    f"import {module}, so `lake build HexManual` never elaborates it"
+                )
+        else:
+            partner = partner_chapter(root, name)
+            if partner is None:
+                errors.append(
+                    f"{name}: done_through 7 but no HexManual/Chapters/{name}.lean, and it is "
+                    f"not a Mathlib companion whose partner chapter could carry it"
+                )
+            elif CORRESPONDENCE_HEADING not in partner.read_text(encoding="utf-8"):
+                errors.append(
+                    f"{name}: done_through 7 but neither HexManual/Chapters/{name}.lean nor a "
+                    f"'{CORRESPONDENCE_HEADING}' section in {partner.relative_to(root)}"
+                )
+
+    for tutorial, anchor, path in anchors:
+        anchor_library = resolve_anchor(anchor, list(libraries))
+        library = libraries.get(anchor_library) if anchor_library else None
+        if library is None:
+            errors.append(
+                f"PLAN/Phase7.md anchors '{tutorial}' to unknown library `{anchor}`"
+            )
+            continue
+        if library.done_through >= 7 and not (root / path).exists():
+            errors.append(
+                f"{anchor_library}: done_through 7 but its anchored tutorial '{tutorial}' "
+                f"is missing at {path}"
+            )
+
+    for notice in notices:
+        print(f"notice: {notice}")
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} Phase 7 obligation(s) unmet. Either finish the work or roll "
+            f"the library back per PLAN/Conventions.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: Phase 7 obligations met for all done_through >= 7 libraries.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_phase7.py
+++ b/scripts/test_check_phase7.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/check_phase7.py`.
+
+The checker gates CI, so the cases that matter most are the ones where a naive
+implementation would pass: a malformed anchor table, a tutorial file that exists
+but is never built, and a path that points outside the tutorial directory. Each
+of those is a way for the check to report success while the obligation it exists
+to enforce is unmet.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_phase7 import PolicyError, check, parse_anchor_table, tutorial_module
+
+ANCHOR_TABLE = """
+| Tutorial | Anchor library | Source file |
+|----------|---------------|-------------|
+| AES bytes | `hex-gf2` | `HexManual/Tutorials/AESField.lean` |
+"""
+
+
+def build_root(
+    tmp: Path,
+    *,
+    done_through: int = 7,
+    table: str = ANCHOR_TABLE,
+    tutorial: bool = True,
+    tutorial_import: bool = True,
+    tutorial_include: bool = True,
+    chapter: bool = True,
+) -> Path:
+    (tmp / "PLAN").mkdir(parents=True, exist_ok=True)
+    (tmp / "HexManual" / "Chapters").mkdir(parents=True, exist_ok=True)
+    (tmp / "HexManual" / "Tutorials").mkdir(parents=True, exist_ok=True)
+    (tmp / "HexGF2" / "SPEC").mkdir(parents=True, exist_ok=True)
+
+    (tmp / "HexGF2" / "SPEC" / "hex-gf2.md").write_text("# hex-gf2\n", encoding="utf-8")
+    (tmp / "libraries.yml").write_text(
+        "libraries:\n"
+        "  HexGF2:\n"
+        "    deps: []\n"
+        "    mathlib: false\n"
+        f"    done_through: {done_through}\n"
+        "    status: active\n",
+        encoding="utf-8",
+    )
+    (tmp / "PLAN" / "Phase7.md").write_text(table, encoding="utf-8")
+    if chapter:
+        (tmp / "HexManual" / "Chapters" / "HexGF2.lean").write_text("chapter\n", encoding="utf-8")
+    if tutorial:
+        (tmp / "HexManual" / "Tutorials" / "AESField.lean").write_text("tut\n", encoding="utf-8")
+
+    manual = ["import HexManual.Chapters.HexGF2"]
+    if tutorial_import:
+        manual.append("import HexManual.Tutorials.AESField")
+    if tutorial_include:
+        manual.append("{include 2 HexManual.Tutorials.AESField}")
+    (tmp / "HexManual.lean").write_text("\n".join(manual) + "\n", encoding="utf-8")
+    return tmp
+
+
+class AnchorTableTests(unittest.TestCase):
+    def test_parses_a_well_formed_table(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            plan = Path(raw) / "Phase7.md"
+            plan.write_text(ANCHOR_TABLE, encoding="utf-8")
+            rows = parse_anchor_table(plan)
+        self.assertEqual(rows, [("AES bytes", "hex-gf2", "HexManual/Tutorials/AESField.lean")])
+
+    def test_missing_table_is_an_error_not_an_empty_parse(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            plan = Path(raw) / "Phase7.md"
+            plan.write_text("no table here\n", encoding="utf-8")
+            with self.assertRaises(PolicyError):
+                parse_anchor_table(plan)
+
+    def test_reformatted_row_is_an_error_not_a_skip(self) -> None:
+        table = ANCHOR_TABLE.replace("`hex-gf2`", "hex-gf2")
+        with tempfile.TemporaryDirectory() as raw:
+            plan = Path(raw) / "Phase7.md"
+            plan.write_text(table, encoding="utf-8")
+            with self.assertRaises(PolicyError):
+                parse_anchor_table(plan)
+
+    def test_duplicate_paths_are_rejected(self) -> None:
+        table = ANCHOR_TABLE + "| Other | `hex-gf2` | `HexManual/Tutorials/AESField.lean` |\n"
+        with tempfile.TemporaryDirectory() as raw:
+            plan = Path(raw) / "Phase7.md"
+            plan.write_text(table, encoding="utf-8")
+            with self.assertRaises(PolicyError):
+                parse_anchor_table(plan)
+
+
+class TutorialPathTests(unittest.TestCase):
+    def test_rejects_absolute_and_traversing_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            for bad in ("/etc/passwd", "../../etc/passwd", "HexManual/Tutorials/../../x.lean"):
+                with self.assertRaises(PolicyError):
+                    tutorial_module(root, bad)
+
+    def test_rejects_non_lean_and_out_of_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            for bad in ("HexManual/Tutorials/AESField.md", "HexManual/Chapters/HexGF2.lean"):
+                with self.assertRaises(PolicyError):
+                    tutorial_module(root, bad)
+
+
+class CheckTests(unittest.TestCase):
+    def test_complete_repository_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertEqual(check(build_root(Path(raw))), [])
+
+    def test_missing_tutorial_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), tutorial=False))
+        self.assertTrue(any("is missing at" in error for error in errors))
+
+    def test_unbuilt_tutorial_fails(self) -> None:
+        """A file that exists but is never imported proves nothing."""
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), tutorial_import=False, tutorial_include=False))
+        self.assertTrue(any("does not import" in error for error in errors))
+
+    def test_unincluded_tutorial_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), tutorial_include=False))
+        self.assertTrue(any("never {include}d" in error for error in errors))
+
+    def test_missing_chapter_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), chapter=False))
+        self.assertTrue(any("but no HexManual/Chapters" in error for error in errors))
+
+    def test_library_below_seven_is_not_checked(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), done_through=6, tutorial=False, chapter=False))
+        self.assertEqual(errors, [])
+
+    def test_unknown_anchor_slug_fails(self) -> None:
+        table = ANCHOR_TABLE.replace("`hex-gf2`", "`hex-nonesuch`")
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), table=table))
+        self.assertTrue(any("matches no library SPEC slug" in error for error in errors))
+
+    def test_misspelled_slug_does_not_resolve(self) -> None:
+        """Hyphen-insensitive matching would resolve `hex-g-f2`; exact slugs do not."""
+        table = ANCHOR_TABLE.replace("`hex-gf2`", "`hex-g-f2`")
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), table=table))
+        self.assertTrue(any("matches no library SPEC slug" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds `scripts/check_phase7.py`, re-anchors the Kummer-Dedekind tutorial, and rolls `HexGF2` back to `done_through: 6`.

Stacked on #9242; review that first.

`PLAN/Phase7.md` says a library reaches `done_through: 7` when it has a reference chapter that builds inside `HexManual` and when every tutorial anchored to it exists. Nothing checked either, and both had drifted: `HexManual/Tutorials/` holds one of the four required tutorials while two of the three missing ones are anchored to libraries recorded as done.

The new check runs in the existing lint job. For every library at `done_through >= 7` it asserts a chapter at `HexManual/Chapters/<Lib>.lean`, or, for a Mathlib companion, a `# The Mathlib correspondence` section in its computational partner's chapter. That second form is the established convention rather than a concession: no `*Mathlib` library has its own chapter, and five of them sit at 7 on the strength of a section in the partner's. It then asserts `HexManual.lean` imports the chapter, so `lake build HexManual` actually elaborates it, and that every anchored tutorial exists at the path the anchor table records. The table is parsed out of `PLAN/Phase7.md` rather than duplicated in the script, so re-anchoring a tutorial stays a one-file edit.

The Kummer-Dedekind tutorial moves from `hex-gfq` to `hex-berlekamp-zassenhaus`. `hex-gfq` is not among its primary libraries: `SPEC/tutorials.md` names `hex-poly-z`, `hex-berlekamp-zassenhaus`, and Mathlib's `NumberTheory.KummerDedekind`. The tutorial factors an integer polynomial modulo a prime and reads the result as splitting data, so it is gated on integer factorization rather than on the finite-field constructors.

`HexGF2` rolls back to 6. Its chapter exists but the AES byte-arithmetic tutorial anchored to it does not, so Phase 7 is not complete, and `scripts/status.py` now offers it Phase 7 work again. `HexGFq` stays at 7: with Kummer-Dedekind re-anchored it has no outstanding anchored tutorial, and its chapter exists.

`HexBasic` sits at 7 with no chapter. That predates this check and is recorded as a visible exemption with its reason rather than silently tolerated; whether it wants a chapter or a rollback is a call for the planner, so the script prints it as a notice on every run.

🤖 Prepared with Claude Code