### PR TITLE
feat(interval): replay endpoint sine chronology

### DIFF
--- a/HexInterval/Experiment/SinTenInterval.lean
+++ b/HexInterval/Experiment/SinTenInterval.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.SemanticReplay
+public import HexInterval.Experiment.PolicySession
+public import HexInterval.Experiment.Rational
+
+@[expose] public section
+
+/-!
+# Endpoint facts through the generic chronology
+
+This experiment uses explicit rational interval endpoints. It intentionally
+supports only top-to-interval refinement and repeated identical facts; general
+interval intersection remains outside this canary.
+-/
+
+namespace Hex.Interval.Experiment.SinTenInterval
+
+open Propagator PayloadArena
+
+abbrev Rat := Rational.Raw
+
+structure Interval where
+  lower : Rat
+  upper : Rat
+  lowerOpen : Bool
+  upperOpen : Bool
+  deriving DecidableEq, Repr
+
+inductive Bound where
+  | all
+  | interval (value : Interval)
+  deriving DecidableEq, Repr
+
+def rat (numerator denominator : Int) : Rat :=
+  { num := numerator, den := denominator }
+
+def openInterval (lower upper : Rat) : Bound :=
+  .interval { lower, upper, lowerOpen := true, upperOpen := true }
+
+def piFact : Bound := openInterval (rat 3 1) (rat 16 5)
+def residualFact : Bound := openInterval (rat 2 5) (rat 1 1)
+def positiveFact : Bound :=
+  .interval
+    { lower := rat 0 1
+      upper := rat 1 1
+      lowerOpen := true
+      upperOpen := false }
+def negativeFact : Bound :=
+  .interval
+    { lower := rat (-1) 1
+      upper := rat 0 1
+      lowerOpen := false
+      upperOpen := true }
+
+namespace Bound
+
+/-- Every explicit endpoint must carry a genuine rational denominator. -/
+def valid : Bound → Bool
+  | .all => true
+  | .interval value => value.lower.valid && value.upper.valid
+
+def code? : Bound → Option Nat
+  | .all => some 0
+  | fact =>
+      if !fact.valid then none
+      else if fact == piFact then some 1
+      else if fact == residualFact then some 2
+      else if fact == positiveFact then some 3
+      else if fact == negativeFact then some 4
+      else none
+
+def ofCode? : Nat → Option Bound
+  | 0 => some .all
+  | 1 => some piFact
+  | 2 => some residualFact
+  | 3 => some positiveFact
+  | 4 => some negativeFact
+  | _ => none
+
+end Bound
+
+/-- A deliberately partial intersection boundary. Unknown combinations are
+malformed rather than silently treated as disjoint. -/
+def factDomain : FactDomain Bound where
+  top _ := .all
+  narrow _ current proposed :=
+    if current == proposed then .noChange
+    else match current, proposed with
+      | _, .all => .noChange
+      | .all, proposed => .improved proposed
+      | _, _ => .malformed 1
+
+def real : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "sin-ten-interval.source" }
+def sineKey : OpKey := { name := "sin-ten-interval.sine" }
+def piKey : OpKey := { name := "sin-ten-interval.pi" }
+def residualKey : OpKey := { name := "sin-ten-interval.reduce" }
+def negationKey : OpKey := { name := "sin-ten-interval.negation" }
+
+def constantRuleKey : RuleKey := { name := "sin-ten-interval.constant" }
+def reductionRuleKey : RuleKey := { name := "sin-ten-interval.reduction" }
+def localRuleKey : RuleKey := { name := "sin-ten-interval.local-sine" }
+def negationRuleKey : RuleKey := { name := "sin-ten-interval.negation" }
+def identityRuleKey : RuleKey := { name := "sin-ten-interval.identity" }
+
+def sourceOperation : Operation := { key := sourceKey, inputs := [], output := real }
+def sineOperation : Operation := { key := sineKey, inputs := [real], output := real }
+def piOperation : Operation := { key := piKey, inputs := [], output := real }
+def residualOperation : Operation :=
+  { key := residualKey, inputs := [real, real], output := real }
+def negationOperation : Operation :=
+  { key := negationKey, inputs := [real], output := real }
+
+def operations : Array Operation :=
+  #[sourceOperation, sineOperation, piOperation, residualOperation, negationOperation]
+
+def node (index : Nat) : NodeId := { index }
+def payload (index : Nat) : PayloadId := { index }
+
+def sourceInstruction : Node :=
+  { domain := real, op := { index := 0 }, args := [] }
+def targetSineInstruction : Node :=
+  { domain := real, op := { index := 1 }, args := [node 0] }
+def piInstruction : Node :=
+  { domain := real, op := { index := 2 }, args := [] }
+def residualInstruction : Node :=
+  { domain := real, op := { index := 3 }, args := [node 0, node 2] }
+def localSineInstruction : Node :=
+  { domain := real, op := { index := 1 }, args := [node 3] }
+def negatedLocalSineInstruction : Node :=
+  { domain := real, op := { index := 4 }, args := [node 4] }
+
+def baseProgram : Program :=
+  { operations
+    nodes := #[sourceInstruction, targetSineInstruction, piInstruction,
+      residualInstruction, localSineInstruction] }
+
+def extendedProgram : Program :=
+  { operations
+    nodes := baseProgram.nodes ++ #[negatedLocalSineInstruction] }
+
+def checkerInput : SemanticReplay.CheckerInput Bound :=
+  { baseProgram
+    initialFacts := #[.all, .all, .all, .all, .all]
+    target := { node := node 1, fact := negativeFact } }
+
+def constantRule : Registration :=
+  { key := constantRuleKey, head := piKey, kind := .forward,
+    watches := [], writes := [.result] }
+def reductionRule : Registration :=
+  { key := reductionRuleKey, head := residualKey, kind := .forward,
+    watches := [.argument 0, .argument 1], writes := [.result] }
+def localRule : Registration :=
+  { key := localRuleKey, head := sineKey, kind := .forward,
+    watches := [.argument 0], writes := [.result] }
+def negationRule : Registration :=
+  { key := negationRuleKey, head := negationKey, kind := .forward,
+    watches := [.argument 0], writes := [.result] }
+def identityRule : Registration :=
+  { key := identityRuleKey, head := residualKey, kind := .instantiate,
+    watches := [.result], writes := [] }
+
+def factFormat : ReplayFormat :=
+  { role := .fact, schema := 1
+    validateBody := fun body =>
+      match body with
+      | [code] => (Bound.ofCode? code).isSome
+      | _ => false }
+def instanceFormat : ReplayFormat :=
+  { role := .instance, schema := 1, validateBody := fun body => body == [1] }
+def equalityFormat : ReplayFormat :=
+  { role := .equality, schema := 1, validateBody := fun body => body == [1] }
+
+def factPlan (fact : Bound) (label : PayloadId) (request : RuleRequest Bound) :
+    Plan Bound :=
+  match fact.code?, request.writes with
+  | some code, [target] =>
+      { outcome := .success [{ node := target, fact, payload := label }] [] {}
+        drafts := [{ label, role := .fact, schema := 1, body := [code] }] }
+  | _, _ => { outcome := .failed 1, drafts := [] }
+
+def constantPlan (request : RuleRequest Bound) : Plan Bound :=
+  factPlan piFact (payload 10) request
+
+def reductionPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [_source, pi] =>
+      if pi.fact == piFact then factPlan residualFact (payload 11) request
+      else { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 2, drafts := [] }
+
+def localPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if input.fact == residualFact then factPlan positiveFact (payload 12) request
+      else { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 3, drafts := [] }
+
+def negationPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if input.fact == positiveFact then factPlan negativeFact (payload 13) request
+      else { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 4, drafts := [] }
+
+def identityPlan (request : RuleRequest Bound) : Plan Bound :=
+  match request.inputs with
+  | [input] =>
+      if input.node != node 3 || input.fact != residualFact then
+        { outcome := .noChange {}, drafts := [] }
+      else
+        match request.program.findOp? sineKey, request.program.findOp? negationKey,
+            request.program.findOp? residualKey, request.program.findOp? piKey,
+            request.program.node? (node 1), request.program.node? (node 2),
+            request.program.node? (node 3), request.program.node? (node 4) with
+        | some (sineId, _), some (negationId, _), some (residualId, _), some (piId, _),
+            some target, some pi, some residual, some localSine =>
+            if target != { domain := real, op := sineId, args := [node 0] } ||
+                pi != { domain := real, op := piId, args := [] } ||
+                residual !=
+                  { domain := real, op := residualId, args := [node 0, node 2] } ||
+                localSine != { domain := real, op := sineId, args := [node 3] } then
+              { outcome := .noChange {}, drafts := [] }
+            else
+              let proposal : InstantiationRequest :=
+                { key := 1
+                  nodes :=
+                    [{ domain := real, op := negationId, args := [.existing (node 4)] }]
+                  equalities :=
+                    [{ left := .existing (node 1)
+                       right := .proposed 0
+                       payload := payload 15 }]
+                  payload := payload 14 }
+              { outcome := .success [] [.instantiate proposal] {}
+                drafts :=
+                  [{ label := payload 14, role := .instance, schema := 1, body := [1] },
+                   { label := payload 15, role := .equality, schema := 1, body := [1] }] }
+        | _, _, _, _, _, _, _, _ => { outcome := .noChange {}, drafts := [] }
+  | _ => { outcome := .failed 5, drafts := [] }
+
+def sourcePackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[sourceOperation], handlers := #[] }
+def constantPackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[piOperation],
+    handlers := #[Handler.statelessPlanned constantRule constantPlan #[factFormat]] }
+def reductionPackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[residualOperation],
+    requiredOperations := #[sineOperation, negationOperation],
+    handlers := #[Handler.statelessPlanned reductionRule reductionPlan #[factFormat],
+      Handler.statelessPlanned identityRule identityPlan #[instanceFormat, equalityFormat]] }
+def localPackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[sineOperation],
+    handlers := #[Handler.statelessPlanned localRule localPlan #[factFormat]] }
+def negationPackage : Package Bound :=
+  { Cache := Unit, cache := (), operations := #[negationOperation],
+    handlers := #[Handler.statelessPlanned negationRule negationPlan #[factFormat]] }
+
+def packages : Array (Package Bound) :=
+  #[sourcePackage, localPackage, constantPackage, reductionPackage, negationPackage]
+
+def engineLimits : Propagator.Limits :=
+  { maxOperations := 5, maxNodes := 6, maxRules := 5, maxRegistryEntries := 24,
+    maxReplayFormats := 8, maxArity := 2, maxScopeNodes := 1,
+    maxApplications := 12, maxQueueEntries := 96, maxActions := 80,
+    maxMatcherVisits := 16, matcherBatchSize := 8, maxAcceptedFacts := 12,
+    maxRetainedSuggestions := 2, maxEffort := 1, maxObservationValue := 24,
+    maxDiagnosticValue := 300, maxOutcomeCandidates := 1,
+    maxOutcomeSuggestions := 1, maxProposalItems := 3, maxInstances := 1,
+    maxGeneration := 1, maxNodeDepth := 3, maxEqualities := 1,
+    splitEndpointLimit := { maxEndpointHeight := 8, maxAlignmentShift := 4 } }
+def policyLimits : Propagator.Policy.Limits :=
+  { maxDecisions := 96, maxTraversal := 768, maxLiveOffers := 64 }
+def arenaLimits : PayloadArena.Limits :=
+  { maxEntries := 24, maxBodyCells := 48, maxDrafts := 12,
+    maxDraftCells := 12, maxAtom := 32, maxSchema := 1, maxUses := 12 }
+def limits : PolicySession.Limits :=
+  { engine := engineLimits, policy := policyLimits, arena := arenaLimits }
+
+end Hex.Interval.Experiment.SinTenInterval
+
+end

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3226,6 +3226,50 @@ integration that has not landed. Those are the next integration boundaries.
 The 1,000-bit provider and `cos (10^10)` remain acceptance targets, not
 delivered claims.
 
+A second, deliberately narrow endpoint canary closes the chronology/replay
+part of that integration boundary. From the first canary it reuses only the
+Machin-derived coarse pi enclosure. It replaces that canary's exact-match
+certificate authentication with per-schema guards: every proof schema checks
+its own exact graph, assumptions, proposed fact or edge, and replay body before
+returning evidence. Its Mathlib-free fact type carries rational lower and upper
+endpoints plus independent closure flags. The retained target fact is
+`sin 10 ∈ [-1, 0)`. Independent executable packages install the coarse pi fact
+`(3, 16/5)`, reduce to `10 - 3*pi ∈ (2/5, 1)`, establish the local fact
+`sin (10 - 3*pi) ∈ (0, 1]`, and negate it to `[-1, 0)`. An
+instantiation handler owned by the reduction package appends the negated
+local-sine node and the periodicity equality. Generic equality contraction then
+transports the endpoint fact to the original `sin 10` node. The retained
+chronology records, in order, the constant, reduction, local-sine,
+instantiation, negation, and transport events, including exact input versions
+and exact replay bodies.
+
+The same six-event trace passes through the generic proof registry and
+`ProofFrontend`. Constant, reduction, local-sine, instantiation, negation, and
+equality schemas own their mathematical replay; the frontend contains no
+function-specific case. Closing the extended graph back to the original graph
+produces the ordinary theorem `-1 ≤ sin 10 ∧ sin 10 < 0`, with the standard
+`#print axioms` guard and no `native_decide`, `sorry`, or new axiom.
+
+This remains a fixed-data orchestration experiment, not a general interval
+implementation. It deliberately reuses the D2 `Rational.Raw` certificate
+representation because the exact Machin endpoints `16/5` and `2/5` are not
+dyadic; its decoder accepts only top and four fixed endpoint facts, all of whose
+denominators are nonzero. The source operation is proof-side constrained to the
+hardcoded value `10`; there is no goal reifier for this endpoint fact, no
+precision-parametric endpoint computation, no alternative provider whose
+selection or fallback is exercised, and no general interval intersection. The
+partial fact domain supports identical facts and top as an intersection
+identity, and rejects other pairs as malformed. The canary uses a first-offer,
+category-major controller; it does not claim that policy is the production
+search policy. Its reduction and replay hardcode the half-turn count `3`; no
+range-reduction choice is computed. The declared limits are an exact-fit
+resource envelope for this retained run (five operations, six nodes, one
+generated instance, one equality, and maximum node depth three), not evidence
+that the controller succeeds under a general resource policy. General
+open/closed/unbounded interval arithmetic, provider competition,
+range-reduction selection, and computed local enclosures remain acceptance
+work.
+
 #### Series as package-owned numerical algorithms
 
 A registered function may supply a power or Taylor series without teaching the

--- a/HexIntervalMathlib/Experiment/SinTenInterval.lean
+++ b/HexIntervalMathlib/Experiment/SinTenInterval.lean
@@ -1,0 +1,575 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.SinTenInterval
+public import HexIntervalMathlib.Experiment.SinTen
+public import HexInterval.Experiment.ProofRegistry
+public import HexInterval.Experiment.OperationSemantics
+
+@[expose] public section
+
+/-!
+# Proof semantics for the endpoint-valued sine canary
+
+The executable scheduler remains unaware of real numbers and transcendental
+functions. These package-owned schemas replay its exact endpoint facts against
+ordinary real semantics.
+-/
+
+namespace Hex.IntervalMathlib.Experiment.SinTenInterval
+
+open Hex.Interval.Experiment
+open Propagator SemanticReplay ChronologicalReplay ProofEmitter ProofRegistry
+open GenericInstanceReconstruction OperationSemantics
+open Hex.Interval.Experiment.SinTenInterval
+
+noncomputable def ratValue
+    (q : Hex.Interval.Experiment.SinTenInterval.Rat) : ℝ :=
+  q.num / q.den
+
+def Contains : Bound → ℝ → Prop
+  | .all, _ => True
+  | .interval interval, value =>
+      (if interval.lowerOpen then ratValue interval.lower < value
+        else ratValue interval.lower ≤ value) ∧
+      (if interval.upperOpen then value < ratValue interval.upper
+        else value ≤ ratValue interval.upper)
+
+def sourceModel : OperationSemantics.Model ℝ :=
+  { operation := sourceOperation
+    relation := fun _ output => output = 10 }
+
+def sineModel : OperationSemantics.Model ℝ :=
+  { operation := sineOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [input] => output = Real.sin input
+      | _ => False }
+
+def piModel : OperationSemantics.Model ℝ :=
+  { operation := piOperation
+    relation := fun _ output => output = Real.pi }
+
+def residualModel : OperationSemantics.Model ℝ :=
+  { operation := residualOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [source, pi] => output = source - 3 * pi
+      | _ => False }
+
+def negationModel : OperationSemantics.Model ℝ :=
+  { operation := negationOperation
+    relation := fun inputs output =>
+      match inputs with
+      | [input] => output = -input
+      | _ => False }
+
+def operationModels : Array (OperationSemantics.Model ℝ) :=
+  #[sourceModel, sineModel, piModel, residualModel, negationModel]
+
+def semantics : Semantics Bound :=
+  OperationSemantics.semantics operationModels Contains
+
+def boundSchema : FactDomainSchema semantics where
+  top := fun _ => .all
+  topSound := by intros; trivial
+  proveMeet := fun _ target previous proposed installed =>
+    if same : previous = proposed then
+      if exact : installed = previous then
+        some
+          { proof := by
+              subst proposed
+              subst installed
+              intro valuation _
+              change Contains previous (valuation target) ↔
+                Contains previous (valuation target) ∧ Contains previous (valuation target)
+              simp }
+      else none
+    else if rightTop : proposed = .all then
+      if installedEq : installed = previous then
+        some
+          { proof := by
+              subst proposed
+              subst installed
+              intro valuation _
+              change Contains previous (valuation target) ↔
+                Contains previous (valuation target) ∧ Contains .all (valuation target)
+              simp [Contains] }
+      else none
+    else if leftTop : previous = .all then
+      if installedEq : installed = proposed then
+        some
+          { proof := by
+              subst previous
+              subst installed
+              intro valuation _
+              change Contains proposed (valuation target) ↔
+                Contains .all (valuation target) ∧ Contains proposed (valuation target)
+              simp [Contains] }
+      else none
+    else none
+
+def laws : Laws semantics :=
+  { holdsEq := by
+      intro _ valuation left right fact _ _ values
+      change Contains fact (valuation left) ↔ Contains fact (valuation right)
+      rw [values] }
+
+def stableLaw : StableLaw semantics :=
+  OperationSemantics.stableLaw operationModels Contains
+
+theorem programPrefix : ProgramPrefix baseProgram extendedProgram := by
+  refine
+    { operationSize := by simp [baseProgram, extendedProgram]
+      nodeSize := by simp [baseProgram, extendedProgram]
+      operationAt := ?_
+      nodeAt := ?_ }
+  · intro index within
+    simp [baseProgram, extendedProgram]
+  · intro index within
+    cases index with
+    | zero => rfl
+    | succ index =>
+        cases index with
+        | zero => rfl
+        | succ index =>
+            cases index with
+            | zero => rfl
+            | succ index =>
+                cases index with
+                | zero => rfl
+                | succ index =>
+                    cases index with
+                    | zero => rfl
+                    | succ index =>
+                        have lower : 5 ≤ index + 1 + 1 + 1 + 1 + 1 :=
+                          Nat.le_add_left 5 index
+                        exact False.elim (Nat.not_lt_of_ge lower (by
+                          simpa [baseProgram] using within))
+
+theorem sameOperations : baseProgram.operations = extendedProgram.operations := rfl
+
+noncomputable def extendValuation (valuation : NodeId → ℝ) : NodeId → ℝ :=
+  fun observed => if observed = node 5 then -valuation (node 4) else valuation observed
+
+theorem extension : semantics.Extends baseProgram extendedProgram := by
+  intro valuation model
+  obtain ⟨old0, at0, related0⟩ := model.2 (node 0) sourceInstruction (by rfl)
+  obtain ⟨old1, at1, related1⟩ := model.2 (node 1) targetSineInstruction (by rfl)
+  obtain ⟨old2, at2, related2⟩ := model.2 (node 2) piInstruction (by rfl)
+  obtain ⟨old3, at3, related3⟩ := model.2 (node 3) residualInstruction (by rfl)
+  obtain ⟨old4, at4, related4⟩ := model.2 (node 4) localSineInstruction (by rfl)
+  simp [operationModels, sourceInstruction] at at0
+  simp [operationModels, targetSineInstruction] at at1
+  simp [operationModels, piInstruction] at at2
+  simp [operationModels, residualInstruction] at at3
+  simp [operationModels, localSineInstruction] at at4
+  subst old0
+  subst old1
+  subst old2
+  subst old3
+  subst old4
+  refine ⟨extendValuation valuation, ?_, ?_⟩
+  · refine ⟨by simpa [baseProgram, extendedProgram] using model.1, ?_⟩
+    intro observed instruction found
+    rcases observed with ⟨index⟩
+    cases index with
+    | zero =>
+        simp [extendedProgram, baseProgram, Program.node?] at found
+        subst instruction
+        refine ⟨sourceModel, by rfl, ?_⟩
+        simpa [sourceModel, sourceInstruction, extendValuation, node] using related0
+    | succ index =>
+        cases index with
+        | zero =>
+            simp [extendedProgram, baseProgram, Program.node?] at found
+            subst instruction
+            refine ⟨sineModel, by rfl, ?_⟩
+            simpa [sineModel, targetSineInstruction, extendValuation, node, List.map]
+              using related1
+        | succ index =>
+            cases index with
+            | zero =>
+                simp [extendedProgram, baseProgram, Program.node?] at found
+                subst instruction
+                refine ⟨piModel, by rfl, ?_⟩
+                simpa [piModel, piInstruction, extendValuation, node] using related2
+            | succ index =>
+                cases index with
+                | zero =>
+                    simp [extendedProgram, baseProgram, Program.node?] at found
+                    subst instruction
+                    refine ⟨residualModel, by rfl, ?_⟩
+                    simpa [residualModel, residualInstruction, extendValuation, node,
+                      List.map] using related3
+                | succ index =>
+                    cases index with
+                    | zero =>
+                        simp [extendedProgram, baseProgram, Program.node?] at found
+                        subst instruction
+                        refine ⟨sineModel, by rfl, ?_⟩
+                        simpa [sineModel, localSineInstruction, extendValuation, node,
+                          List.map] using related4
+                    | succ index =>
+                        cases index with
+                        | zero =>
+                            simp [extendedProgram, baseProgram, Program.node?] at found
+                            subst instruction
+                            refine ⟨negationModel, by rfl, ?_⟩
+                            simp [negationModel, negatedLocalSineInstruction,
+                              extendValuation, node, List.map]
+                        | succ index =>
+                            simp [extendedProgram, baseProgram, Program.node?] at found
+  · intro observed within
+    have notFive : observed ≠ node 5 := by
+      intro equal
+      subst observed
+      simp [baseProgram, node] at within
+    simp [extendValuation, notFive]
+
+def stable : StableStep semantics baseProgram extendedProgram :=
+  stableLaw.stable (by rfl) (by rfl) programPrefix sameOperations
+
+theorem constantEntails :
+    semantics.Entails baseProgram [] { node := node 2, fact := piFact } := by
+  intro valuation model _
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 (node 2) piInstruction (by rfl)
+  simp [operationModels, piInstruction] at meaningAt
+  subst meaning
+  have output : valuation (node 2) = Real.pi := by
+    simpa [piModel, piInstruction] using related
+  change Contains piFact (valuation (node 2))
+  simp only [Contains, piFact, openInterval, rat, ratValue, if_true]
+  rw [output]
+  norm_num
+  exact Hex.IntervalMathlib.Experiment.SinTen.MachinReplay.pi_bounds
+
+theorem reductionEntails :
+    semantics.Entails baseProgram
+      [{ node := node 0, fact := .all }, { node := node 2, fact := piFact }]
+      { node := node 3, fact := residualFact } := by
+  intro valuation model holds
+  change NodeId → ℝ at valuation
+  obtain ⟨sourceMeaning, sourceAt, sourceRelated⟩ :=
+    model.2 (node 0) sourceInstruction (by rfl)
+  obtain ⟨residualMeaning, residualAt, residualRelated⟩ :=
+    model.2 (node 3) residualInstruction (by rfl)
+  simp [operationModels, sourceInstruction] at sourceAt
+  simp [operationModels, residualInstruction] at residualAt
+  subst sourceMeaning
+  subst residualMeaning
+  have sourceValue : valuation (node 0) = 10 := by
+    simpa [sourceModel, sourceInstruction] using sourceRelated
+  have residualValue :
+      valuation (node 3) = valuation (node 0) - 3 * valuation (node 2) := by
+    simpa [residualModel, residualInstruction, List.map] using residualRelated
+  have piBounds : (3 : ℝ) < valuation (node 2) ∧ valuation (node 2) < 16 / 5 := by
+    have := holds { node := node 2, fact := piFact } (by simp)
+    change Contains piFact (valuation (node 2)) at this
+    simpa [Contains, piFact, openInterval, rat, ratValue] using this
+  change Contains residualFact (valuation (node 3))
+  simp only [Contains, residualFact, openInterval, rat, ratValue, if_true]
+  rw [residualValue, sourceValue]
+  constructor <;> linarith
+
+theorem localEntails :
+    semantics.Entails baseProgram
+      [{ node := node 3, fact := residualFact }]
+      { node := node 4, fact := positiveFact } := by
+  intro valuation model holds
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 (node 4) localSineInstruction (by rfl)
+  simp [operationModels, localSineInstruction] at meaningAt
+  subst meaning
+  have output : valuation (node 4) = Real.sin (valuation (node 3)) := by
+    simpa [sineModel, localSineInstruction, List.map] using related
+  have residualBounds :
+      (2 / 5 : ℝ) < valuation (node 3) ∧ valuation (node 3) < 1 := by
+    have := holds { node := node 3, fact := residualFact } (by simp)
+    change Contains residualFact (valuation (node 3)) at this
+    simpa [Contains, residualFact, openInterval, rat, ratValue] using this
+  change Contains positiveFact (valuation (node 4))
+  simp only [Contains, positiveFact, rat, ratValue, if_true]
+  rw [output]
+  norm_num
+  exact ⟨Real.sin_pos_of_pos_of_lt_pi (by linarith)
+      (residualBounds.2.trans (by
+        have := Hex.IntervalMathlib.Experiment.SinTen.MachinReplay.pi_bounds.1
+        linarith)),
+    Real.sin_le_one _⟩
+
+theorem negationEntails :
+    semantics.Entails extendedProgram
+      [{ node := node 4, fact := positiveFact }]
+      { node := node 5, fact := negativeFact } := by
+  intro valuation model holds
+  change NodeId → ℝ at valuation
+  obtain ⟨meaning, meaningAt, related⟩ :=
+    model.2 (node 5) negatedLocalSineInstruction (by rfl)
+  simp [operationModels, negatedLocalSineInstruction] at meaningAt
+  subst meaning
+  have output : valuation (node 5) = -valuation (node 4) := by
+    simpa [negationModel, negatedLocalSineInstruction, List.map] using related
+  have positive : 0 < valuation (node 4) ∧ valuation (node 4) ≤ 1 := by
+    have := holds { node := node 4, fact := positiveFact } (by simp)
+    change Contains positiveFact (valuation (node 4)) at this
+    simpa [Contains, positiveFact, rat, ratValue] using this
+  change Contains negativeFact (valuation (node 5))
+  simp only [Contains, negativeFact, rat, ratValue, if_true]
+  rw [output]
+  norm_num
+  exact ⟨positive.2, positive.1⟩
+
+theorem periodicEntails :
+    semantics.EntailsEq extendedProgram
+      [{ node := node 3, fact := residualFact }] (node 1) (node 5) := by
+  intro valuation model _
+  change NodeId → ℝ at valuation
+  obtain ⟨targetMeaning, targetAt, targetRelated⟩ :=
+    model.2 (node 1) targetSineInstruction (by rfl)
+  obtain ⟨sourceMeaning, sourceAt, sourceRelated⟩ :=
+    model.2 (node 0) sourceInstruction (by rfl)
+  obtain ⟨residualMeaning, residualAt, residualRelated⟩ :=
+    model.2 (node 3) residualInstruction (by rfl)
+  obtain ⟨localMeaning, localAt, localRelated⟩ :=
+    model.2 (node 4) localSineInstruction (by rfl)
+  obtain ⟨negMeaning, negAt, negRelated⟩ :=
+    model.2 (node 5) negatedLocalSineInstruction (by rfl)
+  simp [operationModels, targetSineInstruction] at targetAt
+  simp [operationModels, sourceInstruction] at sourceAt
+  simp [operationModels, residualInstruction] at residualAt
+  simp [operationModels, localSineInstruction] at localAt
+  simp [operationModels, negatedLocalSineInstruction] at negAt
+  subst targetMeaning
+  subst sourceMeaning
+  subst residualMeaning
+  subst localMeaning
+  subst negMeaning
+  have targetValue : valuation (node 1) = Real.sin (valuation (node 0)) := by
+    simpa [sineModel, targetSineInstruction, List.map] using targetRelated
+  have sourceValue : valuation (node 0) = 10 := by
+    simpa [sourceModel, sourceInstruction] using sourceRelated
+  have residualValue :
+      valuation (node 3) = valuation (node 0) - 3 * valuation (node 2) := by
+    simpa [residualModel, residualInstruction, List.map] using residualRelated
+  have piValue : valuation (node 2) = Real.pi := by
+    obtain ⟨piMeaning, piAt, piRelated⟩ := model.2 (node 2) piInstruction (by rfl)
+    simp [operationModels, piInstruction] at piAt
+    subst piMeaning
+    simpa [piModel, piInstruction] using piRelated
+  have localValue : valuation (node 4) = Real.sin (valuation (node 3)) := by
+    simpa [sineModel, localSineInstruction, List.map] using localRelated
+  have negValue : valuation (node 5) = -valuation (node 4) := by
+    simpa [negationModel, negatedLocalSineInstruction, List.map] using negRelated
+  have periodic : Real.sin (10 - 3 * Real.pi) = -Real.sin 10 := by
+    convert (Real.sin_sub_nat_mul_pi 10 3) using 1 <;> norm_num
+  rw [targetValue, sourceValue, negValue, localValue, residualValue, sourceValue, piValue]
+  calc
+    Real.sin 10 = -(-Real.sin 10) := (neg_neg _).symm
+    _ = -Real.sin (10 - 3 * Real.pi) := congrArg Neg.neg periodic.symm
+
+def constantSchema : PackedFactSchema semantics where
+  rule := constantRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [1] then some () else none
+  replay := fun _ _ context _ =>
+    if graph : context.program = baseProgram then
+      if assumptions : context.assumptions = [] then
+        if proposed : context.proposed = { node := node 2, fact := piFact } then
+          some { proof := by simpa only [graph, assumptions, proposed] using constantEntails }
+        else none
+      else none
+    else none
+
+def reductionSchema : PackedFactSchema semantics where
+  rule := reductionRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [2] then some () else none
+  replay := fun _ _ context _ =>
+    if graph : context.program = baseProgram then
+      if assumptions : context.assumptions =
+          [{ node := node 0, fact := .all }, { node := node 2, fact := piFact }] then
+        if proposed : context.proposed = { node := node 3, fact := residualFact } then
+          some { proof := by simpa only [graph, assumptions, proposed] using reductionEntails }
+        else none
+      else none
+    else none
+
+def localSchema : PackedFactSchema semantics where
+  rule := localRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [3] then some () else none
+  replay := fun _ _ context _ =>
+    if graph : context.program = baseProgram then
+      if assumptions : context.assumptions = [{ node := node 3, fact := residualFact }] then
+        if proposed : context.proposed = { node := node 4, fact := positiveFact } then
+          some { proof := by simpa only [graph, assumptions, proposed] using localEntails }
+        else none
+      else none
+    else none
+
+def negationSchema : PackedFactSchema semantics where
+  rule := negationRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [4] then some () else none
+  replay := fun _ _ context _ =>
+    if graph : context.program = extendedProgram then
+      if assumptions : context.assumptions = [{ node := node 4, fact := positiveFact }] then
+        if proposed : context.proposed = { node := node 5, fact := negativeFact } then
+          some { proof := by simpa only [graph, assumptions, proposed] using negationEntails }
+        else none
+      else none
+    else none
+
+def identityInstanceSchema : PackedInstanceSchema semantics where
+  rule := identityRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [1] then some () else none
+  replay := fun _ _ context _ =>
+    if before : context.before = baseProgram then
+      if after : context.after = extendedProgram then
+        some { proof := by simpa only [before, after] using extension }
+      else none
+    else none
+
+def identityEqualitySchema : PackedEqualitySchema semantics where
+  rule := identityRuleKey
+  schema := 1
+  Certificate := Unit
+  decode := fun body => if body == [1] then some () else none
+  replay := fun _ _ context _ =>
+    if graph : context.program = extendedProgram then
+      if assumptions : context.assumptions =
+          [{ node := node 3, fact := residualFact }] then
+        if left : context.edge.left = node 1 then
+          if right : context.edge.right = node 5 then
+            some
+              { proof := by
+                  simpa only [graph, assumptions, left, right] using periodicEntails }
+          else none
+        else none
+      else none
+    else none
+
+def sourceProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[] }, emit := { schemas := [] } }
+
+def constantProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[constantSchema] }
+    emit := { schemas := [{ key := constantSchema.key, handle := ``constantSchema }] } }
+
+def reductionProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic :=
+      { factSchemas := #[reductionSchema]
+        instanceSchemas := #[identityInstanceSchema]
+        equalitySchemas := #[identityEqualitySchema] }
+    emit :=
+      { schemas :=
+          [{ key := reductionSchema.key, handle := ``reductionSchema },
+           { key := identityInstanceSchema.key, handle := ``identityInstanceSchema },
+           { key := identityEqualitySchema.key, handle := ``identityEqualitySchema }] } }
+
+def localProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[localSchema] }
+    emit := { schemas := [{ key := localSchema.key, handle := ``localSchema }] } }
+
+def negationProof : ProofRegistry.Package semantics Lean.Name :=
+  { semantic := { factSchemas := #[negationSchema] }
+    emit := { schemas := [{ key := negationSchema.key, handle := ``negationSchema }] } }
+
+def proofPackages : Array (ProofRegistry.Package semantics Lean.Name) :=
+  #[sourceProof, localProof, constantProof, reductionProof, negationProof]
+
+def semanticPackages : Array (SemanticReplay.Package semantics) :=
+  proofPackages.map fun package => package.semantic
+
+def baseFacts : List (NodeFact Bound) :=
+  [{ node := node 0, fact := .all }, { node := node 1, fact := .all },
+   { node := node 2, fact := .all }, { node := node 3, fact := .all },
+   { node := node 4, fact := .all }]
+
+theorem baseWithin : FactsWithin baseProgram baseFacts := by
+  intro fact member
+  simp only [baseFacts, List.mem_cons, List.not_mem_nil, or_false] at member
+  rcases member with rfl | rfl | rfl | rfl | rfl <;> simp [baseProgram, node]
+
+theorem basePrefix : ProgramPrefix baseProgram baseProgram :=
+  ProgramPrefix.refl baseProgram
+
+def initialExtension : Evidence (semantics.Extends baseProgram baseProgram) :=
+  extendRefl semantics baseProgram
+
+theorem targetWithin : (node 1).index < baseProgram.nodes.size := by decide
+
+def closeEvidence
+    (extensionEvidence : Evidence (semantics.Extends baseProgram extendedProgram))
+    (final : Evidence (semantics.Entails extendedProgram baseFacts checkerInput.target)) :
+    Evidence (semantics.Entails baseProgram baseFacts checkerInput.target) :=
+  closeBase (input := checkerInput) stable baseWithin targetWithin
+    extensionEvidence final
+
+noncomputable def valuation : NodeId → ℝ
+  | ⟨0⟩ => 10
+  | ⟨1⟩ => Real.sin 10
+  | ⟨2⟩ => Real.pi
+  | ⟨3⟩ => 10 - 3 * Real.pi
+  | ⟨4⟩ => Real.sin (10 - 3 * Real.pi)
+  | _ => 0
+
+theorem valuationModels : semantics.models baseProgram valuation := by
+  refine ⟨by simp [baseProgram, operations, operationModels, sourceModel, sineModel,
+    piModel, residualModel, negationModel], ?_⟩
+  rintro ⟨index⟩ instruction found
+  cases index with
+  | zero =>
+      simp [Program.node?, baseProgram] at found
+      subst instruction
+      exact ⟨sourceModel, by rfl, by rfl⟩
+  | succ index =>
+      cases index with
+      | zero =>
+          simp [Program.node?, baseProgram] at found
+          subst instruction
+          exact ⟨sineModel, by rfl, by rfl⟩
+      | succ index =>
+          cases index with
+          | zero =>
+              simp [Program.node?, baseProgram] at found
+              subst instruction
+              exact ⟨piModel, by rfl, by rfl⟩
+          | succ index =>
+              cases index with
+              | zero =>
+                  simp [Program.node?, baseProgram] at found
+                  subst instruction
+                  exact ⟨residualModel, by rfl, by rfl⟩
+              | succ index =>
+                  cases index with
+                  | zero =>
+                      simp [Program.node?, baseProgram] at found
+                      subst instruction
+                      exact ⟨sineModel, by rfl, by rfl⟩
+                  | succ index => simp [Program.node?, baseProgram] at found
+
+theorem baseHolds :
+    ∀ fact ∈ baseFacts, semantics.holds baseProgram valuation fact := by
+  intro fact member
+  simp only [baseFacts, List.mem_cons, List.not_mem_nil, or_false] at member
+  rcases member with rfl | rfl | rfl | rfl | rfl <;> trivial
+
+end Hex.IntervalMathlib.Experiment.SinTenInterval
+
+end

--- a/conformance/HexInterval/SinTenIntervalConformance.lean
+++ b/conformance/HexInterval/SinTenIntervalConformance.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.SinTenInterval
+import HexInterval.Experiment.ProofFrontend
+import HexInterval.Experiment.TargetRun
+
+namespace Hex.Interval.SinTenIntervalConformance
+
+open Hex.Interval.Experiment
+open Propagator PolicySession ProofEmitter
+open SinTenInterval
+
+private def firstOffer : TargetRun.Controller Bound Unit :=
+  { update := fun state _ => state
+    choose := fun state view =>
+      match view.offers[0]? with
+      | some offer => .select offer state
+      | none => .stop state }
+
+private def reorderedView : ProgramView :=
+  { programVersion := 0
+    operations :=
+      #[negationOperation, sourceOperation, sineOperation, piOperation,
+        residualOperation]
+    nodes :=
+      #[{ sourceInstruction with op := { index := 1 } },
+        { targetSineInstruction with op := { index := 2 } },
+        { piInstruction with op := { index := 3 } },
+        { residualInstruction with op := { index := 4 } },
+        { localSineInstruction with op := { index := 2 } }]
+    generations := #[0, 0, 0, 0, 0]
+    depths := #[0, 1, 0, 1, 2] }
+
+private def identityRequest (program : ProgramView) : RuleRequest Bound :=
+  { action :=
+      { serial := 0
+        programVersion := program.programVersion
+        application := { index := 0 }
+        rule := { index := 0 }
+        key := identityRuleKey
+        node := node 3
+        kind := .instantiate
+        effort := 0
+        inputs := [{ node := node 3, version := 1 }] }
+    program
+    inputs := [{ node := node 3, fact := residualFact, version := 1 }]
+    writes := [] }
+
+private def reorderedIdentityOp? : Option OpId :=
+  match (identityPlan (identityRequest reorderedView)).outcome with
+  | .success [] [.instantiate proposal] _ =>
+      match proposal.nodes with
+      | [proposed] => some proposed.op
+      | _ => none
+  | _ => none
+
+#guard reorderedIdentityOp? == some { index := 0 }
+
+private def missingNegationView : ProgramView :=
+  { reorderedView with
+    operations := #[sourceOperation, sineOperation, piOperation, residualOperation]
+    nodes :=
+      #[sourceInstruction, targetSineInstruction,
+        { piInstruction with op := { index := 2 } },
+        { residualInstruction with op := { index := 3 } }, localSineInstruction] }
+
+#guard match (identityPlan (identityRequest missingNegationView)).outcome with
+  | .noChange _ => true
+  | _ => false
+
+private def missingSineView : ProgramView :=
+  { reorderedView with
+    operations := #[negationOperation, sourceOperation, piOperation, residualOperation]
+    nodes :=
+      #[{ sourceInstruction with op := { index := 1 } },
+        { targetSineInstruction with op := { index := 1 } },
+        { piInstruction with op := { index := 2 } },
+        { residualInstruction with op := { index := 3 } },
+        { localSineInstruction with op := { index := 1 } }] }
+
+#guard match (identityPlan (identityRequest missingSineView)).outcome with
+  | .noChange _ => true
+  | _ => false
+
+private def malformedResidualView : ProgramView :=
+  { reorderedView with
+    nodes := reorderedView.nodes.set! 3
+      { domain := real, op := { index := 4 }, args := [node 2, node 0] } }
+
+#guard match (identityPlan (identityRequest malformedResidualView)).outcome with
+  | .noChange _ => true
+  | _ => false
+
+private def malformedPiView : ProgramView :=
+  { reorderedView with
+    nodes := reorderedView.nodes.set! 2
+      { domain := real, op := { index := 3 }, args := [node 0] }
+    depths := reorderedView.depths.set! 2 1 }
+
+#guard match (identityPlan (identityRequest malformedPiView)).outcome with
+  | .noChange _ => true
+  | _ => false
+
+private def liveTrace? : Option (Frontend.Trace Bound) := do
+  let .ok session := Session.start factDomain checkerInput.baseProgram
+      packages checkerInput.initialFacts limits
+    | none
+  let result := TargetRun.drive factDomain checkerInput.target.node
+    checkerInput.target.fact firstOffer limits.policy.maxDecisions session ()
+  let .target _ := result.stop | none
+  Frontend.trace? result.session.state.engine result.session.arena
+
+private def exactInput (step : RuleStep Bound) (expected : List SeenVersion) : Bool :=
+  match step.event.cause with
+  | .rule action _ _ => action.inputs == expected
+  | .transport _ _ => false
+
+private def exactTransport (step : TransportStep Bound)
+    (equality : EqualityId) (source : SeenVersion) : Bool :=
+  match step.event.cause with
+  | .transport actualEquality actualSource =>
+      actualEquality == equality && actualSource == source
+  | .rule _ _ _ => false
+
+private def exactRule (step : RuleStep Bound) (expected : RuleKey) : Bool :=
+  match step.event.cause with
+  | .rule action _ _ => action.key == expected
+  | .transport _ _ => false
+
+#guard
+  liveTrace?.any fun trace =>
+    trace.program == extendedProgram &&
+      match trace.events with
+      | [.rule constant, .rule reduction, .rule localSine,
+          .instantiation identity, .rule negation, .transport transport] =>
+          identity.event.newNodes == [node 5] &&
+            identity.event.newEqualities == [{ index := 0 }] &&
+            identity.entry.body == [1] &&
+            constant.event.node == node 2 && constant.event.fact == piFact &&
+              constant.entry.body == [1] && exactRule constant constantRuleKey &&
+              exactInput constant [] &&
+            reduction.event.node == node 3 &&
+              reduction.event.fact == residualFact && reduction.entry.body == [2] &&
+              exactRule reduction reductionRuleKey &&
+              exactInput reduction [{ node := node 0, version := 0 },
+                { node := node 2, version := 1 }] &&
+            localSine.event.node == node 4 &&
+              localSine.event.fact == positiveFact && localSine.entry.body == [3] &&
+              exactRule localSine localRuleKey &&
+              exactInput localSine [{ node := node 3, version := 1 }] &&
+            negation.event.node == node 5 &&
+              negation.event.fact == negativeFact && negation.entry.body == [4] &&
+              exactRule negation negationRuleKey &&
+              exactInput negation [{ node := node 4, version := 1 }] &&
+            transport.event.node == node 1 &&
+              transport.event.fact == negativeFact && transport.entry.body == [1] &&
+              exactTransport transport { index := 0 }
+                { node := node 5, version := 1 }
+      | _ => false
+
+#guard Bound.code? (.interval
+  { lower := rat 3 1, upper := rat 17 5,
+    lowerOpen := true, upperOpen := true }) == none
+
+#guard Bound.code? (.interval
+  { lower := rat 3 1, upper := rat 16 5,
+    lowerOpen := false, upperOpen := true }) == none
+
+#guard !Bound.valid (.interval
+  { lower := rat 3 0, upper := rat 16 5,
+    lowerOpen := true, upperOpen := true })
+
+#guard Bound.code? (.interval
+  { lower := rat 3 0, upper := rat 16 5,
+    lowerOpen := true, upperOpen := true }) == none
+
+#guard match factDomain.narrow real positiveFact negativeFact with
+  | .malformed 1 => true
+  | _ => false
+
+end Hex.Interval.SinTenIntervalConformance

--- a/conformance/HexIntervalMathlib/SinTenIntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/SinTenIntervalConformance.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Experiment.SinTenInterval
+import HexInterval.Experiment.ProofFrontend
+import HexInterval.Experiment.TargetRun
+import Mathlib.Lean.Elab.Tactic.Meta
+
+/-!
+# Endpoint-valued `sin 10` replay conformance
+
+The fixed canary drives four package-owned fact steps plus structural
+instantiation through the generic runtime chronology and proof frontend.
+-/
+
+namespace Hex.IntervalMathlib.SinTenIntervalConformance
+
+open Lean Elab Tactic Meta
+open Hex.Interval.Experiment
+open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
+open Frontend FrontendEncoder ProofFrontend ProofRegistry
+open Hex.Interval.Experiment.SinTenInterval
+open Hex.IntervalMathlib.Experiment.SinTenInterval
+
+private def firstOffer : TargetRun.Controller Bound Unit :=
+  { update := fun state _ => state
+    choose := fun state view =>
+      match view.offers[0]? with
+      | some offer => .select offer state
+      | none => .stop state }
+
+private structure Fixture where
+  result : TargetRun.Result Bound Unit
+  reached : TargetRun.Reached Bound
+  registry : ProofRegistry.Registry semantics Name
+
+private def fixture? : Option Fixture := do
+  let .ok session := Session.start factDomain checkerInput.baseProgram packages
+      checkerInput.initialFacts limits
+    | none
+  let result := TargetRun.drive factDomain checkerInput.target.node
+    checkerInput.target.fact firstOffer limits.policy.maxDecisions session ()
+  let .target reached := result.stop | none
+  let .ok registry := ProofRegistry.build result.session.registry proofPackages
+    | none
+  some { result, reached, registry }
+
+#guard fixture?.isSome
+#guard (constantSchema.decode [2]).isNone
+#guard (reductionSchema.decode [3]).isNone
+#guard (localSchema.decode [4]).isNone
+#guard (negationSchema.decode [3]).isNone
+#guard (identityInstanceSchema.decode [0]).isNone
+#guard (identityEqualitySchema.decode [0]).isNone
+
+private def boundExpr? : Bound → Option Expr
+  | .all => some (mkConst ``Bound.all)
+  | fact =>
+      if fact == piFact then some (mkConst ``piFact)
+      else if fact == residualFact then some (mkConst ``residualFact)
+      else if fact == positiveFact then some (mkConst ``positiveFact)
+      else if fact == negativeFact then some (mkConst ``negativeFact)
+      else none
+
+private def boundEncoder : FrontendEncoder.Encoder Bound :=
+  FrontendEncoder.make (mkConst ``Bound) fun fact =>
+    match boundExpr? fact with
+    | some expression => pure expression
+    | none => throwError "sin-ten interval: unrecognized endpoint fact"
+
+private def seedAssumed (graph : Program) (base : List (NodeFact Bound))
+    (index : Nat) (fact : NodeFact Bound) (found : base[index]? = some fact) :
+    Evidence (semantics.Entails graph base fact) :=
+  ProofEmitter.assumedAt graph base index fact found
+
+private def frontendContext : ProofFrontend.Context Bound Name :=
+  { encoder := boundEncoder
+    resolveSchema := pure
+    semantics := mkConst ``semantics
+    domain := mkConst ``boundSchema
+    laws := mkConst ``laws
+    stableLaw := mkConst ``stableLaw
+    input := mkConst ``checkerInput
+    assumed := ``seedAssumed
+    baseFacts
+    baseFactsTerm := mkConst ``baseFacts
+    baseProgram
+    baseProgramTerm := mkConst ``baseProgram
+    basePrefix := mkConst ``basePrefix
+    baseWithin := mkConst ``baseWithin
+    initialExtension := mkConst ``initialExtension
+    finalPrefix := mkConst ``programPrefix
+    sameOperations := mkConst ``sameOperations
+    top := boundSchema.top }
+
+private meta def emitEvidence : MetaM Expr := do
+  let some fixture := fixture?
+    | throwError "sin-ten interval: search or proof registry failed"
+  let some trace := Frontend.trace? fixture.result.session.state.engine
+      fixture.result.session.arena
+    | throwError "sin-ten interval: chronology quotation failed"
+  unless trace.program == extendedProgram do
+    throwError "sin-ten interval: unexpected instantiated graph"
+  let state ← ProofFrontend.emitTrace frontendContext trace.program trace.events
+    fixture.registry.emit
+  let final ← ProofFrontend.closeTarget frontendContext state fixture.reached.seen
+    fixture.reached.fact checkerInput.target
+  mkAppM ``closeEvidence #[state.extension, final]
+
+syntax (name := intervalSinTenTac) "interval_sin_ten" : tactic
+
+@[tactic intervalSinTenTac] meta def evalIntervalSinTen : Tactic := fun stx => do
+  match stx with
+  | `(tactic| interval_sin_ten) =>
+      let goal ← getMainGoal
+      goal.withContext do
+        let evidence ← emitEvidence
+        let proof ← mkAppM ``Evidence.proof
+          #[evidence, mkConst ``valuation, mkConst ``valuationModels, mkConst ``baseHolds]
+        unless ← isDefEq (← inferType proof) (← goal.getType) do
+          throwError "sin-ten interval: emitted proof has the wrong target"
+        goal.assign (← instantiateMVars proof)
+        replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+private theorem endpointFact : Contains negativeFact (Real.sin 10) := by
+  interval_sin_ten
+
+/-- The generic chronology and proof frontend establish an endpoint-valued
+interval enclosure for the original expression node. -/
+theorem sinTenInterval : (-1 : ℝ) ≤ Real.sin 10 ∧ Real.sin 10 < 0 := by
+  simpa [Contains, negativeFact, rat, ratValue] using endpointFact
+
+/--
+info: 'Hex.IntervalMathlib.SinTenIntervalConformance.sinTenInterval' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound]
+-/
+#guard_msgs in
+#print axioms sinTenInterval
+
+end Hex.IntervalMathlib.SinTenIntervalConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -323,14 +323,16 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.SineSign,
     `HexInterval.Experiment.ExpSign,
     `HexInterval.Experiment.PntLogTable,
-    `HexInterval.Experiment.SinTen].map Glob.one
+    `HexInterval.Experiment.SinTen,
+    `HexInterval.Experiment.SinTenInterval].map Glob.one
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center,
     `HexIntervalMathlib.Experiment.SineSign,
     `HexIntervalMathlib.Experiment.ExpSign,
     `HexIntervalMathlib.Experiment.PntLogTable,
-    `HexIntervalMathlib.Experiment.SinTen]
+    `HexIntervalMathlib.Experiment.SinTen,
+    `HexIntervalMathlib.Experiment.SinTenInterval]
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -394,7 +396,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.ScopeConformance, `HexInterval.StructuralMatcherConformance, `HexInterval.MatcherSchedulerConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexInterval.PayloadSessionConformance, `HexInterval.PolicySessionConformance, `HexInterval.PolicyFunctionConformance, `HexInterval.SemanticReplayConformance, `HexInterval.ChronologicalReplayConformance, `HexInterval.GenericInstanceReconstructionConformance, `HexInterval.ProofEmitterConformance, `HexInterval.TraceReplayConformance, `HexIntervalMathlib.SineSignConformance, `HexIntervalMathlib.SineProofConformance, `HexIntervalMathlib.SineTacticConformance, `HexIntervalMathlib.ProofRegistryConformance, `HexIntervalMathlib.ExpSignConformance, `HexIntervalMathlib.RefuteConformance, `HexIntervalMathlib.PntLogTableConformance, `HexIntervalMathlib.SinTenConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexMvPolyFixtures, `HexMvPoly.Conformance, `HexMvPolyMathlib.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.ScopeConformance, `HexInterval.StructuralMatcherConformance, `HexInterval.MatcherSchedulerConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexInterval.PayloadSessionConformance, `HexInterval.PolicySessionConformance, `HexInterval.PolicyFunctionConformance, `HexInterval.SemanticReplayConformance, `HexInterval.ChronologicalReplayConformance, `HexInterval.GenericInstanceReconstructionConformance, `HexInterval.ProofEmitterConformance, `HexInterval.TraceReplayConformance, `HexInterval.SinTenIntervalConformance, `HexIntervalMathlib.SineSignConformance, `HexIntervalMathlib.SineProofConformance, `HexIntervalMathlib.SineTacticConformance, `HexIntervalMathlib.ProofRegistryConformance, `HexIntervalMathlib.ExpSignConformance, `HexIntervalMathlib.RefuteConformance, `HexIntervalMathlib.PntLogTableConformance, `HexIntervalMathlib.SinTenConformance, `HexIntervalMathlib.SinTenIntervalConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexMvPolyFixtures, `HexMvPoly.Conformance, `HexMvPolyMathlib.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260814T161000Z.md
+++ b/progress/20260814T161000Z.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Added the fixed endpoint-valued `sin 10` experiment with six retained events:
+  constant, reduction, local sine, instantiation, negation, and transport.
+- Replayed the exact chronology through the generic proof registry and
+  `ProofFrontend`, yielding `-1 ≤ Real.sin 10 ∧ Real.sin 10 < 0`.
+- Folded the stable-key operation resolution and exact target, residual, pi,
+  and malformed-input shape guards into the delivered endpoint canary.
+- Reused `Rational.Raw` with a decoder restricted to valid fixed endpoint
+  facts, and registered only the new endpoint modules on the final stacked
+  Machin ancestry after the PNT work merged.
+
+# Current frontier
+
+The endpoint canary exercises package-owned constant, reduction,
+local-function, instantiation, negation, and equality replay over exact fixed
+data. Its retained six-event chronology and theorem are kernel checked.
+
+# Next step
+
+Generalize beyond the hardcoded `10`, add precision-parametric endpoint
+computation and provider competition, and route endpoint facts through a goal
+reifier and production search policy.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -156,6 +156,12 @@
     "reason": "Additionally registers the Mathlib-free sin-ten certificate data, its proof-only Machin range-reduction companion, and conformance module; the factorization service target and executable dependency graph are unchanged."
   },
   {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "52adcea5e56f2c241816ea1cf3613b859c60ae40",
+    "reason": "Additionally registers the fixed-data endpoint-valued sin-ten chronology experiment, its proof-only real-semantics companion, and conformance modules; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
     "path": "HexBerlekamp/FactorTacticTests.lean",
     "baseline_blob": "4063e15934a89c671ac72d201fa60c2ef6feaf59",
     "current_blob": "ac61dae5d09d966186661b1b85943b9fe0d91128",


### PR DESCRIPTION
## Summary

- add the fixed endpoint-valued `sin 10` canary with exact rational bounds
- retain the six-event constant, reduction, local-sine, instantiation, negation, and transport chronology
- replay the trace through the generic proof registry and `ProofFrontend` to prove `-1 ≤ Real.sin 10 ∧ Real.sin 10 < 0`
- guard operation resolution and exact node shapes by stable keys, including malformed and missing-operation refusal cases
- document that this layer reuses only the Machin pi enclosure from the base canary, uses per-schema guards, hardcodes half-turn `3`, and has an exact-fit resource envelope

## Validation

- `lake build HexInterval.SinTenIntervalConformance HexIntervalMathlib.SinTenIntervalConformance` (2230 jobs)
- `lake build HexIntervalMathlib.SinTenConformance` (2215 jobs)
- conformance target registration check
- DAG and Phase-4 checks
- published trust-surface check
- exact proof-only freshness check
- `git diff --check`

Stacked on #9258.