### PR TITLE
feat(interval): cap direct power execution work

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -19,8 +19,8 @@ The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
 maximum, and absolute value. The arithmetic resource layer preflights product
-and direct-power growth independently of exact comparison work; public interval
-power remains future work. Raw cuts remain visible as the explicit decoder and
-inspection boundary; D2 propagation and replay experiments still live outside
-this supported umbrella.
+growth, direct-power retained growth, and exponent work independently of
+exact comparison work; public interval power remains future work. Raw cuts
+remain visible as the explicit decoder and inspection boundary; D2 propagation
+and replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -44,13 +44,36 @@ def allowed (limit : EndpointLimit) (growth : Growth) : Bool :=
 
 end Growth
 
+/-- Execution-work limit for a future direct natural-power operation. The cap
+is on the actual exponent value, not the size of its binary encoding. -/
+structure PowLimits where
+  maxExponent : Nat
+  deriving DecidableEq, Repr
+
+/-- Work demanded by Core's nonzero dyadic natural-power path. -/
+structure PowWork where
+  exponent : Nat
+  deriving DecidableEq, Repr
+
+namespace PowWork
+
+/-- Admit Core nonzero power work only when the actual natural exponent is no
+larger than the configured scalar cap. `Nat` comparison is arbitrary precision
+and cannot wrap at a machine-word boundary. -/
+def allowed (limits : PowLimits) (work : PowWork) : Bool :=
+  work.exponent ≤ limits.maxExponent
+
+end PowWork
+
 /-- Resource diagnostics for checked public arithmetic. Product growth is a
 separate case from endpoint and comparison work: a comparison between two
-admitted factors may be cheap even when their product is too large. -/
+admitted factors may be cheap even when their product is too large. Direct
+power execution work is also reported separately from retained growth. -/
 inductive Cost where
   | endpoint (cost : EndpointCost)
   | comparison (cost : CompareCost)
   | growth (cost : Growth)
+  | power (work : PowWork)
   deriving DecidableEq, Repr
 
 /-- Result type for public arithmetic whose work is not described by
@@ -113,7 +136,8 @@ signed dyadic-exponent multiplication. In particular, a unit mantissa at
 dyadic exponent zero can pass this growth check for an arbitrarily large
 natural exponent. A future public power operation must enforce a separate
 exponent/work limit before invoking `Dyadic.pow`. -/
-def preflightPow (limit : EndpointLimit) (source : Dyadic) (exponent : Nat) :
+def preflightPowGrowth (limit : EndpointLimit) (source : Dyadic)
+    (exponent : Nat) :
     Except Cost Growth := do
   let sourceCost := EndpointCost.ofDyadic source
   if !sourceCost.allowed limit then
@@ -137,5 +161,26 @@ def preflightPow (limit : EndpointLimit) (source : Dyadic) (exponent : Nat) :
   if !cost.allowed limit then
     throw (.growth cost)
   pure cost
+
+/-- Transactional prerequisite for invoking Core direct dyadic power.
+
+For a nonzero source, the actual `Nat` exponent is checked before the retained
+growth preflight and before any call to `Dyadic.pow`; refusal has the distinct
+`Cost.power` diagnostic. A successful result therefore authenticates both the
+work cap and `preflightPowGrowth`'s source/result endpoint-growth boundary.
+
+The zero source deliberately bypasses the exponent cap. Core's `Dyadic.pow`
+zero branch only tests whether the exponent is zero and returns `1` or `0`; it
+does not evaluate `Nat.pow`, convert the exponent to `Int`, or multiply a
+dyadic exponent. This exception does not apply to either `1` or `-1`. -/
+def preflightPow (endpointLimit : EndpointLimit) (workLimits : PowLimits)
+    (source : Dyadic) (exponent : Nat) : Except Cost Growth :=
+  match source with
+  | .zero => preflightPowGrowth endpointLimit source exponent
+  | .ofOdd _ _ _ => do
+      let work : PowWork := { exponent }
+      if !work.allowed workLimits then
+        throw (.power work)
+      preflightPowGrowth endpointLimit source exponent
 
 end Hex.Interval.Arithmetic

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -489,9 +489,10 @@ mantissas. For example, under endpoint height `8`, the endpoints `255` and
 `255` and their comparison are admitted, while their predicted sixteen-bit
 product numerator is refused before multiplication.
 
-`Arithmetic.preflightPow` applies the same boundary to a direct natural power
-with one source. It predicts the exact magnitude of the dyadic exponent and a
-conservative mantissa-bit count without raising the mantissa. Numerators of
+`Arithmetic.preflightPowGrowth` applies the same boundary to a direct natural
+power with one source. It predicts the exact magnitude of the dyadic exponent
+and a conservative mantissa-bit count without raising the mantissa. Numerators
+of
 absolute value one retain their exact one-bit cost, so large powers of `1`,
 `-1`, and unit-mantissa powers of two do not incur fictitious mantissa growth;
 powers of two are still charged their exact signed exponent magnitude. The
@@ -509,6 +510,27 @@ resource gate for a public interval power. In particular, when the dyadic
 exponent is zero and the mantissa has absolute value one, arbitrarily large
 natural exponents pass the endpoint-growth check. A future `powWithin` must add
 and enforce a separate exponent/work cap before invoking `Dyadic.pow`.
+
+`Arithmetic.PowLimits` supplies that smallest execution-work prerequisite.
+Its `maxExponent` bounds the actual arbitrary-precision `Nat` value, not the
+number of bits used to encode it. `Arithmetic.preflightPow` checks this cap
+for every nonzero dyadic before composing transactionally with
+`preflightPowGrowth`; a work refusal is `Arithmetic.Cost.power`, never a
+fabricated endpoint or growth diagnostic. A successful composite check
+guarantees that a future caller reaches Core's nonzero power only with a
+bounded source, bounded retained-result growth, and
+`exponent ≤ maxExponent`.
+
+Zero alone bypasses the work cap. Core's zero branch only distinguishes `0^0`
+from a positive power and returns `1` or `0`; it does not invoke `Nat.pow`,
+convert the exponent to `Int`, or form the signed dyadic-exponent product.
+This exemption does not extend to `1` or `-1`, whose Core path still processes
+the natural exponent. The scalar cap is sufficient to bound that Core path
+when combined with the existing endpoint/growth limits, but it is not a
+wall-clock estimate and does not charge work already spent constructing,
+parsing, or reifying the input `Nat`. A future public `powWithin` must use the
+composite gate before Core power; this prerequisite still does not expose that
+operation.
 
 `Arithmetic.Cost.growth` keeps these refusals distinct from endpoint and exact
 comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
@@ -4051,9 +4073,9 @@ their declared cost inside a scheduler bound.
   normalization.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
-- `HexInterval/Arithmetic.lean`: multiplication and direct-power endpoint
-  growth prerequisites; it does not expose an interval multiplication or power
-  operation.
+- `HexInterval/Arithmetic.lean`: multiplication growth plus direct-power
+  retained-growth and exponent-work prerequisites; it does not expose an
+  interval operation.
 - `HexInterval/Multiplication.lean`: resource-checked interval multiplication,
   unconditional extended-corner evaluation, attainment-aware extremum
   selection, and the sealed `mulWithin` entry point.

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -31,6 +31,13 @@ private def eightBitLimit : EndpointLimit where
   maxEndpointHeight := 8
   maxAlignmentShift := 0
 
+private def nineBitLimit : EndpointLimit where
+  maxEndpointHeight := 9
+  maxAlignmentShift := 0
+
+private def smallPowLimits : Arithmetic.PowLimits where
+  maxExponent := 8
+
 #guard Raw.empty.normalizeUnchecked = .empty
 #guard (Raw.bounds .unbounded .unbounded).normalizeUnchecked = .bounds .unbounded .unbounded
 #guard
@@ -169,7 +176,7 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
 -- eight-bit endpoint limit, while `3^5` is refused from metadata before
 -- `Dyadic.pow` can allocate its mantissa.
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d 3) 4 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d 3) 4 with
   | .ok cost =>
       cost.sources.map (·.numeratorBits) == [2] &&
         cost.predicted.numeratorBits == 8 &&
@@ -178,7 +185,7 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d 3) 5 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d 3) 5 with
   | .error (.growth cost) =>
       cost.sources.map (·.numeratorBits) == [2] &&
         cost.predicted.numeratorBits == 10 &&
@@ -188,24 +195,24 @@ private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
 -- Unit numerators remain unit-sized even at a large exponent. This keeps the
 -- preflight useful for exact powers of `1`, `-1`, and powers of two.
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d 1) 1000000000 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d 1) 1000000000 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic (d 1)
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d (-1)) 1000000001 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d (-1)) 1000000001 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic (d 1)
   | _ => false
 
 -- The direct-image convention keeps `0^0 = 1`; positive powers of zero stay
 -- zero. Both have exact constant-size predictions.
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d 0) 0 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d 0) 0 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic ((d 0) ^ 0)
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit (d 0) 1000000000 with
+  match Arithmetic.preflightPowGrowth eightBitLimit (d 0) 1000000000 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic ((d 0) ^ 1000000000)
   | _ => false
 
@@ -217,7 +224,7 @@ private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
 -- Both signs of Core's signed dyadic exponent multiplication are reflected by
 -- the exact magnitude metadata. Unit mantissas do not acquire numerator cost.
 #guard
-  match Arithmetic.preflightPow eightBitLimit two 3 with
+  match Arithmetic.preflightPowGrowth eightBitLimit two 3 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic (two ^ 3)
   | _ => false
 
@@ -225,7 +232,7 @@ private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
 -- the predicted retained height. Six mantissa bits plus exponent magnitude
 -- three exceed the eight-bit combined endpoint limit.
 #guard
-  match Arithmetic.preflightPow eightBitLimit threeHalves 3 with
+  match Arithmetic.preflightPowGrowth eightBitLimit threeHalves 3 with
   | .error (.growth cost) =>
       cost.predicted.numeratorBits == 6 &&
         cost.predicted.exponentMagnitude == 3 &&
@@ -234,19 +241,19 @@ private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
 
 -- Sign does not alter growth metadata, and exponent one is the identity case.
 #guard
-  match Arithmetic.preflightPow eightBitLimit negThreeHalves 1 with
+  match Arithmetic.preflightPowGrowth eightBitLimit negThreeHalves 1 with
   | .ok cost => cost.predicted == EndpointCost.ofDyadic (negThreeHalves ^ 1)
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit quarter 3 with
+  match Arithmetic.preflightPowGrowth eightBitLimit quarter 3 with
   | .ok cost =>
       cost.predicted.numeratorBits == 1 &&
         cost.predicted.exponentMagnitude == 6
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit quarter 4 with
+  match Arithmetic.preflightPowGrowth eightBitLimit quarter 4 with
   | .error (.growth cost) =>
       cost.predicted.numeratorBits == 1 &&
         cost.predicted.exponentMagnitude == 8 &&
@@ -256,12 +263,12 @@ private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
 -- An inadmissible source is reported before multiplying its exponent by the
 -- natural power. This separates source admission from predicted growth.
 #guard
-  match Arithmetic.preflightPow eightBitLimit far 1000000000 with
+  match Arithmetic.preflightPowGrowth eightBitLimit far 1000000000 with
   | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
   | _ => false
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit far 0 with
+  match Arithmetic.preflightPowGrowth eightBitLimit far 0 with
   | .error (.endpoint cost) => cost.exponentMagnitude == 1000000000
   | _ => false
 
@@ -271,11 +278,80 @@ private def negThreeHalves : Dyadic := .ofOdd (-3) 1 (by decide)
 private def beyondUInt64 : Nat := 18446744073709551616
 
 #guard
-  match Arithmetic.preflightPow eightBitLimit two beyondUInt64 with
+  match Arithmetic.preflightPowGrowth eightBitLimit two beyondUInt64 with
   | .error (.growth cost) =>
       cost.predicted.numeratorBits == 1 &&
         cost.predicted.exponentMagnitude == beyondUInt64 &&
         !cost.allowed eightBitLimit
+  | _ => false
+
+-- The composite prerequisite refuses huge nonzero unit powers with a distinct
+-- work diagnostic even though their retained-growth prediction is constant.
+#guard
+  match Arithmetic.preflightPow eightBitLimit smallPowLimits
+      (d 1) beyondUInt64 with
+  | .error (.power work) => work.exponent == beyondUInt64
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit smallPowLimits
+      (d (-1)) beyondUInt64 with
+  | .error (.power work) => work.exponent == beyondUInt64
+  | _ => false
+
+-- Core's zero branch does not execute natural power or exponent conversion,
+-- so it safely bypasses the scalar work cap even for an arbitrary large Nat.
+#guard
+  match Arithmetic.preflightPow eightBitLimit smallPowLimits
+      (d 0) beyondUInt64 with
+  | .ok cost =>
+      cost.predicted == EndpointCost.ofDyadic ((d 0) ^ beyondUInt64)
+  | _ => false
+
+-- Once work passes, the composite preserves the growth prerequisite's exact
+-- source and predicted-result diagnostic.
+#guard
+  match Arithmetic.preflightPow eightBitLimit smallPowLimits
+      threeHalves 3 with
+  | .error (.growth cost) =>
+      cost.sources == [EndpointCost.ofDyadic threeHalves] &&
+        cost.predicted.numeratorBits == 6 &&
+        cost.predicted.encodedExponentBits == EndpointCost.natBits 3 &&
+        cost.predicted.exponentMagnitude == 3 &&
+        !cost.allowed eightBitLimit
+  | _ => false
+
+-- Source admission remains load-bearing after the work cap succeeds.
+#guard
+  match Arithmetic.preflightPow eightBitLimit smallPowLimits far 1 with
+  | .error (.endpoint cost) => cost == EndpointCost.ofDyadic far
+  | _ => false
+
+-- An ordinary nonunit power is admitted only after both the actual exponent
+-- and its combined retained growth pass.
+#guard
+  match Arithmetic.preflightPow nineBitLimit smallPowLimits
+      threeHalves 3 with
+  | .ok cost =>
+      cost.predicted.numeratorBits == 6 &&
+        cost.predicted.exponentMagnitude == 3
+  | _ => false
+
+-- Actual arbitrary-precision Nat comparison has no UInt64 wraparound: the
+-- boundary value is admitted, while its successor is refused.
+private def widePowLimits : Arithmetic.PowLimits where
+  maxExponent := beyondUInt64
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit widePowLimits
+      (d 1) beyondUInt64 with
+  | .ok cost => cost.predicted == EndpointCost.ofDyadic (d 1)
+  | _ => false
+
+#guard
+  match Arithmetic.preflightPow eightBitLimit widePowLimits
+      (d 1) (beyondUInt64 + 1) with
+  | .error (.power work) => work.exponent == beyondUInt64 + 1
   | _ => false
 
 private def ready (raw : Raw) : Hex.Interval :=

--- a/progress/20260815T093426Z.md
+++ b/progress/20260815T093426Z.md
@@ -1,0 +1,36 @@
+# Accomplished
+
+- Audited Core `Dyadic.pow`: zero only tests whether the exponent is zero and
+  returns a constant, while every nonzero dyadic evaluates `n ^ i` and the
+  signed exponent product `k * i`.
+- Added `Arithmetic.PowLimits` and `PowWork`, whose scalar cap compares the
+  actual arbitrary-precision natural exponent rather than its encoding size.
+  Added the distinct `Arithmetic.Cost.power` refusal diagnostic.
+- Added transactional `preflightPow`. Nonzero sources cross the exponent
+  work cap before the retained-growth prerequisite and before any future Core
+  power call; zero safely bypasses the cap because Core performs neither
+  natural power nor exponent conversion on that branch.
+- Confirmed that one exponent-value scalar is sufficient for Core execution
+  when composed with the existing source and predicted retained-height limits:
+  those limits bound the other inputs and result size. Documented that the gate
+  is not a wall-clock estimate and does not charge construction, parsing, or
+  reification of the already supplied `Nat`.
+- Added guards for huge `1` and `-1` refusal, huge-zero admission, an ordinary
+  admitted nonunit power, and an exact beyond-`UInt64` boundary/successor
+  comparison. Kept the feature prerequisite-only with no public `powWithin` or
+  Mathlib semantics.
+
+# Current frontier
+
+The execution-work prerequisite is a direct child of the merged multiplication
+surface on main. It adds no Lake registration or freshness exemption, and the
+public `powWithin` feature remains a separate local follow-up.
+
+# Next step
+
+Land this prerequisite independently before the public interval power
+operation.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add `Arithmetic.PowLimits` and an actual-`Nat` exponent work diagnostic
- compose the work cap transactionally with retained-growth `preflightPow`
- exempt only Core's zero short-circuit, while refusing huge `1` and `-1` powers
- document the exact guarantee and retain this layer as a prerequisite only

This PR deliberately does not expose public interval `powWithin` or Mathlib power semantics.

## Validation

- `lake build HexInterval HexInterval.Conformance HexIntervalMathlib.PntFks2ShardConformance HexIntervalMathlib.PntBKLNWPowConformance`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/conformance_targets.py --check`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- added-line trust scan: no `sorry`, `axiom`, or `native_decide`