### PR TITLE
feat(interval): preflight direct power growth

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -18,7 +18,7 @@ The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, minimum, maximum, and
 absolute value. A separate arithmetic resource layer preflights product growth
-without yet exposing interval multiplication. Raw cuts remain
-visible as the explicit decoder and inspection boundary; D2 propagation and
-replay experiments still live outside this supported umbrella.
+and direct-power growth without yet exposing interval multiplication or power.
+Raw cuts remain visible as the explicit decoder and inspection boundary; D2
+propagation and replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -13,11 +13,12 @@ public import HexInterval.Canonical
 /-!
 # Arithmetic resource preflight
 
-Endpoint comparison cost does not bound numerator growth in multiplication.
-This module supplies a separate, nonbreaking result and diagnostic layer for
-checked arithmetic. Existing constructors and the additive public operations
-continue to return `BuildResult`; multiplicative operations can report product
-growth without fabricating a `CompareCost`.
+Endpoint comparison cost does not bound numerator growth in multiplication or
+direct powers. This module supplies a separate, nonbreaking result and
+diagnostic layer for checked arithmetic. Existing constructors and supported
+public interval operations continue to return `BuildResult`; future
+multiplicative operations can report growth without fabricating a
+`CompareCost`.
 -/
 
 namespace Hex.Interval.Arithmetic
@@ -91,6 +92,46 @@ def preflightMul (limit : EndpointLimit) (left right : Dyadic) :
           encodedExponentBits := EndpointCost.natBits exponentMagnitude
           exponentMagnitude }
   let cost : Growth := { sources := [leftCost, rightCost], predicted }
+  if !cost.allowed limit then
+    throw (.growth cost)
+  pure cost
+
+/-- Preflight a direct dyadic natural power without raising its mantissa.
+
+The source endpoint is admitted before any products involving the exponent
+are formed. The remaining calculations use arbitrary-precision natural-number
+metadata, not fixed-width counters: a conservative numerator-bit count and the
+exact magnitude of the result exponent. Numerators of absolute value one are
+treated exactly, so powers of `1` and `-1` are not spuriously charged in
+proportion to the exponent.
+
+This is only a retained-endpoint growth prerequisite. It does not bound the
+execution work of `Nat.pow` or conversion of the natural exponent into Core's
+signed dyadic-exponent multiplication. In particular, a unit mantissa at
+dyadic exponent zero can pass this growth check for an arbitrarily large
+natural exponent. A future public power operation must enforce a separate
+exponent/work limit before invoking `Dyadic.pow`. -/
+def preflightPow (limit : EndpointLimit) (source : Dyadic) (exponent : Nat) :
+    Except Cost Growth := do
+  let sourceCost := EndpointCost.ofDyadic source
+  if !sourceCost.allowed limit then
+    throw (.endpoint sourceCost)
+  let predicted :=
+    match source with
+    | .zero =>
+        if exponent = 0 then EndpointCost.ofDyadic 1
+        else EndpointCost.ofDyadic 0
+    | .ofOdd numerator sourceExponent _ =>
+        if exponent = 0 then EndpointCost.ofDyadic 1
+        else
+          let numeratorBits :=
+            if numerator.natAbs = 1 then 1
+            else sourceCost.numeratorBits * exponent
+          let exponentMagnitude := sourceExponent.natAbs * exponent
+          { numeratorBits
+            encodedExponentBits := EndpointCost.natBits exponentMagnitude
+            exponentMagnitude }
+  let cost : Growth := { sources := [sourceCost], predicted }
   if !cost.allowed limit then
     throw (.growth cost)
   pure cost

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -477,19 +477,41 @@ the selector aligns finite dyadics, and the selected raw cuts then cross
 `ofRawWithin`. Thus an interval admitted under a larger earlier budget cannot
 force an unchecked alignment or silently turn refusal into empty.
 
-The supported tree also contains the resource prerequisite for multiplicative
-arithmetic, but not yet interval multiplication itself. `Arithmetic.Growth`
-records admitted source endpoint costs and a conservative predicted result;
-multiplication records the sum of input numerator-bit lengths and the exact
-magnitude of the signed exponent sum. A direct power can reuse the same shape
-with one source and its separately predicted endpoint. `Arithmetic.preflightMul`
-checks the inputs before forming that small signed exponent sum and never
-multiplies their mantissas. `Arithmetic.Cost.growth` keeps this refusal distinct
-from endpoint and exact comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
+The supported tree also contains the resource prerequisites for multiplicative
+arithmetic, but not yet interval multiplication or powers. `Arithmetic.Growth`
+records admitted source endpoint costs and a conservative predicted result.
+Multiplication records the sum of input numerator-bit lengths and the exact
+magnitude of the signed exponent sum. `Arithmetic.preflightMul` checks both
+inputs before forming that small signed exponent sum and never multiplies their
+mantissas. For example, under endpoint height `8`, the endpoints `255` and
+`255` and their comparison are admitted, while their predicted sixteen-bit
+product numerator is refused before multiplication.
+
+`Arithmetic.preflightPow` applies the same boundary to a direct natural power
+with one source. It predicts the exact magnitude of the dyadic exponent and a
+conservative mantissa-bit count without raising the mantissa. Numerators of
+absolute value one retain their exact one-bit cost, so large powers of `1`,
+`-1`, and unit-mantissa powers of two do not incur fictitious mantissa growth;
+powers of two are still charged their exact signed exponent magnitude. The
+metadata uses arbitrary-precision `Nat` arithmetic rather than fixed-width
+counters. Under endpoint height `8`, `3^4` is admitted by its eight-bit bound,
+while `3^5` is refused from its ten-bit bound before `Dyadic.pow` allocates the
+result. A quarter cubed is admitted with exponent magnitude six, while its
+fourth power is refused because one numerator bit plus exponent magnitude
+eight exceeds the retained-height budget.
+
+This preflight bounds retained endpoint growth only. It does not bound the
+execution work of `Nat.pow` or the conversion of the natural exponent used in
+Core's signed dyadic-exponent multiplication, and it is not the complete
+resource gate for a public interval power. In particular, when the dyadic
+exponent is zero and the mantissa has absolute value one, arbitrarily large
+natural exponents pass the endpoint-growth check. A future `powWithin` must add
+and enforce a separate exponent/work cap before invoking `Dyadic.pow`.
+
+`Arithmetic.Cost.growth` keeps these refusals distinct from endpoint and exact
+comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
 result so the existing `BuildResult` APIs above do not acquire a misleading or
-breaking cost variant. For example, under endpoint height `8`, the endpoints
-`255` and `255` and their comparison are admitted, while their predicted
-sixteen-bit product numerator is refused before multiplication.
+breaking cost variant.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
@@ -4005,6 +4027,9 @@ their declared cost inside a scheduler bound.
   normalization.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
+- `HexInterval/Arithmetic.lean`: multiplication and direct-power endpoint
+  growth prerequisites; it does not expose an interval multiplication or power
+  operation.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
   negation, addition, subtraction, minimum, maximum, and absolute value,
   followed by future arithmetic, splitting, and regularization operations.

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -139,6 +139,119 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
         !cost.allowed eightBitLimit
   | _ => false
 
+-- Direct powers have their own one-source growth prediction. `3^4` fits the
+-- eight-bit endpoint limit, while `3^5` is refused from metadata before
+-- `Dyadic.pow` can allocate its mantissa.
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d 3) 4 with
+  | .ok cost =>
+      cost.sources.map (·.numeratorBits) == [2] &&
+        cost.predicted.numeratorBits == 8 &&
+        (EndpointCost.ofDyadic ((d 3) ^ 4)).numeratorBits == 7 &&
+        cost.predicted.exponentMagnitude == 0
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d 3) 5 with
+  | .error (.growth cost) =>
+      cost.sources.map (·.numeratorBits) == [2] &&
+        cost.predicted.numeratorBits == 10 &&
+        !cost.allowed eightBitLimit
+  | _ => false
+
+-- Unit numerators remain unit-sized even at a large exponent. This keeps the
+-- preflight useful for exact powers of `1`, `-1`, and powers of two.
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d 1) 1000000000 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic (d 1)
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d (-1)) 1000000001 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic (d 1)
+  | _ => false
+
+-- The direct-image convention keeps `0^0 = 1`; positive powers of zero stay
+-- zero. Both have exact constant-size predictions.
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d 0) 0 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic ((d 0) ^ 0)
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit (d 0) 1000000000 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic ((d 0) ^ 1000000000)
+  | _ => false
+
+private def quarter : Dyadic := .ofOdd 1 2 (by decide)
+private def two : Dyadic := .ofOdd 1 (-1) (by decide)
+private def threeHalves : Dyadic := .ofOdd 3 1 (by decide)
+private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
+
+-- Both signs of Core's signed dyadic exponent multiplication are reflected by
+-- the exact magnitude metadata. Unit mantissas do not acquire numerator cost.
+#guard
+  match Arithmetic.preflightPow eightBitLimit two 3 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic (two ^ 3)
+  | _ => false
+
+-- A non-unit mantissa and nonzero dyadic exponent contribute independently to
+-- the predicted retained height. Six mantissa bits plus exponent magnitude
+-- three exceed the eight-bit combined endpoint limit.
+#guard
+  match Arithmetic.preflightPow eightBitLimit threeHalves 3 with
+  | .error (.growth cost) =>
+      cost.predicted.numeratorBits == 6 &&
+        cost.predicted.exponentMagnitude == 3 &&
+        !cost.allowed eightBitLimit
+  | _ => false
+
+-- Sign does not alter growth metadata, and exponent one is the identity case.
+#guard
+  match Arithmetic.preflightPow eightBitLimit negThreeHalves 1 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic (negThreeHalves ^ 1)
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit quarter 3 with
+  | .ok cost =>
+      cost.predicted.numeratorBits == 1 &&
+        cost.predicted.exponentMagnitude == 6
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit quarter 4 with
+  | .error (.growth cost) =>
+      cost.predicted.numeratorBits == 1 &&
+        cost.predicted.exponentMagnitude == 8 &&
+        !cost.allowed eightBitLimit
+  | _ => false
+
+-- An inadmissible source is reported before multiplying its exponent by the
+-- natural power. This separates source admission from predicted growth.
+#guard
+  match Arithmetic.preflightPow eightBitLimit far 1000000000 with
+  | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit far 0 with
+  | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+-- Growth metadata is arbitrary-precision `Nat`, not a machine counter. This
+-- exponent is one beyond `UInt64` range; it is diagnosed without wrapping and
+-- without invoking Core power.
+private def beyondUInt64 : Nat := 18446744073709551616
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit two beyondUInt64 with
+  | .error (.growth cost) =>
+      cost.predicted.numeratorBits == 1 &&
+        cost.predicted.exponentMagnitude == beyondUInt64 &&
+        !cost.allowed eightBitLimit
+  | _ => false
+
 private def ready (raw : Raw) : Hex.Interval :=
   match Hex.Interval.ofRawWithin smallLimit raw with
   | .ready interval => interval

--- a/progress/20260815T092233Z.md
+++ b/progress/20260815T092233Z.md
@@ -1,0 +1,31 @@
+# Accomplished
+
+- Restacked the direct-power growth prerequisite as one direct child of exact
+  merged absolute-value main `0ff321f28efcda881593a84c81efabcdb1db45f5`.
+- Made the resource boundary explicit in the API documentation and runtime
+  SPEC: `preflightPow` bounds retained endpoint growth only, not `Nat.pow`
+  execution work or natural-to-signed exponent conversion. A future public
+  `powWithin` must apply a separate exponent/work cap before Core power.
+- Added a combined non-unit/nonzero-precision canary for `(3/2)^3`, pinning six
+  predicted mantissa bits and exponent magnitude three, plus a negative
+  non-unit exponent-one identity canary.
+- Retained the exact zero, unit-mantissa, signed-precision, source-refusal, and
+  arbitrary-precision metadata checks, without adding a public interval power
+  operation or semantic theorem.
+- Replaced the two out-of-order prerequisite progress records with this single
+  current handoff and kept the Lake blob and freshness exemption unchanged.
+
+# Current frontier
+
+The prerequisite is a single clean commit on exact merged absolute-value main.
+Its remote PR remains prerequisite-only and introduces no Lake registration.
+
+# Next step
+
+Complete the normal exact-head review and CI cycle, then land this resource
+edge before implementing the separately capped public interval power.
+
+# Blockers
+
+None. The future operation still requires an exponent/work budget in addition
+to this retained endpoint-growth check.


### PR DESCRIPTION
## Summary

- add `Arithmetic.preflightPow`, a one-source resource preflight for direct dyadic natural powers
- admit the source before exponent metadata products, conservatively bound powered mantissa bits, and compute exact signed-exponent magnitude without invoking `Dyadic.pow`
- handle `0^0`, positive powers of zero, and unit mantissas exactly; retain arbitrary-precision `Nat` diagnostics and discriminating refusal guards

This is a resource prerequisite only. It does not add or claim a public `powWithin` operation or a real-image theorem.

## Validation

- `lake build HexInterval HexInterval.Conformance HexIntervalMathlib.Absolute HexIntervalMathlib HexIntervalMathlib.IntervalConformance HexInterval.MinMaxConformance HexIntervalMathlib.MinMaxConformance`
- static, phase-4, conformance-registration, release-manifest, manual-split, trust-surface, PNT-inventory, and factor-freshness checks