### PR TITLE
feat(interval): expose checked subtraction

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -16,7 +16,7 @@ data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
-intersection, hull, negation, and addition. Raw cuts remain visible as the
-explicit decoder and inspection boundary; D2 propagation and replay
-experiments still live outside this supported umbrella.
+intersection, hull, negation, addition, and subtraction. Raw cuts remain
+visible as the explicit decoder and inspection boundary; D2 propagation and
+replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -14,7 +14,8 @@ public section
 # Public exact interval operations
 
 This module begins the supported arithmetic surface with exact intersection,
-hull, negation, and addition.  The operations retain a resource-aware result: public
+hull, negation, addition, and subtraction. The operations retain a
+resource-aware result: public
 interval values do not remember the construction budget under which their
 endpoints were admitted, so a later comparison must preflight its own alignment
 work.
@@ -117,6 +118,41 @@ the public wrapper checks its retained endpoint sizes and final comparison. -/
         (addLowerUnchecked leftLower rightLower)
         (addUpperUnchecked leftUpper rightUpper)
 
+/-- Exact lower cut of a Minkowski difference. An unbounded left lower or
+right upper cut makes the result unbounded below. Finite strictness is
+disjunction because the endpoint is attained exactly when both contributors
+attain theirs.
+
+This helper may align dyadic mantissas. Call it only after preflighting the
+finite endpoint pair with `CompareCost`. -/
+@[expose] def subLowerUnchecked : Lower → Upper → Lower
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | .finite left leftStrict, .finite right rightStrict =>
+      .finite (left - right) (leftStrict || rightStrict)
+
+/-- Exact upper cut of a Minkowski difference. An unbounded left upper or
+right lower cut makes the result unbounded above. Finite strictness is
+disjunction because the endpoint is attained exactly when both contributors
+attain theirs.
+
+This helper may align dyadic mantissas. Call it only after preflighting the
+finite endpoint pair with `CompareCost`. -/
+@[expose] def subUpperUnchecked : Upper → Lower → Upper
+  | .unbounded, _ | _, .unbounded => .unbounded
+  | .finite left leftStrict, .finite right rightStrict =>
+      .finite (left - right) (leftStrict || rightStrict)
+
+/-- Exact raw Minkowski-difference cuts after the crossed finite endpoint
+subtractions have been preflighted. Empty is absorbing. The candidate remains
+unnormalized so the public wrapper checks retained endpoint sizes and the final
+comparison. -/
+@[expose] def subUnchecked : Raw → Raw → Raw
+  | .empty, _ | _, .empty => .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      .bounds
+        (subLowerUnchecked leftLower rightUpper)
+        (subUpperUnchecked leftUpper rightLower)
+
 /-- Exact raw image under negation.  Negation swaps the cuts and preserves
 their strictness. -/
 @[expose] def negUnchecked : Raw → Raw
@@ -132,6 +168,20 @@ their strictness. -/
         | .finite value strict => Upper.finite (-value) strict
       Raw.bounds resultLower resultUpper
 
+/-- Direct raw subtraction agrees with addition after raw negation. The
+checked public operation uses the direct form so it can preflight only the two
+crossed endpoint pairs, without normalizing an intermediate negated interval. -/
+theorem sub_eq_add_neg (left right : Raw) :
+    subUnchecked left right = addUnchecked left (negUnchecked right) := by
+  cases left with
+  | empty => cases right <;> rfl
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => rfl
+      | bounds rightLower rightUpper =>
+          cases leftLower <;> cases leftUpper <;>
+            cases rightLower <;> cases rightUpper <;> rfl
+
 end Raw
 
 private def compareCost? (limit : EndpointLimit) (left right : Dyadic) :
@@ -144,6 +194,14 @@ private def lowerCost? (limit : EndpointLimit) : Lower → Lower → Option Comp
   | _, _ => none
 
 private def upperCost? (limit : EndpointLimit) : Upper → Upper → Option CompareCost
+  | .finite left _, .finite right _ => compareCost? limit left right
+  | _, _ => none
+
+private def lowerUpperCost? (limit : EndpointLimit) : Lower → Upper → Option CompareCost
+  | .finite left _, .finite right _ => compareCost? limit left right
+  | _, _ => none
+
+private def upperLowerCost? (limit : EndpointLimit) : Upper → Lower → Option CompareCost
   | .finite left _, .finite right _ => compareCost? limit left right
   | _, _ => none
 
@@ -175,6 +233,17 @@ private def addCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCos
       match lowerCost? limit leftLower rightLower with
       | some cost => some cost
       | none => upperCost? limit leftUpper rightUpper
+
+/-- The first crossed finite endpoint subtraction refused by the direct
+Minkowski-difference preflight. `CompareCost.allowed` bounds both inputs and
+their exponent gap before `Dyadic.sub` negates and shifts a mantissa. The raw
+result is retained only after the separate `ofRawWithin` check. -/
+private def subCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCost
+  | .empty, _ | _, .empty => none
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match lowerUpperCost? limit leftLower rightUpper with
+      | some cost => some cost
+      | none => upperLowerCost? limit leftUpper rightLower
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -230,6 +299,27 @@ theorem view_addWithin_ready {limit : EndpointLimit}
     (h : addWithin limit left right = .ready result) :
     result.view = (Raw.addUnchecked left.view right.view).normalizeUnchecked := by
   unfold addWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
+
+/-- Exact interval subtraction with allocation-safe crossed endpoint
+differences. The direct implementation avoids an intermediate checked
+negation, whose unrelated endpoint comparison could refuse before either
+subtraction. Empty is absorbing and resource refusal remains distinct. -/
+def subWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : BuildResult :=
+  match subCost? limit left.view right.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.subUnchecked left.view right.view)
+
+/-- A successful subtraction exposes exactly the normalized
+Minkowski-difference cuts. -/
+theorem view_subWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (h : subWithin limit left right = .ready result) :
+    result.view = (Raw.subUnchecked left.view right.view).normalizeUnchecked := by
+  unfold subWithin at h
   split at h
   · contradiction
   · exact view_ofRawWithin_ready h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -181,9 +181,9 @@ value's proof field.
 
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
-supported operations are resource-checked intersection, hull, negation, and
-addition.
-Their Mathlib companion proves exact set semantics for the complete cut language;
+supported operations are resource-checked intersection, hull, negation,
+addition, and subtraction.
+Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
 examples use the fully qualified `Hex.Interval`, because Mathlib also has a
@@ -200,6 +200,10 @@ meaning and contains both inputs; this is deliberately not set union. A
 successful `negWithin` contains `x` exactly when the input contains `-x`.
 Successful `addWithin` exposes the exact independently summed lower and upper
 Minkowski cuts, and its image theorem maps any two input members to their sum.
+Successful `subWithin` similarly exposes the crossed left-lower-minus-right-upper
+and left-upper-minus-right-lower cuts, and maps two input members to their
+difference. Neither arithmetic theorem currently claims the separate
+representation-independent tightness converse for the real Minkowski image.
 Separately, the experiment form of the intersection theorem is installed as the
 generic `FactDomainSchema.proveMeet` boundary, and the transparent proof
 frontend uses it to close a weaker requested interval from a stronger
@@ -417,6 +421,7 @@ def intersectWithin : EndpointLimit → Interval → Interval → BuildResult
 def hullWithin      : EndpointLimit → Interval → Interval → BuildResult
 def negWithin       : EndpointLimit → Interval → BuildResult
 def addWithin       : EndpointLimit → Interval → Interval → BuildResult
+def subWithin       : EndpointLimit → Interval → Interval → BuildResult
 ```
 
 These names retain the budget because a public interval does not store the
@@ -435,19 +440,29 @@ bounded by the larger input numerator plus `S` and one carry bit. The summed
 raw cuts then cross `ofRawWithin`, which separately checks retained endpoint
 height and their final crossed comparison.
 
+`subWithin` uses the same allocation argument on the crossed pairs: left lower
+with right upper, then left upper with right lower. It is deliberately direct,
+not `addWithin left` after `negWithin right`. The composed form would first
+normalize an intermediate negated interval and could refuse its unrelated
+right-endpoint comparison even when both crossed subtraction pairs fit. Direct
+preflight therefore admits strictly more valid operations and performs no
+dyadic negation or aligned subtraction until both crossed pairs are admitted;
+the resulting raw cuts then cross `ofRawWithin` exactly once. The theorem
+`Raw.sub_eq_add_neg` pins that the direct raw result still agrees with addition
+after raw negation.
+
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
-`hullUnchecked`, `negUnchecked`, and `addUnchecked` are related to the checked
-operations by successful-result and semantic theorems. Like
+`hullUnchecked`, `negUnchecked`, `addUnchecked`, and `subUnchecked` are related
+to the checked operations by successful-result and semantic theorems. Like
 `Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface includes subtraction, multiplication,
+The remaining target surface includes multiplication,
 precision-indexed reciprocal and division, powers, absolute value, min/max,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
-compare, or enlarge arbitrary-precision endpoints. Subtraction in particular
-requires a checked `subWithin` boundary for the same reason as addition.
+compare, or enlarge arbitrary-precision endpoints.
 
 For the initial dyadic backend, `Precision` is an alias for signed `Int` and
 the implementation reuses core `Dyadic.roundDown`, `roundUp`, `invAtPrec`, and
@@ -464,6 +479,11 @@ tests also check the following exactness rules.
 - `addWithin` absorbs empty, adds corresponding finite endpoints, and retains
   an unbounded side if either corresponding input side is unbounded. A finite
   endpoint of a sum is closed exactly when both contributing endpoints are
+  closed.
+- `subWithin` absorbs empty and uses crossed endpoints: the lower cut is left
+  lower minus right upper, and the upper cut is left upper minus right lower.
+  Either corresponding unbounded contributor makes that result side
+  unbounded; a finite side is closed exactly when both contributors are
   closed.
 - After the empty-input short circuit, multiplication partitions both inputs
   by sign, enumerates finite corner and zero candidates, and tracks whether
@@ -3907,12 +3927,14 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
-  negation, and addition, followed by future arithmetic, splitting, and regularization
+  negation, addition, and subtraction, followed by future arithmetic, splitting, and regularization
   operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
   successful addition image theorem.
+- `HexIntervalMathlib/Subtraction.lean`: exact crossed-difference-cut semantics
+  and the successful subtraction image theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -9,10 +9,12 @@ module
 
 public import HexIntervalMathlib.Interval
 public import HexIntervalMathlib.Addition
+public import HexIntervalMathlib.Subtraction
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
-the supported `Hex.Interval` operations, including resource-checked addition.
+the supported `Hex.Interval` operations, including resource-checked addition
+and subtraction.
 -/

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -10,7 +10,8 @@ perform planner search or turn runtime checks into proof evidence.
 The foundational supported module is `HexIntervalMathlib.Interval`. It defines the
 real value of a dyadic endpoint and membership for every public interval cut:
 strict or closed finite ends, independent unbounded ends, and canonical empty.
-`HexIntervalMathlib.Addition` adds the public arithmetic image theorem.
+`HexIntervalMathlib.Addition` and `HexIntervalMathlib.Subtraction` add the
+public arithmetic image theorems.
 
 For every successful resource-checked public operation it proves:
 
@@ -27,7 +28,12 @@ For every successful resource-checked public operation it proves:
   summed Minkowski cuts, with empty absorption, unbounded sides, and endpoint
   strictness;
 - `add_mem_addWithin`: two input members add to a member of every successful
-  result.
+  result;
+- `contains_subWithin`: exact successful-result membership in the crossed
+  difference cuts, including empty absorption and independent unbounded
+  sides;
+- `sub_mem_subWithin`: two input members subtract to a member of every
+  successful result.
 
 These theorems depend on the exact successful `BuildResult` equation. A
 resource refusal has no set interpretation and is never treated as an empty
@@ -48,7 +54,8 @@ set-enclosure and stated tightness theorems before promotion.
 
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
 membership, exact hull closure and both input inclusions, negation transport,
-addition cut exactness and image transport, and the exact ordinary-kernel axiom surface.
+addition and subtraction cut exactness and image transport, and the exact
+ordinary-kernel axiom surface.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/HexIntervalMathlib/Subtraction.lean
+++ b/HexIntervalMathlib/Subtraction.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Addition
+
+@[expose] public section
+
+/-!
+# Exact semantics of public interval subtraction
+
+This module relates successful resource-checked subtraction to its computed
+crossed endpoint cuts and proves the arithmetic image theorem. Empty inputs
+are absorbing, unbounded cuts remain independent, and a finite result endpoint
+is strict exactly when either contributing endpoint is strict.
+-/
+
+namespace Hex.Interval
+
+@[simp]
+theorem toReal_sub (left right : Dyadic) :
+    toReal (left - right) = toReal left - toReal right := by
+  simp [toReal]
+
+/-- Computed cut-level Minkowski-difference predicate. Empty is absorbing. For
+two nonempty inputs it uses the left lower minus right upper cut and the left
+upper minus right lower cut. -/
+def Raw.SubContains : Raw → Raw → ℝ → Prop
+  | .empty, _, _ | _, .empty, _ => False
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      (Raw.subLowerUnchecked leftLower rightUpper).Contains x ∧
+        (Raw.subUpperUnchecked leftUpper rightLower).Contains x
+
+private theorem rawContains_subUnchecked (left right : Raw) (x : ℝ) :
+    (Raw.subUnchecked left right).Contains x ↔ left.SubContains right x := by
+  cases left <;> cases right <;>
+    simp [Raw.subUnchecked, Raw.Contains, Raw.SubContains]
+
+private theorem lowerContains_sub (left : Lower) (right : Upper) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.subLowerUnchecked left right).Contains (x - y) := by
+  cases left with
+  | unbounded => simp [Raw.subLowerUnchecked, Lower.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.subLowerUnchecked, Lower.Contains]
+      | finite right rightStrict =>
+          cases leftStrict <;> cases rightStrict <;>
+            simp [Raw.subLowerUnchecked, Lower.Contains, Upper.Contains,
+              toReal_sub] at * <;>
+            linarith
+
+private theorem upperContains_sub (left : Upper) (right : Lower) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.subUpperUnchecked left right).Contains (x - y) := by
+  cases left with
+  | unbounded => simp [Raw.subUpperUnchecked, Upper.Contains]
+  | finite left leftStrict =>
+      cases right with
+      | unbounded => simp [Raw.subUpperUnchecked, Upper.Contains]
+      | finite right rightStrict =>
+          cases leftStrict <;> cases rightStrict <;>
+            simp [Raw.subUpperUnchecked, Lower.Contains, Upper.Contains,
+              toReal_sub] at * <;>
+            linarith
+
+private theorem rawContains_sub (left right : Raw) {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (Raw.subUnchecked left right).Contains (x - y) := by
+  cases left with
+  | empty => simp [Raw.Contains] at leftMember
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains] at rightMember
+      | bounds rightLower rightUpper =>
+          rcases leftMember with ⟨leftLowerMember, leftUpperMember⟩
+          rcases rightMember with ⟨rightLowerMember, rightUpperMember⟩
+          exact ⟨
+            lowerContains_sub leftLower rightUpper leftLowerMember rightUpperMember,
+            upperContains_sub leftUpper rightLower leftUpperMember rightLowerMember⟩
+
+/-- A successful public subtraction has the normalized raw crossed difference
+cuts. This characterizes the computed cut predicate; `sub_mem_subWithin`
+supplies the representation-independent enclosure theorem. -/
+theorem contains_subWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : subWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.SubContains right.view x := by
+  simp only [Contains]
+  rw [view_subWithin_ready checked, contains_normalize]
+  exact rawContains_subUnchecked left.view right.view x
+
+/-- Subtraction maps every pair of input members into the successful public
+Minkowski difference. -/
+theorem sub_mem_subWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : subWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x - y) :=
+  (contains_subWithin checked (x - y)).2
+    ((rawContains_subUnchecked left.view right.view (x - y)).1
+      (rawContains_sub left.view right.view leftMember rightMember))
+
+end Hex.Interval

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,7 +7,7 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-negation, and addition. Propagator, provider, replay, and tactic modules remain experiments
+negation, addition, and subtraction. Propagator, provider, replay, and tactic modules remain experiments
 and are not re-exported by the public umbrella. The user-facing tactic contract
 below is the release target, not a claim that the tactic is already supported.
 
@@ -135,6 +135,14 @@ theorem contains_addWithin
 theorem add_mem_addWithin
     (h : addWithin limit I J = .ready result) :
     I.Contains x → J.Contains y → result.Contains (x + y)
+
+theorem contains_subWithin
+    (h : subWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.SubContains J.view x
+
+theorem sub_mem_subWithin
+    (h : subWithin limit I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (x - y)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -151,6 +159,13 @@ strict if either contributor is strict. The successful image theorem consumes
 both source membership proofs. A representation-independent tightness theorem
 for the real Minkowski sum remains future work. Resource refusal has no
 membership semantics.
+
+`SubContains` is the directional crossed-cut analogue: left lower minus right
+upper, and left upper minus right lower. Empty is absorbing, either relevant
+unbounded input makes that output side unbounded, and finite strictness is
+disjunction. `sub_mem_subWithin` proves the representation-independent image
+enclosure. As for addition, a separate real Minkowski-image tightness converse
+remains future work rather than a current claim.
 
 The remaining target theorems include:
 

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -138,6 +138,7 @@ private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
 private def openClosed01 : Hex.Interval := ready (finite 0 true 1 false)
 private def closedOpen23 : Hex.Interval := ready (finite 2 false 3 true)
 private def singletonOne : Hex.Interval := ready (finite 1 false 1 false)
+private def singletonNegOne : Hex.Interval := ready (finite (-1) false (-1) false)
 private def half : Dyadic := .ofOdd 1 1 (by decide)
 private def singletonHalf : Hex.Interval :=
   ready (.bounds (.finite half false) (.finite half false))
@@ -146,6 +147,14 @@ private def widePower : Hex.Interval :=
   match Hex.Interval.betweenWithin
       { maxEndpointHeight := 128, maxAlignmentShift := 128 }
       (d 1) false twoPow100 false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+private def powerPlusOne : Dyadic := twoPow100 + d 1
+private def powerPlusTwo : Dyadic := twoPow100 + d 2
+private def powerBand : Hex.Interval :=
+  match Hex.Interval.betweenWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 128 }
+      powerPlusOne false powerPlusTwo false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
@@ -185,6 +194,15 @@ private def farLower : Hex.Interval :=
 private def farUpper : Hex.Interval :=
   match Hex.Interval.belowWithin
       { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def mediumFar : Dyadic := .ofOdd 1 200 (by decide)
+
+private def mediumToOne : Hex.Interval :=
+  match Hex.Interval.betweenWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 200 }
+      mediumFar false (d 1) false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
@@ -374,6 +392,100 @@ private def farUpper : Hex.Interval :=
   match Hex.Interval.addWithin
       { maxEndpointHeight := 256, maxAlignmentShift := 50 }
       widePower widePower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 100
+
+-- Subtraction uses crossed endpoints and is directional: [2,3] - [0,1] is
+-- [1,3], while reversing the operands yields [-3,-1].
+#guard
+  match Hex.Interval.subWithin smallLimit closed23 closed01 with
+  | .ready interval => interval.view == finite 1 false 3 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit closed01 closed23 with
+  | .ready interval => interval.view == finite (-3) false (-1) false
+  | .resourceLimit _ => false
+
+-- The lower result consumes the left lower and right upper strictness; the
+-- upper result consumes the left upper and right lower strictness.
+#guard
+  match Hex.Interval.subWithin smallLimit openClosed01 closedOpen23 with
+  | .ready interval => interval.view == finite (-3) true (-1) false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit closedOpen23 openClosed01 with
+  | .ready interval => interval.view == finite 1 false 3 true
+  | .resourceLimit _ => false
+
+-- Empty is absorbing. The right upper controls lower unboundedness and the
+-- right lower controls upper unboundedness; two matching half-lines can span
+-- the whole line.
+#guard
+  match Hex.Interval.subWithin smallLimit Hex.Interval.empty closed01 with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit closed01 Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit closed01 atLeastOne with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d 0) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit closed01 atMostOne with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d (-1)) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.subWithin smallLimit atMostOne atMostOne with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Each crossed endpoint pair has its own pre-allocation check.
+#guard
+  match Hex.Interval.subWithin smallLimit closed12 farUpper with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+#guard
+  match Hex.Interval.subWithin smallLimit atMostOne farLower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- The lower subtraction `1 - 1` is cheap, but the upper pair needs a 200-bit
+-- shift. The second preflight rejects before either unchecked subtraction
+-- runs; the fixture itself stays small enough not to perform a huge admitted
+-- comparison during construction.
+#guard
+  match Hex.Interval.subWithin smallLimit singletonOne mediumToOne with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 200
+
+-- Both endpoint subtractions fit this tiny budget, but retaining the result
+-- singleton `2` does not.
+#guard
+  match Hex.Interval.subWithin
+      { maxEndpointHeight := 1, maxAlignmentShift := 0 }
+      singletonOne singletonNegOne with
+  | .ready _ => false
+  | .resourceLimit cost =>
+      cost.lower.exponentMagnitude == 1 && cost.upper.exponentMagnitude == 1
+
+-- The two crossed input pairs need shifts zero and one. Cancellation produces
+-- output endpoints `2^100` and `2^100 + 1`, so only the distinct final
+-- canonical comparison exceeds this operation's alignment budget.
+#guard
+  match Hex.Interval.subWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 50 }
+      powerBand singletonOne with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 100
 

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -9,8 +9,8 @@ import HexIntervalMathlib
 /-!
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
-ordinary-kernel meaning of every successful intersection, hull, addition, and
-negation.
+ordinary-kernel meaning of every successful intersection, hull, addition,
+subtraction, and negation.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -77,6 +77,23 @@ theorem addImage {limit : Hex.Interval.EndpointLimit}
     result.Contains (x + y) :=
   Hex.Interval.add_mem_addWithin checked leftMember rightMember
 
+/-- A successful subtraction has exactly its crossed lower and upper cut
+semantics, including empty absorption and independent unbounded sides. -/
+theorem subExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.subWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.SubContains right.view x :=
+  Hex.Interval.contains_subWithin checked x
+
+/-- Both source membership proofs are consumed by the arithmetic image
+theorem for successful interval subtraction. -/
+theorem subImage {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.subWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x - y) :=
+  Hex.Interval.sub_mem_subWithin checked leftMember rightMember
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -108,5 +125,13 @@ theorem addImage {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.addImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms addImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.subExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms subExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.subImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms subImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -361,7 +361,7 @@ lean_lib HexIntervalMathlibExperiment where
 @[default_target]
 lean_lib HexIntervalMathlib where
   globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
-    `HexIntervalMathlib.Addition].map Glob.one
+    `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T054041Z.md
+++ b/progress/20260815T054041Z.md
@@ -1,0 +1,41 @@
+# Accomplished
+
+Added resource-checked public interval subtraction on top of the merged
+addition slice. The implementation directly preflights the crossed endpoint
+pairs—left lower with right upper, then left upper with right lower—before
+either dyadic subtraction. It then sends the unnormalized difference cuts
+through the canonical checked boundary. This preserves direct crossed-pair
+admissibility and keeps resource refusal distinct from empty.
+
+Composition through checked negation and addition was audited and rejected:
+it would normalize an intermediate negated interval and could refuse an
+unrelated comparison before reaching either crossed subtraction. The direct
+operation avoids that extra work and preserves the same bounded-temporary
+argument as addition; `Raw.sub_eq_add_neg` kernel-pins equality with the raw
+composed result.
+
+Added computed crossed-cut semantics and a Mathlib image theorem consuming
+both source memberships. Conformance distinguishes operand order, mixed
+strictness, empty and unbounded shapes, lower and upper billion-shift refusal,
+a cheap first pair followed by a bounded 200-bit oversized second pair,
+retained output-height refusal, and final output-comparison refusal after both
+pair preflights pass.
+
+# Current frontier
+
+The supported public API covers construction, intersection, hull, negation,
+addition, and subtraction. Addition and subtraction have exact computed-cut
+characterizations and representation-independent image theorems. Neither
+currently claims the separate real Minkowski-image tightness converse.
+
+# Next step
+
+Restack this local-only candidate if its base advances, then obtain fresh
+exact-head review and CI before opening or merging a PR. Multiplication should
+receive an independent allocation and extremum-attainment audit before public
+promotion.
+
+# Blockers
+
+None. `EndpointLimit` and `CompareCost` honestly bound subtraction's aligned
+temporaries and diagnostics without expanding the public result type.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -316,5 +316,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "846818b2f96227358b161fa809a75dd9eb30cc74",
     "reason": "Additionally registers the supported HexIntervalMathlib addition-semantics module; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "82289ef5817989df25bca5e0275a1de22ea22e37",
+    "reason": "Additionally registers the supported HexIntervalMathlib subtraction-semantics module; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add direct resource-checked `Hex.Interval.subWithin`
- preflight the crossed endpoint pairs before either dyadic subtraction, avoiding an unnecessary checked-negation intermediate
- add computed-cut semantics and prove the real image enclosure for every successful result
- pin direction, strictness, empty/unbounded behavior, staged billion-shift refusals, retained-height refusal, and output-comparison refusal

The SPEC deliberately does not claim the unproved real Minkowski tightness converse.

## Verification

- focused 855-job public/Mathlib/conformance build
- copyright, line-count, DAG, Phase 4, trust-surface, conformance-target, and factor-freshness checks
- no added `native_decide`, `axiom`, or `sorry`

Fresh exact-head Opus review and exact CI are required before merge.