### PR TITLE
feat(interval): add checked transactional splitting

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -18,9 +18,10 @@ data, propagation search, and replayable derivations.
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
-maximum, absolute value, and natural power. The arithmetic resource layer
-preflights product growth, direct-power retained growth, and exponent work
-independently of exact comparison work. Raw cuts remain visible as the explicit
-decoder and inspection boundary; D2 propagation and replay experiments still
-live outside this supported umbrella.
+maximum, absolute value, natural power, and transactional splitting at a
+dyadic cut. The arithmetic resource layer preflights product growth,
+direct-power retained growth, and exponent work independently of exact
+comparison work. Raw cuts remain visible as the explicit decoder and inspection
+boundary; D2 propagation and replay experiments still live outside this
+supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -14,13 +14,13 @@ public section
 # Public exact interval operations
 
 This module begins the supported arithmetic surface with exact intersection,
-hull, negation, addition, subtraction, minimum, maximum, and absolute value.
-The operations retain a resource-aware result: public
-interval values do not remember the construction budget under which their
-endpoints were admitted, so a later comparison must preflight its own alignment
-work. Resource-checked multiplication is kept in `HexInterval.Multiplication`
-because it additionally depends on arithmetic-growth diagnostics and corner
-candidate selection.
+hull, negation, addition, subtraction, minimum, maximum, absolute value,
+natural power, and splitting. The operations retain a resource-aware result:
+public interval values do not remember the construction budget under which
+their endpoints were admitted, so a later comparison must preflight its own
+alignment work. Resource-checked multiplication is kept in
+`HexInterval.Multiplication` because it additionally depends on
+arithmetic-growth diagnostics and corner candidate selection.
 -/
 
 namespace Hex.Interval
@@ -278,7 +278,27 @@ theorem sub_eq_add_neg (left right : Raw) :
           cases leftLower <;> cases leftUpper <;>
             cases rightLower <;> cases rightUpper <;> rfl
 
+/-! ## Interval splitting -/
+
+/-- Raw split at a dyadic point. The left child owns the point and the right
+child excludes it. The pair remains unnormalized so the public wrapper can
+preflight both final child comparisons before constructing either result. -/
+@[expose] def splitUnchecked (input : Raw) (point : Dyadic) : Raw × Raw :=
+  match input with
+  | .empty => (.empty, .empty)
+  | .bounds lower upper =>
+      ( .bounds lower
+          (intersectUpperUnchecked upper (.finite point false)),
+        .bounds
+          (intersectLowerUnchecked lower (.finite point true)) upper )
+
 end Raw
+
+/-- Transactional result of a checked split. A successful value contains both
+sealed canonical children; refusal exposes no partial pair. -/
+inductive SplitResult where
+  | ready (left right : Hex.Interval)
+  | resourceLimit (cost : CompareCost)
 
 private def compareCost? (limit : EndpointLimit) (left right : Dyadic) :
     Option CompareCost :=
@@ -408,6 +428,39 @@ private def powCost? (endpointLimit : EndpointLimit)
         | some cost => some (.comparison cost)
         | none =>
             powCutsCost? endpointLimit workLimits raw.absUnchecked exponent
+
+private def refused? (limit : EndpointLimit) (cost : CompareCost) : Option CompareCost :=
+  if cost.allowed limit then none else some cost
+
+/-- Authenticated raw split candidate. The equality is proof-only; the runtime
+payload is the one selected pair that the checked wrapper will seal. -/
+private structure PreparedSplit (input : Raw) (point : Dyadic) where
+  children : Raw × Raw
+  selected : children = input.splitUnchecked point
+
+/-- Prepare both raw children only after point and selector preflight, then
+preflight both final normalization comparisons before returning the selected
+pair. -/
+private def admitSplit (limit : EndpointLimit) (input : Raw) (point : Dyadic) :
+    Except CompareCost (PreparedSplit input point) := do
+  match hinput : input with
+  | .empty => pure ⟨(.empty, .empty), by simp [hinput, Raw.splitUnchecked]⟩
+  | .bounds lower upper =>
+      let pointCost :=
+        (Raw.bounds .unbounded (.finite point false)).normalizeCost
+      if let some cost := refused? limit pointCost then throw cost
+      match lower with
+      | .finite lower _ =>
+          if let some cost := compareCost? limit lower point then throw cost
+      | .unbounded => pure ()
+      match upper with
+      | .finite upper _ =>
+          if let some cost := compareCost? limit point upper then throw cost
+      | .unbounded => pure ()
+      let children := Raw.splitUnchecked (.bounds lower upper) point
+      if let some cost := refused? limit children.1.normalizeCost then throw cost
+      if let some cost := refused? limit children.2.normalizeCost then throw cost
+      pure ⟨children, by simp [hinput, children, Raw.splitUnchecked]⟩
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -585,5 +638,39 @@ theorem view_powWithin_ready {endpointLimit : EndpointLimit}
         exact view_ofRawWithin_ready hraw
     | resourceLimit cost =>
         simp [Arithmetic.Result.ofBuild, hraw] at h
+
+/-- Split an interval into `input ∩ (-∞, point]` and
+`input ∩ (point, +∞)`. Empty short-circuits without inspecting the point.
+For a nonempty input, all point, selector, and final child comparisons are
+preflighted before the transactional result can expose either child. -/
+def splitWithin (limit : EndpointLimit) (input : Hex.Interval)
+    (point : Dyadic) : SplitResult :=
+  match admitSplit limit input.view point with
+  | .error cost => .resourceLimit cost
+  | .ok prepared =>
+      match ofRawWithin limit prepared.children.1,
+          ofRawWithin limit prepared.children.2 with
+      | .ready left, .ready right => .ready left right
+      -- `admitSplit` already admitted these exact normalization costs. These
+      -- defensive arms keep final sealing honest and still expose no partial
+      -- pair if that checked constructor is strengthened in the future.
+      | .resourceLimit cost, _ | _, .resourceLimit cost => .resourceLimit cost
+
+/-- A successful split exposes exactly both normalized raw children. -/
+theorem view_splitWithin_ready {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (h : splitWithin limit input point = .ready left right) :
+    let children := Raw.splitUnchecked input.view point
+    left.view = children.1.normalizeUnchecked ∧
+      right.view = children.2.normalizeUnchecked := by
+  unfold splitWithin at h
+  split at h
+  · contradiction
+  · next prepared preparedEq =>
+      generalize leftEq : ofRawWithin limit prepared.children.1 = leftResult at h
+      generalize rightEq : ofRawWithin limit prepared.children.2 = rightResult at h
+      cases leftResult <;> cases rightResult <;> simp_all
+      rw [← prepared.selected]
+      exact ⟨view_ofRawWithin_ready leftEq, view_ofRawWithin_ready rightEq⟩
 
 end Hex.Interval

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -182,7 +182,8 @@ value's proof field.
 The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
 supported operations are resource-checked intersection, hull, negation,
-addition, subtraction, minimum, maximum, absolute value, and natural power.
+addition, subtraction, multiplication, minimum, maximum, absolute value,
+natural power, and transactional splitting at a dyadic point.
 Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -438,7 +439,13 @@ def absWithin       : EndpointLimit → Interval → BuildResult
 def mulWithin       : EndpointLimit → Interval → Interval → Arithmetic.Result
 def powWithin       : EndpointLimit → Arithmetic.PowLimits → Interval → Nat →
   Arithmetic.Result
+def splitWithin     : EndpointLimit → Interval → Dyadic → SplitResult
 ```
+
+`SplitResult.ready left right` carries both children together;
+`SplitResult.resourceLimit cost` carries neither. This dedicated result keeps
+refusal distinct from both canonical empty children and makes a partial pair
+unrepresentable.
 
 These names retain the budget because a public interval does not store the
 limit under which it was constructed. Comparing endpoints admitted under two
@@ -482,6 +489,15 @@ endpoints are strict. The opposite-magnitude comparison is preflighted before
 the selector aligns finite dyadics, and the selected raw cuts then cross
 `ofRawWithin`. Thus an interval admitted under a larger earlier budget cannot
 force an unchecked alignment or silently turn refusal into empty.
+
+`splitWithin` is likewise direct and transactional. Empty short-circuits to
+two empty children without inspecting the point. For a nonempty source it
+first checks the retained point endpoint, then every finite source/point
+selector comparison, before running an unchecked selector. It next preflights
+the normalization cost of both raw candidates before constructing either
+sealed child. Success returns the canonical intersections with `(-∞, point]`
+and `(point, +∞)` together; any failed check returns one resource refusal and
+no child.
 
 Multiplication uses the separate checked-arithmetic result because growth
 refusal is distinct from both empty output and endpoint/comparison refusal.
@@ -583,8 +599,9 @@ is currently claimed.
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
 `maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and
-`mulUnchecked` are related to the checked operations by successful-result and
-semantic theorems. `powCutsUnchecked` is only the strictly monotone cut mapper;
+`mulUnchecked`, together with `splitUnchecked`, are related to the checked
+operations by successful-result and semantic theorems. `powCutsUnchecked` is
+only the strictly monotone cut mapper;
 its caller must establish the positive odd or nonnegative positive-exponent
 case. `powUnchecked` performs the zero/odd/even direct-hull selection. Like
 `Raw.normalizeUnchecked`, they
@@ -592,8 +609,7 @@ are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
 The remaining target surface includes precision-indexed reciprocal and
-division,
-splitting, and regularization. Their public signatures are fixed only after an
+division and regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.
 
@@ -640,12 +656,13 @@ tests also check the following exactness rules.
   contains a closed zero exactly when the input contains zero, and a tied
   magnitude extremum combines both contributing closure witnesses rather than
   copying one endpoint flag.
-- `split I m` returns `I ∩ (-∞,m]` and `I ∩ (m,+∞)`. The children are disjoint
-  and cover `I`.
+- `splitWithin limit I m` returns `I ∩ (-∞,m]` and `I ∩ (m,+∞)` together.
+  The left child owns `m` exactly when `I` does, the right child never owns
+  `m`, and the children are disjoint and cover `I`.
 - Empty is canonical. Unary image operations and regularization preserve empty;
   binary image and intersection operations absorb an empty argument; and
-  `split empty m = (empty, empty)`. Hull instead has empty as a two-sided
-  identity.
+  `splitWithin limit empty m = SplitResult.ready empty empty` without charging
+  the point. Hull instead has empty as a two-sided identity.
 - `pow I 0` is `{1}` for nonempty `I`, including unbounded `I`, and is `empty`
   for empty `I`. Thus the operation is the direct image of Lean's power
   function rather than a vacuously sound but noncanonical enclosure.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -14,6 +14,7 @@ public import HexIntervalMathlib.MinMax
 public import HexIntervalMathlib.Absolute
 public import HexIntervalMathlib.Multiplication
 public import HexIntervalMathlib.Power
+public import HexIntervalMathlib.Split
 
 public section
 
@@ -21,5 +22,5 @@ public section
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition,
 subtraction, and multiplication, exact minimum/maximum images, absolute value,
-and natural power.
+natural power, and closed-left/strict-right transactional splitting.
 -/

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -17,6 +17,8 @@ enclosure theorems for minimum and maximum, and
 `HexIntervalMathlib.Absolute` supplies the corresponding absolute-value
 theorems. `HexIntervalMathlib.Power` supplies exact selected-cut semantics
 and a one-way real-image theorem for checked natural power.
+`HexIntervalMathlib.Split` proves exact closed-left/strict-right membership
+for transactional splitting.
 
 For every successful resource-checked public operation it proves:
 
@@ -59,12 +61,19 @@ For every successful resource-checked public operation it proves:
 - `contains_powWithin`: exact membership in the normalized direct cuts selected
   for exponent zero, positive odd powers, and positive even powers;
 - `pow_mem_powWithin`: every source member raised to the caller's natural
-  exponent belongs to every successful result.
+  exponent belongs to every successful result;
+- `contains_splitWithin_left` and `contains_splitWithin_right`: exact child
+  membership as source membership conjoined with `x ≤ point` or `point < x`;
+- `splitWithin_contained`, `splitWithin_cover`, and `splitWithin_disjoint`:
+  both children remain in the source, jointly cover it, and do not overlap;
+- `splitWithin_point_left` and `splitWithin_point_not_right`: the cut point is
+  left-owned exactly when it belonged to the source and never right-owned.
 
-These theorems depend on the exact successful operation-result equation
-(`BuildResult` or `Arithmetic.Result`). A resource refusal has no set
-interpretation and is never treated as an empty interval. The proofs use the
-public operation's checked view-characterization
+These theorems depend on the exact successful result equation: `BuildResult`
+or `Arithmetic.Result` for unary/binary images, and transactional
+`SplitResult` for splitting. A resource refusal has no set interpretation and
+is never treated as an empty interval. The proofs use the public operation's
+checked view-characterization
 theorems and independently establish the complete raw-cut semantics; they do
 not import the experimental propagation fact domain.
 
@@ -73,8 +82,8 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Further arithmetic images, splitting, regularization,
-and precision-indexed reciprocal/division require their own
+are not re-exported here. Further arithmetic images, regularization, and
+precision-indexed reciprocal/division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
@@ -84,7 +93,8 @@ it claims a tightness converse only when that converse is separately proved.
 `HexIntervalMathlib.IntervalConformance` pins both directions of intersection
 membership, exact hull closure and both input inclusions, negation transport,
 addition, subtraction, and multiplication cut exactness and image transport,
-and the exact ordinary-kernel axiom surface.
+exact split membership/coverage/disjointness/point ownership, and the exact
+ordinary-kernel axiom surface.
 `HexIntervalMathlib.MinMaxConformance` separately pins exact selected cuts,
 both image enclosures, and their axiom surfaces; it does not assert a set-image
 converse.

--- a/HexIntervalMathlib/Split.lean
+++ b/HexIntervalMathlib/Split.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+
+@[expose] public section
+
+/-!
+# Exact semantics of checked interval splitting
+
+The public split owns its dyadic point on the left and excludes it on the
+right. This module proves exact child membership directly from the supported
+raw cuts; the experimental branch manager and propagation fact domain are not
+proof inputs.
+-/
+
+namespace Hex.Interval
+
+private theorem upperContains_split (upper : Upper) (point : Dyadic) (x : ℝ) :
+    (Raw.intersectUpperUnchecked upper (.finite point false)).Contains x ↔
+      upper.Contains x ∧ x ≤ toReal point := by
+  simpa [Upper.Contains] using
+    upperContains_intersect upper (.finite point false) x
+
+private theorem lowerContains_split (lower : Lower) (point : Dyadic) (x : ℝ) :
+    (Raw.intersectLowerUnchecked lower (.finite point true)).Contains x ↔
+      lower.Contains x ∧ toReal point < x := by
+  simpa [Lower.Contains] using
+    lowerContains_intersect lower (.finite point true) x
+
+private theorem rawContains_splitLeft (raw : Raw) (point : Dyadic) (x : ℝ) :
+    (raw.splitUnchecked point).1.Contains x ↔
+      raw.Contains x ∧ x ≤ toReal point := by
+  cases raw with
+  | empty => simp [Raw.splitUnchecked, Raw.Contains]
+  | bounds lower upper =>
+      simp only [Raw.splitUnchecked, Raw.Contains]
+      rw [upperContains_split]
+      aesop
+
+private theorem rawContains_splitRight (raw : Raw) (point : Dyadic) (x : ℝ) :
+    (raw.splitUnchecked point).2.Contains x ↔
+      raw.Contains x ∧ toReal point < x := by
+  cases raw with
+  | empty => simp [Raw.splitUnchecked, Raw.Contains]
+  | bounds lower upper =>
+      simp only [Raw.splitUnchecked, Raw.Contains]
+      rw [lowerContains_split]
+      aesop
+
+/-- Exact membership in the left child: original membership together with the
+closed condition `x ≤ point`. -/
+theorem contains_splitWithin_left {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) (x : ℝ) :
+    left.Contains x ↔ input.Contains x ∧ x ≤ toReal point := by
+  have views := view_splitWithin_ready checked
+  simp only [Contains]
+  rw [views.1, contains_normalize]
+  exact rawContains_splitLeft input.view point x
+
+/-- Exact membership in the right child: original membership together with
+the strict condition `point < x`. -/
+theorem contains_splitWithin_right {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) (x : ℝ) :
+    right.Contains x ↔ input.Contains x ∧ toReal point < x := by
+  have views := view_splitWithin_ready checked
+  simp only [Contains]
+  rw [views.2, contains_normalize]
+  exact rawContains_splitRight input.view point x
+
+/-- Both children are subsets of the source interval. -/
+theorem splitWithin_contained {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) {x : ℝ} :
+    (left.Contains x → input.Contains x) ∧
+      (right.Contains x → input.Contains x) :=
+  ⟨fun member => (contains_splitWithin_left checked x).1 member |>.1,
+    fun member => (contains_splitWithin_right checked x).1 member |>.1⟩
+
+/-- The two children cover the source interval. -/
+theorem splitWithin_cover {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) {x : ℝ}
+    (member : input.Contains x) : left.Contains x ∨ right.Contains x := by
+  by_cases side : x ≤ toReal point
+  · exact Or.inl ((contains_splitWithin_left checked x).2 ⟨member, side⟩)
+  · exact Or.inr ((contains_splitWithin_right checked x).2
+      ⟨member, lt_of_not_ge side⟩)
+
+/-- The left-closed/right-open ownership makes the children disjoint. -/
+theorem splitWithin_disjoint {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) (x : ℝ) :
+    ¬(left.Contains x ∧ right.Contains x) := by
+  rintro ⟨leftMember, rightMember⟩
+  have leftBound := (contains_splitWithin_left checked x).1 leftMember |>.2
+  have rightBound := (contains_splitWithin_right checked x).1 rightMember |>.2
+  exact (not_lt_of_ge leftBound) rightBound
+
+/-- The split point belongs to the left child exactly when it belonged to the
+source. -/
+theorem splitWithin_point_left {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) :
+    left.Contains (toReal point) ↔ input.Contains (toReal point) := by
+  simpa using contains_splitWithin_left checked (toReal point)
+
+/-- The strict right child never owns the split point. -/
+theorem splitWithin_point_not_right {limit : EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : splitWithin limit input point = .ready left right) :
+    ¬right.Contains (toReal point) := by
+  intro member
+  exact lt_irrefl _ ((contains_splitWithin_right checked _).1 member |>.2)
+
+end Hex.Interval

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -7,9 +7,12 @@ theorems for interval operations and propagators. It depends on Mathlib and
 
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
-negation, addition, subtraction, minimum, maximum, absolute value, and natural
-power. Natural power exposes exact computed cuts and a sound pointwise real
-image theorem, without claiming a set-image converse.
+negation, addition, subtraction, multiplication, minimum, maximum, absolute
+value, natural power, and transactional splitting. Natural power exposes exact
+computed cuts and a sound pointwise real image theorem, without claiming a
+set-image converse. Splitting exposes both children together and proves exact
+closed-left/strict-right membership, containment, cover, disjointness, and cut
+ownership.
 Propagator, provider, replay, and tactic modules remain experiments and are not
 re-exported by the public umbrella. The user-facing tactic contract below is
 the release target, not a claim that the tactic is already supported.
@@ -175,6 +178,14 @@ theorem abs_mem_absWithin
     (h : absWithin limit I = .ready result) :
     I.Contains x → result.Contains |x|
 
+theorem contains_mulWithin
+    (h : mulWithin limit I J = .ready result) :
+    result.Contains x ↔ I.view.MulContains J.view x
+
+theorem mul_mem_mulWithin
+    (h : mulWithin limit I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (x * y)
+
 theorem contains_powWithin
     (h : powWithin limit workLimits I exponent = .ready result) :
     result.Contains x ↔ (I.view.powUnchecked exponent).Contains x
@@ -182,6 +193,35 @@ theorem contains_powWithin
 theorem pow_mem_powWithin
     (h : powWithin limit workLimits I exponent = .ready result) :
     I.Contains x → result.Contains (x ^ exponent)
+
+theorem contains_splitWithin_left
+    (h : splitWithin limit I point = .ready left right) :
+    left.Contains x ↔ I.Contains x ∧ x ≤ toReal point
+
+theorem contains_splitWithin_right
+    (h : splitWithin limit I point = .ready left right) :
+    right.Contains x ↔ I.Contains x ∧ toReal point < x
+
+theorem splitWithin_contained
+    (h : splitWithin limit I point = .ready left right) :
+    (left.Contains x → I.Contains x) ∧
+      (right.Contains x → I.Contains x)
+
+theorem splitWithin_cover
+    (h : splitWithin limit I point = .ready left right) :
+    I.Contains x → left.Contains x ∨ right.Contains x
+
+theorem splitWithin_disjoint
+    (h : splitWithin limit I point = .ready left right) :
+    ¬(left.Contains x ∧ right.Contains x)
+
+theorem splitWithin_point_left
+    (h : splitWithin limit I point = .ready left right) :
+    left.Contains (toReal point) ↔ I.Contains (toReal point)
+
+theorem splitWithin_point_not_right
+    (h : splitWithin limit I point = .ready left right) :
+    ¬right.Contains (toReal point)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -218,11 +258,17 @@ nonempty exponent zero, positive odd, and positive even cases; the even case
 maps the exact absolute-value hull. Neither operation exports an unproved
 set-image converse.
 
+Transactional splitting returns both sealed children or one resource refusal;
+it cannot expose a partial pair. Empty bypasses point inspection. For a
+nonempty input, the retained point, both finite source/point selectors, and
+both selected child normalization costs are admitted before final sealing.
+Successful children are exactly `I ∩ (-∞, point]` and
+`I ∩ (point, +∞)`, so they remain inside `I`, cover it, and are disjoint.
+
 The remaining target theorems include:
 
 ```lean
 theorem mem_intersect : x ∈ᵢ I → x ∈ᵢ J → x ∈ᵢ intersect I J
-theorem split_cover : x ∈ᵢ I → x ∈ᵢ (split I m).1 ∨ x ∈ᵢ (split I m).2
 theorem not_mem_empty : ¬x ∈ᵢ .empty
 ```
 

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -432,6 +432,118 @@ private def absCrossFar : Hex.Interval :=
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
+-- Checked splitting is transactional: success carries both canonical
+-- children, with the point closed on the left and strict on the right.
+#guard
+  match Hex.Interval.splitWithin smallLimit closed12 (d 1) with
+  | .ready left right =>
+      left.view == finite 1 false 1 false &&
+        right.view == finite 1 true 2 false
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.splitWithin smallLimit closed23 (d 2) with
+  | .ready left right =>
+      left.view == finite 2 false 2 false &&
+        right.view == finite 2 true 3 false
+  | .resourceLimit _ => false
+
+-- Whole has no source endpoints to select. A retained zero therefore produces
+-- the canonical closed-left/strict-right half-lines directly.
+#guard
+  match Hex.Interval.splitWithin smallLimit Hex.Interval.whole (d 0) with
+  | .ready left right =>
+      left.view == .bounds .unbounded (.finite (d 0) false) &&
+        right.view == .bounds (.finite (d 0) true) .unbounded
+  | .resourceLimit _ => false
+
+-- Point admission precedes every selector and child-normalization check, even
+-- when the source itself has no finite endpoints.
+#guard
+  match Hex.Interval.splitWithin smallLimit Hex.Interval.whole far with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
+
+-- A point outside the source gives one empty child and leaves the other
+-- source set unchanged; no partial result is observable.
+#guard
+  match Hex.Interval.splitWithin smallLimit closed12 (d 0) with
+  | .ready left right =>
+      left == Hex.Interval.empty && right == closed12
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.splitWithin smallLimit closed12 (d 3) with
+  | .ready left right =>
+      left == closed12 && right == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+-- Point ownership never adds a point excluded by the source interval.
+#guard
+  match Hex.Interval.splitWithin smallLimit openLower12 (d 1) with
+  | .ready left right =>
+      left == Hex.Interval.empty && right == openLower12
+  | .resourceLimit _ => false
+
+-- Empty bypasses point inspection and succeeds even for an endpoint that
+-- would be over budget on a nonempty source.
+#guard
+  match Hex.Interval.splitWithin smallLimit Hex.Interval.empty far with
+  | .ready left right =>
+      left == Hex.Interval.empty && right == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.splitWithin smallLimit closed12 far with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
+
+-- Once the point itself fits, each source-boundary selector comparison is
+-- still independently refused before the unchecked dyadic comparison can
+-- allocate its aligned mantissa.
+private def splitFar : Dyadic := .ofOdd 1 100 (by decide)
+
+#guard
+  match Hex.Interval.splitWithin smallLimit atLeastOne splitFar with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.alignmentShift == 100
+
+#guard
+  match Hex.Interval.splitWithin smallLimit atMostOne splitFar with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.alignmentShift == 100
+
+-- This bounded source was admitted with a ten-bit alignment budget. The
+-- outside point lies between the endpoint exponents, so both selector
+-- comparisons need only five bits, but the retained left child is the source
+-- itself and its final normalization still needs ten. This isolates the
+-- child-normalization preflight from point and selector refusal.
+private def splitChildLimit : EndpointLimit where
+  maxEndpointHeight := 16
+  maxAlignmentShift := 5
+
+private def splitSourceLimit : EndpointLimit where
+  maxEndpointHeight := 16
+  maxAlignmentShift := 10
+
+private def splitLower : Dyadic := .ofOdd 1 10 (by decide)
+private def splitOutside : Dyadic := .ofOdd 33 5 (by decide)
+
+private def splitWideSource : Hex.Interval :=
+  match Hex.Interval.betweenWithin splitSourceLimit
+      splitLower false (d 1) false with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+#guard (CompareCost.ofDyadic splitLower splitOutside).allowed splitChildLimit
+#guard (CompareCost.ofDyadic splitOutside (d 1)).allowed splitChildLimit
+#guard !(splitWideSource.view.normalizeCost.allowed splitChildLimit)
+
+#guard
+  match Hex.Interval.splitWithin splitChildLimit splitWideSource splitOutside with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.alignmentShift == 10
+
 -- Public intersection is exact at tied open/closed cuts, absorbs empty, and
 -- retains independently unbounded ends.
 #guard
@@ -476,6 +588,19 @@ private def farNegative : Hex.Interval :=
       { maxEndpointHeight := 1000000100, maxAlignmentShift := 64 } (-far) false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
+
+-- A source created under a larger budget is recharged at this operation's
+-- boundary; sealing the source does not let an oversized endpoint bypass the
+-- split preflight.
+#guard
+  match Hex.Interval.splitWithin smallLimit farLower (d 0) with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.lower.exponentMagnitude == 1000000000
+
+#guard
+  match Hex.Interval.splitWithin smallLimit farUpper (d 0) with
+  | .ready _ _ => false
+  | .resourceLimit cost => cost.upper.exponentMagnitude == 1000000000
 
 private def mediumFar : Dyadic := .ofOdd 1 200 (by decide)
 

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -144,6 +144,45 @@ theorem powImage {limit : Hex.Interval.EndpointLimit}
     (member : input.Contains x) : result.Contains (x ^ exponent) :=
   Hex.Interval.pow_mem_powWithin checked member
 
+/-- Successful splitting has exact closed-left membership. -/
+theorem splitLeft {limit : Hex.Interval.EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic} {x : ℝ}
+    (checked : Hex.Interval.splitWithin limit input point = .ready left right) :
+    left.Contains x ↔ input.Contains x ∧ x ≤ Hex.Interval.toReal point :=
+  Hex.Interval.contains_splitWithin_left checked x
+
+/-- Successful splitting has exact strict-right membership. -/
+theorem splitRight {limit : Hex.Interval.EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic} {x : ℝ}
+    (checked : Hex.Interval.splitWithin limit input point = .ready left right) :
+    right.Contains x ↔ input.Contains x ∧ Hex.Interval.toReal point < x :=
+  Hex.Interval.contains_splitWithin_right checked x
+
+/-- Both source subsets are produced by a successful transactional split. -/
+theorem splitCover {limit : Hex.Interval.EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic} {x : ℝ}
+    (checked : Hex.Interval.splitWithin limit input point = .ready left right)
+    (member : input.Contains x) : left.Contains x ∨ right.Contains x :=
+  Hex.Interval.splitWithin_cover checked member
+
+/-- Closed-left/strict-right ownership makes successful children disjoint. -/
+theorem splitDisjoint {limit : Hex.Interval.EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic} (x : ℝ)
+    (checked : Hex.Interval.splitWithin limit input point = .ready left right) :
+    ¬(left.Contains x ∧ right.Contains x) :=
+  Hex.Interval.splitWithin_disjoint checked x
+
+/-- The point is owned by the left child exactly when it was in the source,
+and is never owned by the right child. -/
+theorem splitPoint {limit : Hex.Interval.EndpointLimit}
+    {input left right : Hex.Interval} {point : Dyadic}
+    (checked : Hex.Interval.splitWithin limit input point = .ready left right) :
+    (left.Contains (Hex.Interval.toReal point) ↔
+        input.Contains (Hex.Interval.toReal point)) ∧
+      ¬right.Contains (Hex.Interval.toReal point) :=
+  ⟨Hex.Interval.splitWithin_point_left checked,
+    Hex.Interval.splitWithin_point_not_right checked⟩
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -207,5 +246,25 @@ theorem powImage {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.powImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms powImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.splitLeft' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitLeft
+
+/-- info: 'Hex.IntervalMathlib.Conformance.splitRight' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitRight
+
+/-- info: 'Hex.IntervalMathlib.Conformance.splitCover' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitCover
+
+/-- info: 'Hex.IntervalMathlib.Conformance.splitDisjoint' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitDisjoint
+
+/-- info: 'Hex.IntervalMathlib.Conformance.splitPoint' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitPoint
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -366,7 +366,7 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
     `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
     `HexIntervalMathlib.Multiplication,
-    `HexIntervalMathlib.Power].map Glob.one
+    `HexIntervalMathlib.Power, `HexIntervalMathlib.Split].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T085655Z.md
+++ b/progress/20260815T085655Z.md
@@ -1,0 +1,38 @@
+# Checked public interval splitting
+
+## Accomplished
+
+- Added a dedicated transactional `SplitResult` and checked `splitWithin` on
+  exact base `3189a20bb3446d438c95e614f2833c33197d8f4c`. Empty succeeds without
+  inspecting the point; nonempty inputs preflight the retained point, both
+  selector comparisons, and both child normalization costs before exposing a
+  pair of sealed canonical intervals.
+- Added exact closed-left/strict-right real semantics, containment, coverage,
+  disjointness, and point-ownership theorems without using the experimental
+  branch manager.
+- Added runtime guards for interior/boundary/exterior cuts, source openness,
+  empty bypass, oversized points and source endpoints, and independent lower
+  and upper selector-allocation refusal. Added ordinary-kernel conformance
+  wrappers with guarded axiom reports.
+- Updated both SPECs, supported umbrellas, Lake registration, and the exact
+  proof-only runtime freshness exemption.
+- Built `HexInterval`, `HexIntervalMathlib`, `HexInterval.Conformance`, and
+  `HexIntervalMathlib.IntervalConformance`. Copyright, line-count, DAG, Phase 4,
+  Mathlib-free bench, trust-surface, freshness, JSON, and diff checks pass.
+
+## Current frontier
+
+The smallest complete public splitting primitive is implemented locally and
+ready for review/rebase when requested.
+
+## Next step
+
+Rebase this isolated commit when the parent selects a landing base, then rerun
+the focused checks and exact freshness hash before any remote action.
+
+## Blockers
+
+None in the implementation. An intentionally broader `HexConformance` build
+reached unrelated modules but exhausted the nearly full shared `/tmp`
+filesystem while writing generated `.olean` files; the task-relevant targets
+were rebuilt cleanly after deleting only this worktree's generated build cache.

--- a/progress/20260815T114804Z.md
+++ b/progress/20260815T114804Z.md
@@ -1,0 +1,31 @@
+# Transactional split rebase
+
+## Accomplished
+
+- Rebased the checked transactional split feature as a direct child of exact
+  main `697bad2e80d97ec1a97a30b2f2ddf596289943b8`, retaining the supported
+  multiplication, natural-power, PNT+, and public interval registrations.
+- Re-audited `SplitResult`, `admitSplit`, and `splitWithin`: the API cannot
+  expose a partial child pair, empty bypasses point inspection, and every
+  retained point, selector comparison, and child normalization is preflighted
+  before either sealed child becomes observable.
+- Rechecked closed-left/strict-right cut ownership and the exact Mathlib
+  membership, source containment, cover, disjointness, and point-ownership
+  theorems. The existing implementation needs no semantic strengthening.
+- Refreshed the exact Lake proof-only-runtime exemption for the combined public
+  module graph and reran focused public, PNT+, static, trust, and freshness
+  checks.
+
+## Current frontier
+
+The split feature is a clean local direct child of the selected main commit and
+is ready for the eventual landing cycle.
+
+## Next step
+
+When requested, publish this exact boundary and run a fresh exact-head review
+and CI cycle without adding unrelated changes.
+
+## Blockers
+
+None.

--- a/progress/20260815T120457Z.md
+++ b/progress/20260815T120457Z.md
@@ -1,0 +1,32 @@
+# Transactional split preparation
+
+## Accomplished
+
+- Kept the feature directly based on
+  `697bad2e80d97ec1a97a30b2f2ddf596289943b8` and preserved the supported
+  multiplication, natural-power, PNT+, and public interval registrations.
+- Changed split preparation to return the single authenticated raw child pair
+  after all point, selector, and child-normalization preflights; final sealing
+  consumes that pair without repeating raw cut selection.
+- Added whole-interval success and point-first refusal coverage, plus a bounded
+  witness where both selector comparisons fit but retained-child normalization
+  alone exceeds the alignment limit.
+- Completed the library-level supported theorem inventory, retained exact
+  pair-or-refusal and cover/disjointness semantics, and narrowed the split
+  proof module to its direct interval-semantics import.
+- Reran focused public and PNT+ builds together with static, trust, inventory,
+  and freshness checks.
+
+## Current frontier
+
+The exact transactional split boundary is locally clean and ready for its
+automatic CI cycle.
+
+## Next step
+
+Keep the exact published head stable while automatic CI runs, repairing only a
+verified semantic or integration blocker.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -352,5 +352,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "6f661baf815f4cbce66e2fed3ca57df1db3b49f5",
     "reason": "Additionally registers the supported HexIntervalMathlib natural-power semantics module on top of the retained multiplication and public interval registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "9dd80526e15dd9e72cd4a157d03021e7a24e2c39",
+    "reason": "Additionally registers the supported HexIntervalMathlib transactional-split semantics module on top of the retained multiplication, natural-power, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add a dedicated `SplitResult` whose success carries both sealed children and whose refusal carries neither
- preflight the retained split point, both source/point selector comparisons, and both child normalization costs before exposing a result
- prove exact closed-left/strict-right membership, source containment, cover, disjointness, and point ownership in the supported Mathlib companion
- add discriminating runtime and guarded ordinary-kernel conformance, supported-surface documentation, and the exact proof-only runtime freshness exemption

## Scope

This is the direct supported interval primitive only. Its semantic proofs are derived from the public raw cuts and checked result equation; the experimental branch manager and propagation fact domain are not proof evidence.

## Validation

- `lake build HexInterval HexIntervalMathlib HexInterval.Conformance HexIntervalMathlib.IntervalConformance`
- PNT+ FKS2, BKLNW power, and Table 12 conformance targets
- DAG, copyright, line-count, conformance-target, published trust-surface, PNT inventory, and factor-sweep freshness checks
- added Lean trust-surface and diff checks