### PR TITLE
feat(interval): add checked absolute value

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -16,9 +16,9 @@ data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
-intersection, hull, negation, addition, subtraction, minimum, and maximum. A separate arithmetic
-resource layer preflights product growth without yet exposing interval
-multiplication. Raw cuts remain
+intersection, hull, negation, addition, subtraction, minimum, maximum, and
+absolute value. A separate arithmetic resource layer preflights product growth
+without yet exposing interval multiplication. Raw cuts remain
 visible as the explicit decoder and inspection boundary; D2 propagation and
 replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -14,8 +14,8 @@ public section
 # Public exact interval operations
 
 This module begins the supported arithmetic surface with exact intersection,
-hull, negation, addition, subtraction, minimum, and maximum. The operations retain a
-resource-aware result: public
+hull, negation, addition, subtraction, minimum, maximum, and absolute value.
+The operations retain a resource-aware result: public
 interval values do not remember the construction budget under which their
 endpoints were admitted, so a later comparison must preflight its own alignment
 work.
@@ -190,6 +190,43 @@ their strictness. -/
         | .finite value strict => Upper.finite (-value) strict
       Raw.bounds resultLower resultUpper
 
+/-- Exact raw image under absolute value. The result retains a zero endpoint
+exactly when the source retains zero. If the source crosses zero, its upper
+cut is selected from the larger endpoint magnitude; tied magnitudes are strict
+only when both source endpoints are strict.
+
+The comparison between opposite endpoint magnitudes is unchecked here. The
+public wrapper preflights it before calling this decoder-level helper. -/
+@[expose] def absUnchecked : Raw → Raw
+  | .empty => .empty
+  | .bounds .unbounded .unbounded =>
+      .bounds (.finite 0 false) .unbounded
+  | .bounds .unbounded (.finite upper upperStrict) =>
+      if upper ≤ 0 then
+        .bounds (.finite (-upper) upperStrict) .unbounded
+      else
+        .bounds (.finite 0 false) .unbounded
+  | .bounds (.finite lower lowerStrict) .unbounded =>
+      if 0 ≤ lower then
+        .bounds (.finite lower lowerStrict) .unbounded
+      else
+        .bounds (.finite 0 false) .unbounded
+  | .bounds (.finite lower lowerStrict) (.finite upper upperStrict) =>
+      if 0 ≤ lower then
+        .bounds (.finite lower lowerStrict) (.finite upper upperStrict)
+      else if upper ≤ 0 then
+        .bounds (.finite (-upper) upperStrict) (.finite (-lower) lowerStrict)
+      else
+        let leftMagnitude := -lower
+        let resultUpper :=
+          if leftMagnitude < upper then
+            Upper.finite upper upperStrict
+          else if leftMagnitude = upper then
+            Upper.finite upper (lowerStrict && upperStrict)
+          else
+            Upper.finite leftMagnitude lowerStrict
+        .bounds (.finite 0 false) resultUpper
+
 /-- Direct raw subtraction agrees with addition after raw negation. The
 checked public operation uses the direct form so it can preflight only the two
 crossed endpoint pairs, without normalizing an intermediate negated interval. -/
@@ -276,6 +313,17 @@ private def subCost? (limit : EndpointLimit) : Raw → Raw → Option CompareCos
       match lowerUpperCost? limit leftLower rightUpper with
       | some cost => some cost
       | none => upperLowerCost? limit leftUpper rightLower
+
+/-- Refused opposite-magnitude comparison for an interval that crosses zero.
+Negation preserves endpoint size and exponent, so the cost is computed from
+the retained lower and upper values before allocating the negated lower used
+by the selector. Sign-separated and unbounded cases need no endpoint selection
+comparison. -/
+private def absCost? (limit : EndpointLimit) : Raw → Option CompareCost
+  | .bounds (.finite lower _) (.finite upper _) =>
+      if 0 ≤ lower || upper ≤ 0 then none
+      else compareCost? limit lower upper
+  | _ => none
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -404,5 +452,22 @@ theorem view_negWithin_ready {limit : EndpointLimit} {input result : Hex.Interva
     (h : negWithin limit input = .ready result) :
     result.view = (Raw.negUnchecked input.view).normalizeUnchecked :=
   view_ofRawWithin_ready h
+
+/-- Exact interval absolute value with preflighted opposite-magnitude
+selection. Empty is preserved. Resource refusal remains distinct from an
+empty image. -/
+def absWithin (limit : EndpointLimit) (input : Hex.Interval) : BuildResult :=
+  match absCost? limit input.view with
+  | some cost => .resourceLimit cost
+  | none => ofRawWithin limit (Raw.absUnchecked input.view)
+
+/-- A successful absolute value exposes exactly the normalized selected cuts. -/
+theorem view_absWithin_ready {limit : EndpointLimit} {input result : Hex.Interval}
+    (h : absWithin limit input = .ready result) :
+    result.view = (Raw.absUnchecked input.view).normalizeUnchecked := by
+  unfold absWithin at h
+  split at h
+  · contradiction
+  · exact view_ofRawWithin_ready h
 
 end Hex.Interval

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -182,7 +182,7 @@ value's proof field.
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
 supported operations are resource-checked intersection, hull, negation,
-addition, subtraction, minimum, and maximum.
+addition, subtraction, minimum, maximum, and absolute value.
 Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -205,8 +205,12 @@ and left-upper-minus-right-lower cuts, and maps two input members to their
 difference. Successful `minWithin` and `maxWithin` expose their exact selected
 cut predicates and enclose the pointwise real minimum and maximum of any two
 input members. They do not claim the converse characterization of every result
-member as a pointwise image. Neither addition nor subtraction currently claims the separate
-representation-independent tightness converse for the real Minkowski image.
+member as a pointwise image. Successful `absWithin` exposes its exact normalized
+selected-cut predicate and maps every input member `x` to `|x|`; it likewise
+does not claim a converse characterization of every result member as an
+absolute-value image. Neither addition nor subtraction currently claims the
+separate representation-independent tightness converse for the real Minkowski
+image.
 Separately, the experiment form of the intersection theorem is installed as the
 generic `FactDomainSchema.proveMeet` boundary, and the transparent proof
 frontend uses it to close a weaker requested interval from a stronger
@@ -427,6 +431,7 @@ def addWithin       : EndpointLimit → Interval → Interval → BuildResult
 def subWithin       : EndpointLimit → Interval → Interval → BuildResult
 def minWithin       : EndpointLimit → Interval → Interval → BuildResult
 def maxWithin       : EndpointLimit → Interval → Interval → BuildResult
+def absWithin       : EndpointLimit → Interval → BuildResult
 ```
 
 These names retain the budget because a public interval does not store the
@@ -464,6 +469,14 @@ the intersection lower cut and hull upper cut. The selected candidate then
 crosses `ofRawWithin`, whose independent endpoint/final-comparison check may
 still refuse even when both selector comparisons fit.
 
+`absWithin` preserves empty and sign-separated endpoint strictness. An input
+crossing zero has a closed zero lower cut and chooses the larger endpoint
+magnitude for its upper cut; equal magnitudes are strict only when both source
+endpoints are strict. The opposite-magnitude comparison is preflighted before
+the selector aligns finite dyadics, and the selected raw cuts then cross
+`ofRawWithin`. Thus an interval admitted under a larger earlier budget cannot
+force an unchecked alignment or silently turn refusal into empty.
+
 The supported tree also contains the resource prerequisite for multiplicative
 arithmetic, but not yet interval multiplication itself. `Arithmetic.Growth`
 records admitted source endpoint costs and a conservative predicted result;
@@ -480,14 +493,14 @@ sixteen-bit product numerator is refused before multiplication.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
-and `maxUnchecked` are related
-to the checked operations by successful-result and semantic theorems. Like
+`maxUnchecked`, and `absUnchecked` are related to the checked operations by
+successful-result and semantic theorems. Like
 `Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
 The remaining target surface includes the interval operation for multiplication,
-precision-indexed reciprocal and division, powers, absolute value,
+precision-indexed reciprocal and division, powers,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.
@@ -3993,8 +4006,8 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
-  negation, addition, subtraction, minimum, and maximum, followed by future arithmetic, splitting, and regularization
-  operations.
+  negation, addition, subtraction, minimum, maximum, and absolute value,
+  followed by future arithmetic, splitting, and regularization operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
@@ -4003,6 +4016,8 @@ their declared cost inside a scheduler bound.
   and the successful subtraction image theorem.
 - `HexIntervalMathlib/MinMax.lean`: exact selected-cut semantics and one-way
   real-image enclosure theorems for minimum and maximum.
+- `HexIntervalMathlib/Absolute.lean`: exact selected-cut semantics and the
+  successful absolute-value image theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -11,11 +11,12 @@ public import HexIntervalMathlib.Interval
 public import HexIntervalMathlib.Addition
 public import HexIntervalMathlib.Subtraction
 public import HexIntervalMathlib.MinMax
+public import HexIntervalMathlib.Absolute
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition
-and subtraction and exact minimum/maximum images.
+and subtraction, exact minimum/maximum images, and absolute value.
 -/

--- a/HexIntervalMathlib/Absolute.lean
+++ b/HexIntervalMathlib/Absolute.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+
+@[expose] public section
+
+/-!
+# Exact semantics of public interval absolute value
+
+This module relates successful resource-checked absolute value to its selected
+raw cuts and proves that the result contains the absolute value of every input
+member. Sign-separated inputs retain their endpoint strictness; an interval
+crossing zero has a closed zero lower cut and selects its upper cut by endpoint
+magnitude and attainment.
+-/
+
+namespace Hex.Interval
+
+private theorem toReal_le {left right : Dyadic} (h : left ≤ right) :
+    toReal left ≤ toReal right := by
+  exact (Rat.cast_le (K := ℝ)).2 (Dyadic.toRat_le_toRat_iff.2 h)
+
+private theorem abs_le_right {lower upper x : ℝ}
+    (lowerBound : lower ≤ x) (upperBound : x ≤ upper)
+    (magnitude : -lower ≤ upper) : |x| ≤ upper := by
+  by_cases nonnegative : 0 ≤ x
+  · rw [abs_of_nonneg nonnegative]
+    exact upperBound
+  · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
+    linarith
+
+private theorem abs_lt_right {lower upper x : ℝ}
+    (lowerBound : lower ≤ x) (upperBound : x < upper)
+    (magnitude : -lower < upper) : |x| < upper := by
+  by_cases nonnegative : 0 ≤ x
+  · rw [abs_of_nonneg nonnegative]
+    exact upperBound
+  · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
+    linarith
+
+private theorem abs_le_left {lower upper x : ℝ}
+    (lowerBound : lower ≤ x) (upperBound : x ≤ upper)
+    (magnitude : upper ≤ -lower) : |x| ≤ -lower := by
+  by_cases nonnegative : 0 ≤ x
+  · rw [abs_of_nonneg nonnegative]
+    linarith
+  · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
+    linarith
+
+private theorem abs_lt_left {lower upper x : ℝ}
+    (lowerBound : lower < x) (upperBound : x ≤ upper)
+    (magnitude : upper < -lower) : |x| < -lower := by
+  by_cases nonnegative : 0 ≤ x
+  · rw [abs_of_nonneg nonnegative]
+    linarith
+  · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
+    linarith
+
+private theorem abs_lt_tied {lower upper x : ℝ}
+    (lowerBound : lower < x) (upperBound : x < upper)
+    (magnitude : -lower = upper) : |x| < upper := by
+  by_cases nonnegative : 0 ≤ x
+  · rw [abs_of_nonneg nonnegative]
+    exact upperBound
+  · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
+    linarith
+
+private theorem rawContains_abs (raw : Raw) {x : ℝ}
+    (member : raw.Contains x) : raw.absUnchecked.Contains |x| := by
+  cases raw with
+  | empty => simp [Raw.Contains] at member
+  | bounds lower upper =>
+      cases lower with
+      | unbounded =>
+          cases upper with
+          | unbounded =>
+              simp [Raw.absUnchecked, Raw.Contains, Lower.Contains,
+                Upper.Contains, toReal]
+          | finite upper upperStrict =>
+              by_cases nonpositive : upper ≤ 0
+              · have upperReal : toReal upper ≤ 0 := by
+                  simpa [toReal] using toReal_le nonpositive
+                have xNonpositive : x ≤ 0 := by
+                  cases upperStrict <;>
+                    simp [Raw.Contains, Upper.Contains] at member <;> linarith
+                have image :
+                    (Raw.bounds .unbounded (.finite upper upperStrict)).absUnchecked =
+                      (Raw.bounds .unbounded (.finite upper upperStrict)).negUnchecked := by
+                  simp [Raw.absUnchecked, Raw.negUnchecked, nonpositive]
+                rw [image, abs_of_nonpos xNonpositive,
+                  contains_negUnchecked]
+                simpa using member
+              · simp [Raw.absUnchecked, Raw.Contains, Lower.Contains,
+                  Upper.Contains, nonpositive, toReal]
+      | finite lower lowerStrict =>
+          cases upper with
+          | unbounded =>
+              by_cases nonnegative : 0 ≤ lower
+              · have lowerReal : 0 ≤ toReal lower := by
+                  simpa [toReal] using toReal_le nonnegative
+                have xNonnegative : 0 ≤ x := by
+                  cases lowerStrict <;>
+                    simp [Raw.Contains, Lower.Contains] at member <;> linarith
+                rw [abs_of_nonneg xNonnegative]
+                simpa [Raw.absUnchecked, nonnegative] using member
+              · simp [Raw.absUnchecked, Raw.Contains, Lower.Contains,
+                  Upper.Contains, nonnegative, toReal]
+          | finite upper upperStrict =>
+              by_cases nonnegative : 0 ≤ lower
+              · have lowerReal : 0 ≤ toReal lower := by
+                  simpa [toReal] using toReal_le nonnegative
+                have xNonnegative : 0 ≤ x := by
+                  cases lowerStrict <;>
+                    simp [Raw.Contains, Lower.Contains] at member <;> linarith
+                rw [abs_of_nonneg xNonnegative]
+                simpa [Raw.absUnchecked, nonnegative] using member
+              · by_cases nonpositive : upper ≤ 0
+                · have upperReal : toReal upper ≤ 0 := by
+                    simpa [toReal] using toReal_le nonpositive
+                  have xNonpositive : x ≤ 0 := by
+                    cases upperStrict <;>
+                      simp [Raw.Contains, Upper.Contains] at member <;> linarith
+                  have image :
+                      (Raw.bounds (.finite lower lowerStrict)
+                          (.finite upper upperStrict)).absUnchecked =
+                        (Raw.bounds (.finite lower lowerStrict)
+                          (.finite upper upperStrict)).negUnchecked := by
+                    simp [Raw.absUnchecked, Raw.negUnchecked, nonnegative,
+                      nonpositive]
+                  rw [image, abs_of_nonpos xNonpositive,
+                    contains_negUnchecked]
+                  simpa using member
+                · rcases member with ⟨lowerMember, upperMember⟩
+                  have lowerWeak : toReal lower ≤ x := by
+                    cases lowerStrict with
+                    | false => exact lowerMember
+                    | true => exact le_of_lt lowerMember
+                  have upperWeak : x ≤ toReal upper := by
+                    cases upperStrict with
+                    | false => exact upperMember
+                    | true => exact le_of_lt upperMember
+                  by_cases leftSmaller : -lower < upper
+                  · have magnitude : -toReal lower < toReal upper := by
+                      simpa [toReal_neg] using toReal_lt leftSmaller
+                    have upperAbs :
+                        (Upper.finite upper upperStrict).Contains |x| := by
+                      cases upperStrict with
+                      | false =>
+                          exact abs_le_right lowerWeak upperWeak (le_of_lt magnitude)
+                      | true => exact abs_lt_right lowerWeak upperMember magnitude
+                    simpa [Raw.absUnchecked, Raw.Contains, Lower.Contains,
+                      nonnegative, nonpositive, leftSmaller, toReal] using
+                        And.intro (abs_nonneg x) upperAbs
+                  · by_cases tied : -lower = upper
+                    · have magnitude : -toReal lower = toReal upper := by
+                        simpa [toReal_neg] using congrArg toReal tied
+                      have upperAbs :
+                          (Upper.finite upper (lowerStrict && upperStrict)).Contains |x| := by
+                        cases lowerStrict <;> cases upperStrict
+                        · exact abs_le_right lowerWeak upperWeak (le_of_eq magnitude)
+                        · exact abs_le_right lowerWeak upperWeak (le_of_eq magnitude)
+                        · exact abs_le_right lowerWeak upperWeak (le_of_eq magnitude)
+                        · exact abs_lt_tied lowerMember upperMember magnitude
+                      have image :
+                          (Raw.bounds (.finite lower lowerStrict)
+                              (.finite upper upperStrict)).absUnchecked =
+                            .bounds (.finite 0 false)
+                              (.finite upper (lowerStrict && upperStrict)) := by
+                        simp [Raw.absUnchecked, nonnegative, nonpositive, tied]
+                      rw [image]
+                      exact ⟨by simp [Lower.Contains, toReal],
+                        upperAbs⟩
+                    · have magnitude : toReal upper < -toReal lower := by
+                        have notLess : ¬-toReal lower < toReal upper := by
+                          intro h
+                          exact leftSmaller (toReal_lt_iff.mp (by simpa [toReal_neg] using h))
+                        have notEqual : toReal upper ≠ -toReal lower := by
+                          intro h
+                          exact tied (toReal_inj.mp (by simpa [toReal_neg] using h.symm))
+                        exact lt_of_le_of_ne (le_of_not_gt notLess) notEqual
+                      have upperAbs :
+                          (Upper.finite (-lower) lowerStrict).Contains |x| := by
+                        cases lowerStrict with
+                        | false =>
+                            simpa [Upper.Contains, toReal_neg] using
+                              abs_le_left lowerWeak upperWeak (le_of_lt magnitude)
+                        | true =>
+                            simpa [Upper.Contains, toReal_neg] using
+                              abs_lt_left lowerMember upperWeak magnitude
+                      simpa [Raw.absUnchecked, Raw.Contains, Lower.Contains,
+                        nonnegative, nonpositive, leftSmaller, tied, toReal,
+                        toReal_neg] using And.intro (abs_nonneg x) upperAbs
+
+/-- A successful public absolute value has exactly the normalized selected
+raw cuts. -/
+theorem contains_absWithin {limit : EndpointLimit}
+    {input result : Hex.Interval}
+    (checked : absWithin limit input = .ready result) (x : ℝ) :
+    result.Contains x ↔ (Raw.absUnchecked input.view).Contains x := by
+  simp only [Contains]
+  rw [view_absWithin_ready checked, contains_normalize]
+
+/-- Absolute value maps every input member into the successful public image. -/
+theorem abs_mem_absWithin {limit : EndpointLimit}
+    {input result : Hex.Interval} {x : ℝ}
+    (checked : absWithin limit input = .ready result)
+    (member : input.Contains x) : result.Contains |x| :=
+  (contains_absWithin checked |x|).2 (rawContains_abs input.view member)
+
+end Hex.Interval

--- a/HexIntervalMathlib/Interval.lean
+++ b/HexIntervalMathlib/Interval.lean
@@ -447,7 +447,8 @@ private theorem upperContains_neg (lower : Lower) (x : ℝ) :
         rw [toReal_neg]
         constructor <;> intro bound <;> linarith
 
-private theorem rawContains_neg (raw : Raw) (x : ℝ) :
+/-- Raw negation contains `x` exactly when its source contains `-x`. -/
+theorem contains_negUnchecked (raw : Raw) (x : ℝ) :
     raw.negUnchecked.Contains x ↔ raw.Contains (-x) := by
   cases raw with
   | empty => simp [Raw.negUnchecked, Raw.Contains]
@@ -469,6 +470,6 @@ theorem contains_negWithin {limit : EndpointLimit} {input result : Hex.Interval}
     result.Contains x ↔ input.Contains (-x) := by
   simp only [Contains]
   rw [view_negWithin_ready checked, contains_normalize]
-  exact rawContains_neg input.view x
+  exact contains_negUnchecked input.view x
 
 end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -12,7 +12,9 @@ real value of a dyadic endpoint and membership for every public interval cut:
 strict or closed finite ends, independent unbounded ends, and canonical empty.
 `HexIntervalMathlib.Addition` and `HexIntervalMathlib.Subtraction` add the
 public arithmetic image theorems, while `HexIntervalMathlib.MinMax` supplies
-selected-cut and real-image enclosure theorems for minimum and maximum.
+selected-cut and real-image enclosure theorems for minimum and maximum, and
+`HexIntervalMathlib.Absolute` supplies the corresponding absolute-value
+theorems.
 
 For every successful resource-checked public operation it proves:
 
@@ -39,6 +41,10 @@ For every successful resource-checked public operation it proves:
   computed selected cuts;
 - `min_mem_minWithin` and `max_mem_maxWithin`: pointwise real minimum and
   maximum of two input members belong to every successful result.
+- `contains_absWithin`: exact membership in the normalized selected absolute
+  value cuts;
+- `abs_mem_absWithin`: the absolute value of every input member belongs to
+  every successful result.
 
 These theorems depend on the exact successful `BuildResult` equation. A
 resource refusal has no set interpretation and is never treated as an empty
@@ -64,7 +70,9 @@ membership, exact hull closure and both input inclusions, negation transport,
 addition and subtraction cut exactness and image transport, and the exact
 ordinary-kernel axiom surface. `HexIntervalMathlib.MinMaxConformance` separately
 pins exact selected cuts, both image enclosures, and their axiom surfaces; it
-does not assert a set-image converse.
+does not assert a set-image converse. The interval conformance module also pins
+absolute-value cut exactness, image transport, and its ordinary-kernel axiom
+surface.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,9 +7,10 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-negation, addition, subtraction, minimum, and maximum. Propagator, provider, replay, and tactic modules remain experiments
-and are not re-exported by the public umbrella. The user-facing tactic contract
-below is the release target, not a claim that the tactic is already supported.
+negation, addition, subtraction, minimum, maximum, and absolute value.
+Propagator, provider, replay, and tactic modules remain experiments and are not
+re-exported by the public umbrella. The user-facing tactic contract below is
+the release target, not a claim that the tactic is already supported.
 
 The tactic proves bounds for ordinary Lean expressions over `ℝ`. It reads
 bounds from the local context, reifies shared expressions to an immutable

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -153,6 +153,15 @@ private def atMostOne : Hex.Interval :=
 private def atLeastOne : Hex.Interval :=
   ready (.bounds (.finite (d 1) false) .unbounded)
 private def closed23 : Hex.Interval := ready (finite 2 false 3 false)
+private def closedNeg21 : Hex.Interval := ready (finite (-2) false (-1) false)
+private def negOneToOpenZero : Hex.Interval := ready (finite (-1) false 0 true)
+private def closedNeg21Cross : Hex.Interval := ready (finite (-2) false 1 false)
+private def rightAbsClosed : Hex.Interval := ready (finite (-1) false 2 false)
+private def rightAbsOpen : Hex.Interval := ready (finite (-1) false 2 true)
+private def leftAbsOpen : Hex.Interval := ready (finite (-2) true 1 false)
+private def tiedAbsMixed : Hex.Interval := ready (finite (-1) false 1 true)
+private def tiedAbsMixedReverse : Hex.Interval := ready (finite (-1) true 1 false)
+private def tiedAbsOpen : Hex.Interval := ready (finite (-1) true 1 true)
 private def bridgeLeft : Hex.Interval := ready (finite 1 false 4 false)
 private def bridgeRight : Hex.Interval := ready (finite 3 false 12 false)
 private def openClosed01 : Hex.Interval := ready (finite 0 true 1 false)
@@ -175,6 +184,15 @@ private def powerBand : Hex.Interval :=
   match Hex.Interval.betweenWithin
       { maxEndpointHeight := 256, maxAlignmentShift := 128 }
       powerPlusOne false powerPlusTwo false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def absFar : Dyadic := .ofOdd 1 200 (by decide)
+
+private def absCrossFar : Hex.Interval :=
+  match Hex.Interval.betweenWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 200 }
+      (-absFar) false (d 1) false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
@@ -214,6 +232,12 @@ private def farLower : Hex.Interval :=
 private def farUpper : Hex.Interval :=
   match Hex.Interval.belowWithin
       { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } far false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+private def farNegative : Hex.Interval :=
+  match Hex.Interval.belowWithin
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } (-far) false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
@@ -257,6 +281,110 @@ private def mediumToOne : Hex.Interval :=
   match Hex.Interval.hullWithin smallLimit openLower12 openLower12 with
   | .ready interval => interval == openLower12
   | .resourceLimit _ => false
+
+-- Absolute value preserves sign-separated cuts, reverses negative cuts, and
+-- closes zero exactly when the source contains it.
+#guard
+  match Hex.Interval.absWithin smallLimit Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit openClosed01 with
+  | .ready interval => interval == openClosed01
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit closedNeg21 with
+  | .ready interval => interval.view == finite 1 false 2 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit negOneToOpenZero with
+  | .ready interval => interval.view == finite 0 true 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit closedNeg21Cross with
+  | .ready interval => interval.view == finite 0 false 2 false
+  | .resourceLimit _ => false
+
+-- Both unequal selector directions and the selected endpoint's strictness are
+-- observable. The larger right magnitude contributes its own closure flag;
+-- the larger left magnitude inherits the source lower cut's strictness after
+-- negation.
+#guard
+  match Hex.Interval.absWithin smallLimit rightAbsClosed with
+  | .ready interval => interval.view == finite 0 false 2 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit rightAbsOpen with
+  | .ready interval => interval.view == finite 0 false 2 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit leftAbsOpen with
+  | .ready interval => interval.view == finite 0 false 2 true
+  | .resourceLimit _ => false
+
+-- At tied magnitudes the image endpoint is attained when either source end
+-- is attained; it remains strict only when both are strict.
+#guard
+  match Hex.Interval.absWithin smallLimit tiedAbsMixed with
+  | .ready interval => interval.view == finite 0 false 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit tiedAbsMixedReverse with
+  | .ready interval => interval.view == finite 0 false 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit tiedAbsOpen with
+  | .ready interval => interval.view == finite 0 false 1 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit Hex.Interval.whole with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit atLeastOne with
+  | .ready interval => interval == atLeastOne
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.absWithin smallLimit atMostOne with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+-- Opposite endpoint magnitudes are preflighted before the unchecked selector
+-- can align their mantissas.
+#guard
+  match Hex.Interval.absWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 64 } absCrossFar with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 200
+
+-- A sign-separated case needs no selector comparison, but the selected
+-- endpoint is still re-admitted under the caller's current retained-height
+-- budget.
+#guard
+  match Hex.Interval.absWithin smallLimit farNegative with
+  | .ready _ => false
+  | .resourceLimit cost => cost.lower.exponentMagnitude == 1000000000
+
+-- Returning an otherwise unchanged positive interval still rechecks its final
+-- canonical comparison under the current caller budget.
+#guard
+  match Hex.Interval.absWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 64 } mediumToOne with
+  | .ready _ => false
+  | .resourceLimit cost => cost.alignmentShift == 200
 
 #guard
   match Hex.Interval.hullWithin smallLimit openAtOne openAtOne with

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -10,7 +10,7 @@ import HexIntervalMathlib
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
 ordinary-kernel meaning of every successful intersection, hull, addition,
-subtraction, and negation.
+subtraction, negation, and absolute value.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -94,6 +94,20 @@ theorem subImage {limit : Hex.Interval.EndpointLimit}
     result.Contains (x - y) :=
   Hex.Interval.sub_mem_subWithin checked leftMember rightMember
 
+/-- A successful absolute value has exactly its selected raw cuts. -/
+theorem absExact {limit : Hex.Interval.EndpointLimit}
+    {input result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.absWithin limit input = .ready result) :
+    result.Contains x ↔ input.view.absUnchecked.Contains x :=
+  Hex.Interval.contains_absWithin checked x
+
+/-- Source membership is consumed by the absolute-value image theorem. -/
+theorem absImage {limit : Hex.Interval.EndpointLimit}
+    {input result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.absWithin limit input = .ready result)
+    (member : input.Contains x) : result.Contains |x| :=
+  Hex.Interval.abs_mem_absWithin checked member
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -133,5 +147,13 @@ theorem subImage {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.subImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms subImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.absExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms absExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.absImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms absImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -364,7 +364,7 @@ lean_lib HexIntervalMathlibExperiment where
 lean_lib HexIntervalMathlib where
   globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
     `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
-    `HexIntervalMathlib.MinMax].map Glob.one
+    `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T074628Z.md
+++ b/progress/20260815T074628Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Added checked public `absWithin` with exact empty, sign-separated,
+  zero-crossing, unbounded, endpoint-attainment, and tied-magnitude behavior.
+- Preflighted the only new selector comparison, between opposite endpoint
+  magnitudes, and retained `ofRawWithin` as the endpoint-height and final
+  canonical-comparison boundary.
+- Added the active Mathlib companion theorem characterizing successful raw
+  cuts and the real image theorem sending every member `x` to `|x|`.
+- Added discriminating computational guards, theorem/axiom guards, umbrella
+  registration, the exact proof-only factor-freshness exemption, and current
+  SPEC/file-organization documentation.
+
+# Current frontier
+
+- Absolute value is complete locally as a supported checked primitive on exact
+  current main. Multiplication is being completed independently and does not
+  overlap this operation's selector or proof helpers.
+
+# Next step
+
+- Rebase after the multiplication and BKLNW edges settle, rerun the exact
+  focused/static suite, obtain an independent exact-head review, and open the
+  operation as its own literal PR.
+- Continue the exact primitive surface with min/max, direct powers, and then
+  precision-indexed reciprocal/division after their allocation audits.
+
+# Blockers
+
+- No premise or proof blocker was found. The theorem intentionally proves the
+  direct real image enclosure and exact selected cuts without introducing an
+  unchecked total API.

--- a/progress/20260815T083107Z.md
+++ b/progress/20260815T083107Z.md
@@ -1,0 +1,41 @@
+# Accomplished
+
+- Replayed the checked absolute-value feature onto exact minimum/maximum
+  candidate `a847946084e6c3fae362343db8db2dbeed32a7fe`, preserving the BKLNW,
+  minimum/maximum, public arithmetic, conformance, and Lake registrations.
+- Re-audited the complete raw case split. Empty is preserved; sign-separated
+  finite cuts retain and reverse strictness correctly; zero-crossing and
+  unbounded cases have the right closed-zero behavior; tied magnitudes are
+  strict exactly when both source endpoints are strict.
+- Confirmed that sign tests against dyadic zero do not align mantissas, the
+  opposite-magnitude comparison cost is computed before negation or unchecked
+  selection, and every selected candidate crosses `ofRawWithin` for retained
+  endpoint and final-comparison validation.
+- Rechecked the exact selected-cut theorem and the load-bearing real-image
+  theorem. Added the missing reversed mixed-attainment runtime discriminator
+  and completed the public umbrella and Mathlib SPEC descriptions.
+- Recomputed the exact proof-only Lake exemption for blob
+  `6afd48a39be31f9d1628c6256b9b7a7b4c724e3d`.
+- Passed the focused public/Mathlib conformance build and a clean 9,005-job
+  public/PNT build including BKLNW, FKS2, all Table 12 variants, log tables,
+  exponential tail, integral canary, and polynomial dispatch. Static, release,
+  trust, Mathlib-free bench, source-pinned PNT inventory, and factor freshness
+  checks are green.
+
+# Current frontier
+
+Absolute value is a clean local feature candidate stacked directly on the
+exact minimum/maximum candidate. No remote action has been taken.
+
+# Next step
+
+Land minimum/maximum first, then rebase this exact feature onto its merged main
+and perform the requested fresh exact-head review and CI cycle.
+
+# Blockers
+
+None for the requested focused/public/PNT gates. An additional broad
+`HexConformance` build reached 9,415 of 9,464 jobs (including every interval and
+PNT target) before an unrelated `HexGF2.Clmul` rebuild exhausted the full host
+filesystem; the scoped clean rebuild above completed successfully after
+discarding only recoverable shared Hex build artifacts.

--- a/progress/20260815T084631Z.md
+++ b/progress/20260815T084631Z.md
@@ -1,0 +1,29 @@
+# Accomplished
+
+- Completed the supported absolute-value runtime SPEC surface and semantic
+  contract: `absWithin` is listed with the public operations, has exact
+  normalized selected-cut semantics, and has a one-way real-image theorem
+  without a converse-image claim.
+- Added discriminating successful runtime guards for a larger right magnitude
+  with both closed and strict selected upper cuts, and for a larger left
+  magnitude whose strict source lower cut becomes the strict result upper cut.
+- Replaced `HexIntervalMathlib.Absolute`'s transitive subtraction import with
+  its direct interval-semantics dependency and rebuilt the proof module.
+- Preserved the exact minimum/maximum main parent, all public/PNT
+  registrations, and the existing Lake blob and proof-only exemption.
+
+# Current frontier
+
+The repaired absolute-value commit is a direct child of exact main
+`3189a20bb3446d438c95e614f2833c33197d8f4c`. The independently prepared
+direct-power prerequisite will be rebased unchanged directly above it.
+
+# Next step
+
+Push the repaired absolute-value boundary to its existing feature branch and
+allow the normal push-triggered review/CI sequence to run. Retain the power
+prerequisite locally until absolute value lands.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -334,5 +334,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "da0f063465448492e3eaedd3e6a4784d6633a588",
     "reason": "Additionally registers the supported HexIntervalMathlib minimum/maximum semantics module and the Mathlib-free and proof-only conformance modules; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "6afd48a39be31f9d1628c6256b9b7a7b4c724e3d",
+    "reason": "Additionally registers the supported HexIntervalMathlib absolute-value semantics module on top of the retained BKLNW and minimum/maximum registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
Adds checked public `absWithin` over the sealed interval API.

The implementation performs allocation-free sign tests, then preflights the sign-invariant magnitude comparison before any raw negation or opposite-endpoint selection. Every selected result still crosses `ofRawWithin`, so resource refusal remains distinct from canonical empty.

The Mathlib companion proves exact successful selected-cut semantics and that every source member maps to its real absolute value in the successful result. Conformance covers empty, sign-separated and zero-crossing intervals, open/closed zero, tied magnitudes in both mixed orders, unbounded inputs, pre-allocation refusal, retained-endpoint refusal, and final canonical-comparison refusal. Exact axiom reports remain ordinary kernel only.

This PR is a direct child of the merged checked min/max layer and preserves the complete PNT+ registration and freshness surface.