### PR TITLE
feat(interval): add arithmetic growth preflight

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -16,7 +16,9 @@ data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
-intersection, hull, negation, addition, and subtraction. Raw cuts remain
+intersection, hull, negation, addition, and subtraction. A separate arithmetic
+resource layer preflights product growth without yet exposing interval
+multiplication. Raw cuts remain
 visible as the explicit decoder and inspection boundary; D2 propagation and
 replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Canonical
+
+@[expose] public section
+
+/-!
+# Arithmetic resource preflight
+
+Endpoint comparison cost does not bound numerator growth in multiplication.
+This module supplies a separate, nonbreaking result and diagnostic layer for
+checked arithmetic. Existing constructors and the additive public operations
+continue to return `BuildResult`; multiplicative operations can report product
+growth without fabricating a `CompareCost`.
+-/
+
+namespace Hex.Interval.Arithmetic
+
+/-- Allocation-independent preflight data for endpoint growth. `sources`
+records the already-admitted inputs and `predicted` is a conservative bound on
+the endpoint an arithmetic action would construct. Multiplication uses two
+sources; a direct power can reuse the same shape with one source. -/
+structure Growth where
+  sources : List EndpointCost
+  predicted : EndpointCost
+  deriving DecidableEq, Repr
+
+namespace Growth
+
+/-- Endpoint growth is admitted only when every source and the conservative
+result bound fit the retained-height budget. -/
+def allowed (limit : EndpointLimit) (growth : Growth) : Bool :=
+  growth.sources.all (EndpointCost.allowed limit) &&
+    growth.predicted.allowed limit
+
+end Growth
+
+/-- Resource diagnostics for checked public arithmetic. Product growth is a
+separate case from endpoint and comparison work: a comparison between two
+admitted factors may be cheap even when their product is too large. -/
+inductive Cost where
+  | endpoint (cost : EndpointCost)
+  | comparison (cost : CompareCost)
+  | growth (cost : Growth)
+  deriving DecidableEq, Repr
+
+/-- Result type for public arithmetic whose work is not described by
+`CompareCost`. Refusal remains distinct from the canonical empty interval. -/
+inductive Result where
+  | ready (interval : Hex.Interval)
+  | resourceLimit (cost : Cost)
+
+namespace Result
+
+/-- Embed the existing checked-construction result into the richer arithmetic
+result without changing the constructor, intersection, hull, addition, or
+subtraction APIs. -/
+def ofBuild : BuildResult → Result
+  | .ready interval => .ready interval
+  | .resourceLimit cost => .resourceLimit (.comparison cost)
+
+end Result
+
+/-- Preflight a dyadic multiplication without multiplying its mantissas.
+
+The source endpoint checks happen before the signed exponent sum is formed.
+After those checks, the sum of exponent representations and the sum of the two
+small numerator-bit counts are bounded metadata computations. A successful
+result bounds the actual product numerator by `predicted.numeratorBits` and
+uses its exact signed exponent magnitude. -/
+def preflightMul (limit : EndpointLimit) (left right : Dyadic) :
+    Except Cost Growth := do
+  let leftCost := EndpointCost.ofDyadic left
+  if !leftCost.allowed limit then
+    throw (.endpoint leftCost)
+  let rightCost := EndpointCost.ofDyadic right
+  if !rightCost.allowed limit then
+    throw (.endpoint rightCost)
+  let predicted :=
+    match left, right with
+    | .zero, _ | _, .zero => EndpointCost.ofDyadic 0
+    | .ofOdd _ leftExponent _, .ofOdd _ rightExponent _ =>
+        let exponentMagnitude := (leftExponent + rightExponent).natAbs
+        { numeratorBits := leftCost.numeratorBits + rightCost.numeratorBits
+          encodedExponentBits := EndpointCost.natBits exponentMagnitude
+          exponentMagnitude }
+  let cost : Growth := { sources := [leftCost, rightCost], predicted }
+  if !cost.allowed limit then
+    throw (.growth cost)
+  pure cost
+
+end Hex.Interval.Arithmetic

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexInterval.Canonical
+public import HexInterval.Arithmetic
 
 public section
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -451,6 +451,20 @@ the resulting raw cuts then cross `ofRawWithin` exactly once. The theorem
 `Raw.sub_eq_add_neg` pins that the direct raw result still agrees with addition
 after raw negation.
 
+The supported tree also contains the resource prerequisite for multiplicative
+arithmetic, but not yet interval multiplication itself. `Arithmetic.Growth`
+records admitted source endpoint costs and a conservative predicted result;
+multiplication records the sum of input numerator-bit lengths and the exact
+magnitude of the signed exponent sum. A direct power can reuse the same shape
+with one source and its separately predicted endpoint. `Arithmetic.preflightMul`
+checks the inputs before forming that small signed exponent sum and never
+multiplies their mantissas. `Arithmetic.Cost.growth` keeps this refusal distinct
+from endpoint and exact comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
+result so the existing `BuildResult` APIs above do not acquire a misleading or
+breaking cost variant. For example, under endpoint height `8`, the endpoints
+`255` and `255` and their comparison are admitted, while their predicted
+sixteen-bit product numerator is refused before multiplication.
+
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, and `subUnchecked` are related
 to the checked operations by successful-result and semantic theorems. Like
@@ -458,7 +472,7 @@ to the checked operations by successful-result and semantic theorems. Like
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface includes multiplication,
+The remaining target surface includes the interval operation for multiplication,
 precision-indexed reciprocal and division, powers, absolute value, min/max,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -27,6 +27,10 @@ private def smallLimit : EndpointLimit where
   maxEndpointHeight := 128
   maxAlignmentShift := 64
 
+private def eightBitLimit : EndpointLimit where
+  maxEndpointHeight := 8
+  maxAlignmentShift := 0
+
 #guard Raw.empty.normalizeUnchecked = .empty
 #guard (Raw.bounds .unbounded .unbounded).normalizeUnchecked = .bounds .unbounded .unbounded
 #guard
@@ -118,6 +122,22 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
   match Hex.Interval.belowWithin smallLimit far false with
   | .ready _ => false
   | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
+
+-- Comparison cost cannot stand in for multiplicative growth. Both factors
+-- fit the eight-bit endpoint limit and compare without alignment, but the
+-- conservative product numerator needs sixteen bits. The arithmetic
+-- preflight refuses before constructing `255 * 255` and reports that distinct
+-- product cost.
+#guard (EndpointCost.ofDyadic (d 255)).allowed eightBitLimit
+#guard (CompareCost.ofDyadic (d 255) (d 255)).allowed eightBitLimit
+#guard
+  match Arithmetic.preflightMul eightBitLimit (d 255) (d 255) with
+  | .error (.growth cost) =>
+      cost.sources.map (·.numeratorBits) == [8, 8] &&
+        cost.predicted.numeratorBits == 16 &&
+        cost.predicted.exponentMagnitude == 0 &&
+        !cost.allowed eightBitLimit
+  | _ => false
 
 private def ready (raw : Raw) : Hex.Interval :=
   match Hex.Interval.ofRawWithin smallLimit raw with

--- a/progress/20260815T062331Z.md
+++ b/progress/20260815T062331Z.md
@@ -1,0 +1,38 @@
+# Accomplished
+
+Added the nonbreaking public arithmetic resource layer required before interval
+multiplication. `Arithmetic.Growth` distinguishes conservative endpoint-growth
+predictions from exact comparison cost, and `Arithmetic.Result` can carry
+endpoint, comparison, or growth refusal without widening the established
+`BuildResult` surface used by constructors, intersection, hull, negation,
+addition, and subtraction.
+
+Added `Arithmetic.preflightMul`. It admits each source endpoint before forming
+the bounded metadata sums, predicts the sum of numerator-bit lengths and the
+exact signed exponent sum, and performs no mantissa multiplication. A
+Mathlib-free discriminator proves operationally that endpoints `255` and
+`255` and their comparison fit height `8`, while the required sixteen-bit
+product growth is refused as growth rather than fabricated comparison cost.
+
+Updated the supported-state SPEC and umbrella documentation. Focused
+`HexInterval`/conformance builds and the static, trust, release, freshness, and
+PNT gates are green.
+
+# Current frontier
+
+The public tree now has an honest checked-arithmetic result and reusable growth
+diagnostic. It still deliberately exposes no public interval multiplication.
+`Arithmetic.Result.ofBuild` is the checked normalization bridge for the next
+operation slice.
+
+# Next step
+
+Implement `mulWithin` using `Arithmetic.preflightMul` before every finite
+candidate product, preflight candidate comparisons separately, preserve zero
+attainment and sign-partitioned unbounded semantics, and route final
+canonicalization through `Arithmetic.Result.ofBuild`.
+
+# Blockers
+
+None. The earlier `CompareCost` premise blocker is resolved without changing
+any established public operation signature.


### PR DESCRIPTION
## Summary

- add reusable public arithmetic growth/cost/result types without widening existing checked `BuildResult` APIs
- add allocation-safe multiplication preflight that predicts numerator/exponent growth without multiplying mantissas
- pin the key discriminator: under height 8, inputs 255 and 255 and their comparison cost pass, while the predicted 16-bit product refuses as arithmetic growth
- document this prerequisite honestly; actual multiplication remains the next slice

## Verification

- focused `HexInterval.Arithmetic`, `HexInterval`, and conformance build
- copyright, line-count, DAG, Phase 4, trust-surface, conformance-target, and factor-freshness checks
- no added `native_decide`, `axiom`, or `sorry`

Fresh exact-head Opus review and exact CI are required before merge.