### PR TITLE
feat(interval): expose checked addition

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -15,8 +15,8 @@ public section
 data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
-representation, resource-safe smart constructors, intersection, hull, and
-negation. Raw cuts remain visible as the explicit decoder and inspection
-boundary; D2 propagation and replay experiments still live outside this
-supported umbrella.
+representation, resource-safe smart constructors, and resource-checked
+intersection, hull, negation, and addition. Raw cuts remain visible as the
+explicit decoder and inspection boundary; D2 propagation and replay
+experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -14,7 +14,7 @@ public section
 # Public exact interval operations
 
 This module begins the supported arithmetic surface with exact intersection,
-hull, and negation.  The operations retain a resource-aware result: public
+hull, negation, and addition.  The operations retain a resource-aware result: public
 interval values do not remember the construction budget under which their
 endpoints were admitted, so a later comparison must preflight its own alignment
 work.
@@ -85,6 +85,38 @@ unnormalized so the supported wrapper preflights its final comparison. -/
         (hullLowerUnchecked leftLower rightLower)
         (hullUpperUnchecked leftUpper rightUpper)
 
+/-- Exact lower cut of a Minkowski sum. Either unbounded lower input makes the
+sum unbounded below; finite endpoint strictness is disjunction because the sum
+attains its lower endpoint exactly when both inputs attain theirs.
+
+This helper may align dyadic mantissas. Call it only after preflighting the
+finite endpoint pair with `CompareCost`. -/
+@[expose] def addLowerUnchecked : Lower → Lower → Lower
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | .finite left leftStrict, .finite right rightStrict =>
+      .finite (left + right) (leftStrict || rightStrict)
+
+/-- Exact upper cut of a Minkowski sum. Either unbounded upper input makes the
+sum unbounded above; finite endpoint strictness is disjunction because the sum
+attains its upper endpoint exactly when both inputs attain theirs.
+
+This helper may align dyadic mantissas. Call it only after preflighting the
+finite endpoint pair with `CompareCost`. -/
+@[expose] def addUpperUnchecked : Upper → Upper → Upper
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | .finite left leftStrict, .finite right rightStrict =>
+      .finite (left + right) (leftStrict || rightStrict)
+
+/-- Exact raw Minkowski-sum cuts after both finite endpoint additions have
+been preflighted. Empty is absorbing. The candidate remains unnormalized so
+the public wrapper checks its retained endpoint sizes and final comparison. -/
+@[expose] def addUnchecked : Raw → Raw → Raw
+  | .empty, _ | _, .empty => .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      .bounds
+        (addLowerUnchecked leftLower rightLower)
+        (addUpperUnchecked leftUpper rightUpper)
+
 /-- Exact raw image under negation.  Negation swaps the cuts and preserves
 their strictness. -/
 @[expose] def negUnchecked : Raw → Raw
@@ -131,6 +163,19 @@ private def hullCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCo
       | some cost => some cost
       | none => upperCost? limit leftUpper rightUpper
 
+/-- The first finite endpoint addition refused by the Minkowski-sum preflight.
+`CompareCost.allowed` bounds both retained inputs and their exponent gap before
+`Dyadic.add` shifts a mantissa. A successful preflight bounds the temporary
+sum numerator by the larger input numerator plus the permitted shift and one
+carry bit. The eventual retained result is checked separately by
+`ofRawWithin`. -/
+private def addCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCost
+  | .empty, _ | _, .empty => none
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match lowerCost? limit leftLower rightLower with
+      | some cost => some cost
+      | none => upperCost? limit leftUpper rightUpper
+
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
 def intersectWithin (limit : EndpointLimit)
@@ -165,6 +210,26 @@ theorem view_hullWithin_ready {limit : EndpointLimit}
     (h : hullWithin limit left right = .ready result) :
     result.view = (Raw.hullUnchecked left.view right.view).normalizeUnchecked := by
   unfold hullWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
+
+/-- Exact interval addition with allocation-safe dyadic endpoint sums.
+Empty is absorbing. Every finite endpoint pair is preflighted before addition;
+the raw result then crosses the checked canonical boundary, so refusal remains
+distinct from an empty sum. -/
+def addWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : BuildResult :=
+  match addCost? limit left.view right.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.addUnchecked left.view right.view)
+
+/-- A successful addition exposes exactly the normalized Minkowski-sum cuts. -/
+theorem view_addWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (h : addWithin limit left right = .ready result) :
+    result.view = (Raw.addUnchecked left.view right.view).normalizeUnchecked := by
+  unfold addWithin at h
   split at h
   · contradiction
   · exact view_ofRawWithin_ready h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -181,7 +181,8 @@ value's proof field.
 
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
-supported operations are resource-checked intersection, hull, and negation.
+supported operations are resource-checked intersection, hull, negation, and
+addition.
 Their Mathlib companion proves exact set semantics for the complete cut language;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -197,6 +198,8 @@ tied endpoints, empty results, and either end unbounded. It also proves that a
 successful `hullWithin` has the exact selected-cut/interval-convex-closure
 meaning and contains both inputs; this is deliberately not set union. A
 successful `negWithin` contains `x` exactly when the input contains `-x`.
+Successful `addWithin` exposes the exact independently summed lower and upper
+Minkowski cuts, and its image theorem maps any two input members to their sum.
 Separately, the experiment form of the intersection theorem is installed as the
 generic `FactDomainSchema.proveMeet` boundary, and the transparent proof
 frontend uses it to close a weaker requested interval from a stronger
@@ -413,6 +416,7 @@ The supported first operation slice is:
 def intersectWithin : EndpointLimit → Interval → Interval → BuildResult
 def hullWithin      : EndpointLimit → Interval → Interval → BuildResult
 def negWithin       : EndpointLimit → Interval → BuildResult
+def addWithin       : EndpointLimit → Interval → Interval → BuildResult
 ```
 
 These names retain the budget because a public interval does not store the
@@ -421,33 +425,29 @@ different caller limits can otherwise allocate an exponent-alignment shift far
 larger than either stored mantissa. A refused comparison returns
 `BuildResult.resourceLimit`; it is never interpreted as an empty interval.
 Negation still takes a limit because its finite output endpoints and final
-canonical comparison cross the same public boundary.
+canonical comparison cross the same public boundary. Addition cannot be the
+previously sketched total `Interval → Interval → Interval`: core
+`Dyadic.add` aligns finite mantissas by their exponent gap, so inputs admitted
+under unrelated limits can request an arbitrarily large shift. `addWithin`
+preflights both finite endpoint pairs before either addition. When endpoint
+height is bounded by `H` and alignment by `S`, the temporary numerator is
+bounded by the larger input numerator plus `S` and one carry bit. The summed
+raw cuts then cross `ofRawWithin`, which separately checks retained endpoint
+height and their final crossed comparison.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
-`hullUnchecked`, and `negUnchecked` are related to the checked operations by
-successful-result and semantic theorems. Like `Raw.normalizeUnchecked`, they
+`hullUnchecked`, `negUnchecked`, and `addUnchecked` are related to the checked
+operations by successful-result and semantic theorems. Like
+`Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface is:
-
-```lean
-namespace Hex.Interval
-
-def add        : Interval → Interval → Interval
-def sub        : Interval → Interval → Interval
-def mul        : Interval → Interval → Interval
-def invAt      : Precision → Interval → Interval
-def divAt      : Precision → Interval → Interval → Interval
-def pow        : Interval → Nat → Interval
-def abs        : Interval → Interval
-def min        : Interval → Interval → Interval
-def max        : Interval → Interval → Interval
-def split      : Interval → Dyadic → Interval × Interval
-def regularize : Precision → Interval → Interval
-
-end Hex.Interval
-```
+The remaining target surface includes subtraction, multiplication,
+precision-indexed reciprocal and division, powers, absolute value, min/max,
+splitting, and regularization. Their public signatures are fixed only after an
+allocation audit; no total API is promised for an operation that may align,
+compare, or enlarge arbitrary-precision endpoints. Subtraction in particular
+requires a checked `subWithin` boundary for the same reason as addition.
 
 For the initial dyadic backend, `Precision` is an alias for signed `Int` and
 the implementation reuses core `Dyadic.roundDown`, `roundUp`, `invAtPrec`, and
@@ -461,8 +461,10 @@ tests also check the following exactness rules.
 - `hullWithin` chooses the smaller lower cut and the larger upper cut. At equal
   endpoints it chooses closed if either input contains the endpoint.
 - `negWithin` swaps the ends and preserves their openness.
-- A finite endpoint of a sum is closed exactly when both contributing
-  endpoints are closed.
+- `addWithin` absorbs empty, adds corresponding finite endpoints, and retains
+  an unbounded side if either corresponding input side is unbounded. A finite
+  endpoint of a sum is closed exactly when both contributing endpoints are
+  closed.
 - After the empty-input short circuit, multiplication partitions both inputs
   by sign, enumerates finite corner and zero candidates, and tracks whether
   each extremum is attained. Zero is an attained extremum whenever either
@@ -3904,11 +3906,13 @@ their declared cost inside a scheduler bound.
   normalization.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
-- `HexInterval/Interval.lean`: supported resource-safe intersection, hull, and
-  negation, followed by future arithmetic, splitting, and regularization
+- `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
+  negation, and addition, followed by future arithmetic, splitting, and regularization
   operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
-  public operations.
+  public construction, intersection, hull, and negation operations.
+- `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
+  successful addition image theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -8,10 +8,11 @@ module
 
 
 public import HexIntervalMathlib.Interval
+public import HexIntervalMathlib.Addition
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
-the supported `Hex.Interval` operations.
+the supported `Hex.Interval` operations, including resource-checked addition.
 -/

--- a/HexIntervalMathlib/Addition.lean
+++ b/HexIntervalMathlib/Addition.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+
+@[expose] public section
+
+/-!
+# Exact semantics of public interval addition
+
+This module relates successful resource-checked addition to the exact raw
+Minkowski-sum cuts and proves the arithmetic image theorem used by propagators.
+Empty inputs are absorbing, unbounded cuts remain independent, and a finite
+result endpoint is strict exactly when either contributing endpoint is strict.
+-/
+
+namespace Hex.Interval
+
+@[simp]
+theorem toReal_add (left right : Dyadic) :
+    toReal (left + right) = toReal left + toReal right := by
+  simp [toReal]
+
+/-- Computed cut-level sum predicate. Empty is absorbing. For two
+nonempty inputs it is the conjunction of the summed lower and upper cuts;
+unboundedness and endpoint attainment are therefore represented independently
+on the two sides. -/
+def Raw.AddContains : Raw → Raw → ℝ → Prop
+  | .empty, _, _ | _, .empty, _ => False
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      (Raw.addLowerUnchecked leftLower rightLower).Contains x ∧
+        (Raw.addUpperUnchecked leftUpper rightUpper).Contains x
+
+private theorem rawContains_addUnchecked (left right : Raw) (x : ℝ) :
+    (Raw.addUnchecked left right).Contains x ↔ left.AddContains right x := by
+  cases left <;> cases right <;>
+    simp [Raw.addUnchecked, Raw.Contains, Raw.AddContains]
+
+private theorem lowerContains_add (left right : Lower) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.addLowerUnchecked left right).Contains (x + y) := by
+  cases left with
+  | unbounded => simp [Raw.addLowerUnchecked, Lower.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.addLowerUnchecked, Lower.Contains]
+      | finite right rightStrict =>
+          cases leftStrict <;> cases rightStrict <;>
+            simp [Raw.addLowerUnchecked, Lower.Contains, toReal_add] at * <;>
+            linarith
+
+private theorem upperContains_add (left right : Upper) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.addUpperUnchecked left right).Contains (x + y) := by
+  cases left with
+  | unbounded => simp [Raw.addUpperUnchecked, Upper.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.addUpperUnchecked, Upper.Contains]
+      | finite right rightStrict =>
+          cases leftStrict <;> cases rightStrict <;>
+            simp [Raw.addUpperUnchecked, Upper.Contains, toReal_add] at * <;>
+            linarith
+
+private theorem rawContains_add (left right : Raw) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.addUnchecked left right).Contains (x + y) := by
+  cases left with
+  | empty => simp [Raw.Contains] at leftMember
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains] at rightMember
+      | bounds rightLower rightUpper =>
+          rcases leftMember with ⟨leftLowerMember, leftUpperMember⟩
+          rcases rightMember with ⟨rightLowerMember, rightUpperMember⟩
+          exact ⟨
+            lowerContains_add leftLower rightLower leftLowerMember rightLowerMember,
+            upperContains_add leftUpper rightUpper leftUpperMember rightUpperMember⟩
+
+/-- A successful public addition has the normalized raw summed cuts. This
+characterizes the computed cut predicate; `add_mem_addWithin` supplies the
+representation-independent enclosure theorem. -/
+theorem contains_addWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : addWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.AddContains right.view x := by
+  simp only [Contains]
+  rw [view_addWithin_ready checked, contains_normalize]
+  exact rawContains_addUnchecked left.view right.view x
+
+/-- Addition maps every pair of input members into the successful public
+Minkowski sum. -/
+theorem add_mem_addWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : addWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x + y) :=
+  (contains_addWithin checked (x + y)).2
+    ((rawContains_addUnchecked left.view right.view (x + y)).1
+      (rawContains_add left.view right.view leftMember rightMember))
+
+end Hex.Interval

--- a/HexIntervalMathlib/Interval.lean
+++ b/HexIntervalMathlib/Interval.lean
@@ -78,7 +78,7 @@ def Raw.HullContains : Raw → Raw → ℝ → Prop
 /-- Mathematical membership in a canonical public interval. -/
 def Contains (interval : Hex.Interval) (x : ℝ) : Prop := interval.view.Contains x
 
-private theorem rawContains_normalize (raw : Raw) (x : ℝ) :
+theorem contains_normalize (raw : Raw) (x : ℝ) :
     raw.normalizeUnchecked.Contains x ↔ raw.Contains x := by
   cases raw with
   | empty => simp [Raw.Contains, Raw.normalizeUnchecked]
@@ -266,7 +266,7 @@ theorem contains_intersectWithin {limit : EndpointLimit}
     (checked : intersectWithin limit left right = .ready result) (x : ℝ) :
     result.Contains x ↔ left.Contains x ∧ right.Contains x := by
   simp only [Contains]
-  rw [view_intersectWithin_ready checked, rawContains_normalize]
+  rw [view_intersectWithin_ready checked, contains_normalize]
   exact rawContains_intersect left.view right.view x
 
 private theorem lowerContains_hull (left right : Lower) (x : ℝ) :
@@ -374,7 +374,7 @@ theorem contains_hullWithin {limit : EndpointLimit}
     (checked : hullWithin limit left right = .ready result) (x : ℝ) :
     result.Contains x ↔ left.view.HullContains right.view x := by
   simp only [Contains]
-  rw [view_hullWithin_ready checked, rawContains_normalize]
+  rw [view_hullWithin_ready checked, contains_normalize]
   exact rawContains_hull left.view right.view x
 
 private theorem rawContains_hull_left (left right : Raw) (x : ℝ) :
@@ -468,7 +468,7 @@ theorem contains_negWithin {limit : EndpointLimit} {input result : Hex.Interval}
     (checked : negWithin limit input = .ready result) (x : ℝ) :
     result.Contains x ↔ input.Contains (-x) := by
   simp only [Contains]
-  rw [view_negWithin_ready checked, rawContains_normalize]
+  rw [view_negWithin_ready checked, contains_normalize]
   exact rawContains_neg input.view x
 
 end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -7,9 +7,10 @@ perform planner search or turn runtime checks into proof evidence.
 
 ## Supported surface
 
-The first supported module is `HexIntervalMathlib.Interval`. It defines the
+The foundational supported module is `HexIntervalMathlib.Interval`. It defines the
 real value of a dyadic endpoint and membership for every public interval cut:
 strict or closed finite ends, independent unbounded ends, and canonical empty.
+`HexIntervalMathlib.Addition` adds the public arithmetic image theorem.
 
 For every successful resource-checked public operation it proves:
 
@@ -21,7 +22,12 @@ For every successful resource-checked public operation it proves:
 - `contains_hullWithin_left` and `contains_hullWithin_right`: each input is
   contained in the result;
 - `contains_negWithin`: membership of `x` in the result is equivalent to
-  membership of `-x` in the input.
+  membership of `-x` in the input;
+- `contains_addWithin`: exact successful-result membership in the independently
+  summed Minkowski cuts, with empty absorption, unbounded sides, and endpoint
+  strictness;
+- `add_mem_addWithin`: two input members add to a member of every successful
+  result.
 
 These theorems depend on the exact successful `BuildResult` equation. A
 resource refusal has no set interpretation and is never treated as an empty
@@ -34,7 +40,7 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Arithmetic images, powers, splitting,
+are not re-exported here. Further arithmetic images, powers, splitting,
 regularization, and precision-indexed reciprocal/division require their own
 set-enclosure and stated tightness theorems before promotion.
 
@@ -42,7 +48,7 @@ set-enclosure and stated tightness theorems before promotion.
 
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
 membership, exact hull closure and both input inclusions, negation transport,
-and the exact ordinary-kernel axiom surface.
+addition cut exactness and image transport, and the exact ordinary-kernel axiom surface.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,7 +7,7 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-and negation. Propagator, provider, replay, and tactic modules remain experiments
+negation, and addition. Propagator, provider, replay, and tactic modules remain experiments
 and are not re-exported by the public umbrella. The user-facing tactic contract
 below is the release target, not a claim that the tactic is already supported.
 
@@ -127,6 +127,14 @@ theorem contains_hullWithin_right
 theorem contains_negWithin
     (h : negWithin limit I = .ready result) :
     result.Contains x ↔ I.Contains (-x)
+
+theorem contains_addWithin
+    (h : addWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.AddContains J.view x
+
+theorem add_mem_addWithin
+    (h : addWithin limit I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (x + y)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -135,6 +143,14 @@ For two nonempty bounded raw inputs, `HullContains` is exactly
 the other input's membership predicate. Thus hull denotes the least interval
 selected by the outer cuts and can contain points in the gap between disjoint
 inputs; it is not their set union.
+
+`AddContains` characterizes the computed summed cuts. Empty is absorbing;
+otherwise it conjoins the sum lower cut and sum upper cut. A corresponding
+side is unbounded if either input side is unbounded, and a finite summed cut is
+strict if either contributor is strict. The successful image theorem consumes
+both source membership proofs. A representation-independent tightness theorem
+for the real Minkowski sum remains future work. Resource refusal has no
+membership semantics.
 
 The remaining target theorems include:
 
@@ -147,7 +163,6 @@ theorem not_mem_empty : ¬x ∈ᵢ .empty
 Each arithmetic operation has an image theorem. Representative shapes are:
 
 ```lean
-theorem mem_add : x ∈ᵢ I → y ∈ᵢ J → x + y ∈ᵢ add I J
 theorem mem_mul : x ∈ᵢ I → y ∈ᵢ J → x * y ∈ᵢ mul I J
 theorem mem_invAt : x ∈ᵢ I → x⁻¹ ∈ᵢ invAt p I
 theorem mem_divAt : x ∈ᵢ I → y ∈ᵢ J → x / y ∈ᵢ divAt p I J
@@ -359,10 +374,11 @@ theorem add_check_sound
     x ∈ᵢ I → y ∈ᵢ J → x + y ∈ᵢ out
 ```
 
-For a theorem whose output is already a transparent function of its inputs,
-the registration may apply `mem_add` directly and omit `payload`. A Taylor
-rule instead stores its polynomial degree, reduced argument, endpoint values,
-and remainder witness, then uses a checker theorem for those fields.
+For a transparent checked operation, the registration may recompute
+`addWithin` from its recorded limit and inputs, discharge the successful-result
+equation, and apply `add_mem_addWithin` without a separate certificate payload.
+A Taylor rule instead stores its polynomial degree, reduced argument, endpoint
+values, and remainder witness, then uses a checker theorem for those fields.
 
 The registration command validates the theorem's conclusion against the head
 symbol and argument mapping. It also rejects duplicate `RuleKey`s.

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -135,6 +135,19 @@ private def atLeastOne : Hex.Interval :=
 private def closed23 : Hex.Interval := ready (finite 2 false 3 false)
 private def bridgeLeft : Hex.Interval := ready (finite 1 false 4 false)
 private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
+private def openClosed01 : Hex.Interval := ready (finite 0 true 1 false)
+private def closedOpen23 : Hex.Interval := ready (finite 2 false 3 true)
+private def singletonOne : Hex.Interval := ready (finite 1 false 1 false)
+private def half : Dyadic := .ofOdd 1 1 (by decide)
+private def singletonHalf : Hex.Interval :=
+  ready (.bounds (.finite half false) (.finite half false))
+private def twoPow100 : Dyadic := .ofOdd 1 (-100) (by decide)
+private def widePower : Hex.Interval :=
+  match Hex.Interval.betweenWithin
+      { maxEndpointHeight := 128, maxAlignmentShift := 128 }
+      (d 1) false twoPow100 false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
 
 -- Public intersection is exact at tied open/closed cuts, absorbs empty, and
 -- retains independently unbounded ends.
@@ -165,6 +178,12 @@ private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
 -- align a billion-bit exponent gap.
 private def farLower : Hex.Interval :=
   match Hex.Interval.aboveWithin
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def farUpper : Hex.Interval :=
+  match Hex.Interval.belowWithin
       { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
@@ -260,6 +279,103 @@ private def farLower : Hex.Interval :=
       bridgeLeft bridgeRight with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 2
+
+-- Addition uses the exact Minkowski endpoint sums. Closed endpoints are
+-- attained, while either strict contributor makes the corresponding result
+-- endpoint strict.
+#guard
+  match Hex.Interval.addWithin smallLimit closed01 closed23 with
+  | .ready interval => interval.view == finite 2 false 4 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit openClosed01 closedOpen23 with
+  | .ready interval => interval.view == finite 2 true 4 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit closedOpen23 openClosed01 with
+  | .ready interval => interval.view == finite 2 true 4 true
+  | .resourceLimit _ => false
+
+-- Opposite exponent orders exercise both alignment branches in `Dyadic.add`.
+#guard
+  match Hex.Interval.addWithin smallLimit singletonHalf singletonOne with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite ((d 3) >>> 1) false) (.finite ((d 3) >>> 1) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit singletonOne singletonHalf with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite ((d 3) >>> 1) false) (.finite ((d 3) >>> 1) false)
+  | .resourceLimit _ => false
+
+-- Empty is absorbing. Independent unbounded ends propagate through the
+-- corresponding Minkowski cut, including the whole-line sum.
+#guard
+  match Hex.Interval.addWithin smallLimit Hex.Interval.empty closed01 with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit closed01 Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit atMostOne closed12 with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d 3) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit atLeastOne closed01 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 1) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.addWithin smallLimit atMostOne atLeastOne with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Endpoint addition refuses the billion-bit shift before `Dyadic.add` can
+-- allocate the aligned mantissa.
+#guard
+  match Hex.Interval.addWithin smallLimit closed12 farLower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- With both lower cuts unbounded, the independently preflighted upper
+-- endpoint pair must still reject the same prohibited allocation.
+#guard
+  match Hex.Interval.addWithin smallLimit atMostOne farUpper with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- Input addition needs no shift and fits this tiny limit, but retaining the
+-- canonical result `2` exceeds its endpoint-height budget. This pins the
+-- separate checked output boundary after bounded temporary arithmetic.
+#guard
+  match Hex.Interval.addWithin
+      { maxEndpointHeight := 1, maxAlignmentShift := 0 }
+      singletonOne singletonOne with
+  | .ready _ => false
+  | .resourceLimit cost =>
+      cost.lower.exponentMagnitude == 1 && cost.upper.exponentMagnitude == 1
+
+-- Corresponding input endpoints require no alignment, but the two summed
+-- output endpoints are one hundred powers of two apart. The final checked
+-- canonicalization must reject that distinct output-comparison cost.
+#guard
+  match Hex.Interval.addWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 50 }
+      widePower widePower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 100
 
 -- Negation swaps the endpoints and preserves openness; empty stays empty.
 #guard

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -9,7 +9,8 @@ import HexIntervalMathlib
 /-!
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
-ordinary-kernel meaning of every successful intersection, hull, and negation.
+ordinary-kernel meaning of every successful intersection, hull, addition, and
+negation.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -59,6 +60,23 @@ theorem negMember {limit : Hex.Interval.EndpointLimit}
     result.Contains x ↔ input.Contains (-x) :=
   Hex.Interval.contains_negWithin checked x
 
+/-- A successful addition has exactly its independent summed lower and upper
+cut semantics, including empty absorption and unbounded sides. -/
+theorem addExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.addWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.AddContains right.view x :=
+  Hex.Interval.contains_addWithin checked x
+
+/-- Both source membership proofs are consumed by the arithmetic image
+theorem for successful interval addition. -/
+theorem addImage {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.addWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x + y) :=
+  Hex.Interval.add_mem_addWithin checked leftMember rightMember
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -82,5 +100,13 @@ theorem negMember {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.negMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms negMember
+
+/-- info: 'Hex.IntervalMathlib.Conformance.addExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms addExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.addImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms addImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -360,7 +360,8 @@ lean_lib HexIntervalMathlibExperiment where
 
 @[default_target]
 lean_lib HexIntervalMathlib where
-  globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval].map Glob.one
+  globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
+    `HexIntervalMathlib.Addition].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T044745Z.md
+++ b/progress/20260815T044745Z.md
@@ -1,0 +1,37 @@
+# Accomplished
+
+Added the first public arithmetic image, resource-checked interval addition.
+The checked API replaces the stale total-signature sketch because dyadic
+addition may align mantissas by an arbitrarily large exponent gap. Both finite
+endpoint pairs are preflighted before either sum; the bounded temporary result
+then crosses the canonical checked boundary for retained endpoint height and
+the final lower/upper comparison. Empty remains distinct from resource refusal.
+
+Implemented exact raw Minkowski-sum cuts with empty absorption, independent
+unbounded sides, and endpoint strictness precisely when either contributor is
+strict. The Mathlib companion proves exact successful-result cut semantics and
+the image theorem taking two input members to their real sum. Computational
+guards distinguish closed and mixed-strict endpoints, both exponent orders,
+empty and unbounded cases, lower and upper billion-shift refusal, retained
+output-height refusal, and output-comparison refusal after cheap input sums.
+Ordinary-theorem axiom guards remain clean.
+
+# Current frontier
+
+The supported public interval API now covers construction, intersection, hull,
+negation, and addition. Addition is exact for the dyadic endpoint backend and
+resource refusal is explicit. Subtraction, multiplication, powers, splitting,
+and precision-indexed reciprocal/division remain future public surface.
+
+# Next step
+
+Restack this local-only candidate if main advances, then obtain fresh exact-head
+review and CI before opening or merging a PR. The next arithmetic slice should
+implement checked `subWithin` under the same allocation doctrine rather than
+copying its old total-signature sketch.
+
+# Blockers
+
+None. Existing `EndpointLimit` and `CompareCost` are sufficient for addition:
+the admitted endpoint heights and exponent gap bound every aligned temporary,
+and `ofRawWithin` separately bounds the retained result.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -310,5 +310,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "5252bf672724ff73f01a47dae06ee45b1ee88d31",
     "reason": "Additionally registers the bounded Mathlib-free PNT+ FKS2 shard experiment, its proof-only real-semantics companion, and conformance module on top of the retained public interval, specialized-polynomial, and numerical registrations; these acceptance-only modules do not enter the factorization service target or its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "846818b2f96227358b161fa809a75dd9eb30cc74",
+    "reason": "Additionally registers the supported HexIntervalMathlib addition-semantics module; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- replace the stale total-addition target with resource-safe `Hex.Interval.addWithin`
- preflight both finite endpoint additions before exponent alignment, then canonicalize through the checked boundary
- add exact summed-cut semantics and prove every pair of input members maps into a successful result
- pin strictness, operand/exponent order, empty/unbounded behavior, billion-shift refusal, and retained-output refusal

## Verification

- focused 854-job public/Mathlib/conformance build
- copyright, line-count, DAG, Phase 4, trust-surface, conformance-target, and factor-freshness checks
- no added `native_decide`, `axiom`, or `sorry`

Fresh exact-head Opus review and exact CI are required before merge.