### PR TITLE
feat(interval): add checked reciprocal enclosure

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -21,8 +21,9 @@ intersection, hull, negation, addition, subtraction, multiplication, minimum,
 maximum, absolute value, natural power, and transactional splitting at a
 dyadic cut. The arithmetic resource layer preflights product growth,
 direct-power retained growth, exponent work, and rational-backed
-precision/quotient work independently of exact comparison work. Reciprocal and
-division operations remain unexposed. Raw cuts remain visible as the explicit
-decoder and inspection boundary; D2 propagation and replay experiments still
-live outside this supported umbrella.
+precision/quotient work independently of exact comparison work. The reciprocal
+operation is a precision-indexed connected outward enclosure; division remains
+unexposed. Raw cuts remain visible as the explicit decoder and inspection
+boundary; D2 propagation and replay experiments still live outside this
+supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -348,6 +348,8 @@ def roundingBound (precision : Precision) (bound : RationalBound) : RationalBoun
         numeratorBits := if bound.numeratorBits = 0 then 0 else bound.numeratorBits + shift }
   | .negSucc shift => { bound with denominatorBits := bound.denominatorBits + shift + 1 }
 
+/-- Whether the retained dyadic input is strictly negative. This private
+classifier supplies the sign of the quotient before floor rounding. -/
 private def negative : Dyadic → Bool
   | .ofOdd (.negSucc _) _ _ => true
   | _ => false
@@ -355,9 +357,9 @@ private def negative : Dyadic → Bool
 /-- Bound the integer quotient passed to `Dyadic.ofIntWithPrec`. A positive
 quotient has no more bits than the shifted rational numerator; flooring a
 negative quotient may add one magnitude bit. -/
-def boundQuotientBits (isNegative : Bool) (rounding : RationalBound) : Nat :=
+def boundQuotientBits (quotientNegative : Bool) (rounding : RationalBound) : Nat :=
   if rounding.numeratorBits = 0 then 0
-  else rounding.numeratorBits + (if isNegative then 1 else 0)
+  else rounding.numeratorBits + (if quotientNegative then 1 else 0)
 
 /-- Bound the canonical result height after `Dyadic.ofIntWithPrec`. Removing
 `t` trailing zeroes decreases numerator bits by `t` while changing exponent

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -348,8 +348,7 @@ def roundingBound (precision : Precision) (bound : RationalBound) : RationalBoun
         numeratorBits := if bound.numeratorBits = 0 then 0 else bound.numeratorBits + shift }
   | .negSucc shift => { bound with denominatorBits := bound.denominatorBits + shift + 1 }
 
-/-- Whether floor rounding may increase the quotient's magnitude by one bit. -/
-def isNegative : Dyadic → Bool
+private def negative : Dyadic → Bool
   | .ofOdd (.negSucc _) _ _ => true
   | _ => false
 
@@ -380,7 +379,7 @@ def preflightInv (limits : PrecisionLimits) (value : Dyadic)
       let converted := QuotientCost.conversionBound value
       let rounding := QuotientCost.roundingBound precision (QuotientCost.invertBound converted)
       let quotientBits :=
-        QuotientCost.boundQuotientBits (QuotientCost.isNegative value) rounding
+        QuotientCost.boundQuotientBits (QuotientCost.negative value) rounding
       let cost : QuotientCost :=
         { sources := [source]
           precision := precisionCost
@@ -411,7 +410,7 @@ def preflightDiv (limits : PrecisionLimits) (left right : Dyadic)
       let crossProduct := QuotientCost.divisionBound left right
       let rounding := QuotientCost.roundingBound precision crossProduct
       let quotientBits := QuotientCost.boundQuotientBits
-        (QuotientCost.isNegative left != QuotientCost.isNegative right) rounding
+        (QuotientCost.negative left != QuotientCost.negative right) rounding
       let cost : QuotientCost :=
         { sources := [leftCost, rightCost]
           precision := precisionCost

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -292,6 +292,72 @@ preflight both final child comparisons before constructing either result. -/
         .bounds
           (intersectLowerUnchecked lower (.finite point true)) upper )
 
+/-! ## Precision-indexed reciprocal enclosure -/
+
+/-- A lower reciprocal cut, rounded toward negative infinity.  A missing
+upper source cut approaches zero from one side; an open zero source endpoint
+approaches infinity and is never passed to `Dyadic.invAtPrec`.  Finite rounded
+cuts are closed because this public operation promises an outward enclosure,
+not exact endpoint attainment. -/
+@[expose] def invLowerUnchecked (precision : Precision) : Upper → Lower
+  | .unbounded => .finite 0 true
+  | .finite value _ =>
+      if value = 0 then .unbounded
+      else .finite (value.invAtPrec precision) false
+
+/-- An upper reciprocal cut, rounded toward positive infinity by negating the
+downward-rounded reciprocal of the negated source lower endpoint. -/
+@[expose] def invUpperUnchecked (precision : Precision) : Lower → Upper
+  | .unbounded => .finite 0 true
+  | .finite value _ =>
+      if value = 0 then .unbounded
+      else .finite (-(-value).invAtPrec precision) false
+
+/-- Whether a lower cut places the entire nonempty interval strictly above
+zero.  The equality case is positive exactly for an open lower cut. -/
+@[expose] def strictlyPositive : Lower → Bool
+  | .unbounded => false
+  | .finite value strict =>
+      if 0 < value then true else if value = 0 then strict else false
+
+/-- Whether an upper cut places the entire nonempty interval strictly below
+zero.  The equality case is negative exactly for an open upper cut. -/
+@[expose] def strictlyNegative : Upper → Bool
+  | .unbounded => false
+  | .finite value strict =>
+      if value < 0 then true else if value = 0 then strict else false
+
+/-- Whether a cut is the closed zero endpoint used by the connected-hull
+policy for Lean's total reciprocal (`0⁻¹ = 0`). -/
+@[expose] def closedZeroLower : Lower → Bool
+  | .finite value strict => value = 0 && !strict
+  | .unbounded => false
+
+@[expose] def closedZeroUpper : Upper → Bool
+  | .finite value strict => value = 0 && !strict
+  | .unbounded => false
+
+/-- Raw connected outward enclosure of Lean's total reciprocal. On an
+interval separated from zero it reverses the cuts and rounds both finite
+endpoints outward.  A closed zero endpoint contributes the value zero and an
+unbounded one-sided branch; a sign-crossing interval has the whole line as its
+connected hull. This cut computation does not claim a tightness converse for
+the generally disconnected image across zero. -/
+@[expose] def invUnchecked (precision : Precision) : Raw → Raw
+  | .empty => .empty
+  | .bounds lower upper =>
+      if Raw.strictlyPositive lower || Raw.strictlyNegative upper then
+        .bounds (invLowerUnchecked precision upper) (invUpperUnchecked precision lower)
+      else if Raw.closedZeroLower lower then
+        if Raw.closedZeroUpper upper then
+          .bounds (.finite 0 false) (.finite 0 false)
+        else
+          .bounds (.finite 0 false) .unbounded
+      else if Raw.closedZeroUpper upper then
+        .bounds .unbounded (.finite 0 false)
+      else
+        .bounds .unbounded .unbounded
+
 end Raw
 
 /-- Transactional result of a checked split. A successful value contains both
@@ -461,6 +527,49 @@ private def admitSplit (limit : EndpointLimit) (input : Raw) (point : Dyadic) :
       if let some cost := refused? limit children.1.normalizeCost then throw cost
       if let some cost := refused? limit children.2.normalizeCost then throw cost
       pure ⟨children, by simp [hinput, children, Raw.splitUnchecked]⟩
+
+private def admitZeroComparison (limits : Arithmetic.PrecisionLimits)
+    (value : Dyadic) : Except Arithmetic.Cost Unit := do
+  let _ ← Arithmetic.admitEndpoint limits value
+  let cost := CompareCost.ofDyadic value 0
+  if !cost.allowed limits.endpoint then
+    throw (.comparison cost)
+
+private def admitLowerZero (limits : Arithmetic.PrecisionLimits) : Lower →
+    Except Arithmetic.Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => admitZeroComparison limits value
+
+private def admitUpperZero (limits : Arithmetic.PrecisionLimits) : Upper →
+    Except Arithmetic.Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => admitZeroComparison limits value
+
+private def admitInvLower (limits : Arithmetic.PrecisionLimits)
+    (precision : Precision) : Upper → Except Arithmetic.Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => do
+      if value ≠ 0 then
+        let _ ← Arithmetic.preflightInv limits value precision
+
+private def admitInvUpper (limits : Arithmetic.PrecisionLimits)
+    (precision : Precision) : Lower → Except Arithmetic.Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => do
+      if value ≠ 0 then
+        let _ ← Arithmetic.preflightInv limits (-value) precision
+
+/-- Preflight every retained source comparison before classification, then
+both rational-backed endpoint computations before either is executed. -/
+private def admitInv (limits : Arithmetic.PrecisionLimits)
+    (precision : Precision) : Raw → Except Arithmetic.Cost Unit
+  | .empty => pure ()
+  | .bounds lower upper => do
+      admitLowerZero limits lower
+      admitUpperZero limits upper
+      if Raw.strictlyPositive lower || Raw.strictlyNegative upper then
+        admitInvLower limits precision upper
+        admitInvUpper limits precision lower
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -672,5 +781,40 @@ theorem view_splitWithin_ready {limit : EndpointLimit}
       cases leftResult <;> cases rightResult <;> simp_all
       rw [← prepared.selected]
       exact ⟨view_ofRawWithin_ready leftEq, view_ofRawWithin_ready rightEq⟩
+
+/-- Precision-indexed connected outward enclosure of Lean's total reciprocal.
+The operation internally invokes `Arithmetic.preflightInv` for every nonzero
+endpoint it will evaluate before either Core reciprocal call; no caller-provided
+plan is accepted. Empty and zero-only inputs perform no precision work. Across
+zero the result follows the connected-hull policy of `Raw.invUnchecked`, not a
+tightness converse for the generally disconnected image. -/
+def invWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
+    (input : Hex.Interval) : Arithmetic.Result :=
+  match admitInv limits precision input.view with
+  | .error cost => .resourceLimit cost
+  | .ok () =>
+      Arithmetic.Result.ofBuild
+        (ofRawWithin limits.endpoint (Raw.invUnchecked precision input.view))
+
+/-- Every successful reciprocal exposes exactly the normalized computed
+outward cuts.  This characterizes the successful result, without claiming
+that a connected hull is the exact image across zero or that rounded finite
+cuts are attained. -/
+theorem view_invWithin_ready {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {input result : Hex.Interval}
+    (h : invWithin limits precision input = .ready result) :
+    result.view = (Raw.invUnchecked precision input.view).normalizeUnchecked := by
+  unfold invWithin at h
+  split at h
+  · contradiction
+  · generalize builtEq :
+        ofRawWithin limits.endpoint (Raw.invUnchecked precision input.view) = built at h
+    cases built with
+    | ready interval =>
+        simp only [Arithmetic.Result.ofBuild] at h
+        cases h
+        exact view_ofRawWithin_ready builtEq
+    | resourceLimit cost =>
+        simp [Arithmetic.Result.ofBuild] at h
 
 end Hex.Interval

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -298,7 +298,8 @@ preflight both final child comparisons before constructing either result. -/
 upper source cut approaches zero from one side; an open zero source endpoint
 approaches infinity and is never passed to `Dyadic.invAtPrec`.  Finite rounded
 cuts are closed because this public operation promises an outward enclosure,
-not exact endpoint attainment. -/
+not exact endpoint attainment. This is a decoder-level cut helper; untrusted
+callers use `invWithin`. -/
 @[expose] def invLowerUnchecked (precision : Precision) : Upper → Lower
   | .unbounded => .finite 0 true
   | .finite value _ =>
@@ -306,7 +307,8 @@ not exact endpoint attainment. -/
       else .finite (value.invAtPrec precision) false
 
 /-- An upper reciprocal cut, rounded toward positive infinity by negating the
-downward-rounded reciprocal of the negated source lower endpoint. -/
+downward-rounded reciprocal of the negated source lower endpoint. This is a
+decoder-level cut helper; untrusted callers use `invWithin`. -/
 @[expose] def invUpperUnchecked (precision : Precision) : Lower → Upper
   | .unbounded => .finite 0 true
   | .finite value _ =>
@@ -314,25 +316,30 @@ downward-rounded reciprocal of the negated source lower endpoint. -/
       else .finite (-(-value).invAtPrec precision) false
 
 /-- Whether a lower cut places the entire nonempty interval strictly above
-zero.  The equality case is positive exactly for an open lower cut. -/
+zero.  The equality case is positive exactly for an open lower cut. This is a
+decoder-level classifier used to interpret checked reciprocal output. -/
 @[expose] def strictlyPositive : Lower → Bool
   | .unbounded => false
   | .finite value strict =>
       if 0 < value then true else if value = 0 then strict else false
 
 /-- Whether an upper cut places the entire nonempty interval strictly below
-zero.  The equality case is negative exactly for an open upper cut. -/
+zero.  The equality case is negative exactly for an open upper cut. This is a
+decoder-level classifier used to interpret checked reciprocal output. -/
 @[expose] def strictlyNegative : Upper → Bool
   | .unbounded => false
   | .finite value strict =>
       if value < 0 then true else if value = 0 then strict else false
 
 /-- Whether a cut is the closed zero endpoint used by the connected-hull
-policy for Lean's total reciprocal (`0⁻¹ = 0`). -/
+policy for Lean's total reciprocal (`0⁻¹ = 0`). This decoder-level
+classifier does not perform resource admission. -/
 @[expose] def closedZeroLower : Lower → Bool
   | .finite value strict => value = 0 && !strict
   | .unbounded => false
 
+/-- Upper-cut counterpart of `closedZeroLower`, used only to decode the
+connected-hull reciprocal shape after checked admission. -/
 @[expose] def closedZeroUpper : Upper → Bool
   | .finite value strict => value = 0 && !strict
   | .unbounded => false
@@ -342,7 +349,8 @@ interval separated from zero it reverses the cuts and rounds both finite
 endpoints outward.  A closed zero endpoint contributes the value zero and an
 unbounded one-sided branch; a sign-crossing interval has the whole line as its
 connected hull. This cut computation does not claim a tightness converse for
-the generally disconnected image across zero. -/
+the generally disconnected image across zero. It is a decoder-level
+combinator; untrusted callers use `invWithin`. -/
 @[expose] def invUnchecked (precision : Precision) : Raw → Raw
   | .empty => .empty
   | .bounds lower upper =>
@@ -785,8 +793,9 @@ theorem view_splitWithin_ready {limit : EndpointLimit}
 /-- Precision-indexed connected outward enclosure of Lean's total reciprocal.
 The operation internally invokes `Arithmetic.preflightInv` for every nonzero
 endpoint it will evaluate before either Core reciprocal call; no caller-provided
-plan is accepted. Empty and zero-only inputs perform no precision work. Across
-zero the result follows the connected-hull policy of `Raw.invUnchecked`, not a
+plan is accepted. Every input not separated from zero, including empty and
+zero-only inputs, performs no precision work. Across zero the result follows
+the connected-hull policy of `Raw.invUnchecked`, not a
 tightness converse for the generally disconnected image. -/
 def invWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
     (input : Hex.Interval) : Arithmetic.Result :=

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -597,8 +597,16 @@ product of source members belongs to it. No separate image-tightness converse
 is currently claimed.
 
 The public tree also contains the allocation prerequisite for
-precision-indexed reciprocal and division, but no `invWithin` or `divWithin`
-interval operation. Core `Dyadic.invAtPrec` converts a nonzero source through
+precision-indexed reciprocal and division. It now exposes the checked
+reciprocal operation
+
+```lean
+invWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
+  (input : Hex.Interval) : Arithmetic.Result
+```
+
+but no `divWithin` interval operation. Core `Dyadic.invAtPrec` converts a
+nonzero source through
 `Dyadic.toRat`, inverts the rational, then calls `Rat.toDyadic`; `divAtPrec`
 converts both sources and additionally runs reduced rational cross-products.
 Neither `CompareCost` nor `Arithmetic.Growth` accounts for those shifts or
@@ -631,15 +639,39 @@ denominator to claim cancellation. Conformance accepts positive and negative
 `{3}` prerequisites and separately exercises precision encoding, zero
 numerators, admitted zero-path sources, failure priority, converted and
 cross-product temporaries, quotient size, non-cancelling conversion shifts,
-and predicted retained result. Endpoint selection, outward cut direction,
-zero-crossing interval semantics, final canonicalization, Mathlib enclosure
-proofs, and the actual public inverse/division operations remain future work.
+and predicted retained result.
+
+`invWithin` admits every finite source cut before classifying it relative to
+zero, then preflights both required nonzero endpoint reciprocals before either
+Core call. The operation invokes `Arithmetic.preflightInv` internally for each
+endpoint it will evaluate and accepts no caller-supplied `QuotientPlan`. Its
+lower endpoint is `invAtPrec upper precision`; its upper endpoint is
+`-invAtPrec (-lower) precision`. Thus both directions reuse Core's downward
+rounding, while the second is upward rounding after sign reflection. Every
+moved finite result cut is conservatively closed: the operation proves outward
+enclosure, not endpoint attainment or grid optimality. Empty and singleton
+zero bypass precision work; open zero maps to the corresponding unbounded
+one-sided limit and is never passed to Core.
+
+Following Lean's total inverse, a closed zero contributes `0⁻¹ = 0`:
+`[0,b]` has connected hull `[0,+∞)`, `[a,0]` has hull `(-∞,0]`, singleton
+zero stays singleton zero, and a two-sign interval returns the whole line.
+Unbounded sign-separated inputs retain a strict zero limit on the output side.
+This is the connected-hull policy expressible by one `Hex.Interval`, not a
+disconnected interval-set representation.
+
+`view_invWithin_ready` exactly characterizes every successful computed cut;
+the Mathlib companion independently proves that every real source member's
+Lean-total inverse lies in that result. No converse image theorem, finite-cut
+attainment, grid optimality, or disconnected-image tightness is claimed. The
+public division operation remains future work.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
 `maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and
-`mulUnchecked`, together with `splitUnchecked`, are related to the checked
-operations by successful-result and semantic theorems. `powCutsUnchecked` is
+`mulUnchecked`, together with `splitUnchecked` and `invUnchecked`, are related
+to the checked operations by successful-result and semantic theorems.
+`powCutsUnchecked` is
 only the strictly monotone cut mapper;
 its caller must establish the positive odd or nonnegative positive-exponent
 case. `powUnchecked` performs the zero/odd/even direct-hull selection. Like
@@ -647,8 +679,8 @@ case. `powUnchecked` performs the zero/odd/even direct-hull selection. Like
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface includes precision-indexed reciprocal and
-division and regularization. Their public signatures are fixed only after an
+The remaining target surface includes precision-indexed division and
+regularization. Their public signatures are fixed only after an
 allocation audit; no total API is promised for an operation that may align,
 compare, or enlarge arbitrary-precision endpoints.
 
@@ -723,14 +755,16 @@ whole-interval hull. A rule can request a split at zero before using a tighter
 sign-specific result. A later `IntervalSet` with at most two components is an
 isolated extension, not a reason to complicate every initial operation.
 
-This paragraph is the target contract, not a description of the current
-component canary. `Experiment.DyadicInterval.reciprocal` currently returns
+The supported `invWithin` implements the connected-hull and outward-direction
+part of this target, but conservatively closes every computed finite cut. It
+therefore does not yet claim the moved-cut attainment rule or grid-optimality.
+The older `Experiment.DyadicInterval.reciprocal` still returns
 `inapplicable` for singleton zero, a closed zero endpoint, or a sign-crossing
 input; it implements only the sign-separated cases (including an open zero
 endpoint mapping to an unbounded side). The concrete package has an executable
-across-zero regression for that behavior. Implementing the connected hull of
-Lean's total inverse, or selecting an interval-set result, is an explicit
-experimental gap before reciprocal can claim the target contract above.
+across-zero regression for that legacy behavior and is not the public
+operation. Selecting an interval-set result remains a possible future
+precision improvement rather than a requirement for sound connected-hull use.
 
 Grid-tightness remains an acceptance target, not an assumed consequence of
 core's API. Core currently proves the one-sided `roundDown_le` and

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -649,9 +649,10 @@ lower endpoint is `invAtPrec upper precision`; its upper endpoint is
 `-invAtPrec (-lower) precision`. Thus both directions reuse Core's downward
 rounding, while the second is upward rounding after sign reflection. Every
 moved finite result cut is conservatively closed: the operation proves outward
-enclosure, not endpoint attainment or grid optimality. Empty and singleton
-zero bypass precision work; open zero maps to the corresponding unbounded
-one-sided limit and is never passed to Core.
+enclosure, not endpoint attainment or grid optimality. Every input not
+separated from zero bypasses precision work; this includes empty, singleton
+zero, one-sided-zero, and sign-crossing inputs. Open zero maps to the
+corresponding unbounded one-sided limit and is never passed to Core.
 
 Following Lean's total inverse, a closed zero contributes `0⁻¹ = 0`:
 `[0,b]` has connected hull `[0,+∞)`, `[a,0]` has hull `(-∞,0]`, singleton
@@ -4196,9 +4197,10 @@ their declared cost inside a scheduler bound.
   selection, and the sealed `mulWithin` entry point.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
   negation, addition, subtraction, minimum, maximum, absolute value, and
-  natural power, including the public decoder helpers `Raw.powCutsUnchecked`
-  and `Raw.powUnchecked`, followed by future arithmetic, splitting, and
-  regularization operations.
+  natural power; transactional splitting; and checked precision-indexed
+  reciprocal. Its public raw helpers, including the power, split, and
+  reciprocal cut selectors, are decoder-level counterparts of checked
+  operations. Division and regularization remain future work.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
@@ -4215,6 +4217,10 @@ their declared cost inside a scheduler bound.
   an image-tightness converse.
 - `HexIntervalMathlib/Power.lean`: exact normalized selected-cut semantics and
   the one-way successful natural-power image theorem.
+- `HexIntervalMathlib/Split.lean`: exact transactional child semantics,
+  containment, coverage, disjointness, and left ownership of the cut point.
+- `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics
+  and the one-way total-real-inverse connected-hull enclosure theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
@@ -4249,8 +4255,9 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - `abs`, `min`, and `max` with tied open and closed extrema;
 - minimum and maximum preflight refusal on either same-side comparison and on
   the distinct selected-cut final comparison;
-- precision-indexed reciprocal and division for `{3}`, positive, negative,
-  singleton-zero, one-sided-zero, and sign-crossing inputs;
+- precision-indexed reciprocal for `{3}`, positive, negative, singleton-zero,
+  one-sided-zero, sign-crossing, and sign-separated unbounded inputs; division
+  remains a future conformance family;
 - powers on negative, mixed-sign, open-zero, and singleton inputs;
 - rational-to-dyadic projection at exact and inexact values, including the
   strict cut gained by moving a closed source outward;

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -15,6 +15,7 @@ public import HexIntervalMathlib.Absolute
 public import HexIntervalMathlib.Multiplication
 public import HexIntervalMathlib.Power
 public import HexIntervalMathlib.Split
+public import HexIntervalMathlib.Inverse
 
 public section
 
@@ -22,5 +23,6 @@ public section
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition,
 subtraction, and multiplication, exact minimum/maximum images, absolute value,
-natural power, and closed-left/strict-right transactional splitting.
+natural power, closed-left/strict-right transactional splitting, and
+precision-indexed reciprocal enclosure.
 -/

--- a/HexIntervalMathlib/Inverse.lean
+++ b/HexIntervalMathlib/Inverse.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexIntervalMathlib.Subtraction
+public import HexIntervalMathlib.Interval
 public import Mathlib.Algebra.Order.Field.Basic
 
 @[expose] public section

--- a/HexIntervalMathlib/Inverse.lean
+++ b/HexIntervalMathlib/Inverse.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Subtraction
+public import Mathlib.Algebra.Order.Field.Basic
+
+@[expose] public section
+
+/-!
+# Real semantics of public reciprocal enclosure
+
+The runtime operation computes a connected outward enclosure.  Finite lower
+cuts use Core's downward `Dyadic.invAtPrec`; finite upper cuts use the same
+primitive at the negated input and negate its result.  Across zero the public
+operation describes the connected hull of Lean's total inverse, not the exact
+generally-disconnected image.
+-/
+
+namespace Hex.Interval
+
+@[simp]
+theorem toReal_zero : toReal 0 = 0 := by simp [toReal]
+
+/-- Core's precision-indexed reciprocal, interpreted in `ℝ`, rounds toward
+negative infinity. -/
+theorem roundedDown_le_inv (value : Dyadic) (precision : Precision) :
+    toReal (value.invAtPrec precision) ≤ (toReal value)⁻¹ := by
+  cases value with
+  | zero => simp [toReal, Dyadic.invAtPrec]
+  | ofOdd numerator exponent odd =>
+      simp only [Dyadic.invAtPrec, toReal]
+      exact_mod_cast Rat.toRat_toDyadic_le
+
+/-- Negating a downward-rounded reciprocal of the negated input rounds the
+original reciprocal toward positive infinity. -/
+theorem inv_le_roundedUp (value : Dyadic) (precision : Precision) :
+    (toReal value)⁻¹ ≤ toReal (-(-value).invAtPrec precision) := by
+  have rounded := roundedDown_le_inv (-value) precision
+  rw [toReal_neg, inv_neg] at rounded
+  simpa using neg_le_neg rounded
+
+/-- Exact membership predicate of the computed raw reciprocal cuts.  This is
+the cut characterization, deliberately distinct from exact image equality. -/
+def Raw.InvContains (precision : Precision) (raw : Raw) (x : ℝ) : Prop :=
+  (raw.invUnchecked precision).Contains x
+
+private theorem positive_of_lower (lower : Lower) {x : ℝ}
+    (shape : Raw.strictlyPositive lower = true) (member : lower.Contains x) :
+    0 < x := by
+  cases lower with
+  | unbounded => simp [Raw.strictlyPositive] at shape
+  | finite value strict =>
+      by_cases valuePositiveDyadic : 0 < value
+      · have valuePositive : 0 < toReal value := by
+          simpa only [toReal_zero] using toReal_lt valuePositiveDyadic
+        cases strict <;> simp [Lower.Contains] at member <;> linarith
+      · by_cases valueZero : value = 0
+        · subst value
+          cases strict
+          · simp [Raw.strictlyPositive, valuePositiveDyadic] at shape
+          · simpa [Lower.Contains] using member
+        · simp [Raw.strictlyPositive, valuePositiveDyadic, valueZero] at shape
+
+private theorem negative_of_upper (upper : Upper) {x : ℝ}
+    (shape : Raw.strictlyNegative upper = true) (member : upper.Contains x) :
+    x < 0 := by
+  cases upper with
+  | unbounded => simp [Raw.strictlyNegative] at shape
+  | finite value strict =>
+      by_cases valueNegativeDyadic : value < 0
+      · have valueNegative : toReal value < 0 := by
+          simpa only [toReal_zero] using toReal_lt valueNegativeDyadic
+        cases strict <;> simp [Upper.Contains] at member <;> linarith
+      · by_cases valueZero : value = 0
+        · subst value
+          cases strict
+          · simp [Raw.strictlyNegative, valueNegativeDyadic] at shape
+          · simpa [Upper.Contains] using member
+        · simp [Raw.strictlyNegative, valueNegativeDyadic, valueZero] at shape
+
+private theorem invLower_positive (precision : Precision) (upper : Upper) {x : ℝ}
+    (positive : 0 < x) (member : upper.Contains x) :
+    (Raw.invLowerUnchecked precision upper).Contains x⁻¹ := by
+  cases upper with
+  | unbounded => simpa [Raw.invLowerUnchecked, Lower.Contains] using inv_pos.2 positive
+  | finite value strict =>
+      have valuePositive : 0 < toReal value := by
+        cases strict <;> simp [Upper.Contains] at member <;> linarith
+      have valueNonzero : value ≠ 0 := by
+        intro equal
+        subst value
+        simp [toReal] at valuePositive
+      simp only [Raw.invLowerUnchecked, valueNonzero, if_false, Lower.Contains]
+      exact (roundedDown_le_inv value precision).trans
+        ((inv_le_inv₀ valuePositive positive).2
+          (by cases strict <;> simp [Upper.Contains] at member ⊢ <;> linarith))
+
+private theorem invLower_negative (precision : Precision) (upper : Upper) {x : ℝ}
+    (shape : Raw.strictlyNegative upper = true) (negative : x < 0)
+    (member : upper.Contains x) :
+    (Raw.invLowerUnchecked precision upper).Contains x⁻¹ := by
+  cases upper with
+  | unbounded => simp [Raw.strictlyNegative] at shape
+  | finite value strict =>
+      by_cases valueZero : value = 0
+      · simp [Raw.invLowerUnchecked, valueZero, Lower.Contains]
+      · have valueNegativeDyadic : value < 0 := by
+          simp [Raw.strictlyNegative, valueZero] at shape
+          exact shape
+        have valueNegative : toReal value < 0 := by
+          simpa only [toReal_zero] using toReal_lt valueNegativeDyadic
+        simp only [Raw.invLowerUnchecked, valueZero, if_false, Lower.Contains]
+        exact (roundedDown_le_inv value precision).trans
+          ((inv_le_inv_of_neg valueNegative negative).2
+            (by cases strict
+                · exact member
+                · exact le_of_lt member))
+
+private theorem invUpper_positive (precision : Precision) (lower : Lower) {x : ℝ}
+    (shape : Raw.strictlyPositive lower = true) (positive : 0 < x)
+    (member : lower.Contains x) :
+    (Raw.invUpperUnchecked precision lower).Contains x⁻¹ := by
+  cases lower with
+  | unbounded => simp [Raw.strictlyPositive] at shape
+  | finite value strict =>
+      by_cases valueZero : value = 0
+      · simp [Raw.invUpperUnchecked, valueZero, Upper.Contains]
+      · have valuePositive : 0 < toReal value := by
+          have valuePositiveDyadic : 0 < value := by
+            simp [Raw.strictlyPositive, valueZero] at shape
+            exact shape
+          simpa only [toReal_zero] using toReal_lt valuePositiveDyadic
+        simp only [Raw.invUpperUnchecked, valueZero, if_false, Upper.Contains]
+        exact ((inv_le_inv₀ positive valuePositive).2
+            (by cases strict
+                · exact member
+                · exact le_of_lt member)).trans
+          (inv_le_roundedUp value precision)
+
+private theorem invUpper_negative (precision : Precision) (lower : Lower) {x : ℝ}
+    (negative : x < 0) (member : lower.Contains x) :
+    (Raw.invUpperUnchecked precision lower).Contains x⁻¹ := by
+  cases lower with
+  | unbounded => simpa [Raw.invUpperUnchecked, Upper.Contains] using inv_neg''.mpr negative
+  | finite value strict =>
+      have valueNegative : toReal value < 0 := by
+        cases strict <;> simp [Lower.Contains] at member <;> linarith
+      have valueNonzero : value ≠ 0 := by
+        intro equal
+        subst value
+        simp [toReal] at valueNegative
+      simp only [Raw.invUpperUnchecked, valueNonzero, if_false, Upper.Contains]
+      exact ((inv_le_inv_of_neg negative valueNegative).2
+          (by cases strict
+              · exact member
+              · exact le_of_lt member)).trans
+        (inv_le_roundedUp value precision)
+
+private theorem rawContains_inv (precision : Precision) (raw : Raw) {x : ℝ}
+    (member : raw.Contains x) : (raw.invUnchecked precision).Contains x⁻¹ := by
+  cases raw with
+  | empty => simp [Raw.Contains] at member
+  | bounds lower upper =>
+      rcases member with ⟨lowerMember, upperMember⟩
+      by_cases positiveShape : Raw.strictlyPositive lower = true
+      · have positive := positive_of_lower lower positiveShape lowerMember
+        simpa [Raw.invUnchecked, positiveShape, Raw.Contains] using
+          And.intro (invLower_positive precision upper positive upperMember)
+            (invUpper_positive precision lower positiveShape positive lowerMember)
+      · by_cases negativeShape : Raw.strictlyNegative upper = true
+        · have negative := negative_of_upper upper negativeShape upperMember
+          simpa [Raw.invUnchecked, positiveShape, negativeShape, Raw.Contains] using
+            And.intro
+              (invLower_negative precision upper negativeShape negative upperMember)
+              (invUpper_negative precision lower negative lowerMember)
+        · simp only [Raw.invUnchecked, positiveShape, negativeShape, Bool.false_or]
+          by_cases lowerZero : Raw.closedZeroLower lower = true
+          · by_cases upperZero : Raw.closedZeroUpper upper = true
+            · simp [lowerZero, upperZero, Raw.Contains, Lower.Contains, Upper.Contains]
+                at lowerMember upperMember ⊢
+              cases lower <;> cases upper <;> simp_all [Raw.closedZeroLower,
+                Raw.closedZeroUpper]
+            · simp [lowerZero, upperZero, Raw.Contains, Lower.Contains, Upper.Contains]
+                at lowerMember upperMember ⊢
+              have nonnegative : 0 ≤ x := by
+                cases lower with
+                | unbounded => simp [Raw.closedZeroLower] at lowerZero
+                | finite value strict =>
+                    simp [Raw.closedZeroLower] at lowerZero
+                    rcases lowerZero with ⟨rfl, rfl⟩
+                    simpa [Lower.Contains] using lowerMember
+              simpa using inv_nonneg.2 nonnegative
+          · by_cases upperZero : Raw.closedZeroUpper upper = true
+            · simp [lowerZero, upperZero, Raw.Contains, Lower.Contains, Upper.Contains]
+                at lowerMember upperMember ⊢
+              have nonpositive : x ≤ 0 := by
+                cases upper with
+                | unbounded => simp [Raw.closedZeroUpper] at upperZero
+                | finite value strict =>
+                    simp [Raw.closedZeroUpper] at upperZero
+                    rcases upperZero with ⟨rfl, rfl⟩
+                    simpa [Upper.Contains] using upperMember
+              simpa using inv_nonpos.2 nonpositive
+            · simp [lowerZero, upperZero, Raw.Contains, Lower.Contains, Upper.Contains]
+
+/-- A successful reciprocal has exactly its normalized computed outward-cut
+predicate. -/
+theorem contains_invWithin {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {input result : Hex.Interval}
+    (checked : invWithin limits precision input = .ready result) (x : ℝ) :
+    result.Contains x ↔ input.view.InvContains precision x := by
+  simp only [Contains, Raw.InvContains]
+  rw [view_invWithin_ready checked, contains_normalize]
+
+/-- Every real member of the source maps under Lean's total reciprocal into a
+successful public connected outward enclosure. -/
+theorem inv_mem_invWithin {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {input result : Hex.Interval} {x : ℝ}
+    (checked : invWithin limits precision input = .ready result)
+    (member : input.Contains x) : result.Contains x⁻¹ :=
+  (contains_invWithin checked x⁻¹).2 (rawContains_inv precision input.view member)
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -18,7 +18,8 @@ enclosure theorems for minimum and maximum, and
 theorems. `HexIntervalMathlib.Power` supplies exact selected-cut semantics
 and a one-way real-image theorem for checked natural power.
 `HexIntervalMathlib.Split` proves exact closed-left/strict-right membership
-for transactional splitting.
+for transactional splitting. `HexIntervalMathlib.Inverse` proves the computed
+connected-cut characterization and sound total-real-inverse enclosure.
 
 For every successful resource-checked public operation it proves:
 
@@ -67,7 +68,12 @@ For every successful resource-checked public operation it proves:
 - `splitWithin_contained`, `splitWithin_cover`, and `splitWithin_disjoint`:
   both children remain in the source, jointly cover it, and do not overlap;
 - `splitWithin_point_left` and `splitWithin_point_not_right`: the cut point is
-  left-owned exactly when it belonged to the source and never right-owned.
+  left-owned exactly when it belonged to the source and never right-owned;
+- `contains_invWithin`: membership in a successful reciprocal is exactly the
+  normalized computed outward-cut predicate; this does not identify the
+  connected hull with the generally-disconnected exact image;
+- `inv_mem_invWithin`: every real source member maps under Lean's total
+  reciprocal into the successful enclosure, including `0⁻¹ = 0`.
 
 These theorems depend on the exact successful result equation: `BuildResult`
 or `Arithmetic.Result` for unary/binary images, and transactional
@@ -83,10 +89,13 @@ The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
 are not re-exported here. Further arithmetic images, regularization, and
-precision-indexed reciprocal/division require their own
+precision-indexed division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
+Public reciprocal is sound but
+conservatively closes finite rounded cuts; endpoint attainment, grid
+optimality, and disconnected interval-set precision remain future work.
 
 ## Conformance
 
@@ -94,7 +103,8 @@ it claims a tightness converse only when that converse is separately proved.
 membership, exact hull closure and both input inclusions, negation transport,
 addition, subtraction, and multiplication cut exactness and image transport,
 exact split membership/coverage/disjointness/point ownership, and the exact
-ordinary-kernel axiom surface.
+ordinary-kernel axiom surface. It also pins reciprocal computed-cut exactness
+and total-real-inverse enclosure, without a tightness converse.
 `HexIntervalMathlib.MinMaxConformance` separately pins exact selected cuts,
 both image enclosures, and their axiom surfaces; it does not assert a set-image
 converse.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -8,11 +8,13 @@ theorems for interval operations and propagators. It depends on Mathlib and
 The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
 negation, addition, subtraction, multiplication, minimum, maximum, absolute
-value, natural power, and transactional splitting. Natural power exposes exact
-computed cuts and a sound pointwise real image theorem, without claiming a
-set-image converse. Splitting exposes both children together and proves exact
-closed-left/strict-right membership, containment, cover, disjointness, and cut
-ownership.
+value, natural power, transactional splitting, and precision-indexed
+reciprocal. Natural power exposes exact computed cuts and a sound pointwise
+real image theorem, without claiming a set-image converse. Splitting exposes
+both children together and proves exact closed-left/strict-right membership,
+containment, cover, disjointness, and cut ownership. Reciprocal exposes its
+computed connected outward cuts and a sound pointwise theorem for Lean's total
+inverse, including `0⁻¹ = 0`.
 Propagator, provider, replay, and tactic modules remain experiments and are not
 re-exported by the public umbrella. The user-facing tactic contract below is
 the release target, not a claim that the tactic is already supported.
@@ -222,6 +224,14 @@ theorem splitWithin_point_left
 theorem splitWithin_point_not_right
     (h : splitWithin limit I point = .ready left right) :
     ¬right.Contains (toReal point)
+
+theorem contains_invWithin
+    (h : invWithin limits precision I = .ready result) :
+    result.Contains x ↔ I.view.InvContains precision x
+
+theorem inv_mem_invWithin
+    (h : invWithin limits precision I = .ready result) :
+    I.Contains x → result.Contains x⁻¹
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -264,6 +274,15 @@ nonempty input, the retained point, both finite source/point selectors, and
 both selected child normalization costs are admitted before final sealing.
 Successful children are exactly `I ∩ (-∞, point]` and
 `I ∩ (point, +∞)`, so they remain inside `I`, cover it, and are disjoint.
+
+`invWithin` uses Core's directed reciprocal rounding only when the input is
+strictly separated from zero. Otherwise it returns the connected interval
+hull required by Lean's total inverse, including zero, one-sided-zero, and
+sign-crossing cases, without precision work. Successful results have exactly
+the normalized computed cuts, and `inv_mem_invWithin` proves the pointwise
+real-image enclosure. Finite rounded cuts are conservatively closed; no
+converse image equality, endpoint attainment, grid optimality, or exact
+disconnected-image claim is made.
 
 The remaining target theorems include:
 
@@ -2564,8 +2583,19 @@ the fixed soundness and trust contracts.
 
 ## File organization
 
-- `HexIntervalMathlib/Semantics.lean`: real membership and cut/set lemmas.
-- `HexIntervalMathlib/Arithmetic.lean`: soundness of exact interval operations.
+- `HexIntervalMathlib/Interval.lean`: real membership, cut lemmas, and exact
+  semantics for construction, intersection, hull, and negation.
+- `HexIntervalMathlib/Addition.lean` and
+  `HexIntervalMathlib/Subtraction.lean`: exact computed-cut semantics and
+  pointwise real-image theorems.
+- `HexIntervalMathlib/MinMax.lean`, `HexIntervalMathlib/Absolute.lean`,
+  `HexIntervalMathlib/Multiplication.lean`, and
+  `HexIntervalMathlib/Power.lean`: exact selected-cut semantics and the current
+  one-way pointwise image theorems.
+- `HexIntervalMathlib/Split.lean`: transactional child membership,
+  containment, cover, disjointness, and cut ownership.
+- `HexIntervalMathlib/Inverse.lean`: computed reciprocal-cut semantics and the
+  total-real-inverse connected-hull enclosure theorem.
 - `HexIntervalMathlib/Program.lean`: real program evaluation and natural
   evaluator soundness.
 - `HexIntervalMathlib/Rule.lean`: registration environment and theorem-schema
@@ -2585,8 +2615,11 @@ the fixed soundness and trust contracts.
   checks for `hex-interval` only.
 - `conformance/HexInterval/EmitFixtures.lean`: Mathlib-free arithmetic oracle
   fixtures.
-- `conformance/HexIntervalMathlib/Conformance.lean`: tactic, replay, axiom, and
-  small migrated downstream regressions in the per-PR `core` profile.
+- `conformance/HexIntervalMathlib/IntervalConformance.lean`: the current
+  supported interval-operation semantics and guarded ordinary-kernel axiom
+  reports.
+- `conformance/HexIntervalMathlib/Conformance.lean`: tactic, replay, and small
+  migrated downstream regressions in the per-PR `core` profile.
 - `conformance/HexIntervalMathlib/CrossCheck.lean`: the measured deterministic
   medium FKS2 shard, included in the per-PR `HexConformance` target under the
   repository's standard heavier-check module name.

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -1477,6 +1477,190 @@ private def nonpositiveOne : Hex.Interval :=
   | .ready interval => interval == Hex.Interval.empty
   | .resourceLimit _ => false
 
+/-! # Supported precision-indexed reciprocal -/
+
+private def singletonNegThree : Hex.Interval := ready (finite (-3) false (-3) false)
+private def closedOneThree : Hex.Interval := ready (finite 1 false 3 false)
+private def closedNegOneZero : Hex.Interval := ready (finite (-1) false 0 false)
+private def crossesZero : Hex.Interval := ready (finite (-1) false 1 false)
+private def invDownThree : Dyadic := .ofOdd 85 8 (by decide)
+private def invUpThree : Dyadic := .ofOdd 43 7 (by decide)
+
+/-- Execute both the public prerequisite and Core reciprocal, then check that
+the actual retained endpoint fits the successful predicted height. -/
+private def invCostBounded (value : Dyadic) (precision : Precision) : Bool :=
+  match Arithmetic.preflightInv precisionLimits value precision with
+  | .ok (.checked cost) =>
+      (EndpointCost.ofDyadic (value.invAtPrec precision)).allowed
+        { maxEndpointHeight := cost.predictedResultHeight, maxAlignmentShift := 0 }
+  | _ => false
+
+-- The conservative prediction is checked against the actual Core result for
+-- both input signs and for a nonzero negative precision. The last case uses
+-- `2⁻⁸`, whose reciprocal is the nonzero coarse-grid value `2⁸`.
+#guard invCostBounded (d 3) 8
+#guard invCostBounded (d (-3)) 8
+#guard invCostBounded oneOver256 (-8)
+#guard oneOver256.invAtPrec (-8) == .ofOdd 1 (-8) (by decide)
+
+-- `{3}` uses two independently rounded Core reciprocal calls.  The unequal
+-- endpoints distinguish the outward upper rounding from copying the downward
+-- result, and the negative case pins the sign-reversed construction.
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 singletonThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite invDownThree false) (.finite invUpThree false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 singletonNegThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (-invUpThree) false) (.finite (-invDownThree) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 closedOneThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite invDownThree false) (.finite (d 1) false)
+  | .resourceLimit _ => false
+
+-- Expected-failure mutations: neither the downward endpoint reused as an
+-- upper cut nor its sign-reflected analogue is the successful result.
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 singletonThree with
+  | .ready interval =>
+      interval.view != .bounds
+        (.finite invDownThree false) (.finite invDownThree false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 singletonNegThree with
+  | .ready interval =>
+      interval.view != .bounds
+        (.finite (-invDownThree) false) (.finite (-invDownThree) false)
+  | .resourceLimit _ => false
+
+-- Open zero is a one-sided limit, while a closed zero contributes Lean's
+-- total-inverse value `0⁻¹ = 0`. Crossing both signs requires the whole
+-- connected hull. The singleton zero remains exact.
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 openClosed01 with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d 1) false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 closed01 with
+  | .ready interval =>
+      interval.view == .bounds (.finite 0 false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 closedNegOneZero with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite 0 false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 crossesZero with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Unbounded sign-separated inputs retain a strict zero limit. Whole remains
+-- whole because the exact total-inverse image has both unbounded signs.
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 atLeastOne with
+  | .ready interval =>
+      interval.view == .bounds (.finite 0 true) (.finite (d 1) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 atMostNegOne with
+  | .ready interval =>
+      interval.view == .bounds (.finite (d (-1)) false) (.finite 0 true)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 negOneToOpenZero with
+  | .ready interval =>
+      interval.view == .bounds .unbounded (.finite (d (-1)) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 Hex.Interval.whole with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 1024 singletonZero with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 1024 Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+-- Exact policy mutations: open zero never contributes Lean's value at zero,
+-- closed zero is never discarded, and an unbounded sign-separated input keeps
+-- its strict zero limit rather than closing it.
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 openClosed01 with
+  | .ready interval =>
+      interval.view != .bounds (.finite 0 false) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 closed01 with
+  | .ready interval =>
+      interval.view != .bounds (.finite 0 true) .unbounded
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 atLeastOne with
+  | .ready interval =>
+      interval.view != .bounds (.finite 0 false) (.finite (d 1) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 8 crossesZero with
+  | .ready interval =>
+      interval.view != .bounds .unbounded (.finite 0 false)
+  | .resourceLimit _ => false
+
+-- Precision, retained source, and predicted retained result are distinct
+-- refusals, all occurring before `Dyadic.invAtPrec` is called.
+#guard
+  match Hex.Interval.invWithin precisionLimits 1024 singletonThree with
+  | .resourceLimit (.precision cost) =>
+      cost.magnitude == 1024 && !cost.allowed precisionLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.invWithin precisionLimits 0 farLower with
+  | .resourceLimit (.endpoint cost) =>
+      cost.exponentMagnitude == 1000000000 &&
+        !cost.allowed precisionLimits.endpoint
+  | _ => false
+
+private def singletonShiftInput : Hex.Interval :=
+  ready (.bounds (.finite inverseShiftInput false) (.finite inverseShiftInput false))
+
+#guard
+  match Hex.Interval.invWithin nonCancellingLimits 8 singletonShiftInput with
+  | .resourceLimit (.quotient cost) =>
+      cost.conversionShift == 16 && !cost.allowed nonCancellingLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.invWithin tightResultLimits 8 singletonThree with
+  | .resourceLimit (.quotient cost) =>
+      cost.predictedResultHeight == 17 && !cost.allowed tightResultLimits
+  | _ => false
+
 /-- The supported public view exposes its carried canonicality theorem without
 adding any trust assumption. -/
 theorem publicViewCanonical (interval : Hex.Interval) : interval.view.CutConsistent :=

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -183,6 +183,23 @@ theorem splitPoint {limit : Hex.Interval.EndpointLimit}
   ⟨Hex.Interval.splitWithin_point_left checked,
     Hex.Interval.splitWithin_point_not_right checked⟩
 
+/-- A successful reciprocal has exactly its computed connected outward-cut
+predicate. This is cut exactness, not a claim that rounded cuts are attained
+or that a connected hull equals the generally-disconnected image. -/
+theorem invExact {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {precision : Hex.Interval.Precision} {input result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.invWithin limits precision input = .ready result) :
+    result.Contains x ↔ input.view.InvContains precision x :=
+  Hex.Interval.contains_invWithin checked x
+
+/-- Lean's total reciprocal maps every source member into every successful
+public enclosure, including `0⁻¹ = 0` and the connected hull across zero. -/
+theorem invImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {precision : Hex.Interval.Precision} {input result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.invWithin limits precision input = .ready result)
+    (member : input.Contains x) : result.Contains x⁻¹ :=
+  Hex.Interval.inv_mem_invWithin checked member
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -266,5 +283,13 @@ theorem splitPoint {limit : Hex.Interval.EndpointLimit}
 /-- info: 'Hex.IntervalMathlib.Conformance.splitPoint' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms splitPoint
+
+/-- info: 'Hex.IntervalMathlib.Conformance.invExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms invExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.invImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms invImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -366,7 +366,8 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.Addition, `HexIntervalMathlib.Subtraction,
     `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
     `HexIntervalMathlib.Multiplication,
-    `HexIntervalMathlib.Power, `HexIntervalMathlib.Split].map Glob.one
+    `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
+    `HexIntervalMathlib.Inverse].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/20260815T083301Z.md
+++ b/progress/20260815T083301Z.md
@@ -1,0 +1,46 @@
+# Checked public reciprocal enclosure
+
+## Accomplished
+
+- Promoted the smallest checked public reciprocal operation, `invWithin`, on
+  top of `Arithmetic.PrecisionLimits` and `preflightInvAtPrec`. Every finite
+  source cut is admitted before sign classification, and both required Core
+  reciprocal calls are preflighted before either executes.
+- Implemented outward lower rounding with `invAtPrec x p` and outward upper
+  rounding with `-invAtPrec (-x) p`. Successful results expose their exact
+  normalized computed cuts through `view_invWithin_ready`.
+- Made the zero policy explicit for Lean's total inverse: open zero is a
+  one-sided unbounded limit, singleton zero stays singleton zero, closed-zero
+  one-sided inputs use the appropriate connected hull, and a two-sign input
+  returns the whole interval.
+- Added `HexIntervalMathlib.Inverse`, proving the Core rounding directions and
+  the generic ordinary-kernel image theorem `inv_mem_invWithin` for every raw
+  cut shape. The separate `contains_invWithin` theorem characterizes computed
+  cuts without claiming exact image equality, endpoint attainment, or grid
+  optimality.
+- Added positive, negative, nonsingleton, open/closed-zero, crossing, empty,
+  mutation, precision, source, non-cancelling-shift, and predicted-result
+  conformance guards, plus guarded axiom reports.
+- Updated both supported SPECs and umbrellas, registered the proof-only
+  Mathlib module, and added the exact Lake freshness exemption.
+- Built `HexInterval.Conformance` and
+  `HexIntervalMathlib.IntervalConformance`. Copyright/file-size/DAG/release,
+  trust, Phase 4, conformance-matrix, Mathlib-free bench, and factor-sweep
+  freshness checks pass.
+
+## Current frontier
+
+The public operation is a sound connected outward enclosure with explicit
+resource refusal. Finite rounded endpoints are conservatively closed, and the
+connected representation deliberately loses the gap in a zero-crossing exact
+image.
+
+## Next step
+
+Decide separately whether to prove grid-optimal endpoint attainment, add a
+two-component interval-set result, or build checked `divWithin` on the existing
+division prerequisite. None is required for this reciprocal soundness slice.
+
+## Blockers
+
+None.

--- a/progress/20260815T125916Z.md
+++ b/progress/20260815T125916Z.md
@@ -1,0 +1,39 @@
+# Checked reciprocal replay
+
+## Accomplished
+
+- Replayed the checked reciprocal feature directly onto exact main
+  `3b715823117f72f744a12449b4a5414b9e3f983e`, preserving public multiplication,
+  power, transactional split, PNT+, Lake, and Mathlib registrations.
+- Reconciled the reciprocal runtime with the final precision prerequisite:
+  `invWithin` internally calls `Arithmetic.preflightInv` for every nonzero
+  endpoint it evaluates and accepts no external `QuotientPlan`.
+- Made the quotient sign classifier private and short-named, removing an
+  accidental public namespace helper without changing the cost schema.
+- Added executable checks that actual Core `invAtPrec` endpoints fit the
+  predicted retained height for positive and negative inputs and for a nonzero
+  result at negative precision.
+- Expanded policy guards for open and closed zero, singleton zero, sign
+  crossing, empty, whole, sign-separated unbounded inputs, and exact mutations
+  of endpoint value and strictness.
+- Preserved the ordinary-kernel cut-characterization and total-real-inverse
+  enclosure theorems and documented that the public result is a connected
+  outward hull with no tightness, attainment, or disconnected-image converse.
+- Recomputed the Lake exemption at exact blob
+  `a311762cafc62e9bbfd16385a2da6cd53639978b`; focused/full public, PNT,
+  static, release, trust, Mathlib-free, inventory, and freshness checks pass.
+
+## Current frontier
+
+Checked reciprocal is complete as a connected outward-enclosure primitive.
+Precision grid optimality and disconnected interval-set results remain
+deliberately unclaimed.
+
+## Next step
+
+Land reciprocal independently, then replay the preserved checked-division
+commit against the final prerequisite and reciprocal APIs.
+
+## Blockers
+
+None.

--- a/progress/20260815T131948Z.md
+++ b/progress/20260815T131948Z.md
@@ -1,0 +1,32 @@
+# Checked reciprocal review repair
+
+## Accomplished
+
+- Repaired the verified documentation and import-boundary findings from the
+  exact-head review of PR #9285 without changing reciprocal computation or
+  proof semantics.
+- Updated the central `hex-interval-mathlib` supported surface, theorem
+  inventory, connected-hull limitations, and current file organization for
+  reciprocal and transactional split.
+- Made `Inverse.lean` import the foundational interval semantics directly and
+  clarified the private quotient-sign cost parameter and decoder-only role of
+  the public raw reciprocal cuts and classifiers.
+- Corrected the runtime contract: every input not strictly separated from zero
+  bypasses reciprocal precision work, including one-sided-zero and
+  sign-crossing intervals.
+- Rebuilt focused runtime and Mathlib conformance and reran static, release,
+  trust, Mathlib-free, and freshness checks successfully.
+
+## Current frontier
+
+The checked reciprocal PR contains the minimal review repair. Its connected
+outward enclosure remains sound and deliberately makes no tightness converse.
+
+## Next step
+
+Push the repaired exact head, bind replacement CI to it, and obtain a fresh
+independent exact-head review before merge.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -358,5 +358,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "9dd80526e15dd9e72cd4a157d03021e7a24e2c39",
     "reason": "Additionally registers the supported HexIntervalMathlib transactional-split semantics module on top of the retained multiplication, natural-power, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "a311762cafc62e9bbfd16385a2da6cd53639978b",
+    "reason": "Additionally registers the supported proof-only HexIntervalMathlib reciprocal-enclosure semantics module on top of the retained multiplication, natural-power, transactional-split, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add checked `invWithin` as a connected outward enclosure of Lean total real inverse
- internally preflight every nonzero Core `invAtPrec` endpoint through the public precision resource layer; no caller-supplied plan is accepted
- prove exact successful computed-cut semantics and ordinary-kernel real-image enclosure
- pin open/closed zero, sign crossing, unbounded, empty/whole, strictness mutations, and actual-result-vs-predicted-cost checks

## Policy and scope

Across zero this returns the connected hull representable by one `Hex.Interval`: closed zero contributes Lean `0⁻¹ = 0`, open zero contributes only its one-sided limit, and a two-sign input returns whole. Finite rounded cuts are conservatively closed. No endpoint-attainment, grid-optimality, disconnected-image, or tightness converse is claimed.

This PR contains reciprocal only. It does not add public division, regularization, LeanCert compatibility shims, or planner-specific evidence.

Exact base: 3b715823117f72f744a12449b4a5414b9e3f983e
Exact head: 9427ec576bba4cbb223d9dbfcc1d9ec3c6793c5c

## Validation

- focused runtime and Mathlib conformance modules
- `lake build HexInterval HexIntervalMathlib HexConformance`
- representative PNT+ conformance targets
- static, release, trust-surface, PNT inventory, Mathlib-free bench, and factor-sweep freshness gates
- guarded `#print axioms` for reciprocal cut and image theorems
- no `axiom`, `sorry`, or `native_decide`
- Lake blob `a311762cafc62e9bbfd16385a2da6cd53639978b` matches the final proof-only exemption