### PR TITLE
feat(interval): add resource-safe public multiplication

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexInterval.Interval
+public import HexInterval.Multiplication
 
 public section
 
@@ -16,9 +17,10 @@ data, propagation search, and replayable derivations.
 
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
-intersection, hull, negation, addition, subtraction, minimum, maximum, and
-absolute value. A separate arithmetic resource layer preflights product growth
-and direct-power growth without yet exposing interval multiplication or power.
-Raw cuts remain visible as the explicit decoder and inspection boundary; D2
-propagation and replay experiments still live outside this supported umbrella.
+intersection, hull, negation, addition, subtraction, multiplication, minimum,
+maximum, and absolute value. The arithmetic resource layer preflights product
+and direct-power growth independently of exact comparison work; public interval
+power remains future work. Raw cuts remain visible as the explicit decoder and
+inspection boundary; D2 propagation and replay experiments still live outside
+this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -8,7 +8,7 @@ module
 
 public import HexInterval.Canonical
 
-@[expose] public section
+public section
 
 /-!
 # Arithmetic resource preflight
@@ -16,9 +16,11 @@ public import HexInterval.Canonical
 Endpoint comparison cost does not bound numerator growth in multiplication or
 direct powers. This module supplies a separate, nonbreaking result and
 diagnostic layer for checked arithmetic. Existing constructors and supported
-public interval operations continue to return `BuildResult`; future
-multiplicative operations can report growth without fabricating a
-`CompareCost`.
+public interval operations continue to return `BuildResult`; multiplicative
+operations can report growth without fabricating a `CompareCost`. Concrete
+corner enumeration and interval multiplication live in
+`HexInterval.Multiplication`, not in this reusable cost layer; direct-power
+preflight remains a prerequisite rather than a public interval-power API.
 -/
 
 namespace Hex.Interval.Arithmetic
@@ -62,7 +64,7 @@ namespace Result
 /-- Embed the existing checked-construction result into the richer arithmetic
 result without changing the constructor, intersection, hull, addition, or
 subtraction APIs. -/
-def ofBuild : BuildResult → Result
+@[expose] def ofBuild : BuildResult → Result
   | .ready interval => .ready interval
   | .resourceLimit cost => .resourceLimit (.comparison cost)
 

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -18,7 +18,9 @@ hull, negation, addition, subtraction, minimum, maximum, and absolute value.
 The operations retain a resource-aware result: public
 interval values do not remember the construction budget under which their
 endpoints were admitted, so a later comparison must preflight its own alignment
-work.
+work. Resource-checked multiplication is kept in `HexInterval.Multiplication`
+because it additionally depends on arithmetic-growth diagnostics and corner
+candidate selection.
 -/
 
 namespace Hex.Interval

--- a/HexInterval/Multiplication.lean
+++ b/HexInterval/Multiplication.lean
@@ -1,0 +1,350 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Interval
+
+@[expose] public section
+
+/-!
+# Resource-checked interval multiplication
+
+The executable core enumerates the four products of extended endpoint cuts,
+omitting the undefined formal products `0 * ±∞`, and adds an attained zero
+candidate exactly when either nonempty factor contains zero. Every finite
+endpoint is admitted before sign inspection, all finite corner products pass
+`Arithmetic.preflightMul` before the first mantissa multiplication, and all
+finite candidate comparisons are admitted before extremum selection.
+-/
+
+namespace Hex.Interval
+
+namespace Raw.Mul
+
+/-- An endpoint viewed in the extended real line. -/
+inductive Edge where
+  | negInf
+  | finite (value : Dyadic) (strict : Bool)
+  | posInf
+  deriving DecidableEq
+
+/-- A product-extremum candidate. Infinite candidates are never attained;
+finite candidates remember whether their endpoint product is attained. -/
+inductive Candidate where
+  | negInf
+  | finite (value : Dyadic) (attained : Bool)
+  | posInf
+  deriving DecidableEq
+
+/-- Lower cut as an extended endpoint. -/
+def lowerEdge : Lower → Edge
+  | .unbounded => .negInf
+  | .finite value strict => .finite value strict
+
+/-- Upper cut as an extended endpoint. -/
+def upperEdge : Upper → Edge
+  | .finite value strict => .finite value strict
+  | .unbounded => .posInf
+
+/-- Sign inspection after the caller has admitted comparison with zero. -/
+def signUnchecked (value : Dyadic) : Ordering :=
+  if value < 0 then .lt else if value = 0 then .eq else .gt
+
+/-- One extended corner product. Formal `0 * ±∞` contributes no corner;
+zero attainment is handled independently from interval membership. -/
+def productUnchecked : Edge → Edge → Option Candidate
+  | .finite left leftStrict, .finite right rightStrict =>
+      some (.finite (left * right) (!leftStrict && !rightStrict))
+  | .negInf, .negInf | .posInf, .posInf => some .posInf
+  | .negInf, .posInf | .posInf, .negInf => some .negInf
+  | .negInf, .finite value _ | .finite value _, .negInf =>
+      match signUnchecked value with
+      | .lt => some .posInf
+      | .eq => none
+      | .gt => some .negInf
+  | .posInf, .finite value _ | .finite value _, .posInf =>
+      match signUnchecked value with
+      | .lt => some .negInf
+      | .eq => none
+      | .gt => some .posInf
+
+/-- The four extended endpoint-pair recipes. -/
+def corners (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) : List (Edge × Edge) :=
+  let ll := lowerEdge leftLower
+  let lu := upperEdge leftUpper
+  let rl := lowerEdge rightLower
+  let ru := upperEdge rightUpper
+  [(ll, rl), (ll, ru), (lu, rl), (lu, ru)]
+
+/-- A lower cut permits zero after its finite comparison with zero is
+admitted. -/
+def lowerAllowsZeroUnchecked : Lower → Bool
+  | .unbounded => true
+  | .finite value strict =>
+      match signUnchecked value with
+      | .lt => true
+      | .eq => !strict
+      | .gt => false
+
+/-- An upper cut permits zero after its finite comparison with zero is
+admitted. -/
+def upperAllowsZeroUnchecked : Upper → Bool
+  | .unbounded => true
+  | .finite value strict =>
+      match signUnchecked value with
+      | .lt => false
+      | .eq => !strict
+      | .gt => true
+
+/-- Whether nonempty bounds contain zero. -/
+def containsZeroUnchecked (lower : Lower) (upper : Upper) : Bool :=
+  lowerAllowsZeroUnchecked lower && upperAllowsZeroUnchecked upper
+
+/-- Admit one finite endpoint before sign inspection. -/
+def preflightEdge (limit : EndpointLimit) : Edge → Except Arithmetic.Cost Unit
+  | .negInf | .posInf => pure ()
+  | .finite value _ =>
+      let cost := CompareCost.ofDyadic value 0
+      if cost.allowed limit then pure () else throw (.comparison cost)
+
+/-- Admit every endpoint sign inspection before any product is formed. -/
+def preflightEdges (limit : EndpointLimit) : List Edge → Except Arithmetic.Cost Unit
+  | [] => pure ()
+  | edge :: rest => do
+      preflightEdge limit edge
+      preflightEdges limit rest
+
+/-- Admit one finite corner product without multiplying its mantissas. -/
+def preflightProduct (limit : EndpointLimit) : Edge × Edge → Except Arithmetic.Cost Unit
+  | (.finite left _, .finite right _) => do
+      let _ ← Arithmetic.preflightMul limit left right
+      pure ()
+  | _ => pure ()
+
+/-- Admit all finite corner products before the first one is evaluated. -/
+def preflightProducts (limit : EndpointLimit) :
+    List (Edge × Edge) → Except Arithmetic.Cost Unit
+  | [] => pure ()
+  | pair :: rest => do
+      preflightProduct limit pair
+      preflightProducts limit rest
+
+/-- Evaluate already-admitted corner recipes. -/
+def evaluate : List (Edge × Edge) → List Candidate
+  | [] => []
+  | pair :: rest =>
+      match productUnchecked pair.1 pair.2 with
+      | none => evaluate rest
+      | some candidate => candidate :: evaluate rest
+
+/-- Admit one exact comparison between finite, already-bounded candidates. -/
+def preflightCompare (limit : EndpointLimit) : Candidate → Candidate →
+    Except Arithmetic.Cost Unit
+  | .finite left _, .finite right _ =>
+      let cost := CompareCost.ofDyadic left right
+      if cost.allowed limit then pure () else throw (.comparison cost)
+  | _, _ => pure ()
+
+/-- Admit all pairwise finite comparisons before extremum selection. -/
+def preflightComparisons (limit : EndpointLimit) :
+    List Candidate → Except Arithmetic.Cost Unit
+  | [] => pure ()
+  | candidate :: rest => do
+      for other in rest do
+        preflightCompare limit candidate other
+      preflightComparisons limit rest
+
+/-- Select the smaller already-admitted candidate, combining attainment at a
+tied finite value. -/
+def minUnchecked : Candidate → Candidate → Candidate
+  | .negInf, _ | _, .negInf => .negInf
+  | .posInf, candidate | candidate, .posInf => candidate
+  | left@(.finite leftValue leftAttained), right@(.finite rightValue rightAttained) =>
+      if leftValue < rightValue then left
+      else if leftValue = rightValue then
+        .finite leftValue (leftAttained || rightAttained)
+      else right
+
+/-- Select the larger already-admitted candidate, combining attainment at a
+tied finite value. -/
+def maxUnchecked : Candidate → Candidate → Candidate
+  | .posInf, _ | _, .posInf => .posInf
+  | .negInf, candidate | candidate, .negInf => candidate
+  | left@(.finite leftValue leftAttained), right@(.finite rightValue rightAttained) =>
+      if leftValue < rightValue then right
+      else if leftValue = rightValue then
+        .finite leftValue (leftAttained || rightAttained)
+      else left
+
+/-- Minimum of a nonempty candidate list. -/
+def minimum : Candidate → List Candidate → Candidate
+  | candidate, [] => candidate
+  | candidate, next :: rest => minimum (minUnchecked candidate next) rest
+
+/-- Maximum of a nonempty candidate list. -/
+def maximum : Candidate → List Candidate → Candidate
+  | candidate, [] => candidate
+  | candidate, next :: rest => maximum (maxUnchecked candidate next) rest
+
+/-- Convert the selected minimum to a lower cut. -/
+def lowerCut : Candidate → Lower
+  | .negInf => .unbounded
+  | .finite value attained => .finite value (!attained)
+  | .posInf => .unbounded
+
+/-- Convert the selected maximum to an upper cut. -/
+def upperCut : Candidate → Upper
+  | .negInf => .unbounded
+  | .finite value attained => .finite value (!attained)
+  | .posInf => .unbounded
+
+/-- Candidate list for two nonempty raw bounds. -/
+def candidatesUnchecked (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) : List Candidate :=
+  let cornerCandidates := evaluate (corners leftLower leftUpper rightLower rightUpper)
+  if containsZeroUnchecked leftLower leftUpper ||
+      containsZeroUnchecked rightLower rightUpper then
+    .finite 0 true :: cornerCandidates
+  else
+    cornerCandidates
+
+/-- Convert a candidate list to its enclosing raw cuts. The empty fallback is
+unreachable for canonical nonempty interval inputs, but keeps this decoder
+helper total on arbitrary raw data. -/
+def result : List Candidate → Raw
+  | [] => .empty
+  | first :: rest =>
+      .bounds (lowerCut (minimum first rest)) (upperCut (maximum first rest))
+
+end Raw.Mul
+
+namespace Raw
+
+/-- Exact raw multiplication candidate without resource checks. Call
+`mulChecked` at untrusted boundaries. -/
+def mulUnchecked : Raw → Raw → Raw
+  | .empty, _ | _, .empty => .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      Mul.result
+        (Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper)
+
+/-- Compute exact multiplication cuts with preflighted sign inspection,
+product growth, and candidate ordering. Empty is absorbing. This raw boundary
+accepts arbitrary cut data; the supported `mulWithin` entry point supplies
+canonical public inputs and checks the final result. -/
+def mulChecked (limit : EndpointLimit) : Raw → Raw → Except Arithmetic.Cost Raw
+  | .empty, _ | _, .empty => pure .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper => do
+      let recipes := Mul.corners leftLower leftUpper rightLower rightUpper
+      Mul.preflightEdges limit
+        [Mul.lowerEdge leftLower, Mul.upperEdge leftUpper,
+          Mul.lowerEdge rightLower, Mul.upperEdge rightUpper]
+      Mul.preflightProducts limit recipes
+      let candidates :=
+        Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper
+      Mul.preflightComparisons limit candidates
+      pure (Mul.result candidates)
+
+/-- Every successful checked raw computation returns the corresponding exact
+unchecked candidate. -/
+theorem eq_mulUnchecked_of_mulChecked {limit : EndpointLimit} {left right raw : Raw}
+    (checked : mulChecked limit left right = .ok raw) :
+    raw = mulUnchecked left right := by
+  cases left with
+  | empty =>
+      change Except.ok .empty = Except.ok raw at checked
+      cases checked
+      rfl
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty =>
+          change Except.ok .empty = Except.ok raw at checked
+          cases checked
+          rfl
+      | bounds rightLower rightUpper =>
+          let edges :=
+            [Mul.lowerEdge leftLower, Mul.upperEdge leftUpper,
+              Mul.lowerEdge rightLower, Mul.upperEdge rightUpper]
+          let recipes := Mul.corners leftLower leftUpper rightLower rightUpper
+          let candidates :=
+            Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper
+          cases edgeCheck : Mul.preflightEdges limit edges with
+          | error cost =>
+              change (do
+                Mul.preflightEdges limit edges
+                Mul.preflightProducts limit recipes
+                Mul.preflightComparisons limit candidates
+                pure (Mul.result candidates)) = .ok raw at checked
+              rw [edgeCheck] at checked
+              contradiction
+          | ok value =>
+              cases value
+              cases productCheck : Mul.preflightProducts limit recipes with
+              | error cost =>
+                  change (do
+                    Mul.preflightEdges limit edges
+                    Mul.preflightProducts limit recipes
+                    Mul.preflightComparisons limit candidates
+                    pure (Mul.result candidates)) = .ok raw at checked
+                  rw [edgeCheck, productCheck] at checked
+                  contradiction
+              | ok value =>
+                  cases value
+                  cases comparisonCheck : Mul.preflightComparisons limit candidates with
+                  | error cost =>
+                      change (do
+                        Mul.preflightEdges limit edges
+                        Mul.preflightProducts limit recipes
+                        Mul.preflightComparisons limit candidates
+                        pure (Mul.result candidates)) = .ok raw at checked
+                      rw [edgeCheck, productCheck, comparisonCheck] at checked
+                      contradiction
+                  | ok value =>
+                      cases value
+                      change (do
+                        Mul.preflightEdges limit edges
+                        Mul.preflightProducts limit recipes
+                        Mul.preflightComparisons limit candidates
+                        pure (Mul.result candidates)) = .ok raw at checked
+                      rw [edgeCheck, productCheck, comparisonCheck] at checked
+                      cases checked
+                      rfl
+
+end Raw
+
+/-- Resource-safe exact interval multiplication. Refusal is distinct from the
+empty product. -/
+def mulWithin (limit : EndpointLimit)
+    (left right : Hex.Interval) : Arithmetic.Result :=
+  match Raw.mulChecked limit left.view right.view with
+  | .error cost => .resourceLimit cost
+  | .ok raw => Arithmetic.Result.ofBuild (ofRawWithin limit raw)
+
+/-- A successful multiplication exposes the normalized exact raw candidate. -/
+theorem view_mulWithin_ready {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : mulWithin limit left right = .ready result) :
+    result.view = (Raw.mulUnchecked left.view right.view).normalizeUnchecked := by
+  unfold mulWithin at checked
+  split at checked
+  · contradiction
+  · next raw rawChecked =>
+      have rawEq := Raw.eq_mulUnchecked_of_mulChecked rawChecked
+      rw [rawEq] at checked
+      generalize buildEq : ofRawWithin limit
+          (Raw.mulUnchecked left.view right.view) = build at checked
+      cases build with
+      | ready interval =>
+          simp only [Arithmetic.Result.ofBuild] at checked
+          cases checked
+          exact view_ofRawWithin_ready buildEq
+      | resourceLimit cost =>
+          simp only [Arithmetic.Result.ofBuild] at checked
+          contradiction
+
+end Hex.Interval

--- a/HexInterval/Multiplication.lean
+++ b/HexInterval/Multiplication.lean
@@ -145,15 +145,19 @@ def preflightProducts (limit : EndpointLimit) :
       | none => evaluate rest
       | some candidate => candidate :: evaluate rest
 
-/-- Admit one finite candidate endpoint after product growth has been
-preflighted and before any candidate comparison. -/
+/-- Defensively re-admit one finite candidate endpoint after product growth
+has been preflighted and before any candidate comparison. In the current
+pipeline every finite corner is bounded by its admitted growth prediction and
+the only extra candidate is zero, so this cannot be the first observable
+`mulWithin` refusal. Keeping the stage explicit protects that invariant if a
+future candidate source is added. -/
 def preflightCandidate (limit : EndpointLimit) : Candidate → Except Arithmetic.Cost Unit
   | .negInf | .posInf => pure ()
   | .finite value _ =>
       let cost := EndpointCost.ofDyadic value
       if cost.allowed limit then pure () else throw (.endpoint cost)
 
-/-- Admit every retained candidate endpoint before comparison. -/
+/-- Defensively re-admit every retained candidate endpoint before comparison. -/
 def preflightCandidates (limit : EndpointLimit) :
     List Candidate → Except Arithmetic.Cost Unit
   | [] => pure ()

--- a/HexInterval/Multiplication.lean
+++ b/HexInterval/Multiplication.lean
@@ -8,7 +8,7 @@ module
 
 public import HexInterval.Interval
 
-@[expose] public section
+public section
 
 /-!
 # Resource-checked interval multiplication
@@ -18,7 +18,8 @@ omitting the undefined formal products `0 * ±∞`, and adds an attained zero
 candidate exactly when either nonempty factor contains zero. Every finite
 endpoint is admitted before sign inspection, all finite corner products pass
 `Arithmetic.preflightMul` before the first mantissa multiplication, and all
-finite candidate comparisons are admitted before extremum selection.
+finite candidate endpoints are admitted before their alignment comparisons
+and extremum selection.
 -/
 
 namespace Hex.Interval
@@ -41,22 +42,22 @@ inductive Candidate where
   deriving DecidableEq
 
 /-- Lower cut as an extended endpoint. -/
-def lowerEdge : Lower → Edge
+@[expose] def lowerEdge : Lower → Edge
   | .unbounded => .negInf
   | .finite value strict => .finite value strict
 
 /-- Upper cut as an extended endpoint. -/
-def upperEdge : Upper → Edge
+@[expose] def upperEdge : Upper → Edge
   | .finite value strict => .finite value strict
   | .unbounded => .posInf
 
 /-- Sign inspection after the caller has admitted comparison with zero. -/
-def signUnchecked (value : Dyadic) : Ordering :=
+@[expose] def signUnchecked (value : Dyadic) : Ordering :=
   if value < 0 then .lt else if value = 0 then .eq else .gt
 
 /-- One extended corner product. Formal `0 * ±∞` contributes no corner;
 zero attainment is handled independently from interval membership. -/
-def productUnchecked : Edge → Edge → Option Candidate
+@[expose] def productUnchecked : Edge → Edge → Option Candidate
   | .finite left leftStrict, .finite right rightStrict =>
       some (.finite (left * right) (!leftStrict && !rightStrict))
   | .negInf, .negInf | .posInf, .posInf => some .posInf
@@ -73,7 +74,7 @@ def productUnchecked : Edge → Edge → Option Candidate
       | .gt => some .posInf
 
 /-- The four extended endpoint-pair recipes. -/
-def corners (leftLower : Lower) (leftUpper : Upper)
+@[expose] def corners (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) : List (Edge × Edge) :=
   let ll := lowerEdge leftLower
   let lu := upperEdge leftUpper
@@ -83,7 +84,7 @@ def corners (leftLower : Lower) (leftUpper : Upper)
 
 /-- A lower cut permits zero after its finite comparison with zero is
 admitted. -/
-def lowerAllowsZeroUnchecked : Lower → Bool
+@[expose] def lowerAllowsZeroUnchecked : Lower → Bool
   | .unbounded => true
   | .finite value strict =>
       match signUnchecked value with
@@ -93,7 +94,7 @@ def lowerAllowsZeroUnchecked : Lower → Bool
 
 /-- An upper cut permits zero after its finite comparison with zero is
 admitted. -/
-def upperAllowsZeroUnchecked : Upper → Bool
+@[expose] def upperAllowsZeroUnchecked : Upper → Bool
   | .unbounded => true
   | .finite value strict =>
       match signUnchecked value with
@@ -102,15 +103,17 @@ def upperAllowsZeroUnchecked : Upper → Bool
       | .gt => true
 
 /-- Whether nonempty bounds contain zero. -/
-def containsZeroUnchecked (lower : Lower) (upper : Upper) : Bool :=
+@[expose] def containsZeroUnchecked (lower : Lower) (upper : Upper) : Bool :=
   lowerAllowsZeroUnchecked lower && upperAllowsZeroUnchecked upper
 
-/-- Admit one finite endpoint before sign inspection. -/
+/-- Admit one finite source endpoint before sign inspection. Comparing a
+dyadic with zero requires no exponent alignment, so a refusal here is an
+endpoint diagnostic rather than a degenerate comparison diagnostic. -/
 def preflightEdge (limit : EndpointLimit) : Edge → Except Arithmetic.Cost Unit
   | .negInf | .posInf => pure ()
   | .finite value _ =>
-      let cost := CompareCost.ofDyadic value 0
-      if cost.allowed limit then pure () else throw (.comparison cost)
+      let cost := EndpointCost.ofDyadic value
+      if cost.allowed limit then pure () else throw (.endpoint cost)
 
 /-- Admit every endpoint sign inspection before any product is formed. -/
 def preflightEdges (limit : EndpointLimit) : List Edge → Except Arithmetic.Cost Unit
@@ -135,19 +138,38 @@ def preflightProducts (limit : EndpointLimit) :
       preflightProducts limit rest
 
 /-- Evaluate already-admitted corner recipes. -/
-def evaluate : List (Edge × Edge) → List Candidate
+@[expose] def evaluate : List (Edge × Edge) → List Candidate
   | [] => []
   | pair :: rest =>
       match productUnchecked pair.1 pair.2 with
       | none => evaluate rest
       | some candidate => candidate :: evaluate rest
 
+/-- Admit one finite candidate endpoint after product growth has been
+preflighted and before any candidate comparison. -/
+def preflightCandidate (limit : EndpointLimit) : Candidate → Except Arithmetic.Cost Unit
+  | .negInf | .posInf => pure ()
+  | .finite value _ =>
+      let cost := EndpointCost.ofDyadic value
+      if cost.allowed limit then pure () else throw (.endpoint cost)
+
+/-- Admit every retained candidate endpoint before comparison. -/
+def preflightCandidates (limit : EndpointLimit) :
+    List Candidate → Except Arithmetic.Cost Unit
+  | [] => pure ()
+  | candidate :: rest => do
+      preflightCandidate limit candidate
+      preflightCandidates limit rest
+
 /-- Admit one exact comparison between finite, already-bounded candidates. -/
 def preflightCompare (limit : EndpointLimit) : Candidate → Candidate →
     Except Arithmetic.Cost Unit
   | .finite left _, .finite right _ =>
       let cost := CompareCost.ofDyadic left right
-      if cost.allowed limit then pure () else throw (.comparison cost)
+      if cost.alignmentShift ≤ limit.maxAlignmentShift then
+        pure ()
+      else
+        throw (.comparison cost)
   | _, _ => pure ()
 
 /-- Admit all pairwise finite comparisons before extremum selection. -/
@@ -161,7 +183,7 @@ def preflightComparisons (limit : EndpointLimit) :
 
 /-- Select the smaller already-admitted candidate, combining attainment at a
 tied finite value. -/
-def minUnchecked : Candidate → Candidate → Candidate
+@[expose] def minUnchecked : Candidate → Candidate → Candidate
   | .negInf, _ | _, .negInf => .negInf
   | .posInf, candidate | candidate, .posInf => candidate
   | left@(.finite leftValue leftAttained), right@(.finite rightValue rightAttained) =>
@@ -172,7 +194,7 @@ def minUnchecked : Candidate → Candidate → Candidate
 
 /-- Select the larger already-admitted candidate, combining attainment at a
 tied finite value. -/
-def maxUnchecked : Candidate → Candidate → Candidate
+@[expose] def maxUnchecked : Candidate → Candidate → Candidate
   | .posInf, _ | _, .posInf => .posInf
   | .negInf, candidate | candidate, .negInf => candidate
   | left@(.finite leftValue leftAttained), right@(.finite rightValue rightAttained) =>
@@ -182,41 +204,48 @@ def maxUnchecked : Candidate → Candidate → Candidate
       else left
 
 /-- Minimum of a nonempty candidate list. -/
-def minimum : Candidate → List Candidate → Candidate
+@[expose] def minimum : Candidate → List Candidate → Candidate
   | candidate, [] => candidate
   | candidate, next :: rest => minimum (minUnchecked candidate next) rest
 
 /-- Maximum of a nonempty candidate list. -/
-def maximum : Candidate → List Candidate → Candidate
+@[expose] def maximum : Candidate → List Candidate → Candidate
   | candidate, [] => candidate
   | candidate, next :: rest => maximum (maxUnchecked candidate next) rest
 
 /-- Convert the selected minimum to a lower cut. -/
-def lowerCut : Candidate → Lower
+@[expose] def lowerCut : Candidate → Lower
   | .negInf => .unbounded
   | .finite value attained => .finite value (!attained)
   | .posInf => .unbounded
 
 /-- Convert the selected maximum to an upper cut. -/
-def upperCut : Candidate → Upper
+@[expose] def upperCut : Candidate → Upper
   | .negInf => .unbounded
   | .finite value attained => .finite value (!attained)
   | .posInf => .unbounded
 
-/-- Candidate list for two nonempty raw bounds. -/
-def candidatesUnchecked (leftLower : Lower) (leftUpper : Upper)
-    (rightLower : Lower) (rightUpper : Upper) : List Candidate :=
-  let cornerCandidates := evaluate (corners leftLower leftUpper rightLower rightUpper)
+/-- Add the attained-zero candidate, when justified, to an already evaluated
+corner list. -/
+@[expose] def withZeroUnchecked (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper)
+    (cornerCandidates : List Candidate) : List Candidate :=
   if containsZeroUnchecked leftLower leftUpper ||
       containsZeroUnchecked rightLower rightUpper then
     .finite 0 true :: cornerCandidates
   else
     cornerCandidates
 
+/-- Candidate list for two nonempty raw bounds. -/
+@[expose] def candidatesUnchecked (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) : List Candidate :=
+  withZeroUnchecked leftLower leftUpper rightLower rightUpper
+    (evaluate (corners leftLower leftUpper rightLower rightUpper))
+
 /-- Convert a candidate list to its enclosing raw cuts. The empty fallback is
 unreachable for canonical nonempty interval inputs, but keeps this decoder
 helper total on arbitrary raw data. -/
-def result : List Candidate → Raw
+@[expose] def result : List Candidate → Raw
   | [] => .empty
   | first :: rest =>
       .bounds (lowerCut (minimum first rest)) (upperCut (maximum first rest))
@@ -227,16 +256,17 @@ namespace Raw
 
 /-- Exact raw multiplication candidate without resource checks. Call
 `mulChecked` at untrusted boundaries. -/
-def mulUnchecked : Raw → Raw → Raw
+@[expose] def mulUnchecked : Raw → Raw → Raw
   | .empty, _ | _, .empty => .empty
   | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
       Mul.result
         (Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper)
 
-/-- Compute exact multiplication cuts with preflighted sign inspection,
-product growth, and candidate ordering. Empty is absorbing. This raw boundary
-accepts arbitrary cut data; the supported `mulWithin` entry point supplies
-canonical public inputs and checks the final result. -/
+/-- Compute exact multiplication cuts with preflighted source endpoints,
+product growth, retained candidates, and candidate ordering. Empty is
+absorbing. This raw boundary accepts arbitrary cut data; the supported
+`mulWithin` entry point supplies canonical public inputs and checks the final
+result. -/
 def mulChecked (limit : EndpointLimit) : Raw → Raw → Except Arithmetic.Cost Raw
   | .empty, _ | _, .empty => pure .empty
   | .bounds leftLower leftUpper, .bounds rightLower rightUpper => do
@@ -245,8 +275,10 @@ def mulChecked (limit : EndpointLimit) : Raw → Raw → Except Arithmetic.Cost 
         [Mul.lowerEdge leftLower, Mul.upperEdge leftUpper,
           Mul.lowerEdge rightLower, Mul.upperEdge rightUpper]
       Mul.preflightProducts limit recipes
-      let candidates :=
-        Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper
+      let cornerCandidates := Mul.evaluate recipes
+      let candidates := Mul.withZeroUnchecked leftLower leftUpper
+        rightLower rightUpper cornerCandidates
+      Mul.preflightCandidates limit candidates
       Mul.preflightComparisons limit candidates
       pure (Mul.result candidates)
 
@@ -271,13 +303,15 @@ theorem eq_mulUnchecked_of_mulChecked {limit : EndpointLimit} {left right raw : 
             [Mul.lowerEdge leftLower, Mul.upperEdge leftUpper,
               Mul.lowerEdge rightLower, Mul.upperEdge rightUpper]
           let recipes := Mul.corners leftLower leftUpper rightLower rightUpper
-          let candidates :=
-            Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper
+          let cornerCandidates := Mul.evaluate recipes
+          let candidates := Mul.withZeroUnchecked leftLower leftUpper
+            rightLower rightUpper cornerCandidates
           cases edgeCheck : Mul.preflightEdges limit edges with
           | error cost =>
               change (do
                 Mul.preflightEdges limit edges
                 Mul.preflightProducts limit recipes
+                Mul.preflightCandidates limit candidates
                 Mul.preflightComparisons limit candidates
                 pure (Mul.result candidates)) = .ok raw at checked
               rw [edgeCheck] at checked
@@ -289,31 +323,48 @@ theorem eq_mulUnchecked_of_mulChecked {limit : EndpointLimit} {left right raw : 
                   change (do
                     Mul.preflightEdges limit edges
                     Mul.preflightProducts limit recipes
+                    Mul.preflightCandidates limit candidates
                     Mul.preflightComparisons limit candidates
                     pure (Mul.result candidates)) = .ok raw at checked
                   rw [edgeCheck, productCheck] at checked
                   contradiction
               | ok value =>
                   cases value
-                  cases comparisonCheck : Mul.preflightComparisons limit candidates with
+                  cases candidateCheck : Mul.preflightCandidates limit candidates with
                   | error cost =>
                       change (do
                         Mul.preflightEdges limit edges
                         Mul.preflightProducts limit recipes
+                        Mul.preflightCandidates limit candidates
                         Mul.preflightComparisons limit candidates
                         pure (Mul.result candidates)) = .ok raw at checked
-                      rw [edgeCheck, productCheck, comparisonCheck] at checked
+                      rw [edgeCheck, productCheck, candidateCheck] at checked
                       contradiction
                   | ok value =>
                       cases value
-                      change (do
-                        Mul.preflightEdges limit edges
-                        Mul.preflightProducts limit recipes
-                        Mul.preflightComparisons limit candidates
-                        pure (Mul.result candidates)) = .ok raw at checked
-                      rw [edgeCheck, productCheck, comparisonCheck] at checked
-                      cases checked
-                      rfl
+                      cases comparisonCheck : Mul.preflightComparisons limit candidates with
+                      | error cost =>
+                          change (do
+                            Mul.preflightEdges limit edges
+                            Mul.preflightProducts limit recipes
+                            Mul.preflightCandidates limit candidates
+                            Mul.preflightComparisons limit candidates
+                            pure (Mul.result candidates)) = .ok raw at checked
+                          rw [edgeCheck, productCheck, candidateCheck,
+                            comparisonCheck] at checked
+                          contradiction
+                      | ok value =>
+                          cases value
+                          change (do
+                            Mul.preflightEdges limit edges
+                            Mul.preflightProducts limit recipes
+                            Mul.preflightCandidates limit candidates
+                            Mul.preflightComparisons limit candidates
+                            pure (Mul.result candidates)) = .ok raw at checked
+                          rw [edgeCheck, productCheck, candidateCheck,
+                            comparisonCheck] at checked
+                          cases checked
+                          rfl
 
 end Raw
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -515,16 +515,20 @@ comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
 result so the existing `BuildResult` APIs above do not acquire a misleading or
 breaking cost variant.
 
-`mulWithin` first admits every finite endpoint comparison with zero. It then
+`mulWithin` first admits every finite source endpoint before sign inspection.
+It then
 admits all four finite corner products through `Arithmetic.preflightMul`
-before multiplying any mantissas, and admits all finite candidate comparisons
-before extremum selection. The exact raw candidate enumerates the four
+before multiplying any mantissas, admits every evaluated finite candidate as
+an endpoint, and only then admits all candidate alignment comparisons before
+extremum selection. Source or candidate height refusal is `Cost.endpoint`,
+predicted product growth is `Cost.growth`, and candidate alignment refusal is
+`Cost.comparison`. The exact raw candidate enumerates the four
 extended-endpoint products, omitting the undefined formal products
 `0 * ±∞`; an attained zero candidate is added exactly when either nonempty
 factor contains zero. Tied corner values combine attainment, so open and
 closed extrema, zero attainment, independent unbounded sides, and empty
-absorption are preserved. A successful result has an exact normalized
-computed-cut characterization, and the Mathlib companion proves that every
+absorption are preserved. A successful result has an explicit selected lower-
+and upper-cut characterization after normalization, and the Mathlib companion proves that every
 product of source members belongs to it. No separate image-tightness converse
 is currently claimed.
 
@@ -571,9 +575,10 @@ tests also check the following exactness rules.
   cut, and uses intersection attainment on the lower tie but hull attainment on
   the upper tie. Thus a tied lower endpoint is closed only if both inputs attain
   it, while a tied upper endpoint is closed if either input attains it.
-- After the empty-input short circuit, multiplication partitions both inputs
-  by sign, enumerates finite corner and zero candidates, and tracks whether
-  each extremum is attained. Zero is an attained extremum whenever either
+- After the empty-input short circuit, multiplication unconditionally
+  enumerates the four extended-endpoint corners plus a justified zero
+  candidate; sign inspection only resolves finite-by-infinite corners. It
+  tracks whether each extremum is attained. Zero is an attained extremum whenever either
   nonempty factor contains zero, not only when a factor is the singleton zero.
   For example,
   `[0,1] * (0,1] = [0,1]`, while `(0,1] * (0,1] = (0,1]`.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -432,6 +432,7 @@ def subWithin       : EndpointLimit → Interval → Interval → BuildResult
 def minWithin       : EndpointLimit → Interval → Interval → BuildResult
 def maxWithin       : EndpointLimit → Interval → Interval → BuildResult
 def absWithin       : EndpointLimit → Interval → BuildResult
+def mulWithin       : EndpointLimit → Interval → Interval → Arithmetic.Result
 ```
 
 These names retain the budget because a public interval does not store the
@@ -477,8 +478,9 @@ the selector aligns finite dyadics, and the selected raw cuts then cross
 `ofRawWithin`. Thus an interval admitted under a larger earlier budget cannot
 force an unchecked alignment or silently turn refusal into empty.
 
-The supported tree also contains the resource prerequisites for multiplicative
-arithmetic, but not yet interval multiplication or powers. `Arithmetic.Growth`
+Multiplication uses the separate checked-arithmetic result because growth
+refusal is distinct from both empty output and endpoint/comparison refusal.
+`Arithmetic.Growth`
 records admitted source endpoint costs and a conservative predicted result.
 Multiplication records the sum of input numerator-bit lengths and the exact
 magnitude of the signed exponent sum. `Arithmetic.preflightMul` checks both
@@ -513,16 +515,29 @@ comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
 result so the existing `BuildResult` APIs above do not acquire a misleading or
 breaking cost variant.
 
+`mulWithin` first admits every finite endpoint comparison with zero. It then
+admits all four finite corner products through `Arithmetic.preflightMul`
+before multiplying any mantissas, and admits all finite candidate comparisons
+before extremum selection. The exact raw candidate enumerates the four
+extended-endpoint products, omitting the undefined formal products
+`0 * ±∞`; an attained zero candidate is added exactly when either nonempty
+factor contains zero. Tied corner values combine attainment, so open and
+closed extrema, zero attainment, independent unbounded sides, and empty
+absorption are preserved. A successful result has an exact normalized
+computed-cut characterization, and the Mathlib companion proves that every
+product of source members belongs to it. No separate image-tightness converse
+is currently claimed.
+
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
-`maxUnchecked`, and `absUnchecked` are related to the checked operations by
-successful-result and semantic theorems. Like
+`maxUnchecked`, `absUnchecked`, and `mulUnchecked` are related
+to the checked operations by successful-result and semantic theorems. Like
 `Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface includes the interval operation for multiplication,
-precision-indexed reciprocal and division, powers,
+The remaining target surface includes precision-indexed reciprocal and
+division and powers,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -520,9 +520,13 @@ It then
 admits all four finite corner products through `Arithmetic.preflightMul`
 before multiplying any mantissas, admits every evaluated finite candidate as
 an endpoint, and only then admits all candidate alignment comparisons before
-extremum selection. Source or candidate height refusal is `Cost.endpoint`,
+extremum selection. Source height refusal is observably `Cost.endpoint`,
 predicted product growth is `Cost.growth`, and candidate alignment refusal is
-`Cost.comparison`. The exact raw candidate enumerates the four
+`Cost.comparison`. Candidate-height admission is a defensive invariant check,
+not a currently reachable first refusal: every finite corner is bounded by its
+already admitted growth prediction, and the only additional candidate is zero.
+The explicit stage ensures a future candidate source cannot bypass endpoint
+admission. The exact raw candidate enumerates the four
 extended-endpoint products, omitting the undefined formal products
 `0 * ±∞`; an attained zero candidate is added exactly when either nonempty
 factor contains zero. Tied corner values combine attainment, so open and
@@ -4050,6 +4054,9 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Arithmetic.lean`: multiplication and direct-power endpoint
   growth prerequisites; it does not expose an interval multiplication or power
   operation.
+- `HexInterval/Multiplication.lean`: resource-checked interval multiplication,
+  unconditional extended-corner evaluation, attainment-aware extremum
+  selection, and the sealed `mulWithin` entry point.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
   negation, addition, subtraction, minimum, maximum, and absolute value,
   followed by future arithmetic, splitting, and regularization operations.
@@ -4063,6 +4070,9 @@ their declared cost inside a scheduler bound.
   real-image enclosure theorems for minimum and maximum.
 - `HexIntervalMathlib/Absolute.lean`: exact selected-cut semantics and the
   successful absolute-value image theorem.
+- `HexIntervalMathlib/Multiplication.lean`: explicit selected-candidate-cut
+  semantics and the one-way real-product enclosure theorem; it does not claim
+  an image-tightness converse.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -12,11 +12,13 @@ public import HexIntervalMathlib.Addition
 public import HexIntervalMathlib.Subtraction
 public import HexIntervalMathlib.MinMax
 public import HexIntervalMathlib.Absolute
+public import HexIntervalMathlib.Multiplication
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
-the supported `Hex.Interval` operations, including resource-checked addition
-and subtraction, exact minimum/maximum images, and absolute value.
+the supported `Hex.Interval` operations, including resource-checked addition,
+subtraction, and multiplication, exact minimum/maximum images, and absolute
+value.
 -/

--- a/HexIntervalMathlib/Multiplication.lean
+++ b/HexIntervalMathlib/Multiplication.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexIntervalMathlib.Subtraction
+public import HexIntervalMathlib.Interval
 public import HexInterval.Multiplication
 
 @[expose] public section

--- a/HexIntervalMathlib/Multiplication.lean
+++ b/HexIntervalMathlib/Multiplication.lean
@@ -29,11 +29,32 @@ theorem toReal_mul (left right : Dyadic) :
 theorem toReal_zero : toReal 0 = 0 := by
   simp [toReal]
 
-/-- Computed cut predicate for exact raw multiplication. This describes the
-algorithm's normalized candidate; it does not claim a separate set-image
-tightness converse. -/
-def Raw.MulContains (left right : Raw) (x : ℝ) : Prop :=
-  (left.mulUnchecked right).normalizeUnchecked.Contains x
+/-- Computed cut predicate for exact raw multiplication. Empty is absorbing.
+For two bounded-cut inputs it is the conjunction of the selected lower and
+upper candidate cuts. This characterizes the algorithm's computed enclosure;
+it does not claim a separate set-image tightness converse. -/
+def Raw.MulContains : Raw → Raw → ℝ → Prop
+  | .empty, _, _ | _, .empty, _ => False
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper, x =>
+      match Raw.Mul.candidatesUnchecked
+          leftLower leftUpper rightLower rightUpper with
+      | [] => False
+      | first :: rest =>
+          (Raw.Mul.lowerCut (Raw.Mul.minimum first rest)).Contains x ∧
+            (Raw.Mul.upperCut (Raw.Mul.maximum first rest)).Contains x
+
+private theorem rawContains_mulUnchecked (left right : Raw) (x : ℝ) :
+    (left.mulUnchecked right).Contains x ↔ left.MulContains right x := by
+  cases left with
+  | empty => simp [Raw.mulUnchecked, Raw.Contains, Raw.MulContains]
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.mulUnchecked, Raw.Contains, Raw.MulContains]
+      | bounds rightLower rightUpper =>
+          simp only [Raw.mulUnchecked, Raw.MulContains]
+          generalize candidatesEq : Raw.Mul.candidatesUnchecked
+            leftLower leftUpper rightLower rightUpper = candidates
+          cases candidates <;> simp [Raw.Mul.result, Raw.Contains]
 
 private def Raw.Mul.Candidate.LowerBounds : Raw.Mul.Candidate → ℝ → Prop
   | .negInf, _ => True
@@ -295,44 +316,6 @@ private theorem mul_upper_eq {x b y d : ℝ} (xPos : 0 < x) (xLe : x ≤ b)
   subst x
   exact ⟨rfl, mul_left_cancel₀ bPos.ne' equal⟩
 
-private theorem finiteLower_nonneg_of_pos_not_zero
-    (lower upper : Dyadic) (lowerStrict upperStrict : Bool) {x : ℝ}
-    (member : (Lower.finite lower lowerStrict).Contains x ∧
-      (Upper.finite upper upperStrict).Contains x)
-    (xPos : 0 < x)
-    (notZero : Raw.Mul.containsZeroUnchecked (.finite lower lowerStrict)
-      (.finite upper upperStrict) = false) :
-    0 ≤ toReal lower := by
-  by_contra notNonneg
-  have lowerNeg : toReal lower < 0 := lt_of_not_ge notNonneg
-  have zeroMember : (Lower.finite lower lowerStrict).Contains 0 ∧
-      (Upper.finite upper upperStrict).Contains 0 := by
-    constructor
-    · cases lowerStrict <;> simp [Lower.Contains] <;> linarith
-    · cases upperStrict <;> simp [Upper.Contains] at member ⊢ <;> linarith
-  have yes := Raw.Mul.containsZeroUnchecked_of_mem
-    (.finite lower lowerStrict) (.finite upper upperStrict) zeroMember rfl
-  simp [notZero] at yes
-
-private theorem finiteUpper_nonpos_of_neg_not_zero
-    (lower upper : Dyadic) (lowerStrict upperStrict : Bool) {x : ℝ}
-    (member : (Lower.finite lower lowerStrict).Contains x ∧
-      (Upper.finite upper upperStrict).Contains x)
-    (xNeg : x < 0)
-    (notZero : Raw.Mul.containsZeroUnchecked (.finite lower lowerStrict)
-      (.finite upper upperStrict) = false) :
-    toReal upper ≤ 0 := by
-  by_contra notNonpos
-  have upperPos : 0 < toReal upper := lt_of_not_ge notNonpos
-  have zeroMember : (Lower.finite lower lowerStrict).Contains 0 ∧
-      (Upper.finite upper upperStrict).Contains 0 := by
-    constructor
-    · cases lowerStrict <;> simp [Lower.Contains] at member ⊢ <;> linarith
-    · cases upperStrict <;> simp [Upper.Contains] <;> linarith
-  have yes := Raw.Mul.containsZeroUnchecked_of_mem
-    (.finite lower lowerStrict) (.finite upper upperStrict) zeroMember rfl
-  simp [notZero] at yes
-
 private theorem upper_nonpos_of_neg_not_zero
     (lower : Lower) (upper : Dyadic) (upperStrict : Bool) {x : ℝ}
     (member : lower.Contains x ∧ (Upper.finite upper upperStrict).Contains x)
@@ -371,310 +354,6 @@ private theorem lower_nonneg_of_pos_not_zero
     (.finite lower lowerStrict) upper zeroMember rfl
   simp [notZero] at yes
 
-private theorem Raw.Mul.finite_corner_bounds
-    (leftLower leftUpper rightLower rightUpper : Dyadic)
-    (leftLowerStrict leftUpperStrict rightLowerStrict rightUpperStrict : Bool)
-    {x y : ℝ}
-    (leftMember :
-      (Lower.finite leftLower leftLowerStrict).Contains x ∧
-        (Upper.finite leftUpper leftUpperStrict).Contains x)
-    (rightMember :
-      (Lower.finite rightLower rightLowerStrict).Contains y ∧
-        (Upper.finite rightUpper rightUpperStrict).Contains y) :
-    (∃ candidate ∈ Raw.Mul.candidatesUnchecked
-        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
-        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict),
-      candidate.LowerBounds (x * y)) ∧
-    (∃ candidate ∈ Raw.Mul.candidatesUnchecked
-        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
-        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict),
-      candidate.UpperBounds (x * y)) := by
-  rw [Lower.contains_iff_bounds, Upper.contains_iff_bounds] at leftMember rightMember
-  by_cases productZero : x * y = 0
-  · rcases mul_eq_zero.mp productZero with xZero | yZero
-    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
-        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
-        ⟨(Lower.contains_iff_bounds _ _).2 leftMember.1,
-          (Upper.contains_iff_bounds _ _).2 leftMember.2⟩ xZero
-      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
-      all_goals simp [Raw.Mul.candidatesUnchecked, containsZero, productZero,
-        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
-    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
-        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict)
-        ⟨(Lower.contains_iff_bounds _ _).2 rightMember.1,
-          (Upper.contains_iff_bounds _ _).2 rightMember.2⟩ yZero
-      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
-      all_goals simp [Raw.Mul.candidatesUnchecked, containsZero, productZero,
-        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
-  have leftContains : (Lower.finite leftLower leftLowerStrict).Contains x ∧
-      (Upper.finite leftUpper leftUpperStrict).Contains x :=
-    ⟨(Lower.contains_iff_bounds _ _).2 leftMember.1,
-      (Upper.contains_iff_bounds _ _).2 leftMember.2⟩
-  have rightContains : (Lower.finite rightLower rightLowerStrict).Contains y ∧
-      (Upper.finite rightUpper rightUpperStrict).Contains y :=
-    ⟨(Lower.contains_iff_bounds _ _).2 rightMember.1,
-      (Upper.contains_iff_bounds _ _).2 rightMember.2⟩
-  have ll : toReal leftLower ≤ x := leftMember.1.1
-  have lu : x ≤ toReal leftUpper := leftMember.2.1
-  have rl : toReal rightLower ≤ y := rightMember.1.1
-  have ru : y ≤ toReal rightUpper := rightMember.2.1
-  have xNonzero : x ≠ 0 := fun equal => productZero (by simp [equal])
-  have yNonzero : y ≠ 0 := fun equal => productZero (by simp [equal])
-  have memberLL : Raw.Mul.Candidate.finite (leftLower * rightLower)
-      (!leftLowerStrict && !rightLowerStrict) ∈
-      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-        (.finite rightUpper rightUpperStrict) := by
-    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
-      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
-      split <;> simp
-  have memberLU : Raw.Mul.Candidate.finite (leftLower * rightUpper)
-      (!leftLowerStrict && !rightUpperStrict) ∈
-      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-        (.finite rightUpper rightUpperStrict) := by
-    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
-      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
-      split <;> simp
-  have memberUL : Raw.Mul.Candidate.finite (leftUpper * rightLower)
-      (!leftUpperStrict && !rightLowerStrict) ∈
-      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-        (.finite rightUpper rightUpperStrict) := by
-    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
-      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
-      split <;> simp
-  have memberUU : Raw.Mul.Candidate.finite (leftUpper * rightUpper)
-      (!leftUpperStrict && !rightUpperStrict) ∈
-      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-        (.finite rightUpper rightUpperStrict) := by
-    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
-      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
-      split <;> simp
-  by_cases hx : x < 0
-  · have nx : 0 < -x := neg_pos.mpr hx
-    by_cases hy : y < 0
-    ·
-      have ny : 0 < -y := neg_pos.mpr hy
-      by_cases zero :
-          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) ||
-            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict)
-      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
-            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict) := by
-          simp [Raw.Mul.candidatesUnchecked, zero]
-        refine ⟨⟨.finite 0 true, memberZero, ?_⟩,
-          ⟨.finite (leftLower * rightLower)
-            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩⟩
-        · exact ⟨by simpa using (mul_pos_of_neg_of_neg hx hy).le, by simp
-            [Raw.Mul.Candidate.LowerBounds]⟩
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg ll) ny.le
-            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg rl)
-              (neg_nonneg.mpr (ll.trans_lt hx).le)
-            nlinarith
-          · intro equal
-            have ends := mul_upper_eq nx (neg_le_neg ll) ny (neg_le_neg rl) (by nlinarith)
-            have leftClosed := leftMember.1.2 (by nlinarith [ends.1])
-            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
-            simp [leftClosed, rightClosed]
-      · have noZero := Bool.eq_false_of_not_eq_true zero
-        have sides := Bool.or_eq_false_iff.mp noZero
-        have leftUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
-          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains hx sides.1
-        have rightUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
-          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains hy sides.2
-        refine ⟨⟨.finite (leftUpper * rightUpper)
-            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩,
-          ⟨.finite (leftLower * rightLower)
-            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          constructor
-          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg lu)
-              (neg_nonneg.mpr rightUpperNonpos)
-            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg ru) nx.le
-            nlinarith
-          · intro equal
-            have ends := mul_lower_eq (neg_nonneg.mpr leftUpperNonpos)
-              (neg_le_neg lu) (neg_nonneg.mpr rightUpperNonpos)
-              (neg_le_neg ru) (by simpa using productZero) (by nlinarith)
-            have leftClosed := leftMember.2.2 (by nlinarith [ends.1])
-            have rightClosed := rightMember.2.2 (by nlinarith [ends.2])
-            simp [leftClosed, rightClosed]
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg ll) ny.le
-            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg rl)
-              (neg_nonneg.mpr (ll.trans_lt hx).le)
-            nlinarith
-          · intro equal
-            have ends := mul_upper_eq nx (neg_le_neg ll) ny (neg_le_neg rl) (by nlinarith)
-            have leftClosed := leftMember.1.2 (by nlinarith [ends.1])
-            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
-            simp [leftClosed, rightClosed]
-    · have yPos : 0 < y := lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero)
-      have lowerBound : toReal leftLower * toReal rightUpper ≤ x * y := by
-        have first := mul_le_mul_of_nonneg_right (neg_le_neg ll) yPos.le
-        have second := mul_le_mul_of_nonneg_left ru nx.le
-        nlinarith
-      have lowerEqual : x * y = toReal leftLower * toReal rightUpper →
-          x = toReal leftLower ∧ y = toReal rightUpper := by
-        intro equal
-        have ends := mul_upper_eq nx (neg_le_neg ll) yPos ru (by nlinarith)
-        exact ⟨by nlinarith [ends.1], ends.2⟩
-      by_cases zero :
-          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) ||
-            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict)
-      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
-            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict) := by
-          simp [Raw.Mul.candidatesUnchecked, zero]
-        refine ⟨⟨.finite (leftLower * rightUpper)
-            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩,
-          ⟨.finite 0 true, memberZero, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          exact ⟨lowerBound, fun equal => by
-            have ends := lowerEqual equal.symm
-            simp [leftMember.1.2 ends.1.symm, rightMember.2.2 ends.2]⟩
-        · exact ⟨by simpa using (mul_neg_of_neg_of_pos hx yPos).le, by simp
-            [Raw.Mul.Candidate.UpperBounds]⟩
-      · have noZero := Bool.eq_false_of_not_eq_true zero
-        have sides := Bool.or_eq_false_iff.mp noZero
-        have leftUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
-          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains hx sides.1
-        have rightLowerNonneg := finiteLower_nonneg_of_pos_not_zero
-          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains yPos sides.2
-        refine ⟨⟨.finite (leftLower * rightUpper)
-            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩,
-          ⟨.finite (leftUpper * rightLower)
-            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          exact ⟨lowerBound, fun equal => by
-            have ends := lowerEqual equal.symm
-            simp [leftMember.1.2 ends.1.symm, rightMember.2.2 ends.2]⟩
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · have first := mul_le_mul_of_nonneg_right (neg_le_neg lu) rightLowerNonneg
-            have second := mul_le_mul_of_nonneg_left rl nx.le
-            nlinarith
-          · intro equal
-            have ends := mul_lower_eq (neg_nonneg.mpr leftUpperNonpos)
-              (neg_le_neg lu) rightLowerNonneg rl
-              (mul_ne_zero (neg_ne_zero.mpr xNonzero) yNonzero) (by nlinarith)
-            have leftClosed := leftMember.2.2 (by nlinarith [ends.1])
-            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
-            simp [leftClosed, rightClosed]
-  · have xPos : 0 < x := lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero)
-    by_cases hy : y < 0
-    · have ny : 0 < -y := neg_pos.mpr hy
-      have lowerBound : toReal leftUpper * toReal rightLower ≤ x * y := by
-        have first := mul_le_mul_of_nonneg_right lu ny.le
-        have second := mul_le_mul_of_nonneg_left (neg_le_neg rl) xPos.le
-        nlinarith
-      have lowerEqual : x * y = toReal leftUpper * toReal rightLower →
-          x = toReal leftUpper ∧ y = toReal rightLower := by
-        intro equal
-        have ends := mul_upper_eq xPos lu ny (neg_le_neg rl) (by nlinarith)
-        exact ⟨ends.1, by nlinarith [ends.2]⟩
-      by_cases zero :
-          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) ||
-            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict)
-      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
-            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict) := by
-          simp [Raw.Mul.candidatesUnchecked, zero]
-        refine ⟨⟨.finite (leftUpper * rightLower)
-            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩,
-          ⟨.finite 0 true, memberZero, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          exact ⟨lowerBound, fun equal => by
-            have ends := lowerEqual equal.symm
-            simp [leftMember.2.2 ends.1, rightMember.1.2 ends.2.symm]⟩
-        · exact ⟨by simpa using (mul_neg_of_pos_of_neg xPos hy).le, by simp
-            [Raw.Mul.Candidate.UpperBounds]⟩
-      · have noZero := Bool.eq_false_of_not_eq_true zero
-        have sides := Bool.or_eq_false_iff.mp noZero
-        have leftLowerNonneg := finiteLower_nonneg_of_pos_not_zero
-          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains xPos sides.1
-        have rightUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
-          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains hy sides.2
-        refine ⟨⟨.finite (leftUpper * rightLower)
-            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩,
-          ⟨.finite (leftLower * rightUpper)
-            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          exact ⟨lowerBound, fun equal => by
-            have ends := lowerEqual equal.symm
-            simp [leftMember.2.2 ends.1, rightMember.1.2 ends.2.symm]⟩
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · have first := mul_le_mul_of_nonneg_right ll (neg_nonneg.mpr rightUpperNonpos)
-            have second := mul_le_mul_of_nonneg_left (neg_le_neg ru) xPos.le
-            nlinarith
-          · intro equal
-            have ends := mul_lower_eq leftLowerNonneg ll
-              (neg_nonneg.mpr rightUpperNonpos) (neg_le_neg ru)
-              (mul_ne_zero xNonzero (neg_ne_zero.mpr yNonzero)) (by nlinarith)
-            have leftClosed := leftMember.1.2 ends.1.symm
-            have rightClosed := rightMember.2.2 (by nlinarith [ends.2])
-            simp [leftClosed, rightClosed]
-    · have yPos : 0 < y := lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero)
-      by_cases zero :
-          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) ||
-            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict)
-      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
-            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
-              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
-              (.finite rightUpper rightUpperStrict) := by
-          simp [Raw.Mul.candidatesUnchecked, zero]
-        refine ⟨⟨.finite 0 true, memberZero, ?_⟩,
-          ⟨.finite (leftUpper * rightUpper)
-            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩⟩
-        · exact ⟨by simpa using (mul_pos xPos yPos).le, by simp
-            [Raw.Mul.Candidate.LowerBounds]⟩
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · exact mul_le_mul lu ru yPos.le (xPos.le.trans lu)
-          · intro equal
-            have ends := mul_upper_eq xPos lu yPos ru equal
-            simp [leftMember.2.2 ends.1, rightMember.2.2 ends.2]
-      · have noZero := Bool.eq_false_of_not_eq_true zero
-        have sides := Bool.or_eq_false_iff.mp noZero
-        have leftLowerNonneg := finiteLower_nonneg_of_pos_not_zero
-          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains xPos sides.1
-        have rightLowerNonneg := finiteLower_nonneg_of_pos_not_zero
-          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains yPos sides.2
-        refine ⟨⟨.finite (leftLower * rightLower)
-            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩,
-          ⟨.finite (leftUpper * rightUpper)
-            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩⟩
-        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
-          constructor
-          · exact mul_le_mul ll rl rightLowerNonneg xPos.le
-          · intro equal
-            have ends := mul_lower_eq leftLowerNonneg ll rightLowerNonneg rl
-              productZero equal.symm
-            simp [leftMember.1.2 ends.1.symm, rightMember.1.2 ends.2.symm]
-        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
-          constructor
-          · exact mul_le_mul lu ru yPos.le (xPos.le.trans lu)
-          · intro equal
-            have ends := mul_upper_eq xPos lu yPos ru equal
-            simp [leftMember.2.2 ends.1, rightMember.2.2 ends.2]
-
 private def Raw.Mul.HasBounds (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) (x y : ℝ) : Prop :=
   (∃ candidate ∈ Raw.Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper,
@@ -710,7 +389,7 @@ private theorem Raw.Mul.mem_cornerLL {leftLower : Lower} {leftUpper : Upper}
     (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
     (pair := (Raw.Mul.lowerEdge leftLower, Raw.Mul.lowerEdge rightLower))
     (by simp [Raw.Mul.corners]) evaluates
-  unfold Raw.Mul.candidatesUnchecked
+  unfold Raw.Mul.candidatesUnchecked Raw.Mul.withZeroUnchecked
   split <;> simp [member]
 
 private theorem Raw.Mul.mem_cornerLU {leftLower : Lower} {leftUpper : Upper}
@@ -723,7 +402,7 @@ private theorem Raw.Mul.mem_cornerLU {leftLower : Lower} {leftUpper : Upper}
     (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
     (pair := (Raw.Mul.lowerEdge leftLower, Raw.Mul.upperEdge rightUpper))
     (by simp [Raw.Mul.corners]) evaluates
-  unfold Raw.Mul.candidatesUnchecked
+  unfold Raw.Mul.candidatesUnchecked Raw.Mul.withZeroUnchecked
   split <;> simp [member]
 
 private theorem Raw.Mul.mem_cornerUL {leftLower : Lower} {leftUpper : Upper}
@@ -736,7 +415,7 @@ private theorem Raw.Mul.mem_cornerUL {leftLower : Lower} {leftUpper : Upper}
     (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
     (pair := (Raw.Mul.upperEdge leftUpper, Raw.Mul.lowerEdge rightLower))
     (by simp [Raw.Mul.corners]) evaluates
-  unfold Raw.Mul.candidatesUnchecked
+  unfold Raw.Mul.candidatesUnchecked Raw.Mul.withZeroUnchecked
   split <;> simp [member]
 
 private theorem Raw.Mul.mem_cornerUU {leftLower : Lower} {leftUpper : Upper}
@@ -749,7 +428,7 @@ private theorem Raw.Mul.mem_cornerUU {leftLower : Lower} {leftUpper : Upper}
     (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
     (pair := (Raw.Mul.upperEdge leftUpper, Raw.Mul.upperEdge rightUpper))
     (by simp [Raw.Mul.corners]) evaluates
-  unfold Raw.Mul.candidatesUnchecked
+  unfold Raw.Mul.candidatesUnchecked Raw.Mul.withZeroUnchecked
   split <;> simp [member]
 
 private theorem Raw.Mul.mem_zero {leftLower : Lower} {leftUpper : Upper}
@@ -758,14 +437,11 @@ private theorem Raw.Mul.mem_zero {leftLower : Lower} {leftUpper : Upper}
       Raw.Mul.containsZeroUnchecked rightLower rightUpper) :
     Raw.Mul.Candidate.finite 0 true ∈ Raw.Mul.candidatesUnchecked
       leftLower leftUpper rightLower rightUpper := by
-  simp [Raw.Mul.candidatesUnchecked, contains]
+  simp [Raw.Mul.candidatesUnchecked, Raw.Mul.withZeroUnchecked, contains]
 
-set_option maxHeartbeats 3000000 in
 private theorem Raw.Mul.corner_bounds_neg_neg
     (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
-    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
-    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
     (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
     (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
     (hx : x < 0) (hy : y < 0) :
@@ -876,12 +552,9 @@ private theorem Raw.Mul.corner_bounds_neg_neg
                 (by nlinarith [ends.2])
               simp [leftClosed, rightClosed]
 
-set_option maxHeartbeats 3000000 in
 private theorem Raw.Mul.corner_bounds_neg_pos
     (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
-    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
-    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
     (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
     (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
     (hx : x < 0) (hy : 0 < y) :
@@ -988,12 +661,9 @@ private theorem Raw.Mul.corner_bounds_neg_pos
                   ends.2.symm
                 simp [leftClosed, rightClosed]
 
-set_option maxHeartbeats 3000000 in
 private theorem Raw.Mul.corner_bounds_pos_neg
     (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
-    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
-    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
     (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
     (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
     (hx : 0 < x) (hy : y < 0) :
@@ -1100,12 +770,9 @@ private theorem Raw.Mul.corner_bounds_pos_neg
                   (by nlinarith [ends.2])
                 simp [leftClosed, rightClosed]
 
-set_option maxHeartbeats 3000000 in
 private theorem Raw.Mul.corner_bounds_pos_pos
     (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
-    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
-    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
     (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
     (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
     (hx : 0 < x) (hy : 0 < y) :
@@ -1208,8 +875,6 @@ private theorem Raw.Mul.corner_bounds_pos_pos
 private theorem Raw.Mul.corner_bounds
     (leftLower : Lower) (leftUpper : Upper)
     (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
-    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
-    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
     (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
     (rightMember : rightLower.Contains y ∧ rightUpper.Contains y) :
     Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
@@ -1218,30 +883,30 @@ private theorem Raw.Mul.corner_bounds
     · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
         leftLower leftUpper leftMember xZero
       refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
-      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked, containsZero,
-        productZero, Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked,
+        Raw.Mul.withZeroUnchecked, containsZero, productZero,
+        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
     · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
         rightLower rightUpper rightMember yZero
       refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
-      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked, containsZero,
-        productZero, Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked,
+        Raw.Mul.withZeroUnchecked, containsZero, productZero,
+        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
   have xNonzero : x ≠ 0 := fun equal => productZero (by simp [equal])
   have yNonzero : y ≠ 0 := fun equal => productZero (by simp [equal])
   by_cases hx : x < 0
   · by_cases hy : y < 0
-    · exact Raw.Mul.corner_bounds_neg_neg _ _ _ _ leftConsistent rightConsistent
-        leftMember rightMember hx hy
-    · exact Raw.Mul.corner_bounds_neg_pos _ _ _ _ leftConsistent rightConsistent
-        leftMember rightMember hx (lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero))
+    · exact Raw.Mul.corner_bounds_neg_neg _ _ _ _ leftMember rightMember hx hy
+    · exact Raw.Mul.corner_bounds_neg_pos _ _ _ _ leftMember rightMember hx
+        (lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero))
   · by_cases hy : y < 0
-    · exact Raw.Mul.corner_bounds_pos_neg _ _ _ _ leftConsistent rightConsistent
-        leftMember rightMember (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero)) hy
-    · exact Raw.Mul.corner_bounds_pos_pos _ _ _ _ leftConsistent rightConsistent
-        leftMember rightMember (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero))
+    · exact Raw.Mul.corner_bounds_pos_neg _ _ _ _ leftMember rightMember
+        (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero)) hy
+    · exact Raw.Mul.corner_bounds_pos_pos _ _ _ _ leftMember rightMember
+        (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero))
         (lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero))
 
 private theorem raw_mul_mem (left right : Raw) {x y : ℝ}
-    (leftConsistent : left.CutConsistent) (rightConsistent : right.CutConsistent)
     (leftMember : left.Contains x) (rightMember : right.Contains y) :
     (left.mulUnchecked right).Contains (x * y) := by
   cases left with
@@ -1252,9 +917,9 @@ private theorem raw_mul_mem (left right : Raw) {x y : ℝ}
       | bounds rightLower rightUpper =>
           apply Raw.Mul.result_mem
           · exact (Raw.Mul.corner_bounds leftLower leftUpper rightLower rightUpper
-              leftConsistent rightConsistent leftMember rightMember).1
+              leftMember rightMember).1
           · exact (Raw.Mul.corner_bounds leftLower leftUpper rightLower rightUpper
-              leftConsistent rightConsistent leftMember rightMember).2
+              leftMember rightMember).2
 
 /-- A successful multiplication has exactly its normalized computed-cut
 predicate. -/
@@ -1262,8 +927,9 @@ theorem contains_mulWithin {limit : EndpointLimit}
     {left right result : Hex.Interval}
     (checked : mulWithin limit left right = .ready result) (x : ℝ) :
     result.Contains x ↔ left.view.MulContains right.view x := by
-  simp only [Contains, Raw.MulContains]
-  rw [view_mulWithin_ready checked]
+  simp only [Contains]
+  rw [view_mulWithin_ready checked, contains_normalize]
+  exact rawContains_mulUnchecked left.view right.view x
 
 /-- Multiplication maps every pair of source members into the successful
 computed interval. -/
@@ -1273,8 +939,7 @@ theorem mul_mem_mulWithin {limit : EndpointLimit}
     (leftMember : left.Contains x) (rightMember : right.Contains y) :
     result.Contains (x * y) :=
   (contains_mulWithin checked (x * y)).2
-    ((contains_normalize (left.view.mulUnchecked right.view) (x * y)).2
-      (raw_mul_mem left.view right.view (view_consistent left)
-        (view_consistent right) leftMember rightMember))
+    ((rawContains_mulUnchecked left.view right.view (x * y)).1
+      (raw_mul_mem left.view right.view leftMember rightMember))
 
 end Hex.Interval

--- a/HexIntervalMathlib/Multiplication.lean
+++ b/HexIntervalMathlib/Multiplication.lean
@@ -1,0 +1,1280 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Subtraction
+public import HexInterval.Multiplication
+
+@[expose] public section
+
+/-!
+# Enclosure semantics of public interval multiplication
+
+This module relates the checked executable multiplication to its computed raw
+candidate and proves that every product of source members belongs to it.
+-/
+
+namespace Hex.Interval
+
+@[simp]
+theorem toReal_mul (left right : Dyadic) :
+    toReal (left * right) = toReal left * toReal right := by
+  simp [toReal]
+
+@[simp]
+theorem toReal_zero : toReal 0 = 0 := by
+  simp [toReal]
+
+/-- Computed cut predicate for exact raw multiplication. This describes the
+algorithm's normalized candidate; it does not claim a separate set-image
+tightness converse. -/
+def Raw.MulContains (left right : Raw) (x : ℝ) : Prop :=
+  (left.mulUnchecked right).normalizeUnchecked.Contains x
+
+private def Raw.Mul.Candidate.LowerBounds : Raw.Mul.Candidate → ℝ → Prop
+  | .negInf, _ => True
+  | .finite value attained, x =>
+      toReal value ≤ x ∧ (toReal value = x → attained = true)
+  | .posInf, _ => False
+
+private def Raw.Mul.Candidate.UpperBounds : Raw.Mul.Candidate → ℝ → Prop
+  | .negInf, _ => False
+  | .finite value attained, x =>
+      x ≤ toReal value ∧ (x = toReal value → attained = true)
+  | .posInf, _ => True
+
+private def Lower.Bounds : Lower → ℝ → Prop
+  | .unbounded, _ => True
+  | .finite value strict, x =>
+      toReal value ≤ x ∧ (toReal value = x → strict = false)
+
+private def Upper.Bounds : Upper → ℝ → Prop
+  | .finite value strict, x =>
+      x ≤ toReal value ∧ (x = toReal value → strict = false)
+  | .unbounded, _ => True
+
+private theorem le_ne_iff_lt {a b : ℝ} : a ≤ b ∧ ¬a = b ↔ a < b := by
+  exact ⟨fun h => lt_of_le_of_ne h.1 h.2, fun h => ⟨h.le, h.ne⟩⟩
+
+private theorem Lower.contains_iff_bounds (lower : Lower) (x : ℝ) :
+    lower.Contains x ↔ lower.Bounds x := by
+  cases lower with
+  | unbounded => simp [Lower.Contains, Lower.Bounds]
+  | finite value strict =>
+      cases strict <;> simp [Lower.Contains, Lower.Bounds, le_ne_iff_lt]
+
+private theorem Upper.contains_iff_bounds (upper : Upper) (x : ℝ) :
+    upper.Contains x ↔ upper.Bounds x := by
+  cases upper with
+  | unbounded => simp [Upper.Contains, Upper.Bounds]
+  | finite value strict =>
+      cases strict <;> simp [Upper.Contains, Upper.Bounds, le_ne_iff_lt]
+
+private theorem Raw.Mul.Candidate.lower_min (left right : Raw.Mul.Candidate)
+    {x : ℝ} (bound : left.LowerBounds x ∨ right.LowerBounds x) :
+    (Raw.Mul.minUnchecked left right).LowerBounds x := by
+  cases left <;> cases right <;>
+    simp_all [LowerBounds, Raw.Mul.minUnchecked]
+  next leftValue leftAttained rightValue rightAttained =>
+    by_cases less : leftValue < rightValue
+    · have realLess := toReal_lt less
+      cases leftAttained <;> cases rightAttained <;>
+        simp [Raw.Mul.minUnchecked, less, LowerBounds, le_ne_iff_lt] at bound ⊢ <;>
+        rcases bound with bound | bound <;> linarith
+    · by_cases equal : leftValue = rightValue
+      · subst rightValue
+        cases leftAttained <;> cases rightAttained <;>
+          simp [Raw.Mul.minUnchecked, less, LowerBounds, le_ne_iff_lt] at bound ⊢ <;>
+          aesop <;> linarith
+      · have realNotLess : ¬toReal leftValue < toReal rightValue := by
+          simpa only [toReal_lt_iff] using less
+        have realNotEqual : toReal leftValue ≠ toReal rightValue := by
+          intro same
+          exact equal (toReal_inj.mp same)
+        have realGreater : toReal rightValue < toReal leftValue :=
+          lt_of_le_of_ne (le_of_not_gt realNotLess) (Ne.symm realNotEqual)
+        cases leftAttained <;> cases rightAttained <;>
+          simp [Raw.Mul.minUnchecked, less, equal, LowerBounds, le_ne_iff_lt] at bound ⊢ <;>
+          rcases bound with bound | bound <;> linarith
+
+private theorem Raw.Mul.Candidate.upper_max (left right : Raw.Mul.Candidate)
+    {x : ℝ} (bound : left.UpperBounds x ∨ right.UpperBounds x) :
+    (Raw.Mul.maxUnchecked left right).UpperBounds x := by
+  cases left <;> cases right <;>
+    simp_all [UpperBounds, Raw.Mul.maxUnchecked]
+  next leftValue leftAttained rightValue rightAttained =>
+    by_cases less : leftValue < rightValue
+    · have realLess := toReal_lt less
+      cases leftAttained <;> cases rightAttained <;>
+        simp [Raw.Mul.maxUnchecked, less, UpperBounds, le_ne_iff_lt] at bound ⊢ <;>
+        rcases bound with bound | bound <;> linarith
+    · by_cases equal : leftValue = rightValue
+      · subst rightValue
+        cases leftAttained <;> cases rightAttained <;>
+          simp [Raw.Mul.maxUnchecked, less, UpperBounds, le_ne_iff_lt] at bound ⊢ <;>
+          aesop <;> linarith
+      · have realNotLess : ¬toReal leftValue < toReal rightValue := by
+          simpa only [toReal_lt_iff] using less
+        have realNotEqual : toReal leftValue ≠ toReal rightValue := by
+          intro same
+          exact equal (toReal_inj.mp same)
+        have realGreater : toReal rightValue < toReal leftValue :=
+          lt_of_le_of_ne (le_of_not_gt realNotLess) (Ne.symm realNotEqual)
+        cases leftAttained <;> cases rightAttained <;>
+          simp [Raw.Mul.maxUnchecked, less, equal, UpperBounds, le_ne_iff_lt] at bound ⊢ <;>
+          rcases bound with bound | bound <;> linarith
+
+private theorem Raw.Mul.Candidate.lower_minimum (first : Raw.Mul.Candidate)
+    (rest : List Raw.Mul.Candidate) {x : ℝ}
+    (bound : first.LowerBounds x ∨
+      ∃ candidate ∈ rest, candidate.LowerBounds x) :
+    (Raw.Mul.minimum first rest).LowerBounds x := by
+  induction rest generalizing first with
+  | nil => simpa [Raw.Mul.minimum] using bound
+  | cons next rest ih =>
+      rw [Raw.Mul.minimum]
+      apply ih
+      rcases bound with firstBound | ⟨candidate, member, candidateBound⟩
+      · exact Or.inl (Raw.Mul.Candidate.lower_min first next (Or.inl firstBound))
+      · simp only [List.mem_cons] at member
+        rcases member with equal | member
+        · subst candidate
+          exact Or.inl (Raw.Mul.Candidate.lower_min first next (Or.inr candidateBound))
+        · exact Or.inr ⟨candidate, member, candidateBound⟩
+
+private theorem Raw.Mul.Candidate.upper_maximum (first : Raw.Mul.Candidate)
+    (rest : List Raw.Mul.Candidate) {x : ℝ}
+    (bound : first.UpperBounds x ∨
+      ∃ candidate ∈ rest, candidate.UpperBounds x) :
+    (Raw.Mul.maximum first rest).UpperBounds x := by
+  induction rest generalizing first with
+  | nil => simpa [Raw.Mul.maximum] using bound
+  | cons next rest ih =>
+      rw [Raw.Mul.maximum]
+      apply ih
+      rcases bound with firstBound | ⟨candidate, member, candidateBound⟩
+      · exact Or.inl (Raw.Mul.Candidate.upper_max first next (Or.inl firstBound))
+      · simp only [List.mem_cons] at member
+        rcases member with equal | member
+        · subst candidate
+          exact Or.inl (Raw.Mul.Candidate.upper_max first next (Or.inr candidateBound))
+        · exact Or.inr ⟨candidate, member, candidateBound⟩
+
+private theorem Raw.Mul.Candidate.lowerCut_contains
+    (candidate : Raw.Mul.Candidate) {x : ℝ}
+    (bound : candidate.LowerBounds x) :
+    (Raw.Mul.lowerCut candidate).Contains x := by
+  cases candidate <;>
+    simp [Raw.Mul.lowerCut, Lower.Contains, LowerBounds, le_ne_iff_lt] at bound ⊢
+  next value attained =>
+    cases attained <;>
+      simp [Raw.Mul.lowerCut, Lower.Contains, LowerBounds, le_ne_iff_lt] at bound ⊢ <;>
+      exact bound
+
+private theorem Raw.Mul.Candidate.upperCut_contains
+    (candidate : Raw.Mul.Candidate) {x : ℝ}
+    (bound : candidate.UpperBounds x) :
+    (Raw.Mul.upperCut candidate).Contains x := by
+  cases candidate <;>
+    simp [Raw.Mul.upperCut, Upper.Contains, UpperBounds, le_ne_iff_lt] at bound ⊢
+  next value attained =>
+    cases attained <;>
+      simp [Raw.Mul.upperCut, Upper.Contains, UpperBounds, le_ne_iff_lt] at bound ⊢ <;>
+      exact bound
+
+private theorem Raw.Mul.result_mem {candidates : List Raw.Mul.Candidate} {x : ℝ}
+    (lower : ∃ candidate ∈ candidates, candidate.LowerBounds x)
+    (upper : ∃ candidate ∈ candidates, candidate.UpperBounds x) :
+    (Raw.Mul.result candidates).Contains x := by
+  cases candidates with
+  | nil => simp at lower
+  | cons first rest =>
+      simp only [Raw.Mul.result, Raw.Contains]
+      constructor
+      · apply Raw.Mul.Candidate.lowerCut_contains
+        apply Raw.Mul.Candidate.lower_minimum
+        rcases lower with ⟨candidate, member, bound⟩
+        simp only [List.mem_cons] at member
+        rcases member with equal | member
+        · subst candidate
+          exact Or.inl bound
+        · exact Or.inr ⟨candidate, member, bound⟩
+      · apply Raw.Mul.Candidate.upperCut_contains
+        apply Raw.Mul.Candidate.upper_maximum
+        rcases upper with ⟨candidate, member, bound⟩
+        simp only [List.mem_cons] at member
+        rcases member with equal | member
+        · subst candidate
+          exact Or.inl bound
+        · exact Or.inr ⟨candidate, member, bound⟩
+
+private theorem Raw.Mul.lowerAllowsZeroUnchecked_of_mem
+    (lower : Lower) (member : lower.Contains 0) :
+    Raw.Mul.lowerAllowsZeroUnchecked lower = true := by
+  cases lower with
+  | unbounded => rfl
+  | finite value strict =>
+      cases strict <;>
+        simp [Lower.Contains] at member
+      all_goals
+        by_cases less : toReal value < 0
+        · simp [Raw.Mul.lowerAllowsZeroUnchecked, Raw.Mul.signUnchecked,
+            ← toReal_lt_iff, ← toReal_inj, less]
+        · by_cases equal : toReal value = 0
+          · simp [Raw.Mul.lowerAllowsZeroUnchecked, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, ← toReal_inj, less, equal] <;> linarith
+          · exfalso
+            have : 0 < toReal value := lt_of_le_of_ne (le_of_not_gt less) (Ne.symm equal)
+            linarith
+
+private theorem Raw.Mul.upperAllowsZeroUnchecked_of_mem
+    (upper : Upper) (member : upper.Contains 0) :
+    Raw.Mul.upperAllowsZeroUnchecked upper = true := by
+  cases upper with
+  | unbounded => rfl
+  | finite value strict =>
+      cases strict <;>
+        simp [Upper.Contains] at member
+      all_goals
+        by_cases less : toReal value < 0
+        · exfalso
+          linarith
+        · by_cases equal : toReal value = 0
+          · simp [Raw.Mul.upperAllowsZeroUnchecked, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, ← toReal_inj, less, equal] <;> linarith
+          · simp [Raw.Mul.upperAllowsZeroUnchecked, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, ← toReal_inj, less, equal]
+
+private theorem Raw.Mul.containsZeroUnchecked_of_mem
+    (lower : Lower) (upper : Upper) {x : ℝ}
+    (member : lower.Contains x ∧ upper.Contains x) (zero : x = 0) :
+    Raw.Mul.containsZeroUnchecked lower upper = true := by
+  subst x
+  simp [Raw.Mul.containsZeroUnchecked,
+    Raw.Mul.lowerAllowsZeroUnchecked_of_mem lower member.1,
+    Raw.Mul.upperAllowsZeroUnchecked_of_mem upper member.2]
+
+private theorem mul_lower_eq {a x c y : ℝ} (aNonneg : 0 ≤ a) (aLe : a ≤ x)
+    (cNonneg : 0 ≤ c) (cLe : c ≤ y) (productNonzero : x * y ≠ 0)
+    (equal : x * y = a * c) : x = a ∧ y = c := by
+  have aNonzero : a ≠ 0 := by
+    intro aZero
+    apply productNonzero
+    rw [equal, aZero, zero_mul]
+  have cNonzero : c ≠ 0 := by
+    intro cZero
+    apply productNonzero
+    rw [equal, cZero, mul_zero]
+  have aPos : 0 < a := lt_of_le_of_ne aNonneg (Ne.symm aNonzero)
+  have cPos : 0 < c := lt_of_le_of_ne cNonneg (Ne.symm cNonzero)
+  have xPos : 0 < x := aPos.trans_le aLe
+  have xEq : x = a := by
+    by_contra notEqual
+    have aLt : a < x := lt_of_le_of_ne aLe (Ne.symm notEqual)
+    have first : a * c < x * c := mul_lt_mul_of_pos_right aLt cPos
+    have second : x * c ≤ x * y := mul_le_mul_of_nonneg_left cLe xPos.le
+    linarith
+  subst x
+  exact ⟨rfl, mul_left_cancel₀ aNonzero equal⟩
+
+private theorem mul_upper_eq {x b y d : ℝ} (xPos : 0 < x) (xLe : x ≤ b)
+    (yPos : 0 < y) (yLe : y ≤ d) (equal : x * y = b * d) :
+    x = b ∧ y = d := by
+  have bPos : 0 < b := xPos.trans_le xLe
+  have dPos : 0 < d := yPos.trans_le yLe
+  have xEq : x = b := by
+    by_contra notEqual
+    have xLt : x < b := lt_of_le_of_ne xLe notEqual
+    have first : x * y ≤ x * d := mul_le_mul_of_nonneg_left yLe xPos.le
+    have second : x * d < b * d := mul_lt_mul_of_pos_right xLt dPos
+    linarith
+  subst x
+  exact ⟨rfl, mul_left_cancel₀ bPos.ne' equal⟩
+
+private theorem finiteLower_nonneg_of_pos_not_zero
+    (lower upper : Dyadic) (lowerStrict upperStrict : Bool) {x : ℝ}
+    (member : (Lower.finite lower lowerStrict).Contains x ∧
+      (Upper.finite upper upperStrict).Contains x)
+    (xPos : 0 < x)
+    (notZero : Raw.Mul.containsZeroUnchecked (.finite lower lowerStrict)
+      (.finite upper upperStrict) = false) :
+    0 ≤ toReal lower := by
+  by_contra notNonneg
+  have lowerNeg : toReal lower < 0 := lt_of_not_ge notNonneg
+  have zeroMember : (Lower.finite lower lowerStrict).Contains 0 ∧
+      (Upper.finite upper upperStrict).Contains 0 := by
+    constructor
+    · cases lowerStrict <;> simp [Lower.Contains] <;> linarith
+    · cases upperStrict <;> simp [Upper.Contains] at member ⊢ <;> linarith
+  have yes := Raw.Mul.containsZeroUnchecked_of_mem
+    (.finite lower lowerStrict) (.finite upper upperStrict) zeroMember rfl
+  simp [notZero] at yes
+
+private theorem finiteUpper_nonpos_of_neg_not_zero
+    (lower upper : Dyadic) (lowerStrict upperStrict : Bool) {x : ℝ}
+    (member : (Lower.finite lower lowerStrict).Contains x ∧
+      (Upper.finite upper upperStrict).Contains x)
+    (xNeg : x < 0)
+    (notZero : Raw.Mul.containsZeroUnchecked (.finite lower lowerStrict)
+      (.finite upper upperStrict) = false) :
+    toReal upper ≤ 0 := by
+  by_contra notNonpos
+  have upperPos : 0 < toReal upper := lt_of_not_ge notNonpos
+  have zeroMember : (Lower.finite lower lowerStrict).Contains 0 ∧
+      (Upper.finite upper upperStrict).Contains 0 := by
+    constructor
+    · cases lowerStrict <;> simp [Lower.Contains] at member ⊢ <;> linarith
+    · cases upperStrict <;> simp [Upper.Contains] <;> linarith
+  have yes := Raw.Mul.containsZeroUnchecked_of_mem
+    (.finite lower lowerStrict) (.finite upper upperStrict) zeroMember rfl
+  simp [notZero] at yes
+
+private theorem upper_nonpos_of_neg_not_zero
+    (lower : Lower) (upper : Dyadic) (upperStrict : Bool) {x : ℝ}
+    (member : lower.Contains x ∧ (Upper.finite upper upperStrict).Contains x)
+    (xNeg : x < 0)
+    (notZero : Raw.Mul.containsZeroUnchecked lower (.finite upper upperStrict) = false) :
+    toReal upper ≤ 0 := by
+  by_contra notNonpos
+  have upperPos : 0 < toReal upper := lt_of_not_ge notNonpos
+  have zeroMember : lower.Contains 0 ∧ (Upper.finite upper upperStrict).Contains 0 := by
+    constructor
+    · cases lower with
+      | unbounded => simp [Lower.Contains]
+      | finite value strict =>
+          cases strict <;> simp [Lower.Contains] at member ⊢ <;> linarith
+    · cases upperStrict <;> simp [Upper.Contains] <;> linarith
+  have yes := Raw.Mul.containsZeroUnchecked_of_mem
+    lower (.finite upper upperStrict) zeroMember rfl
+  simp [notZero] at yes
+
+private theorem lower_nonneg_of_pos_not_zero
+    (lower : Dyadic) (lowerStrict : Bool) (upper : Upper) {x : ℝ}
+    (member : (Lower.finite lower lowerStrict).Contains x ∧ upper.Contains x)
+    (xPos : 0 < x)
+    (notZero : Raw.Mul.containsZeroUnchecked (.finite lower lowerStrict) upper = false) :
+    0 ≤ toReal lower := by
+  by_contra notNonneg
+  have lowerNeg : toReal lower < 0 := lt_of_not_ge notNonneg
+  have zeroMember : (Lower.finite lower lowerStrict).Contains 0 ∧ upper.Contains 0 := by
+    constructor
+    · cases lowerStrict <;> simp [Lower.Contains] <;> linarith
+    · cases upper with
+      | unbounded => simp [Upper.Contains]
+      | finite value strict =>
+          cases strict <;> simp [Upper.Contains] at member ⊢ <;> linarith
+  have yes := Raw.Mul.containsZeroUnchecked_of_mem
+    (.finite lower lowerStrict) upper zeroMember rfl
+  simp [notZero] at yes
+
+private theorem Raw.Mul.finite_corner_bounds
+    (leftLower leftUpper rightLower rightUpper : Dyadic)
+    (leftLowerStrict leftUpperStrict rightLowerStrict rightUpperStrict : Bool)
+    {x y : ℝ}
+    (leftMember :
+      (Lower.finite leftLower leftLowerStrict).Contains x ∧
+        (Upper.finite leftUpper leftUpperStrict).Contains x)
+    (rightMember :
+      (Lower.finite rightLower rightLowerStrict).Contains y ∧
+        (Upper.finite rightUpper rightUpperStrict).Contains y) :
+    (∃ candidate ∈ Raw.Mul.candidatesUnchecked
+        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
+        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict),
+      candidate.LowerBounds (x * y)) ∧
+    (∃ candidate ∈ Raw.Mul.candidatesUnchecked
+        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
+        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict),
+      candidate.UpperBounds (x * y)) := by
+  rw [Lower.contains_iff_bounds, Upper.contains_iff_bounds] at leftMember rightMember
+  by_cases productZero : x * y = 0
+  · rcases mul_eq_zero.mp productZero with xZero | yZero
+    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
+        (.finite leftLower leftLowerStrict) (.finite leftUpper leftUpperStrict)
+        ⟨(Lower.contains_iff_bounds _ _).2 leftMember.1,
+          (Upper.contains_iff_bounds _ _).2 leftMember.2⟩ xZero
+      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
+      all_goals simp [Raw.Mul.candidatesUnchecked, containsZero, productZero,
+        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
+        (.finite rightLower rightLowerStrict) (.finite rightUpper rightUpperStrict)
+        ⟨(Lower.contains_iff_bounds _ _).2 rightMember.1,
+          (Upper.contains_iff_bounds _ _).2 rightMember.2⟩ yZero
+      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
+      all_goals simp [Raw.Mul.candidatesUnchecked, containsZero, productZero,
+        Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+  have leftContains : (Lower.finite leftLower leftLowerStrict).Contains x ∧
+      (Upper.finite leftUpper leftUpperStrict).Contains x :=
+    ⟨(Lower.contains_iff_bounds _ _).2 leftMember.1,
+      (Upper.contains_iff_bounds _ _).2 leftMember.2⟩
+  have rightContains : (Lower.finite rightLower rightLowerStrict).Contains y ∧
+      (Upper.finite rightUpper rightUpperStrict).Contains y :=
+    ⟨(Lower.contains_iff_bounds _ _).2 rightMember.1,
+      (Upper.contains_iff_bounds _ _).2 rightMember.2⟩
+  have ll : toReal leftLower ≤ x := leftMember.1.1
+  have lu : x ≤ toReal leftUpper := leftMember.2.1
+  have rl : toReal rightLower ≤ y := rightMember.1.1
+  have ru : y ≤ toReal rightUpper := rightMember.2.1
+  have xNonzero : x ≠ 0 := fun equal => productZero (by simp [equal])
+  have yNonzero : y ≠ 0 := fun equal => productZero (by simp [equal])
+  have memberLL : Raw.Mul.Candidate.finite (leftLower * rightLower)
+      (!leftLowerStrict && !rightLowerStrict) ∈
+      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+        (.finite rightUpper rightUpperStrict) := by
+    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
+      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
+      split <;> simp
+  have memberLU : Raw.Mul.Candidate.finite (leftLower * rightUpper)
+      (!leftLowerStrict && !rightUpperStrict) ∈
+      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+        (.finite rightUpper rightUpperStrict) := by
+    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
+      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
+      split <;> simp
+  have memberUL : Raw.Mul.Candidate.finite (leftUpper * rightLower)
+      (!leftUpperStrict && !rightLowerStrict) ∈
+      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+        (.finite rightUpper rightUpperStrict) := by
+    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
+      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
+      split <;> simp
+  have memberUU : Raw.Mul.Candidate.finite (leftUpper * rightUpper)
+      (!leftUpperStrict && !rightUpperStrict) ∈
+      Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+        (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+        (.finite rightUpper rightUpperStrict) := by
+    simp [Raw.Mul.candidatesUnchecked, Raw.Mul.corners, Raw.Mul.evaluate,
+      Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge] <;>
+      split <;> simp
+  by_cases hx : x < 0
+  · have nx : 0 < -x := neg_pos.mpr hx
+    by_cases hy : y < 0
+    ·
+      have ny : 0 < -y := neg_pos.mpr hy
+      by_cases zero :
+          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) ||
+            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict)
+      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
+            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict) := by
+          simp [Raw.Mul.candidatesUnchecked, zero]
+        refine ⟨⟨.finite 0 true, memberZero, ?_⟩,
+          ⟨.finite (leftLower * rightLower)
+            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩⟩
+        · exact ⟨by simpa using (mul_pos_of_neg_of_neg hx hy).le, by simp
+            [Raw.Mul.Candidate.LowerBounds]⟩
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg ll) ny.le
+            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg rl)
+              (neg_nonneg.mpr (ll.trans_lt hx).le)
+            nlinarith
+          · intro equal
+            have ends := mul_upper_eq nx (neg_le_neg ll) ny (neg_le_neg rl) (by nlinarith)
+            have leftClosed := leftMember.1.2 (by nlinarith [ends.1])
+            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
+            simp [leftClosed, rightClosed]
+      · have noZero := Bool.eq_false_of_not_eq_true zero
+        have sides := Bool.or_eq_false_iff.mp noZero
+        have leftUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
+          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains hx sides.1
+        have rightUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
+          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains hy sides.2
+        refine ⟨⟨.finite (leftUpper * rightUpper)
+            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩,
+          ⟨.finite (leftLower * rightLower)
+            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          constructor
+          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg lu)
+              (neg_nonneg.mpr rightUpperNonpos)
+            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg ru) nx.le
+            nlinarith
+          · intro equal
+            have ends := mul_lower_eq (neg_nonneg.mpr leftUpperNonpos)
+              (neg_le_neg lu) (neg_nonneg.mpr rightUpperNonpos)
+              (neg_le_neg ru) (by simpa using productZero) (by nlinarith)
+            have leftClosed := leftMember.2.2 (by nlinarith [ends.1])
+            have rightClosed := rightMember.2.2 (by nlinarith [ends.2])
+            simp [leftClosed, rightClosed]
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · have bound := mul_le_mul_of_nonneg_right (neg_le_neg ll) ny.le
+            have bound' := mul_le_mul_of_nonneg_left (neg_le_neg rl)
+              (neg_nonneg.mpr (ll.trans_lt hx).le)
+            nlinarith
+          · intro equal
+            have ends := mul_upper_eq nx (neg_le_neg ll) ny (neg_le_neg rl) (by nlinarith)
+            have leftClosed := leftMember.1.2 (by nlinarith [ends.1])
+            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
+            simp [leftClosed, rightClosed]
+    · have yPos : 0 < y := lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero)
+      have lowerBound : toReal leftLower * toReal rightUpper ≤ x * y := by
+        have first := mul_le_mul_of_nonneg_right (neg_le_neg ll) yPos.le
+        have second := mul_le_mul_of_nonneg_left ru nx.le
+        nlinarith
+      have lowerEqual : x * y = toReal leftLower * toReal rightUpper →
+          x = toReal leftLower ∧ y = toReal rightUpper := by
+        intro equal
+        have ends := mul_upper_eq nx (neg_le_neg ll) yPos ru (by nlinarith)
+        exact ⟨by nlinarith [ends.1], ends.2⟩
+      by_cases zero :
+          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) ||
+            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict)
+      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
+            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict) := by
+          simp [Raw.Mul.candidatesUnchecked, zero]
+        refine ⟨⟨.finite (leftLower * rightUpper)
+            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩,
+          ⟨.finite 0 true, memberZero, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          exact ⟨lowerBound, fun equal => by
+            have ends := lowerEqual equal.symm
+            simp [leftMember.1.2 ends.1.symm, rightMember.2.2 ends.2]⟩
+        · exact ⟨by simpa using (mul_neg_of_neg_of_pos hx yPos).le, by simp
+            [Raw.Mul.Candidate.UpperBounds]⟩
+      · have noZero := Bool.eq_false_of_not_eq_true zero
+        have sides := Bool.or_eq_false_iff.mp noZero
+        have leftUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
+          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains hx sides.1
+        have rightLowerNonneg := finiteLower_nonneg_of_pos_not_zero
+          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains yPos sides.2
+        refine ⟨⟨.finite (leftLower * rightUpper)
+            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩,
+          ⟨.finite (leftUpper * rightLower)
+            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          exact ⟨lowerBound, fun equal => by
+            have ends := lowerEqual equal.symm
+            simp [leftMember.1.2 ends.1.symm, rightMember.2.2 ends.2]⟩
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · have first := mul_le_mul_of_nonneg_right (neg_le_neg lu) rightLowerNonneg
+            have second := mul_le_mul_of_nonneg_left rl nx.le
+            nlinarith
+          · intro equal
+            have ends := mul_lower_eq (neg_nonneg.mpr leftUpperNonpos)
+              (neg_le_neg lu) rightLowerNonneg rl
+              (mul_ne_zero (neg_ne_zero.mpr xNonzero) yNonzero) (by nlinarith)
+            have leftClosed := leftMember.2.2 (by nlinarith [ends.1])
+            have rightClosed := rightMember.1.2 (by nlinarith [ends.2])
+            simp [leftClosed, rightClosed]
+  · have xPos : 0 < x := lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero)
+    by_cases hy : y < 0
+    · have ny : 0 < -y := neg_pos.mpr hy
+      have lowerBound : toReal leftUpper * toReal rightLower ≤ x * y := by
+        have first := mul_le_mul_of_nonneg_right lu ny.le
+        have second := mul_le_mul_of_nonneg_left (neg_le_neg rl) xPos.le
+        nlinarith
+      have lowerEqual : x * y = toReal leftUpper * toReal rightLower →
+          x = toReal leftUpper ∧ y = toReal rightLower := by
+        intro equal
+        have ends := mul_upper_eq xPos lu ny (neg_le_neg rl) (by nlinarith)
+        exact ⟨ends.1, by nlinarith [ends.2]⟩
+      by_cases zero :
+          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) ||
+            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict)
+      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
+            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict) := by
+          simp [Raw.Mul.candidatesUnchecked, zero]
+        refine ⟨⟨.finite (leftUpper * rightLower)
+            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩,
+          ⟨.finite 0 true, memberZero, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          exact ⟨lowerBound, fun equal => by
+            have ends := lowerEqual equal.symm
+            simp [leftMember.2.2 ends.1, rightMember.1.2 ends.2.symm]⟩
+        · exact ⟨by simpa using (mul_neg_of_pos_of_neg xPos hy).le, by simp
+            [Raw.Mul.Candidate.UpperBounds]⟩
+      · have noZero := Bool.eq_false_of_not_eq_true zero
+        have sides := Bool.or_eq_false_iff.mp noZero
+        have leftLowerNonneg := finiteLower_nonneg_of_pos_not_zero
+          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains xPos sides.1
+        have rightUpperNonpos := finiteUpper_nonpos_of_neg_not_zero
+          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains hy sides.2
+        refine ⟨⟨.finite (leftUpper * rightLower)
+            (!leftUpperStrict && !rightLowerStrict), memberUL, ?_⟩,
+          ⟨.finite (leftLower * rightUpper)
+            (!leftLowerStrict && !rightUpperStrict), memberLU, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          exact ⟨lowerBound, fun equal => by
+            have ends := lowerEqual equal.symm
+            simp [leftMember.2.2 ends.1, rightMember.1.2 ends.2.symm]⟩
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · have first := mul_le_mul_of_nonneg_right ll (neg_nonneg.mpr rightUpperNonpos)
+            have second := mul_le_mul_of_nonneg_left (neg_le_neg ru) xPos.le
+            nlinarith
+          · intro equal
+            have ends := mul_lower_eq leftLowerNonneg ll
+              (neg_nonneg.mpr rightUpperNonpos) (neg_le_neg ru)
+              (mul_ne_zero xNonzero (neg_ne_zero.mpr yNonzero)) (by nlinarith)
+            have leftClosed := leftMember.1.2 ends.1.symm
+            have rightClosed := rightMember.2.2 (by nlinarith [ends.2])
+            simp [leftClosed, rightClosed]
+    · have yPos : 0 < y := lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero)
+      by_cases zero :
+          Raw.Mul.containsZeroUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) ||
+            Raw.Mul.containsZeroUnchecked (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict)
+      · have memberZero : Raw.Mul.Candidate.finite 0 true ∈
+            Raw.Mul.candidatesUnchecked (.finite leftLower leftLowerStrict)
+              (.finite leftUpper leftUpperStrict) (.finite rightLower rightLowerStrict)
+              (.finite rightUpper rightUpperStrict) := by
+          simp [Raw.Mul.candidatesUnchecked, zero]
+        refine ⟨⟨.finite 0 true, memberZero, ?_⟩,
+          ⟨.finite (leftUpper * rightUpper)
+            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩⟩
+        · exact ⟨by simpa using (mul_pos xPos yPos).le, by simp
+            [Raw.Mul.Candidate.LowerBounds]⟩
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · exact mul_le_mul lu ru yPos.le (xPos.le.trans lu)
+          · intro equal
+            have ends := mul_upper_eq xPos lu yPos ru equal
+            simp [leftMember.2.2 ends.1, rightMember.2.2 ends.2]
+      · have noZero := Bool.eq_false_of_not_eq_true zero
+        have sides := Bool.or_eq_false_iff.mp noZero
+        have leftLowerNonneg := finiteLower_nonneg_of_pos_not_zero
+          leftLower leftUpper leftLowerStrict leftUpperStrict leftContains xPos sides.1
+        have rightLowerNonneg := finiteLower_nonneg_of_pos_not_zero
+          rightLower rightUpper rightLowerStrict rightUpperStrict rightContains yPos sides.2
+        refine ⟨⟨.finite (leftLower * rightLower)
+            (!leftLowerStrict && !rightLowerStrict), memberLL, ?_⟩,
+          ⟨.finite (leftUpper * rightUpper)
+            (!leftUpperStrict && !rightUpperStrict), memberUU, ?_⟩⟩
+        · simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+          constructor
+          · exact mul_le_mul ll rl rightLowerNonneg xPos.le
+          · intro equal
+            have ends := mul_lower_eq leftLowerNonneg ll rightLowerNonneg rl
+              productZero equal.symm
+            simp [leftMember.1.2 ends.1.symm, rightMember.1.2 ends.2.symm]
+        · simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+          constructor
+          · exact mul_le_mul lu ru yPos.le (xPos.le.trans lu)
+          · intro equal
+            have ends := mul_upper_eq xPos lu yPos ru equal
+            simp [leftMember.2.2 ends.1, rightMember.2.2 ends.2]
+
+private def Raw.Mul.HasBounds (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) (x y : ℝ) : Prop :=
+  (∃ candidate ∈ Raw.Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper,
+      candidate.LowerBounds (x * y)) ∧
+    (∃ candidate ∈ Raw.Mul.candidatesUnchecked leftLower leftUpper rightLower rightUpper,
+      candidate.UpperBounds (x * y))
+
+private theorem Raw.Mul.mem_evaluate {pairs : List (Raw.Mul.Edge × Raw.Mul.Edge)}
+    {pair : Raw.Mul.Edge × Raw.Mul.Edge} {candidate : Raw.Mul.Candidate}
+    (pairMem : pair ∈ pairs)
+    (evaluates : Raw.Mul.productUnchecked pair.1 pair.2 = some candidate) :
+    candidate ∈ Raw.Mul.evaluate pairs := by
+  induction pairs with
+  | nil => simp at pairMem
+  | cons first rest ih =>
+      simp only [List.mem_cons] at pairMem
+      rcases pairMem with equal | member
+      · subst pair
+        simp [Raw.Mul.evaluate, evaluates]
+      · simp only [Raw.Mul.evaluate]
+        split
+        · exact ih member
+        · simp only [List.mem_cons]
+          exact Or.inr (ih member)
+
+private theorem Raw.Mul.mem_cornerLL {leftLower : Lower} {leftUpper : Upper}
+    {rightLower : Lower} {rightUpper : Upper} {candidate : Raw.Mul.Candidate}
+    (evaluates : Raw.Mul.productUnchecked (Raw.Mul.lowerEdge leftLower)
+      (Raw.Mul.lowerEdge rightLower) = some candidate) :
+    candidate ∈ Raw.Mul.candidatesUnchecked
+      leftLower leftUpper rightLower rightUpper := by
+  have member := Raw.Mul.mem_evaluate
+    (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
+    (pair := (Raw.Mul.lowerEdge leftLower, Raw.Mul.lowerEdge rightLower))
+    (by simp [Raw.Mul.corners]) evaluates
+  unfold Raw.Mul.candidatesUnchecked
+  split <;> simp [member]
+
+private theorem Raw.Mul.mem_cornerLU {leftLower : Lower} {leftUpper : Upper}
+    {rightLower : Lower} {rightUpper : Upper} {candidate : Raw.Mul.Candidate}
+    (evaluates : Raw.Mul.productUnchecked (Raw.Mul.lowerEdge leftLower)
+      (Raw.Mul.upperEdge rightUpper) = some candidate) :
+    candidate ∈ Raw.Mul.candidatesUnchecked
+      leftLower leftUpper rightLower rightUpper := by
+  have member := Raw.Mul.mem_evaluate
+    (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
+    (pair := (Raw.Mul.lowerEdge leftLower, Raw.Mul.upperEdge rightUpper))
+    (by simp [Raw.Mul.corners]) evaluates
+  unfold Raw.Mul.candidatesUnchecked
+  split <;> simp [member]
+
+private theorem Raw.Mul.mem_cornerUL {leftLower : Lower} {leftUpper : Upper}
+    {rightLower : Lower} {rightUpper : Upper} {candidate : Raw.Mul.Candidate}
+    (evaluates : Raw.Mul.productUnchecked (Raw.Mul.upperEdge leftUpper)
+      (Raw.Mul.lowerEdge rightLower) = some candidate) :
+    candidate ∈ Raw.Mul.candidatesUnchecked
+      leftLower leftUpper rightLower rightUpper := by
+  have member := Raw.Mul.mem_evaluate
+    (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
+    (pair := (Raw.Mul.upperEdge leftUpper, Raw.Mul.lowerEdge rightLower))
+    (by simp [Raw.Mul.corners]) evaluates
+  unfold Raw.Mul.candidatesUnchecked
+  split <;> simp [member]
+
+private theorem Raw.Mul.mem_cornerUU {leftLower : Lower} {leftUpper : Upper}
+    {rightLower : Lower} {rightUpper : Upper} {candidate : Raw.Mul.Candidate}
+    (evaluates : Raw.Mul.productUnchecked (Raw.Mul.upperEdge leftUpper)
+      (Raw.Mul.upperEdge rightUpper) = some candidate) :
+    candidate ∈ Raw.Mul.candidatesUnchecked
+      leftLower leftUpper rightLower rightUpper := by
+  have member := Raw.Mul.mem_evaluate
+    (pairs := Raw.Mul.corners leftLower leftUpper rightLower rightUpper)
+    (pair := (Raw.Mul.upperEdge leftUpper, Raw.Mul.upperEdge rightUpper))
+    (by simp [Raw.Mul.corners]) evaluates
+  unfold Raw.Mul.candidatesUnchecked
+  split <;> simp [member]
+
+private theorem Raw.Mul.mem_zero {leftLower : Lower} {leftUpper : Upper}
+    {rightLower : Lower} {rightUpper : Upper}
+    (contains : Raw.Mul.containsZeroUnchecked leftLower leftUpper ||
+      Raw.Mul.containsZeroUnchecked rightLower rightUpper) :
+    Raw.Mul.Candidate.finite 0 true ∈ Raw.Mul.candidatesUnchecked
+      leftLower leftUpper rightLower rightUpper := by
+  simp [Raw.Mul.candidatesUnchecked, contains]
+
+set_option maxHeartbeats 3000000 in
+private theorem Raw.Mul.corner_bounds_neg_neg
+    (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
+    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
+    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
+    (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
+    (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
+    (hx : x < 0) (hy : y < 0) :
+    Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
+  unfold Raw.Mul.HasBounds
+  constructor
+  · by_cases zero : Raw.Mul.containsZeroUnchecked leftLower leftUpper ||
+        Raw.Mul.containsZeroUnchecked rightLower rightUpper
+    · exact ⟨.finite 0 true, Raw.Mul.mem_zero zero,
+        by simp [Raw.Mul.Candidate.LowerBounds, (mul_pos_of_neg_of_neg hx hy).le]⟩
+    · have noZero := Bool.eq_false_of_not_eq_true zero
+      have sides := Bool.or_eq_false_iff.mp noZero
+      cases leftUpper with
+      | unbounded =>
+          have zeroMember : leftLower.Contains 0 ∧ Upper.unbounded.Contains 0 := by
+            constructor
+            · cases leftLower with
+              | unbounded => simp [Lower.Contains]
+              | finite value strict =>
+                  cases strict <;> simp [Lower.Contains] at leftMember ⊢ <;> linarith
+            · simp [Upper.Contains]
+          have yes := Raw.Mul.containsZeroUnchecked_of_mem
+            leftLower .unbounded zeroMember rfl
+          simp [sides.1] at yes
+      | finite leftValue leftStrict =>
+          have leftNonpos := upper_nonpos_of_neg_not_zero leftLower leftValue leftStrict
+            leftMember hx sides.1
+          cases rightUpper with
+          | unbounded =>
+              have zeroMember : rightLower.Contains 0 ∧ Upper.unbounded.Contains 0 := by
+                constructor
+                · cases rightLower with
+                  | unbounded => simp [Lower.Contains]
+                  | finite value strict =>
+                      cases strict <;> simp [Lower.Contains] at rightMember ⊢ <;> linarith
+                · simp [Upper.Contains]
+              have yes := Raw.Mul.containsZeroUnchecked_of_mem
+                rightLower .unbounded zeroMember rfl
+              simp [sides.2] at yes
+          | finite rightValue rightStrict =>
+              have rightNonpos := upper_nonpos_of_neg_not_zero rightLower rightValue
+                rightStrict rightMember hy sides.2
+              refine ⟨.finite (leftValue * rightValue) (!leftStrict && !rightStrict),
+                Raw.Mul.mem_cornerUU rfl, ?_⟩
+              simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+              constructor
+              · have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+                  |> neg_le_neg
+                have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+                  |> neg_le_neg
+                have first := mul_le_mul_of_nonneg_right leftLe
+                  (neg_nonneg.mpr rightNonpos)
+                have second := mul_le_mul_of_nonneg_left rightLe (neg_pos.mpr hx).le
+                nlinarith
+              · intro equal
+                have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+                have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+                have ends := mul_lower_eq (neg_nonneg.mpr leftNonpos)
+                  (neg_le_neg leftLe) (neg_nonneg.mpr rightNonpos)
+                  (neg_le_neg rightLe)
+                  (mul_ne_zero (neg_ne_zero.mpr (ne_of_lt hx))
+                    (neg_ne_zero.mpr (ne_of_lt hy))) (by nlinarith)
+                have leftClosed := ((Upper.contains_iff_bounds _ _).1 leftMember.2).2
+                  (by nlinarith [ends.1])
+                have rightClosed := ((Upper.contains_iff_bounds _ _).1 rightMember.2).2
+                  (by nlinarith [ends.2])
+                simp [leftClosed, rightClosed]
+  · cases leftLower with
+    | unbounded =>
+        cases rightLower with
+        | unbounded => exact ⟨.posInf, Raw.Mul.mem_cornerLL rfl, by simp
+            [Raw.Mul.Candidate.UpperBounds]⟩
+        | finite rightValue rightStrict =>
+            have rightNeg : toReal rightValue < 0 := by
+              have bound := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+              linarith
+            refine ⟨.posInf, Raw.Mul.mem_cornerLL ?_, by simp
+              [Raw.Mul.Candidate.UpperBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, rightNeg]
+    | finite leftValue leftStrict =>
+        have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+        have leftNeg : toReal leftValue < 0 := leftLe.trans_lt hx
+        cases rightLower with
+        | unbounded =>
+            refine ⟨.posInf, Raw.Mul.mem_cornerLL ?_, by simp
+              [Raw.Mul.Candidate.UpperBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, leftNeg]
+        | finite rightValue rightStrict =>
+            have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+            have rightNeg : toReal rightValue < 0 := rightLe.trans_lt hy
+            refine ⟨.finite (leftValue * rightValue)
+                (!leftStrict && !rightStrict), Raw.Mul.mem_cornerLL rfl, ?_⟩
+            simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+            constructor
+            · have first := mul_le_mul_of_nonneg_right (neg_le_neg leftLe)
+                (neg_pos.mpr hy).le
+              have second := mul_le_mul_of_nonneg_left (neg_le_neg rightLe)
+                (neg_nonneg.mpr leftNeg.le)
+              nlinarith
+            · intro equal
+              have ends := mul_upper_eq (neg_pos.mpr hx) (neg_le_neg leftLe)
+                (neg_pos.mpr hy) (neg_le_neg rightLe) (by nlinarith)
+              have leftClosed := ((Lower.contains_iff_bounds _ _).1 leftMember.1).2
+                (by nlinarith [ends.1])
+              have rightClosed := ((Lower.contains_iff_bounds _ _).1 rightMember.1).2
+                (by nlinarith [ends.2])
+              simp [leftClosed, rightClosed]
+
+set_option maxHeartbeats 3000000 in
+private theorem Raw.Mul.corner_bounds_neg_pos
+    (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
+    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
+    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
+    (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
+    (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
+    (hx : x < 0) (hy : 0 < y) :
+    Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
+  unfold Raw.Mul.HasBounds
+  constructor
+  · cases leftLower with
+    | unbounded =>
+        cases rightUpper with
+        | unbounded => exact ⟨.negInf, Raw.Mul.mem_cornerLU rfl, by simp
+            [Raw.Mul.Candidate.LowerBounds]⟩
+        | finite rightValue rightStrict =>
+            have rightPos : 0 < toReal rightValue := by
+              have bound := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+              exact hy.trans_le bound
+            refine ⟨.negInf, Raw.Mul.mem_cornerLU ?_, by simp
+              [Raw.Mul.Candidate.LowerBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge,
+              Raw.Mul.signUnchecked, ← toReal_lt_iff, ← toReal_inj,
+              not_lt_of_ge rightPos.le, rightPos.ne']
+    | finite leftValue leftStrict =>
+        have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+        have leftNeg : toReal leftValue < 0 := leftLe.trans_lt hx
+        cases rightUpper with
+        | unbounded =>
+            refine ⟨.negInf, Raw.Mul.mem_cornerLU ?_, by simp
+              [Raw.Mul.Candidate.LowerBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge,
+              Raw.Mul.signUnchecked, ← toReal_lt_iff, leftNeg]
+        | finite rightValue rightStrict =>
+            have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+            have rightPos : 0 < toReal rightValue := hy.trans_le rightLe
+            refine ⟨.finite (leftValue * rightValue)
+                (!leftStrict && !rightStrict), Raw.Mul.mem_cornerLU rfl, ?_⟩
+            simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+            constructor
+            · have first := mul_le_mul_of_nonneg_right (neg_le_neg leftLe) hy.le
+              have second := mul_le_mul_of_nonneg_left rightLe (neg_pos.mpr hx).le
+              nlinarith
+            · intro equal
+              have ends := mul_upper_eq (neg_pos.mpr hx) (neg_le_neg leftLe)
+                hy rightLe (by nlinarith)
+              have leftClosed := ((Lower.contains_iff_bounds _ _).1 leftMember.1).2
+                (by nlinarith [ends.1])
+              have rightClosed := ((Upper.contains_iff_bounds _ _).1 rightMember.2).2
+                ends.2
+              simp [leftClosed, rightClosed]
+  · by_cases zero : Raw.Mul.containsZeroUnchecked leftLower leftUpper ||
+        Raw.Mul.containsZeroUnchecked rightLower rightUpper
+    · exact ⟨.finite 0 true, Raw.Mul.mem_zero zero,
+        by simp [Raw.Mul.Candidate.UpperBounds, (mul_neg_of_neg_of_pos hx hy).le]⟩
+    · have noZero := Bool.eq_false_of_not_eq_true zero
+      have sides := Bool.or_eq_false_iff.mp noZero
+      cases leftUpper with
+      | unbounded =>
+          have zeroMember : leftLower.Contains 0 ∧ Upper.unbounded.Contains 0 := by
+            constructor
+            · cases leftLower with
+              | unbounded => simp [Lower.Contains]
+              | finite value strict =>
+                  cases strict <;> simp [Lower.Contains] at leftMember ⊢ <;> linarith
+            · simp [Upper.Contains]
+          have yes := Raw.Mul.containsZeroUnchecked_of_mem
+            leftLower .unbounded zeroMember rfl
+          simp [sides.1] at yes
+      | finite leftValue leftStrict =>
+          have leftNonpos := upper_nonpos_of_neg_not_zero leftLower leftValue leftStrict
+            leftMember hx sides.1
+          cases rightLower with
+          | unbounded =>
+              have zeroMember : Lower.unbounded.Contains 0 ∧ rightUpper.Contains 0 := by
+                constructor
+                · simp [Lower.Contains]
+                · cases rightUpper with
+                  | unbounded => simp [Upper.Contains]
+                  | finite value strict =>
+                      cases strict <;> simp [Upper.Contains] at rightMember ⊢ <;> linarith
+              have yes := Raw.Mul.containsZeroUnchecked_of_mem
+                .unbounded rightUpper zeroMember rfl
+              simp [sides.2] at yes
+          | finite rightValue rightStrict =>
+              have rightNonneg := lower_nonneg_of_pos_not_zero rightValue rightStrict
+                rightUpper rightMember hy sides.2
+              refine ⟨.finite (leftValue * rightValue)
+                  (!leftStrict && !rightStrict), Raw.Mul.mem_cornerUL rfl, ?_⟩
+              simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+              constructor
+              · have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+                  |> neg_le_neg
+                have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+                have first := mul_le_mul_of_nonneg_right leftLe rightNonneg
+                have second := mul_le_mul_of_nonneg_left rightLe (neg_pos.mpr hx).le
+                nlinarith
+              · intro equal
+                have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+                have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+                have ends := mul_lower_eq (neg_nonneg.mpr leftNonpos)
+                  (neg_le_neg leftLe) rightNonneg rightLe
+                  (mul_ne_zero (neg_ne_zero.mpr (ne_of_lt hx)) (ne_of_gt hy))
+                  (by nlinarith)
+                have leftClosed := ((Upper.contains_iff_bounds _ _).1 leftMember.2).2
+                  (by nlinarith [ends.1])
+                have rightClosed := ((Lower.contains_iff_bounds _ _).1 rightMember.1).2
+                  ends.2.symm
+                simp [leftClosed, rightClosed]
+
+set_option maxHeartbeats 3000000 in
+private theorem Raw.Mul.corner_bounds_pos_neg
+    (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
+    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
+    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
+    (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
+    (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
+    (hx : 0 < x) (hy : y < 0) :
+    Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
+  unfold Raw.Mul.HasBounds
+  constructor
+  · cases leftUpper with
+    | unbounded =>
+        cases rightLower with
+        | unbounded => exact ⟨.negInf, Raw.Mul.mem_cornerUL rfl, by simp
+            [Raw.Mul.Candidate.LowerBounds]⟩
+        | finite rightValue rightStrict =>
+            have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+            have rightNeg : toReal rightValue < 0 := rightLe.trans_lt hy
+            refine ⟨.negInf, Raw.Mul.mem_cornerUL ?_, by simp
+              [Raw.Mul.Candidate.LowerBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge,
+              Raw.Mul.signUnchecked, ← toReal_lt_iff, rightNeg]
+    | finite leftValue leftStrict =>
+        have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+        have leftPos : 0 < toReal leftValue := hx.trans_le leftLe
+        cases rightLower with
+        | unbounded =>
+            refine ⟨.negInf, Raw.Mul.mem_cornerUL ?_, by simp
+              [Raw.Mul.Candidate.LowerBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.lowerEdge, Raw.Mul.upperEdge,
+              Raw.Mul.signUnchecked, ← toReal_lt_iff, ← toReal_inj,
+              not_lt_of_ge leftPos.le, leftPos.ne']
+        | finite rightValue rightStrict =>
+            have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+            have rightNeg : toReal rightValue < 0 := rightLe.trans_lt hy
+            refine ⟨.finite (leftValue * rightValue)
+                (!leftStrict && !rightStrict), Raw.Mul.mem_cornerUL rfl, ?_⟩
+            simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+            constructor
+            · have first := mul_le_mul_of_nonneg_right leftLe (neg_pos.mpr hy).le
+              have second := mul_le_mul_of_nonneg_left (neg_le_neg rightLe) hx.le
+              nlinarith
+            · intro equal
+              have ends := mul_upper_eq hx leftLe (neg_pos.mpr hy)
+                (neg_le_neg rightLe) (by nlinarith)
+              have leftClosed := ((Upper.contains_iff_bounds _ _).1 leftMember.2).2
+                ends.1
+              have rightClosed := ((Lower.contains_iff_bounds _ _).1 rightMember.1).2
+                (by nlinarith [ends.2])
+              simp [leftClosed, rightClosed]
+  · by_cases zero : Raw.Mul.containsZeroUnchecked leftLower leftUpper ||
+        Raw.Mul.containsZeroUnchecked rightLower rightUpper
+    · exact ⟨.finite 0 true, Raw.Mul.mem_zero zero,
+        by simp [Raw.Mul.Candidate.UpperBounds, (mul_neg_of_pos_of_neg hx hy).le]⟩
+    · have noZero := Bool.eq_false_of_not_eq_true zero
+      have sides := Bool.or_eq_false_iff.mp noZero
+      cases leftLower with
+      | unbounded =>
+          have zeroMember : Lower.unbounded.Contains 0 ∧ leftUpper.Contains 0 := by
+            constructor
+            · simp [Lower.Contains]
+            · cases leftUpper with
+              | unbounded => simp [Upper.Contains]
+              | finite value strict =>
+                  cases strict <;> simp [Upper.Contains] at leftMember ⊢ <;> linarith
+          have yes := Raw.Mul.containsZeroUnchecked_of_mem
+            .unbounded leftUpper zeroMember rfl
+          simp [sides.1] at yes
+      | finite leftValue leftStrict =>
+          have leftNonneg := lower_nonneg_of_pos_not_zero leftValue leftStrict
+            leftUpper leftMember hx sides.1
+          cases rightUpper with
+          | unbounded =>
+              have zeroMember : rightLower.Contains 0 ∧ Upper.unbounded.Contains 0 := by
+                constructor
+                · cases rightLower with
+                  | unbounded => simp [Lower.Contains]
+                  | finite value strict =>
+                      cases strict <;> simp [Lower.Contains] at rightMember ⊢ <;> linarith
+                · simp [Upper.Contains]
+              have yes := Raw.Mul.containsZeroUnchecked_of_mem
+                rightLower .unbounded zeroMember rfl
+              simp [sides.2] at yes
+          | finite rightValue rightStrict =>
+              have rightNonpos := upper_nonpos_of_neg_not_zero rightLower rightValue
+                rightStrict rightMember hy sides.2
+              refine ⟨.finite (leftValue * rightValue)
+                  (!leftStrict && !rightStrict), Raw.Mul.mem_cornerLU rfl, ?_⟩
+              simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+              constructor
+              · have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+                have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+                  |> neg_le_neg
+                have first := mul_le_mul_of_nonneg_right leftLe
+                  (neg_nonneg.mpr rightNonpos)
+                have second := mul_le_mul_of_nonneg_left rightLe hx.le
+                nlinarith
+              · intro equal
+                have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+                have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+                have ends := mul_lower_eq leftNonneg leftLe
+                  (neg_nonneg.mpr rightNonpos) (neg_le_neg rightLe)
+                  (mul_ne_zero (ne_of_gt hx) (neg_ne_zero.mpr (ne_of_lt hy)))
+                  (by nlinarith)
+                have leftClosed := ((Lower.contains_iff_bounds _ _).1 leftMember.1).2
+                  ends.1.symm
+                have rightClosed := ((Upper.contains_iff_bounds _ _).1 rightMember.2).2
+                  (by nlinarith [ends.2])
+                simp [leftClosed, rightClosed]
+
+set_option maxHeartbeats 3000000 in
+private theorem Raw.Mul.corner_bounds_pos_pos
+    (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
+    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
+    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
+    (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
+    (rightMember : rightLower.Contains y ∧ rightUpper.Contains y)
+    (hx : 0 < x) (hy : 0 < y) :
+    Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
+  unfold Raw.Mul.HasBounds
+  constructor
+  · by_cases zero : Raw.Mul.containsZeroUnchecked leftLower leftUpper ||
+        Raw.Mul.containsZeroUnchecked rightLower rightUpper
+    · exact ⟨.finite 0 true, Raw.Mul.mem_zero zero,
+        by simp [Raw.Mul.Candidate.LowerBounds, (mul_pos hx hy).le]⟩
+    · have noZero := Bool.eq_false_of_not_eq_true zero
+      have sides := Bool.or_eq_false_iff.mp noZero
+      cases leftLower with
+      | unbounded =>
+          have zeroMember : Lower.unbounded.Contains 0 ∧ leftUpper.Contains 0 := by
+            constructor
+            · simp [Lower.Contains]
+            · cases leftUpper with
+              | unbounded => simp [Upper.Contains]
+              | finite value strict =>
+                  cases strict <;> simp [Upper.Contains] at leftMember ⊢ <;> linarith
+          have yes := Raw.Mul.containsZeroUnchecked_of_mem
+            .unbounded leftUpper zeroMember rfl
+          simp [sides.1] at yes
+      | finite leftValue leftStrict =>
+          have leftNonneg := lower_nonneg_of_pos_not_zero leftValue leftStrict
+            leftUpper leftMember hx sides.1
+          cases rightLower with
+          | unbounded =>
+              have zeroMember : Lower.unbounded.Contains 0 ∧ rightUpper.Contains 0 := by
+                constructor
+                · simp [Lower.Contains]
+                · cases rightUpper with
+                  | unbounded => simp [Upper.Contains]
+                  | finite value strict =>
+                      cases strict <;> simp [Upper.Contains] at rightMember ⊢ <;> linarith
+              have yes := Raw.Mul.containsZeroUnchecked_of_mem
+                .unbounded rightUpper zeroMember rfl
+              simp [sides.2] at yes
+          | finite rightValue rightStrict =>
+              have rightNonneg := lower_nonneg_of_pos_not_zero rightValue rightStrict
+                rightUpper rightMember hy sides.2
+              refine ⟨.finite (leftValue * rightValue)
+                  (!leftStrict && !rightStrict), Raw.Mul.mem_cornerLL rfl, ?_⟩
+              simp only [Raw.Mul.Candidate.LowerBounds, toReal_mul]
+              constructor
+              · have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+                have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+                exact mul_le_mul leftLe rightLe rightNonneg hx.le
+              · intro equal
+                have leftLe := ((Lower.contains_iff_bounds _ _).1 leftMember.1).1
+                have rightLe := ((Lower.contains_iff_bounds _ _).1 rightMember.1).1
+                have ends := mul_lower_eq leftNonneg leftLe rightNonneg rightLe
+                  (mul_ne_zero (ne_of_gt hx) (ne_of_gt hy)) equal.symm
+                have leftClosed := ((Lower.contains_iff_bounds _ _).1 leftMember.1).2
+                  ends.1.symm
+                have rightClosed := ((Lower.contains_iff_bounds _ _).1 rightMember.1).2
+                  ends.2.symm
+                simp [leftClosed, rightClosed]
+  · cases leftUpper with
+    | unbounded =>
+        cases rightUpper with
+        | unbounded => exact ⟨.posInf, Raw.Mul.mem_cornerUU rfl, by simp
+            [Raw.Mul.Candidate.UpperBounds]⟩
+        | finite rightValue rightStrict =>
+            have rightPos : 0 < toReal rightValue := by
+              have bound := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+              exact hy.trans_le bound
+            refine ⟨.posInf, Raw.Mul.mem_cornerUU ?_, by simp
+              [Raw.Mul.Candidate.UpperBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.upperEdge, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, ← toReal_inj, not_lt_of_ge rightPos.le,
+              rightPos.ne']
+    | finite leftValue leftStrict =>
+        have leftLe := ((Upper.contains_iff_bounds _ _).1 leftMember.2).1
+        have leftPos : 0 < toReal leftValue := hx.trans_le leftLe
+        cases rightUpper with
+        | unbounded =>
+            refine ⟨.posInf, Raw.Mul.mem_cornerUU ?_, by simp
+              [Raw.Mul.Candidate.UpperBounds]⟩
+            simp [Raw.Mul.productUnchecked, Raw.Mul.upperEdge, Raw.Mul.signUnchecked,
+              ← toReal_lt_iff, ← toReal_inj, not_lt_of_ge leftPos.le,
+              leftPos.ne']
+        | finite rightValue rightStrict =>
+            have rightLe := ((Upper.contains_iff_bounds _ _).1 rightMember.2).1
+            have rightPos : 0 < toReal rightValue := hy.trans_le rightLe
+            refine ⟨.finite (leftValue * rightValue)
+                (!leftStrict && !rightStrict), Raw.Mul.mem_cornerUU rfl, ?_⟩
+            simp only [Raw.Mul.Candidate.UpperBounds, toReal_mul]
+            constructor
+            · exact mul_le_mul leftLe rightLe hy.le (hx.le.trans leftLe)
+            · intro equal
+              have ends := mul_upper_eq hx leftLe hy rightLe equal
+              have leftClosed := ((Upper.contains_iff_bounds _ _).1 leftMember.2).2
+                ends.1
+              have rightClosed := ((Upper.contains_iff_bounds _ _).1 rightMember.2).2
+                ends.2
+              simp [leftClosed, rightClosed]
+
+private theorem Raw.Mul.corner_bounds
+    (leftLower : Lower) (leftUpper : Upper)
+    (rightLower : Lower) (rightUpper : Upper) {x y : ℝ}
+    (leftConsistent : (Raw.bounds leftLower leftUpper).CutConsistent)
+    (rightConsistent : (Raw.bounds rightLower rightUpper).CutConsistent)
+    (leftMember : leftLower.Contains x ∧ leftUpper.Contains x)
+    (rightMember : rightLower.Contains y ∧ rightUpper.Contains y) :
+    Raw.Mul.HasBounds leftLower leftUpper rightLower rightUpper x y := by
+  by_cases productZero : x * y = 0
+  · rcases mul_eq_zero.mp productZero with xZero | yZero
+    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
+        leftLower leftUpper leftMember xZero
+      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
+      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked, containsZero,
+        productZero, Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+    · have containsZero := Raw.Mul.containsZeroUnchecked_of_mem
+        rightLower rightUpper rightMember yZero
+      refine ⟨⟨.finite 0 true, ?_, ?_⟩, ⟨.finite 0 true, ?_, ?_⟩⟩
+      all_goals simp [Raw.Mul.HasBounds, Raw.Mul.candidatesUnchecked, containsZero,
+        productZero, Raw.Mul.Candidate.LowerBounds, Raw.Mul.Candidate.UpperBounds]
+  have xNonzero : x ≠ 0 := fun equal => productZero (by simp [equal])
+  have yNonzero : y ≠ 0 := fun equal => productZero (by simp [equal])
+  by_cases hx : x < 0
+  · by_cases hy : y < 0
+    · exact Raw.Mul.corner_bounds_neg_neg _ _ _ _ leftConsistent rightConsistent
+        leftMember rightMember hx hy
+    · exact Raw.Mul.corner_bounds_neg_pos _ _ _ _ leftConsistent rightConsistent
+        leftMember rightMember hx (lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero))
+  · by_cases hy : y < 0
+    · exact Raw.Mul.corner_bounds_pos_neg _ _ _ _ leftConsistent rightConsistent
+        leftMember rightMember (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero)) hy
+    · exact Raw.Mul.corner_bounds_pos_pos _ _ _ _ leftConsistent rightConsistent
+        leftMember rightMember (lt_of_le_of_ne (le_of_not_gt hx) (Ne.symm xNonzero))
+        (lt_of_le_of_ne (le_of_not_gt hy) (Ne.symm yNonzero))
+
+private theorem raw_mul_mem (left right : Raw) {x y : ℝ}
+    (leftConsistent : left.CutConsistent) (rightConsistent : right.CutConsistent)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    (left.mulUnchecked right).Contains (x * y) := by
+  cases left with
+  | empty => simp [Raw.Contains] at leftMember
+  | bounds leftLower leftUpper =>
+      cases right with
+      | empty => simp [Raw.Contains] at rightMember
+      | bounds rightLower rightUpper =>
+          apply Raw.Mul.result_mem
+          · exact (Raw.Mul.corner_bounds leftLower leftUpper rightLower rightUpper
+              leftConsistent rightConsistent leftMember rightMember).1
+          · exact (Raw.Mul.corner_bounds leftLower leftUpper rightLower rightUpper
+              leftConsistent rightConsistent leftMember rightMember).2
+
+/-- A successful multiplication has exactly its normalized computed-cut
+predicate. -/
+theorem contains_mulWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval}
+    (checked : mulWithin limit left right = .ready result) (x : ℝ) :
+    result.Contains x ↔ left.view.MulContains right.view x := by
+  simp only [Contains, Raw.MulContains]
+  rw [view_mulWithin_ready checked]
+
+/-- Multiplication maps every pair of source members into the successful
+computed interval. -/
+theorem mul_mem_mulWithin {limit : EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : mulWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x * y) :=
+  (contains_mulWithin checked (x * y)).2
+    ((contains_normalize (left.view.mulUnchecked right.view) (x * y)).2
+      (raw_mul_mem left.view right.view (view_consistent left)
+        (view_consistent right) leftMember rightMember))
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -10,9 +10,10 @@ perform planner search or turn runtime checks into proof evidence.
 The foundational supported module is `HexIntervalMathlib.Interval`. It defines the
 real value of a dyadic endpoint and membership for every public interval cut:
 strict or closed finite ends, independent unbounded ends, and canonical empty.
-`HexIntervalMathlib.Addition` and `HexIntervalMathlib.Subtraction` add the
-public arithmetic image theorems, while `HexIntervalMathlib.MinMax` supplies
-selected-cut and real-image enclosure theorems for minimum and maximum, and
+`HexIntervalMathlib.Addition`, `HexIntervalMathlib.Subtraction`, and
+`HexIntervalMathlib.Multiplication` add the public arithmetic image theorems,
+while `HexIntervalMathlib.MinMax` supplies selected-cut and real-image
+enclosure theorems for minimum and maximum, and
 `HexIntervalMathlib.Absolute` supplies the corresponding absolute-value
 theorems.
 
@@ -36,15 +37,21 @@ For every successful resource-checked public operation it proves:
   difference cuts, including empty absorption and independent unbounded
   sides;
 - `sub_mem_subWithin`: two input members subtract to a member of every
-  successful result.
+  successful result;
 - `contains_minWithin` and `contains_maxWithin`: exact membership in the
   computed selected cuts;
 - `min_mem_minWithin` and `max_mem_maxWithin`: pointwise real minimum and
-  maximum of two input members belong to every successful result.
+  maximum of two input members belong to every successful result;
 - `contains_absWithin`: exact membership in the normalized selected absolute
   value cuts;
-- `abs_mem_absWithin`: the absolute value of every input member belongs to
-  every successful result.
+- `abs_mem_absWithin`: the absolute value of every input member belongs to every
+  successful result;
+- `contains_mulWithin`: exact successful-result membership in the normalized
+  computed corner candidate, including empty, unbounded, strict, closed, and
+  zero-attainment cases;
+- `mul_mem_mulWithin`: two input members multiply to a member of every
+  successful result. This is an enclosure theorem; no separate image-tightness
+  converse is claimed.
 
 These theorems depend on the exact successful `BuildResult` equation. A
 resource refusal has no set interpretation and is never treated as an empty
@@ -67,12 +74,13 @@ it claims a tightness converse only when that converse is separately proved.
 
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
 membership, exact hull closure and both input inclusions, negation transport,
-addition and subtraction cut exactness and image transport, and the exact
-ordinary-kernel axiom surface. `HexIntervalMathlib.MinMaxConformance` separately
-pins exact selected cuts, both image enclosures, and their axiom surfaces; it
-does not assert a set-image converse. The interval conformance module also pins
-absolute-value cut exactness, image transport, and its ordinary-kernel axiom
-surface.
+addition, subtraction, and multiplication cut exactness and image transport,
+and the exact ordinary-kernel axiom surface.
+`HexIntervalMathlib.MinMaxConformance` separately pins exact selected cuts,
+both image enclosures, and their axiom surfaces; it does not assert a set-image
+converse.
+The interval conformance module also pins absolute-value cut exactness, image
+transport, and its ordinary-kernel axiom surface.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -46,16 +46,17 @@ For every successful resource-checked public operation it proves:
   value cuts;
 - `abs_mem_absWithin`: the absolute value of every input member belongs to every
   successful result;
-- `contains_mulWithin`: exact successful-result membership in the normalized
-  computed corner candidate, including empty, unbounded, strict, closed, and
-  zero-attainment cases;
+- `contains_mulWithin`: exact successful-result membership in the explicit
+  selected lower and upper candidate cuts after normalization, including
+  empty, unbounded, strict, closed, and zero-attainment cases;
 - `mul_mem_mulWithin`: two input members multiply to a member of every
   successful result. This is an enclosure theorem; no separate image-tightness
   converse is claimed.
 
-These theorems depend on the exact successful `BuildResult` equation. A
-resource refusal has no set interpretation and is never treated as an empty
-interval. The proofs use the public operation's checked view-characterization
+These theorems depend on the exact successful operation-result equation
+(`BuildResult` or `Arithmetic.Result`). A resource refusal has no set
+interpretation and is never treated as an empty interval. The proofs use the
+public operation's checked view-characterization
 theorems and independently establish the complete raw-cut semantics; they do
 not import the experimental propagation fact domain.
 

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -281,6 +281,15 @@ private def openClosed01 : Hex.Interval := ready (finite 0 true 1 false)
 private def closedOpen23 : Hex.Interval := ready (finite 2 false 3 true)
 private def singletonOne : Hex.Interval := ready (finite 1 false 1 false)
 private def singletonNegOne : Hex.Interval := ready (finite (-1) false (-1) false)
+private def singletonZero : Hex.Interval := ready (finite 0 false 0 false)
+private def singleton255 : Hex.Interval :=
+  match Hex.Interval.singletonWithin eightBitLimit (d 255) with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+private def mixedLeft : Hex.Interval := ready (finite (-2) false 3 false)
+private def mixedRight : Hex.Interval := ready (finite (-4) false 5 false)
+private def nonnegative : Hex.Interval :=
+  ready (.bounds (.finite (d 0) false) .unbounded)
 private def half : Dyadic := .ofOdd 1 1 (by decide)
 private def singletonHalf : Hex.Interval :=
   ready (.bounds (.finite half false) (.finite half false))
@@ -749,6 +758,78 @@ private def mediumToOne : Hex.Interval :=
       powerBand singletonOne with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 100
+
+-- Multiplication tracks endpoint attainment independently from the numerical
+-- corner value. A contained zero closes the lower product endpoint even when
+-- the other factor approaches zero only strictly.
+#guard
+  match Hex.Interval.mulWithin smallLimit closed01 openClosed01 with
+  | .ready interval => interval == closed01
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.mulWithin smallLimit openClosed01 openClosed01 with
+  | .ready interval => interval == openClosed01
+  | .resourceLimit _ => false
+
+-- Mixed signs exercise both minimum and maximum corner selectors.
+#guard
+  match Hex.Interval.mulWithin smallLimit mixedLeft mixedRight with
+  | .ready interval => interval.view == finite (-12) false 15 false
+  | .resourceLimit _ => false
+
+-- Empty is absorbing. Singleton zero annihilates even a two-sided unbounded
+-- factor, whereas a non-singleton interval containing zero still exposes both
+-- unbounded directions when multiplied by the whole line.
+#guard
+  match Hex.Interval.mulWithin smallLimit Hex.Interval.empty Hex.Interval.whole with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.mulWithin smallLimit singletonZero Hex.Interval.whole with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.mulWithin smallLimit Hex.Interval.whole singletonZero with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.mulWithin smallLimit closed01 Hex.Interval.whole with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Independent unbounded sides are selected by endpoint signs.
+#guard
+  match Hex.Interval.mulWithin smallLimit nonnegative closed01 with
+  | .ready interval => interval == nonnegative
+  | .resourceLimit _ => false
+
+private def nonpositiveOne : Hex.Interval :=
+  ready (.bounds .unbounded (.finite (d (-1)) false))
+
+#guard
+  match Hex.Interval.mulWithin smallLimit nonpositiveOne nonpositiveOne with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 1) false) .unbounded
+  | .resourceLimit _ => false
+
+-- Product-growth refusal remains distinct from empty and happens while both
+-- input endpoints and their exact comparison still fit the caller limit.
+#guard
+  match Hex.Interval.mulWithin eightBitLimit singleton255 singleton255 with
+  | .ready _ => false
+  | .resourceLimit (.growth cost) => cost.predicted.numeratorBits == 16
+  | .resourceLimit _ => false
+
+-- Ordinary positive multiplication succeeds through the richer arithmetic
+-- result and retains both closed extrema.
+#guard
+  match Hex.Interval.mulWithin smallLimit closed12 closed23 with
+  | .ready interval => interval.view == finite 2 false 6 false
+  | .resourceLimit _ => false
 
 -- Negation swaps the endpoints and preserves openness; empty stays empty.
 #guard

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -82,9 +82,11 @@ private def eightBitLimit : EndpointLimit where
 -- can allocate an aligned mantissa.
 private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
 
--- Multiplication's four refusal phases remain distinguishable. Source and
--- candidate size failures are endpoint diagnostics; product growth has its own
--- diagnostic; only comparison alignment is reported as comparison work.
+-- Multiplication's phase helpers remain distinguishable. Source size is an
+-- observable endpoint refusal; the direct candidate guard pins the defensive
+-- endpoint stage even though admitted corner growth makes it unreachable as
+-- the first refusal of the current `mulWithin` pipeline. Only alignment is
+-- reported as comparison work.
 #guard
   match Raw.Mul.preflightEdge smallLimit (.finite far false) with
   | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
@@ -280,6 +282,15 @@ private def ready (raw : Raw) : Hex.Interval :=
   match Hex.Interval.ofRawWithin smallLimit raw with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
+
+private def farSingleton : Hex.Interval :=
+  match Hex.Interval.singletonWithin
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 0 } far with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+#guard farSingleton.view ==
+  .bounds (.finite far false) (.finite far false)
 
 private def closed01 : Hex.Interval := ready (finite 0 false 1 false)
 private def closed12 : Hex.Interval := ready (finite 1 false 2 false)
@@ -782,6 +793,26 @@ private def mediumToOne : Hex.Interval :=
       powerBand singletonOne with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 100
+
+-- A public interval admitted under a larger construction budget is rejected
+-- at multiplication's source-endpoint phase under a smaller caller budget.
+#guard
+  match Hex.Interval.mulWithin smallLimit farSingleton singletonOne with
+  | .resourceLimit (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+-- Source endpoints and all product-growth predictions fit, but the retained
+-- candidates 1 and 2^100 require a prohibited alignment shift. This reaches
+-- the public candidate-comparison diagnostic rather than only its helper.
+#guard
+  match Hex.Interval.mulWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 50 }
+      widePower singletonOne with
+  | .resourceLimit (.comparison cost) =>
+      cost.lower.allowed { maxEndpointHeight := 256, maxAlignmentShift := 50 } &&
+        cost.upper.allowed { maxEndpointHeight := 256, maxAlignmentShift := 50 } &&
+        cost.alignmentShift == 100
+  | _ => false
 
 -- Multiplication tracks endpoint attainment independently from the numerical
 -- corner value. A contained zero closes the lower product endpoint even when

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -82,6 +82,30 @@ private def eightBitLimit : EndpointLimit where
 -- can allocate an aligned mantissa.
 private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
 
+-- Multiplication's four refusal phases remain distinguishable. Source and
+-- candidate size failures are endpoint diagnostics; product growth has its own
+-- diagnostic; only comparison alignment is reported as comparison work.
+#guard
+  match Raw.Mul.preflightEdge smallLimit (.finite far false) with
+  | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+#guard
+  match Raw.Mul.preflightCandidate smallLimit (.finite far true) with
+  | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+#guard
+  match Raw.Mul.preflightCompare
+      { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 }
+      (.finite (d 1) true) (.finite far false) with
+  | .error (.comparison cost) =>
+      cost.lower.allowed { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } &&
+        cost.upper.allowed
+          { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } &&
+        cost.alignmentShift == 1000000000
+  | _ => false
+
 #guard
   match Raw.normalizeWithin
       { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 }
@@ -801,7 +825,8 @@ private def mediumToOne : Hex.Interval :=
   | .ready interval => interval == Hex.Interval.whole
   | .resourceLimit _ => false
 
--- Independent unbounded sides are selected by endpoint signs.
+-- The unconditional extended-corner enumeration retains independent
+-- unbounded sides; sign inspection only resolves finite-by-infinite corners.
 #guard
   match Hex.Interval.mulWithin smallLimit nonnegative closed01 with
   | .ready interval => interval == nonnegative

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -10,7 +10,7 @@ import HexIntervalMathlib
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
 ordinary-kernel meaning of every successful intersection, hull, addition,
-subtraction, negation, and absolute value.
+subtraction, multiplication, negation, and absolute value.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -108,6 +108,23 @@ theorem absImage {limit : Hex.Interval.EndpointLimit}
     (member : input.Contains x) : result.Contains |x| :=
   Hex.Interval.abs_mem_absWithin checked member
 
+/-- A successful multiplication has exactly its normalized computed corner
+candidate semantics. -/
+theorem mulExact {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.mulWithin limit left right = .ready result) :
+    result.Contains x ↔ left.view.MulContains right.view x :=
+  Hex.Interval.contains_mulWithin checked x
+
+/-- Both source membership proofs are consumed by the arithmetic image theorem
+for successful interval multiplication. -/
+theorem mulImage {limit : Hex.Interval.EndpointLimit}
+    {left right result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.mulWithin limit left right = .ready result)
+    (leftMember : left.Contains x) (rightMember : right.Contains y) :
+    result.Contains (x * y) :=
+  Hex.Interval.mul_mem_mulWithin checked leftMember rightMember
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -155,5 +172,13 @@ theorem absImage {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.absImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms absImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.mulExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms mulExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.mulImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms mulImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -364,7 +364,8 @@ lean_lib HexIntervalMathlibExperiment where
 lean_lib HexIntervalMathlib where
   globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
     `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
-    `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute].map Glob.one
+    `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
+    `HexIntervalMathlib.Multiplication].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T085522Z.md
+++ b/progress/20260815T085522Z.md
@@ -1,0 +1,34 @@
+# Accomplished
+
+Implemented resource-safe public interval multiplication. `mulWithin` admits
+all source endpoints, finite-product growth, and candidate comparisons before
+forming any mantissa product or alignment, preserves independent unbounded
+sides and exact endpoint attainment, and distinguishes growth/comparison
+refusal from the empty interval.
+
+Proved the computed candidate-cut characterization and the real image
+enclosure theorem for finite and unbounded inputs.  The proof factors all
+extended-endpoint cases through reusable corner-membership and sign-monotonicity
+lemmas; it does not claim a converse tightness theorem.  Added Mathlib-free and
+Mathlib conformance guards for strict/closed endpoints, mixed signs, zero,
+unbounded products, operand direction, and pre-allocation refusal.
+
+Focused executable, umbrella, Mathlib bridge, and conformance builds pass.
+The changed Lean files contain no `native_decide`, `axiom`, or `sorry`.
+
+# Current frontier
+
+The multiplication feature is proof-complete and restacked onto the latest
+main.  Its umbrella and Lake registrations preserve the subsequently merged
+minimum/maximum and PNT example surface, and its final Lake blob has an exact,
+narrow proof-only factor-freshness exemption.
+
+# Next step
+
+Review the checked multiplication API and proofs as the next public arithmetic
+slice; direct checked powers and absolute value can then restack on this common
+resource layer without being coupled to the multiplication candidate helpers.
+
+# Blockers
+
+None.

--- a/progress/20260815T085522Z.md
+++ b/progress/20260815T085522Z.md
@@ -1,10 +1,16 @@
 # Accomplished
 
 Implemented resource-safe public interval multiplication. `mulWithin` admits
-all source endpoints, finite-product growth, and candidate comparisons before
-forming any mantissa product or alignment, preserves independent unbounded
-sides and exact endpoint attainment, and distinguishes growth/comparison
-refusal from the empty interval.
+all source endpoints, finite-product growth, candidate endpoints, and candidate
+comparisons before forming any unadmitted mantissa product or alignment,
+preserves independent unbounded sides and exact endpoint attainment, and
+distinguishes growth/comparison refusal from the empty interval.
+
+The review repair makes the runtime phases explicit: source endpoints,
+product growth, evaluated candidate endpoints, then candidate alignment.
+Endpoint and alignment diagnostics are no longer conflated, and conformance
+guards discriminate all four refusal phases. The checked path reuses one
+corner-recipe list and one evaluated candidate list.
 
 Proved the computed candidate-cut characterization and the real image
 enclosure theorem for finite and unbounded inputs.  The proof factors all
@@ -13,21 +19,29 @@ lemmas; it does not claim a converse tightness theorem.  Added Mathlib-free and
 Mathlib conformance guards for strict/closed endpoints, mixed signs, zero,
 unbounded products, operand direction, and pre-allocation refusal.
 
+Removed the unused finite-only proof path and unused consistency parameters.
+`Raw.MulContains` is now an explicit empty/selected-cut predicate, with a
+separate raw correspondence theorem and a substantive normalization step in
+`contains_mulWithin`. The Mathlib proof shrank by more than three hundred lines
+and compiles under the default heartbeat limit.
+
 Focused executable, umbrella, Mathlib bridge, and conformance builds pass.
 The changed Lean files contain no `native_decide`, `axiom`, or `sorry`.
 
 # Current frontier
 
-The multiplication feature is proof-complete and restacked onto the latest
-main.  Its umbrella and Lake registrations preserve the subsequently merged
-minimum/maximum and PNT example surface, and its final Lake blob has an exact,
-narrow proof-only factor-freshness exemption.
+The multiplication feature and accepted review repairs are proof-complete and
+restacked onto current main. The merged absolute-value, minimum/maximum, PNT,
+and other registrations remain intact. The merged `preflightPow` API, its
+resource caveat, and its conformance guards are preserved independently of the
+multiplication candidates. The multiplication registration has an exact narrow
+exemption for the resulting Lake blob.
 
 # Next step
 
-Review the checked multiplication API and proofs as the next public arithmetic
-slice; direct checked powers and absolute value can then restack on this common
-resource layer without being coupled to the multiplication candidate helpers.
+Review the repaired checked-multiplication slice. Direct powers can reuse the
+arithmetic growth layer without depending on multiplication's private
+candidate scheduler; downstream absolute value remains independent.
 
 # Blockers
 

--- a/progress/20260815T100500Z.md
+++ b/progress/20260815T100500Z.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Added the runtime and Mathlib multiplication modules explicitly to the
+  interval file-organization inventory.
+- Reduced the Mathlib multiplication dependency to the direct interval bridge.
+- Clarified that candidate-height admission is a defensive invariant in the
+  current pipeline, while source endpoint and candidate comparison refusals
+  remain observable through `mulWithin`.
+- Added end-to-end guards for those observable endpoint and comparison
+  diagnostics.
+- Rebuilt the focused runtime, Mathlib, and conformance targets and ran the
+  repository formatting, DAG, trust, registration, PNT, and freshness checks.
+
+# Current frontier
+
+The multiplication slice exposes a sealed resource-checked operation and a
+one-way real-image enclosure theorem. It deliberately makes no tightness
+converse claim.
+
+# Next step
+
+Complete the exact-head CI gate and merge the multiplication slice when it is
+green.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -340,5 +340,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "6afd48a39be31f9d1628c6256b9b7a7b4c724e3d",
     "reason": "Additionally registers the supported HexIntervalMathlib absolute-value semantics module on top of the retained BKLNW and minimum/maximum registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "d121290ce99315ecaa1d322726f85308bf8be15e",
+    "reason": "Additionally registers the supported HexIntervalMathlib multiplication-semantics module and its Mathlib-free and proof-only conformance coverage; the factorization service target and executable dependency graph are unchanged."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -344,7 +344,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "d121290ce99315ecaa1d322726f85308bf8be15e",
-    "reason": "Additionally registers the supported HexIntervalMathlib multiplication-semantics module and its Mathlib-free and proof-only conformance coverage; the factorization service target and executable dependency graph are unchanged."
+    "current_blob": "5531e22c687dc8534e79fac44549fa8819044211",
+    "reason": "Additionally registers the supported HexIntervalMathlib multiplication-semantics module and its Mathlib-free and proof-only conformance coverage on top of the retained absolute-value and minimum/maximum registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add `mulWithin`, a Mathlib-free checked interval multiplication API with separate source-endpoint, product-growth, candidate-endpoint, and candidate-alignment admission phases
- enumerate all four extended-endpoint corners unconditionally, resolve finite-by-infinite corners by sign, and add an attained zero candidate exactly when a nonempty factor contains zero
- preserve strict/closed extrema, empty absorption, independent unbounded sides, and pre-allocation refusal diagnostics
- add an explicit selected-cut `Raw.MulContains` predicate, a successful-result characterization, and the ordinary-kernel enclosure theorem `mul_mem_mulWithin`
- add discriminating runtime and semantic conformance guards, umbrella registrations, and current-state SPEC documentation

## Scope

This PR proves that every product of source members belongs to the successful computed interval. It deliberately does **not** claim a set-image tightness converse. Precision-indexed reciprocal/division and public interval powers remain future work; the merged `preflightPow` prerequisite and its execution-work caveat are preserved unchanged.

`mulChecked` and `mulWithin` remain sealed. Only raw computational helpers required by the Mathlib correspondence proof are exposed. No `native_decide`, `axiom`, or `sorry` is introduced.

## Verification

- `lake build HexInterval.Arithmetic HexInterval.Multiplication HexInterval.Conformance HexIntervalMathlib.Multiplication HexIntervalMathlib.IntervalConformance HexIntervalMathlib.Absolute HexIntervalMathlib.MinMax HexInterval HexIntervalMathlib`
- copyright-header and file-line-count checks
- DAG, released-manifest, and conformance-target checks
- published trust-surface check
- PNT inventory check
- factor-sweep freshness check
- exact proof-only Lake exemption for blob `5531e22c687dc8534e79fac44549fa8819044211`
- `git diff --check`
