### PR TITLE
feat(interval): select canonical public representation

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexInterval.Basic
+public import HexInterval.Canonical
 
 public section
 
@@ -14,7 +14,8 @@ public section
 `HexInterval` is the Mathlib-free computational kernel for exact interval
 data, propagation search, and replayable derivations.
 
-The initial public implementation exposes only the representation-independent
-raw cut layer. D2 experiments live outside this supported umbrella while they
-select the opaque interval representation and proof-facing encoding.
+The public implementation exposes canonical exact intervals through a sealed
+representation and resource-safe smart constructors.  Raw cuts remain visible
+as the explicit decoder and inspection boundary; D2 propagation and replay
+experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Basic.lean
+++ b/HexInterval/Basic.lean
@@ -14,15 +14,15 @@ public import Init.Data.Dyadic
 # Exact interval cuts
 
 This module defines the representation-independent raw data shared by the
-`hex-interval` representation experiments.  A finite cut carries its exact
+`hex-interval` representation and replay layers.  A finite cut carries its exact
 dyadic value and a strictness bit; either side may instead be unbounded.
 
 `Raw.normalizeUnchecked` is the exact canonicalizer for values that have
 already passed an endpoint-cost preflight. `Raw.normalizeWithin` is the safe
 entry point for untrusted values: it rejects an excessive dyadic height or
-alignment shift before comparison can allocate a shifted mantissa. The
-eventual opaque `Hex.Interval` backing store will be selected by the D2
-measurements; neither candidate is baked into this module.
+alignment shift before comparison can allocate a shifted mantissa. The sealed
+`Hex.Interval` wrapper selected by the D2 measurements lives in
+`HexInterval.Canonical`; this module remains the explicit raw decoder boundary.
 -/
 
 namespace Hex.Interval

--- a/HexInterval/Canonical.lean
+++ b/HexInterval/Canonical.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Basic
+
+public section
+
+/-!
+# Canonical public intervals
+
+`Hex.Interval` is the sealed public value selected by the D2 representation
+measurement.  It stores canonical raw cuts together with their consistency
+proof.  The proof is erased from compiled code; callers observe the value only
+through `view` and construct it through resource-safe smart constructors.
+-/
+
+namespace Hex
+
+/-- A canonical exact interval.  Its constructor and representation fields are
+private so every public value has exactly one canonical empty shape and
+consistent finite cuts. -/
+structure Interval where
+  private mk ::
+  /-- The canonical raw-cut view. -/
+  view : Hex.Interval.Raw
+  private valid : view.CutConsistent
+
+namespace Interval
+
+/-- Every observable public interval has canonical cuts. -/
+theorem view_consistent (interval : Hex.Interval) : interval.view.CutConsistent :=
+  interval.valid
+
+/-- Equality of canonical views determines equality of public intervals. -/
+@[ext]
+opaque ext {left right : Hex.Interval} (h : left.view = right.view) : left = right := by
+  cases left
+  cases right
+  simp_all
+
+/-- Public intervals compare through their canonical raw views. -/
+instance : DecidableEq Hex.Interval := fun left right =>
+  if h : left.view = right.view then
+    isTrue (ext h)
+  else
+    isFalse fun equal => h (congrArg Hex.Interval.view equal)
+
+/-- Result of constructing a canonical public interval from untrusted cuts. -/
+inductive BuildResult where
+  | ready (interval : Hex.Interval)
+  | resourceLimit (cost : CompareCost)
+
+/-- Canonicalize untrusted raw cuts after preflighting endpoint height and
+alignment cost.  Resource refusal is distinct from an empty interval. -/
+def ofRawWithin (limit : EndpointLimit) (raw : Raw) : BuildResult :=
+  match raw.normalizeWithin limit with
+  | .ready normalized valid => .ready (.mk normalized valid)
+  | .resourceLimit cost => .resourceLimit cost
+
+/-- A successful untrusted construction exposes exactly the canonicalized
+input cuts. -/
+opaque view_ofRawWithin_ready {limit : EndpointLimit} {raw : Raw}
+    {interval : Hex.Interval} (h : ofRawWithin limit raw = .ready interval) :
+    interval.view = raw.normalizeUnchecked := by
+  unfold ofRawWithin at h
+  split at h
+  · next normalized valid equality =>
+      unfold Raw.normalizeWithin at equality
+      dsimp only at equality
+      split at equality
+      · cases equality
+        cases h
+        rfl
+      · contradiction
+  · contradiction
+
+/-- The canonical empty interval. -/
+def empty : Hex.Interval := .mk .empty (by rfl)
+
+/-- The interval containing every value. -/
+def whole : Hex.Interval :=
+  .mk (.bounds .unbounded .unbounded) (by rfl)
+
+/-- Construct a singleton after endpoint-cost preflight. -/
+def singletonWithin (limit : EndpointLimit) (value : Dyadic) : BuildResult :=
+  ofRawWithin limit (.bounds (.finite value false) (.finite value false))
+
+/-- Construct a one-sided interval with a finite lower cut. -/
+def aboveWithin (limit : EndpointLimit) (value : Dyadic) (strict : Bool) : BuildResult :=
+  ofRawWithin limit (.bounds (.finite value strict) .unbounded)
+
+/-- Construct a one-sided interval with a finite upper cut. -/
+def belowWithin (limit : EndpointLimit) (value : Dyadic) (strict : Bool) : BuildResult :=
+  ofRawWithin limit (.bounds .unbounded (.finite value strict))
+
+/-- Construct a finite interval after endpoint-cost and consistency checks. -/
+def betweenWithin (limit : EndpointLimit)
+    (lower : Dyadic) (lowerStrict : Bool)
+    (upper : Dyadic) (upperStrict : Bool) : BuildResult :=
+  ofRawWithin limit
+    (.bounds (.finite lower lowerStrict) (.finite upper upperStrict))
+
+@[simp]
+opaque view_empty : empty.view = .empty := by rfl
+
+@[simp]
+opaque view_whole : whole.view = .bounds .unbounded .unbounded := by rfl
+
+end Interval
+end Hex

--- a/HexInterval/Canonical.lean
+++ b/HexInterval/Canonical.lean
@@ -38,7 +38,7 @@ theorem view_consistent (interval : Hex.Interval) : interval.view.CutConsistent 
 
 /-- Equality of canonical views determines equality of public intervals. -/
 @[ext]
-opaque ext {left right : Hex.Interval} (h : left.view = right.view) : left = right := by
+theorem ext {left right : Hex.Interval} (h : left.view = right.view) : left = right := by
   cases left
   cases right
   simp_all
@@ -64,7 +64,7 @@ def ofRawWithin (limit : EndpointLimit) (raw : Raw) : BuildResult :=
 
 /-- A successful untrusted construction exposes exactly the canonicalized
 input cuts. -/
-opaque view_ofRawWithin_ready {limit : EndpointLimit} {raw : Raw}
+theorem view_ofRawWithin_ready {limit : EndpointLimit} {raw : Raw}
     {interval : Hex.Interval} (h : ofRawWithin limit raw = .ready interval) :
     interval.view = raw.normalizeUnchecked := by
   unfold ofRawWithin at h
@@ -106,10 +106,10 @@ def betweenWithin (limit : EndpointLimit)
     (.bounds (.finite lower lowerStrict) (.finite upper upperStrict))
 
 @[simp]
-opaque view_empty : empty.view = .empty := by rfl
+theorem view_empty : empty.view = .empty := by rfl
 
 @[simp]
-opaque view_whole : whole.view = .bounds .unbounded .unbounded := by rfl
+theorem view_whole : whole.view = .bounds .unbounded .unbounded := by rfl
 
 end Interval
 end Hex

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -127,12 +127,12 @@ validator, checker soundness theorem, and native absence/rejection fallback.
 
 ## Interval representation
 
-The semantic shape is intentionally small. The exact constructors and the
-placement of the canonicity invariant remain experimental, but the observable
-distinctions below are part of the contract. `Dyadic` means Lean core's
-`Init.Data.Dyadic` type. The rounding precision used by the initial dyadic
-backend is signed `Int`, as in core; negative values are needed for coarse
-grids at large magnitudes.
+The semantic shape is intentionally small. The D2 measurement selected a
+sealed public value carrying canonical raw cuts and their consistency proof;
+the observable distinctions below are part of the contract. `Dyadic` means
+Lean core's `Init.Data.Dyadic` type. The rounding precision used by the initial
+dyadic backend is signed `Int`, as in core; negative values are needed for
+coarse grids at large magnitudes.
 
 ```lean
 namespace Hex
@@ -156,24 +156,38 @@ end Interval
 end Hex
 ```
 
-`Raw` avoids shadowing Lean's `Repr` typeclass. The public `Hex.Interval` is an
-opaque API with a `view : Hex.Interval → Hex.Interval.Raw` eliminator, smart
-constructors, and normalization; consumers do not project its backing store.
-Two internal candidates must be compared during the vertical feasibility
-prototype:
+`Raw` avoids shadowing Lean's `Repr` typeclass. The public `Hex.Interval` is a
+sealed API with a canonical `view`, smart constructors, and normalization. Its
+constructor and consistency proof are private. Two internal candidates were
+compared during the vertical feasibility prototype:
 
 1. a structure bundling `raw : Raw` with a proof of `raw.CutConsistent`;
 2. plain data whose `Bool`-valued consistency and normalization are checked at
    construction or replay boundaries, without carrying a proof in every hot
    value.
 
-The comparison measures compiled search, ordinary kernel replay, proof bytes,
-allocation, and whether a proof field obstructs safe `#eval`. The SPEC freezes
-neither candidate before that measurement. All public examples use the fully
-qualified `Hex.Interval`, because Mathlib also has a root `Interval` type; the
-public namespace is itself revisitable before release if qualification proves
-awkward. Unless a block explicitly says otherwise, unqualified API sketches
-below are declarations inside `Hex.Interval`.
+The refreshed five-sample comparison at repository commit `31024b715` and Lean
+`v4.33.0-rc1` records both 433-value and 4096-value workloads in
+`reports/bench-results/hex-interval-d2-representation.json`. The checked hot
+loop is within two percent of the bundled loop, while revalidating the checked
+arena at the boundary costs about twelve percent relative to using the bundled
+invariant. Generated C and object sizes are identical because the proof field
+erases. Kernel replay and WHNF timings favor different candidates and are noisy
+after import-baseline subtraction; they do not justify moving validation into
+every trust boundary. The public value therefore uses the bundled invariant.
+Internal planners and certificates may still use plain data when their own
+checked boundary authenticates it; proof traces do not inherit the public
+value's proof field.
+
+The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
+preflighted raw, singleton, one-sided, and finite constructors. Arithmetic is
+promoted separately with its complete semantic theorems rather than being
+declared public merely because narrower experiment implementations exist. All
+public examples use the fully qualified `Hex.Interval`, because Mathlib also
+has a root `Interval` type; the public namespace is itself revisitable before
+release if qualification proves awkward. Unless a block explicitly says
+otherwise, unqualified API sketches below are declarations inside
+`Hex.Interval`.
 
 The bundled candidate now has a Mathlib companion interpreting every canonical
 fact as a subset of `ℝ`. It proves that a successful executable `intersect`
@@ -181,9 +195,10 @@ denotes logical conjunction for the complete cut language: strict and closed
 ends, tied endpoints, empty results, and either end unbounded. That theorem is
 installed as the generic `FactDomainSchema.proveMeet` boundary, and the
 transparent proof frontend uses it to close a weaker requested interval from a
-stronger established one. This validates the semantic interface without
-settling the representation comparison or adding a function case to the
-frontend.
+stronger established one. This validated the semantic interface used to select
+the public bundled representation without adding a function case to the
+frontend. Porting that complete semantic theorem from the experiment companion
+to the supported public value accompanies the public `intersect` operation.
 
 The comments describe cuts as viewed from outside the interval. In semantic
 notation, a finite lower cut `(a, false)` means `a ≤ x`, and `(a, true)` means
@@ -3840,9 +3855,12 @@ their declared cost inside a scheduler bound.
 
 ## File organization
 
-- `HexInterval/Bound.lean`: lower and upper cuts, comparison, normalization.
-- `HexInterval/Interval.lean`: intersection, hull, arithmetic, splitting, and
-  regularization.
+- `HexInterval/Basic.lean`: raw lower and upper cuts, comparison, and
+  normalization.
+- `HexInterval/Canonical.lean`: sealed canonical values, views, and
+  resource-safe smart constructors.
+- `HexInterval/Interval.lean`: future supported intersection, hull, arithmetic,
+  splitting, and regularization operations.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -166,7 +166,7 @@ compared during the vertical feasibility prototype:
    construction or replay boundaries, without carrying a proof in every hot
    value.
 
-The refreshed five-sample comparison at repository commit `31024b715` and Lean
+The refreshed five-sample comparison at repository commit `9c87f7cf2` and Lean
 `v4.33.0-rc1` records both 433-value and 4096-value workloads in
 `reports/bench-results/hex-interval-d2-representation.json`. The checked hot
 loop is within two percent of the bundled loop, while revalidating the checked

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -119,8 +119,14 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
   | .ready _ => false
   | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
 
-example (interval : Hex.Interval) : interval.view.CutConsistent :=
+/-- The supported public view exposes its carried canonicality theorem without
+adding any trust assumption. -/
+theorem publicViewCanonical (interval : Hex.Interval) : interval.view.CutConsistent :=
   Hex.Interval.view_consistent interval
+
+/-- info: 'Hex.Interval.Conformance.publicViewCanonical' depends on axioms: [propext] -/
+#guard_msgs in
+#print axioms publicViewCanonical
 
 example {limit : EndpointLimit} {raw : Raw} {interval : Hex.Interval}
     (h : Hex.Interval.ofRawWithin limit raw = .ready interval) :

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -4,13 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import HexInterval
 import HexInterval.Experiment.Representation
 
 /-!
 Conformance checks for exact raw interval cuts and canonical normalization.
 The table covers every finite closure combination, both one-sided unbounded
 shapes, the whole interval, the unique empty value, proper singletons, all
-three empty equal-endpoint shapes, and reversed endpoints.
+three empty equal-endpoint shapes, and reversed endpoints.  It also pins the
+sealed public representation and its resource-safe constructors.
 -/
 
 namespace Hex.Interval.Conformance
@@ -90,5 +92,42 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
       (.bounds .unbounded (.finite far false)) with
   | .ready _ _ => false
   | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
+
+-- Public construction exposes the same canonical views without exposing a
+-- constructor or representation field.
+#guard Hex.Interval.empty.view == .empty
+#guard Hex.Interval.whole.view == .bounds .unbounded .unbounded
+#guard decide (Hex.Interval.empty ≠ Hex.Interval.whole)
+
+#guard
+  match Hex.Interval.betweenWithin smallLimit (d 0) false (d 1) true with
+  | .ready interval => interval.view == finite 0 false 1 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.betweenWithin smallLimit (d 2) false (d 1) false with
+  | .ready interval => interval.view == .empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.singletonWithin smallLimit (d 1) with
+  | .ready interval => interval.view == finite 1 false 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.belowWithin smallLimit far false with
+  | .ready _ => false
+  | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
+
+example (interval : Hex.Interval) : interval.view.CutConsistent :=
+  Hex.Interval.view_consistent interval
+
+example {limit : EndpointLimit} {raw : Raw} {interval : Hex.Interval}
+    (h : Hex.Interval.ofRawWithin limit raw = .ready interval) :
+    interval.view = raw.normalizeUnchecked :=
+  Hex.Interval.view_ofRawWithin_ready h
+
+example (left right : Hex.Interval) (h : left.view = right.view) : left = right :=
+  Hex.Interval.ext h
 
 end Hex.Interval.Conformance

--- a/progress/20260815T024015Z.md
+++ b/progress/20260815T024015Z.md
@@ -1,0 +1,34 @@
+# Accomplished
+
+Refreshed the D2 bundled-versus-checked representation sweep on the current
+Lean toolchain and source.  The checked raw hot loop remains within two percent
+of the bundled loop, while a checked arena pays about twelve percent to
+revalidate the same canonical values at its boundary.  Proof erasure produces
+identical generated C and object sizes; kernel replay and WHNF samples point in
+different directions and do not justify repeated boundary validation.
+
+Selected the bundled invariant for the supported public value and added
+`HexInterval.Canonical`.  `Hex.Interval` has a private constructor and private
+consistency proof, a canonical raw `view`, view extensionality and decidable
+equality, distinct construction/resource outcomes, and endpoint-preflighted
+raw, singleton, one-sided, and finite constructors.  The public umbrella now
+exports that sealed slice.  Conformance pins canonicalization, resource
+refusal, view soundness, extensionality, and successful-construction linkage.
+
+# Current frontier
+
+The public type and construction boundary compile, but public interval
+arithmetic is deliberately not exported yet.  Existing experiment operations
+remain evidence for the next slice rather than an unsupported public promise.
+
+# Next step
+
+Regenerate the committed representation report from a clean commit so its
+source hashes and environment identify this exact implementation, then run the
+full static/trust/freshness gates and obtain independent review and CI.  Follow
+with public `intersect`, `hull`, and negation together with complete Mathlib
+set-semantics theorems before promoting wider arithmetic.
+
+# Blockers
+
+None.

--- a/reports/bench-results/hex-interval-d2-representation.json
+++ b/reports/bench-results/hex-interval-d2-representation.json
@@ -1,7 +1,7 @@
 {
   "schema": "hex-interval-d2-representation-v2",
   "environment": {
-    "git_commit": "31024b715d648dee2298c74c608d6f4583fe9c20",
+    "git_commit": "9c87f7cf28bea3bf346f94ab1e6956c6fdc90e83",
     "git_dirty": false,
     "toolchain": "leanprover/lean4:v4.33.0-rc1",
     "hostname": "chungus2",
@@ -15,10 +15,10 @@
       4096
     ],
     "source_sha256": {
-      "HexInterval/Basic.lean": "f9efacc79d8cb1eaf717cafd04e728f131840efc2ca98cff3e0dfd3c6de4c3e5",
+      "HexInterval/Basic.lean": "48ee7967e265beba21c355b5ac2657321637794ce322c9ad7f2880c853ecd850",
       "HexInterval/Experiment/Rational.lean": "a02f3d348856c1b3c71490f02136cf759a640247d85092f8ded25a68fb222564",
       "HexInterval/Experiment/Representation.lean": "32b974a49ccc73d46a793a44b8130f5c9399d25ddd3281ee95fde525e75fde2b",
-      "HexInterval.lean": "c1178859f2397cea0c2e93b7c0808acaf394c2e6aae8934ea69211bf50205239",
+      "HexInterval.lean": "694903e86de1e9e41f29fa1897dddc95cdc4718664dbcb80989eefaa5dc1dcf6",
       "bench/HexBench/IntervalRepresentationSpike.lean": "786b3dd6e361fe86a08b4f1f6d6d1cc53230eee18b23066cd057ccfa4ffe08fd",
       "bench/HexInterval/ImportBundled.lean": "b84644ce36b3b455d11d878752c27ca4cfc3f0a8e53c5adf1213aed8a803a0de",
       "bench/HexInterval/ImportChecked.lean": "5bfe1acee71f4fc55970d7acb2025cec1dd8be4e91600da75d5b4115c42e036b",
@@ -36,7 +36,7 @@
       "bench/HexInterval/WhnfRationalChecked.lean": "3836add542af8827440bc6af74ff9fb58f5f421f42e687a8a0690edff3a0850e",
       "bench/HexInterval/WhnfRationalDirect.lean": "bc7dd6ef8188dd43a63c64090b55146b3aae4542df37138017d85e8fd7b383c6",
       "lake-manifest.json": "a3fe83c407715b04ccabe01b74d561ced52b899aa9b6a0b0742e092e5db6c3b1",
-      "lakefile.lean": "4e25a2076945582b69aed3c76794c51f40c8bb48af925ee6593edf48b47ccd7c",
+      "lakefile.lean": "5f13f66d89725e7afcd8f1bd83788eb28a6f379921cc5f474f77c9b5c3221d64",
       "lean-toolchain": "62c2d9c0fc1ec4c67e151c11eff41ca004ef38e179cf9476c230406e6defedef",
       "scripts/bench/interval_representation_sweep.py": "7ad6ac110324cf16650ecee42f949ffda0b59f811748790963daac608c0f7212"
     },
@@ -50,43 +50,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 194116920,
-          "inner_total_nanos": 183348837,
-          "per_call_nanos": 39703,
+          "outer_wall_nanos": 184350502,
+          "inner_total_nanos": 181240850,
+          "per_call_nanos": 39246,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8340
+          "peak_rss_kb": 8412
         },
         {
-          "outer_wall_nanos": 189378752,
-          "inner_total_nanos": 179718292,
-          "per_call_nanos": 38916,
+          "outer_wall_nanos": 192727835,
+          "inner_total_nanos": 188711649,
+          "per_call_nanos": 40864,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8416
+          "peak_rss_kb": 8348
         },
         {
-          "outer_wall_nanos": 188002429,
-          "inner_total_nanos": 178337213,
-          "per_call_nanos": 38617,
+          "outer_wall_nanos": 182607757,
+          "inner_total_nanos": 179682300,
+          "per_call_nanos": 38909,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8352
+          "peak_rss_kb": 8396
         },
         {
-          "outer_wall_nanos": 190995138,
-          "inner_total_nanos": 181460586,
-          "per_call_nanos": 39294,
+          "outer_wall_nanos": 182867924,
+          "inner_total_nanos": 180111366,
+          "per_call_nanos": 39002,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8420
+          "peak_rss_kb": 8388
         },
         {
-          "outer_wall_nanos": 188552956,
-          "inner_total_nanos": 182194445,
-          "per_call_nanos": 39453,
+          "outer_wall_nanos": 185872258,
+          "inner_total_nanos": 183074119,
+          "per_call_nanos": 39643,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8452
+          "peak_rss_kb": 8360
         }
       ],
-      "median_per_call_nanos": 39294,
-      "median_peak_rss_kb": 8416
+      "median_per_call_nanos": 39246,
+      "median_peak_rss_kb": 8388
     },
     "checked:433": {
       "variant": "checked",
@@ -94,43 +94,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 214581155,
-          "inner_total_nanos": 204124544,
-          "per_call_nanos": 44201,
+          "outer_wall_nanos": 182649119,
+          "inner_total_nanos": 179752924,
+          "per_call_nanos": 38924,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8456
+          "peak_rss_kb": 8468
         },
         {
-          "outer_wall_nanos": 187202113,
-          "inner_total_nanos": 177299213,
-          "per_call_nanos": 38393,
+          "outer_wall_nanos": 180722512,
+          "inner_total_nanos": 177930651,
+          "per_call_nanos": 38529,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8508
+          "peak_rss_kb": 8504
         },
         {
-          "outer_wall_nanos": 187025010,
-          "inner_total_nanos": 177520451,
-          "per_call_nanos": 38440,
+          "outer_wall_nanos": 184017368,
+          "inner_total_nanos": 181188783,
+          "per_call_nanos": 39235,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8428
+          "peak_rss_kb": 8408
         },
         {
-          "outer_wall_nanos": 188903276,
-          "inner_total_nanos": 179509752,
-          "per_call_nanos": 38871,
+          "outer_wall_nanos": 184628434,
+          "inner_total_nanos": 181749705,
+          "per_call_nanos": 39356,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8360
+          "peak_rss_kb": 8348
         },
         {
-          "outer_wall_nanos": 188746724,
-          "inner_total_nanos": 179637642,
-          "per_call_nanos": 38899,
+          "outer_wall_nanos": 183708129,
+          "inner_total_nanos": 180854908,
+          "per_call_nanos": 39163,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8416
+          "peak_rss_kb": 8404
         }
       ],
-      "median_per_call_nanos": 38871,
-      "median_peak_rss_kb": 8428
+      "median_per_call_nanos": 39163,
+      "median_peak_rss_kb": 8408
     },
     "bundled-boundary:433": {
       "variant": "bundled-boundary",
@@ -138,43 +138,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 190560505,
-          "inner_total_nanos": 183062462,
-          "per_call_nanos": 39641,
+          "outer_wall_nanos": 181645761,
+          "inner_total_nanos": 178886239,
+          "per_call_nanos": 38736,
           "checksum": 13103900578367572860,
           "peak_rss_kb": 8364
         },
         {
-          "outer_wall_nanos": 192227297,
-          "inner_total_nanos": 182496853,
-          "per_call_nanos": 39518,
+          "outer_wall_nanos": 182376645,
+          "inner_total_nanos": 179790479,
+          "per_call_nanos": 38932,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8392
+          "peak_rss_kb": 8432
         },
         {
-          "outer_wall_nanos": 187484201,
-          "inner_total_nanos": 177883350,
-          "per_call_nanos": 38519,
+          "outer_wall_nanos": 185813641,
+          "inner_total_nanos": 181329321,
+          "per_call_nanos": 39265,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8392
+          "peak_rss_kb": 8388
         },
         {
-          "outer_wall_nanos": 190233659,
-          "inner_total_nanos": 180808148,
-          "per_call_nanos": 39152,
+          "outer_wall_nanos": 182301703,
+          "inner_total_nanos": 179404206,
+          "per_call_nanos": 38848,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8392
+          "peak_rss_kb": 8348
         },
         {
-          "outer_wall_nanos": 194363035,
-          "inner_total_nanos": 184132418,
-          "per_call_nanos": 39872,
+          "outer_wall_nanos": 182839421,
+          "inner_total_nanos": 179668709,
+          "per_call_nanos": 38906,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8380
+          "peak_rss_kb": 8352
         }
       ],
-      "median_per_call_nanos": 39518,
-      "median_peak_rss_kb": 8392
+      "median_per_call_nanos": 38906,
+      "median_peak_rss_kb": 8364
     },
     "checked-boundary:433": {
       "variant": "checked-boundary",
@@ -182,43 +182,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 222019078,
-          "inner_total_nanos": 214187261,
-          "per_call_nanos": 46380,
+          "outer_wall_nanos": 206418988,
+          "inner_total_nanos": 203654288,
+          "per_call_nanos": 44100,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8452
+          "peak_rss_kb": 8360
         },
         {
-          "outer_wall_nanos": 211625681,
-          "inner_total_nanos": 201855548,
-          "per_call_nanos": 43710,
+          "outer_wall_nanos": 203568120,
+          "inner_total_nanos": 200846624,
+          "per_call_nanos": 43492,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8408
+          "peak_rss_kb": 8356
         },
         {
-          "outer_wall_nanos": 210890931,
-          "inner_total_nanos": 201403247,
-          "per_call_nanos": 43612,
+          "outer_wall_nanos": 208729885,
+          "inner_total_nanos": 205477952,
+          "per_call_nanos": 44495,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8420
+          "peak_rss_kb": 8376
         },
         {
-          "outer_wall_nanos": 213000390,
-          "inner_total_nanos": 203369615,
-          "per_call_nanos": 44038,
+          "outer_wall_nanos": 202417133,
+          "inner_total_nanos": 199577553,
+          "per_call_nanos": 43217,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8404
+          "peak_rss_kb": 8440
         },
         {
-          "outer_wall_nanos": 213421313,
-          "inner_total_nanos": 203506497,
-          "per_call_nanos": 44068,
+          "outer_wall_nanos": 204565770,
+          "inner_total_nanos": 201501676,
+          "per_call_nanos": 43633,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8444
+          "peak_rss_kb": 8484
         }
       ],
-      "median_per_call_nanos": 44038,
-      "median_peak_rss_kb": 8420
+      "median_per_call_nanos": 43633,
+      "median_peak_rss_kb": 8376
     },
     "bundled:4096": {
       "variant": "bundled",
@@ -226,43 +226,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 197164850,
-          "inner_total_nanos": 186182960,
-          "per_call_nanos": 381522,
+          "outer_wall_nanos": 191111889,
+          "inner_total_nanos": 187050666,
+          "per_call_nanos": 383300,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8460
+          "peak_rss_kb": 8332
         },
         {
-          "outer_wall_nanos": 198162410,
-          "inner_total_nanos": 187099039,
-          "per_call_nanos": 383399,
+          "outer_wall_nanos": 192012704,
+          "inner_total_nanos": 188005692,
+          "per_call_nanos": 385257,
           "checksum": 18433152544017910708,
           "peak_rss_kb": 8396
         },
         {
-          "outer_wall_nanos": 201237761,
-          "inner_total_nanos": 190116335,
-          "per_call_nanos": 389582,
+          "outer_wall_nanos": 192224518,
+          "inner_total_nanos": 188339006,
+          "per_call_nanos": 385940,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8336
+          "peak_rss_kb": 8376
         },
         {
-          "outer_wall_nanos": 201892002,
-          "inner_total_nanos": 190199918,
-          "per_call_nanos": 389753,
+          "outer_wall_nanos": 192974401,
+          "inner_total_nanos": 189047607,
+          "per_call_nanos": 387392,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8360
+          "peak_rss_kb": 8356
         },
         {
-          "outer_wall_nanos": 198694158,
-          "inner_total_nanos": 187698198,
-          "per_call_nanos": 384627,
+          "outer_wall_nanos": 191822152,
+          "inner_total_nanos": 187861538,
+          "per_call_nanos": 384962,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8340
+          "peak_rss_kb": 8364
         }
       ],
-      "median_per_call_nanos": 384627,
-      "median_peak_rss_kb": 8360
+      "median_per_call_nanos": 385257,
+      "median_peak_rss_kb": 8364
     },
     "checked:4096": {
       "variant": "checked",
@@ -270,43 +270,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 198493191,
-          "inner_total_nanos": 186908827,
-          "per_call_nanos": 383009,
+          "outer_wall_nanos": 189647708,
+          "inner_total_nanos": 185605453,
+          "per_call_nanos": 380339,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8312
+          "peak_rss_kb": 8424
         },
         {
-          "outer_wall_nanos": 198542393,
-          "inner_total_nanos": 187229362,
-          "per_call_nanos": 383666,
+          "outer_wall_nanos": 190176701,
+          "inner_total_nanos": 186108148,
+          "per_call_nanos": 381369,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8364
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 197779842,
-          "inner_total_nanos": 186493091,
-          "per_call_nanos": 382157,
+          "outer_wall_nanos": 188537821,
+          "inner_total_nanos": 184672229,
+          "per_call_nanos": 378426,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8484
+          "peak_rss_kb": 8496
         },
         {
-          "outer_wall_nanos": 197890896,
-          "inner_total_nanos": 186891541,
-          "per_call_nanos": 382974,
+          "outer_wall_nanos": 188348380,
+          "inner_total_nanos": 184424821,
+          "per_call_nanos": 377919,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8352
+          "peak_rss_kb": 8400
         },
         {
-          "outer_wall_nanos": 195995565,
-          "inner_total_nanos": 185177419,
-          "per_call_nanos": 379461,
+          "outer_wall_nanos": 189530223,
+          "inner_total_nanos": 185635858,
+          "per_call_nanos": 380401,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8504
+          "peak_rss_kb": 8420
         }
       ],
-      "median_per_call_nanos": 382974,
-      "median_peak_rss_kb": 8364
+      "median_per_call_nanos": 380339,
+      "median_peak_rss_kb": 8420
     },
     "bundled-boundary:4096": {
       "variant": "bundled-boundary",
@@ -314,43 +314,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 200151060,
-          "inner_total_nanos": 188897507,
-          "per_call_nanos": 387085,
+          "outer_wall_nanos": 192062188,
+          "inner_total_nanos": 187955127,
+          "per_call_nanos": 385153,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8332
+          "peak_rss_kb": 8472
         },
         {
-          "outer_wall_nanos": 199051388,
-          "inner_total_nanos": 188142347,
-          "per_call_nanos": 385537,
+          "outer_wall_nanos": 190966362,
+          "inner_total_nanos": 187104155,
+          "per_call_nanos": 383410,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8404
+          "peak_rss_kb": 8360
         },
         {
-          "outer_wall_nanos": 198147187,
-          "inner_total_nanos": 187233909,
-          "per_call_nanos": 383676,
+          "outer_wall_nanos": 191816423,
+          "inner_total_nanos": 187779086,
+          "per_call_nanos": 384793,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8352
+          "peak_rss_kb": 8408
         },
         {
-          "outer_wall_nanos": 198212193,
-          "inner_total_nanos": 187420686,
-          "per_call_nanos": 384058,
+          "outer_wall_nanos": 191797626,
+          "inner_total_nanos": 187860197,
+          "per_call_nanos": 384959,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8392
+          "peak_rss_kb": 8360
         },
         {
-          "outer_wall_nanos": 197531714,
-          "inner_total_nanos": 186647408,
-          "per_call_nanos": 382474,
+          "outer_wall_nanos": 190416797,
+          "inner_total_nanos": 186492928,
+          "per_call_nanos": 382157,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8400
+          "peak_rss_kb": 8440
         }
       ],
-      "median_per_call_nanos": 384058,
-      "median_peak_rss_kb": 8392
+      "median_per_call_nanos": 384793,
+      "median_peak_rss_kb": 8408
     },
     "checked-boundary:4096": {
       "variant": "checked-boundary",
@@ -358,43 +358,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 214288731,
-          "inner_total_nanos": 208878796,
-          "per_call_nanos": 428030,
+          "outer_wall_nanos": 214177063,
+          "inner_total_nanos": 209965397,
+          "per_call_nanos": 430256,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8472
+          "peak_rss_kb": 8468
         },
         {
-          "outer_wall_nanos": 220237614,
-          "inner_total_nanos": 208961498,
-          "per_call_nanos": 428199,
+          "outer_wall_nanos": 213807825,
+          "inner_total_nanos": 209547527,
+          "per_call_nanos": 429400,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8436
+          "peak_rss_kb": 8400
         },
         {
-          "outer_wall_nanos": 222467762,
-          "inner_total_nanos": 211545651,
-          "per_call_nanos": 433495,
+          "outer_wall_nanos": 213048689,
+          "inner_total_nanos": 208877083,
+          "per_call_nanos": 428026,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8404
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 221752662,
-          "inner_total_nanos": 210735790,
-          "per_call_nanos": 431835,
+          "outer_wall_nanos": 212802765,
+          "inner_total_nanos": 208545361,
+          "per_call_nanos": 427347,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8380
+          "peak_rss_kb": 8372
         },
         {
-          "outer_wall_nanos": 221022047,
-          "inner_total_nanos": 210085305,
-          "per_call_nanos": 430502,
+          "outer_wall_nanos": 212602859,
+          "inner_total_nanos": 208478933,
+          "per_call_nanos": 427210,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8352
+          "peak_rss_kb": 8392
         }
       ],
-      "median_per_call_nanos": 430502,
-      "median_peak_rss_kb": 8404
+      "median_per_call_nanos": 428026,
+      "median_peak_rss_kb": 8392
     }
   },
   "replay": {
@@ -402,45 +402,45 @@
       "module": "HexInterval.ReplayBaseline",
       "samples": [
         {
-          "wall_nanos": 1058929235,
-          "peak_rss_kb": 845448,
+          "wall_nanos": 863730604,
+          "peak_rss_kb": 844068,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 853465461,
-          "peak_rss_kb": 845512,
+          "wall_nanos": 865301020,
+          "peak_rss_kb": 844116,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1071568355,
-          "peak_rss_kb": 838652,
+          "wall_nanos": 864450859,
+          "peak_rss_kb": 844204,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1041345847,
-          "peak_rss_kb": 836544,
+          "wall_nanos": 882802292,
+          "peak_rss_kb": 843928,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 855868604,
-          "peak_rss_kb": 845436,
+          "wall_nanos": 864309055,
+          "peak_rss_kb": 844208,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1041345847,
-      "median_peak_rss_kb": 845436
+      "median_wall_nanos": 864450859,
+      "median_peak_rss_kb": 844116
     },
     "bundled": {
       "module": "HexInterval.ReplayBundled",
       "samples": [
         {
-          "wall_nanos": 1661406412,
-          "peak_rss_kb": 844728,
+          "wall_nanos": 1272339178,
+          "peak_rss_kb": 843548,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -448,8 +448,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1290563382,
-          "peak_rss_kb": 845236,
+          "wall_nanos": 1262112420,
+          "peak_rss_kb": 844300,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -457,8 +457,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1578468197,
-          "peak_rss_kb": 835500,
+          "wall_nanos": 1274394140,
+          "peak_rss_kb": 844096,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -466,8 +466,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1509806669,
-          "peak_rss_kb": 836620,
+          "wall_nanos": 1276426221,
+          "peak_rss_kb": 844512,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -475,8 +475,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1273764571,
-          "peak_rss_kb": 845412,
+          "wall_nanos": 1278935540,
+          "peak_rss_kb": 845720,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -484,16 +484,16 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1509806669,
-      "median_import_baseline_subtracted_nanos": 468460822,
-      "median_peak_rss_kb": 844728
+      "median_wall_nanos": 1274394140,
+      "median_import_baseline_subtracted_nanos": 409943281,
+      "median_peak_rss_kb": 844300
     },
     "import_bundled": {
       "module": "HexInterval.ImportBundled",
       "samples": [
         {
-          "wall_nanos": 881996634,
-          "peak_rss_kb": 844900,
+          "wall_nanos": 858826311,
+          "peak_rss_kb": 844868,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -501,8 +501,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 856827953,
-          "peak_rss_kb": 845432,
+          "wall_nanos": 869837940,
+          "peak_rss_kb": 844844,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -510,8 +510,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 991087254,
-          "peak_rss_kb": 840556,
+          "wall_nanos": 859875675,
+          "peak_rss_kb": 844000,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -519,8 +519,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1060955311,
-          "peak_rss_kb": 835584,
+          "wall_nanos": 860598275,
+          "peak_rss_kb": 844780,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -528,8 +528,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 872306083,
-          "peak_rss_kb": 845588,
+          "wall_nanos": 861228557,
+          "peak_rss_kb": 843920,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -537,55 +537,55 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 881996634,
-      "median_import_baseline_subtracted_nanos": -159349213,
-      "median_peak_rss_kb": 844900
+      "median_wall_nanos": 860598275,
+      "median_import_baseline_subtracted_nanos": -3852584,
+      "median_peak_rss_kb": 844780
     },
     "whnf_bundled": {
       "module": "HexInterval.WhnfBundled",
       "samples": [
         {
-          "wall_nanos": 1597733918,
-          "peak_rss_kb": 945872,
+          "wall_nanos": 1550965274,
+          "peak_rss_kb": 939776,
           "axioms": [],
-          "whnf_nanos": 412654248
+          "whnf_nanos": 370497617
         },
         {
-          "wall_nanos": 1568306997,
-          "peak_rss_kb": 940400,
+          "wall_nanos": 1560284181,
+          "peak_rss_kb": 941620,
           "axioms": [],
-          "whnf_nanos": 395986702
+          "whnf_nanos": 361870803
         },
         {
-          "wall_nanos": 1960014313,
-          "peak_rss_kb": 910676,
+          "wall_nanos": 1569039782,
+          "peak_rss_kb": 945236,
           "axioms": [],
-          "whnf_nanos": 532237679
+          "whnf_nanos": 380466499
         },
         {
-          "wall_nanos": 2039634066,
-          "peak_rss_kb": 914308,
+          "wall_nanos": 1566817685,
+          "peak_rss_kb": 938180,
           "axioms": [],
-          "whnf_nanos": 527816927
+          "whnf_nanos": 363717801
         },
         {
-          "wall_nanos": 1564505929,
-          "peak_rss_kb": 939368,
+          "wall_nanos": 1571746222,
+          "peak_rss_kb": 939080,
           "axioms": [],
-          "whnf_nanos": 369082875
+          "whnf_nanos": 386640714
         }
       ],
-      "median_wall_nanos": 1597733918,
-      "median_import_baseline_subtracted_nanos": 263445008,
-      "median_peak_rss_kb": 939368,
-      "median_whnf_nanos": 412654248
+      "median_wall_nanos": 1566817685,
+      "median_import_baseline_subtracted_nanos": 393554809,
+      "median_peak_rss_kb": 939776,
+      "median_whnf_nanos": 370497617
     },
     "checked": {
       "module": "HexInterval.ReplayChecked",
       "samples": [
         {
-          "wall_nanos": 1262712278,
-          "peak_rss_kb": 845448,
+          "wall_nanos": 1286551603,
+          "peak_rss_kb": 846800,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -593,8 +593,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1274391102,
-          "peak_rss_kb": 845388,
+          "wall_nanos": 1273131421,
+          "peak_rss_kb": 844792,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -602,8 +602,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1608173113,
-          "peak_rss_kb": 844176,
+          "wall_nanos": 1260440058,
+          "peak_rss_kb": 844092,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -611,8 +611,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1323978851,
-          "peak_rss_kb": 841496,
+          "wall_nanos": 1276758464,
+          "peak_rss_kb": 846400,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -620,8 +620,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1269306727,
-          "peak_rss_kb": 845044,
+          "wall_nanos": 1271125208,
+          "peak_rss_kb": 844892,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -629,16 +629,16 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1274391102,
-      "median_import_baseline_subtracted_nanos": 233045255,
-      "median_peak_rss_kb": 845044
+      "median_wall_nanos": 1273131421,
+      "median_import_baseline_subtracted_nanos": 408680562,
+      "median_peak_rss_kb": 844892
     },
     "import_checked": {
       "module": "HexInterval.ImportChecked",
       "samples": [
         {
-          "wall_nanos": 866533736,
-          "peak_rss_kb": 843952,
+          "wall_nanos": 856029314,
+          "peak_rss_kb": 844936,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -646,8 +646,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 852974968,
-          "peak_rss_kb": 845408,
+          "wall_nanos": 878626603,
+          "peak_rss_kb": 843660,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -655,8 +655,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 977748338,
-          "peak_rss_kb": 842640,
+          "wall_nanos": 870436556,
+          "peak_rss_kb": 844820,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -664,8 +664,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1057692650,
-          "peak_rss_kb": 833160,
+          "wall_nanos": 869109617,
+          "peak_rss_kb": 843080,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -673,8 +673,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 875112482,
-          "peak_rss_kb": 845400,
+          "wall_nanos": 869667302,
+          "peak_rss_kb": 845052,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -682,129 +682,129 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 875112482,
-      "median_import_baseline_subtracted_nanos": -166233365,
-      "median_peak_rss_kb": 843952
+      "median_wall_nanos": 869667302,
+      "median_import_baseline_subtracted_nanos": 5216443,
+      "median_peak_rss_kb": 844820
     },
     "whnf_checked": {
       "module": "HexInterval.WhnfChecked",
       "samples": [
         {
-          "wall_nanos": 1575405325,
-          "peak_rss_kb": 940360,
+          "wall_nanos": 1560295940,
+          "peak_rss_kb": 941708,
           "axioms": [],
-          "whnf_nanos": 381499304
+          "whnf_nanos": 372211608
         },
         {
-          "wall_nanos": 1766874401,
-          "peak_rss_kb": 944956,
+          "wall_nanos": 1566318668,
+          "peak_rss_kb": 936732,
           "axioms": [],
-          "whnf_nanos": 536429891
+          "whnf_nanos": 355956373
         },
         {
-          "wall_nanos": 1928617379,
-          "peak_rss_kb": 916032,
+          "wall_nanos": 1570057702,
+          "peak_rss_kb": 941084,
           "axioms": [],
-          "whnf_nanos": 491042183
+          "whnf_nanos": 384244452
         },
         {
-          "wall_nanos": 2049295324,
-          "peak_rss_kb": 916132,
+          "wall_nanos": 1577819640,
+          "peak_rss_kb": 944828,
           "axioms": [],
-          "whnf_nanos": 580691434
+          "whnf_nanos": 387617734
         },
         {
-          "wall_nanos": 1554224946,
-          "peak_rss_kb": 941608,
+          "wall_nanos": 1566240847,
+          "peak_rss_kb": 938616,
           "axioms": [],
-          "whnf_nanos": 376121766
+          "whnf_nanos": 412812755
         }
       ],
-      "median_wall_nanos": 1766874401,
-      "median_import_baseline_subtracted_nanos": 432585491,
-      "median_peak_rss_kb": 940360,
-      "median_whnf_nanos": 491042183
+      "median_wall_nanos": 1566318668,
+      "median_import_baseline_subtracted_nanos": 393055792,
+      "median_peak_rss_kb": 941084,
+      "median_whnf_nanos": 384244452
     },
     "whnf_baseline": {
       "module": "HexInterval.WhnfBaseline",
       "samples": [
         {
-          "wall_nanos": 1185599378,
-          "peak_rss_kb": 844548,
+          "wall_nanos": 1176005879,
+          "peak_rss_kb": 844976,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1480192591,
-          "peak_rss_kb": 843916,
+          "wall_nanos": 1178959898,
+          "peak_rss_kb": 844980,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1334288910,
-          "peak_rss_kb": 836568,
+          "wall_nanos": 1155268244,
+          "peak_rss_kb": 843460,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1428338751,
-          "peak_rss_kb": 830960,
+          "wall_nanos": 1173262876,
+          "peak_rss_kb": 844280,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1176398361,
-          "peak_rss_kb": 844672,
+          "wall_nanos": 1165491221,
+          "peak_rss_kb": 845084,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1334288910,
-      "median_peak_rss_kb": 843916
+      "median_wall_nanos": 1173262876,
+      "median_peak_rss_kb": 844976
     },
     "rational_baseline": {
       "module": "HexInterval.ReplayRationalBaseline",
       "samples": [
         {
-          "wall_nanos": 866542183,
-          "peak_rss_kb": 845052,
+          "wall_nanos": 871397257,
+          "peak_rss_kb": 844320,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 883649688,
-          "peak_rss_kb": 845452,
+          "wall_nanos": 868242086,
+          "peak_rss_kb": 845028,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 874803483,
-          "peak_rss_kb": 845368,
+          "wall_nanos": 870796032,
+          "peak_rss_kb": 844200,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 876678710,
-          "peak_rss_kb": 845424,
+          "wall_nanos": 863200177,
+          "peak_rss_kb": 844884,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 876532578,
-          "peak_rss_kb": 845440,
+          "wall_nanos": 850666110,
+          "peak_rss_kb": 844412,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 876532578,
-      "median_peak_rss_kb": 845424
+      "median_wall_nanos": 868242086,
+      "median_peak_rss_kb": 844412
     },
     "rational_direct": {
       "module": "HexInterval.ReplayRationalDirect",
       "samples": [
         {
-          "wall_nanos": 862043800,
-          "peak_rss_kb": 845368,
+          "wall_nanos": 863419456,
+          "peak_rss_kb": 844276,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -813,8 +813,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 860243425,
-          "peak_rss_kb": 845396,
+          "wall_nanos": 972629637,
+          "peak_rss_kb": 844860,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -823,8 +823,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 843042002,
-          "peak_rss_kb": 845444,
+          "wall_nanos": 867450010,
+          "peak_rss_kb": 845052,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -833,8 +833,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 877020746,
-          "peak_rss_kb": 844528,
+          "wall_nanos": 869770030,
+          "peak_rss_kb": 844744,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -843,8 +843,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 860890657,
-          "peak_rss_kb": 845600,
+          "wall_nanos": 878024069,
+          "peak_rss_kb": 844672,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -853,54 +853,54 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 860890657,
-      "median_import_baseline_subtracted_nanos": -15641921,
-      "median_peak_rss_kb": 845396
+      "median_wall_nanos": 869770030,
+      "median_import_baseline_subtracted_nanos": 1527944,
+      "median_peak_rss_kb": 844744
     },
     "rational_checked": {
       "module": "HexInterval.ReplayRationalChecked",
       "samples": [
         {
-          "wall_nanos": 970425770,
-          "peak_rss_kb": 844680,
+          "wall_nanos": 970450296,
+          "peak_rss_kb": 844416,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 976002918,
-          "peak_rss_kb": 845600,
+          "wall_nanos": 959351386,
+          "peak_rss_kb": 845080,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 978259068,
-          "peak_rss_kb": 844412,
+          "wall_nanos": 966204768,
+          "peak_rss_kb": 844736,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 977615393,
-          "peak_rss_kb": 843092,
+          "wall_nanos": 950893710,
+          "peak_rss_kb": 844340,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 963774098,
-          "peak_rss_kb": 844916,
+          "wall_nanos": 968398058,
+          "peak_rss_kb": 844984,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 976002918,
-      "median_import_baseline_subtracted_nanos": 99470340,
-      "median_peak_rss_kb": 844680
+      "median_wall_nanos": 966204768,
+      "median_import_baseline_subtracted_nanos": 97962682,
+      "median_peak_rss_kb": 844736
     },
     "rational_ops": {
       "module": "HexInterval.ReplayRational",
       "samples": [
         {
-          "wall_nanos": 869085563,
-          "peak_rss_kb": 849564,
+          "wall_nanos": 866202603,
+          "peak_rss_kb": 849100,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -909,8 +909,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 874961575,
-          "peak_rss_kb": 847484,
+          "wall_nanos": 876234578,
+          "peak_rss_kb": 845764,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -919,8 +919,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 890657902,
-          "peak_rss_kb": 847476,
+          "wall_nanos": 856080801,
+          "peak_rss_kb": 847152,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -929,8 +929,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 880309007,
-          "peak_rss_kb": 847232,
+          "wall_nanos": 867063536,
+          "peak_rss_kb": 847312,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -939,8 +939,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 906102386,
-          "peak_rss_kb": 851688,
+          "wall_nanos": 863093869,
+          "peak_rss_kb": 846608,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -949,124 +949,124 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 880309007,
-      "median_import_baseline_subtracted_nanos": 3776429,
-      "median_peak_rss_kb": 847484
+      "median_wall_nanos": 866202603,
+      "median_import_baseline_subtracted_nanos": -2039483,
+      "median_peak_rss_kb": 847152
     },
     "whnf_rational_direct": {
       "module": "HexInterval.WhnfRationalDirect",
       "samples": [
         {
-          "wall_nanos": 1210219448,
-          "peak_rss_kb": 853360,
+          "wall_nanos": 1169841891,
+          "peak_rss_kb": 857128,
           "axioms": [],
-          "whnf_nanos": 37921678
+          "whnf_nanos": 37518808
         },
         {
-          "wall_nanos": 1277073545,
-          "peak_rss_kb": 857944,
+          "wall_nanos": 1265805376,
+          "peak_rss_kb": 855016,
           "axioms": [],
-          "whnf_nanos": 38419045
+          "whnf_nanos": 39645292
         },
         {
-          "wall_nanos": 1183838155,
-          "peak_rss_kb": 853952,
+          "wall_nanos": 1165250099,
+          "peak_rss_kb": 855468,
           "axioms": [],
-          "whnf_nanos": 37348498
+          "whnf_nanos": 36770809
         },
         {
-          "wall_nanos": 1297431447,
-          "peak_rss_kb": 856056,
+          "wall_nanos": 1273156355,
+          "peak_rss_kb": 857452,
           "axioms": [],
-          "whnf_nanos": 37981637
+          "whnf_nanos": 38217744
         },
         {
-          "wall_nanos": 1277619995,
-          "peak_rss_kb": 859352,
+          "wall_nanos": 1282005045,
+          "peak_rss_kb": 859152,
           "axioms": [],
-          "whnf_nanos": 38169214
+          "whnf_nanos": 39870164
         }
       ],
-      "median_wall_nanos": 1277073545,
-      "median_import_baseline_subtracted_nanos": 103908818,
-      "median_peak_rss_kb": 856056,
-      "median_whnf_nanos": 37981637
+      "median_wall_nanos": 1265805376,
+      "median_import_baseline_subtracted_nanos": 98389576,
+      "median_peak_rss_kb": 857128,
+      "median_whnf_nanos": 38217744
     },
     "whnf_rational_checked": {
       "module": "HexInterval.WhnfRationalChecked",
       "samples": [
         {
-          "wall_nanos": 1288273002,
-          "peak_rss_kb": 864064,
+          "wall_nanos": 1267526951,
+          "peak_rss_kb": 866288,
           "axioms": [],
-          "whnf_nanos": 69019334
+          "whnf_nanos": 70728336
         },
         {
-          "wall_nanos": 1264786107,
-          "peak_rss_kb": 860452,
+          "wall_nanos": 1275885625,
+          "peak_rss_kb": 868428,
           "axioms": [],
-          "whnf_nanos": 69335423
+          "whnf_nanos": 72621624
         },
         {
-          "wall_nanos": 1252667356,
-          "peak_rss_kb": 869120,
+          "wall_nanos": 1252598440,
+          "peak_rss_kb": 866732,
           "axioms": [],
-          "whnf_nanos": 98967164
+          "whnf_nanos": 72408227
         },
         {
-          "wall_nanos": 1270946793,
-          "peak_rss_kb": 863080,
+          "wall_nanos": 1273510850,
+          "peak_rss_kb": 863716,
           "axioms": [],
-          "whnf_nanos": 70264030
+          "whnf_nanos": 68136101
         },
         {
-          "wall_nanos": 1262266831,
-          "peak_rss_kb": 872300,
+          "wall_nanos": 1266062424,
+          "peak_rss_kb": 868940,
           "axioms": [],
-          "whnf_nanos": 71601813
+          "whnf_nanos": 70822415
         }
       ],
-      "median_wall_nanos": 1264786107,
-      "median_import_baseline_subtracted_nanos": 91621380,
-      "median_peak_rss_kb": 864064,
-      "median_whnf_nanos": 70264030
+      "median_wall_nanos": 1267526951,
+      "median_import_baseline_subtracted_nanos": 100111151,
+      "median_peak_rss_kb": 866732,
+      "median_whnf_nanos": 70822415
     },
     "whnf_rational_baseline": {
       "module": "HexInterval.WhnfRationalBaseline",
       "samples": [
         {
-          "wall_nanos": 1180066490,
-          "peak_rss_kb": 844288,
+          "wall_nanos": 1166690547,
+          "peak_rss_kb": 844032,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1173164727,
-          "peak_rss_kb": 842420,
+          "wall_nanos": 1171120294,
+          "peak_rss_kb": 845012,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1160712111,
-          "peak_rss_kb": 845408,
+          "wall_nanos": 1167415800,
+          "peak_rss_kb": 844832,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1162659644,
-          "peak_rss_kb": 844672,
+          "wall_nanos": 1174028875,
+          "peak_rss_kb": 844084,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1173518804,
-          "peak_rss_kb": 845680,
+          "wall_nanos": 1155705261,
+          "peak_rss_kb": 844904,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1173164727,
-      "median_peak_rss_kb": 844672
+      "median_wall_nanos": 1167415800,
+      "median_peak_rss_kb": 844832
     }
   },
   "artifacts": {

--- a/reports/bench-results/hex-interval-d2-representation.json
+++ b/reports/bench-results/hex-interval-d2-representation.json
@@ -1,12 +1,12 @@
 {
   "schema": "hex-interval-d2-representation-v2",
   "environment": {
-    "git_commit": "f57ab4ad78e471a24841d9f5e2122f358fe2aa21",
+    "git_commit": "31024b715d648dee2298c74c608d6f4583fe9c20",
     "git_dirty": false,
-    "toolchain": "leanprover/lean4:v4.32.0-rc1",
+    "toolchain": "leanprover/lean4:v4.33.0-rc1",
     "hostname": "chungus2",
-    "platform": "Linux-6.12.95-x86_64-with-glibc2.42",
-    "python": "3.13.13"
+    "platform": "Linux-6.12.100-x86_64-with-glibc2.42",
+    "python": "3.14.6"
   },
   "config": {
     "samples": 5,
@@ -15,8 +15,8 @@
       4096
     ],
     "source_sha256": {
-      "HexInterval/Basic.lean": "3a0e40636583ba19b36b44f6858d8da25bc26a5bfdec52ac82034f866d2301fc",
-      "HexInterval/Experiment/Rational.lean": "950b2ae5fb3934fa31b967fae21129ee0cfed0d284def09ad9f24cf38cae71bf",
+      "HexInterval/Basic.lean": "f9efacc79d8cb1eaf717cafd04e728f131840efc2ca98cff3e0dfd3c6de4c3e5",
+      "HexInterval/Experiment/Rational.lean": "a02f3d348856c1b3c71490f02136cf759a640247d85092f8ded25a68fb222564",
       "HexInterval/Experiment/Representation.lean": "32b974a49ccc73d46a793a44b8130f5c9399d25ddd3281ee95fde525e75fde2b",
       "HexInterval.lean": "c1178859f2397cea0c2e93b7c0808acaf394c2e6aae8934ea69211bf50205239",
       "bench/HexBench/IntervalRepresentationSpike.lean": "786b3dd6e361fe86a08b4f1f6d6d1cc53230eee18b23066cd057ccfa4ffe08fd",
@@ -35,9 +35,9 @@
       "bench/HexInterval/WhnfRationalBaseline.lean": "dfa9c7e76b4f2656e149c81dc0e4784cfcb8beb8c5df38861c12e1b9eb6d01d8",
       "bench/HexInterval/WhnfRationalChecked.lean": "3836add542af8827440bc6af74ff9fb58f5f421f42e687a8a0690edff3a0850e",
       "bench/HexInterval/WhnfRationalDirect.lean": "bc7dd6ef8188dd43a63c64090b55146b3aae4542df37138017d85e8fd7b383c6",
-      "lake-manifest.json": "5315ef9d575b3b13138a8e10e222cec2b7cf16a96069f550a79d2fe6d20e3264",
-      "lakefile.lean": "88b35a8cdeb0cf1cc3513d84764153c3c43a9fd6e35a33ed125580b0b0c67eb1",
-      "lean-toolchain": "72681913b978b3f7c2f48229836771f736f6e97d833917726b2263afbc6108ed",
+      "lake-manifest.json": "a3fe83c407715b04ccabe01b74d561ced52b899aa9b6a0b0742e092e5db6c3b1",
+      "lakefile.lean": "4e25a2076945582b69aed3c76794c51f40c8bb48af925ee6593edf48b47ccd7c",
+      "lean-toolchain": "62c2d9c0fc1ec4c67e151c11eff41ca004ef38e179cf9476c230406e6defedef",
       "scripts/bench/interval_representation_sweep.py": "7ad6ac110324cf16650ecee42f949ffda0b59f811748790963daac608c0f7212"
     },
     "compiled_driver": ".lake/build/bin/hex_interval_representation_spike",
@@ -50,43 +50,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 193552846,
-          "inner_total_nanos": 180452432,
-          "per_call_nanos": 39075,
+          "outer_wall_nanos": 194116920,
+          "inner_total_nanos": 183348837,
+          "per_call_nanos": 39703,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3976
+          "peak_rss_kb": 8340
         },
         {
-          "outer_wall_nanos": 182183800,
-          "inner_total_nanos": 178584323,
-          "per_call_nanos": 38671,
+          "outer_wall_nanos": 189378752,
+          "inner_total_nanos": 179718292,
+          "per_call_nanos": 38916,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 6320
+          "peak_rss_kb": 8416
         },
         {
-          "outer_wall_nanos": 185593685,
-          "inner_total_nanos": 180446954,
-          "per_call_nanos": 39074,
+          "outer_wall_nanos": 188002429,
+          "inner_total_nanos": 178337213,
+          "per_call_nanos": 38617,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 6372
+          "peak_rss_kb": 8352
         },
         {
-          "outer_wall_nanos": 188266788,
-          "inner_total_nanos": 180233888,
-          "per_call_nanos": 39028,
+          "outer_wall_nanos": 190995138,
+          "inner_total_nanos": 181460586,
+          "per_call_nanos": 39294,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3980
+          "peak_rss_kb": 8420
         },
         {
-          "outer_wall_nanos": 185366819,
-          "inner_total_nanos": 177965415,
-          "per_call_nanos": 38537,
+          "outer_wall_nanos": 188552956,
+          "inner_total_nanos": 182194445,
+          "per_call_nanos": 39453,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3940
+          "peak_rss_kb": 8452
         }
       ],
-      "median_per_call_nanos": 39028,
-      "median_peak_rss_kb": 3980
+      "median_per_call_nanos": 39294,
+      "median_peak_rss_kb": 8416
     },
     "checked:433": {
       "variant": "checked",
@@ -94,43 +94,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 182531575,
-          "inner_total_nanos": 178232251,
-          "per_call_nanos": 38595,
+          "outer_wall_nanos": 214581155,
+          "inner_total_nanos": 204124544,
+          "per_call_nanos": 44201,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 4000
+          "peak_rss_kb": 8456
         },
         {
-          "outer_wall_nanos": 182599336,
-          "inner_total_nanos": 177370512,
-          "per_call_nanos": 38408,
+          "outer_wall_nanos": 187202113,
+          "inner_total_nanos": 177299213,
+          "per_call_nanos": 38393,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3956
+          "peak_rss_kb": 8508
         },
         {
-          "outer_wall_nanos": 183529665,
-          "inner_total_nanos": 177597900,
-          "per_call_nanos": 38457,
+          "outer_wall_nanos": 187025010,
+          "inner_total_nanos": 177520451,
+          "per_call_nanos": 38440,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 6288
+          "peak_rss_kb": 8428
         },
         {
-          "outer_wall_nanos": 187196241,
-          "inner_total_nanos": 182192051,
-          "per_call_nanos": 39452,
+          "outer_wall_nanos": 188903276,
+          "inner_total_nanos": 179509752,
+          "per_call_nanos": 38871,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3980
+          "peak_rss_kb": 8360
         },
         {
-          "outer_wall_nanos": 190758874,
-          "inner_total_nanos": 177280779,
-          "per_call_nanos": 38389,
+          "outer_wall_nanos": 188746724,
+          "inner_total_nanos": 179637642,
+          "per_call_nanos": 38899,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3916
+          "peak_rss_kb": 8416
         }
       ],
-      "median_per_call_nanos": 38457,
-      "median_peak_rss_kb": 3980
+      "median_per_call_nanos": 38871,
+      "median_peak_rss_kb": 8428
     },
     "bundled-boundary:433": {
       "variant": "bundled-boundary",
@@ -138,43 +138,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 187966093,
-          "inner_total_nanos": 178552976,
-          "per_call_nanos": 38664,
+          "outer_wall_nanos": 190560505,
+          "inner_total_nanos": 183062462,
+          "per_call_nanos": 39641,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3916
+          "peak_rss_kb": 8364
         },
         {
-          "outer_wall_nanos": 190323789,
-          "inner_total_nanos": 179659577,
-          "per_call_nanos": 38904,
+          "outer_wall_nanos": 192227297,
+          "inner_total_nanos": 182496853,
+          "per_call_nanos": 39518,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 4028
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 194488644,
-          "inner_total_nanos": 178028418,
-          "per_call_nanos": 38550,
+          "outer_wall_nanos": 187484201,
+          "inner_total_nanos": 177883350,
+          "per_call_nanos": 38519,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 6288
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 202535896,
-          "inner_total_nanos": 179032697,
-          "per_call_nanos": 38768,
+          "outer_wall_nanos": 190233659,
+          "inner_total_nanos": 180808148,
+          "per_call_nanos": 39152,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3956
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 181906238,
-          "inner_total_nanos": 177959576,
-          "per_call_nanos": 38536,
+          "outer_wall_nanos": 194363035,
+          "inner_total_nanos": 184132418,
+          "per_call_nanos": 39872,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3960
+          "peak_rss_kb": 8380
         }
       ],
-      "median_per_call_nanos": 38664,
-      "median_peak_rss_kb": 3960
+      "median_per_call_nanos": 39518,
+      "median_peak_rss_kb": 8392
     },
     "checked-boundary:433": {
       "variant": "checked-boundary",
@@ -182,43 +182,43 @@
       "repeats": 4618,
       "samples": [
         {
-          "outer_wall_nanos": 212158093,
-          "inner_total_nanos": 207028047,
-          "per_call_nanos": 44830,
+          "outer_wall_nanos": 222019078,
+          "inner_total_nanos": 214187261,
+          "per_call_nanos": 46380,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 4008
+          "peak_rss_kb": 8452
         },
         {
-          "outer_wall_nanos": 205027701,
-          "inner_total_nanos": 200662058,
-          "per_call_nanos": 43452,
+          "outer_wall_nanos": 211625681,
+          "inner_total_nanos": 201855548,
+          "per_call_nanos": 43710,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 8392
+          "peak_rss_kb": 8408
         },
         {
-          "outer_wall_nanos": 209687820,
-          "inner_total_nanos": 200059664,
-          "per_call_nanos": 43321,
+          "outer_wall_nanos": 210890931,
+          "inner_total_nanos": 201403247,
+          "per_call_nanos": 43612,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 6324
+          "peak_rss_kb": 8420
         },
         {
-          "outer_wall_nanos": 214161864,
-          "inner_total_nanos": 209999803,
-          "per_call_nanos": 45474,
+          "outer_wall_nanos": 213000390,
+          "inner_total_nanos": 203369615,
+          "per_call_nanos": 44038,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3976
+          "peak_rss_kb": 8404
         },
         {
-          "outer_wall_nanos": 215341614,
-          "inner_total_nanos": 199664408,
-          "per_call_nanos": 43236,
+          "outer_wall_nanos": 213421313,
+          "inner_total_nanos": 203506497,
+          "per_call_nanos": 44068,
           "checksum": 13103900578367572860,
-          "peak_rss_kb": 3968
+          "peak_rss_kb": 8444
         }
       ],
-      "median_per_call_nanos": 43452,
-      "median_peak_rss_kb": 4008
+      "median_per_call_nanos": 44038,
+      "median_peak_rss_kb": 8420
     },
     "bundled:4096": {
       "variant": "bundled",
@@ -226,43 +226,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 192820450,
-          "inner_total_nanos": 187537157,
-          "per_call_nanos": 384297,
+          "outer_wall_nanos": 197164850,
+          "inner_total_nanos": 186182960,
+          "per_call_nanos": 381522,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3912
+          "peak_rss_kb": 8460
         },
         {
-          "outer_wall_nanos": 191278885,
-          "inner_total_nanos": 185662959,
-          "per_call_nanos": 380456,
+          "outer_wall_nanos": 198162410,
+          "inner_total_nanos": 187099039,
+          "per_call_nanos": 383399,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6316
+          "peak_rss_kb": 8396
         },
         {
-          "outer_wall_nanos": 208561030,
-          "inner_total_nanos": 202709934,
-          "per_call_nanos": 415389,
+          "outer_wall_nanos": 201237761,
+          "inner_total_nanos": 190116335,
+          "per_call_nanos": 389582,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6344
+          "peak_rss_kb": 8336
         },
         {
-          "outer_wall_nanos": 196391305,
-          "inner_total_nanos": 190094719,
-          "per_call_nanos": 389538,
+          "outer_wall_nanos": 201892002,
+          "inner_total_nanos": 190199918,
+          "per_call_nanos": 389753,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 4020
+          "peak_rss_kb": 8360
         },
         {
-          "outer_wall_nanos": 193133956,
-          "inner_total_nanos": 186680587,
-          "per_call_nanos": 382542,
+          "outer_wall_nanos": 198694158,
+          "inner_total_nanos": 187698198,
+          "per_call_nanos": 384627,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3980
+          "peak_rss_kb": 8340
         }
       ],
-      "median_per_call_nanos": 384297,
-      "median_peak_rss_kb": 4020
+      "median_per_call_nanos": 384627,
+      "median_peak_rss_kb": 8360
     },
     "checked:4096": {
       "variant": "checked",
@@ -270,43 +270,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 199466375,
-          "inner_total_nanos": 191529076,
-          "per_call_nanos": 392477,
+          "outer_wall_nanos": 198493191,
+          "inner_total_nanos": 186908827,
+          "per_call_nanos": 383009,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3968
+          "peak_rss_kb": 8312
         },
         {
-          "outer_wall_nanos": 189671402,
-          "inner_total_nanos": 185419327,
-          "per_call_nanos": 379957,
+          "outer_wall_nanos": 198542393,
+          "inner_total_nanos": 187229362,
+          "per_call_nanos": 383666,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8404
+          "peak_rss_kb": 8364
         },
         {
-          "outer_wall_nanos": 220233617,
-          "inner_total_nanos": 189031353,
-          "per_call_nanos": 387359,
+          "outer_wall_nanos": 197779842,
+          "inner_total_nanos": 186493091,
+          "per_call_nanos": 382157,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6336
+          "peak_rss_kb": 8484
         },
         {
-          "outer_wall_nanos": 253720959,
-          "inner_total_nanos": 184483900,
-          "per_call_nanos": 378040,
+          "outer_wall_nanos": 197890896,
+          "inner_total_nanos": 186891541,
+          "per_call_nanos": 382974,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6432
+          "peak_rss_kb": 8352
         },
         {
-          "outer_wall_nanos": 194283721,
-          "inner_total_nanos": 186615561,
-          "per_call_nanos": 382408,
+          "outer_wall_nanos": 195995565,
+          "inner_total_nanos": 185177419,
+          "per_call_nanos": 379461,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3936
+          "peak_rss_kb": 8504
         }
       ],
-      "median_per_call_nanos": 382408,
-      "median_peak_rss_kb": 6336
+      "median_per_call_nanos": 382974,
+      "median_peak_rss_kb": 8364
     },
     "bundled-boundary:4096": {
       "variant": "bundled-boundary",
@@ -314,43 +314,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 202478591,
-          "inner_total_nanos": 186108939,
-          "per_call_nanos": 381370,
+          "outer_wall_nanos": 200151060,
+          "inner_total_nanos": 188897507,
+          "per_call_nanos": 387085,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3960
+          "peak_rss_kb": 8332
         },
         {
-          "outer_wall_nanos": 194026228,
-          "inner_total_nanos": 186842207,
-          "per_call_nanos": 382873,
+          "outer_wall_nanos": 199051388,
+          "inner_total_nanos": 188142347,
+          "per_call_nanos": 385537,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 8520
+          "peak_rss_kb": 8404
         },
         {
-          "outer_wall_nanos": 194069793,
-          "inner_total_nanos": 188450021,
-          "per_call_nanos": 386168,
+          "outer_wall_nanos": 198147187,
+          "inner_total_nanos": 187233909,
+          "per_call_nanos": 383676,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6296
+          "peak_rss_kb": 8352
         },
         {
-          "outer_wall_nanos": 193447620,
-          "inner_total_nanos": 187060681,
-          "per_call_nanos": 383321,
+          "outer_wall_nanos": 198212193,
+          "inner_total_nanos": 187420686,
+          "per_call_nanos": 384058,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 4020
+          "peak_rss_kb": 8392
         },
         {
-          "outer_wall_nanos": 193538916,
-          "inner_total_nanos": 187601562,
-          "per_call_nanos": 384429,
+          "outer_wall_nanos": 197531714,
+          "inner_total_nanos": 186647408,
+          "per_call_nanos": 382474,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3988
+          "peak_rss_kb": 8400
         }
       ],
-      "median_per_call_nanos": 383321,
-      "median_peak_rss_kb": 4020
+      "median_per_call_nanos": 384058,
+      "median_peak_rss_kb": 8392
     },
     "checked-boundary:4096": {
       "variant": "checked-boundary",
@@ -358,43 +358,43 @@
       "repeats": 488,
       "samples": [
         {
-          "outer_wall_nanos": 229624041,
-          "inner_total_nanos": 209427935,
-          "per_call_nanos": 429155,
+          "outer_wall_nanos": 214288731,
+          "inner_total_nanos": 208878796,
+          "per_call_nanos": 428030,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 4008
+          "peak_rss_kb": 8472
         },
         {
-          "outer_wall_nanos": 234158584,
-          "inner_total_nanos": 210835733,
-          "per_call_nanos": 432040,
+          "outer_wall_nanos": 220237614,
+          "inner_total_nanos": 208961498,
+          "per_call_nanos": 428199,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6280
+          "peak_rss_kb": 8436
         },
         {
-          "outer_wall_nanos": 233492707,
-          "inner_total_nanos": 207957245,
-          "per_call_nanos": 426141,
+          "outer_wall_nanos": 222467762,
+          "inner_total_nanos": 211545651,
+          "per_call_nanos": 433495,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 6372
+          "peak_rss_kb": 8404
         },
         {
-          "outer_wall_nanos": 221133181,
-          "inner_total_nanos": 208994803,
-          "per_call_nanos": 428268,
+          "outer_wall_nanos": 221752662,
+          "inner_total_nanos": 210735790,
+          "per_call_nanos": 431835,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3968
+          "peak_rss_kb": 8380
         },
         {
-          "outer_wall_nanos": 220259876,
-          "inner_total_nanos": 210948300,
-          "per_call_nanos": 432271,
+          "outer_wall_nanos": 221022047,
+          "inner_total_nanos": 210085305,
+          "per_call_nanos": 430502,
           "checksum": 18433152544017910708,
-          "peak_rss_kb": 3992
+          "peak_rss_kb": 8352
         }
       ],
-      "median_per_call_nanos": 429155,
-      "median_peak_rss_kb": 4008
+      "median_per_call_nanos": 430502,
+      "median_peak_rss_kb": 8404
     }
   },
   "replay": {
@@ -402,45 +402,45 @@
       "module": "HexInterval.ReplayBaseline",
       "samples": [
         {
-          "wall_nanos": 1165298014,
-          "peak_rss_kb": 808216,
+          "wall_nanos": 1058929235,
+          "peak_rss_kb": 845448,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1416469189,
-          "peak_rss_kb": 808048,
+          "wall_nanos": 853465461,
+          "peak_rss_kb": 845512,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1680206986,
-          "peak_rss_kb": 808676,
+          "wall_nanos": 1071568355,
+          "peak_rss_kb": 838652,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1096703154,
-          "peak_rss_kb": 823304,
+          "wall_nanos": 1041345847,
+          "peak_rss_kb": 836544,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 902354207,
-          "peak_rss_kb": 822228,
+          "wall_nanos": 855868604,
+          "peak_rss_kb": 845436,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1165298014,
-      "median_peak_rss_kb": 808676
+      "median_wall_nanos": 1041345847,
+      "median_peak_rss_kb": 845436
     },
     "bundled": {
       "module": "HexInterval.ReplayBundled",
       "samples": [
         {
-          "wall_nanos": 2130896437,
-          "peak_rss_kb": 809548,
+          "wall_nanos": 1661406412,
+          "peak_rss_kb": 844728,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -448,8 +448,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2354085762,
-          "peak_rss_kb": 809508,
+          "wall_nanos": 1290563382,
+          "peak_rss_kb": 845236,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -457,8 +457,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2311267473,
-          "peak_rss_kb": 809924,
+          "wall_nanos": 1578468197,
+          "peak_rss_kb": 835500,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -466,8 +466,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1563533532,
-          "peak_rss_kb": 823248,
+          "wall_nanos": 1509806669,
+          "peak_rss_kb": 836620,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -475,8 +475,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1808498975,
-          "peak_rss_kb": 822508,
+          "wall_nanos": 1273764571,
+          "peak_rss_kb": 845412,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -484,16 +484,16 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 2130896437,
-      "median_import_baseline_subtracted_nanos": 965598423,
-      "median_peak_rss_kb": 809924
+      "median_wall_nanos": 1509806669,
+      "median_import_baseline_subtracted_nanos": 468460822,
+      "median_peak_rss_kb": 844728
     },
     "import_bundled": {
       "module": "HexInterval.ImportBundled",
       "samples": [
         {
-          "wall_nanos": 1273555070,
-          "peak_rss_kb": 808496,
+          "wall_nanos": 881996634,
+          "peak_rss_kb": 844900,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -501,8 +501,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1074533898,
-          "peak_rss_kb": 810288,
+          "wall_nanos": 856827953,
+          "peak_rss_kb": 845432,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -510,8 +510,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1484309689,
-          "peak_rss_kb": 808788,
+          "wall_nanos": 991087254,
+          "peak_rss_kb": 840556,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -519,8 +519,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1326264292,
-          "peak_rss_kb": 813128,
+          "wall_nanos": 1060955311,
+          "peak_rss_kb": 835584,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -528,8 +528,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1393725274,
-          "peak_rss_kb": 813856,
+          "wall_nanos": 872306083,
+          "peak_rss_kb": 845588,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -537,55 +537,55 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1326264292,
-      "median_import_baseline_subtracted_nanos": 160966278,
-      "median_peak_rss_kb": 810288
+      "median_wall_nanos": 881996634,
+      "median_import_baseline_subtracted_nanos": -159349213,
+      "median_peak_rss_kb": 844900
     },
     "whnf_bundled": {
       "module": "HexInterval.WhnfBundled",
       "samples": [
         {
-          "wall_nanos": 2522852775,
-          "peak_rss_kb": 886940,
+          "wall_nanos": 1597733918,
+          "peak_rss_kb": 945872,
           "axioms": [],
-          "whnf_nanos": 672423353
+          "whnf_nanos": 412654248
         },
         {
-          "wall_nanos": 2485328392,
-          "peak_rss_kb": 886852,
+          "wall_nanos": 1568306997,
+          "peak_rss_kb": 940400,
           "axioms": [],
-          "whnf_nanos": 747300038
+          "whnf_nanos": 395986702
         },
         {
-          "wall_nanos": 2859350182,
-          "peak_rss_kb": 889764,
+          "wall_nanos": 1960014313,
+          "peak_rss_kb": 910676,
           "axioms": [],
-          "whnf_nanos": 820201612
+          "whnf_nanos": 532237679
         },
         {
-          "wall_nanos": 2614368124,
-          "peak_rss_kb": 906760,
+          "wall_nanos": 2039634066,
+          "peak_rss_kb": 914308,
           "axioms": [],
-          "whnf_nanos": 622322963
+          "whnf_nanos": 527816927
         },
         {
-          "wall_nanos": 2203885399,
-          "peak_rss_kb": 896852,
+          "wall_nanos": 1564505929,
+          "peak_rss_kb": 939368,
           "axioms": [],
-          "whnf_nanos": 729337828
+          "whnf_nanos": 369082875
         }
       ],
-      "median_wall_nanos": 2522852775,
-      "median_import_baseline_subtracted_nanos": 789065157,
-      "median_peak_rss_kb": 889764,
-      "median_whnf_nanos": 729337828
+      "median_wall_nanos": 1597733918,
+      "median_import_baseline_subtracted_nanos": 263445008,
+      "median_peak_rss_kb": 939368,
+      "median_whnf_nanos": 412654248
     },
     "checked": {
       "module": "HexInterval.ReplayChecked",
       "samples": [
         {
-          "wall_nanos": 1967934028,
-          "peak_rss_kb": 808064,
+          "wall_nanos": 1262712278,
+          "peak_rss_kb": 845448,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -593,8 +593,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1758408001,
-          "peak_rss_kb": 811268,
+          "wall_nanos": 1274391102,
+          "peak_rss_kb": 845388,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -602,8 +602,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2385189836,
-          "peak_rss_kb": 808636,
+          "wall_nanos": 1608173113,
+          "peak_rss_kb": 844176,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -611,8 +611,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1613555432,
-          "peak_rss_kb": 822436,
+          "wall_nanos": 1323978851,
+          "peak_rss_kb": 841496,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -620,8 +620,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2646728963,
-          "peak_rss_kb": 814064,
+          "wall_nanos": 1269306727,
+          "peak_rss_kb": 845044,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -629,16 +629,16 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1967934028,
-      "median_import_baseline_subtracted_nanos": 802636014,
-      "median_peak_rss_kb": 811268
+      "median_wall_nanos": 1274391102,
+      "median_import_baseline_subtracted_nanos": 233045255,
+      "median_peak_rss_kb": 845044
     },
     "import_checked": {
       "module": "HexInterval.ImportChecked",
       "samples": [
         {
-          "wall_nanos": 1306830891,
-          "peak_rss_kb": 809408,
+          "wall_nanos": 866533736,
+          "peak_rss_kb": 843952,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -646,8 +646,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1161077930,
-          "peak_rss_kb": 809288,
+          "wall_nanos": 852974968,
+          "peak_rss_kb": 845408,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -655,8 +655,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1331685338,
-          "peak_rss_kb": 814608,
+          "wall_nanos": 977748338,
+          "peak_rss_kb": 842640,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -664,8 +664,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1475859283,
-          "peak_rss_kb": 813844,
+          "wall_nanos": 1057692650,
+          "peak_rss_kb": 833160,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -673,8 +673,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1182522333,
-          "peak_rss_kb": 822440,
+          "wall_nanos": 875112482,
+          "peak_rss_kb": 845400,
           "axioms": [
             "propext",
             "Quot.sound"
@@ -682,129 +682,129 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1306830891,
-      "median_import_baseline_subtracted_nanos": 141532877,
-      "median_peak_rss_kb": 813844
+      "median_wall_nanos": 875112482,
+      "median_import_baseline_subtracted_nanos": -166233365,
+      "median_peak_rss_kb": 843952
     },
     "whnf_checked": {
       "module": "HexInterval.WhnfChecked",
       "samples": [
         {
-          "wall_nanos": 2507388627,
-          "peak_rss_kb": 886668,
+          "wall_nanos": 1575405325,
+          "peak_rss_kb": 940360,
           "axioms": [],
-          "whnf_nanos": 804692935
+          "whnf_nanos": 381499304
         },
         {
-          "wall_nanos": 2784406346,
-          "peak_rss_kb": 887700,
+          "wall_nanos": 1766874401,
+          "peak_rss_kb": 944956,
           "axioms": [],
-          "whnf_nanos": 885667771
+          "whnf_nanos": 536429891
         },
         {
-          "wall_nanos": 3030364023,
-          "peak_rss_kb": 900532,
+          "wall_nanos": 1928617379,
+          "peak_rss_kb": 916032,
           "axioms": [],
-          "whnf_nanos": 929931223
+          "whnf_nanos": 491042183
         },
         {
-          "wall_nanos": 1667756607,
-          "peak_rss_kb": 915092,
+          "wall_nanos": 2049295324,
+          "peak_rss_kb": 916132,
           "axioms": [],
-          "whnf_nanos": 505391073
+          "whnf_nanos": 580691434
         },
         {
-          "wall_nanos": 1949348658,
-          "peak_rss_kb": 911916,
+          "wall_nanos": 1554224946,
+          "peak_rss_kb": 941608,
           "axioms": [],
-          "whnf_nanos": 525340393
+          "whnf_nanos": 376121766
         }
       ],
-      "median_wall_nanos": 2507388627,
-      "median_import_baseline_subtracted_nanos": 773601009,
-      "median_peak_rss_kb": 900532,
-      "median_whnf_nanos": 804692935
+      "median_wall_nanos": 1766874401,
+      "median_import_baseline_subtracted_nanos": 432585491,
+      "median_peak_rss_kb": 940360,
+      "median_whnf_nanos": 491042183
     },
     "whnf_baseline": {
       "module": "HexInterval.WhnfBaseline",
       "samples": [
         {
-          "wall_nanos": 3169081712,
-          "peak_rss_kb": 802240,
+          "wall_nanos": 1185599378,
+          "peak_rss_kb": 844548,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1733787618,
-          "peak_rss_kb": 817216,
+          "wall_nanos": 1480192591,
+          "peak_rss_kb": 843916,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1974581455,
-          "peak_rss_kb": 811356,
+          "wall_nanos": 1334288910,
+          "peak_rss_kb": 836568,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1236511593,
-          "peak_rss_kb": 822516,
+          "wall_nanos": 1428338751,
+          "peak_rss_kb": 830960,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1367948793,
-          "peak_rss_kb": 823264,
+          "wall_nanos": 1176398361,
+          "peak_rss_kb": 844672,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1733787618,
-      "median_peak_rss_kb": 817216
+      "median_wall_nanos": 1334288910,
+      "median_peak_rss_kb": 843916
     },
     "rational_baseline": {
       "module": "HexInterval.ReplayRationalBaseline",
       "samples": [
         {
-          "wall_nanos": 1373412475,
-          "peak_rss_kb": 819028,
+          "wall_nanos": 866542183,
+          "peak_rss_kb": 845052,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1348053238,
-          "peak_rss_kb": 812896,
+          "wall_nanos": 883649688,
+          "peak_rss_kb": 845452,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1351551396,
-          "peak_rss_kb": 809092,
+          "wall_nanos": 874803483,
+          "peak_rss_kb": 845368,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1652279593,
-          "peak_rss_kb": 806100,
+          "wall_nanos": 876678710,
+          "peak_rss_kb": 845424,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1351508026,
-          "peak_rss_kb": 807648,
+          "wall_nanos": 876532578,
+          "peak_rss_kb": 845440,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1351551396,
-      "median_peak_rss_kb": 809092
+      "median_wall_nanos": 876532578,
+      "median_peak_rss_kb": 845424
     },
     "rational_direct": {
       "module": "HexInterval.ReplayRationalDirect",
       "samples": [
         {
-          "wall_nanos": 1107139301,
-          "peak_rss_kb": 823056,
+          "wall_nanos": 862043800,
+          "peak_rss_kb": 845368,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -813,8 +813,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1344507499,
-          "peak_rss_kb": 810992,
+          "wall_nanos": 860243425,
+          "peak_rss_kb": 845396,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -823,8 +823,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1430964086,
-          "peak_rss_kb": 809308,
+          "wall_nanos": 843042002,
+          "peak_rss_kb": 845444,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -833,8 +833,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1653309399,
-          "peak_rss_kb": 809380,
+          "wall_nanos": 877020746,
+          "peak_rss_kb": 844528,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -843,8 +843,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1464436711,
-          "peak_rss_kb": 807844,
+          "wall_nanos": 860890657,
+          "peak_rss_kb": 845600,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -853,54 +853,54 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1430964086,
-      "median_import_baseline_subtracted_nanos": 79412690,
-      "median_peak_rss_kb": 809380
+      "median_wall_nanos": 860890657,
+      "median_import_baseline_subtracted_nanos": -15641921,
+      "median_peak_rss_kb": 845396
     },
     "rational_checked": {
       "module": "HexInterval.ReplayRationalChecked",
       "samples": [
         {
-          "wall_nanos": 1459494784,
-          "peak_rss_kb": 817612,
+          "wall_nanos": 970425770,
+          "peak_rss_kb": 844680,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1563899081,
-          "peak_rss_kb": 813576,
+          "wall_nanos": 976002918,
+          "peak_rss_kb": 845600,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1600691206,
-          "peak_rss_kb": 810828,
+          "wall_nanos": 978259068,
+          "peak_rss_kb": 844412,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1589048457,
-          "peak_rss_kb": 807276,
+          "wall_nanos": 977615393,
+          "peak_rss_kb": 843092,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1528498699,
-          "peak_rss_kb": 812324,
+          "wall_nanos": 963774098,
+          "peak_rss_kb": 844916,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1563899081,
-      "median_import_baseline_subtracted_nanos": 212347685,
-      "median_peak_rss_kb": 812324
+      "median_wall_nanos": 976002918,
+      "median_import_baseline_subtracted_nanos": 99470340,
+      "median_peak_rss_kb": 844680
     },
     "rational_ops": {
       "module": "HexInterval.ReplayRational",
       "samples": [
         {
-          "wall_nanos": 1854762174,
-          "peak_rss_kb": 815412,
+          "wall_nanos": 869085563,
+          "peak_rss_kb": 849564,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -909,8 +909,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1355533117,
-          "peak_rss_kb": 811388,
+          "wall_nanos": 874961575,
+          "peak_rss_kb": 847484,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -919,8 +919,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1503183487,
-          "peak_rss_kb": 808944,
+          "wall_nanos": 890657902,
+          "peak_rss_kb": 847476,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -929,8 +929,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1591122090,
-          "peak_rss_kb": 811952,
+          "wall_nanos": 880309007,
+          "peak_rss_kb": 847232,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -939,8 +939,8 @@
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1190595564,
-          "peak_rss_kb": 807468,
+          "wall_nanos": 906102386,
+          "peak_rss_kb": 851688,
           "axioms": [
             "propext",
             "Classical.choice",
@@ -949,124 +949,124 @@
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1503183487,
-      "median_import_baseline_subtracted_nanos": 151632091,
-      "median_peak_rss_kb": 811388
+      "median_wall_nanos": 880309007,
+      "median_import_baseline_subtracted_nanos": 3776429,
+      "median_peak_rss_kb": 847484
     },
     "whnf_rational_direct": {
       "module": "HexInterval.WhnfRationalDirect",
       "samples": [
         {
-          "wall_nanos": 1900417209,
-          "peak_rss_kb": 827788,
+          "wall_nanos": 1210219448,
+          "peak_rss_kb": 853360,
           "axioms": [],
-          "whnf_nanos": 49202915
+          "whnf_nanos": 37921678
         },
         {
-          "wall_nanos": 2009470950,
-          "peak_rss_kb": 811832,
+          "wall_nanos": 1277073545,
+          "peak_rss_kb": 857944,
           "axioms": [],
-          "whnf_nanos": 118233720
+          "whnf_nanos": 38419045
         },
         {
-          "wall_nanos": 1948980881,
-          "peak_rss_kb": 814788,
+          "wall_nanos": 1183838155,
+          "peak_rss_kb": 853952,
           "axioms": [],
-          "whnf_nanos": 95169602
+          "whnf_nanos": 37348498
         },
         {
-          "wall_nanos": 1971435768,
-          "peak_rss_kb": 808048,
+          "wall_nanos": 1297431447,
+          "peak_rss_kb": 856056,
           "axioms": [],
-          "whnf_nanos": 91346414
+          "whnf_nanos": 37981637
         },
         {
-          "wall_nanos": 2090537849,
-          "peak_rss_kb": 810192,
+          "wall_nanos": 1277619995,
+          "peak_rss_kb": 859352,
           "axioms": [],
-          "whnf_nanos": 92736966
+          "whnf_nanos": 38169214
         }
       ],
-      "median_wall_nanos": 1971435768,
-      "median_import_baseline_subtracted_nanos": 103567891,
-      "median_peak_rss_kb": 811832,
-      "median_whnf_nanos": 92736966
+      "median_wall_nanos": 1277073545,
+      "median_import_baseline_subtracted_nanos": 103908818,
+      "median_peak_rss_kb": 856056,
+      "median_whnf_nanos": 37981637
     },
     "whnf_rational_checked": {
       "module": "HexInterval.WhnfRationalChecked",
       "samples": [
         {
-          "wall_nanos": 1807010110,
-          "peak_rss_kb": 835780,
+          "wall_nanos": 1288273002,
+          "peak_rss_kb": 864064,
           "axioms": [],
-          "whnf_nanos": 142809871
+          "whnf_nanos": 69019334
         },
         {
-          "wall_nanos": 2146319071,
-          "peak_rss_kb": 833640,
+          "wall_nanos": 1264786107,
+          "peak_rss_kb": 860452,
           "axioms": [],
-          "whnf_nanos": 122086623
+          "whnf_nanos": 69335423
         },
         {
-          "wall_nanos": 2001146130,
-          "peak_rss_kb": 817736,
+          "wall_nanos": 1252667356,
+          "peak_rss_kb": 869120,
           "axioms": [],
-          "whnf_nanos": 190936380
+          "whnf_nanos": 98967164
         },
         {
-          "wall_nanos": 2327207528,
-          "peak_rss_kb": 808284,
+          "wall_nanos": 1270946793,
+          "peak_rss_kb": 863080,
           "axioms": [],
-          "whnf_nanos": 290232291
+          "whnf_nanos": 70264030
         },
         {
-          "wall_nanos": 2057870483,
-          "peak_rss_kb": 814564,
+          "wall_nanos": 1262266831,
+          "peak_rss_kb": 872300,
           "axioms": [],
-          "whnf_nanos": 157013691
+          "whnf_nanos": 71601813
         }
       ],
-      "median_wall_nanos": 2057870483,
-      "median_import_baseline_subtracted_nanos": 190002606,
-      "median_peak_rss_kb": 817736,
-      "median_whnf_nanos": 157013691
+      "median_wall_nanos": 1264786107,
+      "median_import_baseline_subtracted_nanos": 91621380,
+      "median_peak_rss_kb": 864064,
+      "median_whnf_nanos": 70264030
     },
     "whnf_rational_baseline": {
       "module": "HexInterval.WhnfRationalBaseline",
       "samples": [
         {
-          "wall_nanos": 1339246859,
-          "peak_rss_kb": 820228,
+          "wall_nanos": 1180066490,
+          "peak_rss_kb": 844288,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2043391516,
-          "peak_rss_kb": 810088,
+          "wall_nanos": 1173164727,
+          "peak_rss_kb": 842420,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1663980690,
-          "peak_rss_kb": 812104,
+          "wall_nanos": 1160712111,
+          "peak_rss_kb": 845408,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 2151360933,
-          "peak_rss_kb": 807580,
+          "wall_nanos": 1162659644,
+          "peak_rss_kb": 844672,
           "axioms": [],
           "whnf_nanos": null
         },
         {
-          "wall_nanos": 1867867877,
-          "peak_rss_kb": 810888,
+          "wall_nanos": 1173518804,
+          "peak_rss_kb": 845680,
           "axioms": [],
           "whnf_nanos": null
         }
       ],
-      "median_wall_nanos": 1867867877,
-      "median_peak_rss_kb": 810888
+      "median_wall_nanos": 1173164727,
+      "median_peak_rss_kb": 844672
     }
   },
   "artifacts": {


### PR DESCRIPTION
## Summary

- select a sealed bundled `Hex.Interval` as the canonical public representation
- expose a canonical raw view, extensionality, decidable equality, and resource-safe constructors
- record the current-source bundled-versus-checked benchmark evidence behind the decision
- export only the supported construction slice; public arithmetic remains a separate acceptance step

## Verification

- `lake build HexInterval HexInterval.Conformance HexIntervalAlgebraic.PolynomialDispatchConformance` (8,962 jobs)
- copyright, line-count, DAG, Phase 4, trust-surface, factor-freshness, PNT inventory, and conformance-target checks
- added-line scan for `native_decide`, `axiom`, `sorry`, and `ofReduceBool`

Fresh exact-head independent review and exact-head CI are required before merge.