### PR TITLE
feat(interval): preflight precision quotients

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -20,8 +20,9 @@ representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
 maximum, absolute value, natural power, and transactional splitting at a
 dyadic cut. The arithmetic resource layer preflights product growth,
-direct-power retained growth, and exponent work independently of exact
-comparison work. Raw cuts remain visible as the explicit decoder and inspection
-boundary; D2 propagation and replay experiments still live outside this
-supported umbrella.
+direct-power retained growth, exponent work, and rational-backed
+precision/quotient work independently of exact comparison work. Reciprocal and
+division operations remain unexposed. Raw cuts remain visible as the explicit
+decoder and inspection boundary; D2 propagation and replay experiments still
+live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -20,7 +20,10 @@ public interval operations whose costs are comparisons continue to return
 `BuildResult`; multiplication and direct natural power report growth without
 fabricating a `CompareCost`. Concrete corner enumeration and interval
 multiplication live in `HexInterval.Multiplication`, not in this reusable cost
-layer.
+layer. Precision-indexed reciprocal and division additionally cross Core's
+`Dyadic.toRat`/`Rat.toDyadic` boundary, so their prerequisites record
+precision, rational-conversion, and temporary product bounds separately from
+retained endpoint growth.
 -/
 
 namespace Hex.Interval.Arithmetic
@@ -65,15 +68,112 @@ def allowed (limits : PowLimits) (work : PowWork) : Bool :=
 
 end PowWork
 
-/-- Resource diagnostics for checked public arithmetic. Product growth is a
-separate case from endpoint and comparison work: a comparison between two
-admitted factors may be cheap even when their product is too large. Direct
-power execution work is also reported separately from retained growth. -/
+/-! ## Precision-indexed rational conversion -/
+
+/-- Limits needed before entering Core's rational-backed dyadic reciprocal or
+division. Retained endpoints and aggregate conversion shifts keep their
+existing meanings. Precision encoding and temporary rational integers have
+separate bounds rather than being disguised as endpoint height or comparison
+cost. -/
+structure PrecisionLimits where
+  endpoint : EndpointLimit
+  maxPrecisionMagnitude : Nat
+  maxPrecisionBits : Nat
+  maxTemporaryBits : Nat
+  deriving DecidableEq, Repr
+
+/-- Allocation-independent size of a requested signed precision. -/
+structure PrecisionCost where
+  encodedBits : Nat
+  magnitude : Nat
+  deriving DecidableEq, Repr
+
+namespace PrecisionCost
+
+/-- Measure a signed precision without constructing a power of two. -/
+def ofPrecision (precision : Precision) : PrecisionCost :=
+  let magnitude := precision.natAbs
+  { encodedBits := EndpointCost.natBits magnitude, magnitude }
+
+/-- Admit both the magnitude of a precision and the size of its existing
+arbitrary-precision encoding. -/
+def allowed (limits : PrecisionLimits) (cost : PrecisionCost) : Bool :=
+  cost.encodedBits ≤ limits.maxPrecisionBits &&
+    cost.magnitude ≤ limits.maxPrecisionMagnitude
+
+end PrecisionCost
+
+/-- Conservative bit bounds for the numerator and denominator of a rational
+temporary. These are integer bit lengths, not retained dyadic endpoint data. -/
+structure RationalBound where
+  numeratorBits : Nat
+  denominatorBits : Nat
+  deriving DecidableEq, Repr
+
+namespace RationalBound
+
+/-- Admit both integer components of a rational temporary. -/
+def allowed (limit : Nat) (bound : RationalBound) : Bool :=
+  bound.numeratorBits ≤ limit && bound.denominatorBits ≤ limit
+
+end RationalBound
+
+/-- Complete pre-allocation record for a nonzero reciprocal or division.
+
+`converted` bounds the exact `Dyadic.toRat` source shapes. `conversionShift`
+charges every source-exponent shift plus the precision shift without signed
+cancellation. `crossProduct` is absent for `invAtPrec` and bounds the reduced
+rational numerator/denominator products formed by `divAtPrec`. `rounding`
+bounds the rational side shifted by `Rat.toDyadic`, `quotientBits` bounds the
+integer passed to `Dyadic.ofIntWithPrec`, and
+`predictedResultHeight` bounds the canonical retained dyadic height after
+trailing-zero normalization. -/
+structure QuotientCost where
+  sources : List EndpointCost
+  precision : PrecisionCost
+  converted : List RationalBound
+  conversionShift : Nat
+  crossProduct : Option RationalBound
+  rounding : RationalBound
+  quotientBits : Nat
+  predictedResultHeight : Nat
+  deriving DecidableEq, Repr
+
+namespace QuotientCost
+
+/-- Admit all retained inputs, precision metadata, conversion work,
+rational temporaries, the integer quotient, and the retained result bound. -/
+def allowed (limits : PrecisionLimits) (cost : QuotientCost) : Bool :=
+  cost.sources.all (EndpointCost.allowed limits.endpoint) &&
+    cost.precision.allowed limits &&
+    cost.converted.all (RationalBound.allowed limits.maxTemporaryBits) &&
+    cost.conversionShift ≤ limits.endpoint.maxAlignmentShift &&
+    cost.crossProduct.all (RationalBound.allowed limits.maxTemporaryBits) &&
+    cost.rounding.allowed limits.maxTemporaryBits &&
+    cost.quotientBits ≤ limits.maxTemporaryBits &&
+    cost.predictedResultHeight ≤ limits.endpoint.maxEndpointHeight
+
+end QuotientCost
+
+/-- A successful preflight. Core returns zero without rational conversion when
+the reciprocal input or division denominator is zero; that plan still retains
+the endpoint costs already admitted before the short circuit. -/
+inductive QuotientPlan where
+  | zero (sources : List EndpointCost)
+  | checked (cost : QuotientCost)
+  deriving DecidableEq, Repr
+
+/-- Resource diagnostics for checked public arithmetic. Product growth,
+direct-power work, precision requests, and rational-backed quotient work are
+separate cases from endpoint and comparison work; none can be inferred
+honestly from the cost of comparing already-admitted endpoints. -/
 inductive Cost where
   | endpoint (cost : EndpointCost)
   | comparison (cost : CompareCost)
   | growth (cost : Growth)
   | power (work : PowWork)
+  | precision (cost : PrecisionCost)
+  | quotient (cost : QuotientCost)
   deriving DecidableEq, Repr
 
 /-- Result type for public arithmetic whose work is not described by
@@ -182,5 +282,147 @@ def preflightPow (endpointLimit : EndpointLimit) (workLimits : PowLimits)
       if !work.allowed workLimits then
         throw (.power work)
       preflightPowGrowth endpointLimit source exponent
+
+/-! ## Reciprocal and division prerequisites -/
+
+/-- Admit one retained source endpoint before any precision or rational work. -/
+def admitEndpoint (limits : PrecisionLimits) (value : Dyadic) :
+    Except Cost EndpointCost := do
+  let cost := EndpointCost.ofDyadic value
+  if !cost.allowed limits.endpoint then throw (.endpoint cost)
+  pure cost
+
+/-- Admit a signed precision before any rational conversion or shift metadata. -/
+def admitPrecision (limits : PrecisionLimits) (precision : Precision) :
+    Except Cost PrecisionCost := do
+  let cost := PrecisionCost.ofPrecision precision
+  if !cost.allowed limits then throw (.precision cost)
+  pure cost
+
+namespace QuotientCost
+
+/-- Exact component bit lengths allocated by `Dyadic.toRat`, computed without
+performing its power-of-two shift. The endpoint cost is derived from the same
+value, so callers cannot pair unrelated cost and value records. -/
+def conversionBound (value : Dyadic) : RationalBound :=
+  let cost := EndpointCost.ofDyadic value
+  match value with
+  | .zero => { numeratorBits := 0, denominatorBits := 1 }
+  | .ofOdd _ (.ofNat exponent) _ =>
+      { numeratorBits := cost.numeratorBits, denominatorBits := exponent + 1 }
+  | .ofOdd _ (.negSucc exponent) _ =>
+      { numeratorBits := cost.numeratorBits + exponent + 1, denominatorBits := 1 }
+
+/-- Swapping a reduced nonzero rational's components performs no allocation. -/
+def invertBound (bound : RationalBound) : RationalBound :=
+  { numeratorBits := bound.denominatorBits
+    denominatorBits := bound.numeratorBits }
+
+/-- Exact bit length of a nonzero integer multiplied by a power of two whose
+bit length is `powerBits`. A zero integer remains zero. This helper is private:
+its second-argument invariant is established only by `conversionBound`. -/
+private def mulPowTwo (valueBits powerBits : Nat) : Nat :=
+  if valueBits = 0 then 0 else valueBits + powerBits - 1
+
+/-- Conservative bounds for `left / right` after `Rat.mul` performs its two
+cross-gcd reductions and before either retained product is allocated.
+
+`conversionBound` establishes structurally that every dyadic denominator is
+an exact power of two (including one). Thus the unreduced numerator is the
+left numerator times the right power-of-two denominator, and the unreduced
+denominator is the left power-of-two denominator times the right numerator.
+The private exact shift bound applies to precisely those products; gcd
+reduction can only make their retained components smaller. -/
+def divisionBound (left right : Dyadic) : RationalBound :=
+  let leftBound := conversionBound left
+  let rightBound := conversionBound right
+  { numeratorBits := mulPowTwo leftBound.numeratorBits rightBound.denominatorBits
+    denominatorBits := mulPowTwo rightBound.numeratorBits leftBound.denominatorBits }
+
+/-- Bound the numerator/denominator shifted by Core `Rat.toDyadic`. Shifting a
+zero numerator left preserves its zero-bit size at every positive precision. -/
+def roundingBound (precision : Precision) (bound : RationalBound) : RationalBound :=
+  match precision with
+  | .ofNat shift =>
+      { bound with
+        numeratorBits := if bound.numeratorBits = 0 then 0 else bound.numeratorBits + shift }
+  | .negSucc shift => { bound with denominatorBits := bound.denominatorBits + shift + 1 }
+
+/-- Whether floor rounding may increase the quotient's magnitude by one bit. -/
+def isNegative : Dyadic → Bool
+  | .ofOdd (.negSucc _) _ _ => true
+  | _ => false
+
+/-- Bound the integer quotient passed to `Dyadic.ofIntWithPrec`. A positive
+quotient has no more bits than the shifted rational numerator; flooring a
+negative quotient may add one magnitude bit. -/
+def boundQuotientBits (isNegative : Bool) (rounding : RationalBound) : Nat :=
+  if rounding.numeratorBits = 0 then 0
+  else rounding.numeratorBits + (if isNegative then 1 else 0)
+
+/-- Bound the canonical result height after `Dyadic.ofIntWithPrec`. Removing
+`t` trailing zeroes decreases numerator bits by `t` while changing exponent
+magnitude by at most `t`, so quotient bits plus precision magnitude suffices. -/
+def boundResultHeight (precision : Precision) (quotientBits : Nat) : Nat :=
+  if quotientBits = 0 then 0 else quotientBits + precision.natAbs
+
+end QuotientCost
+
+/-- Preflight the public resource prerequisite for Core `Dyadic.invAtPrec`.
+No rational conversion, shift, division, or result construction occurs here. -/
+def preflightInv (limits : PrecisionLimits) (value : Dyadic)
+    (precision : Precision) : Except Cost QuotientPlan := do
+  let source ← admitEndpoint limits value
+  match value with
+  | .zero => pure (.zero [source])
+  | _ =>
+      let precisionCost ← admitPrecision limits precision
+      let converted := QuotientCost.conversionBound value
+      let rounding := QuotientCost.roundingBound precision (QuotientCost.invertBound converted)
+      let quotientBits :=
+        QuotientCost.boundQuotientBits (QuotientCost.isNegative value) rounding
+      let cost : QuotientCost :=
+        { sources := [source]
+          precision := precisionCost
+          converted := [converted]
+          conversionShift := source.exponentMagnitude + precisionCost.magnitude
+          crossProduct := none
+          rounding
+          quotientBits
+          predictedResultHeight := QuotientCost.boundResultHeight precision quotientBits }
+      if !cost.allowed limits then throw (.quotient cost)
+      pure (.checked cost)
+
+/-- Preflight the public resource prerequisite for Core `Dyadic.divAtPrec`.
+Both retained sources are admitted before the denominator-zero short circuit.
+For a nonzero denominator, the record bounds both `toRat` conversions, the
+reduced rational cross-products, the precision shift, and the retained result.
+No source conversion or arithmetic is executed here. -/
+def preflightDiv (limits : PrecisionLimits) (left right : Dyadic)
+    (precision : Precision) : Except Cost QuotientPlan := do
+  let leftCost ← admitEndpoint limits left
+  let rightCost ← admitEndpoint limits right
+  match right with
+  | .zero => pure (.zero [leftCost, rightCost])
+  | _ =>
+      let precisionCost ← admitPrecision limits precision
+      let leftBound := QuotientCost.conversionBound left
+      let rightBound := QuotientCost.conversionBound right
+      let crossProduct := QuotientCost.divisionBound left right
+      let rounding := QuotientCost.roundingBound precision crossProduct
+      let quotientBits := QuotientCost.boundQuotientBits
+        (QuotientCost.isNegative left != QuotientCost.isNegative right) rounding
+      let cost : QuotientCost :=
+        { sources := [leftCost, rightCost]
+          precision := precisionCost
+          converted := [leftBound, rightBound]
+          conversionShift := leftCost.exponentMagnitude + rightCost.exponentMagnitude +
+            precisionCost.magnitude
+          crossProduct := some crossProduct
+          rounding
+          quotientBits
+          predictedResultHeight := QuotientCost.boundResultHeight precision quotientBits }
+      if !cost.allowed limits then throw (.quotient cost)
+      pure (.checked cost)
 
 end Hex.Interval.Arithmetic

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -596,6 +596,45 @@ and upper-cut characterization after normalization, and the Mathlib companion pr
 product of source members belongs to it. No separate image-tightness converse
 is currently claimed.
 
+The public tree also contains the allocation prerequisite for
+precision-indexed reciprocal and division, but no `invWithin` or `divWithin`
+interval operation. Core `Dyadic.invAtPrec` converts a nonzero source through
+`Dyadic.toRat`, inverts the rational, then calls `Rat.toDyadic`; `divAtPrec`
+converts both sources and additionally runs reduced rational cross-products.
+Neither `CompareCost` nor `Arithmetic.Growth` accounts for those shifts or
+temporary numerators and denominators. `Arithmetic.PrecisionLimits` therefore
+retains the existing endpoint-height and aggregate-shift policy while adding
+separate precision-magnitude, encoded-precision, and rational-temporary bit
+limits. Its embedded `EndpointLimit.maxAlignmentShift` is deliberately reused
+as the cap on the sum of all source-conversion shift magnitudes plus the
+precision-shift magnitude: this is an aggregate allocation-work budget, not a
+claim that those signed shifts are one comparison alignment or may cancel.
+`Arithmetic.Cost.precision` refuses an oversized request before any
+source conversion or source-exponent/precision sum. After admitted precision,
+`Arithmetic.QuotientCost` records exact source conversion shapes, the sum of
+source exponent magnitudes and precision magnitude without signed
+cancellation, an explicit division cross-product bound, the `toDyadic` shift,
+and a conservative retained result-height bound. For positive precision the
+precision magnitude can occur once in the shifted quotient-bit bound and again
+in the canonical endpoint-height bound. This intentional doubled allowance
+avoids assuming how many trailing zeroes `Dyadic.ofIntWithPrec` will remove;
+zero quotients remain exactly zero-sized.
+
+`preflightInv` and `preflightDiv` construct only this metadata; they
+do not call the Core arithmetic. The reciprocal zero and division-by-zero
+paths record Core's no-conversion short circuit, although division first admits
+both retained public sources; their `QuotientPlan.zero` records those admitted
+source costs rather than discarding preflight provenance. The result-height
+bound deliberately allows one
+extra quotient-magnitude bit for negative floor rounding and does not use the
+denominator to claim cancellation. Conformance accepts positive and negative
+`{3}` prerequisites and separately exercises precision encoding, zero
+numerators, admitted zero-path sources, failure priority, converted and
+cross-product temporaries, quotient size, non-cancelling conversion shifts,
+and predicted retained result. Endpoint selection, outward cut direction,
+zero-crossing interval semantics, final canonicalization, Mathlib enclosure
+proofs, and the actual public inverse/division operations remain future work.
+
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
 `maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -354,6 +354,223 @@ private def widePowLimits : Arithmetic.PowLimits where
   | .error (.power work) => work.exponent == beyondUInt64 + 1
   | _ => false
 
+/-! # Precision-indexed reciprocal/division resource prerequisite -/
+
+private def precisionLimits : Arithmetic.PrecisionLimits where
+  endpoint := { maxEndpointHeight := 18, maxAlignmentShift := 16 }
+  maxPrecisionMagnitude := 16
+  maxPrecisionBits := 8
+  maxTemporaryBits := 32
+
+-- The prerequisite authenticates Core's two rational-conversion shifts and
+-- retained result without computing the reciprocal.  Positive and negative
+-- `{3}` differ by the possible one-bit magnitude carry from flooring a
+-- negative rational.
+#guard
+  match Arithmetic.preflightInv precisionLimits (d 3) 8 with
+  | .ok (.checked cost) =>
+      cost.sources.length == 1 &&
+        cost.precision.magnitude == 8 && cost.precision.encodedBits == 4 &&
+        cost.conversionShift == 8 && cost.crossProduct.isNone &&
+        cost.rounding.numeratorBits == 9 && cost.rounding.denominatorBits == 2 &&
+        cost.quotientBits == 9 && cost.predictedResultHeight == 17 &&
+        cost.allowed precisionLimits
+  | _ => false
+
+#guard
+  match Arithmetic.preflightInv precisionLimits (d (-3)) 8 with
+  | .ok (.checked cost) =>
+      cost.rounding.numeratorBits == 9 &&
+        cost.quotientBits == 10 && cost.predictedResultHeight == 18 &&
+        cost.allowed precisionLimits
+  | _ => false
+
+-- Direct division records the reduced rational cross-product bounds.  These
+-- are not inferred from a comparison or from retained endpoint growth.
+#guard
+  match Arithmetic.preflightDiv precisionLimits (d 1) (d 3) 8 with
+  | .ok (.checked cost) =>
+      match cost.crossProduct with
+      | some cross =>
+          cross.numeratorBits == 1 && cross.denominatorBits == 2 &&
+            cost.predictedResultHeight == 17 && cost.allowed precisionLimits
+      | none => false
+  | _ => false
+
+#guard
+  match Arithmetic.preflightDiv precisionLimits (d (-1)) (d 3) 8 with
+  | .ok (.checked cost) =>
+      cost.predictedResultHeight == 18 && cost.allowed precisionLimits
+  | _ => false
+
+-- A zero numerator remains zero through positive-precision rounding instead
+-- of acquiring the precision's bit count. The nonzero denominator is still an
+-- admitted, load-bearing source.
+#guard
+  match Arithmetic.preflightDiv precisionLimits 0 (d 3) 8 with
+  | .ok (.checked cost) =>
+      cost.sources == [EndpointCost.ofDyadic 0, EndpointCost.ofDyadic (d 3)] &&
+        cost.rounding.numeratorBits == 0 && cost.quotientBits == 0 &&
+        cost.predictedResultHeight == 0 && cost.allowed precisionLimits
+  | _ => false
+
+#guard
+  match Arithmetic.preflightDiv precisionLimits 0 (d 3) (-8) with
+  | .ok (.checked cost) =>
+      cost.rounding.numeratorBits == 0 && cost.rounding.denominatorBits == 10 &&
+        cost.quotientBits == 0 && cost.predictedResultHeight == 0 &&
+        cost.allowed precisionLimits
+  | _ => false
+
+-- Core's zero cases do not inspect precision or enter rational conversion,
+-- but the plan preserves every endpoint cost admitted before the short cut.
+#guard
+  match Arithmetic.preflightInv precisionLimits 0 1024 with
+  | .ok (.zero sources) => sources == [EndpointCost.ofDyadic 0]
+  | _ => false
+#guard
+  match Arithmetic.preflightDiv precisionLimits (d 1) 0 1024 with
+  | .ok (.zero sources) =>
+      sources == [EndpointCost.ofDyadic (d 1), EndpointCost.ofDyadic 0]
+  | _ => false
+
+-- Precision magnitude and encoding are refused before either rational
+-- conversion or the source-exponent/precision metadata sum is formed.
+#guard
+  match Arithmetic.preflightInv precisionLimits (d 3) 1024 with
+  | .error (.precision cost) =>
+      cost.magnitude == 1024 && cost.encodedBits == 11 &&
+        !cost.allowed precisionLimits
+  | _ => false
+
+private def tightPrecisionBitsLimits : Arithmetic.PrecisionLimits :=
+  { precisionLimits with maxPrecisionMagnitude := 1024, maxPrecisionBits := 3 }
+
+-- Encoding size is an independent gate: magnitude eight is admitted while
+-- its four-bit encoding exceeds this deliberately smaller cap.
+#guard
+  match Arithmetic.preflightInv tightPrecisionBitsLimits (d 3) 8 with
+  | .error (.precision cost) =>
+      cost.magnitude == 8 && cost.encodedBits == 4 &&
+        cost.magnitude ≤ tightPrecisionBitsLimits.maxPrecisionMagnitude &&
+        !cost.allowed tightPrecisionBitsLimits
+  | _ => false
+
+private def inverseShiftInput : Dyadic := .ofOdd 3 (-8) (by decide)
+
+private def nonCancellingLimits : Arithmetic.PrecisionLimits where
+  endpoint := { maxEndpointHeight := 32, maxAlignmentShift := 15 }
+  maxPrecisionMagnitude := 16
+  maxPrecisionBits := 8
+  maxTemporaryBits := 32
+
+-- Core performs the source conversion and precision shifts separately.  The
+-- signed values `-8` and `8` cancel algebraically, but the allocation work is
+-- charged as `8 + 8` and refused before `toRat`.
+#guard
+  match Arithmetic.preflightInv nonCancellingLimits inverseShiftInput 8 with
+  | .error (.quotient cost) =>
+      cost.conversionShift == 16 &&
+        cost.predictedResultHeight == 17 && !cost.allowed nonCancellingLimits
+  | _ => false
+
+private def oversizedSource : Dyadic := .ofOdd 1 32 (by decide)
+
+-- Retained source admission precedes precision and rational-shape work.
+#guard
+  match Arithmetic.preflightInv precisionLimits oversizedSource 0 with
+  | .error (.endpoint cost) =>
+      cost.numeratorBits == 1 && cost.exponentMagnitude == 32 &&
+        !cost.allowed precisionLimits.endpoint
+  | _ => false
+
+-- When source and precision both exceed their limits, source admission wins
+-- deterministically and no precision metadata is consulted.
+#guard
+  match Arithmetic.preflightInv precisionLimits oversizedSource 1024 with
+  | .error (.endpoint cost) => cost == EndpointCost.ofDyadic oversizedSource
+  | _ => false
+
+private def convertedTemporary : Dyadic := .ofOdd 3 16 (by decide)
+
+private def tightConvertedLimits : Arithmetic.PrecisionLimits :=
+  { precisionLimits with maxTemporaryBits := 16 }
+
+-- The source and precision fit, but `toRat` would allocate a seventeen-bit
+-- power-of-two denominator. The converted-shape gate is therefore
+-- load-bearing independently of endpoint admission.
+#guard
+  match Arithmetic.preflightInv tightConvertedLimits convertedTemporary 0 with
+  | .error (.quotient cost) =>
+      cost.sources.all (EndpointCost.allowed tightConvertedLimits.endpoint) &&
+        cost.precision.allowed tightConvertedLimits &&
+        cost.converted == [{ numeratorBits := 2, denominatorBits := 17 }] &&
+        !cost.converted.all
+          (Arithmetic.RationalBound.allowed tightConvertedLimits.maxTemporaryBits) &&
+        !cost.allowed tightConvertedLimits
+  | _ => false
+
+private def tightResultLimits : Arithmetic.PrecisionLimits where
+  endpoint := { maxEndpointHeight := 16, maxAlignmentShift := 16 }
+  maxPrecisionMagnitude := 16
+  maxPrecisionBits := 8
+  maxTemporaryBits := 32
+
+-- Conversion and rounding temporaries fit, but the separately predicted
+-- retained result height does not.
+#guard
+  match Arithmetic.preflightInv tightResultLimits (d 3) 8 with
+  | .error (.quotient cost) =>
+      cost.conversionShift == 8 &&
+        cost.rounding.numeratorBits == 9 && cost.rounding.denominatorBits == 2 &&
+        cost.rounding.allowed tightResultLimits.maxTemporaryBits &&
+        cost.quotientBits == 9 && cost.predictedResultHeight == 17 &&
+        !cost.allowed tightResultLimits
+  | _ => false
+
+private def tightQuotientLimits : Arithmetic.PrecisionLimits :=
+  { precisionLimits with maxTemporaryBits := 9 }
+
+-- Negative flooring may add one quotient-magnitude bit. All rational
+-- temporaries fit nine bits, while the ten-bit integer quotient does not.
+#guard
+  match Arithmetic.preflightInv tightQuotientLimits (d (-3)) 8 with
+  | .error (.quotient cost) =>
+      cost.converted.all
+          (Arithmetic.RationalBound.allowed tightQuotientLimits.maxTemporaryBits) &&
+        cost.rounding.allowed tightQuotientLimits.maxTemporaryBits &&
+        cost.quotientBits == 10 &&
+        !(cost.quotientBits ≤ tightQuotientLimits.maxTemporaryBits) &&
+        cost.predictedResultHeight ≤ tightQuotientLimits.endpoint.maxEndpointHeight &&
+        !cost.allowed tightQuotientLimits
+  | _ => false
+
+private def oneOver256 : Dyadic := .ofOdd 1 8 (by decide)
+
+private def tightTemporaryLimits : Arithmetic.PrecisionLimits where
+  endpoint := { maxEndpointHeight := 16, maxAlignmentShift := 16 }
+  maxPrecisionMagnitude := 16
+  maxPrecisionBits := 8
+  maxTemporaryBits := 15
+
+-- Both retained sources and their `toRat` shapes fit, as does the predicted
+-- retained result.  Division is nevertheless refused because `Rat.mul` may
+-- allocate the sixteen-bit cross-product `255 * 256`.
+#guard
+  match Arithmetic.preflightDiv tightTemporaryLimits (d 255) oneOver256 0 with
+  | .error (.quotient cost) =>
+      cost.converted.all
+          (Arithmetic.RationalBound.allowed tightTemporaryLimits.maxTemporaryBits) &&
+        cost.conversionShift == 8 && cost.predictedResultHeight == 16 &&
+        match cost.crossProduct with
+        | some cross =>
+            cross.numeratorBits == 16 && cross.denominatorBits == 1 &&
+              !cross.allowed tightTemporaryLimits.maxTemporaryBits &&
+              cost.quotientBits == 16 &&
+              !cost.allowed tightTemporaryLimits
+        | none => false
+  | _ => false
+
 private def ready (raw : Raw) : Hex.Interval :=
   match Hex.Interval.ofRawWithin smallLimit raw with
   | .ready interval => interval

--- a/progress/20260815T080927Z.md
+++ b/progress/20260815T080927Z.md
@@ -1,0 +1,42 @@
+# Precision-indexed reciprocal/division resource prerequisite
+
+## Accomplished
+
+- Audited Core `Dyadic.invAtPrec` and `divAtPrec`: nonzero inputs cross
+  `Dyadic.toRat`, division adds reduced rational cross-products, and
+  `Rat.toDyadic` shifts either the rational numerator or denominator before
+  integer division and `Dyadic.ofIntWithPrec` normalization.
+- Added public precision limits and staged precision/quotient diagnostics
+  without changing existing interval, `BuildResult`, or arithmetic function
+  signatures.
+- Added allocation-independent preflights for reciprocal and division. They
+  admit retained sources first, reject precision before conversion metadata,
+  charge source and precision shifts without signed cancellation, bound source
+  rational shapes, division cross-products, rounding operands, the signed
+  integer quotient, and the predicted retained result.
+- Added positive and negative `{3}` prerequisite guards and distinct refusal
+  guards for precision, source endpoint, non-cancelling shifts, division
+  cross-products, and retained result height.
+- Updated the supported-state SPEC and umbrella documentation without claiming
+  public inverse or division operations.
+- Built `HexInterval` and `HexInterval.Conformance`; repository static, trust,
+  Mathlib-free bench, conformance-registration, and freshness checks pass.
+
+## Current frontier
+
+The public kernel can now decide whether entering Core's rational-backed
+precision arithmetic is resource-safe, but it deliberately constructs no
+reciprocal or quotient endpoint. The checker is conservative for negative
+flooring and does not use denominator cancellation to reduce retained-height
+bounds.
+
+## Next step
+
+Use the prerequisite while designing `invWithin` and `divWithin`, then add the
+cut-direction, zero-crossing, attainment, final-canonicalization, and Mathlib
+enclosure layers without weakening these pre-allocation checks.
+
+## Blockers
+
+None for the prerequisite. Public interval inverse/division semantics and
+their correspondence proofs remain intentionally outside this slice.

--- a/progress/20260815T115058Z.md
+++ b/progress/20260815T115058Z.md
@@ -1,0 +1,34 @@
+# Precision quotient prerequisite restack
+
+## Accomplished
+
+- Replayed the precision/quotient resource prerequisite directly onto exact
+  main `697bad2e80d97ec1a97a30b2f2ddf596289943b8`, preserving the merged
+  multiplication and checked-power resource layers and their conformance
+  guards.
+- Resolved the additive `Arithmetic.Cost` surface so `power`, `precision`, and
+  `quotient` remain distinct diagnostics; `PowLimits` and `PrecisionLimits`
+  retain non-overlapping contracts.
+- Renamed the newly introduced four-part preflight entry points to the shorter
+  `preflightInv` and `preflightDiv`, matching `preflightMul` and
+  `preflightPow`; the explicit precision parameter still fixes their Core
+  `invAtPrec`/`divAtPrec` meaning.
+- Built the public interval library, its focused conformance module, the full
+  conformance target, and representative PNT+ conformance targets. Repository
+  static, release-manifest, trust-surface, PNT-inventory, Mathlib-free bench,
+  and factor-sweep freshness checks pass.
+
+## Current frontier
+
+The branch exposes only allocation-independent precision and quotient
+preflight metadata. It does not construct reciprocal or division intervals and
+does not claim their real-image semantics.
+
+## Next step
+
+Land this prerequisite independently, then replay the preserved local checked
+reciprocal and checked division commits above its final public API.
+
+## Blockers
+
+None for the prerequisite-only slice.

--- a/progress/20260815T121105Z.md
+++ b/progress/20260815T121105Z.md
@@ -1,0 +1,35 @@
+# Precision quotient prerequisite review repair
+
+## Accomplished
+
+- Removed the false public general product-bit helper. Division cross-product
+  bounds now accept actual dyadics, derive their rational shapes internally,
+  and use a private power-of-two shift helper only where `conversionBound`
+  structurally establishes that invariant.
+- Made `conversionBound` derive its endpoint cost from the same value, fixed
+  zero-numerator rounding at both precision signs, and retained admitted source
+  costs in zero short-circuit plans.
+- Added missing public helper documentation and separated the quotient-bit and
+  canonical-result-height contracts.
+- Added discriminating guards for precision encoding, converted temporaries,
+  quotient size, zero numerators, zero-plan provenance, and simultaneous
+  source/precision refusal priority.
+- Clarified in the SPEC that `maxAlignmentShift` is reused as an aggregate
+  conversion-work cap and that positive precision is intentionally allowed in
+  both shifted quotient size and conservative canonical endpoint height.
+- Rebuilt focused and full public conformance and reran the static, release,
+  trust, PNT inventory, Mathlib-free bench, and freshness gates successfully.
+
+## Current frontier
+
+The repaired slice remains a metadata-only prerequisite. No reciprocal,
+division, or regularization interval operation is exposed or claimed.
+
+## Next step
+
+Land the prerequisite, then deliberately replay the preserved local reciprocal
+and division commits against its final public schema.
+
+## Blockers
+
+None for this prerequisite repair.

--- a/progress/20260815T123217Z.md
+++ b/progress/20260815T123217Z.md
@@ -1,0 +1,30 @@
+# Precision prerequisite split restack
+
+## Accomplished
+
+- Replayed the repaired precision/quotient prerequisite directly onto exact
+  main `ff5abb4faaf77b21584b03cf5dba3c1cd2b20b7b` after transactional interval
+  splitting landed.
+- Preserved the split operation, Mathlib semantics module, SPEC material,
+  conformance guards, Lake registrations, PNT+ registrations, and existing
+  public multiplication/power arithmetic.
+- Resolved the sole semantic overlap in the public umbrella so it names both
+  transactional splitting and the rational-backed precision resource layer.
+- Confirmed by range-diff that the prerequisite feature is otherwise
+  unchanged. The current Lake git blob is
+  `9dd80526e15dd9e72cd4a157d03021e7a24e2c39`, exactly matching the merged
+  proof-only runtime exemption, and the freshness check passes.
+
+## Current frontier
+
+The branch remains a prerequisite-only public resource layer. It exposes no
+reciprocal, division, or regularization interval semantics.
+
+## Next step
+
+Complete the replacement exact-head CI gate, land the prerequisite, and only
+then replay the preserved local reciprocal/division work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add a public, allocation-independent resource prerequisite for Core precision-indexed reciprocal and division
- keep precision encoding/magnitude, rational conversion shifts, rational temporaries, division cross-products, quotient size, and retained result height distinct from comparison, multiplication growth, and direct-power work
- derive rational conversion bounds from their dyadic values and restrict exact product-bit arithmetic to a private power-of-two helper whose invariant is structurally established
- retain admitted source costs in zero short-circuit plans and add discriminating guards for every resource component and refusal priority

## Scope

This PR is prerequisite-only. `preflightInv` and `preflightDiv` construct metadata and return refusal diagnostics; they do not call Core arithmetic or expose `invWithin`/`divWithin`, cut semantics, regularization, or Mathlib enclosure theorems. The reciprocal and division implementation commits remain local for a later deliberate replay. Transactional splitting and all current public arithmetic are preserved from main.

Exact base: ff5abb4faaf77b21584b03cf5dba3c1cd2b20b7b
Exact head: e3f21defdc4c61e495f1b4a99e292704d1ff5e1d

## Validation

- `lake build HexInterval HexConformance`
- focused `lake build HexInterval.Conformance`
- representative PNT+ conformance targets (`PntBKLNWPow`, `PntFks2Shard`, `PntTable12`, `PntNestedLog`)
- copyright, line-count, DAG, phase-4, conformance-registration, release-manifest/manual-split, trust-surface, PNT inventory, Mathlib-free bench, and factor-sweep freshness checks
- Lake blob `9dd80526e15dd9e72cd4a157d03021e7a24e2c39` exactly matches the merged proof-only runtime exemption
- changed Lean source contains no `axiom`, `sorry`, or `native_decide`