### PR TITLE
feat(interval): certify a Machin sine reduction

### DIFF
--- a/HexInterval/Experiment/SinTen.lean
+++ b/HexInterval/Experiment/SinTen.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+@[expose] public section
+
+/-!
+# Candidate data for a first certified range-reduction canary
+
+The executable side chooses a constant provider, an integer half-turn, and a
+local sine method.  These values are untrusted replay data.  This module knows
+nothing about real numbers or trigonometric theorems.
+-/
+
+namespace Hex.Interval.Experiment.SinTen
+
+/-- Coarse rational endpoints proposed for a constant. -/
+structure ConstantCandidate where
+  lowerNumerator : Nat
+  lowerDenominator : Nat
+  upperNumerator : Nat
+  upperDenominator : Nat
+  deriving DecidableEq, Repr
+
+namespace Machin
+
+/-- The first provider asks replay to establish `3 < pi < 16/5`. -/
+def candidate : ConstantCandidate :=
+  { lowerNumerator := 3
+    lowerDenominator := 1
+    upperNumerator := 16
+    upperDenominator := 5 }
+
+/-- Provider-owned structural authentication before mathematical replay. -/
+def accepts (candidate : ConstantCandidate) : Bool := candidate == Machin.candidate
+
+end Machin
+
+/-- Integer/quadrant data proposed by the range reducer. `negativeOutput`
+records the sign introduced by an odd number of half-turns. -/
+structure ReductionCandidate where
+  halfTurns : Nat
+  negativeOutput : Bool
+  deriving DecidableEq, Repr
+
+namespace Reduction
+
+def candidate : ReductionCandidate :=
+  { halfTurns := 3, negativeOutput := true }
+
+def accepts (candidate : ReductionCandidate) : Bool :=
+  candidate == Reduction.candidate
+
+/-- Per-field preflight bound for the fixed reduction canary. Checking it
+before the cross-products keeps malformed provider data fail-closed. -/
+def endpointLimit : Nat := 32
+
+/-- A provider enclosure is strong enough to select half-turn `3` when its
+encoded endpoints are bounded, genuine rationals and satisfy
+`3 * upper ≤ 10 ≤ 4 * lower`. -/
+def adequate (constant : ConstantCandidate) : Bool :=
+  decide (
+    constant.lowerNumerator ≤ endpointLimit ∧
+    constant.lowerDenominator ≤ endpointLimit ∧
+    constant.upperNumerator ≤ endpointLimit ∧
+    constant.upperDenominator ≤ endpointLimit ∧
+    constant.lowerDenominator ≠ 0 ∧
+    constant.upperDenominator ≠ 0 ∧
+    3 * constant.upperNumerator ≤ 10 * constant.upperDenominator ∧
+    10 * constant.lowerDenominator ≤ 4 * constant.lowerNumerator)
+
+end Reduction
+
+/-- The local sine package currently exposes only the strict-positive core
+method needed by this acceptance case. -/
+inductive LocalMethod where
+  | positiveCore
+  | taylorThree
+  deriving DecidableEq, Repr
+
+namespace Local
+
+def accepts (method : LocalMethod) : Bool := method == .positiveCore
+
+end Local
+
+/-- Complete untrusted certificate assembled from independently owned roles. -/
+structure Certificate where
+  constant : ConstantCandidate
+  reduction : ReductionCandidate
+  method : LocalMethod
+  deriving DecidableEq, Repr
+
+def certificate : Certificate :=
+  { constant := Machin.candidate
+    reduction := Reduction.candidate
+    method := .positiveCore }
+
+end Hex.Interval.Experiment.SinTen
+
+end

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3189,6 +3189,43 @@ available, conformance compares two independently proved Machin-style
 identities. The acceptance target is a 1,000-bit pi enclosure; the engine may
 cache and share it across every trigonometric node in a run.
 
+The first proof-side range-reduction canary toward the smaller
+`Real.sin 10 < 0` acceptance target produces that ordinary theorem without yet
+passing through the interval tactic. Its executable, Mathlib-free certificate
+names three provider choices: a rational constant enclosure, a combined
+integer-half-turn/quadrant reduction, and a local sine method. A
+Machin-owned replay theorem derives the coarse enclosure `3 < pi < 16/5`
+directly from Machin's arctangent identity and elementary kernel proofs that
+`x - x^3/3 < arctan x < x` for positive `x`. It deliberately does not consume
+Mathlib's existing decimal pi bounds, which are proved by a different
+square-root iteration. Range-reduction replay uses that enclosure to prove
+`0 < 10 - 3*pi < pi` and records the exact periodic reconstruction. The local
+sine replay sees only the reduced core interval, and final replay composes its
+positive result with the recorded odd-half-turn sign. Provider replay still
+authenticates the fixed Machin certificate, but reduction replay consumes its
+proved enclosure without matching the provider identity. A bounded numeric
+guard first limits every endpoint field to `32`, rejects zero denominators,
+then checks by cross multiplication that `3 * upper ≤ 10 ≤ 4 * lower`; those
+inequalities authenticate half-turn `3`. Reduction and local-method choices
+remain exact fixed-canary guards. Endpoint mutations outside the adequacy
+envelope, half-turns `2` or `4`, the wrong output sign, and the alternate local
+method return no evidence. The resulting theorem is ordinary kernel evidence
+and uses neither `native_decide` nor an unchecked arithmetic oracle.
+
+This canary resolves the first architectural risk: a formula can in principle
+own a checked constant enclosure strong enough to authenticate a reduction
+integer. It does not yet demonstrate a replaceable-provider registry or the
+general interval tactic. The orchestration is a fixed four-stage pipeline; the
+input `10` is hardcoded on the proof side; the local step proves only a strict
+sign and produces no endpoint enclosure; its rational certificate is exact
+fixed data rather than output from a precision-parametric series evaluator.
+The current minimal sign-fact lattice cannot express a strict-negative result,
+and the current goal parser recognizes only fixed non-strict targets, so
+routing this certificate through that frontend would falsely imply an
+integration that has not landed. Those are the next integration boundaries.
+The 1,000-bit provider and `cos (10^10)` remain acceptance targets, not
+delivered claims.
+
 #### Series as package-owned numerical algorithms
 
 A registered function may supply a power or Taylor series without teaching the

--- a/HexIntervalMathlib/Experiment/SinTen.lean
+++ b/HexIntervalMathlib/Experiment/SinTen.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.SinTen
+public import HexInterval.Experiment.SemanticReplay
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+
+@[expose] public section
+
+/-!
+# A Machin-derived range reduction for `Real.sin 10`
+
+This proof-side experiment keeps constant replay, integer range reduction,
+local sine enclosure, and final reconstruction as distinct steps. Candidate
+data is executable and untrusted; every accepted step returns ordinary kernel
+evidence.
+-/
+
+namespace Hex.IntervalMathlib.Experiment.SinTen
+
+open Set
+open Hex.Interval.Experiment.SemanticReplay
+open Hex.Interval.Experiment.SinTen
+
+noncomputable def candidateValue (numerator denominator : Nat) : ℝ :=
+  numerator / denominator
+
+namespace MachinReplay
+
+/-- The first two alternating terms give a strict lower bound on arctangent.
+This calculus proof is provider-owned rather than a fact known to the interval
+scheduler. -/
+theorem subCube_lt_arctan {x : ℝ} (positive : 0 < x) :
+    x - x ^ 3 / 3 < Real.arctan x := by
+  let f (t : ℝ) := Real.arctan t - (t - t ^ 3 / 3)
+  have derivative (t : ℝ) :
+      deriv f t = 1 / (1 + t ^ 2) - 1 + t ^ 2 := by
+    simp (disch := first | exact Real.differentiableAt_arctan _ | fun_prop)
+      [f, Real.deriv_arctan]
+    ring
+  have monotone : StrictMonoOn f (Set.Ici 0) := by
+    apply strictMonoOn_of_deriv_pos (convex_Ici 0) (by fun_prop)
+    intro t ht
+    rw [interior_Ici, mem_Ioi] at ht
+    rw [derivative]
+    have denominator : 0 < 1 + t ^ 2 := by positivity
+    rw [show 1 / (1 + t ^ 2) - 1 + t ^ 2 = t ^ 4 / (1 + t ^ 2) by
+      field_simp
+      ring]
+    exact div_pos (pow_pos ht 4) denominator
+  have compared : f 0 < f x := monotone (by simp) positive.le positive
+  simpa [f] using compared
+
+/-- Arctangent lies strictly below its positive argument. -/
+theorem arctan_lt {x : ℝ} (positive : 0 < x) : Real.arctan x < x := by
+  have range := Real.arctan_mem_Ioo x
+  have anglePositive : 0 < Real.arctan x := Real.arctan_pos.mpr positive
+  simpa only [Real.tan_arctan] using Real.lt_tan anglePositive range.2
+
+/-- A coarse Machin-derived enclosure sufficient to authenticate the
+reduction integer for this canary. -/
+theorem pi_bounds : (3 : ℝ) < Real.pi ∧ Real.pi < 16 / 5 := by
+  have identity := Real.four_mul_arctan_inv_5_sub_arctan_inv_239
+  have lowerFive :
+      (1 / 5 : ℝ) - (1 / 5 : ℝ) ^ 3 / 3 < Real.arctan (5 : ℝ)⁻¹ := by
+    convert subCube_lt_arctan (x := (1 / 5 : ℝ)) (by norm_num) using 1
+    all_goals norm_num
+  have upperFive : Real.arctan (5 : ℝ)⁻¹ < (1 / 5 : ℝ) := by
+    convert arctan_lt (x := (1 / 5 : ℝ)) (by norm_num) using 1
+    all_goals norm_num
+  have positiveTwoThirtyNine : 0 < Real.arctan (239 : ℝ)⁻¹ :=
+    Real.arctan_pos.mpr (by positivity)
+  have upperTwoThirtyNine :
+      Real.arctan (239 : ℝ)⁻¹ < (1 / 239 : ℝ) := by
+    convert arctan_lt (x := (1 / 239 : ℝ)) (by norm_num) using 1
+    all_goals norm_num
+  constructor <;> nlinarith
+
+/-- The mathematical claim is indexed by the untrusted endpoint data. -/
+noncomputable def Claim (candidate : ConstantCandidate) : Prop :=
+  candidateValue candidate.lowerNumerator candidate.lowerDenominator < Real.pi ∧
+    Real.pi < candidateValue candidate.upperNumerator candidate.upperDenominator
+
+/-- Exact endpoint acceptance is the load-bearing authentication step. -/
+def replay? (candidate : ConstantCandidate) : Option (Evidence (Claim candidate)) :=
+  if accepted : Machin.accepts candidate then
+    have equal : candidate = Machin.candidate := by
+      simpa [Machin.accepts] using accepted
+    some
+      { proof := by
+          subst candidate
+          simpa [Claim, candidateValue, Machin.candidate] using pi_bounds }
+  else none
+
+end MachinReplay
+
+namespace LocalReplay
+
+/-- The complete interface consumed by the local sine theorem. -/
+structure Core (x : ℝ) : Prop where
+  positive : 0 < x
+  belowPi : x < Real.pi
+
+def Claim (x : ℝ) : Prop := 0 < Real.sin x
+
+/-- Local replay consumes only core-domain facts, not a range-reduction
+certificate or reconstruction theorem. -/
+def replay? (method : LocalMethod) {x : ℝ} (core : Evidence (Core x)) :
+    Option (Evidence (Claim x)) :=
+  if accepted : Local.accepts method then
+    have equal : method = .positiveCore := by
+      simpa [Local.accepts] using accepted
+    some
+      { proof := by
+          subst method
+          exact Real.sin_pos_of_pos_of_lt_pi core.proof.positive core.proof.belowPi }
+  else none
+
+end LocalReplay
+
+namespace ReductionReplay
+
+noncomputable def residual (candidate : ReductionCandidate) : ℝ :=
+  10 - candidate.halfTurns * Real.pi
+
+/-- Apply the quadrant sign selected by the candidate. -/
+def signed (negative : Bool) (value : ℝ) : ℝ :=
+  if negative then -value else value
+
+structure Result (candidate : ReductionCandidate) : Prop where
+  accepted : Reduction.accepts candidate = true
+  core : LocalReplay.Core (residual candidate)
+  reconstruct :
+    Real.sin (residual candidate) = signed candidate.negativeOutput (Real.sin 10)
+
+/-- Reduction replay accepts any proved constant enclosure whose numeric
+endpoints are bounded and strong enough to authenticate half-turn `3`. -/
+def replay? (constantCandidate : ConstantCandidate)
+    (candidate : ReductionCandidate)
+    (constant : Evidence (MachinReplay.Claim constantCandidate)) :
+    Option (Evidence (Result candidate)) :=
+  if constantAdequate : Reduction.adequate constantCandidate then
+    if reductionAccepted : Reduction.accepts candidate then
+      have reductionEqual : candidate = Reduction.candidate := by
+        simpa [Reduction.accepts] using reductionAccepted
+      some
+        { proof := by
+            subst candidate
+            simp only [Reduction.adequate, decide_eq_true_eq] at constantAdequate
+            rcases constantAdequate with
+              ⟨_, _, _, _, lowerNonzero, upperNonzero, upperCross, lowerCross⟩
+            have lowerPositive : (0 : ℝ) < constantCandidate.lowerDenominator := by
+              exact_mod_cast Nat.pos_of_ne_zero lowerNonzero
+            have upperPositive : (0 : ℝ) < constantCandidate.upperDenominator := by
+              exact_mod_cast Nat.pos_of_ne_zero upperNonzero
+            have upperCrossReal :
+                (3 : ℝ) * constantCandidate.upperNumerator ≤
+                  10 * constantCandidate.upperDenominator := by
+              exact_mod_cast upperCross
+            have lowerCrossReal :
+                (10 : ℝ) * constantCandidate.lowerDenominator ≤
+                  4 * constantCandidate.lowerNumerator := by
+              exact_mod_cast lowerCross
+            have upperAdequate :
+                3 * candidateValue constantCandidate.upperNumerator
+                    constantCandidate.upperDenominator ≤ 10 := by
+              calc
+                3 * candidateValue constantCandidate.upperNumerator
+                    constantCandidate.upperDenominator =
+                    (3 * constantCandidate.upperNumerator : ℝ) /
+                      constantCandidate.upperDenominator := by
+                      simp only [candidateValue]
+                      ring
+                _ ≤ 10 := (div_le_iff₀ upperPositive).2 (by
+                  simpa only [mul_comm] using upperCrossReal)
+            have lowerAdequate :
+                10 ≤ 4 * candidateValue constantCandidate.lowerNumerator
+                    constantCandidate.lowerDenominator := by
+              calc
+                10 ≤ (4 * constantCandidate.lowerNumerator : ℝ) /
+                    constantCandidate.lowerDenominator :=
+                  (le_div_iff₀ lowerPositive).2 (by
+                    simpa only [mul_comm] using lowerCrossReal)
+                _ = 4 * candidateValue constantCandidate.lowerNumerator
+                    constantCandidate.lowerDenominator := by
+                      simp only [candidateValue]
+                      ring
+            rcases constant.proof with ⟨piLower, piUpper⟩
+            have threePi : 3 * Real.pi < 10 :=
+              lt_of_lt_of_le (mul_lt_mul_of_pos_left piUpper (by norm_num))
+                upperAdequate
+            have fourPi : 10 < 4 * Real.pi :=
+              lt_of_le_of_lt lowerAdequate
+                (mul_lt_mul_of_pos_left piLower (by norm_num))
+            refine ⟨by simp [Reduction.accepts], ⟨?_, ?_⟩, ?_⟩
+            · simp only [residual, Reduction.candidate]
+              norm_num at threePi ⊢
+              linarith
+            · simp only [residual, Reduction.candidate]
+              norm_num at fourPi ⊢
+              linarith
+            · convert (Real.sin_sub_nat_mul_pi 10 3) using 1 <;>
+                norm_num [residual, signed, Reduction.candidate] }
+    else none
+  else none
+
+end ReductionReplay
+
+namespace CertificateReplay
+
+/-- Fixed pipeline orchestration for this canary. The individual stages own
+their acceptance tests and mathematical theorems. -/
+noncomputable def replay? (certificate : Certificate) :
+    Option (Evidence (Real.sin 10 < 0)) := do
+  let constant ← MachinReplay.replay? certificate.constant
+  let reduction ← ReductionReplay.replay? certificate.constant
+    certificate.reduction constant
+  let localEvidence ← LocalReplay.replay? certificate.method
+    { proof := reduction.proof.core }
+  some
+    { proof := by
+        have reductionEqual : certificate.reduction = Reduction.candidate := by
+          simpa [Reduction.accepts] using reduction.proof.accepted
+        have positive := localEvidence.proof
+        have reconstructed := reduction.proof.reconstruct
+        rw [reductionEqual] at positive reconstructed
+        simp only [Reduction.candidate, LocalReplay.Claim] at positive
+        simp only [Reduction.candidate, ReductionReplay.signed, if_true] at reconstructed
+        linarith }
+
+end CertificateReplay
+
+end Hex.IntervalMathlib.Experiment.SinTen
+
+end

--- a/conformance/HexIntervalMathlib/SinTenConformance.lean
+++ b/conformance/HexIntervalMathlib/SinTenConformance.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Experiment.SinTen
+
+/-!
+# Machin range-reduction conformance
+
+The successful certificate produces an ordinary theorem. Endpoint mutations
+exercise the bounded numeric adequacy gate; reduction and method mutations
+remain exact fixed-canary refusals.
+-/
+
+namespace Hex.IntervalMathlib.SinTenConformance
+
+open Hex.Interval.Experiment.SemanticReplay
+open Hex.Interval.Experiment.SinTen
+open Hex.IntervalMathlib.Experiment.SinTen
+
+/-- A differently encoded provider enclosure with the same numeric bounds. -/
+def rescaledConstant : ConstantCandidate :=
+  { lowerNumerator := 6, lowerDenominator := 2,
+    upperNumerator := 32, upperDenominator := 10 }
+
+#guard Reduction.adequate Machin.candidate
+#guard Reduction.adequate rescaledConstant
+#guard !Reduction.adequate { Machin.candidate with lowerNumerator := 2 }
+#guard !Reduction.adequate { Machin.candidate with lowerDenominator := 2 }
+#guard !Reduction.adequate { Machin.candidate with upperNumerator := 17 }
+#guard !Reduction.adequate { Machin.candidate with upperDenominator := 4 }
+#guard !Reduction.adequate { Machin.candidate with lowerDenominator := 0 }
+#guard !Reduction.adequate { Machin.candidate with upperDenominator := 0 }
+#guard !Reduction.adequate { rescaledConstant with upperNumerator := 33 }
+
+noncomputable def rescaledEvidence :
+    Evidence (MachinReplay.Claim rescaledConstant) :=
+  { proof := by
+      change (6 : ℝ) / 2 < Real.pi ∧ Real.pi < (32 : ℝ) / 10
+      convert MachinReplay.pi_bounds using 1 <;> norm_num }
+
+example : Option.isSome
+    (ReductionReplay.replay? rescaledConstant Reduction.candidate rescaledEvidence) = true := by
+  rfl
+
+example : CertificateReplay.replay?
+    { certificate with reduction.halfTurns := 2 } = none := by rfl
+
+example : CertificateReplay.replay?
+    { certificate with reduction.halfTurns := 4 } = none := by rfl
+
+example : CertificateReplay.replay?
+    { certificate with reduction.negativeOutput := false } = none := by rfl
+
+example : CertificateReplay.replay?
+    { certificate with constant.upperNumerator := 17 } = none := by rfl
+
+example : CertificateReplay.replay?
+    { certificate with method := .taylorThree } = none := by rfl
+
+/-- First ordinary theorem produced by the numerical provider pipeline. -/
+theorem sinTenNegative : Real.sin 10 < 0 :=
+  (CertificateReplay.replay? certificate).get (by rfl) |>.proof
+
+/--
+info: 'Hex.IntervalMathlib.SinTenConformance.sinTenNegative' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms sinTenNegative
+
+end Hex.IntervalMathlib.SinTenConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -322,13 +322,15 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.TraceReplay,
     `HexInterval.Experiment.SineSign,
     `HexInterval.Experiment.ExpSign,
-    `HexInterval.Experiment.PntLogTable]
+    `HexInterval.Experiment.PntLogTable,
+    `HexInterval.Experiment.SinTen].map Glob.one
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center,
     `HexIntervalMathlib.Experiment.SineSign,
     `HexIntervalMathlib.Experiment.ExpSign,
-    `HexIntervalMathlib.Experiment.PntLogTable]
+    `HexIntervalMathlib.Experiment.PntLogTable,
+    `HexIntervalMathlib.Experiment.SinTen]
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -392,7 +394,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.ScopeConformance, `HexInterval.StructuralMatcherConformance, `HexInterval.MatcherSchedulerConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexInterval.PayloadSessionConformance, `HexInterval.PolicySessionConformance, `HexInterval.PolicyFunctionConformance, `HexInterval.SemanticReplayConformance, `HexInterval.ChronologicalReplayConformance, `HexInterval.GenericInstanceReconstructionConformance, `HexInterval.ProofEmitterConformance, `HexInterval.TraceReplayConformance, `HexIntervalMathlib.SineSignConformance, `HexIntervalMathlib.SineProofConformance, `HexIntervalMathlib.SineTacticConformance, `HexIntervalMathlib.ProofRegistryConformance, `HexIntervalMathlib.ExpSignConformance, `HexIntervalMathlib.RefuteConformance, `HexIntervalMathlib.PntLogTableConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexMvPolyFixtures, `HexMvPoly.Conformance, `HexMvPolyMathlib.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.ScopeConformance, `HexInterval.StructuralMatcherConformance, `HexInterval.MatcherSchedulerConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexInterval.PayloadSessionConformance, `HexInterval.PolicySessionConformance, `HexInterval.PolicyFunctionConformance, `HexInterval.SemanticReplayConformance, `HexInterval.ChronologicalReplayConformance, `HexInterval.GenericInstanceReconstructionConformance, `HexInterval.ProofEmitterConformance, `HexInterval.TraceReplayConformance, `HexIntervalMathlib.SineSignConformance, `HexIntervalMathlib.SineProofConformance, `HexIntervalMathlib.SineTacticConformance, `HexIntervalMathlib.ProofRegistryConformance, `HexIntervalMathlib.ExpSignConformance, `HexIntervalMathlib.RefuteConformance, `HexIntervalMathlib.PntLogTableConformance, `HexIntervalMathlib.SinTenConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexMvPolyFixtures, `HexMvPoly.Conformance, `HexMvPolyMathlib.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260814T160000Z.md
+++ b/progress/20260814T160000Z.md
@@ -1,0 +1,25 @@
+# Accomplished
+
+- Added a Mathlib-free fixed-data certificate for the `sin 10` range-reduction
+  canary and a proof-only replay through a Machin enclosure of pi.
+- Proved the ordinary kernel theorem `Real.sin 10 < 0` without `native_decide`,
+  `sorry`, a new axiom, or an unchecked arithmetic oracle.
+- Registered only the new SinTen experiment and conformance modules on current
+  `main`, retaining the existing registry and PNT+ work after the PNT stack
+  merged.
+
+# Current frontier
+
+The proof-side canary authenticates its fixed Machin provider, then selects
+half-turn `3` from bounded numeric endpoint adequacy rather than provider
+identity. Reduction and local-method choices remain fixed. It is not yet routed
+through the generic endpoint chronology or proof frontend.
+
+# Next step
+
+Replay the endpoint-valued six-event chronology and close the retained
+`sin 10 ∈ [-1, 0)` fact through the generic proof registry and frontend.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -150,6 +150,12 @@
     "reason": "Additionally registers the Mathlib-free PNT log-two experiment, its Mathlib semantic companion, and its conformance module only; the factorization service target and executable dependency graph are unchanged."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "373b193abb5bdb8eaf6345d3e913009861d49616",
+    "reason": "Additionally registers the Mathlib-free sin-ten certificate data, its proof-only Machin range-reduction companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",


### PR DESCRIPTION
## Summary

- add a Mathlib-free fixed-data certificate for the `sin 10` range-reduction canary
- replay a coarse Machin enclosure `3 < pi < 16/5` through ordinary kernel proofs
- derive the ordinary theorem `Real.sin 10 < 0` without the interval tactic or unchecked arithmetic

## Validation

- `lake build HexIntervalMathlib.SinTenConformance` (2215 jobs)
- conformance target registration check
- DAG and Phase-4 checks
- published trust-surface check
- exact proof-only freshness check
- `git diff --check`

This is the base of the endpoint-valued chronology stack.