### PR TITLE
feat(interval): add checked outward regularization

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -18,13 +18,14 @@ data, propagation search, and replayable derivations.
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
-maximum, absolute value, natural power, and transactional splitting at a
-dyadic cut. The arithmetic resource layer preflights product growth,
-direct-power retained growth, exponent work, and rational-backed
-precision/quotient work independently of exact comparison work. The reciprocal
-operation is a precision-indexed connected outward enclosure. Division exposes
-direct outward cuts for two nonzero finite singletons, exact empty and total-zero
-cases, and a sound whole-line fallback for every other nonempty shape. Raw cuts
-remain visible as the explicit decoder and inspection boundary; D2 propagation
-and replay experiments still live outside this supported umbrella.
+maximum, absolute value, natural power, outward regularization, and
+transactional splitting at a dyadic cut. The arithmetic resource layer
+preflights product growth, direct-power retained growth, exponent work,
+rational-backed precision/quotient work, and Core directed-rounding work
+independently of exact comparison work. The reciprocal operation is a
+precision-indexed connected outward enclosure. Division exposes direct outward
+cuts for two nonzero finite singletons, exact empty and total-zero cases, and a
+sound whole-line fallback for every other nonempty shape. Raw cuts remain
+visible as the explicit decoder and inspection boundary; D2 propagation and
+replay experiments still live outside this supported umbrella.
 -/

--- a/HexInterval/Arithmetic.lean
+++ b/HexInterval/Arithmetic.lean
@@ -68,13 +68,13 @@ def allowed (limits : PowLimits) (work : PowWork) : Bool :=
 
 end PowWork
 
-/-! ## Precision-indexed rational conversion -/
+/-! ## Precision-indexed arithmetic -/
 
 /-- Limits needed before entering Core's rational-backed dyadic reciprocal or
-division. Retained endpoints and aggregate conversion shifts keep their
-existing meanings. Precision encoding and temporary rational integers have
-separate bounds rather than being disguised as endpoint height or comparison
-cost. -/
+division and directed dyadic rounding. Retained endpoints and aggregate
+conversion/rounding shifts keep their existing meanings. Precision encoding
+and temporary integer sizes have separate bounds rather than being disguised
+as endpoint height or comparison cost. -/
 structure PrecisionLimits where
   endpoint : EndpointLimit
   maxPrecisionMagnitude : Nat
@@ -102,6 +102,116 @@ def allowed (limits : PrecisionLimits) (cost : PrecisionCost) : Bool :=
     cost.magnitude ≤ limits.maxPrecisionMagnitude
 
 end PrecisionCost
+
+/-! ## Directed-rounding resources -/
+
+/-- Conservative pre-allocation record for one nonzero Core dyadic rounding.
+
+`shiftBound` bounds the signed subtraction of the source exponent and requested
+precision without assuming cancellation. `temporaryBits` bounds the shifted
+integer passed to `Dyadic.ofIntWithPrec`. The predicted result fields bound the
+canonical endpoint after trailing-zero removal. -/
+structure RoundCost where
+  source : EndpointCost
+  shiftBound : Nat
+  temporaryBits : Nat
+  predictedNumeratorBits : Nat
+  predictedExponentMagnitude : Nat
+  predictedResultHeight : Nat
+  deriving DecidableEq, Repr
+
+namespace RoundCost
+
+/-- Derive a rounding bound from the exact source and already-authenticated
+precision. This computes metadata only; it does not call Core rounding. -/
+def ofDyadic (value : Dyadic) (precision : Precision)
+    (precisionCost : PrecisionCost) : RoundCost :=
+  let source := EndpointCost.ofDyadic value
+  match value with
+  | .zero =>
+      { source
+        shiftBound := 0
+        temporaryBits := 0
+        predictedNumeratorBits := 0
+        predictedExponentMagnitude := 0
+        predictedResultHeight := 0 }
+  | .ofOdd _ exponent _ =>
+      let unchanged := exponent ≤ precision
+      let temporaryBits := if exponent < precision then 0 else source.numeratorBits
+      let predictedNumeratorBits := source.numeratorBits
+      let predictedExponentMagnitude :=
+        if unchanged then source.exponentMagnitude
+        else precisionCost.magnitude + source.numeratorBits
+      { source
+        shiftBound := source.exponentMagnitude + precisionCost.magnitude
+        temporaryBits
+        predictedNumeratorBits
+        predictedExponentMagnitude
+        predictedResultHeight := predictedNumeratorBits + predictedExponentMagnitude }
+
+/-- Admit retained source size, exponent/precision subtraction, integer
+temporary, and conservative canonical result height. -/
+def allowed (limits : PrecisionLimits) (cost : RoundCost) : Bool :=
+  cost.source.allowed limits.endpoint &&
+    cost.shiftBound ≤ limits.endpoint.maxAlignmentShift &&
+    cost.temporaryBits ≤ limits.maxTemporaryBits &&
+    cost.predictedResultHeight ≤ limits.endpoint.maxEndpointHeight
+
+end RoundCost
+
+/-- Complete resource record for regularizing both finite interval cuts. A
+missing side is unbounded or zero and performs no Core rounding work.
+`finalAlignmentBound` conservatively bounds the comparison used to seal the
+two rounded cuts. -/
+structure RegularizeCost where
+  precision : PrecisionCost
+  lower : Option RoundCost
+  upper : Option RoundCost
+  finalAlignmentBound : Nat
+  deriving DecidableEq, Repr
+
+namespace RegularizeCost
+
+private def ofLower (precision : Precision) (precisionCost : PrecisionCost) :
+    Lower → Option RoundCost
+  | .unbounded | .finite .zero _ => none
+  | .finite value _ => some (RoundCost.ofDyadic value precision precisionCost)
+
+private def ofUpper (precision : Precision) (precisionCost : PrecisionCost) :
+    Upper → Option RoundCost
+  | .unbounded | .finite .zero _ => none
+  | .finite value _ => some (RoundCost.ofDyadic value precision precisionCost)
+
+/-- Build the interval-wide rounding record after source and precision
+admission. -/
+def ofCuts (lower : Lower) (upper : Upper) (precision : Precision)
+    (precisionCost : PrecisionCost) : RegularizeCost :=
+  let lowerCost := ofLower precision precisionCost lower
+  let upperCost := ofUpper precision precisionCost upper
+  let lowerExponent := lowerCost.map (·.predictedExponentMagnitude) |>.getD 0
+  let upperExponent := upperCost.map (·.predictedExponentMagnitude) |>.getD 0
+  { precision := precisionCost
+    lower := lowerCost
+    upper := upperCost
+    finalAlignmentBound := lowerExponent + upperExponent }
+
+/-- Admit all endpoint-local rounding bounds and the final rounded-cut
+alignment. -/
+def allowed (limits : PrecisionLimits) (cost : RegularizeCost) : Bool :=
+  cost.precision.allowed limits &&
+    cost.lower.all (RoundCost.allowed limits) &&
+    cost.upper.all (RoundCost.allowed limits) &&
+    cost.finalAlignmentBound ≤ limits.endpoint.maxAlignmentShift
+
+end RegularizeCost
+
+/-- Successful regularization preflight. `unchanged` covers shapes containing
+no nonzero finite endpoint, for which Core rounding does not inspect the
+precision. -/
+inductive RegularizePlan where
+  | unchanged
+  | checked (cost : RegularizeCost)
+  deriving DecidableEq, Repr
 
 /-- Conservative bit bounds for the numerator and denominator of a rational
 temporary. These are integer bit lengths, not retained dyadic endpoint data. -/
@@ -164,9 +274,10 @@ inductive QuotientPlan where
   deriving DecidableEq, Repr
 
 /-- Resource diagnostics for checked public arithmetic. Product growth,
-direct-power work, precision requests, and rational-backed quotient work are
-separate cases from endpoint and comparison work; none can be inferred
-honestly from the cost of comparing already-admitted endpoints. -/
+direct-power work, precision requests, rational-backed quotient work, and
+directed regularization work are separate cases from endpoint and comparison
+work; none can be inferred honestly from the cost of comparing already-admitted
+endpoints. -/
 inductive Cost where
   | endpoint (cost : EndpointCost)
   | comparison (cost : CompareCost)
@@ -174,6 +285,7 @@ inductive Cost where
   | power (work : PowWork)
   | precision (cost : PrecisionCost)
   | quotient (cost : QuotientCost)
+  | regularization (cost : RegularizeCost)
   deriving DecidableEq, Repr
 
 /-- Result type for public arithmetic whose work is not described by
@@ -298,6 +410,46 @@ def admitPrecision (limits : PrecisionLimits) (precision : Precision) :
   let cost := PrecisionCost.ofPrecision precision
   if !cost.allowed limits then throw (.precision cost)
   pure cost
+
+private def needsLowerRound : Lower → Bool
+  | .unbounded | .finite .zero _ => false
+  | .finite (.ofOdd _ _ _) _ => true
+
+private def needsUpperRound : Upper → Bool
+  | .unbounded | .finite .zero _ => false
+  | .finite (.ofOdd _ _ _) _ => true
+
+private def admitLower (limits : PrecisionLimits) : Lower → Except Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => do
+      let _ ← admitEndpoint limits value
+      pure ()
+
+private def admitUpper (limits : PrecisionLimits) : Upper → Except Cost Unit
+  | .unbounded => pure ()
+  | .finite value _ => do
+      let _ ← admitEndpoint limits value
+      pure ()
+
+/-- Preflight Core `Dyadic.roundDown` / `roundUp` for every finite nonzero cut
+before either is evaluated. A shape with no nonzero finite endpoint preserves
+its cuts without inspecting the requested precision. For a real rounding path,
+all retained sources precede precision, rounding temporary/result bounds, and
+the final rounded-cut alignment. -/
+def preflightRegularize (limits : PrecisionLimits) (raw : Raw)
+    (precision : Precision) : Except Cost RegularizePlan := do
+  match raw with
+  | .empty => pure .unchanged
+  | .bounds lower upper =>
+      if !(needsLowerRound lower || needsUpperRound upper) then
+        pure .unchanged
+      else
+        admitLower limits lower
+        admitUpper limits upper
+        let precisionCost ← admitPrecision limits precision
+        let cost := RegularizeCost.ofCuts lower upper precision precisionCost
+        if !cost.allowed limits then throw (.regularization cost)
+        pure (.checked cost)
 
 namespace QuotientCost
 

--- a/HexInterval/Interval.lean
+++ b/HexInterval/Interval.lean
@@ -15,7 +15,8 @@ public section
 
 This module begins the supported arithmetic surface with exact intersection,
 hull, negation, addition, subtraction, minimum, maximum, absolute value,
-natural power, and splitting. The operations retain a resource-aware result:
+natural power, outward regularization, and splitting. The operations retain a
+resource-aware result:
 public interval values do not remember the construction budget under which
 their endpoints were admitted, so a later comparison must preflight its own
 alignment work. Resource-checked multiplication is kept in
@@ -263,6 +264,37 @@ this decoder-level helper. -/
         powCutsUnchecked raw exponent
       else
         powCutsUnchecked raw.absUnchecked exponent
+
+/-! ## Directed outward regularization -/
+
+/-- Round one finite lower cut down. A moved endpoint becomes strict because
+the new grid point lies strictly below the source endpoint; an unchanged grid
+point inherits source attainment. Resource admission belongs to the public
+wrapper. -/
+@[expose] def regularizeLowerUnchecked (precision : Precision) : Lower → Lower
+  | .unbounded => .unbounded
+  | .finite value strict =>
+      let rounded := value.roundDown precision
+      .finite rounded (if rounded = value then strict else true)
+
+/-- Round one finite upper cut up. A moved endpoint becomes strict because the
+new grid point lies strictly above the source endpoint; an unchanged grid
+point inherits source attainment. Resource admission belongs to the public
+wrapper. -/
+@[expose] def regularizeUpperUnchecked (precision : Precision) : Upper → Upper
+  | .unbounded => .unbounded
+  | .finite value strict =>
+      let rounded := value.roundUp precision
+      .finite rounded (if rounded = value then strict else true)
+
+/-- Direct outward dyadic-grid view. Empty and unbounded sides are preserved;
+finite lower cuts use Core `roundDown` and finite upper cuts use Core
+`roundUp`. -/
+@[expose] def regularizeUnchecked : Raw → Precision → Raw
+  | .empty, _ => .empty
+  | .bounds lower upper, precision =>
+      .bounds (regularizeLowerUnchecked precision lower)
+        (regularizeUpperUnchecked precision upper)
 
 /-- Direct raw subtraction agrees with addition after raw negation. The
 checked public operation uses the direct form so it can preflight only the two
@@ -815,6 +847,39 @@ theorem view_powWithin_ready {endpointLimit : EndpointLimit}
   · contradiction
   · cases hraw : ofRawWithin endpointLimit
         (Raw.powUnchecked input.view exponent) with
+    | ready interval =>
+        simp only [Arithmetic.Result.ofBuild, hraw] at h
+        cases h
+        exact view_ofRawWithin_ready hraw
+    | resourceLimit cost =>
+        simp [Arithmetic.Result.ofBuild, hraw] at h
+
+/-- Outward regularization on the requested dyadic grid. Every nonzero finite
+source, requested precision, Core rounding temporary/result, and the final
+rounded-cut alignment is preflighted before either endpoint is rounded. A
+shape with no nonzero finite endpoint does not inspect the requested
+precision. -/
+def regularizeWithin (limits : Arithmetic.PrecisionLimits)
+    (precision : Precision) (input : Hex.Interval) : Arithmetic.Result :=
+  match Arithmetic.preflightRegularize limits input.view precision with
+  | .error cost => .resourceLimit cost
+  | .ok _ =>
+      Arithmetic.Result.ofBuild
+        (ofRawWithin limits.endpoint
+          (Raw.regularizeUnchecked input.view precision))
+
+/-- A successful regularization exposes exactly the normalized direct rounded
+cuts. -/
+theorem view_regularizeWithin_ready {limits : Arithmetic.PrecisionLimits}
+    {input result : Hex.Interval} {precision : Precision}
+    (h : regularizeWithin limits precision input = .ready result) :
+    result.view =
+      (Raw.regularizeUnchecked input.view precision).normalizeUnchecked := by
+  unfold regularizeWithin at h
+  split at h
+  · contradiction
+  · cases hraw : ofRawWithin limits.endpoint
+        (Raw.regularizeUnchecked input.view precision) with
     | ready interval =>
         simp only [Arithmetic.Result.ofBuild, hraw] at h
         cases h

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -183,7 +183,8 @@ The initial supported slice exposes `view`, `empty`, `whole`, and endpoint-cost
 preflighted raw, singleton, one-sided, and finite constructors. The first
 supported operations are resource-checked intersection, hull, negation,
 addition, subtraction, multiplication, minimum, maximum, absolute value,
-natural power, and transactional splitting at a dyadic point.
+natural power, outward regularization, and transactional splitting at a dyadic
+point.
 Their Mathlib companion proves exact computed-cut semantics and image theorems;
 the remaining arithmetic is promoted separately rather than being declared
 public merely because narrower experiment implementations exist. All public
@@ -212,7 +213,10 @@ does not claim a converse characterization of every result member as an
 absolute-value image. Successful `powWithin` exposes its exact normalized
 direct cuts for exponent zero, positive odd powers, and positive even powers,
 and maps every input member to its real natural power. It likewise makes no
-set-image converse claim. Neither addition nor subtraction currently claims the
+set-image converse claim. Successful `regularizeWithin` exposes the exact
+normalized Core-rounded cuts and contains every member of its source. Repeating
+the raw cut transform at the same precision is idempotent; no global
+grid-tightest claim is made. Neither addition nor subtraction currently claims the
 separate representation-independent tightness converse for the real Minkowski
 image.
 Separately, the experiment form of the intersection theorem is installed as the
@@ -438,6 +442,8 @@ def maxWithin       : EndpointLimit → Interval → Interval → BuildResult
 def absWithin       : EndpointLimit → Interval → BuildResult
 def mulWithin       : EndpointLimit → Interval → Interval → Arithmetic.Result
 def powWithin       : EndpointLimit → Arithmetic.PowLimits → Interval → Nat →
+  Arithmetic.Result
+def regularizeWithin : Arithmetic.PrecisionLimits → Precision → Interval →
   Arithmetic.Result
 def splitWithin     : EndpointLimit → Interval → Dyadic → SplitResult
 ```
@@ -689,12 +695,27 @@ for Lean's total real division. No converse image theorem, rounded-cut
 attainment, grid optimality, useful bounded nonsingleton quotient, or
 disconnected-result precision is claimed.
 
+The same `PrecisionLimits` also supports public outward regularization, but a
+rational-quotient cost would be fictitious for Core `roundDown` / `roundUp`.
+`Arithmetic.RegularizeCost` instead records each nonzero finite source, a
+non-cancelling bound for the exponent/precision subtraction, the shifted
+integer temporary, conservative canonical result height, and a final two-cut
+alignment bound. `preflightRegularize` admits all finite sources before the
+precision and every rounding bound before either Core operation executes.
+A shape with no nonzero finite endpoint performs no nontrivial rounding work
+and does not inspect the requested precision. `regularizeWithin` then rounds
+lower cuts down and upper cuts up and seals the resulting pair. A moved
+endpoint is strict because it lies strictly outside the old cut; an unchanged
+endpoint inherits its source strictness. Refusal remains an
+`Arithmetic.Result.resourceLimit`, with the dedicated `Cost.regularization`
+diagnostic rather than a fabricated quotient or comparison.
+
 The public raw intersection and hull cut selectors, `intersectUnchecked`,
 `hullUnchecked`, `negUnchecked`, `addUnchecked`, `subUnchecked`, `minUnchecked`,
 `maxUnchecked`, `absUnchecked`, `powCutsUnchecked`, `powUnchecked`, and
 `mulUnchecked`, together with `splitUnchecked`, `invUnchecked`,
-`singletonValue?`, and `divUnchecked`, are related to the checked operations by
-successful-result and semantic theorems.
+`singletonValue?`, `divUnchecked`, and `regularizeUnchecked`, are related to
+the checked operations by successful-result and semantic theorems.
 `powCutsUnchecked` is
 only the strictly monotone cut mapper;
 its caller must establish the positive odd or nonnegative positive-exponent
@@ -704,9 +725,9 @@ are decoder-level combinators: untrusted callers use the checked `Interval`
 operations above.
 
 The remaining target surface includes useful bounded nonsingleton division and
-regularization. Its public signatures and resource policy are fixed only after
-the corresponding allocation audit; no operation may silently align, compare,
-or enlarge arbitrary-precision endpoints.
+other arithmetic images. Their public signatures and resource policies are
+fixed only after the corresponding allocation audits; no operation may
+silently align, compare, or enlarge arbitrary-precision endpoints.
 
 For the initial dyadic backend, `Precision` is an alias for signed `Int` and
 the implementation reuses core `Dyadic.roundDown`, `roundUp`, `invAtPrec`, and
@@ -824,18 +845,21 @@ using a tighter theorem.
 
 ### Outward regularization
 
-`regularize p I` widens finite endpoints onto the grid `2^-p · ℤ`. It rounds a
-lower endpoint down and an upper endpoint up. It never
-replaces the strongest fact in the solver. Instead, it creates a cheaper view
-that a later rule may use.
+`regularizeWithin limits p I` widens finite endpoints onto the grid
+`2^-p · ℤ`. It rounds a lower endpoint down and an upper endpoint up. It never
+replaces the strongest fact in the solver. Instead, it creates a coarser
+outward view that a later rule may use. This is not necessarily cheaper to
+store: coarse negative precision can raise retained endpoint height, and that
+predicted result growth is preflighted before rounding.
 
 If an endpoint moves, the regularized cut is strict: a moved lower endpoint
 is strictly below the old lower endpoint, and a moved upper endpoint is
 strictly above the old upper endpoint. An unchanged endpoint inherits its old
 strictness. This is the candidate strongest sound outward view and makes
 regularization idempotent without throwing away useful strict inequalities;
-the same rounding-characterization lemmas used for grid-tightness must certify
-both claims.
+Core's one-sided rounding inequalities prove containment and its precision and
+fixed-point lemmas prove raw-cut idempotence. The missing converse optimality
+lemmas still prevent a global grid-tightest theorem.
 
 This distinction matters. Exact dyadic numerators can still grow rapidly.
 Discarding a strong fact to shorten it would make the state order-dependent.
@@ -4219,19 +4243,20 @@ their declared cost inside a scheduler bound.
   normalization.
 - `HexInterval/Canonical.lean`: sealed canonical values, views, and
   resource-safe smart constructors.
-- `HexInterval/Arithmetic.lean`: multiplication growth plus direct-power
-  retained-growth and exponent-work prerequisites; it does not expose an
-  interval operation.
+- `HexInterval/Arithmetic.lean`: multiplication growth, direct-power
+  retained-growth and exponent-work prerequisites, rational-backed precision
+  prerequisites, and the dedicated regularization preflight metadata; it does
+  not expose an interval operation.
 - `HexInterval/Multiplication.lean`: resource-checked interval multiplication,
   unconditional extended-corner evaluation, attainment-aware extremum
   selection, and the sealed `mulWithin` entry point.
 - `HexInterval/Interval.lean`: supported resource-safe intersection, hull,
   negation, addition, subtraction, minimum, maximum, absolute value, and
-  natural power; transactional splitting; and checked precision-indexed
-  reciprocal and first-slice division. Its public raw helpers, including the
-  power, split, reciprocal, and division cut selectors, are decoder-level
-  counterparts of checked operations. Useful bounded nonsingleton division and
-  regularization remain future work.
+  natural power; outward regularization; transactional splitting; and checked
+  precision-indexed reciprocal and first-slice division. Its public raw
+  helpers, including the power, regularization, split, reciprocal, and division
+  cut selectors, are decoder-level counterparts of checked operations. Useful
+  bounded nonsingleton division remains future work.
 - `HexIntervalMathlib/Interval.lean`: real-set semantics for the supported
   public construction, intersection, hull, and negation operations.
 - `HexIntervalMathlib/Addition.lean`: exact summed-cut semantics and the
@@ -4254,6 +4279,8 @@ their declared cost inside a scheduler bound.
   and the one-way total-real-inverse connected-hull enclosure theorem.
 - `HexIntervalMathlib/Division.lean`: exact computed first-slice quotient-cut
   semantics and the one-way total-real-division enclosure theorem.
+- `HexIntervalMathlib/Regularize.lean`: exact normalized rounded-cut semantics,
+  outward containment, and raw-cut idempotence without a grid-tightest claim.
 - `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
 - `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
 - `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
@@ -4300,7 +4327,7 @@ typical, boundary, and adversarial inputs. In particular it includes:
   `0 / 1`, and rejection of zero denominators, noncoprime equivalent
   encodings, unused oversized entries, excessive projection shifts, and
   one-step-over-budget cross-products before allocation;
-- regularization idempotence, outward containment, moved closed cuts, and
+- regularization idempotence, outward containment, moved strict cuts, and
   exact-grid open cuts;
 - a dependency worklist in which one fact wakes only the affected consumers;
 - opaque unary chains, fan-out with a ternary join, and forward/backward rule

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -17,6 +17,7 @@ public import HexIntervalMathlib.Power
 public import HexIntervalMathlib.Split
 public import HexIntervalMathlib.Inverse
 public import HexIntervalMathlib.Division
+public import HexIntervalMathlib.Regularize
 
 public section
 
@@ -24,6 +25,7 @@ public section
 `HexIntervalMathlib` supplies Mathlib semantics and proof-facing theorems for
 the supported `Hex.Interval` operations, including resource-checked addition,
 subtraction, and multiplication, exact minimum/maximum images, absolute value,
-natural power, closed-left/strict-right transactional splitting, and
-precision-indexed reciprocal and division enclosures.
+natural power, outward regularization, and closed-left/strict-right
+transactional splitting, plus precision-indexed reciprocal and division
+enclosures.
 -/

--- a/HexIntervalMathlib/Regularize.lean
+++ b/HexIntervalMathlib/Regularize.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Interval
+
+@[expose] public section
+
+/-!
+# Exact semantics of checked outward regularization
+
+Finite lower cuts use Core `Dyadic.roundDown`; finite upper cuts use
+`Dyadic.roundUp`. A moved endpoint is strict, while an unchanged endpoint
+inherits source attainment. The proofs establish outward containment and
+idempotence of the computed raw cuts. They deliberately do not claim a
+globally tight grid enclosure because Core does not yet provide the converse
+rounding optimality lemmas.
+-/
+
+namespace Hex.Interval
+
+private theorem toReal_le {left right : Dyadic} (h : left ≤ right) :
+    toReal left ≤ toReal right := by
+  exact (Rat.cast_le (K := ℝ)).2 (Dyadic.toRat_le_toRat_iff.2 h)
+
+private theorem lowerContains_regularize (lower : Lower)
+    (precision : Precision) (x : ℝ) :
+    lower.Contains x →
+      (Raw.regularizeLowerUnchecked precision lower).Contains x := by
+  cases lower with
+  | unbounded => simp [Lower.Contains, Raw.regularizeLowerUnchecked]
+  | finite value strict =>
+      intro member
+      by_cases same : value.roundDown precision = value
+      · simpa [Raw.regularizeLowerUnchecked, same, Lower.Contains] using member
+      · have lowerBound : toReal (value.roundDown precision) ≤ toReal value :=
+          toReal_le Dyadic.roundDown_le
+        have moved : toReal (value.roundDown precision) < toReal value :=
+          lt_of_le_of_ne lowerBound fun equal => same (toReal_inj.mp equal)
+        cases strict <;>
+          simp [Raw.regularizeLowerUnchecked, same, Lower.Contains] at member ⊢ <;>
+          linarith
+
+private theorem upperContains_regularize (upper : Upper)
+    (precision : Precision) (x : ℝ) :
+    upper.Contains x →
+      (Raw.regularizeUpperUnchecked precision upper).Contains x := by
+  cases upper with
+  | unbounded => simp [Upper.Contains, Raw.regularizeUpperUnchecked]
+  | finite value strict =>
+      intro member
+      by_cases same : value.roundUp precision = value
+      · simpa [Raw.regularizeUpperUnchecked, same, Upper.Contains] using member
+      · have upperBound : toReal value ≤ toReal (value.roundUp precision) :=
+          toReal_le Dyadic.le_roundUp
+        have moved : toReal value < toReal (value.roundUp precision) :=
+          lt_of_le_of_ne upperBound fun equal => same (toReal_inj.mp equal.symm)
+        cases strict <;>
+          simp [Raw.regularizeUpperUnchecked, same, Upper.Contains] at member ⊢ <;>
+          linarith
+
+/-- Every member of raw cuts remains in their outward-regularized view. -/
+theorem contains_regularizeUnchecked (raw : Raw) (precision : Precision)
+    (x : ℝ) :
+    raw.Contains x → (raw.regularizeUnchecked precision).Contains x := by
+  cases raw with
+  | empty => simp [Raw.Contains]
+  | bounds lower upper =>
+      rintro ⟨lowerMember, upperMember⟩
+      exact ⟨lowerContains_regularize lower precision x lowerMember,
+        upperContains_regularize upper precision x upperMember⟩
+
+/-- A successful checked regularization has exactly the normalized direct
+rounded-cut membership predicate. -/
+theorem contains_regularizeWithin {limits : Arithmetic.PrecisionLimits}
+    {input result : Hex.Interval} {precision : Precision}
+    (checked : regularizeWithin limits precision input = .ready result)
+    (x : ℝ) :
+    result.Contains x ↔
+      (input.view.regularizeUnchecked precision).Contains x := by
+  simp only [Contains]
+  rw [view_regularizeWithin_ready checked, contains_normalize]
+
+/-- Every source member remains in every successful outward regularization. -/
+theorem mem_regularizeWithin {limits : Arithmetic.PrecisionLimits}
+    {input result : Hex.Interval} {precision : Precision} {x : ℝ}
+    (checked : regularizeWithin limits precision input = .ready result)
+    (member : input.Contains x) : result.Contains x :=
+  (contains_regularizeWithin checked x).2
+    (contains_regularizeUnchecked input.view precision x member)
+
+private theorem roundDown_idem (value : Dyadic) (precision : Precision) :
+    (value.roundDown precision).roundDown precision =
+      value.roundDown precision :=
+  Dyadic.roundDown_eq_self_of_le Dyadic.precision_roundDown
+
+private theorem roundUp_eq_self_of_le {value : Dyadic} {precision : Precision}
+    (h : value.precision ≤ some precision) : value.roundUp precision = value := by
+  rw [Dyadic.roundUp_eq_neg_roundDown_neg,
+    Dyadic.roundDown_eq_self_of_le (by simpa using h)]
+  apply Dyadic.toRat_inj.mp
+  rw [Dyadic.toRat_neg, Dyadic.toRat_neg]
+  exact neg_neg _
+
+private theorem roundUp_idem (value : Dyadic) (precision : Precision) :
+    (value.roundUp precision).roundUp precision = value.roundUp precision :=
+  roundUp_eq_self_of_le Dyadic.precision_roundUp
+
+/-- Repeating the same directed rounding leaves every computed raw cut
+unchanged. This is cut idempotence, not a global grid-optimality claim. -/
+theorem regularizeUnchecked_idem (raw : Raw) (precision : Precision) :
+    (raw.regularizeUnchecked precision).regularizeUnchecked precision =
+      raw.regularizeUnchecked precision := by
+  cases raw with
+  | empty => rfl
+  | bounds lower upper =>
+      cases lower <;> cases upper <;>
+        simp [Raw.regularizeUnchecked, Raw.regularizeLowerUnchecked,
+          Raw.regularizeUpperUnchecked, roundDown_idem, roundUp_idem]
+
+end Hex.Interval

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -21,7 +21,8 @@ and a one-way real-image theorem for checked natural power.
 for transactional splitting. `HexIntervalMathlib.Inverse` proves the computed
 connected-cut characterization and sound total-real-inverse enclosure, while
 `HexIntervalMathlib.Division` proves the computed first-slice quotient cuts and
-sound total-real-division enclosure.
+sound total-real-division enclosure. `HexIntervalMathlib.Regularize` proves
+exact rounded-cut semantics, outward containment, and raw-cut idempotence.
 
 For every successful resource-checked public operation it proves:
 
@@ -65,6 +66,12 @@ For every successful resource-checked public operation it proves:
   for exponent zero, positive odd powers, and positive even powers;
 - `pow_mem_powWithin`: every source member raised to the caller's natural
   exponent belongs to every successful result;
+- `contains_regularizeWithin`: exact membership in the normalized Core-rounded
+  cuts;
+- `contains_regularizeUnchecked` and `mem_regularizeWithin`: every source
+  member remains in the raw and checked outward views;
+- `regularizeUnchecked_idem`: repeating the same requested precision leaves
+  every computed raw cut unchanged, without claiming global grid tightness;
 - `contains_splitWithin_left` and `contains_splitWithin_right`: exact child
   membership as source membership conjoined with `x ≤ point` or `point < x`;
 - `splitWithin_contained`, `splitWithin_cover`, and `splitWithin_disjoint`:
@@ -94,8 +101,8 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. The
 existing modules under `HexIntervalMathlib/Experiment` remain evidence for
 future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Further arithmetic images, regularization, and useful
-bounded nonsingleton division require their own
+are not re-exported here. Further arithmetic images and useful bounded
+nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
@@ -113,6 +120,7 @@ claimed.
 membership, exact hull closure and both input inclusions, negation transport,
 addition, subtraction, and multiplication cut exactness and image transport,
 exact split membership/coverage/disjointness/point ownership, and the exact
+regularization cut semantics/outward containment/idempotence, together with the
 ordinary-kernel axiom surface. It also pins reciprocal computed-cut exactness
 and total-real-inverse enclosure, plus division computed-cut exactness and
 total-real-division enclosure, without tightness converses.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -17,6 +17,8 @@ computed connected outward cuts and a sound pointwise theorem for Lean's total
 inverse, including `0⁻¹ = 0`.
 Division exposes direct outward cuts for two nonzero finite singletons, exact
 empty and total-zero cases, and a sound whole-line fallback otherwise.
+Outward regularization exposes exact Core-rounded cuts, source containment,
+and raw-cut idempotence without claiming a globally grid-tightest enclosure.
 Propagator, provider, replay, and tactic modules remain experiments and are not
 re-exported by the public umbrella. The user-facing tactic contract below is
 the release target, not a claim that the tactic is already supported.
@@ -198,6 +200,19 @@ theorem pow_mem_powWithin
     (h : powWithin limit workLimits I exponent = .ready result) :
     I.Contains x → result.Contains (x ^ exponent)
 
+theorem contains_regularizeWithin
+    (h : regularizeWithin limits precision I = .ready result) :
+    result.Contains x ↔
+      (I.view.regularizeUnchecked precision).Contains x
+
+theorem mem_regularizeWithin
+    (h : regularizeWithin limits precision I = .ready result) :
+    I.Contains x → result.Contains x
+
+theorem regularizeUnchecked_idem :
+    (raw.regularizeUnchecked precision).regularizeUnchecked precision =
+      raw.regularizeUnchecked precision
+
 theorem contains_splitWithin_left
     (h : splitWithin limit I point = .ready left right) :
     left.Contains x ↔ I.Contains x ∧ x ≤ toReal point
@@ -278,6 +293,15 @@ nonempty exponent zero, positive odd, and positive even cases; the even case
 maps the exact absolute-value hull. Neither operation exports an unproved
 set-image converse.
 
+Outward regularization preserves empty and unbounded sides, rounds finite lower
+cuts down and upper cuts up with Core's directed dyadic operations, makes moved
+cuts strict, and inherits strictness at unchanged endpoints. A dedicated
+preflight bounds the exponent/precision subtraction, shifted integer
+temporaries, retained rounded endpoints, and final cut alignment before either
+rounding operation executes. The one-sided Core inequalities prove source
+containment and its fixed-point lemmas prove raw-cut idempotence. The absent
+converse optimality lemmas are why no global grid-tightest theorem is exported.
+
 Transactional splitting returns both sealed children or one resource refusal;
 it cannot expose a partial pair. Empty bypasses point inspection. For a
 nonempty input, the retained point, both finite source/point selectors, and
@@ -317,7 +341,6 @@ theorem mem_mul : x ∈ᵢ I → y ∈ᵢ J → x * y ∈ᵢ mul I J
 theorem mem_invAt : x ∈ᵢ I → x⁻¹ ∈ᵢ invAt p I
 theorem mem_divAt : x ∈ᵢ I → y ∈ᵢ J → x / y ∈ᵢ divAt p I J
 theorem mem_pow : x ∈ᵢ I → x ^ n ∈ᵢ pow I n
-theorem mem_regularize : x ∈ᵢ I → x ∈ᵢ regularize p I
 ```
 
 Proofs cover empty and unbounded inputs directly. They do not infer field laws

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -571,6 +571,128 @@ private def tightTemporaryLimits : Arithmetic.PrecisionLimits where
         | none => false
   | _ => false
 
+/-! # Directed-rounding and regularization resources -/
+
+private def threeQuarters : Dyadic := .ofOdd 3 2 (by decide)
+private def fiveQuarters : Dyadic := .ofOdd 5 2 (by decide)
+
+-- Pin the exact Core operations used by the interval wrapper at positive and
+-- negative requested precision.
+#guard threeQuarters.roundDown 1 == .ofOdd 1 1 (by decide)
+#guard threeQuarters.roundUp 1 == d 1
+#guard threeQuarters.roundDown (-1) == d 0
+#guard threeQuarters.roundUp (-1) == d 2
+#guard (-threeQuarters).roundDown 1 == d (-1)
+#guard (-threeQuarters).roundUp 1 == .ofOdd (-1) 1 (by decide)
+
+private def regularizeLimits : Arithmetic.PrecisionLimits where
+  endpoint := { maxEndpointHeight := 32, maxAlignmentShift := 32 }
+  maxPrecisionMagnitude := 16
+  maxPrecisionBits := 8
+  maxTemporaryBits := 16
+
+private def regularizeRaw : Raw :=
+  .bounds (.finite threeQuarters false) (.finite fiveQuarters false)
+
+-- Both endpoint plans are tied to the same authenticated precision. The
+-- conservative result and final-alignment fields are computed without
+-- invoking either Core rounding function.
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits regularizeRaw 1 with
+  | .ok (.checked cost) =>
+      cost.precision == Arithmetic.PrecisionCost.ofPrecision 1 &&
+        match cost.lower, cost.upper with
+        | some lower, some upper =>
+            lower.source == EndpointCost.ofDyadic threeQuarters &&
+              lower.shiftBound == 3 && lower.temporaryBits == 2 &&
+              lower.predictedResultHeight == 5 &&
+              upper.source == EndpointCost.ofDyadic fiveQuarters &&
+              upper.shiftBound == 3 && upper.temporaryBits == 3 &&
+              upper.predictedResultHeight == 7 &&
+              cost.finalAlignmentBound == 7 && cost.allowed regularizeLimits
+        | _, _ => false
+  | _ => false
+
+-- Shapes with no nonzero finite endpoint execute no rounding and therefore do
+-- not inspect even an otherwise prohibited precision.
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits .empty 1024 with
+  | .ok .unchanged => true
+  | _ => false
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits
+      (.bounds .unbounded .unbounded) 1024 with
+  | .ok .unchanged => true
+  | _ => false
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits
+      (.bounds (.finite 0 false) (.finite 0 false)) 1024 with
+  | .ok .unchanged => true
+  | _ => false
+
+-- Retained sources precede precision; a genuine nonzero rounding request then
+-- refuses excessive precision before shift/result metadata is constructed.
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits
+      (.bounds (.finite oversizedSource false) .unbounded) 1024 with
+  | .error (.endpoint cost) => cost == EndpointCost.ofDyadic oversizedSource
+  | _ => false
+
+#guard
+  match Arithmetic.preflightRegularize regularizeLimits regularizeRaw 1024 with
+  | .error (.precision cost) =>
+      cost.magnitude == 1024 && cost.encodedBits == 11 &&
+        !cost.allowed regularizeLimits
+  | _ => false
+
+private def tightRoundTemporary : Arithmetic.PrecisionLimits :=
+  { regularizeLimits with maxTemporaryBits := 4 }
+
+#guard
+  match Arithmetic.preflightRegularize tightRoundTemporary
+      (.bounds (.finite (d 31) false) (.finite (d 31) false)) (-1) with
+  | .error (.regularization cost) =>
+      match cost.lower with
+      | some lower =>
+          lower.temporaryBits == 5 &&
+            !(lower.temporaryBits ≤ tightRoundTemporary.maxTemporaryBits) &&
+            !cost.allowed tightRoundTemporary
+      | none => false
+  | _ => false
+
+private def tightRoundResult : Arithmetic.PrecisionLimits :=
+  { regularizeLimits with
+    endpoint := { maxEndpointHeight := 8, maxAlignmentShift := 32 } }
+
+#guard
+  match Arithmetic.preflightRegularize tightRoundResult
+      (.bounds (.finite threeQuarters false)
+        (.finite threeQuarters false)) (-5) with
+  | .error (.regularization cost) =>
+      match cost.lower with
+      | some lower =>
+          lower.predictedNumeratorBits == 2 &&
+            lower.predictedExponentMagnitude == 7 &&
+            lower.predictedResultHeight == 9 &&
+            !cost.allowed tightRoundResult
+      | none => false
+  | _ => false
+
+private def tightRoundAlignment : Arithmetic.PrecisionLimits :=
+  { regularizeLimits with
+    endpoint := { maxEndpointHeight := 32, maxAlignmentShift := 6 } }
+
+-- Both endpoint-local subtraction bounds fit, but the separately predicted
+-- final rounded-cut comparison does not.
+#guard
+  match Arithmetic.preflightRegularize tightRoundAlignment regularizeRaw 1 with
+  | .error (.regularization cost) =>
+      cost.lower.all (fun lower => lower.shiftBound ≤ 6) &&
+        cost.upper.all (fun upper => upper.shiftBound ≤ 6) &&
+        cost.finalAlignmentBound == 7 &&
+        !cost.allowed tightRoundAlignment
+  | _ => false
+
 private def ready (raw : Raw) : Hex.Interval :=
   match Hex.Interval.ofRawWithin smallLimit raw with
   | .ready interval => interval
@@ -622,6 +744,15 @@ private def singletonThree : Hex.Interval := ready (finite 3 false 3 false)
 private def atMostNegOne : Hex.Interval :=
   ready (.bounds .unbounded (.finite (d (-1)) false))
 private def half : Dyadic := .ofOdd 1 1 (by decide)
+
+-- Pin the strict `<` boundary in the Core-rounding temporary model: matching
+-- the source precision still retains its numerator, while a strictly coarser
+-- source than the requested precision needs no shifted temporary.
+#guard (Arithmetic.RoundCost.ofDyadic half 1
+    (Arithmetic.PrecisionCost.ofPrecision 1)).temporaryBits == 1
+#guard (Arithmetic.RoundCost.ofDyadic half 2
+    (Arithmetic.PrecisionCost.ofPrecision 2)).temporaryBits == 0
+
 private def singletonHalf : Hex.Interval :=
   ready (.bounds (.finite half false) (.finite half false))
 private def twoPow100 : Dyadic := .ofOdd 1 (-100) (by decide)
@@ -640,6 +771,27 @@ private def powerBand : Hex.Interval :=
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
 
+private def regularizeBand : Hex.Interval :=
+  ready (.bounds (.finite threeQuarters false) (.finite fiveQuarters false))
+
+private def regularizeInherited : Hex.Interval :=
+  ready (.bounds (.finite half true) (.finite fiveQuarters false))
+
+private def regularizeClosedInherited : Hex.Interval :=
+  ready (.bounds (.finite half false) (.finite fiveQuarters false))
+
+private def regularizeAtMost : Hex.Interval :=
+  ready (.bounds .unbounded (.finite fiveQuarters false))
+
+private def regularizeAtLeast : Hex.Interval :=
+  ready (.bounds (.finite threeQuarters false) .unbounded)
+
+private def regularize31 : Hex.Interval :=
+  ready (.bounds (.finite (d 31) false) (.finite (d 31) false))
+
+private def regularizeThreeQuarters : Hex.Interval :=
+  ready (.bounds (.finite threeQuarters false) (.finite threeQuarters false))
+
 private def absFar : Dyadic := .ofOdd 1 200 (by decide)
 
 private def absCrossFar : Hex.Interval :=
@@ -648,6 +800,94 @@ private def absCrossFar : Hex.Interval :=
       (-absFar) false (d 1) false with
   | .ready interval => interval
   | .resourceLimit _ => Hex.Interval.empty
+
+-- Public regularization uses the same Core values pinned above. Moved cuts are
+-- strict; an unchanged cut inherits source strictness.
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1 regularizeBand with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (.ofOdd 1 1 (by decide)) true)
+        (.finite (.ofOdd 3 1 (by decide)) true)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits (-1) regularizeBand with
+  | .ready interval => interval.view == finite 0 true 2 true
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1 regularizeInherited with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (.ofOdd 1 1 (by decide)) true)
+        (.finite (.ofOdd 3 1 (by decide)) true)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits
+      1 regularizeClosedInherited with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (.ofOdd 1 1 (by decide)) false)
+        (.finite (.ofOdd 3 1 (by decide)) true)
+  | .resourceLimit _ => false
+
+-- Shapes with no nonzero finite endpoint preserve their exact structure and
+-- do not inspect an otherwise oversized precision. One-sided shapes still
+-- regularize their single nonzero finite endpoint.
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1024 Hex.Interval.empty with
+  | .ready interval => interval == Hex.Interval.empty
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1024 Hex.Interval.whole with
+  | .ready interval => interval == Hex.Interval.whole
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1024 singletonZero with
+  | .ready interval => interval == singletonZero
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1 regularizeAtMost with
+  | .ready interval =>
+      interval.view == .bounds .unbounded
+        (.finite (.ofOdd 3 1 (by decide)) true)
+  | .resourceLimit _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1 regularizeAtLeast with
+  | .ready interval =>
+      interval.view == .bounds
+        (.finite (.ofOdd 1 1 (by decide)) true) .unbounded
+  | .resourceLimit _ => false
+
+-- Public refusal retains the preflight chronology and dedicated cost shape.
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 0 farSingleton with
+  | .resourceLimit (.endpoint cost) => cost.exponentMagnitude == 1000000000
+  | _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin regularizeLimits 1024 regularizeBand with
+  | .resourceLimit (.precision cost) => cost.magnitude == 1024
+  | _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin tightRoundTemporary (-1) regularize31 with
+  | .resourceLimit (.regularization cost) =>
+      cost.lower.any (fun lower => lower.temporaryBits == 5)
+  | _ => false
+
+#guard
+  match Hex.Interval.regularizeWithin tightRoundResult
+      (-5) regularizeThreeQuarters with
+  | .resourceLimit (.regularization cost) =>
+      cost.lower.any (fun lower => lower.predictedResultHeight == 9)
+  | _ => false
 
 -- Checked splitting is transactional: success carries both canonical
 -- children, with the point closed on the left and strict on the right.

--- a/conformance/HexIntervalMathlib/IntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/IntervalConformance.lean
@@ -11,7 +11,7 @@ Conformance checks for the supported public interval semantics.  Computational
 shape/resource cases live in `HexInterval.Conformance`; this companion pins the
 ordinary-kernel meaning of every successful intersection, hull, addition,
 subtraction, multiplication, negation, absolute value, natural power,
-transactional split, reciprocal, and division.
+regularization, transactional split, reciprocal, and division.
 -/
 
 namespace Hex.IntervalMathlib.Conformance
@@ -144,6 +144,31 @@ theorem powImage {limit : Hex.Interval.EndpointLimit}
       .ready result)
     (member : input.Contains x) : result.Contains (x ^ exponent) :=
   Hex.Interval.pow_mem_powWithin checked member
+
+/-- A successful regularization has exactly its normalized direct rounded-cut
+semantics. -/
+theorem regularizeExact {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {input result : Hex.Interval} {precision : Hex.Interval.Precision} {x : ℝ}
+    (checked : Hex.Interval.regularizeWithin limits precision input =
+      .ready result) :
+    result.Contains x ↔
+      (input.view.regularizeUnchecked precision).Contains x :=
+  Hex.Interval.contains_regularizeWithin checked x
+
+/-- Source membership is consumed by the outward-containment theorem. -/
+theorem regularizeImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
+    {input result : Hex.Interval} {precision : Hex.Interval.Precision} {x : ℝ}
+    (checked : Hex.Interval.regularizeWithin limits precision input =
+      .ready result)
+    (member : input.Contains x) : result.Contains x :=
+  Hex.Interval.mem_regularizeWithin checked member
+
+/-- Repeating a requested precision leaves the computed raw cuts unchanged. -/
+theorem regularizeIdem (raw : Hex.Interval.Raw)
+    (precision : Hex.Interval.Precision) :
+    (raw.regularizeUnchecked precision).regularizeUnchecked precision =
+      raw.regularizeUnchecked precision :=
+  Hex.Interval.regularizeUnchecked_idem raw precision
 
 /-- Successful splitting has exact closed-left membership. -/
 theorem splitLeft {limit : Hex.Interval.EndpointLimit}
@@ -287,6 +312,18 @@ theorem divImage {limits : Hex.Interval.Arithmetic.PrecisionLimits}
 /-- info: 'Hex.IntervalMathlib.Conformance.powImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms powImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.regularizeExact' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms regularizeExact
+
+/-- info: 'Hex.IntervalMathlib.Conformance.regularizeImage' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms regularizeImage
+
+/-- info: 'Hex.IntervalMathlib.Conformance.regularizeIdem' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms regularizeIdem
 
 /-- info: 'Hex.IntervalMathlib.Conformance.splitLeft' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -367,7 +367,8 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.MinMax, `HexIntervalMathlib.Absolute,
     `HexIntervalMathlib.Multiplication,
     `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
-    `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division].map Glob.one
+    `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division,
+    `HexIntervalMathlib.Regularize].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"

--- a/progress/2026-08-15T14-56-01Z.md
+++ b/progress/2026-08-15T14-56-01Z.md
@@ -1,0 +1,42 @@
+# Accomplished
+
+- Replayed checked outward regularization directly onto exact merged division
+  base `a5846a0ea31d69e59f46364312bbca95b0af6c56`, preserving reciprocal,
+  division, multiplication, power, split, and PNT registrations.
+- Re-audited `preflightRegularize`: every retained finite source precedes
+  precision admission, both endpoint-local temporary/result bounds and the
+  final cut-alignment bound precede either Core directed-rounding call, and
+  refusal remains distinct from empty.
+- Revalidated empty, whole, zero, and independently unbounded behavior;
+  positive and negative precisions; moved strict cuts; unchanged strict and
+  closed cuts; and source, precision, temporary, result, and final-alignment
+  refusals.
+- Revalidated exact `roundDown`/`roundUp` correspondence, normalized
+  computed-cut semantics, outward real containment, raw-cut idempotence, and
+  the explicit absence of a grid-tightest claim.
+- Ordered the public operation as `regularizeWithin limits precision input`,
+  matching the other checked unary arithmetic entry points, and pinned the
+  strict temporary-work boundary for `1/2` at precisions one and two.
+- Documented precisely that only shapes with no nonzero finite endpoint skip
+  precision inspection, and that coarse negative precision can increase
+  retained endpoint height even though the result is an outward coarsening.
+- Reconciled both interval SPECs, public umbrellas, conformance, Lake
+  registration, and the exact proof-only runtime exemption.
+- Built the focused public and Mathlib conformance targets, all retained PNT
+  targets, and the complete 9,775-job repository graph. Static, trust-surface,
+  source-pinned inventory, and factor-freshness checks pass.
+
+# Current frontier
+
+The regularization edge is complete as one direct child of the exact merged
+division commit. It adds the checked public operation and ordinary kernel
+semantics without compatibility shims or global grid-optimality claims.
+
+# Next step
+
+Retain the exact published head through CI and final merge-readiness checks
+unless a verified blocker requires repair.
+
+# Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -370,5 +370,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "f25ec93d933118cf82e3044a4a1ee93f7d150441",
     "reason": "Additionally registers the supported proof-only HexIntervalMathlib first-slice division-enclosure semantics module on top of the retained reciprocal, multiplication, natural-power, transactional-split, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "9ba2195e5e253f4b322594da01e7c59573951877",
+    "reason": "Additionally registers the supported HexIntervalMathlib outward-regularization semantics module on top of the retained reciprocal, division, transactional split, multiplication, natural-power, PNT+, and public interval registrations; the factorization service target and executable dependency graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- add resource-checked outward interval regularization using Core `roundDown` and `roundUp`
- preflight retained sources, precision, rounding temporaries/results, and final cut alignment before evaluation
- prove exact computed-cut semantics, source containment, and raw-cut idempotence without claiming globally grid-tight endpoints
- cover moved and inherited strictness, empty/unbounded cases, both precision signs, and discriminating resource refusals

## Validation

- `lake build` (9,775 jobs)
- focused public and Mathlib interval conformance
- retained PNT conformance targets and pinned-source inventory verification
- DAG, copyright, line-count, conformance-target, trust-surface, factor-freshness, and banned-token checks