### PR TITLE
feat(interval): add checked natural power

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -18,9 +18,9 @@ data, propagation search, and replayable derivations.
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
-maximum, and absolute value. The arithmetic resource layer preflights product
-growth, direct-power retained growth, and exponent work independently of
-exact comparison work; public interval power remains future work. Raw cuts
-remain visible as the explicit decoder and inspection boundary; D2 propagation
-and replay experiments still live outside this supported umbrella.
+maximum, absolute value, and natural power. The arithmetic resource layer
+preflights product growth, direct-power retained growth, and exponent work
+independently of exact comparison work. Raw cuts remain visible as the explicit
+decoder and inspection boundary; D2 propagation and replay experiments still
+live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -16,11 +16,11 @@ public section
 Endpoint comparison cost does not bound numerator growth in multiplication or
 direct powers. This module supplies a separate, nonbreaking result and
 diagnostic layer for checked arithmetic. Existing constructors and supported
-public interval operations continue to return `BuildResult`; multiplicative
-operations can report growth without fabricating a `CompareCost`. Concrete
-corner enumeration and interval multiplication live in
-`HexInterval.Multiplication`, not in this reusable cost layer; direct-power
-preflight remains a prerequisite rather than a public interval-power API.
+public interval operations whose costs are comparisons continue to return
+`BuildResult`; multiplication and direct natural power report growth without
+fabricating a `CompareCost`. Concrete corner enumeration and interval
+multiplication live in `HexInterval.Multiplication`, not in this reusable cost
+layer.
 -/
 
 namespace Hex.Interval.Arithmetic
@@ -44,7 +44,7 @@ def allowed (limit : EndpointLimit) (growth : Growth) : Bool :=
 
 end Growth
 
-/-- Execution-work limit for a future direct natural-power operation. The cap
+/-- Execution-work limit for the direct natural-power operation. The cap
 is on the actual exponent value, not the size of its binary encoding. -/
 structure PowLimits where
   maxExponent : Nat
@@ -134,8 +134,8 @@ This is only a retained-endpoint growth prerequisite. It does not bound the
 execution work of `Nat.pow` or conversion of the natural exponent into Core's
 signed dyadic-exponent multiplication. In particular, a unit mantissa at
 dyadic exponent zero can pass this growth check for an arbitrarily large
-natural exponent. A future public power operation must enforce a separate
-exponent/work limit before invoking `Dyadic.pow`. -/
+natural exponent. Public `powWithin` therefore composes this check with the
+separate exponent/work limit before invoking `Dyadic.pow`. -/
 def preflightPowGrowth (limit : EndpointLimit) (source : Dyadic)
     (exponent : Nat) :
     Except Cost Growth := do

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -229,6 +229,41 @@ public wrapper preflights it before calling this decoder-level helper. -/
             Upper.finite leftMagnitude lowerStrict
         .bounds (.finite 0 false) resultUpper
 
+/-- Raise both finite cuts to a natural power, preserving strictness and
+unbounded sides. This decoder-level helper is used only where the power map is
+known to be strictly monotone: directly for odd exponents, and after
+`absUnchecked` for positive even exponents. -/
+@[expose] def powCutsUnchecked : Raw → Nat → Raw
+  | .empty, _ => .empty
+  | .bounds lower upper, exponent =>
+      let resultLower :=
+        match lower with
+        | .unbounded => Lower.unbounded
+        | .finite value strict => Lower.finite (value ^ exponent) strict
+      let resultUpper :=
+        match upper with
+        | .unbounded => Upper.unbounded
+        | .finite value strict => Upper.finite (value ^ exponent) strict
+      .bounds resultLower resultUpper
+
+/-- Exact raw hull of a natural-power image. Empty remains empty even at
+exponent zero. Every nonempty zero power is `{1}`. Positive odd powers map the
+source cuts directly; positive even powers first select the exact absolute
+value cuts and then map their nonnegative endpoints.
+
+Endpoint powers and the magnitude comparison inside `absUnchecked` are
+unchecked here. The public wrapper authenticates all of them before calling
+this decoder-level helper. -/
+@[expose] def powUnchecked : Raw → Nat → Raw
+  | .empty, _ => .empty
+  | .bounds _ _, 0 =>
+      .bounds (.finite 1 false) (.finite 1 false)
+  | raw@(.bounds _ _), exponent =>
+      if exponent % 2 = 1 then
+        powCutsUnchecked raw exponent
+      else
+        powCutsUnchecked raw.absUnchecked exponent
+
 /-- Direct raw subtraction agrees with addition after raw negation. The
 checked public operation uses the direct form so it can preflight only the two
 crossed endpoint pairs, without normalizing an intermediate negated interval. -/
@@ -326,6 +361,53 @@ private def absCost? (limit : EndpointLimit) : Raw → Option CompareCost
       if 0 ≤ lower || upper ≤ 0 then none
       else compareCost? limit lower upper
   | _ => none
+
+/-- First refused Core-power prerequisite for one selected finite cut. -/
+private def powValueCost? (endpointLimit : EndpointLimit)
+    (workLimits : Arithmetic.PowLimits) (value : Dyadic) (exponent : Nat) :
+    Option Arithmetic.Cost :=
+  match Arithmetic.preflightPow endpointLimit workLimits value exponent with
+  | .ok _ => none
+  | .error cost => some cost
+
+/-- First refused Core-power prerequisite for the finite cuts selected by a
+monotone power map. Both cuts are checked before either is evaluated. -/
+private def powCutsCost? (endpointLimit : EndpointLimit)
+    (workLimits : Arithmetic.PowLimits) (raw : Raw) (exponent : Nat) :
+    Option Arithmetic.Cost :=
+  match raw with
+  | .empty => none
+  | .bounds lower upper =>
+      let lowerCost :=
+        match lower with
+        | .unbounded => none
+        | .finite value _ =>
+            powValueCost? endpointLimit workLimits value exponent
+      match lowerCost with
+      | some cost => some cost
+      | none =>
+          match upper with
+          | .unbounded => none
+          | .finite value _ =>
+              powValueCost? endpointLimit workLimits value exponent
+
+/-- First refusal before constructing a natural-power image. The mixed-sign
+absolute-value selector comparison is authenticated before it executes, then
+all selected finite endpoint powers are preflighted before any Core power.
+Exponent zero and empty inputs perform no endpoint power. -/
+private def powCost? (endpointLimit : EndpointLimit)
+    (workLimits : Arithmetic.PowLimits) (raw : Raw) (exponent : Nat) :
+    Option Arithmetic.Cost :=
+  match raw, exponent with
+  | .empty, _ | _, 0 => none
+  | raw@(.bounds _ _), exponent =>
+      if exponent % 2 = 1 then
+        powCutsCost? endpointLimit workLimits raw exponent
+      else
+        match absCost? endpointLimit raw with
+        | some cost => some (.comparison cost)
+        | none =>
+            powCutsCost? endpointLimit workLimits raw.absUnchecked exponent
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -471,5 +553,37 @@ theorem view_absWithin_ready {limit : EndpointLimit} {input result : Hex.Interva
   split at h
   · contradiction
   · exact view_ofRawWithin_ready h
+
+/-- Exact interval natural power with authenticated exponent work, retained
+endpoint growth, even-power magnitude selection, and final canonicalization.
+Empty is absorbing, including at exponent zero. Refusal is never interpreted
+as an empty image. -/
+def powWithin (endpointLimit : EndpointLimit)
+    (workLimits : Arithmetic.PowLimits) (input : Hex.Interval)
+    (exponent : Nat) : Arithmetic.Result :=
+  match powCost? endpointLimit workLimits input.view exponent with
+  | some cost => .resourceLimit cost
+  | none =>
+      Arithmetic.Result.ofBuild
+        (ofRawWithin endpointLimit (Raw.powUnchecked input.view exponent))
+
+/-- A successful natural power exposes exactly the normalized direct image
+cuts selected by `Raw.powUnchecked`. -/
+theorem view_powWithin_ready {endpointLimit : EndpointLimit}
+    {workLimits : Arithmetic.PowLimits} {input result : Hex.Interval}
+    {exponent : Nat}
+    (h : powWithin endpointLimit workLimits input exponent = .ready result) :
+    result.view = (Raw.powUnchecked input.view exponent).normalizeUnchecked := by
+  unfold powWithin at h
+  split at h
+  · contradiction
+  · cases hraw : ofRawWithin endpointLimit
+        (Raw.powUnchecked input.view exponent) with
+    | ready interval =>
+        simp only [Arithmetic.Result.ofBuild, hraw] at h
+        cases h
+        exact view_ofRawWithin_ready hraw
+    | resourceLimit cost =>
+        simp [Arithmetic.Result.ofBuild, hraw] at h
 
 end Hex.Interval

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -182,7 +182,7 @@ value's proof field.
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
 supported operations are resource-checked intersection, hull, negation,
-addition, subtraction, minimum, maximum, and absolute value.
+addition, subtraction, minimum, maximum, absolute value, and natural power.
 Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -208,7 +208,10 @@ input members. They do not claim the converse characterization of every result
 member as a pointwise image. Successful `absWithin` exposes its exact normalized
 selected-cut predicate and maps every input member `x` to `|x|`; it likewise
 does not claim a converse characterization of every result member as an
-absolute-value image. Neither addition nor subtraction currently claims the
+absolute-value image. Successful `powWithin` exposes its exact normalized
+direct cuts for exponent zero, positive odd powers, and positive even powers,
+and maps every input member to its real natural power. It likewise makes no
+set-image converse claim. Neither addition nor subtraction currently claims the
 separate representation-independent tightness converse for the real Minkowski
 image.
 Separately, the experiment form of the intersection theorem is installed as the
@@ -433,6 +436,8 @@ def minWithin       : EndpointLimit → Interval → Interval → BuildResult
 def maxWithin       : EndpointLimit → Interval → Interval → BuildResult
 def absWithin       : EndpointLimit → Interval → BuildResult
 def mulWithin       : EndpointLimit → Interval → Interval → Arithmetic.Result
+def powWithin       : EndpointLimit → Arithmetic.PowLimits → Interval → Nat →
+  Arithmetic.Result
 ```
 
 These names retain the budget because a public interval does not store the
@@ -503,13 +508,13 @@ result. A quarter cubed is admitted with exponent magnitude six, while its
 fourth power is refused because one numerator bit plus exponent magnitude
 eight exceeds the retained-height budget.
 
-This preflight bounds retained endpoint growth only. It does not bound the
+On its own, this preflight bounds retained endpoint growth only. It does not bound the
 execution work of `Nat.pow` or the conversion of the natural exponent used in
-Core's signed dyadic-exponent multiplication, and it is not the complete
-resource gate for a public interval power. In particular, when the dyadic
+Core's signed dyadic-exponent multiplication, and therefore is not the complete
+resource gate used by public interval power. In particular, when the dyadic
 exponent is zero and the mantissa has absolute value one, arbitrarily large
-natural exponents pass the endpoint-growth check. A future `powWithin` must add
-and enforce a separate exponent/work cap before invoking `Dyadic.pow`.
+natural exponents pass the endpoint-growth check. `powWithin` therefore adds
+and enforces a separate exponent/work cap before invoking `Dyadic.pow`.
 
 `Arithmetic.PowLimits` supplies that smallest execution-work prerequisite.
 Its `maxExponent` bounds the actual arbitrary-precision `Nat` value, not the
@@ -517,9 +522,8 @@ number of bits used to encode it. `Arithmetic.preflightPow` checks this cap
 for every nonzero dyadic before composing transactionally with
 `preflightPowGrowth`; a work refusal is `Arithmetic.Cost.power`, never a
 fabricated endpoint or growth diagnostic. A successful composite check
-guarantees that a future caller reaches Core's nonzero power only with a
-bounded source, bounded retained-result growth, and
-`exponent ≤ maxExponent`.
+guarantees that `powWithin` reaches Core's nonzero power only with a bounded
+source, bounded retained-result growth, and `exponent ≤ maxExponent`.
 
 Zero alone bypasses the work cap. Core's zero branch only distinguishes `0^0`
 from a positive power and returns `1` or `0`; it does not invoke `Nat.pow`,
@@ -528,9 +532,27 @@ This exemption does not extend to `1` or `-1`, whose Core path still processes
 the natural exponent. The scalar cap is sufficient to bound that Core path
 when combined with the existing endpoint/growth limits, but it is not a
 wall-clock estimate and does not charge work already spent constructing,
-parsing, or reifying the input `Nat`. A future public `powWithin` must use the
-composite gate before Core power; this prerequisite still does not expose that
-operation.
+parsing, or reifying the input `Nat`.
+
+`powWithin` is the direct checked hull, rather than repeated interval
+multiplication. Empty is absorbing at every exponent. A nonempty input at
+exponent zero becomes the closed singleton `{1}` without evaluating an
+endpoint power. A positive odd exponent maps the two source cuts directly. A
+positive even exponent first computes the exact absolute-value hull, so a
+negative interval reverses magnitude order and a mixed interval gets a closed
+zero exactly when zero belongs to the source; it then maps the nonnegative
+cuts with their selected attainment flags.
+
+Before any Core power evaluation, every selected finite endpoint passes
+`preflightPow`. The even mixed-sign magnitude comparison passes the same
+exact comparison preflight used by `absWithin` before selection. Both selected
+endpoint prerequisites are checked before either power is evaluated, and the
+resulting raw cuts finally cross `ofRawWithin` for endpoint retention and
+canonical-order comparison. A refusal at any stage is an
+`Arithmetic.Result.resourceLimit`, not empty. The public view theorem exposes
+exactly the normalized `Raw.powUnchecked` cuts; the Mathlib companion proves
+that every input member maps to its real natural power. It does not claim the
+set-image converse.
 
 `Arithmetic.Cost.growth` keeps these refusals distinct from endpoint and exact
 comparison costs, and `Arithmetic.Result` is a separate checked-arithmetic
@@ -560,14 +582,17 @@ is currently claimed.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
-`maxUnchecked`, `absUnchecked`, and `mulUnchecked` are related
-to the checked operations by successful-result and semantic theorems. Like
+`maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and
+`mulUnchecked` are related to the checked operations by successful-result and
+semantic theorems. `powCutsUnchecked` is only the strictly monotone cut mapper;
+its caller must establish the positive odd or nonnegative positive-exponent
+case. `powUnchecked` performs the zero/odd/even direct-hull selection. Like
 `Raw.normalizeUnchecked`, they
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
 The remaining target surface includes precision-indexed reciprocal and
-division and powers,
+division,
 splitting, and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.
@@ -4080,8 +4105,10 @@ their declared cost inside a scheduler bound.
   unconditional extended-corner evaluation, attainment-aware extremum
   selection, and the sealed `mulWithin` entry point.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
-  negation, addition, subtraction, minimum, maximum, and absolute value,
-  followed by future arithmetic, splitting, and regularization operations.
+  negation, addition, subtraction, minimum, maximum, absolute value, and
+  natural power, including the public decoder helpers `Raw.powCutsUnchecked`
+  and `Raw.powUnchecked`, followed by future arithmetic, splitting, and
+  regularization operations.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
@@ -4091,10 +4118,13 @@ their declared cost inside a scheduler bound.
 - `HexIntervalMathlib/MinMax.lean`: exact selected-cut semantics and one-way
   real-image enclosure theorems for minimum and maximum.
 - `HexIntervalMathlib/Absolute.lean`: exact selected-cut semantics and the
-  successful absolute-value image theorem.
+  successful absolute-value image theorem, plus the raw one-way theorem
+  `contains_absUnchecked` used by natural power.
 - `HexIntervalMathlib/Multiplication.lean`: explicit selected-candidate-cut
   semantics and the one-way real-product enclosure theorem; it does not claim
   an image-tightness converse.
+- `HexIntervalMathlib/Power.lean`: exact normalized selected-cut semantics and
+  the one-way successful natural-power image theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -13,12 +13,13 @@ public import HexIntervalMathlib.Subtraction
 public import HexIntervalMathlib.MinMax
 public import HexIntervalMathlib.Absolute
 public import HexIntervalMathlib.Multiplication
+public import HexIntervalMathlib.Power
 
 public section
 
 /-!
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition,
-subtraction, and multiplication, exact minimum/maximum images, and absolute
-value.
+subtraction, and multiplication, exact minimum/maximum images, absolute value,
+and natural power.
 -/

--- a/HexIntervalMathlib/Absolute.lean
+++ b/HexIntervalMathlib/Absolute.lean
@@ -71,7 +71,8 @@ private theorem abs_lt_tied {lower upper x : ℝ}
   · rw [abs_of_nonpos (le_of_not_ge nonnegative)]
     linarith
 
-private theorem rawContains_abs (raw : Raw) {x : ℝ}
+/-- Raw absolute-value cuts contain the absolute value of every source member. -/
+theorem contains_absUnchecked (raw : Raw) {x : ℝ}
     (member : raw.Contains x) : raw.absUnchecked.Contains |x| := by
   cases raw with
   | empty => simp [Raw.Contains] at member
@@ -211,6 +212,6 @@ theorem abs_mem_absWithin {limit : EndpointLimit}
     {input result : Hex.Interval} {x : ℝ}
     (checked : absWithin limit input = .ready result)
     (member : input.Contains x) : result.Contains |x| :=
-  (contains_absWithin checked |x|).2 (rawContains_abs input.view member)
+  (contains_absWithin checked |x|).2 (contains_absUnchecked input.view member)
 
 end Hex.Interval

--- a/HexIntervalMathlib/Power.lean
+++ b/HexIntervalMathlib/Power.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Absolute
+
+@[expose] public section
+
+/-!
+# Exact semantics of public interval natural power
+
+This module characterizes the direct cuts selected by every successful checked
+natural power and proves the one-way real image theorem. Empty remains empty at
+every exponent. Positive odd powers map source cuts directly; positive even
+powers map the exact absolute-value hull before applying the strictly monotone
+nonnegative power map.
+-/
+
+namespace Hex.Interval
+
+@[simp]
+theorem toReal_pow (value : Dyadic) (exponent : Nat) :
+    toReal (value ^ exponent) = toReal value ^ exponent := by
+  simp [toReal, Dyadic.toRat_pow]
+
+@[simp]
+private theorem toReal_one : toReal (1 : Dyadic) = 1 := by
+  have dyadicOne : (1 : Dyadic).toRat = (1 : Rat) :=
+    Dyadic.toRat_natCast 1
+  simp [toReal, dyadicOne]
+
+/-- A raw interval has a finite nonnegative lower cut. This syntactic property
+is the premise needed for strict monotonicity of positive natural power. -/
+private def Raw.Nonnegative : Raw → Prop
+  | .empty => True
+  | .bounds .unbounded _ => False
+  | .bounds (.finite value _) _ => 0 ≤ value
+
+private theorem toReal_le {left right : Dyadic} (h : left ≤ right) :
+    toReal left ≤ toReal right := by
+  exact (Rat.cast_le (K := ℝ)).2 (Dyadic.toRat_le_toRat_iff.2 h)
+
+private theorem nonnegative_absUnchecked (raw : Raw) :
+    raw.absUnchecked.Nonnegative := by
+  cases raw with
+  | empty => simp [Raw.absUnchecked, Raw.Nonnegative]
+  | bounds lower upper =>
+      cases lower with
+      | unbounded =>
+          cases upper with
+          | unbounded => simp [Raw.absUnchecked, Raw.Nonnegative]
+          | finite upper upperStrict =>
+              by_cases nonpositive : upper ≤ 0
+              · simp only [Raw.absUnchecked, nonpositive, ↓reduceIte,
+                  Raw.Nonnegative]
+                rw [← Dyadic.toRat_le_toRat_iff] at nonpositive ⊢
+                simpa [Dyadic.toRat_neg] using nonpositive
+              · simp [Raw.absUnchecked, Raw.Nonnegative, nonpositive]
+      | finite lower lowerStrict =>
+          cases upper with
+          | unbounded =>
+              by_cases nonnegative : 0 ≤ lower <;>
+                simp [Raw.absUnchecked, Raw.Nonnegative, nonnegative]
+          | finite upper upperStrict =>
+              by_cases nonnegative : 0 ≤ lower
+              · simp [Raw.absUnchecked, Raw.Nonnegative, nonnegative]
+              · by_cases nonpositive : upper ≤ 0
+                · simp only [Raw.absUnchecked, nonnegative, ↓reduceIte,
+                    nonpositive, Raw.Nonnegative]
+                  rw [← Dyadic.toRat_le_toRat_iff] at nonpositive ⊢
+                  simpa [Dyadic.toRat_neg] using nonpositive
+                · simp [Raw.absUnchecked, Raw.Nonnegative, nonnegative,
+                    nonpositive]
+
+private theorem contains_powCuts_odd (raw : Raw) {x : ℝ} {exponent : Nat}
+    (odd : Odd exponent) (member : raw.Contains x) :
+    (raw.powCutsUnchecked exponent).Contains (x ^ exponent) := by
+  cases raw with
+  | empty => simp [Raw.Contains] at member
+  | bounds lower upper =>
+      cases lower with
+      | unbounded =>
+          cases upper with
+          | unbounded =>
+              simp [Raw.powCutsUnchecked, Raw.Contains, Lower.Contains,
+                Upper.Contains]
+          | finite upper upperStrict =>
+              cases upperStrict <;>
+                simpa [Raw.powCutsUnchecked, Raw.Contains, Lower.Contains,
+                  Upper.Contains, toReal_pow, odd.pow_le_pow,
+                  odd.pow_lt_pow] using member
+      | finite lower lowerStrict =>
+          cases upper with
+          | unbounded =>
+              cases lowerStrict <;>
+                simpa [Raw.powCutsUnchecked, Raw.Contains, Lower.Contains,
+                  Upper.Contains, toReal_pow, odd.pow_le_pow,
+                  odd.pow_lt_pow] using member
+          | finite upper upperStrict =>
+              cases lowerStrict <;> cases upperStrict <;>
+                simpa [Raw.powCutsUnchecked, Raw.Contains, Lower.Contains,
+                  Upper.Contains, toReal_pow, odd.pow_le_pow,
+                  odd.pow_lt_pow] using member
+
+private theorem contains_powCuts_nonnegative (raw : Raw) {x : ℝ}
+    {exponent : Nat} (positiveExponent : exponent ≠ 0)
+    (nonnegative : raw.Nonnegative) (member : raw.Contains x) :
+    (raw.powCutsUnchecked exponent).Contains (x ^ exponent) := by
+  cases raw with
+  | empty => simp [Raw.Contains] at member
+  | bounds lower upper =>
+      cases lower with
+      | unbounded => simp [Raw.Nonnegative] at nonnegative
+      | finite lower lowerStrict =>
+          have lowerDyadic : (0 : Dyadic) ≤ lower := by
+            simpa [Raw.Nonnegative] using nonnegative
+          have lowerNonnegative : 0 ≤ toReal lower := by
+            simpa [toReal] using toReal_le lowerDyadic
+          rcases member with ⟨lowerMember, upperMember⟩
+          have xNonnegative : 0 ≤ x := by
+            cases lowerStrict <;>
+              simp [Lower.Contains] at lowerMember <;> linarith
+          have resultLower :
+              (Lower.finite (lower ^ exponent) lowerStrict).Contains
+                (x ^ exponent) := by
+            cases lowerStrict with
+            | false =>
+                simp only [Lower.Contains, toReal_pow]
+                exact (pow_le_pow_iff_left₀ lowerNonnegative xNonnegative
+                  positiveExponent).2 lowerMember
+            | true =>
+                simp only [Lower.Contains, toReal_pow]
+                exact (pow_lt_pow_iff_left₀ lowerNonnegative xNonnegative
+                  positiveExponent).2 lowerMember
+          cases upper with
+          | unbounded =>
+              exact ⟨resultLower, by simp [Upper.Contains]⟩
+          | finite upper upperStrict =>
+              have upperNonnegative : 0 ≤ toReal upper := by
+                cases upperStrict <;>
+                  simp [Upper.Contains] at upperMember <;> linarith
+              have resultUpper :
+                  (Upper.finite (upper ^ exponent) upperStrict).Contains
+                    (x ^ exponent) := by
+                cases upperStrict with
+                | false =>
+                    simp only [Upper.Contains, toReal_pow]
+                    exact (pow_le_pow_iff_left₀ xNonnegative upperNonnegative
+                      positiveExponent).2 upperMember
+                | true =>
+                    simp only [Upper.Contains, toReal_pow]
+                    exact (pow_lt_pow_iff_left₀ xNonnegative upperNonnegative
+                      positiveExponent).2 upperMember
+              exact ⟨resultLower, resultUpper⟩
+
+private theorem contains_powUnchecked (raw : Raw) {x : ℝ}
+    (exponent : Nat) (member : raw.Contains x) :
+    (raw.powUnchecked exponent).Contains (x ^ exponent) := by
+  cases raw with
+  | empty => simp [Raw.Contains] at member
+  | bounds lower upper =>
+      by_cases zero : exponent = 0
+      · subst exponent
+        norm_num [Raw.powUnchecked, Raw.Contains, Lower.Contains,
+          Upper.Contains, toReal_one]
+      · by_cases odd : Odd exponent
+        · have mapped := contains_powCuts_odd
+            (Raw.bounds lower upper) odd member
+          simpa [Raw.powUnchecked, zero, Nat.odd_iff.mp odd] using mapped
+        · have even : Even exponent := Nat.not_odd_iff_even.mp odd
+          have absolute := contains_absUnchecked
+            (Raw.bounds lower upper) member
+          have mapped := contains_powCuts_nonnegative
+            (Raw.bounds lower upper).absUnchecked zero
+            (nonnegative_absUnchecked (Raw.bounds lower upper)) absolute
+          simpa [Raw.powUnchecked, zero, Nat.not_odd_iff.mp odd,
+            even.pow_abs] using mapped
+
+/-- A successful public natural power has exactly its normalized selected raw
+cuts. -/
+theorem contains_powWithin {endpointLimit : EndpointLimit}
+    {workLimits : Arithmetic.PowLimits} {input result : Hex.Interval}
+    {exponent : Nat}
+    (checked : powWithin endpointLimit workLimits input exponent = .ready result)
+    (x : ℝ) :
+    result.Contains x ↔ (Raw.powUnchecked input.view exponent).Contains x := by
+  simp only [Contains]
+  rw [view_powWithin_ready checked, contains_normalize]
+
+/-- Natural power maps every input member into every successful public image. -/
+theorem pow_mem_powWithin {endpointLimit : EndpointLimit}
+    {workLimits : Arithmetic.PowLimits} {input result : Hex.Interval}
+    {exponent : Nat} {x : ℝ}
+    (checked : powWithin endpointLimit workLimits input exponent = .ready result)
+    (member : input.Contains x) : result.Contains (x ^ exponent) :=
+  (contains_powWithin checked (x ^ exponent)).2
+    (contains_powUnchecked input.view exponent member)
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -15,7 +15,8 @@ strict or closed finite ends, independent unbounded ends, and canonical empty.
 while `HexIntervalMathlib.MinMax` supplies selected-cut and real-image
 enclosure theorems for minimum and maximum, and
 `HexIntervalMathlib.Absolute` supplies the corresponding absolute-value
-theorems.
+theorems. `HexIntervalMathlib.Power` supplies exact selected-cut semantics
+and a one-way real-image theorem for checked natural power.
 
 For every successful resource-checked public operation it proves:
 
@@ -44,6 +45,9 @@ For every successful resource-checked public operation it proves:
   maximum of two input members belong to every successful result;
 - `contains_absWithin`: exact membership in the normalized selected absolute
   value cuts;
+- `contains_absUnchecked`: raw absolute-value cuts contain `|x|` whenever the
+  source raw interval contains `x`; this is a one-way image theorem, not a
+  converse characterization;
 - `abs_mem_absWithin`: the absolute value of every input member belongs to every
   successful result;
 - `contains_mulWithin`: exact successful-result membership in the explicit
@@ -51,7 +55,11 @@ For every successful resource-checked public operation it proves:
   empty, unbounded, strict, closed, and zero-attainment cases;
 - `mul_mem_mulWithin`: two input members multiply to a member of every
   successful result. This is an enclosure theorem; no separate image-tightness
-  converse is claimed.
+  converse is claimed;
+- `contains_powWithin`: exact membership in the normalized direct cuts selected
+  for exponent zero, positive odd powers, and positive even powers;
+- `pow_mem_powWithin`: every source member raised to the caller's natural
+  exponent belongs to every successful result.
 
 These theorems depend on the exact successful operation-result equation
 (`BuildResult` or `Arithmetic.Result`). A resource refusal has no set
@@ -65,8 +73,8 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Further arithmetic images, powers, splitting,
-regularization, and precision-indexed reciprocal/division require their own
+are not re-exported here. Further arithmetic images, splitting, regularization,
+and precision-indexed reciprocal/division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
@@ -81,7 +89,9 @@ and the exact ordinary-kernel axiom surface.
 both image enclosures, and their axiom surfaces; it does not assert a set-image
 converse.
 The interval conformance module also pins absolute-value cut exactness, image
-transport, and its ordinary-kernel axiom surface.
+transport, and its ordinary-kernel axiom surface, together with natural-power
+cut exactness and image transport. The power theorem is one-way: no unproved
+set-image converse is exported.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,7 +7,9 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-negation, addition, subtraction, minimum, maximum, and absolute value.
+negation, addition, subtraction, minimum, maximum, absolute value, and natural
+power. Natural power exposes exact computed cuts and a sound pointwise real
+image theorem, without claiming a set-image converse.
 Propagator, provider, replay, and tactic modules remain experiments and are not
 re-exported by the public umbrella. The user-facing tactic contract below is
 the release target, not a claim that the tactic is already supported.
@@ -160,6 +162,26 @@ theorem contains_maxWithin
 theorem max_mem_maxWithin
     (h : maxWithin limit I J = .ready result) :
     I.Contains x → J.Contains y → result.Contains (max x y)
+
+theorem contains_absWithin
+    (h : absWithin limit I = .ready result) :
+    result.Contains x ↔ I.view.absUnchecked.Contains x
+
+theorem contains_absUnchecked
+    (h : raw.Contains x) :
+    raw.absUnchecked.Contains |x|
+
+theorem abs_mem_absWithin
+    (h : absWithin limit I = .ready result) :
+    I.Contains x → result.Contains |x|
+
+theorem contains_powWithin
+    (h : powWithin limit workLimits I exponent = .ready result) :
+    result.Contains x ↔ (I.view.powUnchecked exponent).Contains x
+
+theorem pow_mem_powWithin
+    (h : powWithin limit workLimits I exponent = .ready result) :
+    I.Contains x → result.Contains (x ^ exponent)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -189,6 +211,12 @@ upper-cut predicates; `MaxContains` uses the intersection of lower-cut
 predicates and union of upper-cut predicates. These characterize the exact
 computed cuts. The corresponding image theorems are one-way enclosures of
 pointwise real `min` and `max`; no converse set-image theorem is claimed.
+
+Absolute value and natural power likewise expose their exact normalized
+selected cuts and one-way pointwise image enclosures. Power distinguishes
+nonempty exponent zero, positive odd, and positive even cases; the even case
+maps the exact absolute-value hull. Neither operation exports an unproved
+set-image converse.
 
 The remaining target theorems include:
 

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -401,6 +401,9 @@ private def mixedLeft : Hex.Interval := ready (finite (-2) false 3 false)
 private def mixedRight : Hex.Interval := ready (finite (-4) false 5 false)
 private def nonnegative : Hex.Interval :=
   ready (.bounds (.finite (d 0) false) .unbounded)
+private def singletonThree : Hex.Interval := ready (finite 3 false 3 false)
+private def atMostNegOne : Hex.Interval :=
+  ready (.bounds .unbounded (.finite (d (-1)) false))
 private def half : Dyadic := .ofOdd 1 1 (by decide)
 private def singletonHalf : Hex.Interval :=
   ready (.bounds (.finite half false) (.finite half false))
@@ -618,6 +621,159 @@ private def mediumToOne : Hex.Interval :=
       { maxEndpointHeight := 256, maxAlignmentShift := 64 } mediumToOne with
   | .ready _ => false
   | .resourceLimit cost => cost.alignmentShift == 200
+
+-- Natural power keeps empty absorbing even at exponent zero, while every
+-- nonempty zero power is the singleton one.
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits
+      Hex.Interval.empty beyondUInt64 with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+-- Core's zero short circuit remains load-bearing through the public operation:
+-- an arbitrary large exponent does not consume the nonzero power-work budget.
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits
+      singletonZero beyondUInt64 with
+  | .ready interval => interval.view == finite 0 false 0 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits closed01 0 with
+  | .ready interval => interval.view == finite 1 false 1 false
+  | .resourceLimit _ => false
+
+-- Positive odd powers are strictly monotone over all reals and map direct
+-- cuts, including negative/open and unbounded endpoints.
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits leftAbsOpen 3 with
+  | .ready interval => interval.view == finite (-8) true 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits closedNeg21 3 with
+  | .ready interval => interval.view == finite (-8) false (-1) false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits atMostOne 3 with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d 1) false)
+  | .resourceLimit _ => false
+
+-- Positive even powers map the exact absolute-value hull. Strict zero is
+-- retained when zero is excluded on either sign-separated side; mixed-sign
+-- inputs contain zero and therefore close it.
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits openClosed01 2 with
+  | .ready interval => interval.view == finite 0 true 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits negOneToOpenZero 2 with
+  | .ready interval => interval.view == finite 0 true 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits closedNeg21 2 with
+  | .ready interval => interval.view == finite 1 false 4 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits rightAbsOpen 2 with
+  | .ready interval => interval.view == finite 0 false 4 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits leftAbsOpen 2 with
+  | .ready interval => interval.view == finite 0 false 4 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits tiedAbsMixed 2 with
+  | .ready interval => interval.view == finite 0 false 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits tiedAbsOpen 2 with
+  | .ready interval => interval.view == finite 0 false 1 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits atMostNegOne 2 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 1) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits atMostOne 2 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits Hex.Interval.whole 2 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits
+      Hex.Interval.whole beyondUInt64 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 0) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits singletonNegOne 2 with
+  | .ready interval => interval.view == finite 1 false 1 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits singletonZero 2 with
+  | .ready interval => interval.view == finite 0 false 0 false
+  | .resourceLimit _ => false
+
+-- Refusal categories remain distinct. Work refuses huge nonzero unit powers;
+-- growth refuses before `3^5`; even-power magnitude selection refuses before
+-- its wide comparison; and final normalization can still refuse independently
+-- after every endpoint power prerequisite succeeds.
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits
+      singletonOne beyondUInt64 with
+  | .resourceLimit (.power work) => work.exponent == beyondUInt64
+  | _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits
+      singletonNegOne beyondUInt64 with
+  | .resourceLimit (.power work) => work.exponent == beyondUInt64
+  | _ => false
+
+#guard
+  match Hex.Interval.powWithin eightBitLimit smallPowLimits singletonThree 5 with
+  | .resourceLimit (.growth cost) =>
+      cost.predicted.numeratorBits == 10 && !cost.allowed eightBitLimit
+  | _ => false
+
+#guard
+  match Hex.Interval.powWithin smallLimit smallPowLimits farNegative 1 with
+  | .resourceLimit (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+#guard
+  match Hex.Interval.powWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 64 }
+      smallPowLimits absCrossFar 2 with
+  | .resourceLimit (.comparison cost) => cost.alignmentShift == 200
+  | _ => false
+
+#guard
+  match Hex.Interval.powWithin
+      { maxEndpointHeight := 256, maxAlignmentShift := 64 }
+      smallPowLimits mediumToOne 1 with
+  | .resourceLimit (.comparison cost) => cost.alignmentShift == 200
+  | _ => false
 
 #guard
   match Hex.Interval.hullWithin smallLimit openAtOne openAtOne with

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -10,7 +10,7 @@ import HexIntervalMathlib
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
 ordinary-kernel meaning of every successful intersection, hull, addition,
-subtraction, multiplication, negation, and absolute value.
+subtraction, multiplication, negation, absolute value, and natural power.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -125,6 +125,25 @@ theorem mulImage {limit : Hex.Interval.EndpointLimit}
     result.Contains (x * y) :=
   Hex.Interval.mul_mem_mulWithin checked leftMember rightMember
 
+/-- A successful natural power has exactly its normalized selected raw cuts. -/
+theorem powExact {limit : Hex.Interval.EndpointLimit}
+    {workLimits : Hex.Interval.Arithmetic.PowLimits}
+    {input result : Hex.Interval} {exponent : Nat} {x : ℝ}
+    (checked : Hex.Interval.powWithin limit workLimits input exponent =
+      .ready result) :
+    result.Contains x ↔ (input.view.powUnchecked exponent).Contains x :=
+  Hex.Interval.contains_powWithin checked x
+
+/-- Source membership and the caller's exponent are consumed by the direct
+natural-power image theorem. -/
+theorem powImage {limit : Hex.Interval.EndpointLimit}
+    {workLimits : Hex.Interval.Arithmetic.PowLimits}
+    {input result : Hex.Interval} {exponent : Nat} {x : ℝ}
+    (checked : Hex.Interval.powWithin limit workLimits input exponent =
+      .ready result)
+    (member : input.Contains x) : result.Contains (x ^ exponent) :=
+  Hex.Interval.pow_mem_powWithin checked member
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -180,5 +199,13 @@ theorem mulImage {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.mulImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms mulImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.powExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms powExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.powImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms powImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -365,7 +365,8 @@ lean_lib HexIntervalMathlib where
   globs := #[`HexIntervalMathlib, `HexIntervalMathlib.Interval,
     `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
     `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
-    `HexIntervalMathlib.Multiplication].map Glob.one
+    `HexIntervalMathlib.Multiplication,
+    `HexIntervalMathlib.Power].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T095416Z.md
+++ b/progress/20260815T095416Z.md
@@ -1,0 +1,42 @@
+# Accomplished
+
+- Added checked public `powWithin` for natural exponents. Empty is absorbing,
+  nonempty exponent zero returns `{1}`, positive odd powers map source cuts
+  directly, and positive even powers map the exact absolute-value hull.
+- Composed `PowLimits` and `preflightPow` before every selected finite Core
+  power, preflighted the even-power magnitude selector, checked both endpoint
+  prerequisites before evaluation, and retained the final `ofRawWithin`
+  endpoint/order boundary. Work, source, growth, selector-comparison, and final
+  comparison refusals remain distinct from empty.
+- Proved exact normalized computed-cut semantics and the one-way real image
+  theorem in the supported Mathlib companion. The proof handles empty, zero,
+  odd, and even exponents and consumes both source membership and exponent.
+- Added successful guards for negative, mixed-sign, open-zero, unbounded, and
+  singleton inputs, plus zero attainment and tied endpoint strictness. Added
+  refusal guards for huge positive and negative units, source size, predicted
+  growth, even-power selection, and final normalization.
+- Updated both supported umbrellas, Lake registration, current-state SPECs,
+  semantic conformance wrappers, axiom guards, and the exact proof-only Lake
+  freshness exemption.
+- Focused public/runtime/Mathlib conformance builds, DAG/copyright/line-count/
+  conformance-target checks, freshness, diff hygiene, and added-token trust
+  checks pass. A full `lake build` reached 9,713 of 9,769 targets before the
+  host filesystem exhausted its free space while writing unrelated cached
+  modules; all feature targets had already passed.
+
+# Current frontier
+
+The clean local stack is based on merged power-resource main
+`c3de961220c122e49257607cc35a3d367c369c20`. The execution-work prerequisite
+is its direct child and `powWithin` is directly above that prerequisite.
+
+# Next step
+
+Put the two commits through the requested landing sequence when authorized,
+and rerun the full build when host disk capacity permits.
+
+# Blockers
+
+The only validation limitation is environmental disk exhaustion during the
+unrelated tail of the full repository build; no feature or proof goal is
+blocked.

--- a/progress/20260815T111723Z.md
+++ b/progress/20260815T111723Z.md
@@ -1,0 +1,25 @@
+# Accomplished
+
+- Completed the supported checked natural-power surface on top of the merged
+  multiplication and power-resource prerequisites.
+- Documented the public `Raw.powCutsUnchecked` monotone mapper separately from
+  `Raw.powUnchecked`'s direct zero/odd/even hull selection, and recorded the
+  raw one-way `contains_absUnchecked` theorem used by the even-power proof.
+- Added public end-to-end guards for a huge exponent on singleton zero and the
+  whole interval, a closed negative odd cube, and an even power of a
+  left-unbounded interval.
+- Kept the exact normalized computed-cut characterization and one-way real
+  image theorem; no set-image tightness converse is claimed.
+
+# Current frontier
+
+The natural-power feature is a direct child of merged power-work main and is
+registered in both supported umbrellas and their conformance surface.
+
+# Next step
+
+Complete the independent merge gate for the public natural-power feature.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -346,5 +346,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "5531e22c687dc8534e79fac44549fa8819044211",
     "reason": "Additionally registers the supported HexIntervalMathlib multiplication-semantics module and its Mathlib-free and proof-only conformance coverage on top of the retained absolute-value and minimum/maximum registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "6f661baf815f4cbce66e2fed3ca57df1db3b49f5",
+    "reason": "Additionally registers the supported HexIntervalMathlib natural-power semantics module on top of the retained multiplication and public interval registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add resource-checked public `powWithin` using the safe composite `preflightPow` before every selected finite Core power
- compute direct natural-power hulls: empty absorption, nonempty exponent-zero `{1}`, direct odd mapping, and positive-even mapping through the exact absolute-value hull
- preserve endpoint attainment for negative, mixed-sign, open-zero, unbounded, and singleton inputs
- expose exact normalized computed-cut semantics and a one-way real-image enclosure theorem

This PR does not claim the separate set-image tightness converse. Refusal remains distinct from empty and diagnoses work, endpoint, growth, selector comparison, or final normalization costs.

## Validation

- public/runtime/Mathlib conformance builds
- retained PNT+ FKS2, BKLNW, and Table 12 conformance builds
- DAG, copyright, line-count, conformance-target, freshness, diff, and added-token trust checks