### PR TITLE
feat(interval): expose resource-safe hull

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -15,7 +15,8 @@ public section
 data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
-representation, resource-safe smart constructors, intersection, and negation.
-Raw cuts remain visible as the explicit decoder and inspection boundary; D2
-propagation and replay experiments still live outside this supported umbrella.
+representation, resource-safe smart constructors, intersection, hull, and
+negation. Raw cuts remain visible as the explicit decoder and inspection
+boundary; D2 propagation and replay experiments still live outside this
+supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -13,10 +13,11 @@ public section
 /-!
 # Public exact interval operations
 
-This module begins the supported arithmetic surface with exact intersection
-and negation.  Both operations retain a resource-aware result: public interval
-values do not remember the construction budget under which their endpoints
-were admitted, so a later comparison must preflight its own alignment work.
+This module begins the supported arithmetic surface with exact intersection,
+hull, and negation.  The operations retain a resource-aware result: public
+interval values do not remember the construction budget under which their
+endpoints were admitted, so a later comparison must preflight its own alignment
+work.
 -/
 
 namespace Hex.Interval
@@ -53,6 +54,36 @@ preflights that final crossed comparison before canonicalization. -/
       Raw.bounds
         (intersectLowerUnchecked leftLower rightLower)
         (intersectUpperUnchecked leftUpper rightUpper)
+
+/-- Smaller of two lower cuts. An unbounded lower cut wins. At a tied finite
+endpoint the hull is strict only when both inputs exclude that endpoint. -/
+@[expose] def hullLowerUnchecked : Lower → Lower → Lower
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | left@(.finite leftValue leftStrict), right@(.finite rightValue rightStrict) =>
+      if leftValue < rightValue then left
+      else if leftValue = rightValue then
+        .finite leftValue (leftStrict && rightStrict)
+      else right
+
+/-- Larger of two upper cuts. An unbounded upper cut wins. At a tied finite
+endpoint the hull is strict only when both inputs exclude that endpoint. -/
+@[expose] def hullUpperUnchecked : Upper → Upper → Upper
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | left@(.finite leftValue leftStrict), right@(.finite rightValue rightStrict) =>
+      if leftValue < rightValue then right
+      else if leftValue = rightValue then
+        .finite leftValue (leftStrict && rightStrict)
+      else left
+
+/-- Exact raw interval-hull candidate after same-side finite comparisons have
+been preflighted. Empty is an identity. The selected lower/upper pair remains
+unnormalized so the supported wrapper preflights its final comparison. -/
+@[expose] def hullUnchecked : Raw → Raw → Raw
+  | .empty, raw | raw, .empty => raw
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      Raw.bounds
+        (hullLowerUnchecked leftLower rightLower)
+        (hullUpperUnchecked leftUpper rightUpper)
 
 /-- Exact raw image under negation.  Negation swaps the cuts and preserves
 their strictness. -/
@@ -92,6 +123,14 @@ private def intersectCost? (limit : EndpointLimit) : Raw → Raw → Option Comp
       | some cost => some cost
       | none => upperCost? limit leftUpper rightUpper
 
+/-- The first same-side finite-cut comparison refused by a hull preflight. -/
+private def hullCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCost
+  | .empty, _ | _, .empty => none
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match lowerCost? limit leftLower rightLower with
+      | some cost => some cost
+      | none => upperCost? limit leftUpper rightUpper
+
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
 def intersectWithin (limit : EndpointLimit)
@@ -107,6 +146,25 @@ theorem view_intersectWithin_ready {limit : EndpointLimit}
     (h : intersectWithin limit left right = .ready result) :
     result.view = (Raw.intersectUnchecked left.view right.view).normalizeUnchecked := by
   unfold intersectWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
+
+/-- Exact interval hull with preflighted same-side endpoint selection and
+checked final canonicalization. Empty is an identity; refusal is distinct from
+an empty interval. -/
+def hullWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : BuildResult :=
+  match hullCost? limit left.view right.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.hullUnchecked left.view right.view)
+
+/-- A successful hull exposes exactly the normalized selected-cut candidate. -/
+theorem view_hullWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (h : hullWithin limit left right = .ready result) :
+    result.view = (Raw.hullUnchecked left.view right.view).normalizeUnchecked := by
+  unfold hullWithin at h
   split at h
   · contradiction
   · exact view_ofRawWithin_ready h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -181,8 +181,8 @@ value's proof field.
 
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
-supported operations are resource-checked intersection and negation. Their
-Mathlib companion proves exact set semantics for the complete cut language;
+supported operations are resource-checked intersection, hull, and negation.
+Their Mathlib companion proves exact set semantics for the complete cut language;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
 examples use the fully qualified `Hex.Interval`, because Mathlib also has a
@@ -194,6 +194,8 @@ The public Mathlib companion interprets every canonical interval as a subset
 of `ℝ`. It proves that a successful executable `intersectWithin` denotes
 logical conjunction for the complete cut language: strict and closed ends,
 tied endpoints, empty results, and either end unbounded. It also proves that a
+successful `hullWithin` has the exact selected-cut/interval-convex-closure
+meaning and contains both inputs; this is deliberately not set union. A
 successful `negWithin` contains `x` exactly when the input contains `-x`.
 Separately, the experiment form of the intersection theorem is installed as the
 generic `FactDomainSchema.proveMeet` boundary, and the transparent proof
@@ -409,6 +411,7 @@ The supported first operation slice is:
 
 ```lean
 def intersectWithin : EndpointLimit → Interval → Interval → BuildResult
+def hullWithin      : EndpointLimit → Interval → Interval → BuildResult
 def negWithin       : EndpointLimit → Interval → BuildResult
 ```
 
@@ -420,17 +423,17 @@ larger than either stored mantissa. A refused comparison returns
 Negation still takes a limit because its finite output endpoints and final
 canonical comparison cross the same public boundary.
 
-The public `Raw.intersectLowerUnchecked`, `intersectUpperUnchecked`,
-`intersectUnchecked`, and `negUnchecked` helpers state successful-result and
-semantic theorems. Like `Raw.normalizeUnchecked`, they are decoder-level
-combinators: untrusted callers use the checked `Interval` operations above.
+The public raw intersection and hull cut selectors, `intersectUnchecked`,
+`hullUnchecked`, and `negUnchecked` are related to the checked operations by
+successful-result and semantic theorems. Like `Raw.normalizeUnchecked`, they
+are decoder-level combinators: untrusted callers use the checked `Interval`
+operations above.
 
 The remaining target surface is:
 
 ```lean
 namespace Hex.Interval
 
-def hullWithin : EndpointLimit → Interval → Interval → BuildResult
 def add        : Interval → Interval → Interval
 def sub        : Interval → Interval → Interval
 def mul        : Interval → Interval → Interval
@@ -455,7 +458,7 @@ tests also check the following exactness rules.
 
 - `intersectWithin` chooses the larger lower cut and the smaller upper cut. At equal
   endpoints it chooses open if either input is open.
-- `hull` chooses the smaller lower cut and the larger upper cut. At equal
+- `hullWithin` chooses the smaller lower cut and the larger upper cut. At equal
   endpoints it chooses closed if either input contains the endpoint.
 - `negWithin` swaps the ends and preserves their openness.
 - A finite endpoint of a sum is closed exactly when both contributing
@@ -3878,8 +3881,8 @@ their declared cost inside a scheduler bound.
   normalization.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
-- `HexInterval/Interval.lean`: supported resource-safe intersection and
-  negation, followed by future hull, arithmetic, splitting, and regularization
+- `HexInterval/Interval.lean`: supported resource-safe intersection, hull, and
+  negation, followed by future arithmetic, splitting, and regularization
   operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public operations.

--- a/HexIntervalMathlib/Interval.lean
+++ b/HexIntervalMathlib/Interval.lean
@@ -17,8 +17,9 @@ public import HexInterval.Interval
 # Real semantics for public intervals
 
 This companion interprets every canonical public interval as a subset of
-`ℝ`.  Successful resource-checked intersection is exactly conjunction, and
-successful negation is exactly precomposition by real negation.
+`ℝ`. Successful resource-checked intersection is exactly conjunction, hull is
+the exact interval/selected-cut closure of its inputs, and negation is exactly
+precomposition by real negation.
 -/
 
 namespace Hex.Interval
@@ -62,6 +63,17 @@ def Upper.Contains : Upper → ℝ → Prop
 def Raw.Contains : Raw → ℝ → Prop
   | .empty, _ => False
   | .bounds lower upper, x => lower.Contains x ∧ upper.Contains x
+
+/-- Exact selected-cut meaning of the interval hull of two raw inputs. Empty
+is an identity. For two bounded inputs, the hull uses the union of their lower
+predicates and the union of their upper predicates; this deliberately includes
+the interval interior between separated inputs and is not set union. -/
+def Raw.HullContains : Raw → Raw → ℝ → Prop
+  | .empty, right, x => right.Contains x
+  | left, .empty, x => left.Contains x
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      (leftLower.Contains x ∨ rightLower.Contains x) ∧
+        (leftUpper.Contains x ∨ rightUpper.Contains x)
 
 /-- Mathematical membership in a canonical public interval. -/
 def Contains (interval : Hex.Interval) (x : ℝ) : Prop := interval.view.Contains x
@@ -256,6 +268,152 @@ theorem contains_intersectWithin {limit : EndpointLimit}
   simp only [Contains]
   rw [view_intersectWithin_ready checked, rawContains_normalize]
   exact rawContains_intersect left.view right.view x
+
+private theorem lowerContains_hull (left right : Lower) (x : ℝ) :
+    (Raw.hullLowerUnchecked left right).Contains x ↔
+      left.Contains x ∨ right.Contains x := by
+  cases left with
+  | unbounded => simp [Raw.hullLowerUnchecked, Lower.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.hullLowerUnchecked, Lower.Contains]
+      | finite right rightStrict =>
+          by_cases less : left < right
+          · have realOrder := toReal_lt less
+            rw [Raw.hullLowerUnchecked]
+            simp only [less, ↓reduceIte]
+            constructor
+            · exact Or.inl
+            · rintro (leftBound | rightBound)
+              · exact leftBound
+              · cases leftStrict <;> cases rightStrict <;>
+                  simp [Lower.Contains] at * <;> linarith
+          · by_cases equal : left = right
+            · subst right
+              rw [Raw.hullLowerUnchecked]
+              simp only [less, ↓reduceIte]
+              cases leftStrict <;> cases rightStrict <;>
+                simp [Lower.Contains] <;> exact le_of_lt
+            · have realNotLess : ¬toReal left < toReal right := by
+                simpa only [toReal_lt_iff] using less
+              have realNotEqual : toReal left ≠ toReal right := by
+                intro same
+                exact equal (toReal_inj.mp same)
+              have realOrder : toReal right < toReal left :=
+                lt_of_le_of_ne (le_of_not_gt realNotLess) (Ne.symm realNotEqual)
+              rw [Raw.hullLowerUnchecked]
+              simp only [less, equal, ↓reduceIte]
+              constructor
+              · exact Or.inr
+              · rintro (leftBound | rightBound)
+                · cases leftStrict <;> cases rightStrict <;>
+                    simp [Lower.Contains] at * <;> linarith
+                · exact rightBound
+
+private theorem upperContains_hull (left right : Upper) (x : ℝ) :
+    (Raw.hullUpperUnchecked left right).Contains x ↔
+      left.Contains x ∨ right.Contains x := by
+  cases left with
+  | unbounded => simp [Raw.hullUpperUnchecked, Upper.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.hullUpperUnchecked, Upper.Contains]
+      | finite right rightStrict =>
+          by_cases less : left < right
+          · have realOrder := toReal_lt less
+            rw [Raw.hullUpperUnchecked]
+            simp only [less, ↓reduceIte]
+            constructor
+            · exact Or.inr
+            · rintro (leftBound | rightBound)
+              · cases leftStrict <;> cases rightStrict <;>
+                  simp [Upper.Contains] at * <;> linarith
+              · exact rightBound
+          · by_cases equal : left = right
+            · subst right
+              rw [Raw.hullUpperUnchecked]
+              simp only [less, ↓reduceIte]
+              cases leftStrict <;> cases rightStrict <;>
+                simp [Upper.Contains] <;> exact le_of_lt
+            · have realNotLess : ¬toReal left < toReal right := by
+                simpa only [toReal_lt_iff] using less
+              have realNotEqual : toReal left ≠ toReal right := by
+                intro same
+                exact equal (toReal_inj.mp same)
+              have realOrder : toReal right < toReal left :=
+                lt_of_le_of_ne (le_of_not_gt realNotLess) (Ne.symm realNotEqual)
+              rw [Raw.hullUpperUnchecked]
+              simp only [less, equal, ↓reduceIte]
+              constructor
+              · exact Or.inl
+              · rintro (leftBound | rightBound)
+                · exact leftBound
+                · cases leftStrict <;> cases rightStrict <;>
+                    simp [Upper.Contains] at * <;> linarith
+
+private theorem rawContains_hull (left right : Raw) (x : ℝ) :
+    (Raw.hullUnchecked left right).Contains x ↔ left.HullContains right x := by
+  cases left with
+  | empty => simp [Raw.hullUnchecked, Raw.HullContains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.hullUnchecked, Raw.HullContains]
+      | bounds rightLower rightUpper =>
+          rw [Raw.hullUnchecked]
+          change
+            (Raw.hullLowerUnchecked leftLower rightLower).Contains x ∧
+                (Raw.hullUpperUnchecked leftUpper rightUpper).Contains x ↔ _
+          rw [lowerContains_hull, upperContains_hull]
+          rfl
+
+/-- Exact membership in a successful interval hull. For two nonempty inputs
+this is the selected-cut (equivalently, interval-convex-closure)
+characterization, not membership in the set union. -/
+theorem contains_hullWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : hullWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.HullContains right.view x := by
+  simp only [Contains]
+  rw [view_hullWithin_ready checked, rawContains_normalize]
+  exact rawContains_hull left.view right.view x
+
+private theorem rawContains_hull_left (left right : Raw) (x : ℝ) :
+    left.Contains x → left.HullContains right x := by
+  cases left with
+  | empty => simp [Raw.Contains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.HullContains]
+      | bounds rightLower rightUpper =>
+          rintro ⟨lower, upper⟩
+          exact ⟨Or.inl lower, Or.inl upper⟩
+
+private theorem rawContains_hull_right (left right : Raw) (x : ℝ) :
+    right.Contains x → left.HullContains right x := by
+  cases left with
+  | empty => simp [Raw.HullContains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains]
+      | bounds rightLower rightUpper =>
+          rintro ⟨lower, upper⟩
+          exact ⟨Or.inr lower, Or.inr upper⟩
+
+/-- Every member of the left input belongs to a successful hull. -/
+theorem contains_hullWithin_left {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : hullWithin limit left right = .ready result)
+    (member : left.Contains x) : result.Contains x :=
+  (contains_hullWithin checked x).2
+    (rawContains_hull_left left.view right.view x member)
+
+/-- Every member of the right input belongs to a successful hull. -/
+theorem contains_hullWithin_right {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : hullWithin limit left right = .ready result)
+    (member : right.Contains x) : result.Contains x :=
+  (contains_hullWithin checked x).2
+    (rawContains_hull_right left.view right.view x member)
 
 private theorem lowerContains_neg (upper : Upper) (x : ℝ) :
     (match upper with

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -15,6 +15,11 @@ For every successful resource-checked public operation it proves:
 
 - `contains_intersectWithin`: membership in the result is equivalent to
   membership in both inputs;
+- `contains_hullWithin`: membership in the result is exactly the selected-cut
+  interval closure, with explicit empty identities and no false set-union
+  claim;
+- `contains_hullWithin_left` and `contains_hullWithin_right`: each input is
+  contained in the result;
 - `contains_negWithin`: membership of `x` in the result is equivalent to
   membership of `-x` in the input.
 
@@ -29,14 +34,15 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Hull, arithmetic images, powers, splitting,
+are not re-exported here. Arithmetic images, powers, splitting,
 regularization, and precision-indexed reciprocal/division require their own
 set-enclosure and stated tightness theorems before promotion.
 
 ## Conformance
 
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
-membership, negation transport, and the exact ordinary-kernel axiom surface.
+membership, exact hull closure and both input inclusions, negation transport,
+and the exact ordinary-kernel axiom surface.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -6,8 +6,8 @@ theorems for interval operations and propagators. It depends on Mathlib and
 `hex-interval`. There is no separate proof-only companion beyond this library.
 
 The current supported surface interprets public canonical intervals over `ℝ`
-and proves exact semantics for successful resource-checked intersection and
-negation. Propagator, provider, replay, and tactic modules remain experiments
+and proves exact semantics for successful resource-checked intersection, hull,
+and negation. Propagator, provider, replay, and tactic modules remain experiments
 and are not re-exported by the public umbrella. The user-facing tactic contract
 below is the release target, not a claim that the tactic is already supported.
 
@@ -112,17 +112,34 @@ theorem contains_intersectWithin
     (h : intersectWithin limit I J = .ready result) :
     result.Contains x ↔ I.Contains x ∧ J.Contains x
 
+theorem contains_hullWithin
+    (h : hullWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.HullContains J.view x
+
+theorem contains_hullWithin_left
+    (h : hullWithin limit I J = .ready result) :
+    I.Contains x → result.Contains x
+
+theorem contains_hullWithin_right
+    (h : hullWithin limit I J = .ready result) :
+    J.Contains x → result.Contains x
+
 theorem contains_negWithin
     (h : negWithin limit I = .ready result) :
     result.Contains x ↔ I.Contains (-x)
 ```
 
+For two nonempty bounded raw inputs, `HullContains` is exactly
+`(I.lower.Contains x ∨ J.lower.Contains x) ∧
+(I.upper.Contains x ∨ J.upper.Contains x)`. If either input is empty it is
+the other input's membership predicate. Thus hull denotes the least interval
+selected by the outer cuts and can contain points in the gap between disjoint
+inputs; it is not their set union.
+
 The remaining target theorems include:
 
 ```lean
 theorem mem_intersect : x ∈ᵢ I → x ∈ᵢ J → x ∈ᵢ intersect I J
-theorem mem_hull_left  : x ∈ᵢ I → x ∈ᵢ hull I J
-theorem mem_hull_right : x ∈ᵢ J → x ∈ᵢ hull I J
 theorem split_cover : x ∈ᵢ I → x ∈ᵢ (split I m).1 ∨ x ∈ᵢ (split I m).2
 theorem not_mem_empty : ¬x ∈ᵢ .empty
 ```

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -130,6 +130,11 @@ private def openLower12 : Hex.Interval := ready (finite 1 true 2 false)
 private def openAtOne : Hex.Interval := ready (finite 0 false 1 true)
 private def atMostOne : Hex.Interval :=
   ready (.bounds .unbounded (.finite (d 1) false))
+private def atLeastOne : Hex.Interval :=
+  ready (.bounds (.finite (d 1) false) .unbounded)
+private def closed23 : Hex.Interval := ready (finite 2 false 3 false)
+private def bridgeLeft : Hex.Interval := ready (finite 1 false 4 false)
+private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
 
 -- Public intersection is exact at tied open/closed cuts, absorbs empty, and
 -- retains independently unbounded ends.
@@ -175,6 +180,86 @@ private def farLower : Hex.Interval :=
   match Hex.Interval.intersectWithin smallLimit farLower atMostOne with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- Hull chooses the smaller lower and larger upper cuts. Tied cuts are closed
+-- when either input contains the endpoint; the strict input is placed first
+-- so these guards reject copying one operand's flag.
+#guard
+  match Hex.Interval.hullWithin smallLimit openLower12 closed12 with
+  | .ready interval => interval == closed12
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit openAtOne closed01 with
+  | .ready interval => interval == closed01
+  | .resourceLimit _ => false
+
+-- Both strict contributors keep a tied endpoint strict; together with the
+-- mixed guards above this pins conjunction rather than a constant flag.
+#guard
+  match Hex.Interval.hullWithin smallLimit openLower12 openLower12 with
+  | .ready interval => interval == openLower12
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit openAtOne openAtOne with
+  | .ready interval => interval == openAtOne
+  | .resourceLimit _ => false
+
+-- Reversing separated inputs exercises both selector directions. The result
+-- is the interval closure [0,3], including the gap between [0,1] and [2,3].
+#guard
+  match Hex.Interval.hullWithin smallLimit closed01 closed23 with
+  | .ready interval => interval.view == finite 0 false 3 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit closed23 closed01 with
+  | .ready interval => interval.view == finite 0 false 3 false
+  | .resourceLimit _ => false
+
+-- Empty is an identity, while either unbounded side is retained.
+#guard
+  match Hex.Interval.hullWithin smallLimit Hex.Interval.empty closed01 with
+  | .ready interval => interval == closed01
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit closed01 Hex.Interval.empty with
+  | .ready interval => interval == closed01
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit atMostOne closed12 with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d 2) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit atLeastOne closed01 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.hullWithin smallLimit atMostOne atLeastOne with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Same-side selection refuses an excessive alignment before ordering.
+#guard
+  match Hex.Interval.hullWithin smallLimit closed12 farLower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- Same-side selectors need no shift here, but their selected outer cuts do.
+-- This pins the separate final-normalization preflight in `ofRawWithin`.
+#guard
+  match Hex.Interval.hullWithin
+      { maxEndpointHeight := 128, maxAlignmentShift := 0 }
+      bridgeLeft bridgeRight with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 2
 
 -- Negation swaps the endpoints and preserves openness; empty stays empty.
 #guard

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -9,7 +9,7 @@ import HexIntervalMathlib
 /-!
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
-ordinary-kernel meaning of every successful intersection and negation.
+ordinary-kernel meaning of every successful intersection, hull, and negation.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -30,6 +30,28 @@ theorem intersectInputs {limit : Hex.Interval.EndpointLimit}
     (member : result.Contains x) : left.Contains x ∧ right.Contains x :=
   (Hex.Interval.contains_intersectWithin checked x).1 member
 
+/-- A successful hull has the exact selected-cut/interval-closure meaning,
+including explicit empty identities. -/
+theorem hullExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.hullWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.HullContains right.view x :=
+  Hex.Interval.contains_hullWithin checked x
+
+/-- The left input is contained in every successful public hull. -/
+theorem hullLeft {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.hullWithin limit left right = .ready result)
+    (member : left.Contains x) : result.Contains x :=
+  Hex.Interval.contains_hullWithin_left checked member
+
+/-- The right input is contained in every successful public hull. -/
+theorem hullRight {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.hullWithin limit left right = .ready result)
+    (member : right.Contains x) : result.Contains x :=
+  Hex.Interval.contains_hullWithin_right checked member
+
 /-- Public negation transports membership in both directions. -/
 theorem negMember {limit : Hex.Interval.EndpointLimit}
     {input result : Hex.Interval} {x : ℝ}
@@ -44,6 +66,18 @@ theorem negMember {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectInputs' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectInputs
+
+/-- info: 'Hex.IntervalMathlib.Conformance.hullExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms hullExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.hullLeft' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms hullLeft
+
+/-- info: 'Hex.IntervalMathlib.Conformance.hullRight' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms hullRight
 
 /-- info: 'Hex.IntervalMathlib.Conformance.negMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in

--- a/progress/20260815T040216Z.md
+++ b/progress/20260815T040216Z.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+Added resource-safe public `hullWithin` on the sealed interval representation.
+Both same-side cut selections are preflighted before dyadic ordering, and the
+selected outer cuts remain unnormalized until `ofRawWithin` preflights the
+final comparison. Empty is an identity, unbounded cuts are retained, and tied
+cuts are closed when either input contains the endpoint.
+
+Added the Mathlib selected-cut semantics with explicit empty handling. A
+successful hull contains both inputs and has exact `Raw.HullContains`
+membership; the specification and separated-input regression state explicitly
+that interval hull fills gaps and is not set union. Added strict/closed tie,
+both selector directions, empty, unbounded, separated, same-side-refusal, and
+final-normalization-refusal conformance guards, plus ordinary-theorem axiom
+guards.
+
+# Current frontier
+
+The supported public interval surface now includes construction,
+intersection, hull, and negation. Arithmetic images remain experimental.
+
+# Next step
+
+Restack this local slice after its public-intersection base lands, refresh any
+exact Lake freshness metadata if the stack moves, then obtain fresh exact-head
+review and CI before opening or merging a PR.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add checked `Hex.Interval.hullWithin` with preflight for both same-side selectors and final normalization
- prove exact selected-cut / interval-convex-closure semantics with explicit empty handling
- prove both input intervals are contained in every successful hull
- pin tied strictness, both selector directions, separated interiors, unbounded/empty cases, and both refusal paths

Hull is deliberately not specified as set union: separated inputs fill the interval between them.

## Verification

- focused 853-job public/Mathlib/conformance build
- copyright, line-count, DAG, Phase 4, trust-surface, and factor-freshness checks
- no added `native_decide`, `axiom`, or `sorry`

Fresh exact-head Opus review and exact CI are required before merge.