### PR TITLE
feat(interval): add checked minimum and maximum

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -16,7 +16,7 @@ data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
-intersection, hull, negation, addition, and subtraction. A separate arithmetic
+intersection, hull, negation, addition, subtraction, minimum, and maximum. A separate arithmetic
 resource layer preflights product growth without yet exposing interval
 multiplication. Raw cuts remain
 visible as the explicit decoder and inspection boundary; D2 propagation and

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -14,7 +14,7 @@ public section
 # Public exact interval operations
 
 This module begins the supported arithmetic surface with exact intersection,
-hull, negation, addition, and subtraction. The operations retain a
+hull, negation, addition, subtraction, minimum, and maximum. The operations retain a
 resource-aware result: public
 interval values do not remember the construction budget under which their
 endpoints were admitted, so a later comparison must preflight its own alignment
@@ -84,6 +84,28 @@ unnormalized so the supported wrapper preflights its final comparison. -/
   | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
       Raw.bounds
         (hullLowerUnchecked leftLower rightLower)
+        (hullUpperUnchecked leftUpper rightUpper)
+
+/-- Exact raw interval image under binary minimum. Empty is absorbing. The
+lower cut is the hull-selected lower cut, while the upper cut is the
+intersection-selected upper cut; their tied strictness records whether the
+corresponding extremum is attained by either or both inputs respectively. -/
+@[expose] def minUnchecked : Raw → Raw → Raw
+  | .empty, _ | _, .empty => .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      .bounds
+        (hullLowerUnchecked leftLower rightLower)
+        (intersectUpperUnchecked leftUpper rightUpper)
+
+/-- Exact raw interval image under binary maximum. Empty is absorbing. The
+lower cut is the intersection-selected lower cut, while the upper cut is the
+hull-selected upper cut; their tied strictness records whether the
+corresponding extremum is attained by both or either input respectively. -/
+@[expose] def maxUnchecked : Raw → Raw → Raw
+  | .empty, _ | _, .empty => .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      .bounds
+        (intersectLowerUnchecked leftLower rightLower)
         (hullUpperUnchecked leftUpper rightUpper)
 
 /-- Exact lower cut of a Minkowski sum. Either unbounded lower input makes the
@@ -221,6 +243,16 @@ private def hullCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCo
       | some cost => some cost
       | none => upperCost? limit leftUpper rightUpper
 
+/-- The first same-side finite-cut comparison refused before selecting the
+cuts of a minimum or maximum image. Both comparisons finish before either
+unchecked selector runs. -/
+private def minMaxCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCost
+  | .empty, _ | _, .empty => none
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match lowerCost? limit leftLower rightLower with
+      | some cost => some cost
+      | none => upperCost? limit leftUpper rightUpper
+
 /-- The first finite endpoint addition refused by the Minkowski-sum preflight.
 `CompareCost.allowed` bounds both retained inputs and their exponent gap before
 `Dyadic.add` shifts a mantissa. A successful preflight bounds the temporary
@@ -279,6 +311,44 @@ theorem view_hullWithin_ready {limit : EndpointLimit}
     (h : hullWithin limit left right = .ready result) :
     result.view = (Raw.hullUnchecked left.view right.view).normalizeUnchecked := by
   unfold hullWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
+
+/-- Exact interval image under binary minimum. Empty is absorbing. Both
+same-side finite comparisons are preflighted before cut selection, and the
+selected candidate crosses `ofRawWithin` for its independent final check. -/
+def minWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : BuildResult :=
+  match minMaxCost? limit left.view right.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.minUnchecked left.view right.view)
+
+/-- A successful minimum exposes exactly the normalized selected cuts. -/
+theorem view_minWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (h : minWithin limit left right = .ready result) :
+    result.view = (Raw.minUnchecked left.view right.view).normalizeUnchecked := by
+  unfold minWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
+
+/-- Exact interval image under binary maximum. Empty is absorbing. Both
+same-side finite comparisons are preflighted before cut selection, and the
+selected candidate crosses `ofRawWithin` for its independent final check. -/
+def maxWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : BuildResult :=
+  match minMaxCost? limit left.view right.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.maxUnchecked left.view right.view)
+
+/-- A successful maximum exposes exactly the normalized selected cuts. -/
+theorem view_maxWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (h : maxWithin limit left right = .ready result) :
+    result.view = (Raw.maxUnchecked left.view right.view).normalizeUnchecked := by
+  unfold maxWithin at h
   split at h
   · contradiction
   · exact view_ofRawWithin_ready h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -182,7 +182,7 @@ value's proof field.
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
 supported operations are resource-checked intersection, hull, negation,
-addition, and subtraction.
+addition, subtraction, minimum, and maximum.
 Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -202,7 +202,10 @@ Successful `addWithin` exposes the exact independently summed lower and upper
 Minkowski cuts, and its image theorem maps any two input members to their sum.
 Successful `subWithin` similarly exposes the crossed left-lower-minus-right-upper
 and left-upper-minus-right-lower cuts, and maps two input members to their
-difference. Neither arithmetic theorem currently claims the separate
+difference. Successful `minWithin` and `maxWithin` expose their exact selected
+cut predicates and enclose the pointwise real minimum and maximum of any two
+input members. They do not claim the converse characterization of every result
+member as a pointwise image. Neither addition nor subtraction currently claims the separate
 representation-independent tightness converse for the real Minkowski image.
 Separately, the experiment form of the intersection theorem is installed as the
 generic `FactDomainSchema.proveMeet` boundary, and the transparent proof
@@ -422,6 +425,8 @@ def hullWithin      : EndpointLimit → Interval → Interval → BuildResult
 def negWithin       : EndpointLimit → Interval → BuildResult
 def addWithin       : EndpointLimit → Interval → Interval → BuildResult
 def subWithin       : EndpointLimit → Interval → Interval → BuildResult
+def minWithin       : EndpointLimit → Interval → Interval → BuildResult
+def maxWithin       : EndpointLimit → Interval → Interval → BuildResult
 ```
 
 These names retain the budget because a public interval does not store the
@@ -451,6 +456,14 @@ the resulting raw cuts then cross `ofRawWithin` exactly once. The theorem
 `Raw.sub_eq_add_neg` pins that the direct raw result still agrees with addition
 after raw negation.
 
+`minWithin` and `maxWithin` are also direct checked primitives, not compositions
+through unchecked total interval APIs. Empty is absorbing. Both same-side
+finite endpoint comparisons are preflighted before either selector executes.
+Minimum selects the hull lower cut and intersection upper cut; maximum selects
+the intersection lower cut and hull upper cut. The selected candidate then
+crosses `ofRawWithin`, whose independent endpoint/final-comparison check may
+still refuse even when both selector comparisons fit.
+
 The supported tree also contains the resource prerequisite for multiplicative
 arithmetic, but not yet interval multiplication itself. `Arithmetic.Growth`
 records admitted source endpoint costs and a conservative predicted result;
@@ -466,14 +479,15 @@ breaking cost variant. For example, under endpoint height `8`, the endpoints
 sixteen-bit product numerator is refused before multiplication.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
-`hullUnchecked`, `negUnchecked`, `addUnchecked`, and `subUnchecked` are related
+`hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
+and `maxUnchecked` are related
 to the checked operations by successful-result and semantic theorems. Like
 `Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
 The remaining target surface includes the interval operation for multiplication,
-precision-indexed reciprocal and division, powers, absolute value, min/max,
+precision-indexed reciprocal and division, powers, absolute value,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.
@@ -499,6 +513,14 @@ tests also check the following exactness rules.
   Either corresponding unbounded contributor makes that result side
   unbounded; a finite side is closed exactly when both contributors are
   closed.
+- `minWithin` absorbs empty, chooses the smaller lower cut and the smaller upper
+  cut, and uses hull attainment on the lower tie but intersection attainment on
+  the upper tie. Thus a tied lower endpoint is closed if either input attains it,
+  while a tied upper endpoint is closed only if both inputs attain it.
+- `maxWithin` absorbs empty, chooses the larger lower cut and the larger upper
+  cut, and uses intersection attainment on the lower tie but hull attainment on
+  the upper tie. Thus a tied lower endpoint is closed only if both inputs attain
+  it, while a tied upper endpoint is closed if either input attains it.
 - After the empty-input short circuit, multiplication partitions both inputs
   by sign, enumerates finite corner and zero candidates, and tracks whether
   each extremum is attained. Zero is an attained extremum whenever either
@@ -508,10 +530,10 @@ tests also check the following exactness rules.
 - A power distinguishes zero, odd powers, and positive even powers. It does
   not implement powers by repeated interval multiplication when a direct hull
   is tighter.
-- `abs`, `min`, and `max` use the same candidate-and-attainment discipline.
-  In particular, `abs` contains a closed zero exactly when the input contains
-  zero, and tied extrema combine the contributing closure witnesses rather
-  than blindly copying one endpoint flag.
+- `abs` uses the same candidate-and-attainment discipline. In particular, it
+  contains a closed zero exactly when the input contains zero, and a tied
+  magnitude extremum combines both contributing closure witnesses rather than
+  copying one endpoint flag.
 - `split I m` returns `I ∩ (-∞,m]` and `I ∩ (m,+∞)`. The children are disjoint
   and cover `I`.
 - Empty is canonical. Unary image operations and regularization preserve empty;
@@ -3971,7 +3993,7 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
-  negation, addition, and subtraction, followed by future arithmetic, splitting, and regularization
+  negation, addition, subtraction, minimum, and maximum, followed by future arithmetic, splitting, and regularization
   operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
@@ -3979,6 +4001,8 @@ their declared cost inside a scheduler bound.
   successful addition image theorem.
 - `HexIntervalMathlib/Subtraction.lean`: exact crossed-difference-cut semantics
   and the successful subtraction image theorem.
+- `HexIntervalMathlib/MinMax.lean`: exact selected-cut semantics and one-way
+  real-image enclosure theorems for minimum and maximum.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
@@ -3986,8 +4010,8 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Policy.lean`: policy interface and `balancedV1`.
 - `HexInterval/Search.lean`: budgeted branch search and derivation slicing.
 - `HexInterval/Trace.lean`: diagnostics and machine-readable telemetry.
-- `conformance/HexInterval/{Conformance,EmitFixtures}.lean`: Lean-only checks
-  and oracle fixtures.
+- `conformance/HexInterval/{Conformance,MinMaxConformance,EmitFixtures}.lean`:
+  Lean-only checks and oracle fixtures.
 - `bench/HexInterval/Bench.lean`: Mathlib-free interval and scheduler
   benchmarks.
 
@@ -4011,6 +4035,8 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - the distinct cases `mul empty whole = empty`, `mul {0} whole = {0}`, and
   `mul whole {0} = {0}`;
 - `abs`, `min`, and `max` with tied open and closed extrema;
+- minimum and maximum preflight refusal on either same-side comparison and on
+  the distinct selected-cut final comparison;
 - precision-indexed reciprocal and division for `{3}`, positive, negative,
   singleton-zero, one-sided-zero, and sign-crossing inputs;
 - powers on negative, mixed-sign, open-zero, and singleton inputs;

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -10,11 +10,12 @@ module
 public import HexIntervalMathlib.Interval
 public import HexIntervalMathlib.Addition
 public import HexIntervalMathlib.Subtraction
+public import HexIntervalMathlib.MinMax
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition
-and subtraction.
+and subtraction and exact minimum/maximum images.
 -/

--- a/HexIntervalMathlib/Interval.lean
+++ b/HexIntervalMathlib/Interval.lean
@@ -142,7 +142,7 @@ theorem contains_normalize (raw : Raw) (x : ℝ) :
                     simpa [Raw.Contains, Lower.Contains, Upper.Contains,
                       Raw.normalizeUnchecked, Raw.consistent, less, equal] using impossible
 
-private theorem lowerContains_intersect (left right : Lower) (x : ℝ) :
+theorem lowerContains_intersect (left right : Lower) (x : ℝ) :
     (Raw.intersectLowerUnchecked left right).Contains x ↔
       left.Contains x ∧ right.Contains x := by
   cases left with
@@ -192,7 +192,7 @@ private theorem lowerContains_intersect (left right : Lower) (x : ℝ) :
                   simp [Lower.Contains] at leftBound ⊢ <;> linarith
               · exact fun bounds => bounds.1
 
-private theorem upperContains_intersect (left right : Upper) (x : ℝ) :
+theorem upperContains_intersect (left right : Upper) (x : ℝ) :
     (Raw.intersectUpperUnchecked left right).Contains x ↔
       left.Contains x ∧ right.Contains x := by
   cases left with
@@ -269,7 +269,7 @@ theorem contains_intersectWithin {limit : EndpointLimit}
   rw [view_intersectWithin_ready checked, contains_normalize]
   exact rawContains_intersect left.view right.view x
 
-private theorem lowerContains_hull (left right : Lower) (x : ℝ) :
+theorem lowerContains_hull (left right : Lower) (x : ℝ) :
     (Raw.hullLowerUnchecked left right).Contains x ↔
       left.Contains x ∨ right.Contains x := by
   cases left with
@@ -310,7 +310,7 @@ private theorem lowerContains_hull (left right : Lower) (x : ℝ) :
                     simp [Lower.Contains] at * <;> linarith
                 · exact rightBound
 
-private theorem upperContains_hull (left right : Upper) (x : ℝ) :
+theorem upperContains_hull (left right : Upper) (x : ℝ) :
     (Raw.hullUpperUnchecked left right).Contains x ↔
       left.Contains x ∨ right.Contains x := by
   cases left with

--- a/HexIntervalMathlib/MinMax.lean
+++ b/HexIntervalMathlib/MinMax.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+
+@[expose] public section
+
+/-!
+# Real semantics for interval minimum and maximum
+
+The exact selected-cut predicates characterize the computed interval. The
+image theorems prove that pointwise real minimum and maximum are enclosed; no
+converse set-image theorem is claimed here.
+-/
+
+namespace Hex.Interval
+
+/-- Exact selected-cut meaning of the interval image under binary minimum. -/
+def Raw.MinContains : Raw → Raw → ℝ → Prop
+  | .empty, _, _ | _, .empty, _ => False
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      (leftLower.Contains x ∨ rightLower.Contains x) ∧
+        (leftUpper.Contains x ∧ rightUpper.Contains x)
+
+/-- Exact selected-cut meaning of the interval image under binary maximum. -/
+def Raw.MaxContains : Raw → Raw → ℝ → Prop
+  | .empty, _, _ | _, .empty, _ => False
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      (leftLower.Contains x ∧ rightLower.Contains x) ∧
+        (leftUpper.Contains x ∨ rightUpper.Contains x)
+
+private theorem rawContains_min (left right : Raw) (x : ℝ) :
+    (Raw.minUnchecked left right).Contains x ↔ left.MinContains right x := by
+  cases left with
+  | empty => simp [Raw.minUnchecked, Raw.Contains, Raw.MinContains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.minUnchecked, Raw.Contains, Raw.MinContains]
+      | bounds rightLower rightUpper =>
+          rw [Raw.minUnchecked]
+          change
+            (Raw.hullLowerUnchecked leftLower rightLower).Contains x ∧
+                (Raw.intersectUpperUnchecked leftUpper rightUpper).Contains x ↔ _
+          rw [lowerContains_hull, upperContains_intersect]
+          rfl
+
+private theorem rawContains_max (left right : Raw) (x : ℝ) :
+    (Raw.maxUnchecked left right).Contains x ↔ left.MaxContains right x := by
+  cases left with
+  | empty => simp [Raw.maxUnchecked, Raw.Contains, Raw.MaxContains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.maxUnchecked, Raw.Contains, Raw.MaxContains]
+      | bounds rightLower rightUpper =>
+          rw [Raw.maxUnchecked]
+          change
+            (Raw.intersectLowerUnchecked leftLower rightLower).Contains x ∧
+                (Raw.hullUpperUnchecked leftUpper rightUpper).Contains x ↔ _
+          rw [lowerContains_intersect, upperContains_hull]
+          rfl
+
+/-- A successful minimum has exactly its selected lower and upper cut
+predicates, including empty absorption and unbounded sides. -/
+theorem contains_minWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : minWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.MinContains right.view x := by
+  simp only [Contains]
+  rw [view_minWithin_ready checked, contains_normalize]
+  exact rawContains_min left.view right.view x
+
+/-- A successful maximum has exactly its selected lower and upper cut
+predicates, including empty absorption and unbounded sides. -/
+theorem contains_maxWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : maxWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.MaxContains right.view x := by
+  simp only [Contains]
+  rw [view_maxWithin_ready checked, contains_normalize]
+  exact rawContains_max left.view right.view x
+
+private theorem lowerContains_mono (cut : Lower) {x y : ℝ}
+    (xy : x ≤ y) (member : cut.Contains x) : cut.Contains y := by
+  cases cut with
+  | unbounded => trivial
+  | finite value strict => cases strict <;> simp [Lower.Contains] at member ⊢ <;> linarith
+
+private theorem upperContains_anti (cut : Upper) {x y : ℝ}
+    (xy : x ≤ y) (member : cut.Contains y) : cut.Contains x := by
+  cases cut with
+  | unbounded => trivial
+  | finite value strict => cases strict <;> simp [Upper.Contains] at member ⊢ <;> linarith
+
+private theorem rawMinImage {left right : Raw} {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    left.MinContains right (min x y) := by
+  cases left with
+  | empty => simp [Raw.Contains] at leftMember
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains] at rightMember
+      | bounds rightLower rightUpper =>
+          rcases leftMember with ⟨leftLowerMember, leftUpperMember⟩
+          rcases rightMember with ⟨rightLowerMember, rightUpperMember⟩
+          by_cases xy : x ≤ y
+          · rw [min_eq_left xy]
+            exact ⟨Or.inl leftLowerMember,
+              leftUpperMember, upperContains_anti rightUpper xy rightUpperMember⟩
+          · have yx : y ≤ x := le_of_not_ge xy
+            rw [min_eq_right yx]
+            exact ⟨Or.inr rightLowerMember,
+              upperContains_anti leftUpper yx leftUpperMember, rightUpperMember⟩
+
+private theorem rawMaxImage {left right : Raw} {x y : ℝ}
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    left.MaxContains right (max x y) := by
+  cases left with
+  | empty => simp [Raw.Contains] at leftMember
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains] at rightMember
+      | bounds rightLower rightUpper =>
+          rcases leftMember with ⟨leftLowerMember, leftUpperMember⟩
+          rcases rightMember with ⟨rightLowerMember, rightUpperMember⟩
+          by_cases xy : x ≤ y
+          · rw [max_eq_right xy]
+            exact ⟨⟨lowerContains_mono leftLower xy leftLowerMember,
+              rightLowerMember⟩, Or.inr rightUpperMember⟩
+          · have yx : y ≤ x := le_of_not_ge xy
+            rw [max_eq_left yx]
+            exact ⟨⟨leftLowerMember,
+              lowerContains_mono rightLower yx rightLowerMember⟩,
+              Or.inl leftUpperMember⟩
+
+/-- Pointwise real minimum of two input members belongs to every successful
+computed minimum interval. -/
+theorem min_mem_minWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : minWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (min x y) :=
+  (contains_minWithin checked (min x y)).2
+    (rawMinImage leftMember rightMember)
+
+/-- Pointwise real maximum of two input members belongs to every successful
+computed maximum interval. -/
+theorem max_mem_maxWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : maxWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (max x y) :=
+  (contains_maxWithin checked (max x y)).2
+    (rawMaxImage leftMember rightMember)
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -11,7 +11,8 @@ The foundational supported module is `HexIntervalMathlib.Interval`. It defines t
 real value of a dyadic endpoint and membership for every public interval cut:
 strict or closed finite ends, independent unbounded ends, and canonical empty.
 `HexIntervalMathlib.Addition` and `HexIntervalMathlib.Subtraction` add the
-public arithmetic image theorems.
+public arithmetic image theorems, while `HexIntervalMathlib.MinMax` supplies
+selected-cut and real-image enclosure theorems for minimum and maximum.
 
 For every successful resource-checked public operation it proves:
 
@@ -34,6 +35,10 @@ For every successful resource-checked public operation it proves:
   sides;
 - `sub_mem_subWithin`: two input members subtract to a member of every
   successful result.
+- `contains_minWithin` and `contains_maxWithin`: exact membership in the
+  computed selected cuts;
+- `min_mem_minWithin` and `max_mem_maxWithin`: pointwise real minimum and
+  maximum of two input members belong to every successful result.
 
 These theorems depend on the exact successful `BuildResult` equation. A
 resource refusal has no set interpretation and is never treated as an empty
@@ -48,14 +53,18 @@ existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
 are not re-exported here. Further arithmetic images, powers, splitting,
 regularization, and precision-indexed reciprocal/division require their own
-set-enclosure and stated tightness theorems before promotion.
+operation-specific semantic theorems before promotion. An image operation must
+at least prove successful-result cut semantics and sound real-image enclosure;
+it claims a tightness converse only when that converse is separately proved.
 
 ## Conformance
 
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
 membership, exact hull closure and both input inclusions, negation transport,
 addition and subtraction cut exactness and image transport, and the exact
-ordinary-kernel axiom surface.
+ordinary-kernel axiom surface. `HexIntervalMathlib.MinMaxConformance` separately
+pins exact selected cuts, both image enclosures, and their axiom surfaces; it
+does not assert a set-image converse.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,7 +7,7 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-negation, addition, and subtraction. Propagator, provider, replay, and tactic modules remain experiments
+negation, addition, subtraction, minimum, and maximum. Propagator, provider, replay, and tactic modules remain experiments
 and are not re-exported by the public umbrella. The user-facing tactic contract
 below is the release target, not a claim that the tactic is already supported.
 
@@ -143,6 +143,22 @@ theorem contains_subWithin
 theorem sub_mem_subWithin
     (h : subWithin limit I J = .ready result) :
     I.Contains x → J.Contains y → result.Contains (x - y)
+
+theorem contains_minWithin
+    (h : minWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.MinContains J.view x
+
+theorem min_mem_minWithin
+    (h : minWithin limit I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (min x y)
+
+theorem contains_maxWithin
+    (h : maxWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.MaxContains J.view x
+
+theorem max_mem_maxWithin
+    (h : maxWithin limit I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (max x y)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -166,6 +182,12 @@ unbounded input makes that output side unbounded, and finite strictness is
 disjunction. `sub_mem_subWithin` proves the representation-independent image
 enclosure. As for addition, a separate real Minkowski-image tightness converse
 remains future work rather than a current claim.
+
+`MinContains` uses the union of lower-cut predicates and intersection of
+upper-cut predicates; `MaxContains` uses the intersection of lower-cut
+predicates and union of upper-cut predicates. These characterize the exact
+computed cuts. The corresponding image theorems are one-way enclosures of
+pointwise real `min` and `max`; no converse set-image theorem is claimed.
 
 The remaining target theorems include:
 

--- a/conformance/HexInterval/MinMaxConformance.lean
+++ b/conformance/HexInterval/MinMaxConformance.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval
+
+/-!
+# Exact minimum and maximum conformance
+
+These guards discriminate every cut selector, tied endpoint attainment, empty
+and unbounded behavior, operand order, both preflight comparisons, and final
+normalization refusal.
+-/
+
+namespace Hex.Interval.MinMaxConformance
+
+private def d (value : Int) : Dyadic := Dyadic.ofInt value
+
+private def finite (lower : Int) (lowerStrict : Bool)
+    (upper : Int) (upperStrict : Bool) : Raw :=
+  .bounds (.finite (d lower) lowerStrict) (.finite (d upper) upperStrict)
+
+private def smallLimit : EndpointLimit where
+  maxEndpointHeight := 128
+  maxAlignmentShift := 64
+
+private def ready (raw : Raw) : Hex.Interval :=
+  match Hex.Interval.ofRawWithin smallLimit raw with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def leftBand : Hex.Interval := ready (finite 1 false 4 false)
+private def rightBand : Hex.Interval := ready (finite 2 false 3 false)
+
+-- Minimum and maximum mix selectors rather than taking an intersection or
+-- hull wholesale. Reversing the inputs pins commutative selection order.
+#guard
+  match Hex.Interval.minWithin smallLimit leftBand rightBand with
+  | .ready interval => interval.view == finite 1 false 3 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit rightBand leftBand with
+  | .ready interval => interval.view == finite 1 false 3 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit leftBand rightBand with
+  | .ready interval => interval.view == finite 2 false 4 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit rightBand leftBand with
+  | .ready interval => interval.view == finite 2 false 4 false
+  | .resourceLimit _ => false
+
+private def leftTie : Hex.Interval := ready (finite 0 false 2 true)
+private def rightTie : Hex.Interval := ready (finite 0 true 2 false)
+
+-- At equal endpoints, minimum inherits lower attainment from either input
+-- but needs upper attainment from both. Maximum has the dual rule.
+#guard
+  match Hex.Interval.minWithin smallLimit leftTie rightTie with
+  | .ready interval => interval.view == finite 0 false 2 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit leftTie rightTie with
+  | .ready interval => interval.view == finite 0 true 2 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit rightTie leftTie with
+  | .ready interval => interval.view == finite 0 false 2 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit rightTie leftTie with
+  | .ready interval => interval.view == finite 0 true 2 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit rightTie rightTie with
+  | .ready interval => interval == rightTie
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit leftTie leftTie with
+  | .ready interval => interval == leftTie
+  | .resourceLimit _ => false
+
+private def atMostOne : Hex.Interval :=
+  ready (.bounds .unbounded (.finite (d 1) false))
+
+private def atLeastOne : Hex.Interval :=
+  ready (.bounds (.finite (d 1) false) .unbounded)
+
+-- Empty is absorbing on both sides. One-sided extrema retain exactly the
+-- unbounded side selected by the corresponding hull cut.
+#guard
+  match Hex.Interval.minWithin smallLimit Hex.Interval.empty leftBand with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit leftBand Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit Hex.Interval.empty leftBand with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit leftBand Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit atMostOne atLeastOne with
+  | .ready interval => interval == atMostOne
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit atMostOne atLeastOne with
+  | .ready interval => interval == atLeastOne
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.minWithin smallLimit Hex.Interval.whole leftBand with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d 4) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.maxWithin smallLimit Hex.Interval.whole leftBand with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 1) false) .unbounded
+  | .resourceLimit _ => false
+
+-- The first and second same-side comparisons are independently preflighted
+-- before either selector can execute.
+private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
+
+private def farLower : Hex.Interval :=
+  match Hex.Interval.aboveWithin
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def farUpper : Hex.Interval :=
+  match Hex.Interval.belowWithin
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+#guard
+  match Hex.Interval.minWithin smallLimit leftBand farLower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+#guard
+  match Hex.Interval.maxWithin smallLimit leftBand farLower with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+#guard
+  match Hex.Interval.minWithin smallLimit atMostOne farUpper with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+#guard
+  match Hex.Interval.maxWithin smallLimit atMostOne farUpper with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 1000000000
+
+-- Same-side comparisons need no shift, but the selected final cuts do. This
+-- pins the separate `ofRawWithin` comparison after selection.
+private def bridgeLeft : Hex.Interval := ready (finite 1 false 4 false)
+private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
+
+#guard
+  match Hex.Interval.minWithin
+      { maxEndpointHeight := 128, maxAlignmentShift := 0 }
+      bridgeLeft bridgeRight with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 2
+
+#guard
+  match Hex.Interval.maxWithin
+      { maxEndpointHeight := 128, maxAlignmentShift := 0 }
+      bridgeLeft bridgeRight with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 2
+
+end Hex.Interval.MinMaxConformance

--- a/conformance/HexIntervalMathlib/MinMaxConformance.lean
+++ b/conformance/HexIntervalMathlib/MinMaxConformance.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib
+
+/-!
+# Minimum and maximum semantic conformance
+
+The ordinary-kernel wrappers pin the exact selected-cut characterizations and
+the two real-image enclosure theorems without asserting a set-image converse.
+-/
+
+namespace Hex.IntervalMathlib.MinMaxConformance
+
+theorem minExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.minWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.MinContains right.view x :=
+  Hex.Interval.contains_minWithin checked x
+
+theorem minImage {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.minWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (min x y) :=
+  Hex.Interval.min_mem_minWithin checked leftMember rightMember
+
+theorem maxExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.maxWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.MaxContains right.view x :=
+  Hex.Interval.contains_maxWithin checked x
+
+theorem maxImage {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.maxWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (max x y) :=
+  Hex.Interval.max_mem_maxWithin checked leftMember rightMember
+
+/-- info: 'Hex.IntervalMathlib.MinMaxConformance.minExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms minExact
+
+/-- info: 'Hex.IntervalMathlib.MinMaxConformance.minImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms minImage
+
+/-- info: 'Hex.IntervalMathlib.MinMaxConformance.maxExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms maxExact
+
+/-- info: 'Hex.IntervalMathlib.MinMaxConformance.maxImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms maxImage
+
+end Hex.IntervalMathlib.MinMaxConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -363,7 +363,8 @@ lean_lib HexIntervalMathlibExperiment where
 @[default_target]
 lean_lib HexIntervalMathlib where
   globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
-    `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction].map Glob.one
+    `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
+    `HexIntervalMathlib.MinMax].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -428,6 +429,9 @@ lean_lib HexRCFProofProbeScientific where
 lean_lib HexConformance where
   srcDir := "conformance"
   globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexIntervalMathlib.IntervalConformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.ScopeConformance, `HexInterval.StructuralMatcherConformance, `HexInterval.MatcherSchedulerConformance, `HexInterval.NestedBranchConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexInterval.PayloadSessionConformance, `HexInterval.PolicySessionConformance, `HexInterval.PolicyFunctionConformance, `HexInterval.SemanticReplayConformance, `HexInterval.ChronologicalReplayConformance, `HexInterval.GenericInstanceReconstructionConformance, `HexInterval.ProofEmitterConformance, `HexInterval.TraceReplayConformance, `HexInterval.SinTenIntervalConformance, `HexIntervalMathlib.DyadicIntervalConformance, `HexIntervalMathlib.CenteredConformance, `HexIntervalMathlib.SineSignConformance, `HexIntervalMathlib.SineProofConformance, `HexIntervalMathlib.SineTacticConformance, `HexIntervalMathlib.ProofRegistryConformance, `HexIntervalMathlib.ExpSignConformance, `HexIntervalMathlib.ReluConformance, `HexIntervalMathlib.RefuteConformance, `HexIntervalMathlib.PntLogTableConformance, `HexIntervalMathlib.PntNestedLogConformance, `HexIntervalMathlib.PntExpTailConformance, `HexIntervalMathlib.PntTable12Conformance, `HexIntervalMathlib.PntTable12OrdinaryConformance, `HexIntervalAlgebraic.PolynomialDispatchConformance, `HexIntervalMathlib.PntTable12LogConformance, `HexIntervalMathlib.PntFks2ShardConformance, `HexIntervalMathlib.LogTablePrecisionConformance, `HexIntervalMathlib.IntegralCanaryConformance, `HexIntervalMathlib.PntBKLNWPowConformance, `HexIntervalMathlib.SinTenConformance, `HexIntervalMathlib.SinTenIntervalConformance, `HexIntervalMathlib.CosBillionConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexMvPolyFixtures, `HexMvPoly.Conformance, `HexMvPolyMathlib.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+
+    ++ #[`HexInterval.MinMaxConformance,
+      `HexIntervalMathlib.MinMaxConformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260815T075752Z.md
+++ b/progress/20260815T075752Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Validated the exact binary minimum and maximum cut formulas, including tied open/closed attainment and empty absorption; no counterexample was found.
+- Added direct resource-checked `minWithin` and `maxWithin` primitives. Both same-side finite comparisons complete before selection, and every selected raw candidate crosses `ofRawWithin` for endpoint and final-comparison validation.
+- Added successful computed-cut view theorems, exact selected-cut real semantics, and one-way pointwise real image enclosure theorems without claiming a set-image converse.
+- Added discriminating Mathlib-free guards for both selector directions, reversed operands, mixed and idempotent tied closure cases, empty, unbounded and whole intervals, both billion-shift preflight positions, and separate final-normalization refusal.
+- Added active Mathlib umbrella exports, ordinary conformance wrappers, and guarded exact axiom reports.
+- Updated the supported API, semantic boundary, file organization, and remaining-work documentation.
+- Kept the promotion boundary explicit: every public image needs exact
+  operation-specific semantics and sound image enclosure, while a tightness
+  converse is claimed only when separately proved; retained the tied-magnitude
+  attainment requirement for absolute value.
+- Rebased the exact feature onto current main `59784796b0842af0005dc23dd489373beb202213`, preserving the newly landed BKLNW power-fold source, inventory, SPEC, Lake, conformance, and freshness registrations.
+- Recomputed the final Lake exemption for blob `da0f063465448492e3eaedd3e6a4784d6633a588` and passed focused builds, the complete PNT set including BKLNW, static checks, trust/release checks, source-pinned inventory, unit tests, and factor-sweep freshness.
+
+# Current frontier
+
+The checked minimum/maximum feature is a clean local-only candidate on exact current base `59784796b0842af0005dc23dd489373beb202213`.
+
+# Next step
+
+Retain the branch for the directed landing sequence; repeat exact-head review and CI only when explicitly requested.
+
+# Blockers
+
+None. The fresh worktree reused the preserved framework worktree's read-only Lake dependency checkout after the host filesystem lacked room for a second Mathlib clone.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -328,5 +328,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "4de4f63a1ec5ad017e23e4cb8bc878cd3138d93b",
     "reason": "Additionally registers the Mathlib-free PNT+ BKLNW power-fold experiment, its proof-only real-semantics companion, and conformance module on top of the retained FKS2 and public interval registrations; these acceptance-only modules do not enter the factorization service target or its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "da0f063465448492e3eaedd3e6a4784d6633a588",
+    "reason": "Additionally registers the supported HexIntervalMathlib minimum/maximum semantics module and the Mathlib-free and proof-only conformance modules; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
Adds checked public `minWithin` and `maxWithin` operations over sealed intervals.

The implementation preflights both same-side finite comparisons before selecting cuts, then uses the existing checked canonicalization boundary. Empty intervals are absorbing. The Mathlib bridge proves exact selected-cut characterizations and one-way real-image enclosure theorems without claiming a false converse.

Conformance covers separated and reversed inputs, strict/closed ties, empty and unbounded cases, billion-shift pre-allocation refusal, final-normalization refusal, and exact axiom reports. The Lake registration and proof-only factor exemption preserve all current PNT+ targets.

Local verification includes focused public/min-max/PNT builds, source-pinned inventory checks, trust/DAG/Phase 4/release gates, Mathlib-free benches, factor freshness, and banned-term scans.