### PR TITLE
doc: specify the modular techniques as three libraries

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -83,7 +83,7 @@ Each library with its immediate dependencies:
 - **hex-hermite**: hex-row-reduce, hex-arith, hex-bareiss
 - **hex-smith**: hex-hermite
 - **hex-mod-arith**: hex-arith
-- **hex-modular**: hex-arith, hex-mod-arith
+- **hex-modular**: hex-arith
 - **hex-modular-matrix**: hex-modular, hex-matrix, hex-row-reduce, hex-determinant, hex-mod-arith, hex-arith, hex-basic
 - **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
 - **hex-lll**: hex-gram-schmidt, hex-matrix, hex-basic
@@ -116,7 +116,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-mv-poly-mathlib**: hex-mv-poly, hex-poly-mathlib
 - **hex-mv-gcd-mathlib**: hex-mv-gcd, hex-mv-poly-mathlib, hex-resultant-mathlib, hex-poly-mathlib
 - **hex-poly-z-mathlib**: hex-poly-z, hex-poly-mathlib
-- **hex-poly-z-gcd-mathlib**: hex-poly-z-gcd, hex-poly-z-mathlib, hex-poly-mathlib, hex-mod-arith-mathlib
+- **hex-poly-z-gcd-mathlib**: hex-poly-z-gcd, hex-poly-z-mathlib, hex-poly-mathlib
 - **hex-roots-mathlib**: hex-roots, hex-poly-z-mathlib
 - **hex-real-roots-mathlib**: hex-real-roots, hex-poly-z-mathlib
 - **hex-interval-mathlib**: hex-interval

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -13,9 +13,12 @@
 - **hex-smith**: Smith normal form over `Int`, invariant factors, and the structure of a finitely generated abelian group
 - **hex-gram-schmidt**: Gram-Schmidt orthogonalization, GS coefficients, Gram determinants, update formulas under row operations
 - **hex-mod-arith**: `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
+- **hex-modular**: integer CRT, rational reconstruction, symmetric representatives, and the modulus supply
+- **hex-modular-matrix**: multi-modular determinant, certified rank, and Dixon p-adic linear solving over `Q`
 - **hex-poly-fp**: polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
 - **hex-gf2**: packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
 - **hex-poly-z**: polynomials over `Z`, content/primitive part, Mignotte bound
+- **hex-poly-z-gcd**: modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division
 - **hex-roots**: certified complex root isolation for `Z[x]` via dyadic squares, Pellet tests, and speculative Newton iteration
 - **hex-real-roots**: certified real root isolation for `Z[x]`: Sturm-count witnesses, a Descartes bisection search with a proven-complete Sturm fallback
 - **hex-interval**: exact open, closed, empty, and unbounded dyadic intervals; a shared expression program; and a budgeted scheduler for propagation, refinement, and subdivision
@@ -37,6 +40,9 @@
 Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 
 - **hex-mod-arith-mathlib**: `ZMod64 p ≃+* ZMod p`
+- **hex-modular-mathlib**: CRT agreement with `ZMod.chineseRemainder`, and the rational-reconstruction statements over `ℚ`
+- **hex-modular-matrix-mathlib**: Hadamard's inequality discharged, `det` = `Matrix.det`, rank = `Matrix.rank`, and the solve and kernel correspondences
+- **hex-poly-z-gcd-mathlib**: gcd divisibility and maximality in `Polynomial ℤ`, and `Decidable (a ∣ b)`
 - **hex-poly-mathlib**: `DensePoly R ≃+* Polynomial R`
 - **hex-mv-poly-mathlib**: `MvPoly n R cmp ≃+* MvPolynomial (Fin n) R`, `aeval`, and operation correspondence
 - **hex-mv-gcd-mathlib**: gcd maximality transported to `MvPolynomial (Fin n) R`, and decidable divisibility and squarefreeness
@@ -77,10 +83,13 @@ Each library with its immediate dependencies:
 - **hex-hermite**: hex-row-reduce, hex-arith, hex-bareiss
 - **hex-smith**: hex-hermite
 - **hex-mod-arith**: hex-arith
+- **hex-modular**: hex-arith, hex-mod-arith
+- **hex-modular-matrix**: hex-modular, hex-matrix, hex-row-reduce, hex-determinant, hex-mod-arith, hex-arith, hex-basic
 - **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
 - **hex-lll**: hex-gram-schmidt, hex-matrix, hex-basic
 - **hex-poly-fp**: hex-poly, hex-mod-arith
 - **hex-poly-z**: hex-poly, hex-arith, hex-basic
+- **hex-poly-z-gcd**: hex-poly-z, hex-poly-fp, hex-poly, hex-modular, hex-mod-arith, hex-arith, hex-resultant
 - **hex-roots**: hex-poly-z
 - **hex-real-roots**: hex-poly-z
 - **hex-interval**: (none)
@@ -101,10 +110,13 @@ Each library with its immediate dependencies:
 Mathlib companion libraries (each also depends on Mathlib):
 
 - **hex-mod-arith-mathlib**: hex-mod-arith
+- **hex-modular-mathlib**: hex-modular, hex-mod-arith-mathlib
+- **hex-modular-matrix-mathlib**: hex-modular-matrix, hex-matrix-mathlib, hex-determinant-mathlib, hex-row-reduce-mathlib, hex-modular-mathlib
 - **hex-poly-mathlib**: hex-poly
 - **hex-mv-poly-mathlib**: hex-mv-poly, hex-poly-mathlib
 - **hex-mv-gcd-mathlib**: hex-mv-gcd, hex-mv-poly-mathlib, hex-resultant-mathlib, hex-poly-mathlib
 - **hex-poly-z-mathlib**: hex-poly-z, hex-poly-mathlib
+- **hex-poly-z-gcd-mathlib**: hex-poly-z-gcd, hex-poly-z-mathlib, hex-poly-mathlib, hex-mod-arith-mathlib
 - **hex-roots-mathlib**: hex-roots, hex-poly-z-mathlib
 - **hex-real-roots-mathlib**: hex-real-roots, hex-poly-z-mathlib
 - **hex-interval-mathlib**: hex-interval
@@ -132,6 +144,15 @@ libraries can still be developed in parallel until BZ recombination is
 implemented, but the dependency of `hex-berlekamp-zassenhaus` on
 `hex-lll` is part of the production graph, not an optional
 optimisation.
+
+The modular libraries split along their dependency seams. `hex-modular`
+holds the reconstruction arithmetic that a matrix consumer and a
+polynomial consumer both need, so it sits below both. `hex-modular-matrix`
+and `hex-poly-z-gcd` each sit above it beside the type they compute with,
+and neither depends on the other. `hex-mv-gcd` gains a dependency on
+`hex-poly-z-gcd`, which is its arity-one case, once that library exists.
+The reasoning is in [hex-modular §Why not inside hex-arith](hex-modular.md)
+and [hex-poly-z-gcd §Why this is not hex-mv-gcd at arity one](hex-poly-z-gcd.md).
 
 ## Library DAG
 
@@ -244,6 +265,8 @@ for developments whose source-local move has not happened yet.
 - [hex-smith.md](hex-smith.md): Smith normal form over `Int`, invariant factors, and abelian group structure (the Mathlib companion is specified in the same file)
 - [hex-mod-arith](../../HexModArith/SPEC/hex-mod-arith.md): `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
 - [hex-mod-arith-mathlib](../../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md): `ZMod64 p ≃+* ZMod p`
+- [hex-modular.md](hex-modular.md): integer CRT, rational reconstruction, symmetric representatives, and the modulus supply (the Mathlib companion is specified in the same file)
+- [hex-modular-matrix.md](hex-modular-matrix.md): multi-modular determinant, certified rank, and Dixon p-adic linear solving (the Mathlib companion is specified in the same file)
 - [hex-poly](../../HexPoly/SPEC/hex-poly.md): dense polynomial library, operations, GCD, CRT
 - [hex-poly-mathlib](../../HexPolyMathlib/SPEC/hex-poly-mathlib.md): `DensePoly R ≃+* Polynomial R`
 - [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md): canonical distributed multivariate polynomials with explicit monomial orders
@@ -254,6 +277,7 @@ for developments whose source-local move has not happened yet.
 - [hex-gf2-mathlib](../../HexGF2Mathlib/SPEC/hex-gf2-mathlib.md): `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
 - [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound
 - [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md): Mignotte bound proof via Mathlib's Mahler measure
+- [hex-poly-z-gcd.md](hex-poly-z-gcd.md): modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division (the Mathlib companion is specified in the same file)
 - [hex-roots.md](../../HexRoots/SPEC/hex-roots.md): certified complex root isolation for `Z[x]`
 - [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
 - [hex-real-roots.md](../../HexRealRoots/SPEC/hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -54,11 +54,6 @@ below all want an exact solve that does not pay that growth. Dixon
 lifting is the standard answer and its output is checkable by one
 matrix-vector product.
 
-**A `Modulus` is now hex-mod-arith's.** `ZMod64.Modulus` and
-`ZMod64.primesBelow` live beside `ZMod64`, per
-[hex-modular §The supply](hex-modular.md); this library consumes them and
-passes bare `Nat` moduli to `crtLoop`.
-
 **hex-hermite needs a determinant.** The Domich-Kannan-Trotter modular
 Hermite algorithm reduces entries modulo a determinant of a square
 nonsingular submatrix, and [hex-hermite](hex-hermite.md) names
@@ -577,6 +572,11 @@ both comes from.
 
 Five, of which three are shared with other planned libraries and are
 listed here because this library is a second consumer.
+
+**The modulus supply should move to hex-mod-arith.** `ZMod64.Modulus`,
+`ZMod64.PrimeModulus`, and `ZMod64.primesBelow` belong beside `ZMod64`,
+per [hex-modular §The supply](hex-modular.md). This library is their
+main consumer, and it passes bare `Nat` moduli on to `crtLoop`.
 
 **`zmod64FieldOfPrime` should move to hex-mod-arith.** Set out in
 [hex-modular](hex-modular.md). Without it, `rankModP` forces a dependency

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -54,6 +54,11 @@ below all want an exact solve that does not pay that growth. Dixon
 lifting is the standard answer and its output is checkable by one
 matrix-vector product.
 
+**A `Modulus` is now hex-mod-arith's.** `ZMod64.Modulus` and
+`ZMod64.primesBelow` live beside `ZMod64`, per
+[hex-modular §The supply](hex-modular.md); this library consumes them and
+passes bare `Nat` moduli to `crtLoop`.
+
 **hex-hermite needs a determinant.** The Domich-Kannan-Trotter modular
 Hermite algorithm reduces entries modulo a determinant of a square
 nonsingular submatrix, and [hex-hermite](hex-hermite.md) names
@@ -104,7 +109,8 @@ and a reconstruction bound large enough to determine the answer". The
 determinant argument never uses primality: reduction modulo any `m` is a
 ring homomorphism, so `det (A mod m) = (det A) mod m` regardless, and
 what the *elimination* needs is that the pivots it inverts are units,
-which the arithmetic discovers rather than assumes. Distinctness is not
+which the arithmetic discovers rather than assumes. `detMod?` returning
+`some d` at a composite modulus is as good an image as any. Distinctness is not
 the right property either, since distinct moduli need not be coprime;
 coprimality is what the reconstruction needs and `Crt.push` checks it.
 [hex-modular](hex-modular.md) sets this out in full under "Primality is
@@ -151,10 +157,21 @@ so rather than accepting `Rat` matrices and doing it silently.
 namespace Hex.Matrix
 
 /-- The determinant of `A` reduced modulo `m`, computed by elimination.
-Returns `none` when a pivot candidate is not invertible modulo `m`, which
-for composite `m` can happen without the matrix being singular. -/
+Returns `some 0` when a pivot column is entirely zero, and `none` when
+the column contains a nonzero entry but no unit, which for composite `m`
+can happen without the matrix being singular. -/
 def detMod? (A : Matrix (ZMod64 m) n n) : Option (ZMod64 m)
 ```
+
+**The two failure branches are different and both are needed.** A pivot
+column that is entirely zero proves the determinant is zero modulo `m`,
+which is a perfectly good residue to fold in: the transformed matrix has
+a zero column, so its determinant is `0`, and the accumulated row
+operations are determinant-preserving. Only a column with a nonzero
+nonunit gives `none`. Collapsing the two makes `det` on the zero matrix
+skip every modulus and never terminate, and it is the kind of mistake
+that no oracle fixture catches because the answer is right whenever the
+function returns.
 
 This is a dedicated elimination rather than a call into
 `hex-row-reduce`. Three reasons, in order of weight:
@@ -226,10 +243,16 @@ bound here as the fallback if a Mathlib-free consumer ever appears.
 ### The reconstruction
 
 ```lean
-/-- The determinant of an integer matrix, by Chinese remaindering over
-enough moduli to determine it. -/
+/-- The determinant by Chinese remaindering, or `none` when the supply of
+moduli runs out before the bound is reached. -/
+def detModular? (A : Matrix Int n n) (fuel : Nat) : Option Int
+
+/-- The determinant. Falls back to `Hex.Matrix.bareiss` when the modular
+route does not finish. -/
 def det (A : Matrix Int n n) : Int
 
+theorem detModular?_eq [LawfulDetBound] (h : detModular? A fuel = some d) :
+    d = Matrix.det A
 theorem det_eq [LawfulDetBound] (A : Matrix Int n n) :
     det A = Matrix.det A
 ```
@@ -238,6 +261,18 @@ The loop folds one image per modulus into a `Crt` and stops when the
 accumulated modulus exceeds `2 · hadamardBound A`, at which point
 `crt_unique` identifies the symmetric representative with the answer.
 Moduli at which `detMod?` returns `none` are skipped.
+
+**The fallback is not defensive coding, it is the only way `det` is
+total.** `ZMod64.Bounds` caps a modulus at `2^31`, so every allowed
+modulus divides `L = lcm(1, …, 2^31 - 1)` and so does every product of
+pairwise coprime allowed moduli. On the `1 x 1` matrix `[L]` the
+determinant is `L`, the Hadamard bound is `L`, every image is zero, and
+the accumulated modulus never exceeds `2L`. No amount of fuel helps.
+[hex-modular](hex-modular.md) records the same obstruction for the
+supply as a whole. Under design principle 8 the classification is neither
+of the two fallback modes: `detModular?` propagates its `Option` upward,
+and `det` is a dispatch between two complete algorithms rather than a
+total form of a partial one.
 
 **Early termination is not available here, and this is the one place in
 the tree where that has to be said out loud.** Stopping when the
@@ -288,9 +323,15 @@ is easy to get wrong:
   their common gcd before using `d`. Omitting that step gives a `d` that
   does not divide the determinant and a wrong answer with no symptom.
 - The cofactor still needs a bound, and it has one: `|det A / d| ≤
-  hadamardBound A / d`, from the same hypothesis as before. Nothing is
-  assumed about how large `d` is. A small `d` costs moduli, never
-  correctness.
+  hadamardBound A / d`, from the same hypothesis as before, with floor
+  division on the right. Nothing is assumed about how large `d` is. A
+  small `d` costs moduli, never correctness.
+- **The images are of the cofactor, not of the determinant**, so each one
+  is `(det A mod m) · (d⁻¹ mod m)` and a modulus with `gcd(d, m) ≠ 1` has
+  no such inverse. Those moduli are skipped, exactly as the ones where
+  `detMod?` returns `none` are. An implementation that reconstructs
+  `det A` and divides afterwards has not saved anything, since the point
+  of the divisor is to shrink the modulus the reconstruction needs.
 
 Nonsingularity is not an extra assumption. The Dixon solve inverts `A`
 modulo a prime, and a matrix invertible modulo `p` has a determinant that
@@ -317,8 +358,9 @@ structure RankCert (n m : Nat) where
   /-- Row and column indices of a nonsingular `r × r` submatrix. -/
   rows : Vector (Fin n) r
   cols : Vector (Fin m) r
-  /-- A modulus at which that submatrix has nonzero determinant. -/
-  modulus : Modulus
+  /-- A modulus at which that submatrix has nonzero determinant. Any
+  positive `Nat`, not a `ZMod64.Modulus`; see below. -/
+  modulus : Nat
   /-- Coefficients expressing the remaining columns over the chosen ones,
   with a common denominator. -/
   coeffs : Matrix Int r (m - r)
@@ -326,41 +368,71 @@ structure RankCert (n m : Nat) where
 
 def checkRank (A : Matrix Int n m) (c : RankCert n m) : Bool
 
-theorem checkRank_sound (h : checkRank A c = true) : rank A = c.r
+/-- The rank over `ℚ`, defined independently of anything in this library:
+row reduction of the entrywise cast. -/
+def ratRank (A : Matrix Int n m) : Nat :=
+  Matrix.rowReduce_rank (A.mapEntries (fun a => (a : Rat)))
+
+theorem checkRank_sound (h : checkRank A c = true) : ratRank A = c.r
 ```
+
+The soundness theorem targets `ratRank`, not the `rank` defined below.
+A certificate checker whose conclusion mentions the function it is meant
+to certify says nothing, and an earlier draft of this SPEC made exactly
+that mistake. `ratRank` is row reduction over `Rat`, which hex-row-reduce
+already supplies and whose agreement with `Matrix.rank` is
+hex-row-reduce-mathlib's existing theorem, so the companion inherits the
+Mathlib statement rather than proving a second one.
 
 `checkRank` verifies, cheapest first: that `rows` and `cols` are strictly
 increasing (so the submatrix is well formed and the complement of `cols`
-is determined); that `detMod?` of the selected `r × r` submatrix is
-`some` and nonzero; that `denom ≠ 0`; and that
+is determined); that `1 < modulus`; that the `r × r` selected submatrix
+has determinant not congruent to `0` modulo `modulus`, computed in `Int`
+arithmetic; that `denom ≠ 0`; and that
 `A[·, cols] * coeffs = denom · A[·, colsᶜ]` as an integer matrix
 identity.
 
 The two halves of the argument:
 
 - The nonzero residue proves the `r × r` minor is a nonzero integer, so
-  those `r` columns are linearly independent over `ℚ` and `rank A ≥ r`.
-  This needs no primality, and it is why `modulus` is a `Modulus` rather
-  than a `PrimeModulus`.
+  those `r` columns are linearly independent over `ℚ` and
+  `ratRank A ≥ r`. This needs no primality.
 - The matrix identity places every remaining column in the rational span
   of the chosen `r`, so the column space has dimension at most `r` and
-  `rank A ≤ r`.
+  `ratRank A ≤ r`.
+
+**The modulus is a bare `Nat` because a bounded one makes the certificate
+incomplete.** With `modulus : ZMod64.Modulus` every value is below
+`2^31`, so on the `1 x 1` matrix `[L]` with `L = lcm(1, …, 2^31 - 1)`
+every residue of the only minor is zero and no certificate exists, even
+though the rank is `1`. Letting the checker do `Int` arithmetic at an
+arbitrary modulus costs one big-integer determinant of an `r × r` matrix
+in the rare case and restores completeness. The producer still finds its
+modulus among the small ones, and falls back to the product of the ones
+it tried.
 
 **Producing a certificate.** Reduce modulo a prime, read the pivot rows
-and columns off `rowReduce`, and Dixon-solve `A[·, cols] X = A[·, colsᶜ]`
-for the coefficients. A bad prime makes `rankModP` too small, the chosen
-column set too small, and the span check fail on some column; the
-response is another prime. The modular rank is never too large, by the
-minor argument above, so a failure always means "try again" and never
-means "the answer is wrong".
+and columns off `rowReduce`, and solve for the coefficients with the
+Dixon solve below applied to the **`r × r` selected minor**, against the
+selected rows of each remaining column. The solve is square, which
+`solve?` requires; the resulting coefficients are then checked against
+all `n` rows, and that full check is what makes the certificate say
+something about `A` rather than about its selected rows. An earlier
+draft handed the `n × r` block to `solve?` directly, which does not
+typecheck and, if it did, would be a different algorithm.
+
+A bad prime makes `rankModP` too small, the chosen column set too small,
+and the span check fail on some column; the response is another prime.
+The modular rank is never too large, by the minor argument above, so a
+failure always means "try again" and never means "the answer is wrong".
 
 ```lean
 def rankCert? (A : Matrix Int n m) (fuel : Nat) : Option (RankCert n m)
 def rank (A : Matrix Int n m) : Nat
 ```
 
-`rank` is `rankCert?` with a default budget, falling back to row
-reduction over `Rat` when the budget runs out. Under design principle 8
+`rank` is `rankCert?` with a default budget, falling back to `ratRank`
+when the budget runs out. Under design principle 8
 that fallback is an `audited-emergency-value` in neither sense: it is a
 second complete algorithm, not a default, and its result is correct on
 its own terms. The API exposes `rankCert?` so that a caller who wants the
@@ -393,11 +465,15 @@ The algorithm, with the two steps that are easy to state wrongly marked:
    `exactDiv` belongs.
 3. After `k` steps, `x ≡ Σ xᵢ pⁱ (mod p^k)`, so the solution is known
    modulo `p^k`.
-4. Reconstruct with `ratReconVec?` at bounds `P = hadamardBound Ab` and
-   `Q = hadamardBound A`, where `Ab` is `A` with one column replaced by
-   `b`. **The number of steps is set by `p^k > 2 P Q`**, from Cramer's
-   rule: the numerators are minors of `Ab` and the denominator divides
-   `det A`.
+4. Reconstruct with `ratReconVec?` at bounds
+   `P = max_i hadamardBound (A with column i replaced by b)` and
+   `Q = hadamardBound A`. **The number of steps is set by
+   `p^k > 2 P Q`**, from Cramer's rule: the `i`-th numerator is the
+   determinant of `A` with column `i` replaced by `b`, and the common
+   denominator divides `det A`. The maximum over `i` is not decoration.
+   For `A = [[1, N], [0, 1]]` and `b = (0, 1)` the solution is `(-N, 1)`,
+   while replacing the second column alone gives a bound of `1`, so a
+   `P` read off one replaced column is wrong by a factor of `N`.
 5. Check `A y = d b` over `ℤ` and return `none` if it fails.
 
 Because of step 5 the whole thing is a checked candidate. `solve?_spec`
@@ -412,13 +488,28 @@ invertible modulo `p` has nonzero determinant. The API therefore also
 offers
 
 ```lean
-/-- The prime at which `A` was inverted, which witnesses `det A ≠ 0`. -/
+/-- The solve together with a checkable witness that `A` is nonsingular:
+a modulus and the nonzero determinant residue at it. -/
+structure SolveWitness (n : Nat) where
+  num : Vector Int n
+  den : Int
+  modulus : Nat
+  detImage : Int
+  nonzero : detImage ≠ 0
+
 def solveWitness? (A : Matrix Int n n) (b : Vector Int n) (fuel : Nat) :
-    Option (Vector Int n × Int × Modulus)
+    Option (SolveWitness n)
+
+theorem solveWitness?_det_ne_zero (h : solveWitness? A b fuel = some w) :
+    Matrix.det A ≠ 0
 ```
 
-so a consumer can carry the nonsingularity evidence rather than
-recompute it.
+The modulus alone witnesses nothing, and an earlier draft of this SPEC
+returned only that. What carries the argument is the residue: a nonzero
+value of `det A` modulo `w.modulus` proves `det A ≠ 0` as an integer, by
+the same one-line argument the rank certificate's lower bound uses. The
+solve already computes it, since inverting `A` modulo `p` produces the
+pivot product.
 
 **Rational input, rational right-hand side.** A caller with `Rat` data
 clears denominators. `solve?` does not accept `Rat`, because the
@@ -429,8 +520,16 @@ accepting `Rat` would invite it to be done per call.
 
 ```lean
 /-- A basis of the rational kernel, as integer columns with a common
-denominator, in reduced column echelon shape against the free columns. -/
-def kernel? (A : Matrix Int n m) (fuel : Nat) : Option (Matrix Int m (m - r))
+denominator, in reduced column echelon shape against the free columns.
+The rank is part of the result rather than a parameter, since the caller
+does not know it in advance. -/
+structure Kernel (m : Nat) where
+  rank : Nat
+  basis : Matrix Int m (m - rank)
+  denom : Int
+  cert : RankCert n m
+
+def kernel? (A : Matrix Int n m) (fuel : Nat) : Option (Kernel m)
 ```
 
 This is the rank certificate's coefficient matrix rearranged: with pivot
@@ -554,9 +653,25 @@ present:
   not over `ℤ` (take a matrix whose determinant is a product of small
   primes), and a matrix whose determinant is exactly a modulus.
 - A determinant near the Hadamard bound (a Hadamard matrix scaled) and
-  one enormously below it (a triangular matrix with unit diagonal), which
-  are the two ends the determinant divisor is designed to separate.
+  one enormously below it with a large divisor: a matrix of large entries
+  whose determinant is a small non-unit, say `6`, where the solve's
+  denominator carries almost all of the answer. **Not** a unit-diagonal
+  triangular matrix, which is unimodular, so every rational solution has
+  denominator `1` and the divisor is `1`. That is the divisor method's
+  worst case rather than its best, and using it as the demonstration
+  contradicts the family list below.
 - A determinant of `±1`, where the divisor is `1` and no shortcut helps.
+- A **composite** modulus at which the elimination succeeds, for instance
+  a matrix with determinant `5` reduced modulo `6`, which is the case the
+  no-primality claim rests on and which a suite of prime moduli never
+  reaches.
+- A matrix whose pivot column modulo a composite modulus is nonzero with
+  no unit, so `detMod?` returns `none`, beside one whose pivot column is
+  entirely zero, so it returns `some 0`. These are the two branches that
+  an oracle comparison cannot distinguish.
+- The `1 x 1` matrix `[L]` from the totality argument is not a fixture:
+  `L` has hundreds of millions of digits. The Bareiss fallback is
+  exercised instead by a fuel of zero, which is the same code path.
 - Rank cases: full rank, rank zero, rank deficient by one, wide and tall,
   and a matrix whose rank drops modulo a small prime, constructed so the
   certificate producer must retry.
@@ -604,15 +719,23 @@ algorithm the comparison is like-for-like and the reason for the
 exemption is gone. Two thresholds, written down in advance:
 
 - **Against `Hex.Matrix.bareiss`**, on the shared tridiagonal fixture,
-  `detViaDivisor` must be faster at every rung `n ≥ 64`, and faster by at
-  least `4x` at `n = 512`. This is a required check, and failing it means
-  the library has not earned its place.
+  `detViaDivisor` must be faster at `n = 512` by at least `4x`, and the
+  crossover rung below which Bareiss wins is **measured rather than
+  predicted**, then written into the dispatch and into this SPEC. An
+  earlier draft required "faster at every rung `n ≥ 64`", which guesses
+  the crossover in the same document that says it will not guess it.
 - **Against FLINT `fmpz_mat.det`**, on the same fixture and using the
   same startup-adjusted ratio the existing report defines,
-  `detViaDivisor` must be within `5x` at every eligible rung. `5x` is
-  chosen as a plausible constant factor between Lean and tuned C over
-  GMP, given that the algorithms then agree; it is a written-down
-  threshold, to be revised only with measurements and a stated reason.
+  `detViaDivisor` should be within `5x` at every eligible rung. `5x` is a
+  plausible constant factor between Lean and tuned C over GMP once the
+  algorithms agree, and it is a target rather than a proved-reachable
+  number: it becomes the required threshold after the first
+  implementation measures it, and until then a miss is a finding to
+  investigate rather than a merge-blocking failure.
+
+Stating it that way is deliberate. A required check whose number nobody
+has measured is either vacuous or an accident waiting to block a correct
+implementation, and this SPEC has no prototype behind either figure.
 
 FLINT's `fmpz_mat.rank` and `fmpq_mat.solve` are `informational`: FLINT's
 solve uses a tuned multi-modular and Dixon hybrid with a different
@@ -718,7 +841,7 @@ HexModularMatrixMathlib.lean
       comparators:
         - tool: FLINT fmpz_mat_det via python-flint
           class: gating
-          goal: within 5x on the shared tridiagonal fixture at every eligible rung
+          goal: faster than Hex.Matrix.bareiss by at least 4x at n = 512 on the shared tridiagonal fixture, with the FLINT ratio recorded and the 5x target reviewed after the first measurement
         - tool: FLINT fmpz_mat_rank via python-flint
           class: informational
           rationale: no shared fixture history and a different crossover policy

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -1,0 +1,778 @@
+# hex-modular-matrix (multi-modular determinant, certified rank, Dixon lifting)
+
+Exact linear algebra over `ℤ` and `ℚ` computed through modular images:
+the determinant of an integer matrix from its residues modulo many
+moduli, the rank with a two-sided certificate, and the solution of
+`A x = b` over `ℚ` by `p`-adic lifting. Mathlib-free. The companion
+`hex-modular-matrix-mathlib` discharges the determinant bound the
+Mathlib-free layer carries as a hypothesis, and identifies the executable
+results with `Matrix.det`, `Matrix.rank`, and `Matrix.mulVec`.
+
+This SPEC expands three of the five bullets in the "Modular techniques"
+entry of [future-work](../future-work.md), and depends on the
+reconstruction operations specified in [hex-modular](hex-modular.md). The
+fourth bullet, the modular gcd for `ℤ[x]`, is
+[hex-poly-z-gcd](hex-poly-z-gcd.md); the fifth, rational reconstruction
+itself, is in [hex-modular](hex-modular.md).
+
+## Why this library exists
+
+**The gap is measured, and it is a factor of twenty.**
+[reports/hex-bareiss-performance.md](../../reports/hex-bareiss-performance.md)
+records `Hex.Matrix.bareiss` against FLINT's `fmpz_mat.det` on the same
+deterministic tridiagonal fixture. The raw ratio crosses unity at
+`n = 128` and reaches `0.062x` at `n = 512`; on the rungs where the
+harness startup cost is small enough for the comparison to be eligible
+(`n = 320, 384, 512`) the adjusted ratio sits at `0.049x` to `0.057x`.
+FLINT spends about five percent of Hex's wall time on the same
+determinant, and the gap widens with `n`.
+
+hex-bareiss's SPEC classifies that comparator as `informational` for a
+stated reason: FLINT uses multi-modular reduction with Chinese
+remaindering, and Bareiss is fraction-free elimination over `Int`, so the
+two have different asymptotic and constant-factor profiles. The report's
+own recommendation is to add "a multimodular CRT path layered over the
+existing Bareiss kernel". This library is that path, and implementing it
+is what turns the comparison into a like-for-like one, which is exactly
+what [future-work](../future-work.md) says.
+
+**Fraction-free elimination pays for coefficient growth it cannot
+avoid.** Bareiss keeps every intermediate an integer, and those integers
+reach the size of a minor of the input, so an `n³` operation count is an
+`n³` count of multiplications on numbers with `O(n log(nB))` bits. A
+modular image is `n³` operations on machine words, and the number of
+images needed grows only like `n log(nB) / 31`. The trade is one factor
+of `n` in the bit complexity, and it is why every computer algebra system
+computes integer determinants this way.
+
+**A rational linear solve has no implementation in the tree at all.**
+hex-row-reduce solves over a field, so `Matrix Rat n m` works and every
+intermediate entry is a rational whose numerator and denominator grow
+through the elimination. hex-number-field's arithmetic, the integer
+kernel bases in [hex-hermite](hex-hermite.md), and the certified rank
+below all want an exact solve that does not pay that growth. Dixon
+lifting is the standard answer and its output is checkable by one
+matrix-vector product.
+
+**hex-hermite needs a determinant.** The Domich-Kannan-Trotter modular
+Hermite algorithm reduces entries modulo a determinant of a square
+nonsingular submatrix, and [hex-hermite](hex-hermite.md) names
+hex-bareiss as the supplier. The determinant here is the faster supplier
+for exactly the sizes where the modular Hermite path is worth taking.
+
+## What has a checker and what does not
+
+[future-work](../future-work.md) opens with a warning that a positive
+certificate establishes only what it carries a witness for. Applied to
+this library, the three operations come out differently, and the
+difference drives the whole design.
+
+**The linear solve has a one-line checker.** A claimed solution `y/d`
+is accepted by testing `A y = d b` over `ℤ`, which is one matrix-vector
+product. Everything that produced it (the prime, the inverse modulo `p`,
+the lifting, the reconstruction) runs untrusted.
+
+**The rank has a two-sided certificate.** A lower bound is a square
+submatrix whose determinant is nonzero modulo one modulus, which is
+cheap and conclusive because a nonzero residue of an integer proves the
+integer nonzero. An upper bound is a rational expression of every other
+column in terms of the chosen ones, which is a matrix product to check.
+Neither half alone settles the rank, and together they settle it exactly.
+
+**The determinant has no cheap checker.** Verifying `det A = d` is, as
+far as anyone knows, no easier than computing it: the natural witnesses
+(the adjugate, a triangular factorisation) are the size of the answer
+times `n`, and checking them costs another `n³` big-integer
+multiplications. So the multi-modular determinant is a *proved algorithm*
+rather than a checked candidate, and it carries the only analytic
+hypothesis in this library. Everything downstream of that difference,
+including which reconstruction rule may be used and which may not, is
+recorded below where it applies.
+
+That asymmetry has one further consequence worth stating in advance.
+Certified dispatch to an untrusted external implementation, in the shape
+`hex-lll`'s `certCheck` uses for fpLLL and [hex-hermite](hex-hermite.md)
+specifies for Hermite forms, is available for the solve and for the rank
+and is **not** available for the determinant. An external determinant
+would have to be trusted, and design principle 4 forbids that.
+
+## Two corrections to the future-work entry
+
+**Primality is not among the checker's obligations.** That entry says
+they are "primality and distinctness of the moduli, the CRT congruences,
+and a reconstruction bound large enough to determine the answer". The
+determinant argument never uses primality: reduction modulo any `m` is a
+ring homomorphism, so `det (A mod m) = (det A) mod m` regardless, and
+what the *elimination* needs is that the pivots it inverts are units,
+which the arithmetic discovers rather than assumes. Distinctness is not
+the right property either, since distinct moduli need not be coprime;
+coprimality is what the reconstruction needs and `Crt.push` checks it.
+[hex-modular](hex-modular.md) sets this out in full under "Primality is
+not what the checkers need". Primality does appear here, once: the rank
+of an image modulo `p` is a rank only when `F_p` is a field, and the
+statement of `rankModP` says so.
+
+**Reduction mod `p` dropping the rank is not by itself the lower
+bound.** The entry says "Reduction mod `p` can only drop rank, so the
+modular computation supplies a lower bound on the rational rank." The
+conclusion is right and the reason as stated is circular: the modular
+rank is a lower bound because a nonvanishing `r × r` minor modulo `p` is
+a nonvanishing integer minor, and that argument produces the *witness*
+the certificate carries. Phrasing it as "reduction can only drop rank"
+suggests the modular computation is the evidence, when in fact the
+submatrix is.
+
+## Scope
+
+In scope: the determinant of a square integer matrix; the rank of a
+rectangular integer matrix with a certificate; the solution of a square
+nonsingular integer system over `ℚ`; a rational kernel basis; and the
+determinant divisor optimisation that links the first to the third.
+
+Not in scope for the first version: rectangular and inconsistent systems
+(the certificate shape differs and the consistency question is a rank
+question); matrix inversion as a returned object, since every consumer
+here wants a solve rather than an inverse; the Smith and Hermite normal
+forms, which are [hex-smith](hex-smith.md) and
+[hex-hermite](hex-hermite.md) and want this library rather than replace
+it; and the characteristic polynomial, whose multi-modular form is a
+separate entry in [future-work](../future-work.md) and is a consumer of
+this one.
+
+Coefficients are `Int` throughout. A rational input is cleared to an
+integer matrix and a scalar denominator by the caller, and the API says
+so rather than accepting `Rat` matrices and doing it silently.
+
+## The determinant
+
+### One image
+
+```lean
+namespace Hex.Matrix
+
+/-- The determinant of `A` reduced modulo `m`, computed by elimination.
+Returns `none` when a pivot candidate is not invertible modulo `m`, which
+for composite `m` can happen without the matrix being singular. -/
+def detMod? (A : Matrix (ZMod64 m) n n) : Option (ZMod64 m)
+```
+
+This is a dedicated elimination rather than a call into
+`hex-row-reduce`. Three reasons, in order of weight:
+
+- `rowReduce` produces the reduced row echelon form and its transform
+  `T` with `T * A = E`. Recovering `det A` from that needs `det T`, which
+  `RowEchelonData` does not carry and which is not cheaper to compute
+  than the determinant itself.
+- Elimination below the pivot is about a third of the work of a full
+  Gauss-Jordan reduction, and this is the operation the whole library
+  exists to make fast.
+- `rowReduce` requires `Lean.Grind.Field`, so it requires the modulus to
+  be prime. `detMod?` is written against the `Option`-returning inverse
+  and works at any modulus, which is what lets the reconstruction argument
+  drop primality.
+
+Correctness comes from the row-operation determinant lemmas that
+hex-determinant already proves: `det_rowSwap`, `det_rowScale`, and
+`det_rowAdd` in `HexDeterminant/RowOps.lean`. The loop invariant is that
+the product of the pivots so far, times the sign of the accumulated
+permutation, times the determinant of the untouched trailing submatrix,
+equals `det A`.
+
+```lean
+theorem detMod?_eq (h : detMod? A = some d) : Matrix.det A = d
+theorem detMod?_reduce (A : Matrix Int n n) :
+    detMod? (A.mapEntries (ZMod64.intCast m)) = some d →
+      (Matrix.det A) % (m : Int) = d.toInt % (m : Int)
+```
+
+The second is the reduction homomorphism, and it holds for every modulus.
+
+### The bound
+
+```lean
+/-- The Hadamard bound: the product over columns of the ceiling of the
+Euclidean norm. An upper bound for `|det A|`. -/
+def hadamardBound (A : Matrix Int n n) : Nat
+
+/-- The one analytic fact the multi-modular determinant rests on.
+Discharged in `hex-modular-matrix-mathlib`. -/
+class LawfulDetBound : Prop where
+  abs_det_le : ∀ {n} (A : Matrix Int n n), (Matrix.det A).natAbs ≤ hadamardBound A
+```
+
+Hadamard's inequality is an analytic statement (it is a Gram-matrix
+inequality, and the sharp form goes through Gram-Schmidt), so under
+design principle 2 the Mathlib-free layer states it and the companion
+proves it. The companion has almost nothing to do, because the proof
+already exists: `Matrix.norm_det_le_prod_norm_column` in
+`HexPolyZMathlib/Hadamard.lean` is the sharp column form over an
+`RCLike` field, written for the Mahler separation bound. That it lives in
+a polynomial library is a placement error, and moving it is one of the
+relocations below.
+
+**The alternative that avoids the hypothesis, and what it costs.**
+The Leibniz expansion gives `|det A| ≤ n! · B^n` for `B` the largest
+entry, and that is an elementary bound with a Mathlib-free proof. It is
+not adopted, for two reasons. It needs
+`(permutationVectors n).length = n !`, which hex-determinant does not
+prove today (the enumeration is in `HexDeterminant/Enumeration.lean` and
+carries inversion-count and nodup lemmas, not a length). And it is worse
+by `n log₂ n / 2 - 1.44 n` bits, which at small entries is close to a
+factor of two in the number of moduli and at large entries is
+negligible beside the `n log₂ B` term. The right resolution is to state
+the good bound as a hypothesis and discharge it, and to record the crude
+bound here as the fallback if a Mathlib-free consumer ever appears.
+
+### The reconstruction
+
+```lean
+/-- The determinant of an integer matrix, by Chinese remaindering over
+enough moduli to determine it. -/
+def det (A : Matrix Int n n) : Int
+
+theorem det_eq [LawfulDetBound] (A : Matrix Int n n) :
+    det A = Matrix.det A
+```
+
+The loop folds one image per modulus into a `Crt` and stops when the
+accumulated modulus exceeds `2 · hadamardBound A`, at which point
+`crt_unique` identifies the symmetric representative with the answer.
+Moduli at which `detMod?` returns `none` are skipped.
+
+**Early termination is not available here, and this is the one place in
+the tree where that has to be said out loud.** Stopping when the
+reconstructed value stops changing across two further moduli is what a
+consumer with a check may do, and this operation has no check. A
+determinant produced by a stabilisation rule is a guess. The bound is
+therefore not an optimisation to be tuned away; it is the correctness
+argument. The next subsection is how to make the bound small rather than
+how to avoid it.
+
+### The determinant divisor
+
+The Hadamard bound is pessimistic by a wide margin on almost every input,
+and the standard remedy, due to Abbott, Bronstein, and Mulders ("Fast
+deterministic computation of determinants of dense matrices", ISSAC
+1999), removes the pessimism without weakening the argument.
+
+Solve `A x = b` for a random `b` by the Dixon solve below, obtaining `y`
+and `d > 0` with `A y = d b` and the pair reduced. The random vector is
+drawn from a seedable generator under the discipline the equal-degree
+splitting item in [future-work](../future-work.md) sets: the generator
+state is an explicit argument rather than a monad, the seed is a
+parameter of the public entry point so a run is reproducible, and the
+draw affects how many moduli the run needs and never what it returns.
+The tree has no such generator today, so the first consumer to land
+writes it, and it belongs in hex-basic rather than here. Then `d` divides
+`det A`, so the remaining factor `det A / d` is bounded by
+`hadamardBound A / d`, and Chinese remaindering only has to determine
+that much smaller number.
+
+```lean
+/-- The determinant, computed as a divisor found by lifting times a
+cofactor found by Chinese remaindering. -/
+def detViaDivisor (A : Matrix Int n n) : Int
+```
+
+Three things make this rigorous rather than heuristic, and the middle one
+is easy to get wrong:
+
+- `d ∣ det A` needs Cramer's rule. From `A y = d b` with `A` nonsingular,
+  `y_i / d = det(A_i) / det(A)`, so `det(A) · y_i = d · det(A_i)` for
+  every `i`, so `d` divides `det(A) · gcd_i(y_i)`.
+- **The pair must be reduced first.** The divisibility conclusion needs
+  `gcd(gcd_i y_i, d) = 1`. Dixon's reconstruction returns a common
+  denominator that need not be the least one
+  ([hex-modular](hex-modular.md) says so explicitly under "Vectors with a
+  common denominator"), so `detViaDivisor` divides `y` and `d` through by
+  their common gcd before using `d`. Omitting that step gives a `d` that
+  does not divide the determinant and a wrong answer with no symptom.
+- The cofactor still needs a bound, and it has one: `|det A / d| ≤
+  hadamardBound A / d`, from the same hypothesis as before. Nothing is
+  assumed about how large `d` is. A small `d` costs moduli, never
+  correctness.
+
+Nonsingularity is not an extra assumption. The Dixon solve inverts `A`
+modulo a prime, and a matrix invertible modulo `p` has a determinant that
+is nonzero modulo `p`, hence nonzero. When the solve fails to find such a
+prime after its budget, `detViaDivisor` falls back to `det` above.
+
+This is the entry point a caller should use, and it is what closes the
+measured gap: on typical input `d` is within a few bits of the
+determinant, so the Chinese remaindering runs over a handful of moduli
+instead of hundreds, and the cost becomes the single `O(n³)` inverse plus
+the lifting.
+
+## Rank
+
+```lean
+/-- The rank of `A` reduced modulo the prime `p`. -/
+def rankModP (A : Matrix (ZMod64 p) n m) [ZMod64.PrimeModulus p] : Nat :=
+  (rowReduce A).rank
+
+/-- A certificate for the rank of an integer matrix. -/
+structure RankCert (n m : Nat) where
+  /-- The claimed rank. -/
+  r : Nat
+  /-- Row and column indices of a nonsingular `r × r` submatrix. -/
+  rows : Vector (Fin n) r
+  cols : Vector (Fin m) r
+  /-- A modulus at which that submatrix has nonzero determinant. -/
+  modulus : Modulus
+  /-- Coefficients expressing the remaining columns over the chosen ones,
+  with a common denominator. -/
+  coeffs : Matrix Int r (m - r)
+  denom : Int
+
+def checkRank (A : Matrix Int n m) (c : RankCert n m) : Bool
+
+theorem checkRank_sound (h : checkRank A c = true) : rank A = c.r
+```
+
+`checkRank` verifies, cheapest first: that `rows` and `cols` are strictly
+increasing (so the submatrix is well formed and the complement of `cols`
+is determined); that `detMod?` of the selected `r × r` submatrix is
+`some` and nonzero; that `denom ≠ 0`; and that
+`A[·, cols] * coeffs = denom · A[·, colsᶜ]` as an integer matrix
+identity.
+
+The two halves of the argument:
+
+- The nonzero residue proves the `r × r` minor is a nonzero integer, so
+  those `r` columns are linearly independent over `ℚ` and `rank A ≥ r`.
+  This needs no primality, and it is why `modulus` is a `Modulus` rather
+  than a `PrimeModulus`.
+- The matrix identity places every remaining column in the rational span
+  of the chosen `r`, so the column space has dimension at most `r` and
+  `rank A ≤ r`.
+
+**Producing a certificate.** Reduce modulo a prime, read the pivot rows
+and columns off `rowReduce`, and Dixon-solve `A[·, cols] X = A[·, colsᶜ]`
+for the coefficients. A bad prime makes `rankModP` too small, the chosen
+column set too small, and the span check fail on some column; the
+response is another prime. The modular rank is never too large, by the
+minor argument above, so a failure always means "try again" and never
+means "the answer is wrong".
+
+```lean
+def rankCert? (A : Matrix Int n m) (fuel : Nat) : Option (RankCert n m)
+def rank (A : Matrix Int n m) : Nat
+```
+
+`rank` is `rankCert?` with a default budget, falling back to row
+reduction over `Rat` when the budget runs out. Under design principle 8
+that fallback is an `audited-emergency-value` in neither sense: it is a
+second complete algorithm, not a default, and its result is correct on
+its own terms. The API exposes `rankCert?` so that a caller who wants the
+witness can have it.
+
+## The Dixon solve
+
+```lean
+/-- Solve `A x = b` over `ℚ` by `p`-adic lifting. Returns the numerator
+vector and the common denominator of `x`, reduced. -/
+def solve? (A : Matrix Int n n) (b : Vector Int n) (fuel : Nat) :
+    Option (Vector Int n × Int)
+
+theorem solve?_spec (h : solve? A b fuel = some (y, d)) :
+    A.mulVec y = d • b ∧ 0 < d
+
+theorem solve?_unique (h : solve? A b fuel = some (y, d))
+    (hA : Matrix.det A ≠ 0) (hz : A.mulVec z = e • b) (he : 0 < e) :
+    e • y = d • z
+```
+
+The algorithm, with the two steps that are easy to state wrongly marked:
+
+1. Find a prime `p` at which `A` is invertible, and compute `B` with
+   `B A ≡ I (mod p)`. This is the only `O(n³)` step, and it is done once.
+2. Set `r₀ = b`. Repeat: `xᵢ = B rᵢ mod p`, then
+   `rᵢ₊₁ = (rᵢ - A xᵢ) / p`. **The division is exact**, because
+   `A xᵢ ≡ A B rᵢ ≡ rᵢ (mod p)`, and it is a division rather than a
+   shift because `p` is not a power of two. This is where hex-arith's
+   `exactDiv` belongs.
+3. After `k` steps, `x ≡ Σ xᵢ pⁱ (mod p^k)`, so the solution is known
+   modulo `p^k`.
+4. Reconstruct with `ratReconVec?` at bounds `P = hadamardBound Ab` and
+   `Q = hadamardBound A`, where `Ab` is `A` with one column replaced by
+   `b`. **The number of steps is set by `p^k > 2 P Q`**, from Cramer's
+   rule: the numerators are minors of `Ab` and the denominator divides
+   `det A`.
+5. Check `A y = d b` over `ℤ` and return `none` if it fails.
+
+Because of step 5 the whole thing is a checked candidate. `solve?_spec`
+follows from the check alone and needs no hypothesis, not even
+`LawfulDetBound`: the bound governs how many lifting steps are enough,
+which is a question about whether the check will pass rather than about
+what it means when it does.
+
+`solve?_unique` is the other half, and the hypothesis it needs is
+nonsingularity, which the caller gets for free from step 1: a matrix
+invertible modulo `p` has nonzero determinant. The API therefore also
+offers
+
+```lean
+/-- The prime at which `A` was inverted, which witnesses `det A ≠ 0`. -/
+def solveWitness? (A : Matrix Int n n) (b : Vector Int n) (fuel : Nat) :
+    Option (Vector Int n × Int × Modulus)
+```
+
+so a consumer can carry the nonsingularity evidence rather than
+recompute it.
+
+**Rational input, rational right-hand side.** A caller with `Rat` data
+clears denominators. `solve?` does not accept `Rat`, because the
+clearing is a scalar multiplication the caller can do exactly once, and
+accepting `Rat` would invite it to be done per call.
+
+## Rational kernel basis
+
+```lean
+/-- A basis of the rational kernel, as integer columns with a common
+denominator, in reduced column echelon shape against the free columns. -/
+def kernel? (A : Matrix Int n m) (fuel : Nat) : Option (Matrix Int m (m - r))
+```
+
+This is the rank certificate's coefficient matrix rearranged: with pivot
+columns `J` and coefficients `C` satisfying `A_J C = d A_{Jᶜ}`, the
+columns `(C, -d I)` reindexed span the kernel. Because the free block is
+`-d I`, the returned matrix has full column rank by inspection, which is
+what makes the dimension count part of the certificate rather than a
+further obligation.
+
+The integer kernel (a basis of `ker A ∩ ℤ^m` as a lattice, saturated) is
+**not** this object, and the difference is the reason
+[hex-hermite](hex-hermite.md) exists: `kernelBasis` there is a lattice
+basis and this is a vector space basis with a denominator. Both are
+wanted, they are not interchangeable, and this SPEC uses the word
+"kernel" only for the rational one.
+
+## Complexity
+
+`A` is `n × n` (or `n × m` with rank `r`) with entries bounded by `B`,
+moduli of `w = 31` bits, and `H = hadamardBound A`, whose bit length is
+`h = (n/2) log₂ n + n log₂ B`.
+
+These are **word-operation counts**. Big-integer operations are counted
+separately where they dominate, because that is the whole comparison.
+
+| operation | algorithm | word ops | big-integer ops |
+|---|---|---|---|
+| `detMod?` | elimination at one modulus | `O(n³)` | none |
+| `det` | `⌈h/w⌉` images plus CRT | `O(n³ h / w)` | `O(n · h² / w²)` for the CRT |
+| `detViaDivisor` | one solve plus `⌈log₂(H/d)/w⌉` images | `O(n³ + n² h)` typical | small |
+| `solve?` | one inverse plus `k = O(h/w)` steps | `O(n³ + n² h / w)` | `O(n·h)` in the reconstruction |
+| `rankCert?` | one modular reduction plus `m - r` solves | `O(n m r + (m-r) · n²h/w)` | check is `O(n r (m-r))` at size `h` |
+| `checkRank` | one integer matrix product | none | `O(n r (m-r))` at size `h` |
+| `Hex.Matrix.bareiss` | fraction-free elimination | none | `O(n³)` at size up to `h` |
+
+The last two rows are the comparison. Bareiss performs `n³`
+multiplications on integers that grow to the size of the answer, so its
+bit cost carries a factor of `h` (and, with schoolbook multiplication, of
+`h²`). The multi-modular determinant performs `n³ h / w` multiplications
+on machine words. Dixon replaces the `h` in the first factor by a single
+`O(n³)` inverse plus `O(n²)` per digit, which is where its advantage over
+both comes from.
+
+## Prerequisite changes in other libraries
+
+Five, of which three are shared with other planned libraries and are
+listed here because this library is a second consumer.
+
+**`zmod64FieldOfPrime` should move to hex-mod-arith.** Set out in
+[hex-modular](hex-modular.md). Without it, `rankModP` forces a dependency
+on hex-poly-fp for one instance about a `ZMod64` type.
+
+**An entrywise `Matrix.mapEntries` is missing.** hex-matrix has
+`mapRows`, `mapRowsIdx`, and `modifyEntries`, and no entrywise map. Reducing an
+integer matrix modulo `m` and lifting a residue matrix back are the two
+most-executed operations in this library, and both are entrywise maps.
+The function belongs in hex-matrix next to `mapRows`, with the linear
+buffer discipline design principle 3 requires, and with the `getElem`
+characterisation lemma.
+
+**`floorSqrt` and `ceilSqrt` should move to hex-arith**, from
+`HexPolyZ/Mignotte.lean` where they sit under the `Hex.ZPoly` namespace.
+`hadamardBound` computes one integer square root per column.
+
+**`exactDiv` should move to hex-arith**, from `HexBareiss/Bareiss.lean`.
+[hex-hermite](hex-hermite.md) already asks for this. Dixon's lifting step
+divides an exactly-divisible vector by `p` once per digit, which is the
+hottest exact division in the tree.
+
+**Hadamard's inequality should move to hex-matrix-mathlib.**
+`HexPolyZMathlib/Hadamard.lean` proves
+`Matrix.norm_det_le_prod_norm_column` for Mathlib matrices over an
+`RCLike` field. It is a determinant inequality with no polynomial content,
+`HexRealRootsMathlib/Hadamard.lean` already exists solely as a
+compatibility import of it across libraries, and this library's companion
+would be a third cross-library consumer. Move the file to
+hex-matrix-mathlib and leave compatibility imports in both current
+places.
+
+None of the five blocks starting work here.
+
+## Conformance
+
+Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+`conformance/HexModularMatrix/EmitFixtures.lean` exposed as
+`lean_exe hexmodularmatrix_emit_fixtures`, a committed snapshot at
+`conformance-fixtures/HexModularMatrix/modmat.jsonl`, and an oracle
+driver at `scripts/oracle/modmat_flint.py`. One tuple appended to
+`ORACLES` in `scripts/ci/run_oracles.sh`:
+
+```
+"HexModularMatrix|hexmodularmatrix_emit_fixtures|scripts/oracle/modmat_flint.py|conformance-fixtures/HexModularMatrix/modmat.jsonl"
+```
+
+python-flint is the oracle: `fmpz_mat.det`, `fmpz_mat.rank`, and
+`fmpq_mat.solve` cover all three operations exactly, and the existing
+`matrix_flint.py` driver in this repository already speaks the persistent
+subprocess protocol, so this extends it rather than adding a second
+driver.
+
+**The oracle cannot catch the bugs this library is most likely to
+have.** `det` and `detViaDivisor` return the same value, and `rank`
+falls back to row reduction over `Rat`, so an end-to-end fixture passes
+even if the determinant divisor is never used, the unlucky-prime path
+never fires, and the lifting loop silently runs to its fuel limit every
+time. The suite therefore has two halves, and the first is worth more.
+
+**Route-level tests**, in Lean, asserting on internals: that
+`detViaDivisor` used the number of moduli its divisor allows and not
+more; that a modulus at which a pivot is not invertible was skipped
+rather than folded in; that `rankCert?` retried after a prime that gave
+too small a rank; that the Dixon loop stopped at the predicted digit
+count; and that the reduction step in `detViaDivisor` actually reduced a
+constructed non-reduced pair.
+
+**Oracle fixtures**, checking the public answers. Cases that must be
+present:
+
+- `n = 0` and `n = 1`, where the determinant conventions live.
+- A singular matrix, a matrix singular modulo the first few primes but
+  not over `ℤ` (take a matrix whose determinant is a product of small
+  primes), and a matrix whose determinant is exactly a modulus.
+- A determinant near the Hadamard bound (a Hadamard matrix scaled) and
+  one enormously below it (a triangular matrix with unit diagonal), which
+  are the two ends the determinant divisor is designed to separate.
+- A determinant of `±1`, where the divisor is `1` and no shortcut helps.
+- Rank cases: full rank, rank zero, rank deficient by one, wide and tall,
+  and a matrix whose rank drops modulo a small prime, constructed so the
+  certificate producer must retry.
+- Solve cases: a system whose solution has a large denominator, one whose
+  solution is integral, and one where the numerators are much larger than
+  the denominator.
+- A matrix with entries of several thousand bits, where the word-op count
+  and the big-integer count separate.
+- Sign conventions on the determinant against FLINT, since the report
+  records that Bareiss tracks the swap permutation parity and FLINT's
+  multimodular path returns the same value by a different route.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+`bench/HexModularMatrix/Bench.lean`. Native only. There is no kernel
+suite: the kernel-facing operation here is `checkRank`, whose cost is a
+matrix product hex-matrix already measures.
+
+Families:
+
+- **Structured determinant**, the same deterministic tridiagonal fixture
+  `HexBareiss.Bench` uses, at the same rungs `n = 16 … 512`. Using the
+  identical fixture is the point: it makes the new path directly
+  comparable both to `Hex.Matrix.bareiss` and to the FLINT numbers
+  already recorded in
+  [reports/hex-bareiss-performance.md](../../reports/hex-bareiss-performance.md).
+- **Dense random determinant**, entries of 8, 64, and 1024 bits, at
+  `n = 32 … 256`. The entry-size sweep is where the multi-modular
+  advantage should grow, since the number of moduli grows with the entry
+  size while Bareiss's operand size grows with both.
+- **Unimodular determinant**, matrices with determinant `±1`, which is
+  the worst case for the determinant divisor and the family that keeps
+  the headline number honest.
+- **Rank**, square and rectangular, at several ranks including full and
+  nearly full.
+- **Solve**, with integral solutions and with large-denominator
+  solutions.
+
+**Comparators.** FLINT's `fmpz_mat_det` becomes `gating` here, and this
+is the one classification change this SPEC makes to an existing
+comparator relationship. hex-bareiss classifies it `informational`
+because the algorithms differ; once this library implements the same
+algorithm the comparison is like-for-like and the reason for the
+exemption is gone. Two thresholds, written down in advance:
+
+- **Against `Hex.Matrix.bareiss`**, on the shared tridiagonal fixture,
+  `detViaDivisor` must be faster at every rung `n ≥ 64`, and faster by at
+  least `4x` at `n = 512`. This is a required check, and failing it means
+  the library has not earned its place.
+- **Against FLINT `fmpz_mat.det`**, on the same fixture and using the
+  same startup-adjusted ratio the existing report defines,
+  `detViaDivisor` must be within `5x` at every eligible rung. `5x` is
+  chosen as a plausible constant factor between Lean and tuned C over
+  GMP, given that the algorithms then agree; it is a written-down
+  threshold, to be revised only with measurements and a stated reason.
+
+FLINT's `fmpz_mat.rank` and `fmpq_mat.solve` are `informational`: FLINT's
+solve uses a tuned multi-modular and Dixon hybrid with a different
+crossover policy, and there is no shared fixture history to anchor a
+required ratio.
+
+## The Mathlib layer
+
+`hex-modular-matrix-mathlib` discharges the hypothesis and transports the
+results. Writing `e` for hex-matrix-mathlib's `matrixEquiv`:
+
+```lean
+instance : LawfulDetBound        -- from Matrix.norm_det_le_prod_norm_column
+
+theorem det_eq (A : Matrix Int n n) : det A = Matrix.det (e A)
+theorem rank_eq (A : Matrix Int n m) : rank A = Matrix.rank (e A)
+
+theorem solve_eq (h : solve? A b fuel = some (y, d)) :
+    Matrix.mulVec (e A) (fun i => (y[i] : ℚ) / d) = fun i => (b[i] : ℚ)
+
+theorem kernel_span (h : kernel? A fuel = some K) :
+    Submodule.span ℚ (Set.range (e K).col) = LinearMap.ker (Matrix.mulVecLin (e A))
+```
+
+`det_eq` is the only one that needs the instance. Getting from the
+Mathlib-free `det_eq [LawfulDetBound]` to this unconditional statement is
+the discharge plus hex-determinant-mathlib's existing agreement between
+the executable `Matrix.det` and Mathlib's.
+
+`rank_eq` needs `Matrix.rank` over `ℚ` of the integer matrix cast into
+`ℚ`, which is the standard meaning of the rank of an integer matrix and
+is what the certificate establishes. The statement over `ZMod p` is
+different and is not claimed.
+
+Two decidability instances follow, in the style of
+hex-berlekamp-mathlib's `Decidable (Irreducible f)`:
+
+```lean
+instance (A : Matrix (Fin n) (Fin n) ℤ) : Decidable (A.det = 0)
+instance (A : Matrix (Fin n) (Fin m) ℤ) (r : Nat) : Decidable (A.rank = r)
+```
+
+Both are the executable computation plus the correspondence, and both are
+worth having because Mathlib's own definitions are noncomputable.
+
+Following the project split, no theorem about `Crt` or `RankCert` belongs
+in the companion beyond these and one correspondence lemma per public
+operation.
+
+## Milestones
+
+1. **One image.** `Matrix.mapEntries` (in hex-matrix), the
+   `Option`-returning modular inverse, `detMod?`, and its two theorems.
+   Nothing multi-modular yet, and everything that follows depends on it.
+
+2. **The determinant.** `hadamardBound`, `LawfulDetBound`, the moduli
+   loop, `det`, and `det_eq`. At the end of this milestone the library
+   has a correct determinant and no performance claim.
+
+3. **The Dixon solve.** `solve?`, `solveWitness?`, the exact division
+   step, the digit count, and the check. `solve?_spec` needs no
+   hypothesis, and `solve?_unique` needs only nonsingularity.
+
+4. **The determinant divisor.** `detViaDivisor`, with the reduction step
+   and its divisibility lemma. This is the milestone that produces the
+   benchmark numbers, and the route-level test for the reduction step is
+   written before the code.
+
+5. **Rank.** `rankModP`, `RankCert`, `checkRank`, `checkRank_sound`,
+   `rankCert?`, `rank`, and `kernel?`.
+
+6. **The companion.** Begins as soon as milestone 2 is done, in parallel
+   with 3 through 5.
+
+## File organisation
+
+```
+HexModularMatrix/
+  Image.lean        -- detMod?, the Option-returning inverse, reduction lemmas
+  Bound.lean        -- hadamardBound, LawfulDetBound
+  Det.lean          -- det, the moduli loop, det_eq
+  Dixon.lean        -- solve?, solveWitness?, the lifting loop
+  Divisor.lean      -- detViaDivisor and the divisibility argument
+  Rank.lean         -- rankModP, RankCert, checkRank, rankCert?, rank, kernel?
+HexModularMatrix.lean
+HexModularMatrixMathlib/
+  Bound.lean        -- the LawfulDetBound instance
+  Det.lean          -- det_eq, Decidable (A.det = 0)
+  Rank.lean         -- rank_eq, kernel_span, Decidable (A.rank = r)
+  Solve.lean        -- solve_eq
+HexModularMatrixMathlib.lean
+```
+
+`libraries.yml` gains:
+
+```yaml
+  HexModularMatrix:
+    deps: [HexModular, HexMatrix, HexRowReduce, HexDeterminant, HexModArith, HexArith, HexBasic]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_mat_det via python-flint
+          class: gating
+          goal: within 5x on the shared tridiagonal fixture at every eligible rung
+        - tool: FLINT fmpz_mat_rank via python-flint
+          class: informational
+          rationale: no shared fixture history and a different crossover policy
+        - tool: FLINT fmpq_mat_solve via python-flint
+          class: informational
+          rationale: FLINT dispatches between multi-modular and Dixon with tuned crossovers
+      input_families:
+        - name: structured-determinant
+          description: the deterministic tridiagonal fixture shared with HexBareiss.Bench
+        - name: dense-random-determinant
+          description: dense random matrices at 8, 64, and 1024 bit entries
+        - name: unimodular-determinant
+          description: matrices of determinant plus or minus one, the worst case for the divisor
+        - name: rank
+          description: square and rectangular matrices at several ranks
+        - name: solve
+          description: systems with integral and with large-denominator solutions
+  HexModularMatrixMathlib:
+    deps: [HexModularMatrix, HexMatrixMathlib, HexDeterminantMathlib, HexRowReduceMathlib, HexModularMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned
+```
+
+`HexDeterminant` is a dependency for the row-operation determinant
+lemmas, not for the Leibniz determinant, which nothing here calls.
+`HexBasic` is for the random generator the determinant divisor draws
+its right-hand side from.
+
+## Open questions
+
+- **Whether `detMod?` should use Barrett or Montgomery reduction.**
+  The inner loop is a multiply-subtract modulo a 31-bit modulus, `n³`
+  times per image, and hex-arith has both reductions. Which one wins
+  depends on whether the modulus is fixed across the whole image (it is)
+  and on how many products can be accumulated before a reduction, which
+  the `ZMod64` bound was chosen to allow. This is a measurement, and it
+  is the single largest constant factor in the library.
+- **Whether the images should be computed in blocks.** Reducing the
+  matrix modulo several moduli at once and eliminating them together
+  shares the memory traffic, and hex-matrix's `Strassen` and `Winograd`
+  suggest the blocking machinery is available. Worth measuring after
+  milestone 4, not before.
+- **Whether `solve?` should return the `p`-adic expansion.** A consumer
+  that wants the solution modulo `p^k` rather than as a rational (a
+  Hensel-style consumer, or [hex-hermite](hex-hermite.md)'s modular path)
+  currently has to reconstruct and re-reduce. Exposing the expansion
+  costs an API and would let the reconstruction be skipped entirely where
+  the caller does not need it.
+- **Whether the determinant should also produce a rank witness.** A
+  singular matrix currently returns `0` with no evidence, and the caller
+  who wants to know why runs `rankCert?` separately, repeating the
+  elimination. Merging them is attractive and would complicate the
+  determinant's loop, which is the hottest code here.
+- **The crossover with Bareiss.** The benchmark will show a size below
+  which the fraction-free path is faster, and the dispatch should use it.
+  This SPEC does not guess the number.

--- a/SPEC/Libraries/hex-modular.md
+++ b/SPEC/Libraries/hex-modular.md
@@ -54,18 +54,28 @@ to need it should not write a third version.
 
 ## Why not inside hex-arith
 
-The scalar operations here (`symMod`, the truncated Euclidean run,
-`ratRecon?`) would sit comfortably next to `extGcd` in hex-arith, and if
-the library were only those it should go there. The modulus supply is
-what makes that impossible: it bundles a `ZMod64.Bounds` instance, so it
-sits above hex-mod-arith, which sits above hex-arith. Splitting the
-library to put three functions one level down would produce a library
-whose only content is a stopping rule for a loop hex-arith already has.
+An earlier draft of this SPEC gave a structural reason: the modulus
+supply bundles a `ZMod64.Bounds` instance, so it sits above
+hex-mod-arith, so the library cannot sit inside hex-arith. That reason
+does not survive putting the supply where it belongs. `Modulus` and
+`PrimeModulus` package `ZMod64` evidence and belong beside `ZMod64` in
+hex-mod-arith, generalising `SmallPrimeCandidate`, and everything left
+here is arithmetic on `Int` and `Nat`. This library therefore depends on
+hex-arith alone.
 
-The argument is structural rather than a remark about hex-arith's phase
-status. If a later consumer wants `ratRecon?` without `ZMod64`, the split
-becomes worth making, and this SPEC records it as the seam to cut along:
-`Recon.lean` and `SymMod.lean` mention nothing from hex-mod-arith.
+The honest reason for a separate library is subject separation rather
+than a dependency. Chinese remaindering and rational reconstruction have
+their own conformance fixtures, their own oracle, their own benchmark
+families, and three consumers that each want a different part; hex-arith
+is a library of scalar primitives with none of that surface, and it is
+complete at `done_through: 7`, so absorbing a new subject there means
+reopening a finished library. Principle 1 asks for many small libraries
+split along their seams, and this is one.
+
+The alternative is defensible and this SPEC records it rather than
+pretending otherwise: folding `SymMod.lean`, `Euclid.lean`, and
+`Recon.lean` into hex-arith and leaving only the loop here would also
+work, and would trade one library for one reopened phase.
 
 ## Scope
 
@@ -128,20 +138,31 @@ symmetric representative of the common solution modulo `modulus`. -/
 structure Crt where
   modulus : Nat
   value : Int
+  pos : 0 < modulus
+  le : 2 * value.natAbs ≤ modulus
 
-def Crt.init : Crt := { modulus := 1, value := 0 }
+def Crt.init : Crt := { modulus := 1, value := 0, pos := by decide, le := by decide }
 
-/-- Fold in the residue `r` modulo `m`. Returns `none` when `m` is not
-coprime to the moduli already folded in. -/
+/-- Fold in the residue `r` modulo `m`. Returns `none` when `m` is zero
+or one, or when `m` is not coprime to the moduli already folded in. -/
 def Crt.push (c : Crt) (r : Int) (m : Nat) : Option Crt
 
 /-- The same, for `k` residues sharing one modulus. -/
 def CrtVec.push (c : CrtVec k) (r : Vector Int k) (m : Nat) : Option (CrtVec k)
 ```
 
-`push` runs `Hex.Int.extGcd c.modulus m`, which returns `(g, s, t)` with
-`s * c.modulus + t * m = g`. It returns `none` unless `g = 1`, and
-otherwise `s` is the inverse of `c.modulus` modulo `m` and the update is
+**The positivity and size fields are structure invariants, not
+afterthoughts.** Without `pos`, `Crt.init.push 1 0` is accepted, because
+`gcd(1, 0) = 1`: the result has `modulus = 0`, and then `push_modulus`,
+`push_le`, and `push_congr_new` below are jointly unsatisfiable. Carrying
+the invariants in the structure makes the bad state unconstructible
+rather than merely unreachable, and `push` rejects `m ≤ 1` before doing
+any arithmetic.
+
+`push` runs `HexArith.Int.extGcd (c.modulus % m) m`, which returns
+`(g, s, t)` with `s * (c.modulus % m) + t * m = g`. It returns `none`
+unless `g = 1`, and otherwise `s` is the inverse of `c.modulus` modulo
+`m` and the update is
 
 ```
 δ        = symMod ((r - c.value) * s) m
@@ -152,6 +173,14 @@ value'   = symMod (c.value + c.modulus * δ) modulus'
 which is Garner's mixed-radix step. The arithmetic that grows with the
 number of moduli is one multiplication and one addition on integers of
 the size of the accumulated value, and everything else is word-sized.
+
+**The reduction `c.modulus % m` before the extended gcd is what makes
+that true.** `c.modulus` reaches thousands of bits, and an inverse
+computed from it directly runs the Euclidean algorithm on a large
+operand for a word-sized answer. Since `s` is determined modulo `m`, the
+reduced operand gives the same inverse. Skipping the reduction is a
+correctness-neutral performance bug, which is the kind this SPEC exists
+to prevent.
 
 **The outer `symMod` is not redundant.** With `|c.value| ≤ c.modulus/2`
 and `|δ| ≤ m/2`, the sum reaches `c.modulus·(m+1)/2`, which exceeds
@@ -221,11 +250,13 @@ is at most `P`. -/
 def euclidUntil (m a P : Int) : Row
 ```
 
-`euclidUntil` is the only new arithmetic in this library. It should be
-written against the same `@[extern]` GMP surface `extGcd` uses, since the
-operands are the same size and the inner loop is the same division.
-Sharing the loop between the two is an implementation question and a
-worthwhile one, and the SPEC does not force an answer.
+`euclidUntil` is the only new arithmetic in this library, and it is more
+than a wrapper. `HexArith.Int.extGcd` is an `@[extern]` binding that
+returns the final triple, so no intermediate row is reachable through it:
+`euclidUntil` needs either its own extern primitive or a refactoring of
+the existing one to take a stopping predicate. Which of those is right is
+an implementation question, and it is the one open question in this
+library that costs real work rather than a decision.
 
 ### The signature is checked, so soundness is free
 
@@ -242,8 +273,10 @@ def ratReconWide? (a : Int) (m : Nat) : Option Rat
 
 The return type is `Rat`, not `Int × Int`. A `Rat` is already a coprime
 pair with a positive denominator, so three of the four output conditions
-are the invariants of the type, and `Rat.mk'` normalisation is where they
-are established.
+are the invariants of the type, and `Rat.normalize` (or `mkRat`) is where
+they are established. Not `Rat.mk'`, which is the raw structure
+constructor and takes the invariants as arguments rather than
+establishing them.
 
 `ratRecon?` takes the row `euclidUntil m a P` returns, forms the
 candidate from `(r, t)` with the sign normalised so the denominator is
@@ -346,9 +379,18 @@ def ratReconVec? (a : Vector Int k) (m : Nat) (P Q : Int) :
 The algorithm reconstructs the first entry, obtaining a denominator `d`,
 and for each later entry first tries `symMod (d * aᵢ) m`, accepting it
 when it is within `P`. That test is one multiplication. Only when it
-fails does the entry get its own Euclidean run, after which `d` is
-multiplied by the new denominator and the accepted numerators are
-rescaled.
+fails does the entry get its own Euclidean run, and then `d` is replaced
+by `lcm d dᵢ`, the accepted numerators are rescaled by `lcm d dᵢ / d`,
+and the whole pair `(y, d)` is divided through by the gcd of all its
+entries.
+
+**The `lcm` and the reduction are both load-bearing, and an earlier draft
+of this SPEC had neither.** Multiplying the denominators instead
+overshoots: at `m = 101`, `P = 2`, `Q = 4`, the residues `(51, 76)` are
+`(1/2, 1/4)`, and multiplying gives `d = 8` with numerators `(4, 2)`,
+both outside the bounds, while `lcm` gives the correct `(2, 1)/4`. No
+amount of further lifting repairs the overshoot, because the fault is in
+the combination step rather than in the precision.
 
 ```lean
 theorem ratReconVec?_spec : ratReconVec? a m P Q = some (y, d) →
@@ -356,12 +398,20 @@ theorem ratReconVec?_spec : ratReconVec? a m P Q = some (y, d) →
     ∀ i, (d * a[i] - y[i]) % (m : Int) = 0 ∧ y[i].natAbs ≤ P
 ```
 
-The output is **not** claimed to be in lowest terms: the common
-denominator may be a proper multiple of the least one. Under `2PQ < m`
-the rational vector `y/d` is still unique, by `ratRecon_unique` applied
-entrywise, which is exactly the case the uniqueness proof covers without
-a coprimality hypothesis. A consumer that wants the reduced form divides
-by the gcd of the numerators and the denominator afterwards.
+The output is reduced as a whole (no integer divides `d` and every `yᵢ`)
+but individual entries need not be in lowest terms, since `d` is the
+common denominator rather than each entry's own. Under `2PQ < m` the
+rational vector `y/d` is unique, by `ratRecon_unique` applied entrywise,
+which is exactly the case the uniqueness proof covers without a
+coprimality hypothesis.
+
+**What `Q` has to bound.** The postcondition asserts `d ≤ Q`, and `d` is
+the least common denominator of the whole vector, not of any one entry.
+A caller whose bound covers each entry separately has not supplied a
+usable `Q`. Dixon's caller does supply one, because Cramer's rule bounds
+the common denominator by `|det A|`, and that is the sense in which the
+completeness statement for the vector form is about the vector rather
+than about its entries.
 
 ### Reconstruction without bounds
 
@@ -459,14 +509,16 @@ preference rather than a requirement. Neither is assumed here. This
 library is written against `isPrimeTrial`, which exists, and the
 switchover is a body change behind an unchanged signature.
 
-### The supply
+### The supply, which belongs in hex-mod-arith
 
 ```lean
-/-- A usable modulus: a natural number with the `ZMod64` small-modulus
-evidence attached. -/
+namespace Hex.ZMod64
+
+/-- A usable modulus: a natural number with the small-modulus evidence
+attached. -/
 structure Modulus where
   m : Nat
-  [bounds : ZMod64.Bounds m]
+  [bounds : Bounds m]
 
 /-- A modulus known to be prime, for the consumers whose statements
 mention `F_p`. -/
@@ -479,27 +531,46 @@ so a wrong answer here is impossible rather than merely unlikely. -/
 def primesBelow (start : Nat) : Nat → Array PrimeModulus
 ```
 
-`PrimeModulus` the structure is not `ZMod64.PrimeModulus` the class,
-which hex-mod-arith already defines and which asserts primality of a
-modulus fixed by the context. The structure's `prime` field yields that
-class through `ZMod64.primeModulusOfPrime`, and the two are named alike
-because they say the same thing about different things: the class is a
-hypothesis about a known `p`, the structure is a `p` carried with its
-evidence. If that proximity reads badly in practice, the structure is the
-one to rename, since it is new.
+These three go in **hex-mod-arith**, not here. They package
+`ZMod64.Bounds` and a primality witness, they mention nothing about
+Chinese remaindering, and hex-mod-arith already has the class
+`ZMod64.PrimeModulus` that the structure's `prime` field produces through
+`primeModulusOfPrime`. Putting them there is what lets this library
+depend on hex-arith alone, and it makes
+`HexBerlekampZassenhaus/PrimeSelection.lean`'s `SmallPrimeCandidate` the
+special case it is rather than a parallel definition.
+
+The naming collision with the existing class is deliberate and worth one
+sentence: the class is a hypothesis about a `p` fixed by the context, the
+structure is a `p` carried with its evidence. If that reads badly in
+practice the structure is the one to rename, since it is new.
 
 The `Bounds` and `Prime` fields are propositions built at runtime from a
 dependent `if` on `isPrimeTrial`, so they are erased in compiled code and
-cost nothing. This is `SmallPrimeCandidate`'s pattern from
-`HexBerlekampZassenhaus/PrimeSelection.lean` with the fixed table
-replaced by generation, and that structure should move here and be
-reused there, which is one of the relocations listed below.
+cost nothing.
 
-The default supply is primes immediately below `2^31`, the largest
-`ZMod64.Bounds` permits. Nothing in this library depends on that choice:
-`Modulus` accepts any bounded value, and a consumer that wants powers of
-a single prime (Dixon) or a stored small prime (a gcd certificate) builds
-its own.
+### The supply is bounded, and the consumers have to say so
+
+`ZMod64.Bounds` requires `m < 2^31`, and that is not only a performance
+limit. Write `L` for the least common multiple of everything below
+`2^31`. Every allowed modulus divides `L`, and any product of pairwise
+coprime allowed moduli divides `L` too, so the accumulated modulus can
+never exceed `L`. On the `1 x 1` matrix `[L]` the determinant is `L`, the
+Hadamard bound is `L`, every image is zero, and a loop that stops when
+the modulus exceeds twice the bound never stops.
+
+Nothing in this library can fix that, and it is recorded here because it
+is the shared cause of three separate obligations elsewhere:
+[hex-modular-matrix](hex-modular-matrix.md)'s determinant needs a
+fallback that does not use moduli at all, its rank certificate needs a
+lower-bound witness that is not restricted to small moduli, and
+[hex-poly-z-gcd](hex-poly-z-gcd.md)'s coprimality certificate needs a
+constructor that names no prime. Each of those SPECs carries the
+counterexample for its own case.
+
+`crtLoop` below therefore takes fuel and returns `Option`, and no
+consumer may present a modular route as total on the strength of a bound
+alone.
 
 ## The multimodular loop
 
@@ -510,10 +581,14 @@ once:
 /-- Fold moduli in until `accept` returns a result. `image` computes the
 residue vector at one modulus, `accept` attempts a reconstruction and
 returns `none` to ask for another modulus. -/
-def crtLoop (image : Modulus → Option (Vector Int k))
-    (accept : CrtVec k → Option α) (supply : Array Modulus) (fuel : Nat) :
+def crtLoop (image : Nat → Option (Vector Int k))
+    (accept : CrtVec k → Option α) (supply : Array Nat) (fuel : Nat) :
     Option α
 ```
+
+The moduli are bare `Nat`s. A consumer computing in `ZMod64` passes the
+`m` field of its `Modulus` values and recovers the evidence on its own
+side, which is what keeps this library independent of hex-mod-arith.
 
 `image` returns `none` for a modulus the consumer rejects (a vanishing
 leading coefficient, a non-invertible pivot), and those moduli are
@@ -572,11 +647,23 @@ find it rather than to assume it.
 
 ## Kernel exposure
 
-The kernel replay closure is `symMod`, `Crt.push`, and the checks inside
-`ratRecon?`, all of which are `@[expose]` and reduce cheaply. Neither
-`euclidUntil` nor the modulus supply is in it: a certificate carries the
-reconstructed answer, never the search that found it, and a checker
-re-runs the congruence rather than the Euclidean sequence.
+The kernel replay closure is `symMod`, `Crt.push`, and a separate
+checker
+
+```lean
+/-- Accepts `x` as the reconstruction of `a` modulo `m` within the given
+bounds. The predicate `ratRecon?` tests before returning, exposed on its
+own so a proof term never mentions the search. -/
+def ratReconCheck (a : Int) (m : Nat) (P Q : Int) (x : Rat) : Bool
+```
+
+all of which are `@[expose]` and reduce cheaply. `ratRecon?` itself is
+**not** exposed, and this is the correction to an earlier draft that
+claimed the checks inside it were in the closure while `euclidUntil` was
+not: an exposed `ratRecon?` unfolds to `euclidUntil`, so the Euclidean
+sequence would be in the closure with it. Splitting the predicate out
+keeps the closure to what a certificate actually replays, which is the
+congruence and the two bounds.
 
 The one thing that *is* expensive in the kernel is a primality proof, and
 the table above prices it. A downstream module carries a `decide +kernel`
@@ -618,6 +705,11 @@ Cases that must be present:
   trivial and off-by-one errors live.
 - The tie at `2|x| = m` for even `m`, checking the interval convention
   in both signs.
+- **The outer-reduction regression**: push `1` modulo `3`, then `0`
+  modulo `2`. Garner's step gives `4`, and the required symmetric
+  representative modulo `6` is `-2`. Without this case, dropping the
+  outer `symMod` passes the whole suite.
+- `m = 0` and `m = 1` offered to `push`, both of which must be rejected.
 - Non-coprime moduli, checking that `Crt.push` returns `none` rather than
   a wrong value.
 - Reconstructions that must fail: a residue with no rational inside the
@@ -706,14 +798,13 @@ operation.
 
 Three relocations, each with a reason independent of this library.
 
-**`SmallPrimeCandidate` should move to hex-mod-arith.** It bundles a
-`Nat` with `ZMod64.Bounds` and `Hex.Nat.Prime`, mentions nothing about
-polynomials or factoring, and lives in
-`HexBerlekampZassenhaus/PrimeSelection.lean` because that was the first
-consumer. `Modulus` and `PrimeModulus` above are the general form, and
-they should be defined once, in hex-mod-arith next to `PrimeModulus` the
-class, with Berlekamp-Zassenhaus importing them and keeping its own fixed
-candidate lists.
+**`Modulus`, `PrimeModulus`, and `primesBelow` belong in
+hex-mod-arith**, as "The supply" above sets out, and
+`SmallPrimeCandidate` from `HexBerlekampZassenhaus/PrimeSelection.lean`
+should become the special case of them rather than a parallel
+definition. Unlike the other two relocations, this one is a
+precondition: without it this library acquires a dependency on
+hex-mod-arith that its subject does not justify.
 
 **`zmod64FieldOfPrime` should move to hex-mod-arith.** The
 `Lean.Grind.Field (ZMod64 p)` instance and the `ZMod64.intPow` it needs
@@ -733,9 +824,10 @@ under the `Hex.ZPoly` namespace, where the Mignotte bound needed them.
 An integer square root under a polynomial namespace is a naming error as
 well as a placement one.
 
-None of the three blocks starting work here. Until they land, this
-library can name the existing paths, at the cost of a dependency on
-hex-poly-fp and hex-poly-z that it should not keep.
+The second and third do not block starting work here, and until they
+land this library can name the existing paths. The first does block, in
+the weak sense that skipping it costs a dependency this SPEC's placement
+argument says should not exist.
 
 ## Milestones
 
@@ -749,9 +841,10 @@ hex-poly-fp and hex-poly-z that it should not keep.
    `ratRecon?_den_coprime`. Completeness may lag by one milestone: it is
    the only hard proof here, and no consumer's soundness depends on it.
 
-3. **The vector forms and the loop.** `ratReconVec?`, `crtLoop`, and the
-   modulus supply. At the end of this milestone both consumer libraries
-   can be written.
+3. **The vector forms and the loop.** `ratReconVec?` with the `lcm`
+   combination and the reduction, and `crtLoop`. The modulus supply lands
+   in hex-mod-arith alongside. At the end of this milestone both consumer
+   libraries can be written.
 
 4. **Completeness and the heuristic.** `ratRecon?_complete` and
    `ratReconMaxQuot?`.
@@ -767,7 +860,6 @@ HexModular/
   Crt.lean          -- Crt, CrtVec, push, crt_unique
   Euclid.lean       -- Row, euclidUntil
   Recon.lean        -- ratRecon?, ratReconWide?, ratReconVec?, ratReconMaxQuot?
-  Modulus.lean      -- Modulus, PrimeModulus, primesBelow
   Loop.lean         -- crtLoop
 HexModular.lean
 HexModularMathlib/
@@ -776,20 +868,19 @@ HexModularMathlib/
 HexModularMathlib.lean
 ```
 
-`SymMod.lean`, `Crt.lean`, `Euclid.lean`, and `Recon.lean` mention
-nothing from hex-mod-arith, which is the seam recorded under "Why not
-inside hex-arith".
+No file here mentions `ZMod64`. `Modulus` and `primesBelow` live in
+hex-mod-arith, per "The supply", and `crtLoop` takes bare `Nat` moduli.
 
 `libraries.yml` gains:
 
 ```yaml
   HexModular:
-    deps: [HexArith, HexModArith]
+    deps: [HexArith]
     mathlib: false
     done_through: 0
     status: planned
   HexModularMathlib:
-    deps: [HexModular, HexModArithMathlib]
+    deps: [HexModular, HexModArithMathlib]   # ZMod correspondence only
     mathlib: true
     done_through: 0
     status: planned

--- a/SPEC/Libraries/hex-modular.md
+++ b/SPEC/Libraries/hex-modular.md
@@ -1,0 +1,832 @@
+# hex-modular (integer CRT, rational reconstruction, and the modulus supply)
+
+Chinese remaindering over `Int`, rational reconstruction from a residue,
+symmetric representatives, and the supply of moduli that the modular
+algorithms elsewhere in the tree draw on. Mathlib-free. The companion
+`hex-modular-mathlib` relates the executable operations to `ZMod`,
+`Int.ModEq`, and `Rat`, and supplies the decidability instances that make
+them usable from a Mathlib goal.
+
+This SPEC is the first of three expanding the "Modular techniques" entry
+in [future-work](../future-work.md). The other two are
+[hex-modular-matrix](hex-modular-matrix.md), which holds the
+multi-modular determinant, certified rank, and Dixon lifting, and
+[hex-poly-z-gcd](hex-poly-z-gcd.md), which holds the modular gcd for
+`ℤ[x]`. This library is what all three of them share.
+
+Two claims in that entry need correcting, and both are corrected below.
+The checker's obligations are **not** "primality and distinctness of the
+moduli": primality is not needed at all for the determinant and the
+polynomial gcd, distinctness does not imply what the argument needs, and
+the property that does the work is pairwise coprimality, which is
+checked. See "Primality is not what the checkers need". And the output
+condition `gcd(q, m) = 1` on a reconstructed rational is a theorem rather
+than a check, derivable from `gcd(p, q) = 1` and the congruence. See
+"The signature is checked, so soundness is free".
+
+## Why this library exists
+
+**Three consumers, none of which should depend on the others.**
+[hex-modular-matrix](hex-modular-matrix.md) reconstructs an integer
+determinant from residues and a rational solution vector from a `p`-adic
+expansion. [hex-poly-z-gcd](hex-poly-z-gcd.md) reconstructs an integer
+polynomial coefficient vector from residues.
+[hex-mv-gcd](hex-mv-gcd.md) does the same one arity up. A matrix library
+and a polynomial library have no business depending on each other, so
+what they share belongs underneath both.
+
+**Rational reconstruction has consumers that want nothing else.**
+hex-number-field's exactification turns a certified approximation into an
+exact algebraic number, and the `p`-adic route to that (rather than the
+continued-fraction route it uses now) is one call to `ratRecon?`.
+Berlekamp-Zassenhaus's lifting phase reconstructs integer factors from
+residues modulo `p^k`, which is the same operation with `P` and `Q`
+chosen from the Mignotte bound rather than symmetrically. Neither
+consumer wants a determinant.
+
+**The modulus supply is one decision, made once.** Every modular
+algorithm needs a stream of moduli, a way to reject one that turns out to
+be unusable, and the `ZMod64.Bounds` evidence to compute in `ZMod64 p` at
+all. Berlekamp-Zassenhaus already solved a small version of this problem
+with `SmallPrimeCandidate` and its two fixed candidate lists. That
+solution is right in shape and too small in range, and the second library
+to need it should not write a third version.
+
+## Why not inside hex-arith
+
+The scalar operations here (`symMod`, the truncated Euclidean run,
+`ratRecon?`) would sit comfortably next to `extGcd` in hex-arith, and if
+the library were only those it should go there. The modulus supply is
+what makes that impossible: it bundles a `ZMod64.Bounds` instance, so it
+sits above hex-mod-arith, which sits above hex-arith. Splitting the
+library to put three functions one level down would produce a library
+whose only content is a stopping rule for a loop hex-arith already has.
+
+The argument is structural rather than a remark about hex-arith's phase
+status. If a later consumer wants `ratRecon?` without `ZMod64`, the split
+becomes worth making, and this SPEC records it as the seam to cut along:
+`Recon.lean` and `SymMod.lean` mention nothing from hex-mod-arith.
+
+## Scope
+
+In scope: symmetric representatives modulo `m`; incremental Chinese
+remaindering for a scalar and for a vector of residues sharing a modulus;
+rational reconstruction with explicit bounds, with symmetric bounds, and
+with the maximal-quotient heuristic; the vector form with a common
+denominator; the modulus supply and its runtime primality test; and the
+loop combinator that adds moduli until a caller-supplied check accepts.
+
+Not in scope: `p`-adic lifting (that is Dixon's, and it lives with its
+consumer in [hex-modular-matrix](hex-modular-matrix.md)); the
+coefficient bounds that tell a consumer how large a modulus it needs
+(a Hadamard bound is a matrix fact and a Mignotte bound is a polynomial
+fact, so each belongs with its own type); prime *choice* heuristics,
+which are per-consumer; and a first-class `Zp` type, which is its own
+entry in [future-work](../future-work.md) and would consume this library
+rather than replace it.
+
+## Symmetric representatives
+
+Every reconstruction in the tree ends by choosing a representative in
+`(-m/2, m/2]`, and every proof that a reconstruction is correct ends by
+citing uniqueness of that representative under a size bound. Both belong
+here, once.
+
+```lean
+namespace Hex.Modular
+
+/-- The representative of `a` modulo `m` in the interval `(-m/2, m/2]`. -/
+def symMod (a : Int) (m : Nat) : Int
+
+theorem symMod_emod (h : 0 < m) : (symMod a m) % (m : Int) = a % (m : Int)
+theorem symMod_le (h : 0 < m) : 2 * (symMod a m).natAbs ≤ m
+theorem symMod_unique (h : 2 * x.natAbs < m) (hx : x % (m : Int) = a % (m : Int)) :
+    symMod a m = x
+```
+
+`symMod_unique` is the lemma the determinant, the gcd, and the linear
+solve all finish with, and it is stated with a **strict** inequality on
+purpose. At `2 * |x| = m` with `m` even there are two representatives,
+`m/2` and `-m/2`, and the interval convention picks one; a consumer whose
+bound is not strict has not proved what it thinks it has. Every caller in
+this tree therefore chooses a modulus exceeding twice its bound rather
+than equalling it, and the extra bit is free because it is one more
+prime out of hundreds.
+
+## Chinese remaindering
+
+The operation is incremental, not batched. A consumer computes an image,
+folds it in, tests whether the accumulated value is already the answer,
+and stops. Batching the residues first would force it to decide the
+number of moduli in advance, which for the determinant means always
+paying the worst case and for the gcd means paying a bound that is
+usually enormously pessimistic.
+
+```lean
+/-- A residue accumulated from several coprime moduli: `value` is the
+symmetric representative of the common solution modulo `modulus`. -/
+structure Crt where
+  modulus : Nat
+  value : Int
+
+def Crt.init : Crt := { modulus := 1, value := 0 }
+
+/-- Fold in the residue `r` modulo `m`. Returns `none` when `m` is not
+coprime to the moduli already folded in. -/
+def Crt.push (c : Crt) (r : Int) (m : Nat) : Option Crt
+
+/-- The same, for `k` residues sharing one modulus. -/
+def CrtVec.push (c : CrtVec k) (r : Vector Int k) (m : Nat) : Option (CrtVec k)
+```
+
+`push` runs `Hex.Int.extGcd c.modulus m`, which returns `(g, s, t)` with
+`s * c.modulus + t * m = g`. It returns `none` unless `g = 1`, and
+otherwise `s` is the inverse of `c.modulus` modulo `m` and the update is
+
+```
+δ        = symMod ((r - c.value) * s) m
+modulus' = c.modulus * m
+value'   = symMod (c.value + c.modulus * δ) modulus'
+```
+
+which is Garner's mixed-radix step. The arithmetic that grows with the
+number of moduli is one multiplication and one addition on integers of
+the size of the accumulated value, and everything else is word-sized.
+
+**The outer `symMod` is not redundant.** With `|c.value| ≤ c.modulus/2`
+and `|δ| ≤ m/2`, the sum reaches `c.modulus·(m+1)/2`, which exceeds
+`modulus'/2` by up to half of `c.modulus`. Dropping the outer reduction
+therefore breaks `push_le` below, and with it the size hypothesis of
+`crt_unique`, which is the only thing standing between a consumer and a
+wrong answer. It costs one division per modulus.
+
+**The vector form is a separate function, not a `map` of the scalar
+one.** The inverse `s` depends only on the two moduli, so `k` residues
+sharing a modulus need one `extGcd` between them rather than `k`. For the
+gcd, `k` is the degree of the answer; for a determinant it is `1`; for a
+matrix reconstruction it is `n²`. Writing the vector form as a fold of
+the scalar one would multiply the extended-gcd cost by `k` on the two
+consumers that care.
+
+```lean
+theorem push_modulus : (c.push r m) = some c' → c'.modulus = c.modulus * m
+theorem push_congr_new : (c.push r m) = some c' → c'.value % m = r % m
+theorem push_congr_old (hd : (d : Int) ∣ c.modulus) :
+    (c.push r m) = some c' → c'.value % d = c.value % d
+theorem push_le : (c.push r m) = some c' → 2 * c'.value.natAbs ≤ c'.modulus
+
+/-- The reconstruction is determined: two integers small enough and
+congruent to the same residues modulo the same moduli are equal. -/
+theorem crt_unique (h : 2 * x.natAbs < c.modulus) (h' : 2 * y.natAbs < c.modulus)
+    (hx : x % (c.modulus : Int) = y % (c.modulus : Int)) : x = y
+```
+
+`push_congr_old` is stated for every divisor `d` of the accumulated
+modulus rather than for the individual moduli, because that is what
+survives the induction over the fold and it specialises to the moduli
+without extra work.
+
+`crt_unique` is `symMod_unique` restated, and it is where the whole
+family of algorithms gets its answer. Nothing above it needs a theorem
+about the Chinese remainder *isomorphism*: the executable statement is
+that a small enough integer is determined by its residues, and the
+isomorphism is the companion's business.
+
+## Rational reconstruction
+
+Fix `m > 0` and a residue `a`, and bounds `P, Q > 0`. The problem is to
+find `p/q` with
+
+```
+q * a ≡ p (mod m),   |p| ≤ P,   0 < q ≤ Q,   gcd(p, q) = 1.
+```
+
+### The stopping rule needs a truncated Euclidean run
+
+`Hex.Int.extGcd` returns the gcd and one Bézout pair. Rational
+reconstruction needs the *intermediate* rows of the same computation: run
+the extended Euclidean algorithm on `(m, a)` producing
+`rⱼ = sⱼ·m + tⱼ·a`, and stop at the first `j` with `rⱼ ≤ P`. So the
+primitive is new, even though the algorithm is one hex-arith already has.
+
+```lean
+/-- One row of the extended Euclidean remainder sequence on `(m, a)`:
+`r = s * m + t * a`, with `s` dropped because no consumer reads it. -/
+structure Row where
+  r : Int
+  t : Int
+
+/-- The first row of the remainder sequence on `(m, a)` whose remainder
+is at most `P`. -/
+def euclidUntil (m a P : Int) : Row
+```
+
+`euclidUntil` is the only new arithmetic in this library. It should be
+written against the same `@[extern]` GMP surface `extGcd` uses, since the
+operands are the same size and the inner loop is the same division.
+Sharing the loop between the two is an implementation question and a
+worthwhile one, and the SPEC does not force an answer.
+
+### The signature is checked, so soundness is free
+
+```lean
+/-- Reconstruct `a mod m` as a rational with numerator at most `P` in
+absolute value and denominator at most `Q`. -/
+def ratRecon? (a : Int) (m : Nat) (P Q : Int) : Option Rat
+
+/-- The symmetric case `P = Q = ⌊√((m-1)/2)⌋`, which satisfies `2PQ < m`
+by construction and is what a caller with no bound of its own should
+use. -/
+def ratReconWide? (a : Int) (m : Nat) : Option Rat
+```
+
+The return type is `Rat`, not `Int × Int`. A `Rat` is already a coprime
+pair with a positive denominator, so three of the four output conditions
+are the invariants of the type, and `Rat.mk'` normalisation is where they
+are established.
+
+`ratRecon?` takes the row `euclidUntil m a P` returns, forms the
+candidate from `(r, t)` with the sign normalised so the denominator is
+positive, divides out `gcd(r, t)`, and then **checks** the congruence and
+both bounds, returning `none` if any fails. Soundness is therefore true
+by construction:
+
+```lean
+theorem ratRecon?_congr : ratRecon? a m P Q = some x →
+    (x.den * a - x.num) % (m : Int) = 0
+theorem ratRecon?_bounds : ratRecon? a m P Q = some x →
+    x.num.natAbs ≤ P ∧ 0 < x.den ∧ (x.den : Int) ≤ Q
+```
+
+`gcd(q, m) = 1` does not appear as a check, because it follows. If
+`d ∣ q` and `d ∣ m`, then from `q·a - p = k·m` we get `d ∣ p`, and
+`gcd(p, q) = 1` forces `d = 1`:
+
+```lean
+theorem ratRecon?_den_coprime : ratRecon? a m P Q = some x →
+    Nat.gcd x.den m = 1
+```
+
+[future-work](../future-work.md) lists it among the conditions the
+algorithm establishes, which reads as though it were a fourth thing to
+test. It is a consequence of the other three, and stating it as a theorem
+rather than a check keeps one modular inverse out of the inner loop.
+
+### Uniqueness
+
+```lean
+theorem ratRecon_unique (hm : 2 * P * Q < m)
+    (h₁ : (y₁.den * a - y₁.num) % (m : Int) = 0)
+    (h₂ : (y₂.den * a - y₂.num) % (m : Int) = 0)
+    (b₁ : y₁.num.natAbs ≤ P ∧ (y₁.den : Int) ≤ Q)
+    (b₂ : y₂.num.natAbs ≤ P ∧ (y₂.den : Int) ≤ Q) : y₁ = y₂
+```
+
+The proof is three lines of arithmetic and it is the reason the whole
+technique is usable. From the two congruences,
+`p₁q₂ ≡ q₁·a·q₂ ≡ p₂q₁ (mod m)`, so `m ∣ p₁q₂ - p₂q₁`. The bounds give
+`|p₁q₂ - p₂q₁| ≤ 2PQ < m`, so the difference is zero and the two
+rationals are equal.
+
+Note what the argument does not use: coprimality of the numerator and
+denominator plays no part, so the uniqueness statement covers unreduced
+pairs as well. That is what makes the common-denominator vector form
+below meaningful.
+
+### Completeness
+
+Soundness is by construction, so the content of the algorithm is that it
+finds a solution whenever one exists.
+
+```lean
+theorem ratRecon?_complete (hm : 2 * P * Q < m)
+    (hy : (y.den * a - y.num) % (m : Int) = 0)
+    (hb : y.num.natAbs ≤ P ∧ (y.den : Int) ≤ Q) :
+    ratRecon? a m P Q = some y
+```
+
+This is the one substantial proof in the library. It rests on the
+standard property of the Euclidean remainder sequence, that
+`|tⱼ| · rⱼ₋₁ ≤ m` for every `j`, which bounds the cofactor of the first
+row below `P` and places the candidate inside the bounds; the target `y`
+then agrees with the candidate by `ratRecon_unique`. The reference to
+follow is von zur Gathen and Gerhard, *Modern Computer Algebra*, §5.10,
+whose Theorem 5.16 is this statement and whose Lemma 5.15 is the cofactor
+bound. Wang, Guy, and Davenport, "P-adic reconstruction of rational
+numbers" (SIGSAM Bulletin 16, 1982), is the original.
+
+Because completeness needs `2PQ < m` and `ratRecon?` does not, a caller
+that supplies bounds violating it still gets a sound answer, just not a
+determined one. The signature does not carry the hypothesis for that
+reason, and `ratReconWide?` exists so that the common case cannot get it
+wrong.
+
+### What the caller does when it returns none
+
+`none` means "not at this modulus", never "no such rational". Every
+consumer's response is the same: fold in another modulus (or one more
+`p`-adic digit) and try again. The reconstruction is therefore always
+inside a loop with a growing modulus, which is why the loop combinator
+below is part of this library rather than each consumer's own.
+
+### Vectors with a common denominator
+
+The linear solve reconstructs `n` rationals that share a denominator
+dividing the determinant, and the polynomial gcd reconstructs a
+coefficient vector whose entries are integers. Reconstructing each entry
+separately would run `k` Euclidean sequences where one usually suffices.
+
+```lean
+/-- Reconstruct `k` residues as rationals with a common denominator.
+Returns the numerators and the denominator. -/
+def ratReconVec? (a : Vector Int k) (m : Nat) (P Q : Int) :
+    Option (Vector Int k × Int)
+```
+
+The algorithm reconstructs the first entry, obtaining a denominator `d`,
+and for each later entry first tries `symMod (d * aᵢ) m`, accepting it
+when it is within `P`. That test is one multiplication. Only when it
+fails does the entry get its own Euclidean run, after which `d` is
+multiplied by the new denominator and the accepted numerators are
+rescaled.
+
+```lean
+theorem ratReconVec?_spec : ratReconVec? a m P Q = some (y, d) →
+    0 < d ∧ (d : Int) ≤ Q ∧
+    ∀ i, (d * a[i] - y[i]) % (m : Int) = 0 ∧ y[i].natAbs ≤ P
+```
+
+The output is **not** claimed to be in lowest terms: the common
+denominator may be a proper multiple of the least one. Under `2PQ < m`
+the rational vector `y/d` is still unique, by `ratRecon_unique` applied
+entrywise, which is exactly the case the uniqueness proof covers without
+a coprimality hypothesis. A consumer that wants the reduced form divides
+by the gcd of the numerators and the denominator afterwards.
+
+### Reconstruction without bounds
+
+Some callers have no usable bound. The determinant of a random matrix is
+enormously smaller than its Hadamard bound, and a caller that waits for
+the bound pays for primes it did not need. The heuristic answer is
+maximal-quotient rational reconstruction: run the remainder sequence,
+take the row before the largest partial quotient, and hand the candidate
+to the caller's own check.
+
+```lean
+/-- The maximal-quotient candidate. Heuristic: the result satisfies the
+congruence, and nothing is claimed about it being the intended rational.
+-/
+def ratReconMaxQuot? (a : Int) (m : Nat) : Option Rat
+```
+
+The soundness theorem is the congruence and nothing else, which is
+honest, and it is enough for a consumer whose check is exact (trial
+division for a gcd, one matrix-vector product for a linear solve). It is
+**not** enough for the multi-modular determinant, which has no cheap
+check, and [hex-modular-matrix](hex-modular-matrix.md) says so in the one
+place it matters. Monagan, "Maximal quotient rational reconstruction: an
+almost optimal algorithm for rational reconstruction" (ISSAC 2004), is
+the reference, and the failure probability analysis there is the reason
+this is offered as a candidate producer rather than as a decision.
+
+## Moduli
+
+### Primality is not what the checkers need
+
+[future-work](../future-work.md) says the checker's obligations include
+"primality and distinctness of the moduli". Neither half is right, and
+getting this wrong would put a large avoidable cost inside the kernel.
+
+**Distinctness is not the property.** Two distinct moduli need not be
+coprime, and the reconstruction argument needs coprimality. For prime
+moduli the two coincide, which is presumably how the sentence came
+about, but the checkable statement is the coprimality one and `Crt.push`
+checks it directly with one extended gcd.
+
+**Primality is not needed for the reconstruction.** `det (A mod m) =
+(det A) mod m` holds for every modulus, prime or not, because reduction
+is a ring homomorphism. The same is true of every polynomial identity the
+gcd certificate checks. What primality buys is that *elimination* can
+divide: Gaussian elimination modulo `m` needs its pivots to be units. The
+implementation gets that from the arithmetic rather than from a
+hypothesis, because inverting a residue runs an extended gcd that either
+returns an inverse or exhibits a nontrivial factor of `m`. A modulus
+whose pivot is not invertible is discarded, and no wrong answer is
+possible.
+
+**Where primality genuinely appears** is in statements that mention
+`F_p` as a field: the rank of an image, and the coprimality witness in
+[hex-poly-z-gcd](hex-poly-z-gcd.md), which needs `F_p[x]` to be a domain.
+Those consumers carry a `Hex.Nat.Prime p` argument, and the rest do not.
+
+### Kernel-replayed primality is priced by the size of the prime
+
+Where a certificate's checker names a prime, replaying that certificate
+in the kernel replays the primality proof. `Hex.Nat.isPrimeTrial` is
+trial division with a balanced recursion, so its cost grows like `√p`.
+Measured on this tree with `decide +kernel`, against a baseline of 0.81 s
+for the import alone:
+
+| prime | bits | elaboration |
+|---|---|---|
+| `65521` | 16 | 0.04 s |
+| `1048573` | 20 | 0.08 s |
+| `16777213` | 24 | 0.42 s |
+| `2147483647` | 31 | 6.2 s |
+
+The consequence is a design rule, not a footnote: **a certificate whose
+checker needs a prime should name the smallest usable one.** The
+coprimality witness in [hex-poly-z-gcd](hex-poly-z-gcd.md) may use any
+prime at which two degrees survive, so it uses a small one and the
+kernel replay is free. A multi-modular determinant wants primes as large
+as `ZMod64.Bounds` allows, and it can have them precisely because its
+correctness argument never mentions primality.
+
+At runtime none of this arises. `isPrimeTrial` on a 31-bit candidate is
+under a millisecond of compiled code, which is negligible beside one
+`O(n³)` image, so moduli are found by running it rather than by consulting
+a table.
+
+**The "Better primality" item in [future-work](../future-work.md) changes
+both halves of this, and neither change is on this library's critical
+path.** Its Miller-Rabin
+compositeness test replaces trial division in `primesBelow`, turning tens
+of microseconds into a few modular exponentiations. Its Pocklington
+certificate replaces the kernel cost above: a checked Pocklington witness
+for a 31-bit prime is a handful of modular exponentiations rather than
+46341 divisions, so the "name a small prime" rule below becomes a
+preference rather than a requirement. Neither is assumed here. This
+library is written against `isPrimeTrial`, which exists, and the
+switchover is a body change behind an unchanged signature.
+
+### The supply
+
+```lean
+/-- A usable modulus: a natural number with the `ZMod64` small-modulus
+evidence attached. -/
+structure Modulus where
+  m : Nat
+  [bounds : ZMod64.Bounds m]
+
+/-- A modulus known to be prime, for the consumers whose statements
+mention `F_p`. -/
+structure PrimeModulus extends Modulus where
+  prime : Hex.Nat.Prime m
+
+/-- Successive primes below `2^31`, descending from `start`. Untrusted:
+the primality test runs at runtime and its result is carried as evidence,
+so a wrong answer here is impossible rather than merely unlikely. -/
+def primesBelow (start : Nat) : Nat → Array PrimeModulus
+```
+
+`PrimeModulus` the structure is not `ZMod64.PrimeModulus` the class,
+which hex-mod-arith already defines and which asserts primality of a
+modulus fixed by the context. The structure's `prime` field yields that
+class through `ZMod64.primeModulusOfPrime`, and the two are named alike
+because they say the same thing about different things: the class is a
+hypothesis about a known `p`, the structure is a `p` carried with its
+evidence. If that proximity reads badly in practice, the structure is the
+one to rename, since it is new.
+
+The `Bounds` and `Prime` fields are propositions built at runtime from a
+dependent `if` on `isPrimeTrial`, so they are erased in compiled code and
+cost nothing. This is `SmallPrimeCandidate`'s pattern from
+`HexBerlekampZassenhaus/PrimeSelection.lean` with the fixed table
+replaced by generation, and that structure should move here and be
+reused there, which is one of the relocations listed below.
+
+The default supply is primes immediately below `2^31`, the largest
+`ZMod64.Bounds` permits. Nothing in this library depends on that choice:
+`Modulus` accepts any bounded value, and a consumer that wants powers of
+a single prime (Dixon) or a stored small prime (a gcd certificate) builds
+its own.
+
+## The multimodular loop
+
+All three consumers have the same outer shape, and it is worth having
+once:
+
+```lean
+/-- Fold moduli in until `accept` returns a result. `image` computes the
+residue vector at one modulus, `accept` attempts a reconstruction and
+returns `none` to ask for another modulus. -/
+def crtLoop (image : Modulus → Option (Vector Int k))
+    (accept : CrtVec k → Option α) (supply : Array Modulus) (fuel : Nat) :
+    Option α
+```
+
+`image` returns `none` for a modulus the consumer rejects (a vanishing
+leading coefficient, a non-invertible pivot), and those moduli are
+skipped without entering the accumulated state. `accept` is where the
+consumer's own check goes: trial division for a gcd, a size bound for a
+determinant, a matrix-vector product for a solve.
+
+Three properties this shape has, each of which was a decision:
+
+- **Rejected moduli never enter the state.** A consumer cannot poison the
+  accumulated residue by folding in an image it computed under a broken
+  assumption.
+- **`accept` decides, and the loop proves nothing.** The loop's own
+  theorem is that its result is one `accept` returned on a state whose
+  modulus is the product of the moduli used, which is all a soundness
+  argument needs, because the consumer's `accept` carries the rest.
+- **Fuel rather than a termination proof.** Whether the loop terminates
+  depends on the consumer's bound, not on the loop, so it is fuelled and
+  returns `Option`. Each consumer proves its own totality statement by
+  supplying the fuel its bound requires. Under design principle 8 this is
+  not a total form of a partial helper at all: the `Option` is
+  propagated, never defaulted.
+
+## What this library does not decide
+
+Prime choice heuristics belong to the consumers. Which primes are bad
+(the leading coefficient vanishes), which are unlucky (the image is
+correct for a different problem than the one asked), how many to try
+before falling back, and what the fallback is are all questions whose
+answers differ per algorithm and none of which affects soundness. This
+library supplies the moduli and the arithmetic. Every consumer's SPEC
+carries its own rejection rules.
+
+## Complexity
+
+`k` moduli of `w` bits, an accumulated modulus of `M = k·w` bits, a
+vector of `n` residues.
+
+| operation | algorithm | cost |
+|---|---|---|
+| `symMod` | one division | `O(M)` word ops |
+| `Crt.push` | one `extGcd` on two words, one multiply-add at size `M` | `O(w²)` plus `O(M)` |
+| `CrtVec.push` | one `extGcd`, `n` multiply-adds | `O(w²)` plus `O(n·M)` |
+| `k` pushes, cumulative | quadratic in the number of moduli | `O(k²·w²)` word ops |
+| `euclidUntil` | truncated Euclidean run at size `M` | `O(M²)` word ops |
+| `ratRecon?` | `euclidUntil` plus checks | `O(M²)` |
+| `ratReconVec?` | one run plus `n` multiplications, on average | `O(M²) + O(n·M)` |
+
+The cumulative `O(k²w²)` for a full multi-modular run is the entry that
+matters, and it is what a product-tree (fast) CRT would improve to
+`O(M(M) log k)`. That is a later milestone: at `k = 400` and `w = 31` the
+incremental cost is under a millisecond of word operations, which is far
+below the `O(n³)` per-image cost that motivates the whole technique. The
+crossover is a measurement, and the benchmark family below is designed to
+find it rather than to assume it.
+
+## Kernel exposure
+
+The kernel replay closure is `symMod`, `Crt.push`, and the checks inside
+`ratRecon?`, all of which are `@[expose]` and reduce cheaply. Neither
+`euclidUntil` nor the modulus supply is in it: a certificate carries the
+reconstructed answer, never the search that found it, and a checker
+re-runs the congruence rather than the Euclidean sequence.
+
+The one thing that *is* expensive in the kernel is a primality proof, and
+the table above prices it. A downstream module carries a `decide +kernel`
+test over a fixed small certificate so that a change making `symMod` or
+`Crt.push` stop reducing is caught.
+
+## Conformance
+
+Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+`conformance/HexModular/EmitFixtures.lean` exposed as
+`lean_exe hexmodular_emit_fixtures`, a committed snapshot at
+`conformance-fixtures/HexModular/modular.jsonl`, and an oracle driver at
+`scripts/oracle/modular_sympy.py`. One tuple appended to `ORACLES` in
+`scripts/ci/run_oracles.sh`, not a new job:
+
+```
+"HexModular|hexmodular_emit_fixtures|scripts/oracle/modular_sympy.py|conformance-fixtures/HexModular/modular.jsonl"
+```
+
+Three fixture kinds: `crt` (a list of residue and modulus pairs, result
+the symmetric representative and the product), `ratrecon` (residue,
+modulus, bounds, result the rational or a failure marker), and `symmod`
+(value, modulus, result).
+
+**The oracle is partly a property check rather than a value check.**
+SymPy's `sympy.ntheory.modular.crt` covers Chinese remaindering directly.
+It has no rational reconstruction, so the oracle script carries a short
+independent implementation using `fractions.Fraction` and its own
+Euclidean loop, and additionally verifies the two properties that matter
+by brute force on the small cases: that the returned rational satisfies
+the congruence and the bounds, and that no other rational within the
+bounds does. The brute-force uniqueness sweep runs only for moduli below
+a few thousand, where it is exhaustive over the denominator, and it is
+the part of the suite that would catch a wrong stopping rule.
+
+Cases that must be present:
+
+- `m = 1`, `a = 0`, and a single modulus, where the reconstruction is
+  trivial and off-by-one errors live.
+- The tie at `2|x| = m` for even `m`, checking the interval convention
+  in both signs.
+- Non-coprime moduli, checking that `Crt.push` returns `none` rather than
+  a wrong value.
+- Reconstructions that must fail: a residue with no rational inside the
+  bounds, where `none` is the answer and returning a candidate would be a
+  soundness bug.
+- Negative numerators, denominators of `1`, and the integer case, which
+  is the one every consumer hits most often.
+- Bounds violating `2PQ < m`, where the result is sound but not
+  determined, checked against the property rather than against a value.
+- A reconstruction just inside and just outside the bound, at several
+  sizes, to catch a boundary error that a random sweep would miss.
+- Vector reconstruction where the common denominator is found on the
+  first entry, on the last entry, and where two entries force it to grow.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+`bench/HexModular/Bench.lean`. Native and kernel: the kernel suite
+measures `symMod` and `Crt.push` reduction, since those are the two
+operations a downstream certificate replay pays for.
+
+Families:
+
+- **Incremental CRT**, `k` from 4 to 4000 moduli of 31 bits. The declared
+  complexity is `k²`, and the family exists to find the point where a
+  product tree would pay.
+- **Vector CRT**, `k` moduli against `n` from 1 to 4096 residues,
+  checking that the extended gcd is amortised across the vector rather
+  than repeated.
+- **Rational reconstruction**, moduli from 64 to 100000 bits, over
+  reconstructions that succeed early, succeed late, and fail.
+- **Failure cost**, the same sizes where no rational exists, since a
+  consumer in a loop pays this on every modulus until the last.
+
+**Comparators.** `gmpy2`'s `gcdext` and FLINT's `fmpz_mod_ctx` CRT are
+`informational`: both are C implementations of the same operations and
+the ratio measures the GMP binding rather than the algorithm. SymPy is
+the oracle and is not a performance comparator. No comparator is
+`gating`, because this library has no algorithmic choice for one to
+discriminate: the algorithms here are the standard ones and the
+performance question is entirely about the arithmetic underneath, which
+hex-arith already measures.
+
+## The Mathlib layer
+
+`hex-modular-mathlib` relates the executable operations to Mathlib's:
+
+```lean
+theorem symMod_cast (h : 0 < m) : ((symMod a m : Int) : ZMod m) = (a : ZMod m)
+theorem symMod_eq_intCast_iff : ...
+
+theorem crt_push_cast (h : c.push r m = some c') :
+    ((c'.value : Int) : ZMod m) = (r : ZMod m)
+
+/-- The accumulated value is the image of the Chinese remainder
+isomorphism at the given residues. -/
+theorem crt_eq_chineseRemainder : ...
+
+theorem ratRecon?_eq (h : ratRecon? a m P Q = some x) :
+    ((x.num : ZMod m)) = (x.den : ZMod m) * (a : ZMod m) ∧ IsUnit ((x.den : ZMod m))
+```
+
+Mathlib has `ZMod.chineseRemainder` for coprime moduli, so the
+correspondence for a two-modulus push is a transport. The `k`-modulus
+statement is an induction over the fold, and the reason to state it at all
+is that a Mathlib-facing consumer (the determinant correspondence in
+[hex-modular-matrix-mathlib](hex-modular-matrix.md)) wants to argue in
+`ZMod` and land in `ℤ`.
+
+Rational reconstruction has no Mathlib counterpart to correspond with, so
+the companion's work there is to restate the uniqueness and completeness
+theorems over `ℚ` with `Rat.cast`, and to supply
+
+```lean
+instance : DecidablePred (fun x : ℚ => (x.den : ZMod m) * a = x.num ∧ |x.num| ≤ P ∧ x.den ≤ Q)
+```
+
+which is what makes `ratRecon?` usable to discharge a Mathlib goal about
+a rational congruence rather than only inside a larger computation.
+
+Following the project split, no theorem about `Crt` or `Row` belongs in
+the companion beyond these and one correspondence lemma per public
+operation.
+
+## Prerequisite changes in other libraries
+
+Three relocations, each with a reason independent of this library.
+
+**`SmallPrimeCandidate` should move to hex-mod-arith.** It bundles a
+`Nat` with `ZMod64.Bounds` and `Hex.Nat.Prime`, mentions nothing about
+polynomials or factoring, and lives in
+`HexBerlekampZassenhaus/PrimeSelection.lean` because that was the first
+consumer. `Modulus` and `PrimeModulus` above are the general form, and
+they should be defined once, in hex-mod-arith next to `PrimeModulus` the
+class, with Berlekamp-Zassenhaus importing them and keeping its own fixed
+candidate lists.
+
+**`zmod64FieldOfPrime` should move to hex-mod-arith.** The
+`Lean.Grind.Field (ZMod64 p)` instance and the `ZMod64.intPow` it needs
+live in `HexPolyFp/PrimeField.lean`. The instance is a statement about a
+hex-mod-arith type, its proof uses `ZMod64` lemmas and
+`Init.Grind.Ring.Field`, and the module's only polynomial import is
+`HexPolyFp.Degree`. As it stands, any library wanting to do linear
+algebra over `F_p` must depend on hex-poly-fp for one instance about a
+type it already has, which is what
+[hex-modular-matrix](hex-modular-matrix.md) would otherwise have to do.
+
+**`floorSqrt` and `ceilSqrt` should move to hex-arith.** They are
+Newton-iteration integer square roots defined in `HexPolyZ/Mignotte.lean`
+under the `Hex.ZPoly` namespace, where the Mignotte bound needed them.
+`ratReconWide?` needs `⌊√((m-1)/2)⌋` and the Hadamard bound in
+[hex-modular-matrix](hex-modular-matrix.md) needs `ceilSqrt` per column.
+An integer square root under a polynomial namespace is a naming error as
+well as a placement one.
+
+None of the three blocks starting work here. Until they land, this
+library can name the existing paths, at the cost of a dependency on
+hex-poly-fp and hex-poly-z that it should not keep.
+
+## Milestones
+
+1. **Symmetric representatives and Chinese remaindering.** `symMod` with
+   its three theorems, `Crt`, `CrtVec`, `push` with the congruence and
+   bound theorems, and `crt_unique`. This milestone alone unblocks the
+   determinant.
+
+2. **Rational reconstruction.** `euclidUntil`, `ratRecon?`,
+   `ratReconWide?`, soundness, `ratRecon_unique`, and
+   `ratRecon?_den_coprime`. Completeness may lag by one milestone: it is
+   the only hard proof here, and no consumer's soundness depends on it.
+
+3. **The vector forms and the loop.** `ratReconVec?`, `crtLoop`, and the
+   modulus supply. At the end of this milestone both consumer libraries
+   can be written.
+
+4. **Completeness and the heuristic.** `ratRecon?_complete` and
+   `ratReconMaxQuot?`.
+
+5. **The companion.** The `ZMod` correspondence, the `ℚ` restatements,
+   and the decidability instances. Begins as soon as milestone 2 is done.
+
+## File organisation
+
+```
+HexModular/
+  SymMod.lean       -- symMod and its uniqueness lemma
+  Crt.lean          -- Crt, CrtVec, push, crt_unique
+  Euclid.lean       -- Row, euclidUntil
+  Recon.lean        -- ratRecon?, ratReconWide?, ratReconVec?, ratReconMaxQuot?
+  Modulus.lean      -- Modulus, PrimeModulus, primesBelow
+  Loop.lean         -- crtLoop
+HexModular.lean
+HexModularMathlib/
+  Crt.lean          -- ZMod correspondence
+  Recon.lean        -- the ℚ restatements and the decidability instances
+HexModularMathlib.lean
+```
+
+`SymMod.lean`, `Crt.lean`, `Euclid.lean`, and `Recon.lean` mention
+nothing from hex-mod-arith, which is the seam recorded under "Why not
+inside hex-arith".
+
+`libraries.yml` gains:
+
+```yaml
+  HexModular:
+    deps: [HexArith, HexModArith]
+    mathlib: false
+    done_through: 0
+    status: planned
+  HexModularMathlib:
+    deps: [HexModular, HexModArithMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned
+```
+
+`status: planned` rather than `draft`: the SPEC is complete, every
+dependency is `active` at `done_through: 7`, and nothing here waits on
+another SPEC.
+
+## Open questions
+
+- **Whether `euclidUntil` and `extGcd` should share an implementation.**
+  Both run the same division loop on the same operand sizes, one keeping
+  the last row and one keeping the first row below a threshold. A single
+  loop with a stopping predicate would serve both, at the cost of an
+  indirection in hex-arith's hottest scalar routine. Measure before
+  merging them.
+- **Whether the product-tree CRT is worth having.** The complexity table
+  says the incremental cost is negligible against the images at the sizes
+  the consumers use. The benchmark family exists to find the size where
+  that stops being true, and the answer may be that no consumer reaches
+  it.
+- **Whether `Modulus` should carry the Barrett context.** hex-arith has
+  Barrett and Montgomery reduction, and a modulus used for `O(n³)`
+  operations wants its reduction context precomputed once. Attaching it
+  to `Modulus` makes that automatic and makes the structure heavier for
+  the consumers that use a modulus twice. This should be settled by the
+  determinant benchmark rather than in advance.
+- **When to switch the modulus supply to a better primality test.** The
+  switch to Miller-Rabin is a strict improvement, and it introduces a
+  dependency on whichever library ends up owning the "Better primality"
+  item in [future-work](../future-work.md). The question is only
+  ordering, and the answer should be "as soon as that library has a
+  compositeness test", at which point it joins the `deps` list above.
+- **Whether a first-class `Zp` type subsumes the Dixon lifting loop.**
+  [future-work](../future-work.md) proposes `Zp` and `Qp` at fixed
+  precision, with Dixon named as a consumer. If that lands, the precision
+  contract it specifies is the natural home for the lifting loop that
+  [hex-modular-matrix](hex-modular-matrix.md) currently writes out. The
+  reconstruction and the CRT stay here either way.

--- a/SPEC/Libraries/hex-mv-gcd.md
+++ b/SPEC/Libraries/hex-mv-gcd.md
@@ -86,6 +86,15 @@ and it depends on this library), Gröbner bases, resultants themselves
 multivariate Hensel lifting, and the sparse Hensel gcd route (see
 "Routes not specified here").
 
+Also not in scope: the univariate integer case, which is
+[hex-poly-z-gcd](hex-poly-z-gcd.md). That library computes gcds of
+`ZPoly` for the consumers that hold `DensePoly Int` and would otherwise
+convert, its certificate is the arity-one specialisation of the one
+below with an unconditional soundness theorem (the content recursion
+bottoms out in `Int.gcd`, so `LawfulContent` does not arise), and this
+library should call it for the base case of its recursion in the main
+variable rather than reimplement it.
+
 The coefficient rings that matter are `Int`, `Rat`, `ZMod64 p`, and
 `FpPoly p`. The algorithms are written against a coefficient interface
 rather than against those four, because the recursive `GcdOps` instance
@@ -446,8 +455,8 @@ whole point of the certificate is to carry the second witness.
 
 [future-work](../future-work.md) said of the modular gcd for `ℤ[x]` that
 the certificate carries cofactors "together with a Bézout witness that
-`f'` and `h'` are coprime". That witness does not exist, in one variable
-or in several. `ℤ[x]` is not a Bézout domain: `x` and `2` are coprime
+`f'` and `h'` are coprime", and now records the correction instead. That
+witness does not exist, in one variable or in several. `ℤ[x]` is not a Bézout domain: `x` and `2` are coprime
 and `u · x + v · 2 = 1` has no solution in `ℤ[x]`. The same holds in
 `R[x₁, …, xₙ]` over any base that is not a field, and over a field as
 soon as `n ≥ 2` (`x₁` and `x₂` are coprime with no Bézout identity).

--- a/SPEC/Libraries/hex-mv-gcd.md
+++ b/SPEC/Libraries/hex-mv-gcd.md
@@ -1394,7 +1394,7 @@ HexMvGcdMathlib.lean
 
 ```yaml
   HexMvGcd:
-    deps: [HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith]
+    deps: [HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith, HexPolyZGcd]
     mathlib: false
     done_through: 0
     status: draft
@@ -1405,7 +1405,9 @@ HexMvGcdMathlib.lean
     status: draft
 ```
 
-`HexPolyFp` and `HexModArith` are for the univariate images over `F_p`.
+`HexPolyZGcd` is the arity-one case, called rather than reimplemented;
+see "Scope". `HexPolyFp` and `HexModArith` are for the univariate images
+over `F_p`.
 `HexResultant` is for route 5 and for the `ExactDivLaws` interface.
 `HexArith` is for the integer gcd and the extended Euclidean algorithm.
 `HexPoly` comes in through `DensePoly`, which `coeffsIn` returns.

--- a/SPEC/Libraries/hex-poly-z-gcd.md
+++ b/SPEC/Libraries/hex-poly-z-gcd.md
@@ -1,0 +1,706 @@
+# hex-poly-z-gcd (modular gcd for `ℤ[x]`, with cofactors and a coprimality witness)
+
+Greatest common divisors of integer polynomials, with cofactors, a
+checked coprimality witness, exact division, and the modular algorithms
+that make them fast. Mathlib-free. The companion
+`hex-poly-z-gcd-mathlib` identifies the results with divisibility in
+`Polynomial ℤ` and supplies the decidability instances.
+
+This SPEC expands the "Modular gcd for `ℤ[x]`" bullet of the "Modular
+techniques" entry in [future-work](../future-work.md). It uses the
+reconstruction operations of [hex-modular](hex-modular.md), and it is the
+one-variable case of [hex-mv-gcd](hex-mv-gcd.md), which is written
+against a different polynomial representation and should call this
+library rather than reimplement it. The relationship is set out under
+"Why this is not hex-mv-gcd at arity one".
+
+The future-work bullet says the certificate carries "a Bézout witness
+that `f'` and `h'` are coprime". No such witness exists: `ℤ[x]` is not a
+Bézout domain, since `x` and `2` are coprime and `u·x + v·2 = 1` has no
+solution there. [hex-mv-gcd](hex-mv-gcd.md) already records the
+correction for the multivariate case. The univariate replacement is
+smaller and better than the multivariate one, and it is specified below
+under "The certificate".
+
+## Why this library exists
+
+**The tree has no integer polynomial gcd.** What it has is a gcd over a
+field: `HexPolyZ.primitiveSquareFreeDecomposition` maps its input into
+`DensePoly Rat` with `toRatPoly`, calls `DensePoly.gcd`, and maps the
+result back with `ratPolyPrimitivePart`. That is correct and it is the
+algorithm every textbook opens by warning against, because the Euclidean
+remainder sequence over `ℚ` produces intermediate rationals whose
+numerators and denominators grow exponentially in the degree even when
+the input and the answer are small.
+
+**Squarefree decomposition over `ℤ` is the first consumer and the
+baseline to beat.** `primitiveSquareFreeDecomposition` is on the
+Berlekamp-Zassenhaus path, so its cost is paid by every integer
+factorisation, and the benchmark family below measures the new gcd
+against exactly that route.
+
+**Berlekamp-Zassenhaus wants it in two more places.** Prime selection
+tests whether the image is squarefree, which is a gcd over `F_p` and is
+already fast, and the recombination phase divides candidate products into
+the input, which is exact division over `ℤ[x]` and belongs here beside
+the gcd rather than being reinvented per consumer.
+
+**hex-number-field and hex-resultant want it.** Trager's algorithm
+computes gcds of polynomials over a number field by norms and gcds over
+`ℚ`, and every gcd it takes is a gcd of integer polynomials after
+clearing denominators. The subresultant chain in hex-resultant produces a
+last nonzero entry whose primitive part is the gcd, which is the fallback
+route below and is much slower than the modular one.
+
+**Rational function simplification wants the cofactors.** `cancel`, the
+second piece of the `Together` and `Apart` item in
+[future-work](../future-work.md), reduces `p/q` to lowest terms. In one
+variable over `ℚ` that is this library plus clearing denominators, and it
+is reachable long before the multivariate machinery lands.
+
+## Why this is not hex-mv-gcd at arity one
+
+[hex-mv-gcd](hex-mv-gcd.md) computes gcds of `MvPoly n R cmp`, and at
+`n = 1` the mathematics is the same. Three things make a separate library
+right anyway.
+
+**The representation is different, and the consumers are on this side of
+it.** Berlekamp-Zassenhaus, hex-poly-z, hex-number-field, and
+hex-resultant all hold `ZPoly = DensePoly Int`. Routing them through
+`MvPoly 1 Int cmp` would mean a conversion per call, a comparator
+argument they have no opinion about, and a dependency on hex-mv-poly,
+which is a large new representation whose SPEC is still a draft.
+
+**The algorithm is simpler by a whole layer.** Brown's algorithm has two
+nested reconstruction schemes: primes with Chinese remaindering for the
+coefficients, and evaluation points with interpolation for the variables.
+In one variable the second layer is empty. There are no evaluation
+points, no bad points, no unlucky points, no leading-coefficient
+correction per point, and no interpolation. What remains is a loop over
+primes.
+
+**The soundness theorem is unconditional here and conditional there.**
+[hex-mv-gcd](hex-mv-gcd.md) states `checkCoprime_sound` under a
+`LawfulContent` hypothesis, because its certificate recursion finishes
+with "so `d` divides both contents", and the universal property of the
+multivariate content is the multivariate gcd's own maximality one
+variable down. In one variable the content is an integer and the
+corresponding fact is `Int.dvd_gcd`, which hex-arith has. So the
+circularity that forces the multivariate statement into the companion
+does not arise, and this library's checker is unconditionally sound.
+
+The right relationship is that hex-mv-gcd depends on this library and
+calls it for its arity-one case, which is also its recursion's base case
+in the main variable.
+
+## Scope
+
+In scope: gcd with cofactors, gcd of a list, lcm, exact division and its
+`Option` form, divisibility, coprimality testing with a witness, and the
+`DensePoly Rat` wrapper that clears denominators and calls the integer
+routine.
+
+Not in scope: squarefree decomposition, which stays in hex-poly-z and
+becomes faster by calling this library; factorisation, which is
+hex-berlekamp-zassenhaus; resultants, which are hex-resultant; and
+anything multivariate.
+
+## Exact division
+
+Every check here runs an exact division, so it is specified before the
+gcd.
+
+```lean
+namespace Hex.ZPoly
+
+/-- The exact quotient `f / g`, or `none` when `g = 0` or `g ∤ f`. -/
+def divExact? (f g : ZPoly) : Option ZPoly
+
+instance : Dvd ZPoly
+instance (f g : ZPoly) : Decidable (g ∣ f)
+
+theorem divExact?_zero_right : divExact? f 0 = none
+theorem divExact?_eq (hg : g ≠ 0) : divExact? f g = some q ↔ f = q * g
+theorem divExact?_isSome_of_dvd (hg : g ≠ 0) : g ∣ f → (divExact? f g).isSome
+```
+
+The `g ≠ 0` hypothesis on `divExact?_eq` is not decoration: at `f = 0`
+and `g = 0` the right-hand side holds for every `q`, and a deterministic
+`Option` returns at most one, so the unconditional biconditional is
+false. This is the same statement [hex-mv-gcd](hex-mv-gcd.md) makes about
+its own `divExact?`, and the two should be provable by the same argument
+in different representations.
+
+`divExact?` fails as soon as a leading coefficient fails to divide,
+rather than dividing to completion and testing the remainder. Trial
+division dominates the running time of a modular gcd whenever the gcd is
+large, so the cheap rejections matter: the degree comparison, the
+divisibility of the leading coefficients, the divisibility of the
+contents, and the divisibility of the values at one small integer each
+reject without allocating a quotient.
+
+## The certificate
+
+The design is one verified checker and several unverified candidate
+producers, following design principle 4. Every prime choice, evaluation
+point, and retry budget below is outside the proof.
+
+### What "greatest" needs
+
+`f = g·f'` and `h = g·h'` are two exact divisions, and they establish
+`g ∣ f` and `g ∣ h` and nothing more. Any common divisor satisfies them,
+`1` included. The second witness the certificate must carry is that the
+cofactors `f'` and `h'` have no nonunit common divisor.
+
+### The witness
+
+Fix a prime `p` with `p ∤ lc f'` and `p ∤ lc h'`. Reduce both cofactors
+into `FpPoly p` and exhibit `α, β` with `α · f'ₚ + β · h'ₚ = 1`. Then
+exhibit that the integer contents of `f'` and `h'` are coprime.
+
+```lean
+structure GcdCert where
+  gcd  : ZPoly
+  cofL : ZPoly
+  cofR : ZPoly
+  prime : Hex.Modular.PrimeModulus
+  alpha : FpPoly prime.m
+  beta  : FpPoly prime.m
+
+def checkGcd (f h : ZPoly) (c : GcdCert) : Bool
+
+theorem checkGcd_sound (hc : checkGcd f h c = true) :
+    f = c.gcd * c.cofL ∧ h = c.gcd * c.cofR ∧
+      ∀ d : ZPoly, d ∣ c.cofL → d ∣ c.cofR → IsUnit d
+```
+
+`checkGcd` verifies, cheapest first: that `c.gcd * c.cofL = f` and
+`c.gcd * c.cofR = h`; that `c.gcd` is normalised (positive leading
+coefficient, positive content); that `Int.gcd (content cofL)
+(content cofR) = 1`; that reduction modulo `p` preserves both cofactor
+degrees; and that `alpha * cofLₚ + beta * cofRₚ = 1` in `FpPoly p`.
+
+The soundness argument, in full, because it is short and because it is
+the whole content of the design. Let `d` divide both cofactors, say
+`f' = d·e`. Reduction modulo `p` is a ring homomorphism, so
+`f'ₚ = dₚ · eₚ`. `F_p` is a field, so degrees add in `FpPoly p`, and
+degrees add in `ℤ[x]` because `ℤ` is a domain, so
+
+```
+deg f' = deg f'ₚ = deg dₚ + deg eₚ ≤ deg d + deg e = deg f',
+```
+
+using the checked degree preservation on the left. So every inequality is
+an equality and `deg dₚ = deg d`. Now `dₚ` divides
+`α·f'ₚ + β·h'ₚ = 1`, so `dₚ` is a unit and `deg d = 0`. So `d` is an
+integer, dividing both contents, which are coprime, so `d = ±1`.
+
+The argument uses `F_p[x]` being a domain, which is where primality
+enters, and it uses `Int.dvd_gcd`, which hex-arith has. There is no
+hypothesis and no companion obligation.
+
+**The prime should be the smallest usable one.**
+[hex-modular](hex-modular.md) measures the cost of a kernel-replayed
+primality proof: 0.04 s at 16 bits and 6.2 s at 31 bits. A certificate
+replayed by `decide +kernel` pays that, and this certificate names a
+prime, so the producer tries small primes first. Any prime not dividing
+either leading coefficient works, so a small one almost always exists,
+and when it does not the certificate is still valid and merely more
+expensive to replay.
+
+The rule is a consequence of trial division rather than of the
+certificate design. The "Better primality" item in
+[future-work](../future-work.md) points at Pocklington certificates,
+whose checker is a handful of modular exponentiations, and once one
+exists a certificate field replaces the `Hex.Nat.Prime` field here and
+the size preference goes away. The
+`GcdCert` field is written as `Hex.Modular.PrimeModulus` so that the
+change is confined to how that structure carries its evidence.
+
+### What the checker establishes and what it does not
+
+```lean
+/-- The cofactor identities together with coprimality of the cofactors. -/
+def CoprimeCofactors (f h g : ZPoly) : Prop :=
+  ∃ f' h', f = g * f' ∧ h = g * h' ∧ ∀ d, d ∣ f' → d ∣ h' → IsUnit d
+```
+
+`CoprimeCofactors f h g` is not literally "`g` is a greatest common
+divisor". Getting from one to the other means showing that a common
+divisor `d` of `f` and `h` divides `g`, which is a statement about
+`ℤ[x]` being a gcd domain.
+
+**Unlike the multivariate case, that step is within reach
+Mathlib-free.** The ingredients are all present: Gauss's lemma is
+`DensePoly.content_mul` (`HexPoly/Euclid.lean:675`, with the `ZPoly`
+wrapper in `HexPolyZ/Core.lean:908`), already Mathlib-free; the Euclidean
+gcd over `DensePoly Rat` with `gcd_dvd_left`, `gcd_dvd_right`, and
+`dvd_gcd` is in `HexPoly/Euclid/DivGcd.lean`; and the passage between
+them is `content_mul_primitivePart` and `ratPolyPrimitivePart`. The
+argument is that a common divisor, made primitive, divides the rational
+gcd, which is associate to `g` because the cofactors stay coprime over
+`ℚ[x]`, and Gauss's lemma brings the divisibility back to `ℤ[x]`.
+
+```lean
+theorem dvd_gcd_of_coprimeCofactors (hc : CoprimeCofactors f h g)
+    (d : ZPoly) (hf : d ∣ f) (hh : d ∣ h) : d ∣ g
+```
+
+This SPEC schedules that theorem in milestone 3 rather than deferring it
+to the companion, and records it as the point where this library is
+genuinely better off than [hex-mv-gcd](hex-mv-gcd.md). If the proof turns
+out to be larger than it looks, the fallback is the multivariate
+resolution (state it in the companion from
+`UniqueFactorizationMonoid`), and the cost of that fallback is that
+Mathlib-free consumers get cofactors without maximality.
+
+## The gcd API
+
+```lean
+def gcdCert (f h : ZPoly) : GcdCert
+def gcd (f h : ZPoly) : ZPoly := (gcdCert f h).gcd
+def cofactors (f h : ZPoly) : ZPoly × ZPoly
+def isCoprime (f h : ZPoly) : Bool
+def gcdList (fs : List ZPoly) : ZPoly
+def lcm (f h : ZPoly) : ZPoly
+
+/-- The gcd of two rational polynomials, monic, computed by clearing
+denominators and calling `gcd`. -/
+def ratGcd (f h : DensePoly Rat) : DensePoly Rat
+```
+
+Contracts on the degenerate inputs: `gcd 0 0 = 0`, `gcd f 0 = normalize f`,
+`gcd f h = 1` when either side is a nonzero constant, `gcdList [] = 0`,
+and `lcm f 0 = 0`. Each has a matching certificate case: a unit or zero
+input is accepted through a `GcdCert` whose Bézout pair is over the
+constants.
+
+`normalize f` makes the content positive and the leading coefficient
+positive. Over `ℤ` the two conditions are the same condition, since the
+content is positive by definition and the sign lives in the primitive
+part, so `normalizePrimitiveSign` in hex-poly-z is the existing function
+and should be reused rather than duplicated.
+
+`ratGcd` returns the monic associate, which is the convention every
+consumer of a gcd over a field expects, and it is what
+`primitiveSquareFreeDecomposition` would call.
+
+## The algorithms
+
+Every route produces a candidate `GcdCert` and `gcdCert` accepts it only
+through `checkGcd`. A rejected candidate falls through to the next route.
+Only the last route's success has to be proved.
+
+**One statement to keep straight.** Trial division shows a candidate is
+*a* common divisor. It does not show it is the greatest: `1` divides both
+inputs. Every stopping rule below is "stop when `checkGcd` accepts",
+never "stop when the candidate divides both inputs". In the modular
+routes the coprimality half is nearly free, because the image gcd the
+route already computed is what produces the Bézout pair.
+
+### 0. Structural reductions, always applied
+
+Zero and constant inputs return immediately. Then, in order: split off the
+power of `x` dividing both and put it into the answer; split off the
+integer content of each input and put `Int.gcd` of the two into the
+answer; and compare degrees, since the gcd's degree is at most the
+smaller of them. Each is linear in the coefficient count.
+
+### 1. Coprime detection
+
+Reduce both primitive parts modulo one small prime that divides neither
+leading coefficient and compute the gcd in `FpPoly p`. A result of `1`
+is conclusive and produces the certificate directly: the image Bézout
+pair is what `xgcd` in `FpPoly p` already returns. A result other than
+`1` proves nothing, because the prime may be unlucky, and the route falls
+through.
+
+The asymmetry is the point. The cheap test is conclusive in the case that
+occurs most often, and `cancel` is dominated by it. The requirement this
+places on the implementation is that `gcd f h` must not run a
+reconstruction when the inputs are coprime, and the benchmark family
+"coprime pairs" checks it.
+
+### 2. The heuristic gcd
+
+Evaluate both inputs at a single large integer `ξ`, take `Int.gcd` of the
+two values, and reconstruct a polynomial from the symmetric `ξ`-adic
+digits. In one variable the Kronecker substitution the multivariate
+version needs is just this evaluation, so the route is a few lines.
+
+Two things are worth stating because the multivariate version of this
+SPEC got them wrong first. Reconstruction being exact does not follow
+from the input coefficient sizes: the integer gcd can carry accidental
+common factors contributed by the evaluated cofactors, so `ξ` chosen from
+the coefficient norms is a heuristic for the success rate and proves
+nothing. And the retry budget must be projected bit size rather than a
+fixed count, since each retry raises `ξ` and the evaluated integers grow
+with it. Char, Geddes, and Gonnet introduced the algorithm (GCDHEU);
+Parisse, ["A correct proof of the heuristic GCD
+algorithm"](https://arxiv.org/abs/cs/0206032), is the correction worth
+reading before implementing.
+
+### 3. Brown's modular algorithm
+
+This is the route the library exists for, and in one variable it is a
+single loop.
+
+Let `γ = Int.gcd (lc f) (lc h)`, an integer that the true gcd's leading
+coefficient divides. For each prime `p` in turn:
+
+- Reject `p` if it divides `γ`, or if it divides either leading
+  coefficient. These are the **bad** primes, and rejecting them is what
+  makes the image degrees meaningful.
+- Compute `gₚ = gcd(fₚ, hₚ)` in `FpPoly p`, monic.
+- **Scale by `γ`.** The image gcd is monic and the true gcd is not, so
+  the image is multiplied by `γ mod p` before it is folded in.
+  Reconstructing unscaled images gives a polynomial that is not the gcd
+  and whose trial division fails, which is a slow way to discover the
+  bug.
+- **Compare degrees.** A prime whose image gcd has larger degree than the
+  running minimum is **unlucky**: discard it and continue. A prime whose
+  image gcd has smaller degree makes every earlier image unlucky: discard
+  the accumulated state and restart from this prime. Both cases occur,
+  and the second is the one an implementation forgets.
+- Fold the coefficient vector into a `CrtVec` from
+  [hex-modular](hex-modular.md).
+- Take the primitive part of the symmetric reconstruction, multiply back
+  the content gcd from route 0, and offer the result to `checkGcd`.
+  Accept on success.
+
+Brown, "On Euclid's algorithm and the computation of polynomial greatest
+common divisors" (JACM 18, 1971), is the reference.
+
+**On the coefficient bound.** No bound is needed for soundness, and none
+is needed for the dispatch to be total, because `checkGcd` decides and
+route 4 is the fallback. A bound is what proves this route eventually
+succeeds, and there is one: the gcd divides `f`, so the Landau-Mignotte
+bound applies to it, scaled by `γ / lc(gcd)`. hex-poly-z already computes
+it as `mignotteCoeffBound`, with the analytic half discharged in
+hex-poly-z-mathlib, so the termination argument is a hypothesis this tree
+already carries rather than a new one. The bound is used only to size the
+fuel, and the loop offers the candidate to `checkGcd` at every step, so
+in practice it stops enormously earlier.
+
+### 4. The subresultant fallback
+
+Run hex-resultant's `subresultantChain` over `Int` unchanged, take the
+primitive part of the terminal nonzero entry, and multiply by the content
+gcd. This is deterministic, needs no prime, and is what makes `gcdCert` a
+total function with a proved postcondition:
+
+```lean
+theorem gcdCert_checks (f h : ZPoly) : checkGcd f h (gcdCert f h) = true
+```
+
+The proof obligation is concentrated: `checkGcd_sound` (short, and given
+above) plus completeness of route 4, which is the standard subresultant
+argument.
+
+**This route is a scheduling dependency, not a mathematical one.**
+hex-resultant is at `done_through: 1`, and its correctness theorems
+additionally require `Lean.Grind.CommRing` on the coefficient type, which
+`Int` has, and `ExactDivLaws Int`, which `HexResultant/ExactDiv.lean`
+supplies as `instExactDivLawsInt`. So the executable chain runs today and
+its theorems apply, and what is missing is the phases of hex-resultant
+rather than anything about this library. Milestone 2 below is written so
+that a working `gcd` exists before that dependency matters, by using the
+`DensePoly Rat` Euclidean route as the initial fallback and swapping in
+the subresultant chain when it is ready.
+
+## Complexity
+
+`f` and `h` of degree at most `n` with coefficients of at most `b` bits,
+a gcd of degree `k`, moduli of `w = 31` bits, and a Landau-Mignotte bound
+of `B` bits (with `B = O(n + b)`).
+
+These are **probe counts** where a probe is an image gcd, an
+evaluation, or a trial division, not machine operations.
+
+| operation | algorithm | probes |
+|---|---|---|
+| `divExact?` | leading-coefficient cancellation, early failure | `O((n-k)·k)` integer ops |
+| `isCoprime` | one image gcd | 1 image gcd |
+| heuristic | one evaluation and one `Int.gcd` at `O(n·(b + log ξ))` bits | 1 integer gcd |
+| Brown | one image gcd per prime, plus one trial division per candidate | `O(B/w)` image gcds |
+| subresultant | the chain over `Int` | `O(n)` pseudo-divisions, coefficients to `O(n·b)` bits |
+| rational Euclid (today's route) | Euclid over `ℚ` | `O(n)` divisions, coefficients growing exponentially |
+
+The last two rows are the comparison, and the last row is what the
+library replaces. An image gcd is `O(n²)` word operations, so Brown costs
+`O(n²·B/w)` word operations against the subresultant chain's `O(n²)`
+integer operations on numbers of `O(n·b)` bits, which is a factor of `n`
+in the bit complexity, and against the rational Euclid route's
+unbounded coefficient growth.
+
+## Kernel exposure
+
+The kernel replay closure is `checkGcd` and what it calls: `DensePoly`
+multiplication and equality over `Int`, `content`, `Int.gcd`, reduction
+into `FpPoly p`, and `FpPoly` multiplication, addition, and equality,
+together with the primality proof for the certificate's prime. Each is
+`@[expose]`, and a downstream module carries a `decide +kernel` test that
+fails if any of them stops reducing.
+
+Nothing in routes 1 through 4 is in that closure. The prime search, the
+Chinese remaindering, the interpolation-free reconstruction, and the
+subresultant chain are search, they never appear in a proof term, and
+they should not pay for exposure.
+
+The primality proof is the one expensive element, and the size table in
+[hex-modular](hex-modular.md) is why the producer prefers a small prime.
+A certificate over a 16-bit prime replays in about a fortieth of a second
+and one over a 31-bit prime in about six seconds, for a witness that is
+equally valid either way.
+
+## Conformance
+
+Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+`conformance/HexPolyZGcd/EmitFixtures.lean` exposed as
+`lean_exe hexpolyzgcd_emit_fixtures`, a committed snapshot at
+`conformance-fixtures/HexPolyZGcd/zgcd.jsonl`, and an oracle driver at
+`scripts/oracle/zgcd_sympy.py`. One tuple appended to `ORACLES` in
+`scripts/ci/run_oracles.sh`:
+
+```
+"HexPolyZGcd|hexpolyzgcd_emit_fixtures|scripts/oracle/zgcd_sympy.py|conformance-fixtures/HexPolyZGcd/zgcd.jsonl"
+```
+
+SymPy's `gcd` and `cofactors` over `ZZ` and `QQ` cover the whole surface
+and fix the same normalisation convention (positive leading coefficient
+over `ℤ`, monic over `ℚ`), so the fixture compares values directly.
+python-flint's `fmpz_poly.gcd` is a performance comparator rather than
+the oracle, because it does not expose cofactors.
+
+**An end-to-end fixture cannot tell which route ran.** Every candidate
+goes through `checkGcd`, and a rejection falls through to a route that
+returns the right answer, so the oracle suite passes even if the leading
+coefficient scaling is inverted, the unlucky-prime restart never fires,
+and the heuristic route is broken. The suite therefore has two halves,
+and the route-level half is worth more.
+
+**Route-level tests**, in Lean, invoking each producer directly: that the
+candidate it produced was accepted; that the intended route succeeded
+before the fallback ran; that a constructed bad prime was rejected; that
+a constructed unlucky prime was discarded; and that the accumulated state
+was restarted when a smaller image degree appeared. Constructing an
+unlucky prime is done by making the resultant of the cofactors divisible
+by it, and the fixture carries that construction rather than a random
+search for one.
+
+**Oracle fixtures**, checking public answers. Cases that must be present:
+
+- `gcd 0 0`, `gcd f 0`, `gcd f 1`, gcds of constants, and `gcd f f`.
+- Coprime pairs at several degrees, checking the answer is `1` and the
+  cofactors are the inputs.
+- A gcd that is a pure power of `x`, so route 0 carries the answer.
+- A gcd that is a constant, so the content recursion carries it.
+- Inputs whose gcd has a leading coefficient that is not `±1`, which is
+  what the `γ` scaling exists for.
+- Inputs where a small prime divides a leading coefficient, and inputs
+  with an unlucky prime among the first few tried.
+- Inputs with large coefficients and a small gcd, where the
+  Landau-Mignotte bound is enormously pessimistic and early acceptance is
+  what makes the route fast.
+- Swell cases: small inputs whose subresultant remainder sequence has
+  large coefficients, and the same inputs over `ℚ` where the rational
+  Euclid route is worst.
+- Content cases over `ℤ`: `2x` and `4x`, `12x` and `18x`, `6` and `4`,
+  where the answer is an integer times a polynomial and the normalisation
+  convention is visible.
+- Cyclotomic and near-cyclotomic pairs, which are the sparse inputs with
+  small coefficients where the heuristic route should win.
+- `ratGcd` on inputs with large denominators, checking the clearing step
+  happens and the result is monic.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+`bench/HexPolyZGcd/Bench.lean`. Native and kernel: the kernel suite
+measures `checkGcd` replay at a small prime, since that is what a
+downstream certificate consumer pays.
+
+Families:
+
+- **Coprime pairs**, degrees 8 to 512. Decides whether route 1 works. The
+  required property is that the time is a small multiple of the time to
+  reduce the inputs modulo one prime. A regression means a reconstruction
+  is running when it should not.
+- **Dense gcds**, degrees 16 to 512 with a gcd of about half the degree,
+  coefficients of 8 and 256 bits.
+- **Swell cases**, small degree with a subresultant sequence whose
+  coefficients explode. Route 4, and the argument for having the others.
+- **Squarefree decomposition**, the existing
+  `primitiveSquareFreeDecomposition` inputs, measured through the old
+  rational route and the new integer gcd. This family is the reason the
+  library exists and it should show the largest improvement.
+- **Rational coefficients**, the same inputs over `ℚ` through `ratGcd`.
+
+**Comparators.** FLINT's `fmpz_poly_gcd` is `gating`. FLINT dispatches
+among a heuristic route, a modular route, and a subresultant fallback,
+which is the same set of routes this SPEC specifies, so the comparison is
+like-for-like and there is no structural reason for an exemption. The
+threshold, written down in advance: within `5x` of FLINT on the dense and
+coprime families at every rung above degree 32. Two required internal
+checks, which matter more than the external one:
+
+- `gcd` must be faster than the existing `DensePoly Rat` Euclidean route
+  on every family except degree-2 inputs, and faster by at least `10x` on
+  the swell family.
+- `primitiveSquareFreeDecomposition` rewritten to call this library must
+  be faster than its current form on the Berlekamp-Zassenhaus input
+  ladder.
+
+SymPy is the oracle and is not a performance comparator.
+
+## The Mathlib layer
+
+`hex-poly-z-gcd-mathlib` transports the results onto `Polynomial ℤ`.
+Writing `e` for hex-poly-mathlib's `DensePoly Int ≃+* Polynomial ℤ`:
+
+```lean
+theorem gcd_dvd_left  : e (gcd f h) ∣ e f
+theorem gcd_dvd_right : e (gcd f h) ∣ e h
+theorem dvd_gcd (d) : d ∣ e f → d ∣ e h → d ∣ e (gcd f h)
+
+theorem coprimeCofactors_greatest (hc : CoprimeCofactors f h g) (d) :
+    d ∣ e f → d ∣ e h → d ∣ e g
+
+theorem divExact?_eq_dvd : (divExact? f g).isSome = true ↔ e g ∣ e f
+
+instance : Decidable (a ∣ b)          -- Polynomial ℤ
+instance : DecidableEq (Polynomial ℤ) -- through the equivalence, for the above
+```
+
+If `dvd_gcd_of_coprimeCofactors` lands Mathlib-free as milestone 3
+schedules, `dvd_gcd` here is a transport rather than a proof, and
+`coprimeCofactors_greatest` is its restatement. If it does not, this is
+where it is proved, from `UniqueFactorizationMonoid (Polynomial ℤ)`,
+and the Mathlib-free layer keeps the weaker `CoprimeCofactors`
+conclusion. Either way the companion's statements are the same, which is
+why the decision can be deferred without changing any signature.
+
+Mathlib has no `NormalizedGCDMonoid (Polynomial ℤ)` instance in the
+elaborator's path, so the statements above are in terms of divisibility
+rather than an equation between named gcds, and an `Associated` version
+is derived where a caller has such an instance in scope. This matches
+what [hex-mv-gcd](hex-mv-gcd.md) does for the multivariate case, and for
+the same reason.
+
+Following the project split, no theorem about `ZPoly` belongs in the
+companion beyond these and one correspondence lemma per public operation.
+
+## Milestones
+
+1. **Exact division and the certificate.** `divExact?` with its
+   theorems, the `Dvd` and `Decidable` instances, `GcdCert`, `checkGcd`,
+   and `checkGcd_sound`. Nothing computes a gcd yet, and the hardest
+   proof in the library is already done.
+
+2. **A correct gcd.** Route 0, route 1, and a fallback, with
+   `gcdCert_checks`. The fallback is the `DensePoly Rat` Euclidean route
+   initially, so this milestone does not wait on hex-resultant. At the
+   end of it the library is usable and slow on the hard cases.
+
+3. **Maximality.** `dvd_gcd_of_coprimeCofactors`, through Gauss's lemma
+   and the rational gcd. This is the milestone that decides whether the
+   companion proves maximality or restates it.
+
+4. **Brown.** Route 3, with the `γ` scaling and the bad and unlucky prime
+   handling. The route-level tests for those traps are written before the
+   code.
+
+5. **The heuristic and the subresultant fallback.** Route 2, and route 4
+   replacing the rational fallback once hex-resultant is far enough
+   along.
+
+6. **The companion**, and the rewrite of
+   `primitiveSquareFreeDecomposition` in hex-poly-z to call `gcd`. The
+   rewrite is the benchmark that justifies the library, so it is a
+   milestone rather than a follow-up.
+
+## File organisation
+
+```
+HexPolyZGcd/
+  Divide.lean       -- divExact?, Dvd, Decidable, the prefilters
+  Cert.lean         -- GcdCert, checkGcd, checkGcd_sound
+  Fast.lean         -- routes 0 and 1, isCoprime
+  Heu.lean          -- route 2 and its bit budget
+  Brown.lean        -- route 3
+  Prs.lean          -- route 4
+  Gcd.lean          -- the dispatch, gcd, cofactors, gcdList, lcm, ratGcd
+  Maximal.lean      -- dvd_gcd_of_coprimeCofactors
+HexPolyZGcd.lean
+HexPolyZGcdMathlib/
+  Gcd.lean          -- divisibility, maximality, the Associated statements
+  Decide.lean       -- Decidable (a ∣ b)
+HexPolyZGcdMathlib.lean
+```
+
+`libraries.yml` gains:
+
+```yaml
+  HexPolyZGcd:
+    deps: [HexPolyZ, HexPolyFp, HexPoly, HexModular, HexModArith, HexArith, HexResultant]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_poly_gcd via python-flint
+          class: gating
+          goal: within 5x on the dense and coprime families above degree 32
+      input_families:
+        - name: coprime-pairs
+          description: coprime inputs at degrees 8 to 512, where route 1 must settle it
+        - name: dense-gcds
+          description: gcds of about half the input degree at 8 and 256 bit coefficients
+        - name: swell
+          description: small inputs whose subresultant sequence has large coefficients
+        - name: squarefree
+          description: the Berlekamp-Zassenhaus squarefree decomposition ladder
+        - name: rational
+          description: the same inputs over the rationals through ratGcd
+  HexPolyZGcdMathlib:
+    deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib, HexModArithMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned
+```
+
+`HexResultant` is a dependency for route 4 only, and it is the one
+dependency at `done_through: 1`. Milestone 2 is arranged so that nothing
+before milestone 5 needs it.
+
+## Open questions
+
+- **Whether `primitiveSquareFreeDecomposition` should move here.** It is
+  hex-poly-z's function today, its only nontrivial dependency after this
+  library exists is the gcd, and Yun's algorithm over `ℤ` is a natural
+  neighbour of the gcd. Against moving it: it is on the
+  Berlekamp-Zassenhaus path and moving a function that far down the
+  dependency graph is disruptive. This SPEC keeps it where it is and
+  rewrites its body, and the question should be revisited if a second
+  squarefree consumer appears.
+- **Whether the certificate should carry the prime's primality proof or
+  recompute it.** Carrying it makes the certificate self-contained and
+  makes its size depend on the proof term. Recomputing it makes the
+  checker run `isPrimeTrial`, priced in the table in
+  [hex-modular](hex-modular.md). The measurement that settles this is
+  the kernel bench family.
+- **Whether to use a prime power rather than several primes.** Lifting a
+  single image modulo `p^k` by Hensel's lemma is an alternative to
+  Chinese remaindering across primes, and hex-hensel already implements
+  the lifting. It replaces one image gcd per prime by one image gcd plus
+  `k` lifting steps, and whether that wins depends on the degree and the
+  coefficient size. Both are unverified producers, so either may be
+  adopted without touching the checker.
+- **Whether `isCoprime` should return the witness.** `cancel` wants to
+  know only whether the gcd is `1`, and a caller that later needs the
+  Bézout pair over `F_p` currently recomputes it. Returning
+  `Option GcdCert` costs nothing and complicates the common call site.
+- **The crossover between routes 2 and 3.** The heuristic route wins on
+  sparse inputs with small coefficients and loses badly as the degree
+  grows. The dispatch tries route 2 first below a degree threshold, and
+  this SPEC does not guess the number.

--- a/SPEC/Libraries/hex-poly-z-gcd.md
+++ b/SPEC/Libraries/hex-poly-z-gcd.md
@@ -37,7 +37,10 @@ the input and the answer are small.
 baseline to beat.** `primitiveSquareFreeDecomposition` is on the
 Berlekamp-Zassenhaus path, so its cost is paid by every integer
 factorisation, and the benchmark family below measures the new gcd
-against exactly that route.
+against exactly that route. The faster version is `ZPoly.sqfDecomp` in
+**this** library rather than a rewrite of hex-poly-z's, because this
+library depends on hex-poly-z and the reverse call would be a cycle. The
+existing implementation stays as the reference and the baseline.
 
 **Berlekamp-Zassenhaus wants it in two more places.** Prime selection
 tests whether the image is squarefree, which is a gcd over `F_p` and is
@@ -100,8 +103,11 @@ In scope: gcd with cofactors, gcd of a list, lcm, exact division and its
 `DensePoly Rat` wrapper that clears denominators and calls the integer
 routine.
 
-Not in scope: squarefree decomposition, which stays in hex-poly-z and
-becomes faster by calling this library; factorisation, which is
+In scope but only just: `ZPoly.sqfDecomp`, Yun's algorithm over `ℤ`
+driven by this library's gcd. It is here rather than in hex-poly-z
+because the dependency runs that way. Not in scope: the rest of
+hex-poly-z's squarefree surface, which stays where it is; factorisation,
+which is
 hex-berlekamp-zassenhaus; resultants, which are hex-resultant; and
 anything multivariate.
 
@@ -116,13 +122,27 @@ namespace Hex.ZPoly
 /-- The exact quotient `f / g`, or `none` when `g = 0` or `g ∤ f`. -/
 def divExact? (f g : ZPoly) : Option ZPoly
 
-instance : Dvd ZPoly
 instance (f g : ZPoly) : Decidable (g ∣ f)
 
 theorem divExact?_zero_right : divExact? f 0 = none
 theorem divExact?_eq (hg : g ≠ 0) : divExact? f g = some q ↔ f = q * g
 theorem divExact?_isSome_of_dvd (hg : g ≠ 0) : g ∣ f → (divExact? f g).isSome
 ```
+
+**No new `Dvd` instance.** `Dvd (DensePoly R)` already exists
+(`HexPoly/Euclid/DivGcd.lean:1077`, `∃ r, q = p * r`), so `ZPoly`
+inherits it, and declaring a second one would risk incoherence on the
+type this library's whole checker runs on. What is new is the decision
+procedure.
+
+**And `divExact?` is not new either, quite.**
+`HexBerlekampZassenhaus.exactQuotient?` (`Records.lean:452`) is the same
+function, written for recombination and carrying a unit-candidate
+rejection that recombination needs and this library does not. Two copies
+of exact integer-polynomial division is one too many. The right move is
+to put `divExact?` in **hex-poly-z**, below both consumers, and have
+Berlekamp-Zassenhaus's version become a thin wrapper that adds its unit
+check. That is the first prerequisite below.
 
 The `g ≠ 0` hypothesis on `divExact?_eq` is not decoration: at `f = 0`
 and `g = 0` the right-hand side holds for every `q`, and a deterministic
@@ -159,13 +179,21 @@ into `FpPoly p` and exhibit `α, β` with `α · f'ₚ + β · h'ₚ = 1`. Then
 exhibit that the integer contents of `f'` and `h'` are coprime.
 
 ```lean
+/-- A witness that two primitive-in-the-relevant-sense cofactors have no
+nonunit common divisor. -/
+inductive CoprimeWitness
+  /-- Reduce at `p`, where both cofactor degrees survive, and exhibit a
+  Bézout pair over `F_p[x]`. -/
+  | modular (p : Hex.ZMod64.PrimeModulus) (alpha beta : FpPoly p.m)
+  /-- Exhibit `u · f' + v · h' = C k` with `k ≠ 0` an integer constant.
+  Needs no prime. -/
+  | constant (u v : ZPoly) (k : Int)
+
 structure GcdCert where
   gcd  : ZPoly
   cofL : ZPoly
   cofR : ZPoly
-  prime : Hex.Modular.PrimeModulus
-  alpha : FpPoly prime.m
-  beta  : FpPoly prime.m
+  coprime : CoprimeWitness
 
 def checkGcd (f h : ZPoly) (c : GcdCert) : Bool
 
@@ -199,14 +227,43 @@ The argument uses `F_p[x]` being a domain, which is where primality
 enters, and it uses `Int.dvd_gcd`, which hex-arith has. There is no
 hypothesis and no companion obligation.
 
+**The `constant` case is what makes the certificate complete**, and an
+earlier draft of this SPEC had only the modular one. `ZMod64.Bounds`
+caps a prime at `2^31`, so with `L = lcm(1, …, 2^31 - 1)` the cofactors
+`f' = x` and `h' = x + L` are coprime over `ℤ[x]` while their images
+coincide at every allowed prime. No modular witness exists, so a total
+`gcdCert` satisfying `gcdCert_checks` was impossible as specified.
+
+Its argument is shorter than the modular one. A common divisor `d`
+divides `u · f' + v · h' = C k`, a nonzero constant, so `deg d = 0` and
+`d` is an integer dividing `k`; it also divides both contents, which are
+coprime, so `d = ±1`. The check is one polynomial identity over `ℤ` plus
+`k ≠ 0`.
+
+Such a pair always exists when the cofactors are coprime over `ℚ[x]`:
+the resultant is a nonzero integer in the ideal they generate, and the
+extended subresultant chain produces it with its cofactors. That is why
+route 4 below, the deterministic fallback, can always produce a
+certificate, and it is why `subresultantChainExt` appears in the
+prerequisites. The modular case stays primary because it is far cheaper
+to produce and to check.
+
+**A prime that preserves both degrees is not enough on its own.** Take
+`f' = x`, `h' = x + 2` and `p = 2`: both leading coefficients and both
+degrees survive, and both images are `x`, so no Bézout pair over
+`F_2[x]` exists. A usable prime must also avoid the resultant of the
+cofactors. Operationally the producer does not test that separately: it
+computes the image gcd, and a result other than `1` means "try another
+prime".
+
 **The prime should be the smallest usable one.**
 [hex-modular](hex-modular.md) measures the cost of a kernel-replayed
 primality proof: 0.04 s at 16 bits and 6.2 s at 31 bits. A certificate
-replayed by `decide +kernel` pays that, and this certificate names a
-prime, so the producer tries small primes first. Any prime not dividing
-either leading coefficient works, so a small one almost always exists,
-and when it does not the certificate is still valid and merely more
-expensive to replay.
+replayed by `decide +kernel` pays that, and the `modular` case names a
+prime, so the producer tries small primes first. Most small primes work,
+and when none does the producer moves on rather than escalating: a large
+prime is still valid and merely more expensive to replay, and the
+`constant` case names no prime at all.
 
 The rule is a consequence of trial division rather than of the
 certificate design. The "Better primality" item in
@@ -214,8 +271,9 @@ certificate design. The "Better primality" item in
 whose checker is a handful of modular exponentiations, and once one
 exists a certificate field replaces the `Hex.Nat.Prime` field here and
 the size preference goes away. The
-`GcdCert` field is written as `Hex.Modular.PrimeModulus` so that the
-change is confined to how that structure carries its evidence.
+`modular` case is written against `Hex.ZMod64.PrimeModulus` from
+hex-mod-arith so that the change is confined to how that structure
+carries its evidence.
 
 ### What the checker establishes and what it does not
 
@@ -240,6 +298,14 @@ them is `content_mul_primitivePart` and `ratPolyPrimitivePart`. The
 argument is that a common divisor, made primitive, divides the rational
 gcd, which is associate to `g` because the cofactors stay coprime over
 `ℚ[x]`, and Gauss's lemma brings the divisibility back to `ℤ[x]`.
+
+The last step already exists:
+`HexPolyZ.ZPoly.dvd_of_toRatPoly_dvd_of_primitive`
+(`HexPolyZ/Decomposition.lean:797`) is exactly "a primitive integer
+polynomial dividing `f` over `ℚ[x]` divides it over `ℤ[x]`", proved
+Mathlib-free. So the milestone is assembling three existing pieces
+rather than proving Gauss descent from scratch, which is the reason to
+schedule it here rather than defer it.
 
 ```lean
 theorem dvd_gcd_of_coprimeCofactors (hc : CoprimeCofactors f h g)
@@ -270,10 +336,16 @@ def ratGcd (f h : DensePoly Rat) : DensePoly Rat
 ```
 
 Contracts on the degenerate inputs: `gcd 0 0 = 0`, `gcd f 0 = normalize f`,
-`gcd f h = 1` when either side is a nonzero constant, `gcdList [] = 0`,
-and `lcm f 0 = 0`. Each has a matching certificate case: a unit or zero
-input is accepted through a `GcdCert` whose Bézout pair is over the
-constants.
+`gcd f c = C (Int.gcd c (content f))` for a nonzero constant `c`,
+`gcdList [] = 0`, and `lcm f 0 = 0`. Each has a matching certificate
+case, through the `constant` witness.
+
+The constant contract is the one an earlier draft got wrong, by saying
+the gcd is `1` whenever either side is a nonzero constant. It is not:
+`gcd(2, 2x) = 2`. Only a **unit** constant forces the answer to be `1`,
+and the general constant case is an integer gcd against the other
+input's content, which is also what the content examples in the
+conformance list below expect.
 
 `normalize f` makes the content positive and the leading coefficient
 positive. Over `ℤ` the two conditions are the same condition, since the
@@ -386,8 +458,12 @@ in practice it stops enormously earlier.
 
 Run hex-resultant's `subresultantChain` over `Int` unchanged, take the
 primitive part of the terminal nonzero entry, and multiply by the content
-gcd. This is deterministic, needs no prime, and is what makes `gcdCert` a
-total function with a proved postcondition:
+gcd. The **extended** chain, which tracks the transformation pair through
+the pseudo-scalings, supplies the `constant` witness for the cofactors:
+the resultant of two coprime polynomials is a nonzero integer in the
+ideal they generate, and the extended chain returns it with its
+cofactors. This is deterministic, needs no prime, and is what makes
+`gcdCert` a total function with a proved postcondition:
 
 ```lean
 theorem gcdCert_checks (f h : ZPoly) : checkGcd f h (gcdCert f h) = true
@@ -407,6 +483,39 @@ rather than anything about this library. Milestone 2 below is written so
 that a working `gcd` exists before that dependency matters, by using the
 `DensePoly Rat` Euclidean route as the initial fallback and swapping in
 the subresultant chain when it is ready.
+
+The extended chain is the one genuinely new piece.
+`subresultantAux` keeps only the remainder of each `pseudoDivMod` and
+discards the quotient (`HexResultant/Subresultant.lean:65` and `:92`), so
+accumulating the transformation is a new recurrence with proofs that each
+cofactor numerator is divisible by the Brown scalar it is divided by.
+[hex-mv-gcd](hex-mv-gcd.md) specifies the same addition as
+`subresultantChainExt` for its own `splitBezout` constructor, and it
+should be written once, in hex-resultant, for both.
+
+## Prerequisite changes in other libraries
+
+Three, each with a reason independent of this library, and each shared
+with another planned one.
+
+**`divExact?` belongs in hex-poly-z.** Exact division of integer
+polynomials already exists once, as
+`HexBerlekampZassenhaus.exactQuotient?` (`Records.lean:452`), written for
+recombination. This library runs it on every candidate, and
+Berlekamp-Zassenhaus is above hex-poly-z, so the function belongs there
+with both consumers importing it. Berlekamp-Zassenhaus keeps its
+unit-candidate rejection as a wrapper, since that rule is about its
+recombination loop rather than about division.
+
+**`subresultantChainExt` belongs in hex-resultant.** Route 4 needs the
+Bézout cofactors of the chain to produce the `constant` witness, and
+`subresultantAux` discards the quotient of each `pseudoDivMod`
+(`HexResultant/Subresultant.lean:65` and `:92`).
+[hex-mv-gcd](hex-mv-gcd.md) asks for the same addition under the same
+name for its `splitBezout` constructor, so it should be written once.
+
+**`Modulus` and `PrimeModulus` belong in hex-mod-arith**, as
+[hex-modular](hex-modular.md) sets out. The `modular` witness names one.
 
 ## Complexity
 
@@ -510,6 +619,15 @@ search for one.
   convention is visible.
 - Cyclotomic and near-cyclotomic pairs, which are the sparse inputs with
   small coefficients where the heuristic route should win.
+- `gcd(2, 2x) = 2` and `gcd(6, 4x) = 2`, the constant-input contract that
+  an earlier draft of this SPEC got wrong.
+- A pair whose cofactors are coprime but share an image at every small
+  prime, so only the `constant` witness applies. `f' = x` and
+  `h' = x + 2·3·5·7·11·13` is small enough to be a fixture and forces the
+  producer past the primes it would try first.
+- A prime that preserves both cofactor degrees and is still unusable
+  (`f' = x`, `h' = x + 2`, `p = 2`), checking that the producer retries
+  rather than emitting an unprovable witness.
 - `ratGcd` on inputs with large denominators, checking the clearing step
   happens and the result is monic.
 
@@ -547,9 +665,10 @@ checks, which matter more than the external one:
 - `gcd` must be faster than the existing `DensePoly Rat` Euclidean route
   on every family except degree-2 inputs, and faster by at least `10x` on
   the swell family.
-- `primitiveSquareFreeDecomposition` rewritten to call this library must
-  be faster than its current form on the Berlekamp-Zassenhaus input
-  ladder.
+- `ZPoly.sqfDecomp`, the fast squarefree entry point specified above,
+  must be faster than `HexPolyZ.primitiveSquareFreeDecomposition` on the
+  Berlekamp-Zassenhaus input ladder. The two compute the same thing by
+  different routes, so this is also a differential test.
 
 SymPy is the oracle and is not a performance comparator.
 
@@ -592,15 +711,19 @@ companion beyond these and one correspondence lemma per public operation.
 
 ## Milestones
 
-1. **Exact division and the certificate.** `divExact?` with its
-   theorems, the `Dvd` and `Decidable` instances, `GcdCert`, `checkGcd`,
-   and `checkGcd_sound`. Nothing computes a gcd yet, and the hardest
-   proof in the library is already done.
+1. **Exact division and the certificate.** `divExact?` (in hex-poly-z,
+   per the prerequisites) with its theorems and the `Decidable (g ∣ f)`
+   instance over the existing `Dvd`, then `CoprimeWitness`, `GcdCert`,
+   `checkGcd`, and `checkGcd_sound` for both witness cases. Nothing
+   computes a gcd yet, and the hardest proof in the library is already
+   done.
 
 2. **A correct gcd.** Route 0, route 1, and a fallback, with
    `gcdCert_checks`. The fallback is the `DensePoly Rat` Euclidean route
-   initially, so this milestone does not wait on hex-resultant. At the
-   end of it the library is usable and slow on the hard cases.
+   initially, so this milestone does not wait on hex-resultant, and it
+   produces the `constant` witness from a rational Bézout identity
+   cleared to `ℤ`. At the end of it the library is usable and slow on the
+   hard cases.
 
 3. **Maximality.** `dvd_gcd_of_coprimeCofactors`, through Gauss's lemma
    and the rational gcd. This is the milestone that decides whether the
@@ -614,17 +737,16 @@ companion beyond these and one correspondence lemma per public operation.
    replacing the rational fallback once hex-resultant is far enough
    along.
 
-6. **The companion**, and the rewrite of
-   `primitiveSquareFreeDecomposition` in hex-poly-z to call `gcd`. The
-   rewrite is the benchmark that justifies the library, so it is a
-   milestone rather than a follow-up.
+6. **The companion**, and the fast squarefree decomposition. The
+   squarefree entry point is the benchmark that justifies the library, so
+   it is a milestone rather than a follow-up.
 
 ## File organisation
 
 ```
 HexPolyZGcd/
-  Divide.lean       -- divExact?, Dvd, Decidable, the prefilters
-  Cert.lean         -- GcdCert, checkGcd, checkGcd_sound
+  Divide.lean       -- Decidable (g ∣ f), the prefilters (divExact? itself is in hex-poly-z)
+  Cert.lean         -- CoprimeWitness, GcdCert, checkGcd, checkGcd_sound
   Fast.lean         -- routes 0 and 1, isCoprime
   Heu.lean          -- route 2 and its bit budget
   Brown.lean        -- route 3
@@ -663,7 +785,7 @@ HexPolyZGcdMathlib.lean
         - name: rational
           description: the same inputs over the rationals through ratGcd
   HexPolyZGcdMathlib:
-    deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib, HexModArithMathlib]
+    deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib]
     mathlib: true
     done_through: 0
     status: planned
@@ -675,14 +797,16 @@ before milestone 5 needs it.
 
 ## Open questions
 
-- **Whether `primitiveSquareFreeDecomposition` should move here.** It is
-  hex-poly-z's function today, its only nontrivial dependency after this
-  library exists is the gcd, and Yun's algorithm over `ℤ` is a natural
-  neighbour of the gcd. Against moving it: it is on the
-  Berlekamp-Zassenhaus path and moving a function that far down the
-  dependency graph is disruptive. This SPEC keeps it where it is and
-  rewrites its body, and the question should be revisited if a second
-  squarefree consumer appears.
+- **How much of the squarefree surface moves here.** Rewriting
+  `HexPolyZ.primitiveSquareFreeDecomposition` to call this library is not
+  available: this library depends on hex-poly-z, so a call back the other
+  way is a cycle. The fast entry point therefore lives here, as
+  `ZPoly.sqfDecomp`, with hex-poly-z's rational implementation left in
+  place below as the reference and the benchmark baseline, and the
+  consumers above both libraries (Berlekamp-Zassenhaus first) switched
+  over. Whether the old implementation is then deleted, and whether the
+  whole squarefree surface should move rather than gain a faster
+  neighbour, is the open part.
 - **Whether the certificate should carry the prime's primality proof or
   recompute it.** Carrying it makes the certificate self-contained and
   makes its size depend on the proof term. Recomputing it makes the

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -77,8 +77,11 @@ about, namely whether they divide at all:
   hex-bareiss, or a detour through `ℚ` and the coefficient growth that
   brings.
 - **Multi-modular**, computing `χ_A` modulo several primes and
-  recombining, using the modular techniques below with a coefficient
-  bound from the matrix norm.
+  recombining, using [hex-modular](Libraries/hex-modular.md) with a
+  coefficient bound from the matrix norm. The determinant in
+  [hex-modular-matrix](Libraries/hex-modular-matrix.md) is the same
+  shape one degree down, and its handling of the bound is the model to
+  follow.
 
 Isolating the roots of `χ_A` with hex-real-roots and hex-roots would give
 certified eigenvalue enclosures; hex-number-field can name the resulting exact
@@ -137,46 +140,66 @@ since the project has no floating-point linear algebra: an unverified
 Lean implementation and an FFI call are equally acceptable, because the
 verification step makes the choice proof-irrelevant.
 
-**Modular techniques.** A toolkit that several libraries want
-independently:
+**Modular techniques.** These have graduated from this file and are
+specified in three libraries: [hex-modular](Libraries/hex-modular.md),
+holding integer CRT, rational reconstruction, symmetric representatives,
+and the modulus supply; [hex-modular-matrix](Libraries/hex-modular-matrix.md),
+holding the multi-modular determinant, certified rank, and Dixon p-adic
+lifting; and [hex-poly-z-gcd](Libraries/hex-poly-z-gcd.md), holding
+Brown's modular gcd for `ℤ[x]` with cofactors and a coprimality witness.
+The split is along the dependency seams: rational reconstruction has
+consumers that want no matrices, and a matrix library and a polynomial
+library should not depend on each other.
 
-- **Rational reconstruction.** Fix bounds `P, Q > 0` with `2PQ < m`.
-  From a residue `a mod m`, recover `p/q` with `q · a ≡ p (mod m)`,
-  `|p| ≤ P`, `0 < q ≤ Q`, `gcd(p, q) = 1`, and `gcd(q, m) = 1`, by
-  running the extended Euclidean algorithm on `(m, a)` and stopping at
-  the first remainder below `P`. Under `2PQ < m` the result is unique
-  when it exists, and that uniqueness theorem is what makes it usable.
-  Existence is conditional, so the signature is partial and the caller
-  retries with a larger `m`. hex-arith has the extended gcd, so this is
-  a short wrapper; the half-gcd below accelerates it without entering
-  the correctness argument.
-- **Multi-modular determinant.** Compute `det` modulo many word-sized
-  primes and recombine by CRT, with a Hadamard bound fixing how many
-  primes suffice. hex-bareiss's SPEC identifies this as the structurally
-  different approach FLINT takes, with its own asymptotic and
-  constant-factor profile, which is why that comparator is informational
-  rather than a required check; the measured ratio lives in
-  `reports/hex-bareiss-performance.md`. Implementing it here makes the
-  comparison like-for-like.
-- **Multi-modular rank**, a stronger statement than the determinant and
-  worth separating from it. Reduction mod `p` can only drop rank, so the
-  modular computation supplies a lower bound on the rational rank. An
-  exact rank pairs that with an upper bound: a rational kernel basis, a
-  rank factorization, or vanishing of all larger minors.
-- **Dixon p-adic lifting.** Solve `A x = b` over `ℚ` by lifting the
-  solution mod `p^k` and reconstructing rationals, avoiding the
-  coefficient growth of fraction-free elimination.
-- **Modular gcd for `ℤ[x]`** (Brown's algorithm): compute gcds modulo
-  several primes, CRT them, and reconstruct. The certificate carries
-  cofactors `f = g · f'` and `h = g · h'` together with a Bézout witness
-  that `f'` and `h'` are coprime, which is what pins `g` as greatest
-  rather than merely common.
+The shared shape survives. An unverified modular route produces a
+candidate and an exact check accepts it, so prime selection and every
+other heuristic needs no correctness proof. Four corrections to what this
+file said around that shape, recorded because they are easy to make
+again.
 
-These share a shape: an unverified modular route produces a candidate,
-and an exact check accepts it, so prime selection and other heuristics
-need no correctness proof. The checker's own obligations are primality
-and distinctness of the moduli, the CRT congruences, and a
-reconstruction bound large enough to determine the answer.
+**The checker's obligations are not "primality and distinctness of the
+moduli".** Primality is not needed for the determinant or for the
+polynomial gcd, because reduction modulo any `m` is a ring homomorphism;
+what elimination needs is that the pivots it inverts are units, which the
+extended gcd discovers rather than assumes. Distinctness is not the right
+property either, since distinct moduli need not be coprime. Pairwise
+coprimality is what the reconstruction needs, and one extended gcd per
+modulus checks it. Primality does appear, in the two places where a
+statement mentions `F_p` as a field: the rank of an image, and the
+coprimality witness for the gcd.
+
+**Where a checker does name a prime, the size of that prime is a cost.**
+Replaying a certificate in the kernel replays the primality proof, and
+trial division costs `√p`: measured on this tree, 0.04 s at 16 bits
+against 6.2 s at 31 bits. Certificates name small primes for that reason,
+and the multi-modular determinant may use large ones precisely because
+its argument never mentions primality.
+
+**"Reduction mod `p` can only drop rank" is the conclusion, not the
+argument.** The modular rank is a lower bound because a nonvanishing
+`r × r` minor modulo `p` is a nonvanishing integer minor, and that
+submatrix is what the certificate carries. Phrasing it the other way
+suggests the modular computation is itself the evidence.
+
+**The Bézout witness for coprime cofactors over `ℤ[x]` does not exist.**
+`ℤ[x]` is not a Bézout domain: `x` and `2` are coprime and
+`u · x + v · 2 = 1` has no solution. The replacement is a modular
+witness, and in one variable it is complete: reduce both cofactors at a
+prime dividing neither leading coefficient, exhibit a Bézout pair over
+`F_p[x]`, and check that the integer contents are coprime. The
+multivariate version of the same correction is in
+[hex-mv-gcd](Libraries/hex-mv-gcd.md), where the recursion on contents
+makes the soundness theorem conditional; in one variable the
+corresponding fact is `Int.dvd_gcd` and the theorem is unconditional.
+
+Two smaller things. The condition `gcd(q, m) = 1` on a reconstructed
+rational is a theorem rather than a fourth check, derivable from
+`gcd(p, q) = 1` and the congruence. And the determinant is the one member
+of this group with no cheap checker at all, so it is a proved algorithm
+rather than a checked candidate, it carries the group's only analytic
+hypothesis (a Hadamard bound, discharged in the companion), and certified
+dispatch to an untrusted external implementation is unavailable for it
+while remaining available for the rank and the linear solve.
 
 **Sparse matrices.** A sparse representation alongside the dense
 `Array`-backed one, with `toDense` as the specification function. The
@@ -396,8 +419,9 @@ After that, in rough order of payoff for this tree:
 - **Newton-iteration inversion** of a power series, giving fast division
   and remainder. Depends on truncated power series, below.
 - **Half-gcd** for quasi-linear gcd and extended gcd, the primitive
-  under fast rational reconstruction, fast Padé approximation, and fast
-  resultants. Its subject is the Euclidean transformation matrices, so
+  under the fast form of the rational reconstruction in
+  [hex-modular](Libraries/hex-modular.md), fast Padé approximation, and
+  fast resultants. Its subject is the Euclidean transformation matrices, so
   the prerequisite is a verified treatment of those rather than anything
   from the series side, and its correctness proof is fiddly in a way
   plain Euclid's is not.
@@ -453,7 +477,7 @@ hypotheses are stated on the individual operations rather than folded
 into the generic polynomial interface.
 
 The certificate is cofactors plus a coprimality witness, and the witness
-is not the Bézout identity the modular gcd item names: `ℤ[x]` and
+is not a Bézout identity: `ℤ[x]` and
 `R[x₁, …, xₙ]` are not Bézout domains, so the replacement is a modular
 witness together with a recursion on contents. That recursion rests on
 the universal property of the content, which is gcd maximality one
@@ -776,8 +800,9 @@ checker has proved itself on the hypergeometric case.
 **p-adic numbers as a type.** hex-hensel implements lifting as an
 algorithm. A first-class `Zp` and `Qp` at fixed precision would be
 shared by consumers that each roll their own modular tower:
-Berlekamp-Zassenhaus's lifting phase, Dixon lifting above, and the
-p-adic route to `ℤ[x]` factoring.
+Berlekamp-Zassenhaus's lifting phase, the Dixon lifting in
+[hex-modular-matrix](Libraries/hex-modular-matrix.md), and the p-adic
+route to `ℤ[x]` factoring.
 
 `Zp` at precision `N` is `ℤ/p^N ℤ` with a valuation, and is the easy
 half. `Qp` needs elements to carry precision explicitly, as a centre

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -158,15 +158,22 @@ file said around that shape, recorded because they are easy to make
 again.
 
 **The checker's obligations are not "primality and distinctness of the
-moduli".** Primality is not needed for the determinant or for the
-polynomial gcd, because reduction modulo any `m` is a ring homomorphism;
-what elimination needs is that the pivots it inverts are units, which the
-extended gcd discovers rather than assumes. Distinctness is not the right
-property either, since distinct moduli need not be coprime. Pairwise
-coprimality is what the reconstruction needs, and one extended gcd per
-modulus checks it. Primality does appear, in the two places where a
-statement mentions `F_p` as a field: the rank of an image, and the
-coprimality witness for the gcd.
+moduli".** Reduction modulo any `m` is a ring homomorphism, so the
+reconstruction argument never uses primality; what elimination needs is
+that the pivots it inverts are units, which the extended gcd discovers
+rather than assumes. Distinctness is not the right property either, since
+distinct moduli need not be coprime. Pairwise coprimality is what the
+reconstruction needs, and one extended gcd per modulus checks it.
+
+Primality still earns its place on the producer side, and the correction
+is about the checker alone. Brown's image gcd over a composite modulus is
+meaningless as a degree bound (`x` and `x - 6` are coprime over `ℤ[x]`
+and identical modulo `6`), so the gcd's producer and its eventual-success
+argument both want primes; what the correction buys is that a spurious
+image cannot produce a wrong answer, because the exact checker rejects
+the candidate. Two statements do need primality outright, and both say
+so: the rank of an image is a rank only over a field, and the gcd's
+modular coprimality witness needs `F_p[x]` to be a domain.
 
 **Where a checker does name a prime, the size of that prime is a cost.**
 Replaying a certificate in the kernel replays the primality proof, and

--- a/progress/20260814T004834Z_modular-techniques-specs.md
+++ b/progress/20260814T004834Z_modular-techniques-specs.md
@@ -93,6 +93,103 @@ corrections. Relinked the four cross-references elsewhere in
   needs is new; and `permutationVectors` with no `length = n !` lemma,
   which is why the crude Leibniz determinant bound is not the default.
 
+## Second opinion, and what it changed
+
+Codex (read-only, full repo access) reviewed the three drafts
+adversarially and returned 22 findings. It endorsed the three-way split,
+and did not dispute the rational-reconstruction uniqueness proof, the
+derivation of `gcd(q, m) = 1`, the necessity of Garner's outer `symMod`,
+determinant reduction over arbitrary moduli, the soundness of a nonzero
+minor modulo a composite modulus, the two-sided rank argument, Dixon's
+exact division, the univariate coprimality checker's unconditional
+soundness, or the Mathlib-free route to maximality. Everything below is
+now fixed in the SPECs.
+
+**Five findings were errors that changed a design rather than a
+sentence.**
+
+- **The `2^31` modulus bound breaks three totality claims.** With
+  `L = lcm(1, …, 2^31 - 1)`, every allowed modulus divides `L`, and so
+  does every product of pairwise coprime allowed moduli. On `[L]` the
+  determinant loop never reaches its bound, the rank certificate does not
+  exist (every minor residue is zero), and for `f = x`, `h = x + L` no
+  modular coprimality witness exists. So `det` now falls back to
+  `Hex.Matrix.bareiss`, `RankCert.modulus` is an arbitrary `Nat` checked
+  in `Int` arithmetic rather than a `ZMod64` modulus, and the gcd
+  certificate gained a `constant` constructor carrying
+  `u f' + v h' = C k` with `k ≠ 0`, which the extended subresultant chain
+  always produces. hex-modular records the shared cause once.
+- **hex-poly-z-gcd's milestone 6 was a dependency cycle.** It proposed
+  rewriting `HexPolyZ.primitiveSquareFreeDecomposition` to call a library
+  that depends on hex-poly-z. The fast squarefree entry point is now
+  `ZPoly.sqfDecomp` in hex-poly-z-gcd, with the existing implementation
+  left below as the reference and the benchmark baseline.
+- **`Crt` could be driven into an inconsistent state.**
+  `Crt.init.push 1 0` passes the coprimality test, because
+  `gcd(1, 0) = 1`, and then `push_modulus`, `push_le`, and
+  `push_congr_new` are jointly unsatisfiable. Positivity and the
+  symmetric bound are now structure invariants and `push` rejects
+  `m ≤ 1`.
+- **The common-denominator vector reconstruction was incomplete.** At
+  `m = 101`, `P = 2`, `Q = 4`, the residues of `(1/2, 1/4)` reconstruct
+  entrywise to denominators `2` and `4`; multiplying them gives `d = 8`
+  and numerators outside the bounds, where `lcm` gives the correct
+  `(2, 1)/4`. The combination step now uses `lcm` and reduces the whole
+  pair, and the SPEC says that `Q` must bound the *common* denominator.
+- **The Dixon numerator bound named one replaced column.** Cramer's rule
+  uses all of them: for `A = [[1, N], [0, 1]]` and `b = (0, 1)` the
+  solution is `(-N, 1)` while the second replaced column bounds at `1`.
+  `P` is now the maximum over `i`.
+
+**Six more were real errors of statement.** `detMod?` must return
+`some 0` on an all-zero pivot column and `none` only on a nonzero
+nonunit, or `det` of a singular matrix never terminates (found
+independently before the review landed). `checkRank_sound` named the
+function it was meant to certify, so it now targets `ratRank`, defined as
+row reduction over `Rat`. `kernel?` had an unbound `r` and returned
+neither the rank nor the denominator, so it returns a structure. The rank
+producer handed an `n × r` block to a square solver; it now solves the
+`r × r` minor and checks against all `n` rows. `gcd f h = 1` for a
+nonzero constant `h` is false (`gcd(2, 2x) = 2`), so the contract is now
+an integer gcd against the content. And the determinant divisor needs
+`d⁻¹ mod m`, so moduli sharing a factor with `d` are skipped.
+
+**Four were misstatements about the tree**, all verified: the public name
+is `HexArith.Int.extGcd`, not `Hex.Int.extGcd`; `Dvd (DensePoly R)`
+already exists (`HexPoly/Euclid/DivGcd.lean:1077`) so the proposed `Dvd
+ZPoly` instance was a duplicate; `HexBerlekampZassenhaus.exactQuotient?`
+(`Records.lean:452`) is already exact integer-polynomial division, so
+`divExact?` belongs in hex-poly-z with both consumers importing it; and
+`Rat.mk'` is the raw constructor, not the normalising one
+(`Rat.normalize` is).
+
+**Two were structural.** The modulus supply belongs in hex-mod-arith
+beside `ZMod64`, not here, which leaves hex-modular depending on
+hex-arith alone and dissolves this SPEC's original "why not inside
+hex-arith" argument; the section now gives the honest reason (subject
+separation, and not reopening a `done_through: 7` library) and records
+the alternative. And "a prime preserving both cofactor degrees works" is
+false: `f' = x`, `h' = x + 2` at `p = 2` preserves both and admits no
+Bézout pair, so the producer must compute the image gcd and retry.
+
+**Two were fair pushback on confidence.** The benchmark thresholds were
+stated as required checks with no prototype behind either number; the
+"faster at every rung `n ≥ 64`" requirement also guessed a crossover in
+the same document that says it will not guess one. The Bareiss
+requirement is now the `n = 512` ratio with the crossover measured, and
+the FLINT figure is a target that becomes required after the first
+measurement. Separately, three conformance cases did not test what they
+claimed: the CRT suite had no outer-reduction regression (push `1 mod 3`
+then `0 mod 2`), nothing exercised a successful composite modulus, and a
+unit-diagonal triangular matrix is unimodular, so it is the determinant
+divisor's worst case rather than a demonstration of it.
+
+One finding strengthened a claim rather than weakening it: the Gauss
+descent step for Mathlib-free maximality already exists as
+`ZPoly.dvd_of_toRatPoly_dvd_of_primitive`
+(`HexPolyZ/Decomposition.lean:797`), so that milestone is assembling
+three existing pieces.
+
 ## Current frontier
 
 The SPECs are drafts in the sense that none of the six libraries is in

--- a/progress/20260814T004834Z_modular-techniques-specs.md
+++ b/progress/20260814T004834Z_modular-techniques-specs.md
@@ -1,0 +1,141 @@
+# Modular techniques SPECs
+
+## Accomplished
+
+Wrote three library SPECs from the "Modular techniques" entry in
+`SPEC/future-work.md`, which listed five bullets and no library
+structure:
+
+- `SPEC/Libraries/hex-modular.md`: symmetric representatives, incremental
+  Chinese remaindering for a scalar and for a residue vector sharing a
+  modulus, rational reconstruction (checked signature, uniqueness,
+  completeness, the common-denominator vector form, the maximal-quotient
+  heuristic), the modulus supply, and the loop combinator that adds
+  moduli until a caller's check accepts.
+- `SPEC/Libraries/hex-modular-matrix.md`: the multi-modular determinant
+  with the Hadamard bound as a discharged hypothesis, the
+  Abbott-Bronstein-Mulders determinant divisor, the two-sided rank
+  certificate, the Dixon `p`-adic solve, and the rational kernel basis.
+- `SPEC/Libraries/hex-poly-z-gcd.md`: modular gcd for `ℤ[x]` with
+  cofactors, the modular coprimality witness and its unconditional
+  soundness proof, exact division, and the four routes (structural,
+  coprime fast path, heuristic, Brown, subresultant fallback).
+
+Each names its prerequisite relocations, records what is out of scope,
+and carries the `libraries.yml` block it would add.
+
+Updated `SPEC/Libraries/README.md` (descriptions, both dependency lists,
+index, and a paragraph on why the three split the way they do) and
+replaced the `SPEC/future-work.md` entry with a pointer plus four
+corrections. Relinked the four cross-references elsewhere in
+`future-work.md` and `hex-mv-gcd.md` that named the item.
+
+## Findings that changed the design
+
+- **Primality is not what the checkers need.** The future-work entry
+  named "primality and distinctness of the moduli" as the checker's
+  obligations. Reduction modulo any `m` is a ring homomorphism, so the
+  determinant and gcd arguments never use primality; what elimination
+  needs is invertible pivots, which the extended gcd discovers. And
+  distinct moduli need not be coprime, which is the property the
+  reconstruction actually uses. This is why the determinant may use
+  31-bit moduli found at runtime rather than a certified table.
+- **Kernel-replayed primality is priced by `√p`, measured here.**
+  `decide +kernel` on `Hex.Nat.isPrimeTrial`, against a 0.81 s
+  import-only baseline: 0.04 s at 16 bits, 0.08 s at 20, 0.42 s at 24,
+  and 6.2 s at 31. So a certificate whose checker names a prime should
+  name a small one, and the gcd certificate does. `hex-primality`'s
+  Pocklington certificate would remove the constraint.
+- **The three operations differ in whether they have a checker**, and
+  that drives the whole matrix SPEC. The linear solve is checked by one
+  matrix-vector product. The rank has a complete two-sided certificate (a
+  nonzero minor modulo one modulus for the lower bound, a rational
+  expression of the remaining columns for the upper). The determinant has
+  no cheap checker, so it is a proved algorithm, it carries the group's
+  only analytic hypothesis, and certified dispatch to an external
+  implementation is unavailable for it while available for the other two.
+- **The determinant divisor is rigorous, not heuristic, but only after a
+  reduction step.** `d ∣ det A` needs `gcd(gcd_i y_i, d) = 1`, and
+  Dixon's reconstruction returns a common denominator that need not be
+  least. Omitting the reduction gives a wrong determinant with no
+  symptom.
+- **`zmod64FieldOfPrime` is in the wrong library.** The
+  `Lean.Grind.Field (ZMod64 p)` instance and `ZMod64.intPow` live in
+  `HexPolyFp/PrimeField.lean`; the instance is about a hex-mod-arith type
+  and its only polynomial import is `HexPolyFp.Degree`. Any library doing
+  linear algebra over `F_p` currently has to depend on hex-poly-fp for
+  it.
+- **Hadamard's inequality is in the wrong library too.**
+  `Matrix.norm_det_le_prod_norm_column` is in `HexPolyZMathlib/Hadamard.lean`,
+  and `HexRealRootsMathlib/Hadamard.lean` already exists solely as a
+  compatibility import of it. It is a determinant inequality and belongs
+  in hex-matrix-mathlib.
+- **The univariate gcd certificate is unconditionally sound**, unlike
+  hex-mv-gcd's. The multivariate checker finishes with "so `d` divides
+  both contents", whose justification is the multivariate gcd's own
+  maximality one variable down, so its soundness is conditional on
+  `LawfulContent`. In one variable the corresponding fact is
+  `Int.dvd_gcd`. Maximality itself is also within Mathlib-free reach
+  here, through `DensePoly.content_mul` (Gauss, `HexPoly/Euclid.lean:675`)
+  and the rational Euclidean gcd.
+- **The measured Bareiss gap is the motivation and the target.**
+  `reports/hex-bareiss-performance.md` records an adjusted ratio of
+  `0.049x` to `0.057x` against FLINT's multi-modular determinant at
+  `n = 320 … 512`. hex-bareiss classifies that comparator
+  `informational` because the algorithms differ; implementing the same
+  algorithm makes it like-for-like, so the new SPEC classifies it
+  `gating` with a written-down threshold.
+- **Other missing infrastructure**, each named in the SPECs: no entrywise
+  `Matrix.mapEntries`; `floorSqrt` / `ceilSqrt` under the `Hex.ZPoly`
+  namespace in `HexPolyZ/Mignotte.lean`; no integer CRT anywhere (only
+  `polyCRT` for polynomials); `Hex.Int.extGcd` returning the final Bézout
+  pair only, so the truncated remainder sequence rational reconstruction
+  needs is new; and `permutationVectors` with no `length = n !` lemma,
+  which is why the crude Leibniz determinant bound is not the default.
+
+## Current frontier
+
+The SPECs are drafts in the sense that none of the six libraries is in
+`libraries.yml`; each SPEC carries the block it would add, following the
+`hex-mv-poly` precedent. All three are marked `status: planned` rather
+than `draft`, since every dependency is `active` at `done_through: 7`
+except `HexResultant` (`done_through: 1`), which only route 4 of the gcd
+needs and which milestone 2 there is arranged around.
+
+A second session was writing `hex-finite-field`, `hex-primality`, and
+`hex-int-factor` in the same worktree during this turn, and those SPECs
+are not in this change. Where the two sets meet, this one refers to the
+`future-work` entry rather than to an unlanded file: the modulus supply
+wants Miller-Rabin and a Pocklington certificate from whatever library
+owns "Better primality", and the determinant divisor wants the seedable
+generator that the equal-degree splitting item calls for. `hex-mv-gcd`
+gains a pointer to `hex-poly-z-gcd` for its arity-one case.
+
+Nothing is committed.
+
+## Next step
+
+The sequencing the three SPECs argue for:
+
+1. The five relocations, each independently justified and each doable
+   before any commit here: `zmod64FieldOfPrime` and `SmallPrimeCandidate`
+   into hex-mod-arith, `floorSqrt` / `ceilSqrt` and `exactDiv` into
+   hex-arith, `Matrix.mapEntries` into hex-matrix, and Hadamard's
+   inequality into hex-matrix-mathlib.
+2. hex-modular milestones 1 to 3 (`symMod`, `Crt`, `ratRecon?`, the
+   vector forms, the modulus supply). Completeness of `ratRecon?` may
+   lag; no consumer's soundness depends on it.
+3. hex-modular-matrix milestones 1 and 2, giving a correct determinant
+   with no performance claim, then milestone 3 (Dixon) and milestone 4
+   (the determinant divisor), which is where the benchmark numbers come
+   from.
+4. hex-poly-z-gcd milestones 1 and 2 in parallel, since they need only
+   hex-modular milestone 1, followed by Brown once the modulus supply
+   exists.
+5. The rank certificate and the rewrite of
+   `primitiveSquareFreeDecomposition` last, since both are consumers of
+   everything above.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR expands the "Modular techniques" entry in `SPEC/future-work.md` into three library SPECs, split along the dependency seams: rational reconstruction has consumers that want no matrices, and a matrix library and a polynomial library should not depend on each other.

`SPEC/Libraries/hex-modular.md` holds symmetric representatives, incremental integer Chinese remaindering for a scalar and for a residue vector sharing a modulus, rational reconstruction (checked signature, uniqueness, completeness, the common-denominator vector form, and the maximal-quotient heuristic), the modulus supply, and the loop combinator that adds moduli until a caller's own check accepts.

`SPEC/Libraries/hex-modular-matrix.md` holds the multi-modular determinant with a Hadamard bound discharged in its companion, the Abbott-Bronstein-Mulders determinant divisor, a two-sided rank certificate, the Dixon p-adic solve, and the rational kernel basis. `reports/hex-bareiss-performance.md` records an adjusted ratio of 0.049x to 0.057x against FLINT's multi-modular determinant at n = 320 to 512, and hex-bareiss classifies that comparator informational because the algorithms differ; implementing the same algorithm makes the comparison like-for-like, so this SPEC classifies it gating with thresholds written down in advance.

`SPEC/Libraries/hex-poly-z-gcd.md` holds Brown's modular gcd for `Z[x]` with cofactors, a modular coprimality witness, exact division, and the route stack from structural reductions through the coprime fast path, the heuristic gcd, and Brown to a subresultant fallback. The tree has no integer polynomial gcd today: `primitiveSquareFreeDecomposition` converts to `DensePoly Rat` and runs the field Euclidean algorithm, which is the baseline the benchmark family measures against.

Four corrections to what the entry said. Primality is not among the checker's obligations, because reduction modulo any `m` is a ring homomorphism and what elimination needs is invertible pivots, which the extended gcd discovers rather than assumes; pairwise coprimality is the property the reconstruction uses, and distinct moduli need not be coprime. A checker that does name a prime pays for it in the kernel, priced by trial division at 0.04 s for 16 bits against 6.2 s for 31 bits, measured on this tree with `decide +kernel` on `Hex.Nat.isPrimeTrial`. The modular rank is a lower bound because a nonvanishing minor modulo `p` is a nonvanishing integer minor, and that submatrix is what the certificate carries. And the Bezout witness for coprime cofactors over `Z[x]` does not exist, since `Z[x]` is not a Bezout domain; the replacement is a modular witness, unconditional in one variable because the content recursion bottoms out in `Int.dvd_gcd`.

The three operations differ in whether they have a checker, which drives the matrix SPEC: the linear solve is checked by one matrix-vector product, the rank has a complete two-sided certificate, and the determinant has neither, so it is a proved algorithm and certified dispatch to an untrusted external implementation is unavailable for it alone.

Each SPEC names its prerequisite relocations. `zmod64FieldOfPrime` is in hex-poly-fp though it is about a `ZMod64` type; Hadamard's inequality is in hex-poly-z-mathlib though it is a determinant inequality; `floorSqrt` and `ceilSqrt` are under the `Hex.ZPoly` namespace; hex-matrix has no entrywise map; and `Hex.Int.extGcd` returns only the final Bezout pair, so the truncated remainder sequence rational reconstruction needs is new.

`hex-mv-gcd` gains a pointer to `hex-poly-z-gcd` for its arity-one case, and `SPEC/Libraries/README.md` gains the six new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145q6AMz5KFcfS9VUeNCULv
