### PR TITLE
feat(interval): add checked division enclosure

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -23,7 +23,7 @@ dyadic cut. The arithmetic resource layer preflights product growth,
 direct-power retained growth, exponent work, and rational-backed
 precision/quotient work independently of exact comparison work. The reciprocal
 operation is a precision-indexed connected outward enclosure. Division exposes
-direct outward cuts for two finite singletons, exact empty and total-zero
+direct outward cuts for two nonzero finite singletons, exact empty and total-zero
 cases, and a sound whole-line fallback for every other nonempty shape. Raw cuts
 remain visible as the explicit decoder and inspection boundary; D2 propagation
 and replay experiments still live outside this supported umbrella.

--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -22,8 +22,9 @@ maximum, absolute value, natural power, and transactional splitting at a
 dyadic cut. The arithmetic resource layer preflights product growth,
 direct-power retained growth, exponent work, and rational-backed
 precision/quotient work independently of exact comparison work. The reciprocal
-operation is a precision-indexed connected outward enclosure; division remains
-unexposed. Raw cuts remain visible as the explicit decoder and inspection
-boundary; D2 propagation and replay experiments still live outside this
-supported umbrella.
+operation is a precision-indexed connected outward enclosure. Division exposes
+direct outward cuts for two finite singletons, exact empty and total-zero
+cases, and a sound whole-line fallback for every other nonempty shape. Raw cuts
+remain visible as the explicit decoder and inspection boundary; D2 propagation
+and replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -388,10 +388,10 @@ resource admission; untrusted callers use `divWithin`. -/
       match numerator.singletonValue?, denominator.singletonValue? with
       | some .zero, _ | _, some .zero =>
           .bounds (.finite 0 false) (.finite 0 false)
-      | some numerator, some denominator =>
+      | some numeratorValue, some denominatorValue =>
           .bounds
-            (.finite (numerator.divAtPrec denominator precision) false)
-            (.finite (-(-numerator).divAtPrec denominator precision) false)
+            (.finite (numeratorValue.divAtPrec denominatorValue precision) false)
+            (.finite (-(-numeratorValue).divAtPrec denominatorValue precision) false)
       | _, _ => .bounds .unbounded .unbounded
 
 end Raw
@@ -607,8 +607,26 @@ private def admitInv (limits : Arithmetic.PrecisionLimits)
         admitInvLower limits precision upper
         admitInvUpper limits precision lower
 
-/-- Preflight both direct Core quotient calls before either executes. Empty,
-total-zero cases, and the whole-line nonsingleton fallback perform no quotient
+/-- Admit every finite cut carried by a nonempty raw source. This performs no
+comparison or arithmetic beyond the public endpoint resource check. -/
+private def admitRawEndpoints (limits : Arithmetic.PrecisionLimits) : Raw →
+    Except Arithmetic.Cost Unit
+  | .empty => pure ()
+  | .bounds lower upper => do
+      match lower with
+      | .unbounded => pure ()
+      | .finite value _ => do
+          let _ ← Arithmetic.admitEndpoint limits value
+          pure ()
+      match upper with
+      | .unbounded => pure ()
+      | .finite value _ => do
+          let _ ← Arithmetic.admitEndpoint limits value
+          pure ()
+
+/-- Admit every finite source cut, then preflight both direct Core quotient
+calls before either executes. Empty remains absorbing before source admission;
+total-zero cases and the whole-line nonsingleton fallback perform no quotient
 work. No caller-provided plan or intermediate reciprocal is accepted. -/
 private def admitDiv (limits : Arithmetic.PrecisionLimits)
     (precision : Precision) (numerator denominator : Raw) :
@@ -616,11 +634,15 @@ private def admitDiv (limits : Arithmetic.PrecisionLimits)
   match numerator, denominator with
   | .empty, _ | _, .empty => pure ()
   | numerator, denominator =>
+      admitRawEndpoints limits numerator
+      admitRawEndpoints limits denominator
       match numerator.singletonValue?, denominator.singletonValue? with
       | some .zero, _ | _, some .zero => pure ()
-      | some numerator, some denominator =>
-          let _ ← Arithmetic.preflightDiv limits numerator denominator precision
-          let _ ← Arithmetic.preflightDiv limits (-numerator) denominator precision
+      | some numeratorValue, some denominatorValue =>
+          let _ ← Arithmetic.preflightDiv
+            limits numeratorValue denominatorValue precision
+          let _ ← Arithmetic.preflightDiv
+            limits (-numeratorValue) denominatorValue precision
       | _, _ => pure ()
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -366,6 +366,34 @@ combinator; untrusted callers use `invWithin`. -/
       else
         .bounds .unbounded .unbounded
 
+/-! ## Precision-indexed division enclosure -/
+
+/-- Recover the value of a closed finite singleton. This decoder-level
+classifier performs no resource admission; untrusted callers use `divWithin`. -/
+@[expose] def singletonValue? : Raw → Option Dyadic
+  | .bounds (.finite lower false) (.finite upper false) =>
+      if lower = upper then some lower else none
+  | _ => none
+
+/-- Raw first-slice enclosure of Lean's total division. Empty is absorbing. A
+singleton-zero numerator or denominator maps exactly to `{0}`. Two nonzero
+finite singletons use direct outward Core division, and every other nonempty
+shape returns the whole interval. This decoder-level combinator performs no
+resource admission; untrusted callers use `divWithin`. -/
+@[expose] def divUnchecked (precision : Precision)
+    (numerator denominator : Raw) : Raw :=
+  match numerator, denominator with
+  | .empty, _ | _, .empty => .empty
+  | numerator, denominator =>
+      match numerator.singletonValue?, denominator.singletonValue? with
+      | some .zero, _ | _, some .zero =>
+          .bounds (.finite 0 false) (.finite 0 false)
+      | some numerator, some denominator =>
+          .bounds
+            (.finite (numerator.divAtPrec denominator precision) false)
+            (.finite (-(-numerator).divAtPrec denominator precision) false)
+      | _, _ => .bounds .unbounded .unbounded
+
 end Raw
 
 /-- Transactional result of a checked split. A successful value contains both
@@ -578,6 +606,22 @@ private def admitInv (limits : Arithmetic.PrecisionLimits)
       if Raw.strictlyPositive lower || Raw.strictlyNegative upper then
         admitInvLower limits precision upper
         admitInvUpper limits precision lower
+
+/-- Preflight both direct Core quotient calls before either executes. Empty,
+total-zero cases, and the whole-line nonsingleton fallback perform no quotient
+work. No caller-provided plan or intermediate reciprocal is accepted. -/
+private def admitDiv (limits : Arithmetic.PrecisionLimits)
+    (precision : Precision) (numerator denominator : Raw) :
+    Except Arithmetic.Cost Unit := do
+  match numerator, denominator with
+  | .empty, _ | _, .empty => pure ()
+  | numerator, denominator =>
+      match numerator.singletonValue?, denominator.singletonValue? with
+      | some .zero, _ | _, some .zero => pure ()
+      | some numerator, some denominator =>
+          let _ ← Arithmetic.preflightDiv limits numerator denominator precision
+          let _ ← Arithmetic.preflightDiv limits (-numerator) denominator precision
+      | _, _ => pure ()
 
 /-- Exact set intersection with preflighted dyadic comparisons.  Refusal is
 distinct from the canonical empty result. -/
@@ -818,6 +862,42 @@ theorem view_invWithin_ready {limits : Arithmetic.PrecisionLimits}
   · contradiction
   · generalize builtEq :
         ofRawWithin limits.endpoint (Raw.invUnchecked precision input.view) = built at h
+    cases built with
+    | ready interval =>
+        simp only [Arithmetic.Result.ofBuild] at h
+        cases h
+        exact view_ofRawWithin_ready builtEq
+    | resourceLimit cost =>
+        simp [Arithmetic.Result.ofBuild] at h
+
+/-- Precision-indexed public division using Core's direct rational quotient
+for two nonzero finite singletons. Both quotient calls are internally
+preflighted before either executes; no caller plan or intermediate reciprocal
+is accepted. Empty and total-zero cases are exact, while every other nonempty
+shape receives the sound whole-line enclosure. -/
+def divWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
+    (numerator denominator : Hex.Interval) : Arithmetic.Result :=
+  match admitDiv limits precision numerator.view denominator.view with
+  | .error cost => .resourceLimit cost
+  | .ok () =>
+      Arithmetic.Result.ofBuild
+        (ofRawWithin limits.endpoint
+          (Raw.divUnchecked precision numerator.view denominator.view))
+
+/-- Every successful division exposes exactly the normalized computed cuts.
+This theorem does not claim that the whole-line fallback is an exact image or
+that rounded singleton endpoints are attained. -/
+theorem view_divWithin_ready {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {numerator denominator result : Hex.Interval}
+    (h : divWithin limits precision numerator denominator = .ready result) :
+    result.view =
+      (Raw.divUnchecked precision numerator.view denominator.view).normalizeUnchecked := by
+  unfold divWithin at h
+  split at h
+  · contradiction
+  · generalize builtEq :
+        ofRawWithin limits.endpoint
+          (Raw.divUnchecked precision numerator.view denominator.view) = built at h
     cases built with
     | ready interval =>
         simp only [Arithmetic.Result.ofBuild] at h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -597,16 +597,17 @@ product of source members belongs to it. No separate image-tightness converse
 is currently claimed.
 
 The public tree also contains the allocation prerequisite for
-precision-indexed reciprocal and division. It now exposes the checked
-reciprocal operation
+precision-indexed reciprocal and division. It exposes the checked operations
 
 ```lean
 invWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
   (input : Hex.Interval) : Arithmetic.Result
+
+divWithin (limits : Arithmetic.PrecisionLimits) (precision : Precision)
+  (numerator denominator : Hex.Interval) : Arithmetic.Result
 ```
 
-but no `divWithin` interval operation. Core `Dyadic.invAtPrec` converts a
-nonzero source through
+Core `Dyadic.invAtPrec` converts a nonzero source through
 `Dyadic.toRat`, inverts the rational, then calls `Rat.toDyadic`; `divAtPrec`
 converts both sources and additionally runs reduced rational cross-products.
 Neither `CompareCost` nor `Arithmetic.Growth` accounts for those shifts or
@@ -664,14 +665,31 @@ disconnected interval-set representation.
 `view_invWithin_ready` exactly characterizes every successful computed cut;
 the Mathlib companion independently proves that every real source member's
 Lean-total inverse lies in that result. No converse image theorem, finite-cut
-attainment, grid optimality, or disconnected-image tightness is claimed. The
-public division operation remains future work.
+attainment, grid optimality, or disconnected-image tightness is claimed.
+
+`divWithin` is a deliberately narrow first supported slice. Empty is
+absorbing. A singleton-zero numerator or denominator returns singleton zero,
+following Lean's total division. Two nonzero finite singletons call Core's
+`divAtPrec numerator denominator precision` directly for the lower endpoint
+and `-divAtPrec (-numerator) denominator precision` for the upper endpoint.
+The operation internally rederives both `preflightDiv` plans, and both must
+pass before either Core call executes; it accepts no caller plan and allocates
+no intermediate reciprocal. Every other nonempty pair returns the whole
+interval without precision work. This explicitly includes nonsingleton,
+unbounded, zero-touching, and sign-crossing shapes.
+
+`view_divWithin_ready` exactly characterizes those computed cuts, and the
+Mathlib companion consumes both source memberships to prove a one-way theorem
+for Lean's total real division. No converse image theorem, rounded-cut
+attainment, grid optimality, useful bounded nonsingleton quotient, or
+disconnected-result precision is claimed.
 
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
 `maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and
-`mulUnchecked`, together with `splitUnchecked` and `invUnchecked`, are related
-to the checked operations by successful-result and semantic theorems.
+`mulUnchecked`, together with `splitUnchecked`, `invUnchecked`,
+`singletonValue?`, and `divUnchecked`, are related to the checked operations by
+successful-result and semantic theorems.
 `powCutsUnchecked` is
 only the strictly monotone cut mapper;
 its caller must establish the positive odd or nonnegative positive-exponent
@@ -680,10 +698,10 @@ case. `powUnchecked` performs the zero/odd/even direct-hull selection. Like
 are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
-The remaining target surface includes precision-indexed division and
-regularization. Their public signatures are fixed only after an
-allocation audit; no total API is promised for an operation that may align,
-compare, or enlarge arbitrary-precision endpoints.
+The remaining target surface includes useful bounded nonsingleton division and
+regularization. Its public signatures and resource policy are fixed only after
+the corresponding allocation audit; no operation may silently align, compare,
+or enlarge arbitrary-precision endpoints.
 
 For the initial dyadic backend, `Precision` is an alias for signed `Int` and
 the implementation reuses core `Dyadic.roundDown`, `roundUp`, `invAtPrec`, and
@@ -766,6 +784,13 @@ endpoint mapping to an unbounded side). The concrete package has an executable
 across-zero regression for that legacy behavior and is not the public
 operation. Selecting an interval-set result remains a possible future
 precision improvement rather than a requirement for sound connected-hull use.
+
+The supported `divWithin` implements only the direct two-finite-singleton grid
+enclosure plus exact empty and total-zero cases. Its whole-line fallback makes
+all remaining shapes sound but does not satisfy the eventual bounded quotient
+or grid-tightness target. In particular, a whole fallback is a deliberate
+first-slice loss of precision, not a claim that the exact image is the whole
+line.
 
 Grid-tightness remains an acceptance target, not an assumed consequence of
 core's API. Core currently proves the one-sided `roundDown_le` and
@@ -4198,9 +4223,10 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
   negation, addition, subtraction, minimum, maximum, absolute value, and
   natural power; transactional splitting; and checked precision-indexed
-  reciprocal. Its public raw helpers, including the power, split, and
-  reciprocal cut selectors, are decoder-level counterparts of checked
-  operations. Division and regularization remain future work.
+  reciprocal and first-slice division. Its public raw helpers, including the
+  power, split, reciprocal, and division cut selectors, are decoder-level
+  counterparts of checked operations. Useful bounded nonsingleton division and
+  regularization remain future work.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
@@ -4221,6 +4247,8 @@ their declared cost inside a scheduler bound.
   containment, coverage, disjointness, and left ownership of the cut point.
 - `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics
   and the one-way total-real-inverse connected-hull enclosure theorem.
+- `HexIntervalMathlib/Division.lean`: exact computed first-slice quotient-cut
+  semantics and the one-way total-real-division enclosure theorem.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
@@ -4256,8 +4284,10 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - minimum and maximum preflight refusal on either same-side comparison and on
   the distinct selected-cut final comparison;
 - precision-indexed reciprocal for `{3}`, positive, negative, singleton-zero,
-  one-sided-zero, sign-crossing, and sign-separated unbounded inputs; division
-  remains a future conformance family;
+  one-sided-zero, sign-crossing, and sign-separated unbounded inputs;
+- first-slice division for all four singleton sign combinations, total-zero,
+  empty, whole fallback, wrong endpoints, actual-result bounds, and every
+  precision/quotient resource refusal stage including second-call priority;
 - powers on negative, mixed-sign, open-zero, and singleton inputs;
 - rational-to-dyadic projection at exact and inexact values, including the
   strict cut gained by moving a closed source outward;

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -678,6 +678,11 @@ no intermediate reciprocal. Every other nonempty pair returns the whole
 interval without precision work. This explicitly includes nonsingleton,
 unbounded, zero-touching, and sign-crossing shapes.
 
+Every finite cut in both nonempty sources is admitted before that
+classification. After the selected Core cuts are computed, they still cross
+`ofRawWithin`; its independent final endpoint-retention and comparison checks
+may refuse the result.
+
 `view_divWithin_ready` exactly characterizes those computed cuts, and the
 Mathlib companion consumes both source memberships to prove a one-way theorem
 for Lean's total real division. No converse image theorem, rounded-cut

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -16,6 +16,7 @@ public import HexIntervalMathlib.Multiplication
 public import HexIntervalMathlib.Power
 public import HexIntervalMathlib.Split
 public import HexIntervalMathlib.Inverse
+public import HexIntervalMathlib.Division
 
 public section
 
@@ -24,5 +25,5 @@ public section
 the supported `Hex.Interval` operations, including resource-checked addition,
 subtraction, and multiplication, exact minimum/maximum images, absolute value,
 natural power, closed-left/strict-right transactional splitting, and
-precision-indexed reciprocal enclosure.
+precision-indexed reciprocal and division enclosures.
 -/

--- a/HexIntervalMathlib/Division.lean
+++ b/HexIntervalMathlib/Division.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+public import Mathlib.Algebra.Order.Field.Basic
+
+@[expose] public section
+
+/-!
+# Real semantics of public division enclosure
+
+The supported first slice performs Core's direct rational-backed `divAtPrec`
+only for two nonzero finite singleton inputs. Empty and total-zero inputs are
+exact; every other nonempty shape uses an explicit whole-line fallback.
+-/
+
+namespace Hex.Interval
+
+/-- Core's direct precision-indexed quotient rounds toward negative infinity
+when interpreted in `ℝ`, including its total denominator-zero branch. -/
+theorem roundedDivDown_le_div (numerator denominator : Dyadic)
+    (precision : Precision) :
+    toReal (numerator.divAtPrec denominator precision) ≤
+      toReal numerator / toReal denominator := by
+  cases denominator with
+  | zero => simp [toReal, Dyadic.divAtPrec]
+  | ofOdd denominator exponent odd =>
+      simp only [Dyadic.divAtPrec, toReal]
+      exact_mod_cast Rat.toRat_toDyadic_le
+
+/-- Sign reflection turns Core's downward quotient into an upward-rounded
+endpoint for the original quotient. -/
+theorem div_le_roundedDivUp (numerator denominator : Dyadic)
+    (precision : Precision) :
+    toReal numerator / toReal denominator ≤
+      toReal (-(-numerator).divAtPrec denominator precision) := by
+  have rounded := roundedDivDown_le_div (-numerator) denominator precision
+  rw [toReal_neg, neg_div] at rounded
+  simpa using neg_le_neg rounded
+
+/-- Exact membership predicate of the computed raw division cuts. This is a
+cut characterization, not an exact image claim for the whole-line fallback. -/
+def Raw.DivContains (precision : Precision) (numerator denominator : Raw)
+    (x : ℝ) : Prop :=
+  (Raw.divUnchecked precision numerator denominator).Contains x
+
+private theorem eq_bounds_of_singletonValue {raw : Raw} {value : Dyadic}
+    (h : raw.singletonValue? = some value) :
+    raw = .bounds (.finite value false) (.finite value false) := by
+  cases raw with
+  | empty => simp [Raw.singletonValue?] at h
+  | bounds lower upper =>
+      cases lower with
+      | unbounded => simp [Raw.singletonValue?] at h
+      | finite lower lowerStrict =>
+          cases upper with
+          | unbounded => simp [Raw.singletonValue?] at h
+          | finite upper upperStrict =>
+              cases lowerStrict <;> cases upperStrict <;>
+                simp [Raw.singletonValue?] at h ⊢
+              rcases h with ⟨rfl, rfl⟩
+              exact ⟨rfl, rfl⟩
+
+private theorem eq_toReal_of_singletonValue {raw : Raw} {value : Dyadic} {x : ℝ}
+    (shape : raw.singletonValue? = some value) (member : raw.Contains x) :
+    x = toReal value := by
+  rw [eq_bounds_of_singletonValue shape] at member
+  simp [Raw.Contains, Lower.Contains, Upper.Contains] at member
+  exact le_antisymm member.2 member.1
+
+private theorem rawContains_div (precision : Precision)
+    (numerator denominator : Raw) {x y : ℝ}
+    (numeratorMember : numerator.Contains x)
+    (denominatorMember : denominator.Contains y) :
+    (Raw.divUnchecked precision numerator denominator).Contains (x / y) := by
+  cases numerator with
+  | empty => simp [Raw.Contains] at numeratorMember
+  | bounds numeratorLower numeratorUpper =>
+      cases denominator with
+      | empty => simp [Raw.Contains] at denominatorMember
+      | bounds denominatorLower denominatorUpper =>
+          let numeratorRaw := Raw.bounds numeratorLower numeratorUpper
+          let denominatorRaw := Raw.bounds denominatorLower denominatorUpper
+          generalize numeratorShape : numeratorRaw.singletonValue? = numeratorValue
+          generalize denominatorShape : denominatorRaw.singletonValue? = denominatorValue
+          dsimp only [numeratorRaw, denominatorRaw] at numeratorShape denominatorShape
+          cases numeratorValue with
+          | none =>
+              cases denominatorValue with
+              | none =>
+                  simp only [Raw.divUnchecked]
+                  rw [numeratorShape, denominatorShape]
+                  simp [Raw.Contains, Lower.Contains, Upper.Contains]
+              | some denominatorValue =>
+                  cases denominatorValue with
+                  | zero =>
+                      have yZero :=
+                        eq_toReal_of_singletonValue denominatorShape denominatorMember
+                      simp only [Raw.divUnchecked]
+                      rw [numeratorShape, denominatorShape]
+                      simp [yZero, toReal, Raw.Contains, Lower.Contains, Upper.Contains]
+                  | ofOdd denominator exponent odd =>
+                      simp only [Raw.divUnchecked]
+                      rw [numeratorShape, denominatorShape]
+                      simp [Raw.Contains, Lower.Contains, Upper.Contains]
+          | some numeratorValue =>
+              cases denominatorValue with
+              | none =>
+                  cases numeratorValue with
+                  | zero =>
+                      have xZero := eq_toReal_of_singletonValue numeratorShape numeratorMember
+                      simp only [Raw.divUnchecked]
+                      rw [numeratorShape]
+                      simp [xZero, toReal, Raw.Contains, Lower.Contains, Upper.Contains]
+                  | ofOdd numerator exponent odd =>
+                      simp only [Raw.divUnchecked]
+                      rw [numeratorShape, denominatorShape]
+                      simp [Raw.Contains, Lower.Contains, Upper.Contains]
+              | some denominatorValue =>
+                  cases numeratorValue with
+                  | zero =>
+                      have xZero := eq_toReal_of_singletonValue numeratorShape numeratorMember
+                      simp only [Raw.divUnchecked]
+                      rw [numeratorShape]
+                      simp [xZero, toReal, Raw.Contains, Lower.Contains, Upper.Contains]
+                  | ofOdd numerator exponent odd =>
+                      cases denominatorValue with
+                      | zero =>
+                          have yZero :=
+                            eq_toReal_of_singletonValue denominatorShape denominatorMember
+                          simp only [Raw.divUnchecked]
+                          rw [numeratorShape, denominatorShape]
+                          simp [yZero, toReal, Raw.Contains, Lower.Contains, Upper.Contains]
+                      | ofOdd denominator denominatorExponent denominatorOdd =>
+                          have xValue :=
+                            eq_toReal_of_singletonValue numeratorShape numeratorMember
+                          have yValue :=
+                            eq_toReal_of_singletonValue denominatorShape denominatorMember
+                          subst x
+                          subst y
+                          simp only [Raw.divUnchecked]
+                          rw [numeratorShape, denominatorShape]
+                          simp only [Raw.Contains, Lower.Contains, Upper.Contains]
+                          exact ⟨
+                            roundedDivDown_le_div
+                              (.ofOdd numerator exponent odd)
+                              (.ofOdd denominator denominatorExponent denominatorOdd) precision,
+                            div_le_roundedDivUp
+                              (.ofOdd numerator exponent odd)
+                              (.ofOdd denominator denominatorExponent denominatorOdd) precision⟩
+
+/-- A successful public division has exactly its normalized computed-cut
+predicate. -/
+theorem contains_divWithin {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {numerator denominator result : Hex.Interval}
+    (checked : divWithin limits precision numerator denominator = .ready result)
+    (x : ℝ) :
+    result.Contains x ↔ numerator.view.DivContains precision denominator.view x := by
+  simp only [Contains, Raw.DivContains]
+  rw [view_divWithin_ready checked, contains_normalize]
+
+/-- Both source memberships are consumed to show that Lean's total real
+division maps into every successful public enclosure. -/
+theorem div_mem_divWithin {limits : Arithmetic.PrecisionLimits}
+    {precision : Precision} {numerator denominator result : Hex.Interval}
+    {x y : ℝ}
+    (checked : divWithin limits precision numerator denominator = .ready result)
+    (numeratorMember : numerator.Contains x)
+    (denominatorMember : denominator.Contains y) :
+    result.Contains (x / y) :=
+  (contains_divWithin checked (x / y)).2
+    (rawContains_div precision numerator.view denominator.view
+      numeratorMember denominatorMember)
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -19,7 +19,9 @@ theorems. `HexIntervalMathlib.Power` supplies exact selected-cut semantics
 and a one-way real-image theorem for checked natural power.
 `HexIntervalMathlib.Split` proves exact closed-left/strict-right membership
 for transactional splitting. `HexIntervalMathlib.Inverse` proves the computed
-connected-cut characterization and sound total-real-inverse enclosure.
+connected-cut characterization and sound total-real-inverse enclosure, while
+`HexIntervalMathlib.Division` proves the computed first-slice quotient cuts and
+sound total-real-division enclosure.
 
 For every successful resource-checked public operation it proves:
 
@@ -73,7 +75,11 @@ For every successful resource-checked public operation it proves:
   normalized computed outward-cut predicate; this does not identify the
   connected hull with the generally-disconnected exact image;
 - `inv_mem_invWithin`: every real source member maps under Lean's total
-  reciprocal into the successful enclosure, including `0⁻¹ = 0`.
+  reciprocal into the successful enclosure, including `0⁻¹ = 0`;
+- `contains_divWithin`: membership in successful division is exactly its
+  computed singleton outward cuts or explicit whole-line fallback;
+- `div_mem_divWithin`: both source memberships are consumed to place their
+  Lean-total real quotient in every successful enclosure.
 
 These theorems depend on the exact successful result equation: `BuildResult`
 or `Arithmetic.Result` for unary/binary images, and transactional
@@ -88,14 +94,18 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Further arithmetic images, regularization, and
-precision-indexed division require their own
+are not re-exported here. Further arithmetic images, regularization, and useful
+bounded nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
 Public reciprocal is sound but
 conservatively closes finite rounded cuts; endpoint attainment, grid
 optimality, and disconnected interval-set precision remain future work.
+Public division directly encloses two nonzero finite singletons, handles empty
+and total-zero cases exactly, and deliberately returns whole for every other
+nonempty shape. No tightness converse or bounded nonsingleton quotient is
+claimed.
 
 ## Conformance
 
@@ -104,7 +114,8 @@ membership, exact hull closure and both input inclusions, negation transport,
 addition, subtraction, and multiplication cut exactness and image transport,
 exact split membership/coverage/disjointness/point ownership, and the exact
 ordinary-kernel axiom surface. It also pins reciprocal computed-cut exactness
-and total-real-inverse enclosure, without a tightness converse.
+and total-real-inverse enclosure, plus division computed-cut exactness and
+total-real-division enclosure, without tightness converses.
 `HexIntervalMathlib.MinMaxConformance` separately pins exact selected cuts,
 both image enclosures, and their axiom surfaces; it does not assert a set-image
 converse.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -9,12 +9,14 @@ The current supported surface interprets public canonical intervals over `ℝ`
 and proves exact semantics for successful resource-checked intersection, hull,
 negation, addition, subtraction, multiplication, minimum, maximum, absolute
 value, natural power, transactional splitting, and precision-indexed
-reciprocal. Natural power exposes exact computed cuts and a sound pointwise
-real image theorem, without claiming a set-image converse. Splitting exposes
+reciprocal and division. Natural power exposes exact computed cuts and a sound
+pointwise real image theorem, without claiming a set-image converse. Splitting exposes
 both children together and proves exact closed-left/strict-right membership,
 containment, cover, disjointness, and cut ownership. Reciprocal exposes its
 computed connected outward cuts and a sound pointwise theorem for Lean's total
 inverse, including `0⁻¹ = 0`.
+Division exposes direct outward cuts for two nonzero finite singletons, exact
+empty and total-zero cases, and a sound whole-line fallback otherwise.
 Propagator, provider, replay, and tactic modules remain experiments and are not
 re-exported by the public umbrella. The user-facing tactic contract below is
 the release target, not a claim that the tactic is already supported.
@@ -232,6 +234,14 @@ theorem contains_invWithin
 theorem inv_mem_invWithin
     (h : invWithin limits precision I = .ready result) :
     I.Contains x → result.Contains x⁻¹
+
+theorem contains_divWithin
+    (h : divWithin limits precision I J = .ready result) :
+    result.Contains x ↔ I.view.DivContains precision J.view x
+
+theorem div_mem_divWithin
+    (h : divWithin limits precision I J = .ready result) :
+    I.Contains x → J.Contains y → result.Contains (x / y)
 ```
 
 For two nonempty bounded raw inputs, `HullContains` is exactly
@@ -283,6 +293,15 @@ the normalized computed cuts, and `inv_mem_invWithin` proves the pointwise
 real-image enclosure. Finite rounded cuts are conservatively closed; no
 converse image equality, endpoint attainment, grid optimality, or exact
 disconnected-image claim is made.
+
+`divWithin` calls Core's direct quotient only for two nonzero finite
+singletons, after internally rederiving and passing both quotient preflights
+before either call. Empty and singleton-zero numerator or denominator cases
+are exact under Lean's total division; every other nonempty pair is the whole
+interval without precision work. `contains_divWithin` characterizes these
+computed cuts and `div_mem_divWithin` consumes both memberships for a one-way
+real-image theorem. It claims no converse, endpoint attainment, grid
+optimality, or useful bounded nonsingleton result.
 
 The remaining target theorems include:
 
@@ -2596,6 +2615,8 @@ the fixed soundness and trust contracts.
   containment, cover, disjointness, and cut ownership.
 - `HexIntervalMathlib/Inverse.lean`: computed reciprocal-cut semantics and the
   total-real-inverse connected-hull enclosure theorem.
+- `HexIntervalMathlib/Division.lean`: computed first-slice quotient-cut
+  semantics and the total-real-division enclosure theorem.
 - `HexIntervalMathlib/Program.lean`: real program evaluation and natural
   evaluator soundness.
 - `HexIntervalMathlib/Rule.lean`: registration environment and theorem-schema

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -1669,6 +1669,8 @@ private def singletonOneOver256 : Hex.Interval :=
 private def singletonConvertedTemporary : Hex.Interval :=
   ready (.bounds (.finite convertedTemporary false) (.finite convertedTemporary false))
 
+private def singleton47 : Hex.Interval := ready (finite 47 false 47 false)
+
 /-- Execute the public prerequisite and Core quotient, then check that the
 actual retained endpoint fits the successful predicted height. -/
 private def divCostBounded (numerator denominator : Dyadic)
@@ -1728,10 +1730,17 @@ private def divCostBounded (numerator denominator : Dyadic)
 
 -- Empty is absorbing. Lean's total zero numerator or denominator is exact.
 -- Every remaining nonsingleton, zero-touching, sign-crossing, or unbounded
--- nonempty pair uses the explicit whole-line fallback without precision work.
+-- nonempty pair uses the explicit whole-line fallback without quotient or
+-- precision work after finite source admission.
 #guard
   match Hex.Interval.divWithin precisionLimits 1024
       Hex.Interval.empty crossesZero with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024
+      crossesZero Hex.Interval.empty with
   | .ready interval => interval == Hex.Interval.empty
   | .resourceLimit _ => false
 
@@ -1754,6 +1763,14 @@ private def divCostBounded (numerator denominator : Dyadic)
   match Hex.Interval.divWithin precisionLimits 1024 closed01 singletonThree with
   | .ready interval => interval == Hex.Interval.whole
   | .resourceLimit _ => false
+
+-- The whole-line fallback never bypasses source admission. This oversized,
+-- zero-touching nonsingleton would otherwise take that fallback immediately.
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 absCrossFar singletonThree with
+  | .resourceLimit (.endpoint cost) =>
+      cost.exponentMagnitude == 200 && !cost.allowed precisionLimits.endpoint
+  | _ => false
 
 -- Precision magnitude and encoding, each retained source, conversion shifts,
 -- converted rationals, division cross-products, integer quotient size, and
@@ -1812,6 +1829,23 @@ private def divCostBounded (numerator denominator : Dyadic)
       | none => false
   | _ => false
 
+-- At negative precision, both converted sources and the reduced
+-- cross-product fit nine bits, but the denominator shifted for rounding does
+-- not. This isolates the rounding-temporary gate from quotient/result bounds.
+#guard
+  match Hex.Interval.divWithin tightQuotientLimits (-8) singletonOne singletonThree with
+  | .resourceLimit (.quotient cost) =>
+      cost.converted.all
+          (Arithmetic.RationalBound.allowed tightQuotientLimits.maxTemporaryBits) &&
+        cost.crossProduct.all
+          (Arithmetic.RationalBound.allowed tightQuotientLimits.maxTemporaryBits) &&
+        cost.rounding.denominatorBits == 10 &&
+        !cost.rounding.allowed tightQuotientLimits.maxTemporaryBits &&
+        cost.quotientBits ≤ tightQuotientLimits.maxTemporaryBits &&
+        cost.predictedResultHeight ≤ tightQuotientLimits.endpoint.maxEndpointHeight &&
+        !cost.allowed tightQuotientLimits
+  | _ => false
+
 #guard
   match Hex.Interval.divWithin tightQuotientLimits 8 singletonNegOne singletonThree with
   | .resourceLimit (.quotient cost) =>
@@ -1825,6 +1859,24 @@ private def divCostBounded (numerator denominator : Dyadic)
   | .resourceLimit (.quotient cost) =>
       cost.predictedResultHeight == 17 && !cost.allowed tightResultLimits
   | _ => false
+
+private def finalCompareLimits : Arithmetic.PrecisionLimits :=
+  { precisionLimits with endpoint := eightBitLimit }
+
+-- Both actual singleton quotient calls pass every arithmetic preflight. Their
+-- outward cuts are `15` and `16`; canonicalization exposes exponents `0` and
+-- `-4`, so only the independent final comparison alignment gate refuses.
+#guard
+  match Arithmetic.preflightDiv finalCompareLimits (d 47) (d 3) 0,
+      Arithmetic.preflightDiv finalCompareLimits (d (-47)) (d 3) 0,
+      Hex.Interval.divWithin finalCompareLimits 0 singleton47 singletonThree with
+  | .ok (.checked lowerCost), .ok (.checked upperCost),
+      .resourceLimit (.comparison cost) =>
+      lowerCost.allowed finalCompareLimits && upperCost.allowed finalCompareLimits &&
+        cost.lower.allowed finalCompareLimits.endpoint &&
+        cost.upper.allowed finalCompareLimits.endpoint &&
+        cost.alignmentShift == 4 && !cost.allowed finalCompareLimits.endpoint
+  | _, _, _ => false
 
 private def upperResultLimits : Arithmetic.PrecisionLimits :=
   { precisionLimits with endpoint.maxEndpointHeight := 17 }

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -1661,6 +1661,184 @@ private def singletonShiftInput : Hex.Interval :=
       cost.predictedResultHeight == 17 && !cost.allowed tightResultLimits
   | _ => false
 
+/-! # Supported precision-indexed division -/
+
+private def singletonOneOver256 : Hex.Interval :=
+  ready (.bounds (.finite oneOver256 false) (.finite oneOver256 false))
+
+private def singletonConvertedTemporary : Hex.Interval :=
+  ready (.bounds (.finite convertedTemporary false) (.finite convertedTemporary false))
+
+/-- Execute the public prerequisite and Core quotient, then check that the
+actual retained endpoint fits the successful predicted height. -/
+private def divCostBounded (numerator denominator : Dyadic)
+    (precision : Precision) : Bool :=
+  match Arithmetic.preflightDiv precisionLimits numerator denominator precision with
+  | .ok (.checked cost) =>
+      (EndpointCost.ofDyadic (numerator.divAtPrec denominator precision)).allowed
+        { maxEndpointHeight := cost.predictedResultHeight, maxAlignmentShift := 0 }
+  | _ => false
+
+-- The conservative prediction bounds actual Core results for both quotient
+-- signs and for a nonzero quotient at negative precision.
+#guard divCostBounded (d 1) (d 3) 8
+#guard divCostBounded (d (-1)) (d 3) 8
+#guard divCostBounded (d 1) oneOver256 (-8)
+#guard (d 1).divAtPrec oneOver256 (-8) == .ofOdd 1 (-8) (by decide)
+
+-- Both numerator and denominator signs are load-bearing. Sign reflection of
+-- the numerator supplies the outward upper endpoint without an intermediate
+-- reciprocal.
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 singletonOne singletonThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite invDownThree false) (.finite invUpThree false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 singletonNegOne singletonThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (-invUpThree) false) (.finite (-invDownThree) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 singletonOne singletonNegThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (-invUpThree) false) (.finite (-invDownThree) false)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 singletonNegOne singletonNegThree with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite invDownThree false) (.finite invUpThree false)
+  | .resourceLimit _ => false
+
+-- Expected-failure mutation: copying the downward endpoint into the upper cut
+-- is not the checked result.
+#guard
+  match Hex.Interval.divWithin precisionLimits 8 singletonOne singletonThree with
+  | .ready interval =>
+      interval.view != .bounds
+        (.finite invDownThree false) (.finite invDownThree false)
+  | .resourceLimit _ => false
+
+-- Empty is absorbing. Lean's total zero numerator or denominator is exact.
+-- Every remaining nonsingleton, zero-touching, sign-crossing, or unbounded
+-- nonempty pair uses the explicit whole-line fallback without precision work.
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024
+      Hex.Interval.empty crossesZero with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024 singletonZero crossesZero with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024 closed01 singletonZero with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024 singletonOne crossesZero with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024 closed01 singletonThree with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+-- Precision magnitude and encoding, each retained source, conversion shifts,
+-- converted rationals, division cross-products, integer quotient size, and
+-- retained result height are discriminating public refusals.
+#guard
+  match Hex.Interval.divWithin precisionLimits 1024 singletonOne singletonThree with
+  | .resourceLimit (.precision cost) =>
+      cost.magnitude == 1024 && !cost.allowed precisionLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin tightPrecisionBitsLimits 8 singletonOne singletonThree with
+  | .resourceLimit (.precision cost) =>
+      cost.magnitude == 8 && cost.encodedBits == 4 &&
+        !cost.allowed tightPrecisionBitsLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 0 farSingleton singletonOne with
+  | .resourceLimit (.endpoint cost) =>
+      cost.exponentMagnitude == 1000000000 &&
+        !cost.allowed precisionLimits.endpoint
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin precisionLimits 0 singletonOne farSingleton with
+  | .resourceLimit (.endpoint cost) =>
+      cost.exponentMagnitude == 1000000000 &&
+        !cost.allowed precisionLimits.endpoint
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin nonCancellingLimits 8 singletonOne singletonShiftInput with
+  | .resourceLimit (.quotient cost) =>
+      cost.conversionShift == 16 && !cost.allowed nonCancellingLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin tightConvertedLimits 0
+      singletonConvertedTemporary singletonOne with
+  | .resourceLimit (.quotient cost) =>
+      cost.converted ==
+        [{ numeratorBits := 2, denominatorBits := 17 },
+          { numeratorBits := 1, denominatorBits := 1 }] &&
+        !cost.allowed tightConvertedLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin tightTemporaryLimits 0 singleton255 singletonOneOver256 with
+  | .resourceLimit (.quotient cost) =>
+      match cost.crossProduct with
+      | some cross =>
+          cross.numeratorBits == 16 &&
+            !cross.allowed tightTemporaryLimits.maxTemporaryBits &&
+            !cost.allowed tightTemporaryLimits
+      | none => false
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin tightQuotientLimits 8 singletonNegOne singletonThree with
+  | .resourceLimit (.quotient cost) =>
+      cost.quotientBits == 10 &&
+        !(cost.quotientBits ≤ tightQuotientLimits.maxTemporaryBits) &&
+        !cost.allowed tightQuotientLimits
+  | _ => false
+
+#guard
+  match Hex.Interval.divWithin tightResultLimits 8 singletonOne singletonThree with
+  | .resourceLimit (.quotient cost) =>
+      cost.predictedResultHeight == 17 && !cost.allowed tightResultLimits
+  | _ => false
+
+private def upperResultLimits : Arithmetic.PrecisionLimits :=
+  { precisionLimits with endpoint.maxEndpointHeight := 17 }
+
+-- The positive lower call passes, then the sign-reflected upper call is the
+-- reported refusal. This pins both-preflights-before-execution ordering.
+#guard
+  match Arithmetic.preflightDiv upperResultLimits (d 1) (d 3) 8,
+      Hex.Interval.divWithin upperResultLimits 8 singletonOne singletonThree with
+  | .ok (.checked lowerCost), .resourceLimit (.quotient upperCost) =>
+      lowerCost.predictedResultHeight == 17 && lowerCost.allowed upperResultLimits &&
+        upperCost.predictedResultHeight == 18 && !upperCost.allowed upperResultLimits
+  | _, _ => false
+
 /-- The supported public view exposes its carried canonicality theorem without
 adding any trust assumption. -/
 theorem publicViewCanonical (interval : Hex.Interval) : interval.view.CutConsistent :=

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -10,7 +10,8 @@ import HexIntervalMathlib
 Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
 ordinary-kernel meaning of every successful intersection, hull, addition,
-subtraction, multiplication, negation, absolute value, and natural power.
+subtraction, multiplication, negation, absolute value, natural power,
+transactional split, reciprocal, and division.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -200,6 +201,29 @@ theorem invImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
     (member : input.Contains x) : result.Contains x⁻¹ :=
   Hex.Interval.inv_mem_invWithin checked member
 
+/-- A successful division has exactly its computed outward-cut or explicit
+whole-line fallback predicate. -/
+theorem divExact {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {precision : Hex.Interval.Precision}
+    {numerator denominator result : Hex.Interval} {x : ℝ}
+    (checked : Hex.Interval.divWithin limits precision numerator denominator =
+      .ready result) :
+    result.Contains x ↔
+      numerator.view.DivContains precision denominator.view x :=
+  Hex.Interval.contains_divWithin checked x
+
+/-- Both source memberships are required by the ordinary-kernel total-division
+image theorem. -/
+theorem divImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {precision : Hex.Interval.Precision}
+    {numerator denominator result : Hex.Interval} {x y : ℝ}
+    (checked : Hex.Interval.divWithin limits precision numerator denominator =
+      .ready result)
+    (numeratorMember : numerator.Contains x)
+    (denominatorMember : denominator.Contains y) :
+    result.Contains (x / y) :=
+  Hex.Interval.div_mem_divWithin checked numeratorMember denominatorMember
+
 /-- info: 'Hex.IntervalMathlib.Conformance.intersectMember' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms intersectMember
@@ -291,5 +315,13 @@ theorem invImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
 /-- info: 'Hex.IntervalMathlib.Conformance.invImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms invImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.divExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms divExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.divImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms divImage
 
 end Hex.IntervalMathlib.Conformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -367,7 +367,7 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
     `HexIntervalMathlib.Multiplication,
     `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
-    `HexIntervalMathlib.Inverse].map Glob.one
+    `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/2026-08-15T13-48-09Z.md
+++ b/progress/2026-08-15T13-48-09Z.md
@@ -1,0 +1,37 @@
+# Checked public interval division
+
+## Accomplished
+
+- Added a checked precision-indexed `Hex.Interval.divWithin` first slice: empty
+  and Lean-total zero cases are exact, two nonzero finite singletons receive
+  direct outward `Dyadic.divAtPrec` cuts, and every other nonempty shape returns
+  the sound whole interval.
+- Kept resource admission internal and transactional by deriving both
+  `preflightDiv` plans before either Core quotient call; callers cannot provide
+  plans or route the operation through an intermediate reciprocal.
+- Proved exact successful computed-cut semantics and a one-way ordinary-kernel
+  real-image theorem that consumes both numerator and denominator membership.
+- Added conformance for all singleton sign combinations, total-zero and fallback
+  policies, actual-result cost bounds, every quotient resource stage,
+  second-call refusal priority, and a wrong-endpoint mutation.
+- Updated public umbrellas, both library SPECs, the central Mathlib SPEC,
+  registration, and the exact proof-only freshness exemption.
+- Built the focused public/conformance targets and the full relevant public/PNT
+  target set; static, release, trust, freshness, Mathlib-free bench, and PNT
+  inventory checks pass.
+
+## Current frontier
+
+- The first public division slice is complete as a direct child of the merged
+  reciprocal operation. It deliberately provides useful bounded output only
+  for two finite singleton inputs.
+
+## Next step
+
+- Obtain independent review and CI on the exact branch edge. A later slice can
+  design bounded nonsingleton quotient images without weakening the current
+  resource or soundness contract.
+
+## Blockers
+
+- None.

--- a/progress/2026-08-15T14-17-18Z.md
+++ b/progress/2026-08-15T14-17-18Z.md
@@ -1,0 +1,29 @@
+# Checked division resource-policy repair
+
+## Accomplished
+
+- Closed the reviewed resource-policy gap by admitting every finite cut from
+  both nonempty division sources before singleton/zero/fallback classification.
+- Preserved empty absorption before source admission and preserved the rule
+  that both direct quotient calls are preflighted before either executes.
+- Added conformance for an oversized zero-touching nonsingleton fallback and
+  for an empty denominator, and documented the independent final
+  `ofRawWithin` retention/comparison gate.
+- Renamed matched singleton payloads to distinguish them from their raw source
+  intervals.
+- Rebuilt the focused division/conformance targets and the full 9,470-job
+  relevant public/PNT target set successfully.
+
+## Current frontier
+
+- The reviewed resource-policy asymmetry is repaired without broadening the
+  deliberately narrow public division result policy.
+
+## Next step
+
+- Replace PR #9286's head, let exact-head CI run, and obtain a fresh independent
+  review of that final edge.
+
+## Blockers
+
+- None.

--- a/progress/2026-08-15T14-32-53Z.md
+++ b/progress/2026-08-15T14-32-53Z.md
@@ -1,0 +1,26 @@
+# Checked division conformance completion
+
+## Accomplished
+
+- Added a division-level negative-precision guard that isolates refusal of the
+  shifted rational rounding temporary while all neighboring cost stages fit.
+- Exhibited a reachable final `ofRawWithin` comparison refusal: both direct
+  quotient preflights for `47 / 3` pass, while outward cuts `15` and `16` have
+  a four-bit exponent-alignment cost rejected by the final zero-shift budget.
+- Corrected the public umbrella to say that direct outward division cuts apply
+  to two nonzero finite singletons.
+- Rebuilt the focused runtime and Mathlib conformance targets successfully.
+
+## Current frontier
+
+- The SPEC claim that division conformance discriminates every resource stage
+  now has direct executable coverage, including final canonical comparison.
+
+## Next step
+
+- Amend PR #9286, replace its exact-head CI run, and obtain a final fresh
+  independent review.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -364,5 +364,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "a311762cafc62e9bbfd16385a2da6cd53639978b",
     "reason": "Additionally registers the supported proof-only HexIntervalMathlib reciprocal-enclosure semantics module on top of the retained multiplication, natural-power, transactional-split, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "f25ec93d933118cf82e3044a4a1ee93f7d150441",
+    "reason": "Additionally registers the supported proof-only HexIntervalMathlib first-slice division-enclosure semantics module on top of the retained reciprocal, multiplication, natural-power, transactional-split, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add checked precision-indexed `Hex.Interval.divWithin` directly over Core `Dyadic.divAtPrec`
- admit every finite cut in both nonempty sources, then preflight both actual quotient calls internally before either executes
- accept no caller plans and allocate no intermediate reciprocal
- prove exact successful computed-cut semantics and a one-way ordinary-kernel real-image theorem consuming both memberships
- add exhaustive first-slice resource/policy/mutation guards and honest supported-surface documentation

## Supported slice

- empty is absorbing before source admission
- singleton-zero numerator or denominator returns `{0}`, following Lean total division, after finite-source admission
- two nonzero finite closed singletons receive direct outward quotient cuts
- every other nonempty pair deliberately returns the whole interval after finite-source admission and without quotient work
- selected cuts independently pass final `ofRawWithin` endpoint-retention and comparison checks

No tightness converse, endpoint attainment, grid optimality, or useful bounded nonsingleton quotient is claimed.

## Verification

- full relevant public/PNT build (9,470 jobs)
- focused runtime and Mathlib conformance targets
- explicit guards for each precision/quotient stage and reachable final comparison refusal
- copyright, line-count, DAG, Phase 4, conformance-target, released-manifest, manual-split, trust-surface, factor-sweep freshness, Mathlib-free bench, and PNT inventory checks

Exact base: `f62dcbb21a3f709866c31162240eb1fa0fc1c25c`
Exact head: `4fd33be4cdaa83cb3058dcf1a225e774196ec10f`