### PR TITLE
feat(interval): extract supported controller contracts

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -8,6 +8,7 @@ module
 
 public import HexInterval.Interval
 public import HexInterval.Multiplication
+public import HexInterval.Action
 
 public section
 
@@ -18,7 +19,8 @@ data, propagation search, and replayable derivations.
 The public implementation exposes canonical exact intervals through a sealed
 representation, resource-safe smart constructors, and resource-checked
 intersection, hull, negation, addition, subtraction, multiplication, minimum,
-maximum, absolute value, natural power, outward regularization, and
+maximum, absolute value, natural power, outward regularization, reciprocal,
+division, and
 transactional splitting at a dyadic cut. The arithmetic resource layer
 preflights product growth, direct-power retained growth, exponent work,
 rational-backed precision/quotient work, and Core directed-rounding work
@@ -26,6 +28,9 @@ independently of exact comparison work. The reciprocal operation is a
 precision-indexed connected outward enclosure. Division exposes direct outward
 cuts for two nonzero finite singletons, exact empty and total-zero cases, and a
 sound whole-line fallback for every other nonempty shape. Raw cuts remain
-visible as the explicit decoder and inspection boundary; D2 propagation and
-replay experiments still live outside this supported umbrella.
+visible as the explicit decoder and inspection boundary. The public structural
+contracts also cover checked typed SSA programs, versioned fact projections,
+registrations, scoped bindings, actions, and immutable package requests.
+Concrete state, callback outcomes and proposals, scheduling, policy, search,
+and replay remain experimental.
 -/

--- a/HexInterval/Action.lean
+++ b/HexInterval/Action.lean
@@ -1,0 +1,344 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Fact
+
+@[expose] public section
+
+/-!
+# Function-agnostic action contracts
+
+This module defines stable identities, scoped registrations, immutable actions,
+and exact package-request projections. It contains no package callback,
+outcome, proposal, scheduler, search policy, real semantics, or theorem
+evidence.
+
+Compact identifiers are meaningful only in the exact validated snapshot named
+by an action. Stable operation and rule keys carry explicit compatibility
+epochs. Passing these structural checks authorizes neither state mutation nor
+theorem evidence.
+-/
+
+namespace Hex.Interval
+
+/-- Stable rule name and compatibility epoch. Payload schema versions remain
+separate recipe variants within this exact rule epoch. -/
+structure RuleKey where
+  name : String
+  schema : Nat := 1
+  deriving DecidableEq, Repr
+
+/-- Compact index into one registry snapshot. -/
+structure RuleId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Compact index of a rule application in one controller snapshot. -/
+structure ApplicationId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Compact index of one admitted structural equality. -/
+structure EqualityId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Stable structural evidence inspected by a matcher. -/
+inductive StructuralKey where
+  | node (node : NodeId)
+  | equality (equality : EqualityId)
+  | application (application : ApplicationId)
+  deriving DecidableEq, Repr
+
+/-- One controller-enumerated structural input with its immutable creation
+generation. -/
+structure StructuralInput where
+  key : StructuralKey
+  generation : Nat
+  deriving DecidableEq, Repr
+
+/-- Rule roles are controller policy data, not operation semantics. -/
+inductive ActionKind where
+  | forward
+  | backward
+  | improve
+  | shave
+  | instantiate
+  | rewrite
+  | regularize
+  | split
+  deriving DecidableEq, Repr
+
+/-- A registration names its result or an argument without depending on
+snapshot-local node identifiers. -/
+inductive Slot where
+  | result
+  | argument (index : Nat)
+  deriving DecidableEq, Repr
+
+/-- How a registration is bound to a validated program. -/
+inductive BindingKind where
+  | local
+  | scoped
+  | global
+  deriving DecidableEq, Repr
+
+/-- Structural enumeration requested by one registration. The supported
+contract currently exposes the reference whole-network watch only; alternate
+matcher indexes remain controller implementation choices. -/
+inductive MatchWatch where
+  | none
+  | network
+  deriving DecidableEq, Repr
+
+/-- One explicit propagator registration. The callback and all proof recipes
+remain outside this structural record. -/
+structure Registration where
+  key : RuleKey
+  head : OpKey
+  kind : ActionKind
+  watches : List Slot
+  writes : List Slot
+  binding : BindingKind := .local
+  watchesProgram : Bool := false
+  matchWatch : MatchWatch := .none
+  initialEffort : Nat := 0
+  deriving Repr
+
+namespace Registration
+
+/-- Exact equality of immutable registration metadata. -/
+def same (left right : Registration) : Bool :=
+  left.key == right.key && left.head == right.head && left.kind == right.kind &&
+    left.watches == right.watches && left.writes == right.writes &&
+      left.binding == right.binding && left.watchesProgram == right.watchesProgram &&
+        left.matchWatch == right.matchWatch && left.initialEffort == right.initialEffort
+
+/-- Resolve a stable rule key in one exact registry snapshot. -/
+def find? (rules : Array Registration) (key : RuleKey) :
+    Option (RuleId × Registration) := do
+  for index in [0:rules.size] do
+    let rule <- rules[index]?
+    if rule.key == key then return ({ index }, rule)
+  none
+
+end Registration
+
+/-- Whether a finite ordered contract projection contains no duplicate item. -/
+def allDistinct [DecidableEq α] : List α → Bool
+  | [] => true
+  | item :: items => !(items.contains item) && allDistinct items
+
+namespace Slot
+
+/-- Whether this result/argument slot belongs to the exact operation
+signature named by a registration. -/
+def validFor (operation : Operation) : Slot → Bool
+  | .result => true
+  | .argument index => operation.inputs[index]?.isSome
+
+/-- Resolve a checked local slot at one concrete instruction. -/
+def resolve? (output : NodeId) (node : Node) : Slot → Option NodeId
+  | .result => some output
+  | .argument index => node.args[index]?
+
+/-- Resolve an ordered local slot projection. -/
+def resolveAll? (output : NodeId) (node : Node)
+    (slots : List Slot) : Option (List NodeId) :=
+  slots.mapM (resolve? output node)
+
+end Slot
+
+namespace Registration
+
+/-- Validate a complete registration snapshot against a checked program.
+Keys are unique, heads exist with exact stable versions, local slots are
+unique and in range, and global matcher registrations have the one supported
+network-watch shape. -/
+def check (program : Program) (rules : Array Registration) : Bool :=
+  allDistinct (rules.toList.map (·.key)) && rules.all fun rule =>
+    match program.operationWithKey? rule.head with
+    | none => false
+    | some operation =>
+        let matchValid :=
+          match rule.matchWatch with
+          | .none => rule.binding != .global
+          | .network =>
+              rule.binding == .global && rule.kind == .instantiate &&
+                rule.watchesProgram && rule.watches.isEmpty && rule.writes.isEmpty
+        matchValid && match rule.binding with
+          | .local =>
+              allDistinct rule.watches && allDistinct rule.writes &&
+                rule.watches.all (Slot.validFor operation) &&
+                  rule.writes.all (Slot.validFor operation)
+          | .scoped => rule.watches.isEmpty && rule.writes.isEmpty
+          | .global => rule.watches.isEmpty && rule.writes.isEmpty
+
+end Registration
+
+/-- One concrete scoped registration application. Exact ordered watches and
+writes are part of its identity and later action authority. -/
+structure ScopeBinding where
+  rule : RuleKey
+  anchor : NodeId
+  watches : List NodeId
+  writes : List NodeId
+  deriving DecidableEq, Repr
+
+namespace ScopeBinding
+
+/-- Exact identity of one ordered scope binding. -/
+def same (left right : ScopeBinding) : Bool :=
+  left.rule == right.rule && left.anchor == right.anchor &&
+    left.watches == right.watches && left.writes == right.writes
+
+/-- Every node named by the binding, retaining watcher/write order. -/
+def nodes (binding : ScopeBinding) : List NodeId :=
+  binding.anchor :: binding.watches ++ binding.writes
+
+/-- Validate one explicit scope against the exact checked program and
+registration snapshot. Package code remains responsible for its semantic
+shape. -/
+def check (program : Program) (rules : Array Registration)
+    (binding : ScopeBinding) : Bool :=
+  match Registration.find? rules binding.rule, program.node? binding.anchor with
+  | some (_, rule), some anchor =>
+      rule.binding == .scoped &&
+        (program.operation? anchor.op).any (fun operation => operation.key == rule.head) &&
+        allDistinct binding.watches && allDistinct binding.writes &&
+        binding.watches.all (fun node => (program.node? node).isSome) &&
+        binding.writes.all (fun node => (program.node? node).isSome)
+  | _, _ => false
+
+/-- Validate a complete, duplicate-free explicit scope snapshot. -/
+def checkAll (program : Program) (rules : Array Registration)
+    (bindings : Array ScopeBinding) : Bool :=
+  allDistinct bindings.toList && bindings.all (check program rules)
+
+end ScopeBinding
+
+/-- One scheduler request. Serial and program version prevent a delayed reply
+from being confused with another invocation; `writes` is exact authority. -/
+structure Action where
+  serial : Nat
+  programVersion : Nat
+  application : ApplicationId
+  rule : RuleId
+  key : RuleKey
+  node : NodeId
+  kind : ActionKind
+  effort : Nat
+  generation : Nat := 0
+  inputs : List SeenVersion
+  writes : List NodeId := []
+  structuralInputs : List StructuralInput := []
+  matcherEpoch : Option Nat := none
+  deriving DecidableEq, Repr
+
+/-- Immutable decoded structural snapshot supplied with an action. Consumers
+validate it with `ProgramView.check`; it grants no mutation or proof
+authority. -/
+structure ProgramView where
+  programVersion : Nat
+  operations : Array Operation
+  nodes : Array Node
+  generations : Array Nat
+  depths : Array Nat
+
+namespace ProgramView
+
+def operation? (view : ProgramView) (operation : OpId) : Option Operation :=
+  view.operations[operation.index]?
+
+/-- Resolve a stable key to its snapshot-local identifier and exact signature. -/
+def findOp? (view : ProgramView) (key : OpKey) : Option (OpId × Operation) := do
+  for index in [0:view.operations.size] do
+    let operation <- view.operations[index]?
+    if operation.key == key then return ({ index }, operation)
+  none
+
+def node? (view : ProgramView) (node : NodeId) : Option Node :=
+  view.nodes[node.index]?
+
+def generation? (view : ProgramView) (node : NodeId) : Option Nat :=
+  view.generations[node.index]?
+
+def depth? (view : ProgramView) (node : NodeId) : Option Nat :=
+  view.depths[node.index]?
+
+def operationKey? (view : ProgramView) (node : NodeId) : Option OpKey := do
+  let instruction <- view.node? node
+  let operation <- view.operation? instruction.op
+  pure operation.key
+
+/-- Validate the decoded program plus the exact generation/depth side tables.
+This does not authenticate `programVersion`; the controller owns that
+snapshot identity. -/
+def check (view : ProgramView) : Bool :=
+  let program : Program := { operations := view.operations, nodes := view.nodes }
+  program.check && view.generations.size == view.nodes.size &&
+    program.depths? == some view.depths
+
+end ProgramView
+
+/-- Function-package request with exactly the action's declared fact inputs
+and immutable structural snapshot. -/
+structure RuleRequest (Fact : Type) where
+  action : Action
+  program : ProgramView
+  inputs : List (FactView Fact)
+  writes : List NodeId
+
+namespace RuleRequest
+
+/-- Lookup is restricted to declared inputs. -/
+def fact? (request : RuleRequest Fact) (node : NodeId) : Option Fact :=
+  (request.inputs.find? fun input => input.node == node).map (fun input => input.fact)
+
+/-- Check that a request is the exact structural projection declared by a
+registration. This validates keys, versions, ordered reads/writes, and the
+immutable program view. The controller must separately authenticate compact
+rule/application identifiers, serials, fact values, and pending ownership. -/
+def accepts (registration : Registration) (request : RuleRequest Fact) : Bool :=
+  if !request.program.check ||
+      request.program.programVersion != request.action.programVersion then
+    false
+  else
+    match request.program.node? request.action.node with
+    | none => false
+    | some anchor =>
+        let inputNodes := request.inputs.map (fun input => input.node)
+        let seen := request.inputs.map fun input =>
+          { node := input.node, version := input.version : SeenVersion }
+        let common := registration.key == request.action.key &&
+          registration.kind == request.action.kind &&
+          request.program.operationKey? request.action.node == some registration.head &&
+          request.action.inputs == seen && request.action.writes == request.writes &&
+          match registration.matchWatch with
+          | .none =>
+              request.action.structuralInputs.isEmpty && request.action.matcherEpoch.isNone
+          | .network =>
+              !request.action.structuralInputs.isEmpty && request.action.matcherEpoch.isSome
+        common && match registration.binding with
+          | .local =>
+              Slot.resolveAll? request.action.node anchor registration.watches ==
+                  some inputNodes &&
+                Slot.resolveAll? request.action.node anchor registration.writes ==
+                  some request.writes
+          | .scoped =>
+              registration.watches.isEmpty && registration.writes.isEmpty &&
+                allDistinct inputNodes && allDistinct request.writes &&
+                inputNodes.all (fun node => (request.program.node? node).isSome) &&
+                request.writes.all (fun node => (request.program.node? node).isSome)
+          | .global =>
+              registration.watches.isEmpty && registration.writes.isEmpty &&
+                inputNodes.isEmpty && request.writes.isEmpty
+
+end RuleRequest
+
+end Hex.Interval

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -377,69 +377,13 @@ def acceptsLimits (registry : Registry Fact) (program : Program)
 
 end Registry
 
-namespace Registration
-
-/-- Exact equality for immutable registration metadata. -/
-def same (left right : Registration) : Bool :=
-  left.key == right.key && left.head == right.head && left.kind == right.kind &&
-    left.watches == right.watches && left.writes == right.writes &&
-      left.binding == right.binding && left.watchesProgram == right.watchesProgram &&
-        left.matchWatch == right.matchWatch &&
-          left.initialEffort == right.initialEffort
-
-/-- Check that a routed handler sees the structural request projection
-described by its immutable registration.  Engine-produced requests satisfy
-this by construction; checking it here catches registry drift and malformed
-direct test requests before a cache update.  A local registration determines
-its exact ports from slots.  A scoped registration can check only internal
-well-formedness here because its concrete binding belongs to the engine; the
-compiled `Application` is the port authority, and the package callback must
-validate the scope's semantic shape.  Authentication of serials, fact values,
-versions, and pending-state ownership remains the engine's job. -/
-def accepts (registration : Registration) (request : RuleRequest Fact) : Bool :=
-  if request.program.programVersion != request.action.programVersion then
-    false
-  else
-    match request.program.node? request.action.node with
-    | none => false
-    | some anchor =>
-        let inputNodes := request.inputs.map (fun input => input.node)
-        let seen := request.inputs.map fun input =>
-          { node := input.node, version := input.version : SeenVersion }
-        let common := registration.key == request.action.key &&
-          registration.kind == request.action.kind &&
-          request.program.operationKey? request.action.node == some registration.head &&
-          request.action.inputs == seen &&
-          match registration.matchWatch with
-          | .none =>
-              request.action.structuralInputs.isEmpty &&
-                request.action.matcherEpoch.isNone
-          | .network =>
-              !request.action.structuralInputs.isEmpty &&
-                request.action.matcherEpoch.isSome
-        common && match registration.binding with
-          | .local =>
-              resolveSlots? request.action.node anchor registration.watches == some inputNodes &&
-                resolveSlots? request.action.node anchor registration.writes ==
-                  some request.writes
-          | .scoped =>
-              registration.watches.isEmpty && registration.writes.isEmpty &&
-                uniqueList inputNodes && uniqueList request.writes &&
-                inputNodes.all (fun node => (request.program.node? node).isSome) &&
-                request.writes.all (fun node => (request.program.node? node).isSome)
-          | .global =>
-              registration.watches.isEmpty && registration.writes.isEmpty &&
-                inputNodes.isEmpty && request.writes.isEmpty
-
-end Registration
-
 namespace Registry
 
 /-- Route a structurally valid start-time scope back to the package which owns
 its rule and ask that package to accept the semantic binding. -/
 def acceptsBinding (registry : Registry Fact) (program : Program)
     (binding : ScopeBinding) : Bool :=
-  match ruleEntry? registry.registrations binding.rule with
+  match Registration.find? registry.registrations binding.rule with
   | none => false
   | some (ruleId, registration) =>
       match registry.routes[ruleId.index]? with
@@ -453,7 +397,7 @@ def acceptsBinding (registry : Registry Fact) (program : Program)
               | some handler =>
                   registration.binding == .scoped &&
                     registration.same handler.registration &&
-                    binding.valid program registry.registrations &&
+                    ScopeBinding.check program registry.registrations binding &&
                     handler.acceptsScope program binding
 
 /-- Check a complete start-time binding table after assembling the final
@@ -462,7 +406,7 @@ package registry and program.  Passing `Registry.acceptsBinding registry` to
 repeats its independent structural validation at its own boundary. -/
 def acceptsBindings (registry : Registry Fact) (program : Program)
     (bindings : Array ScopeBinding) : Bool :=
-  scopeBindingsCheck program registry.registrations bindings &&
+  ScopeBinding.checkAll program registry.registrations bindings &&
     bindings.all (registry.acceptsBinding program)
 
 /-- A negative plan for a dispatch failure before any callback or replay
@@ -496,7 +440,7 @@ opaque invokePlanned (registry : Registry Fact) (request : RuleRequest Fact) :
               | some handler =>
                   if !registration.same handler.registration then
                     (failedInvocation request.action.key DispatchCode.registryMismatch, registry)
-                  else if !handler.registration.accepts request then
+                  else if !RuleRequest.accepts handler.registration request then
                     (failedInvocation request.action.key DispatchCode.requestMismatch, registry)
                   else
                     let program : Program :=

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -151,7 +151,7 @@ def invocationOfRequest (scope : ScopeId) (request : RuleRequest Fact) : Invocat
 /-- Internal fuelled loop.  The only action passed to the registry comes from
 {name}`Hex.Interval.Experiment.Propagator.Policy.State.select`; the driver
 merely echoes it through
-{name}`Hex.Interval.Experiment.Propagator.Action.reply`. -/
+{name}`Hex.Interval.Action.reply`. -/
 def driveFrom {Cache : Type u} (controller : Controller Fact PolicyState)
     (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
     Nat -> State Fact -> Cache -> PolicyState -> Array (Event Fact) ->

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexInterval.Action
 public import HexInterval.Experiment.StructuralCursor
 
 @[expose] public section
@@ -27,163 +28,17 @@ semantically untrusted: intersection can preserve consistency and monotonicity,
 but only successful replay of their opaque proof payloads establishes
 soundness.
 
-This experimental module is separate from the supported `HexInterval` API.
-Selecting a
-retained expression proposal runs a separate atomic validator before extending
-the live program and appending its new concrete rule applications.
+The stable structural `Program`, `Fact`, and `Action` records live in the
+supported Mathlib-free library. This module remains experimental because it
+chooses concrete application storage, queues, resource counters, suggestion
+handling, package callbacks, and search transitions. Selecting a retained
+expression proposal runs a separate atomic validator before extending the live
+program and appending its new concrete rule applications.
 -/
 
 namespace Hex.Interval.Experiment.Propagator
 
-/-! # Typed expression program -/
-
-/-- Compact domain identifier.  The initial corpus uses only the real domain,
-but the scheduler does not assume that all nodes have the same type. -/
-structure DomainId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Stable, versioned semantic operation name. -/
-structure OpKey where
-  name : String
-  version : Nat := 1
-  deriving DecidableEq, Repr
-
-/-- Compact index into a program's operation table. -/
-structure OpId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Compact index into a program's node table. -/
-structure NodeId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- An operation signature known to the typed frontend, but not interpreted by
-the scheduler. -/
-structure Operation where
-  key : OpKey
-  inputs : List DomainId
-  output : DomainId
-  deriving DecidableEq, Repr
-
-/-- One instruction in a typed single-assignment expression DAG. -/
-structure Node where
-  domain : DomainId
-  op : OpId
-  args : List NodeId
-  deriving DecidableEq, Repr
-
-/-- Immutable base expression program. -/
-structure Program where
-  operations : Array Operation
-  nodes : Array Node
-  deriving DecidableEq, Repr
-
-namespace Program
-
-/-- Exact optional operation lookup. -/
-def operation? (program : Program) (operation : OpId) : Option Operation :=
-  program.operations[operation.index]?
-
-/-- Exact optional node lookup. -/
-def node? (program : Program) (node : NodeId) : Option Node :=
-  program.nodes[node.index]?
-
-def uniqueOpKeys : List Operation -> Bool
-  | [] => true
-  | operation :: operations =>
-      !(operations.any fun other => other.key == operation.key) &&
-        uniqueOpKeys operations
-
-def argsCheck (program : Program) (outputIndex : Nat) :
-    List NodeId -> List DomainId -> Bool
-  | [], [] => true
-  | argument :: arguments, domain :: domains =>
-      argument.index < outputIndex &&
-        (program.node? argument).any (fun node => node.domain == domain) &&
-        argsCheck program outputIndex arguments domains
-  | _, _ => false
-
-def nodeCheck (program : Program) (outputIndex : Nat) (node : Node) : Bool :=
-  match program.operation? node.op with
-  | none => false
-  | some operation =>
-      node.domain == operation.output &&
-        argsCheck program outputIndex node.args operation.inputs
-
-def nodesCheckFrom (program : Program) : Nat -> List Node -> Bool
-  | _, [] => true
-  | outputIndex, node :: nodes =>
-      nodeCheck program outputIndex node && nodesCheckFrom program (outputIndex + 1) nodes
-
-/-- Validate operation-key uniqueness, operation references, arities, domains,
-and SSA topology. -/
-def check (program : Program) : Bool :=
-  uniqueOpKeys program.operations.toList && nodesCheckFrom program 0 program.nodes.toList
-
-/-- Structural expression depth, with nullary nodes at depth zero. -/
-def nodeDepth? (depths : Array Nat) (arguments : List NodeId) : Option Nat := do
-  if arguments.isEmpty then
-    pure 0
-  else
-    let mut greatest := 0
-    for argument in arguments do
-      let depth <- depths[argument.index]?
-      greatest := Nat.max greatest depth
-    pure (greatest + 1)
-
-/-- Reconstruct the structural depth of every node in a validated SSA
-program.  This measure is independent of theorem-instantiation generation. -/
-def depths? (program : Program) : Option (Array Nat) := do
-  let mut depths := #[]
-  for index in [0:program.nodes.size] do
-    let node <- program.nodes[index]?
-    let depth <- nodeDepth? depths node.args
-    depths := depths.push depth
-  pure depths
-
-end Program
-
-/-! # Rule registration -/
-
-/-- Stable rule name and compatibility epoch.  `schema` versions the complete
-handler/theorem contract; replay requires this exact key and never falls back
-to a newer epoch.  A payload's own schema is a separate recipe variant within
-this epoch. -/
-structure RuleKey where
-  name : String
-  schema : Nat := 1
-  deriving DecidableEq, Repr
-
-/-- Compact index into one registry snapshot. -/
-structure RuleId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Compact index of a rule application to a particular expression node. -/
-structure ApplicationId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Compact index of one admitted structural equality. -/
-structure EqualityId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Stable structural evidence inspected by a matcher. -/
-inductive StructuralKey where
-  | node (node : NodeId)
-  | equality (equality : EqualityId)
-  | application (application : ApplicationId)
-  deriving DecidableEq, Repr
-
-/-- One engine-enumerated structural input with its immutable creation
-generation. -/
-structure StructuralInput where
-  key : StructuralKey
-  generation : Nat
-  deriving DecidableEq, Repr
+/-! # Experimental controller state -/
 
 abbrev MatcherSize := StructuralCursor.Size
 abbrev MatcherView := StructuralCursor.View
@@ -197,76 +52,6 @@ and engine-owned equality contractors. -/
 inductive WorkItem where
   | application (application : ApplicationId)
   | equality (equality : EqualityId)
-  deriving DecidableEq, Repr
-
-/-- Propagator roles are policy data, not operation semantics. -/
-inductive ActionKind where
-  | forward
-  | backward
-  | improve
-  | shave
-  | instantiate
-  | rewrite
-  | regularize
-  | split
-  deriving DecidableEq, Repr
-
-/-- A registration names the result node or one of its arguments without
-depending on concrete node identifiers. -/
-inductive Slot where
-  | result
-  | argument (index : Nat)
-  deriving DecidableEq, Repr
-
-/-- How concrete applications of a registration enter the scheduler.  Local
-registrations are resolved at every node with the matching head operation.
-Scoped registrations are bound explicitly to an arbitrary finite set of
-program nodes by the frontend or a package matcher. -/
-inductive BindingKind where
-  | local
-  | scoped
-  /-- One registration-wide application, anchored at the first node with the
-  declared head.  This is the initial ownership model for whole-network
-  structural matchers: program growth wakes one cursor, not one cursor per
-  matching expression. -/
-  | global
-  deriving DecidableEq, Repr
-
-/-- Structural enumeration attached to one concrete application.  The first
-reference arm scans the whole append-only network; selective operation,
-equality, and compiled-pattern watches remain later variants. -/
-inductive MatchWatch where
-  | none
-  | network
-  deriving DecidableEq, Repr
-
-/-- One explicit propagator registration.  Several registrations may have the
-same `head`; they remain independent methods with independent rule keys. -/
-structure Registration where
-  key : RuleKey
-  head : OpKey
-  kind : ActionKind
-  watches : List Slot
-  writes : List Slot
-  binding : BindingKind := .local
-  /-- Re-run existing applications after any append-only program extension.
-  This is the coarse first trigger for rules whose result depends on shape
-  outside their anchor's immutable argument subgraph. -/
-  watchesProgram : Bool := false
-  matchWatch : MatchWatch := .none
-  initialEffort : Nat := 0
-  deriving Repr
-
-/-- One concrete application of a scoped registration.  Start-time bindings
-come from the frontend or a package matcher; later bindings may be resolved
-from an atomic instantiation proposal.  The anchor identifies the structural
-occurrence which justifies the application; ordered `watches` and `writes` may
-name any nodes in the validated program. -/
-structure ScopeBinding where
-  rule : RuleKey
-  anchor : NodeId
-  watches : List NodeId
-  writes : List NodeId
   deriving DecidableEq, Repr
 
 /-- A registration resolved against one concrete program node. -/
@@ -301,102 +86,8 @@ def dedupListFrom [DecidableEq alpha] (seen : List alpha) : List alpha -> List a
 def dedupList [DecidableEq alpha] (items : List alpha) : List alpha :=
   dedupListFrom [] items
 
-def uniqueRuleKeys : List Registration -> Bool
-  | [] => true
-  | rule :: rules =>
-      !(rules.any fun other => other.key == rule.key) && uniqueRuleKeys rules
-
-/-- Resolve a stable rule key to its compact identifier and immutable
-registration in this registry snapshot. -/
-def ruleEntry? (rules : Array Registration) (key : RuleKey) :
-    Option (RuleId × Registration) := do
-  for index in [0:rules.size] do
-    let rule <- rules[index]?
-    if rule.key == key then return ({ index }, rule)
-  none
-
 def opKeyExists (program : Program) (key : OpKey) : Bool :=
   program.operations.any fun operation => operation.key == key
-
-def Program.operationWithKey? (program : Program) (key : OpKey) : Option Operation :=
-  program.operations.toList.find? fun operation => operation.key == key
-
-/-- Resolve both the signature and the compact identifier assigned by this
-particular final program.  Package-local operation order is not authoritative
-for frontend nodes. -/
-def Program.operationEntry? (program : Program) (key : OpKey) :
-    Option (OpId × Operation) := do
-  for index in [0:program.operations.size] do
-    let operation <- program.operations[index]?
-    if operation.key == key then return ({ index }, operation)
-  none
-
-def Slot.validFor (operation : Operation) : Slot -> Bool
-  | .result => true
-  | .argument index => operation.inputs[index]?.isSome
-
-def resolveSlot? (output : NodeId) (node : Node) : Slot -> Option NodeId
-  | .result => some output
-  | .argument index => node.args[index]?
-
-def resolveSlots? (output : NodeId) (node : Node)
-    (slots : List Slot) : Option (List NodeId) :=
-  slots.mapM (resolveSlot? output node)
-
-/-- Reject duplicate keys and unknown heads.  Local registrations additionally
-require unique in-range slots; scoped registrations leave their concrete ports
-to `ScopeBinding`.  Empty writes are valid for discovery and split rules. -/
-def registrationsCheck (program : Program) (rules : Array Registration) : Bool :=
-  uniqueRuleKeys rules.toList && rules.all fun rule =>
-    match program.operationWithKey? rule.head with
-    | none => false
-    | some operation =>
-        let matchValid :=
-          match rule.matchWatch with
-          | .none => rule.binding != .global
-          | .network =>
-              rule.binding == .global && rule.kind == .instantiate &&
-                rule.watchesProgram && rule.watches.isEmpty && rule.writes.isEmpty
-        matchValid && match rule.binding with
-          | .local =>
-              uniqueList rule.watches && uniqueList rule.writes &&
-                rule.watches.all (Slot.validFor operation) &&
-                  rule.writes.all (Slot.validFor operation)
-          | .scoped => rule.watches.isEmpty && rule.writes.isEmpty
-          | .global => rule.watches.isEmpty && rule.writes.isEmpty
-
-def ScopeBinding.same (left right : ScopeBinding) : Bool :=
-  left.rule == right.rule && left.anchor == right.anchor &&
-    left.watches == right.watches && left.writes == right.writes
-
-def ScopeBinding.nodes (binding : ScopeBinding) : List NodeId :=
-  binding.anchor :: binding.watches ++ binding.writes
-
-def uniqueScopeBindings : List ScopeBinding -> Bool
-  | [] => true
-  | binding :: bindings =>
-      !(bindings.any fun other => binding.same other) && uniqueScopeBindings bindings
-
-/-- Validate one concrete scoped application without interpreting its
-operation or rule key. -/
-def ScopeBinding.valid (program : Program) (rules : Array Registration)
-    (binding : ScopeBinding) : Bool :=
-  match ruleEntry? rules binding.rule, program.node? binding.anchor with
-  | some (_, rule), some anchor =>
-      rule.binding == .scoped &&
-        (program.operation? anchor.op).any (fun operation => operation.key == rule.head) &&
-        uniqueList binding.watches && uniqueList binding.writes &&
-        binding.watches.all (fun node => (program.node? node).isSome) &&
-        binding.writes.all (fun node => (program.node? node).isSome)
-  | _, _ => false
-
-/-- Validate explicit scoped applications.  Package-owned semantic checkers
-remain responsible for proving that each chosen scope is an instance of their
-contractor schema. -/
-def scopeBindingsCheck (program : Program) (rules : Array Registration)
-    (bindings : Array ScopeBinding) : Bool :=
-  uniqueScopeBindings bindings.toList &&
-    bindings.all (ScopeBinding.valid program rules)
 
 /-- Resolve immutable scoped bindings in their declared order, followed by
 every local `(registration, node)` match in node-major, registration-minor
@@ -405,14 +96,14 @@ instantiated.  Operation keys are opaque to this compiler. -/
 def compileApplications (program : Program) (rules : Array Registration)
     (bindings : Array ScopeBinding := #[]) :
     Option (Array Application) := do
-  if !program.check || !registrationsCheck program rules ||
-      !scopeBindingsCheck program rules bindings then
+  if !program.check || !Registration.check program rules ||
+      !ScopeBinding.checkAll program rules bindings then
     none
   else
     let mut applications := #[]
     let mut globalCompiled := Array.replicate rules.size false
     for binding in bindings do
-      let (ruleId, rule) <- ruleEntry? rules binding.rule
+      let (ruleId, rule) <- Registration.find? rules binding.rule
       applications := applications.push
         { rule := ruleId
           node := binding.anchor
@@ -427,8 +118,8 @@ def compileApplications (program : Program) (rules : Array Registration)
       for ruleIndex in [0:rules.size] do
         let rule <- rules[ruleIndex]?
         if rule.binding == .local && rule.head == operation.key then
-          let watches <- resolveSlots? { index := nodeIndex } node rule.watches
-          let writes <- resolveSlots? { index := nodeIndex } node rule.writes
+          let watches <- Slot.resolveAll? { index := nodeIndex } node rule.watches
+          let writes <- Slot.resolveAll? { index := nodeIndex } node rule.writes
           applications := applications.push
             { rule := { index := ruleIndex }
               node := { index := nodeIndex }
@@ -454,15 +145,15 @@ registry; error `true` denotes the exact application cap. -/
 def compileApplicationsWithin (limit : Nat) (program : Program)
     (rules : Array Registration) (bindings : Array ScopeBinding := #[]) :
     Except Bool (Array Application) := do
-  if !program.check || !registrationsCheck program rules ||
-      !scopeBindingsCheck program rules bindings then
+  if !program.check || !Registration.check program rules ||
+      !ScopeBinding.checkAll program rules bindings then
     throw false
   let mut applications := #[]
   let mut globalCompiled := Array.replicate rules.size false
   for binding in bindings do
     if limit <= applications.size then
       throw true
-    let some (ruleId, rule) := ruleEntry? rules binding.rule | throw false
+    let some (ruleId, rule) := Registration.find? rules binding.rule | throw false
     applications := applications.push
       { rule := ruleId
         node := binding.anchor
@@ -479,9 +170,9 @@ def compileApplicationsWithin (limit : Nat) (program : Program)
       if rule.binding == .local && rule.head == operation.key then
         if limit <= applications.size then
           throw true
-        let some watches := resolveSlots? { index := nodeIndex } node rule.watches
+        let some watches := Slot.resolveAll? { index := nodeIndex } node rule.watches
           | throw false
-        let some writes := resolveSlots? { index := nodeIndex } node rule.writes
+        let some writes := Slot.resolveAll? { index := nodeIndex } node rule.writes
           | throw false
         applications := applications.push
           { rule := { index := ruleIndex }
@@ -536,7 +227,7 @@ scope.  The registration snapshot, rather than proposal metadata, supplies
 the action kind and baseline effort. -/
 def applicationForBinding? (rules : Array Registration)
     (binding : ScopeBinding) : Option Application := do
-  let (ruleId, rule) <- ruleEntry? rules binding.rule
+  let (ruleId, rule) <- Registration.find? rules binding.rule
   if rule.binding != .scoped then none else pure ()
   pure
     { rule := ruleId
@@ -600,7 +291,7 @@ def compileLocalApplicationsWithin (limit start : Nat) (program : Program)
     (rules : Array Registration) (existing : Array Application := #[])
     (generation : Nat := 0) :
     Except Bool (Array Application) := do
-  if program.nodes.size < start || !program.check || !registrationsCheck program rules then
+  if program.nodes.size < start || !program.check || !Registration.check program rules then
     throw false
   let mut applications := #[]
   let mut globalCompiled := Array.replicate rules.size false
@@ -616,9 +307,9 @@ def compileLocalApplicationsWithin (limit start : Nat) (program : Program)
       let some rule := rules[ruleIndex]? | throw false
       if rule.binding == .local && rule.head == operation.key then
         if limit <= applications.size then throw true
-        let some watches := resolveSlots? { index := nodeIndex } node rule.watches
+        let some watches := Slot.resolveAll? { index := nodeIndex } node rule.watches
           | throw false
-        let some writes := resolveSlots? { index := nodeIndex } node rule.writes
+        let some writes := Slot.resolveAll? { index := nodeIndex } node rule.writes
           | throw false
         applications := applications.push
           { rule := { index := ruleIndex }
@@ -645,173 +336,40 @@ def compileLocalApplicationsWithin (limit start : Nat) (program : Program)
 
 /-! # Request/reply protocol -/
 
-/-- Monotone version observed for one watched fact. -/
-structure SeenVersion where
-  node : NodeId
-  version : Nat
-  deriving DecidableEq, Repr
-
-/-- One scheduler request.  `serial` prevents a delayed registry reply from
-being confused with a later invocation of the same rule. -/
-structure Action where
-  serial : Nat
-  programVersion : Nat
-  application : ApplicationId
-  rule : RuleId
-  key : RuleKey
-  node : NodeId
-  kind : ActionKind
-  effort : Nat
-  generation : Nat := 0
-  inputs : List SeenVersion
-  /-- Exact write authority frozen from the concrete application. -/
-  writes : List NodeId := []
-  /-- Engine-enumerated structural inputs for this exact matcher batch. -/
-  structuralInputs : List StructuralInput := []
-  /-- Frozen matcher epoch which produced `structuralInputs`. -/
-  matcherEpoch : Option Nat := none
-  deriving DecidableEq, Repr
-
-/-- Immutable fact view supplied with an action. -/
-structure Snapshot (Fact : Type) where
-  facts : Array Fact
-  versions : Array Nat
-  contradictory : Bool
-
-namespace Snapshot
-
-/-- Exact optional fact lookup. -/
-def fact? (snapshot : Snapshot Fact) (node : NodeId) : Option Fact :=
-  snapshot.facts[node.index]?
-
-/-- Exact optional version lookup. -/
-def version? (snapshot : Snapshot Fact) (node : NodeId) : Option Nat :=
-  snapshot.versions[node.index]?
-
-end Snapshot
-
-/-- One declared rule input.  Propagators receive these projected views rather
-than an unrestricted snapshot, so every semantic dependency has a watcher. -/
-structure FactView (Fact : Type) where
-  node : NodeId
-  fact : Fact
-  version : Nat
-
-/-- Immutable structural metadata supplied to a propagator.  The engine builds
-this view only from a validated program whose operation, node, arity, and
-generation arrays are already covered by its structural limits.  It contains
-no interval facts: semantic fact access remains restricted to declared
-`FactView`s.
-
-The explicit version lets registries key structural caches by the exact
-append-only snapshot.  Reply validation remains bound to the engine-owned
-`Action`, while retained instantiations recheck action freshness and resolve
-their complete structural effect against the current program.  Observing this
-view grants no mutation authority.
-
-A matcher may follow structure determined by its action anchor. Any additional
-side node which affects a proposed theorem instance must be named either by a
-declared fact input or by an explicit `existing` proposal reference.
-Generation accounting does not track arbitrary calls to `ProgramView.node?`. -/
-structure ProgramView where
-  programVersion : Nat
-  operations : Array Operation
-  nodes : Array Node
-  generations : Array Nat
-  depths : Array Nat
-
-namespace ProgramView
-
-/-- Exact optional operation lookup in this immutable snapshot. -/
-def operation? (view : ProgramView) (operation : OpId) : Option Operation :=
-  view.operations[operation.index]?
-
-/-- Resolve a stable operation key to this snapshot's compact identifier and
-exact signature. Package callbacks must not assume a particular operation-table
-order. -/
-def findOp? (view : ProgramView) (key : OpKey) : Option (OpId × Operation) := do
-  for index in [0:view.operations.size] do
-    let operation <- view.operations[index]?
-    if operation.key == key then return ({ index }, operation)
-  none
-
-/-- Exact optional node lookup in this immutable snapshot. -/
-def node? (view : ProgramView) (node : NodeId) : Option Node :=
-  view.nodes[node.index]?
-
-/-- Exact optional instantiation-generation lookup. -/
-def generation? (view : ProgramView) (node : NodeId) : Option Nat :=
-  view.generations[node.index]?
-
-/-- Exact optional structural-depth lookup. -/
-def depth? (view : ProgramView) (node : NodeId) : Option Nat :=
-  view.depths[node.index]?
-
-/-- Resolve a node's opaque semantic operation key without interpreting it. -/
-def operationKey? (view : ProgramView) (node : NodeId) : Option OpKey := do
-  let instruction <- view.node? node
-  let operation <- view.operation? instruction.op
-  pure operation.key
-
-end ProgramView
-
-/-- Function-specific registry request with exactly the application's declared
-fact inputs and a bounded structural snapshot. -/
-structure RuleRequest (Fact : Type) where
-  action : Action
-  program : ProgramView
-  inputs : List (FactView Fact)
-  writes : List NodeId
-
-namespace RuleRequest
-
-/-- Lookup is restricted to declared inputs. -/
-def fact? (request : RuleRequest Fact) (node : NodeId) : Option Fact :=
-  (request.inputs.find? fun input => input.node == node).map (fun input => input.fact)
-
-end RuleRequest
-
-/-- Immutable proof payload allocated by the companion registry.  It is not a
-pointer into a mutable propagator cache. -/
+/-- Immutable proof-payload address allocated by the experimental companion
+registry. It is not a pointer into mutable package cache state. -/
 structure PayloadId where
   index : Nat
   deriving DecidableEq, Repr
 
-/-- One semantically untrusted proposed fact about an existing expression
-node. Its payload must later replay to a checked theorem; merely intersecting
-the fact into engine state does not prove it sound. -/
+/-- One semantically untrusted proposed fact. Its payload must later replay to
+an independently checked theorem. -/
 structure Candidate (Fact : Type) where
   node : NodeId
   fact : Fact
   payload : PayloadId
 
-/-- A reference in a proposed expression extension. -/
+/-- A reference in one proposed expression extension. -/
 inductive NodeRef where
   | existing (node : NodeId)
   | proposed (index : Nat)
   deriving DecidableEq, Repr
 
-/-- One SSA instruction proposed by a shape-triggered propagator. -/
+/-- One SSA instruction proposed by an experimental package matcher. -/
 structure ProposedNode where
   domain : DomainId
   op : OpId
   args : List NodeRef
   deriving Repr
 
-/-- An equality proposed alongside new expressions.  This experiment retains
-the opaque payload and endpoints as untrusted replay data.  Once admitted, the
-edge is scheduler-active: its typed endpoints drive equality contraction, and
-replay must reconstruct and check the payload before any transported fact can
-prove a goal. -/
+/-- One untrusted equality proposed alongside an extension. -/
 structure ProposedEquality where
   left : NodeRef
   right : NodeRef
   payload : PayloadId
   deriving Repr
 
-/-- One scoped application proposed against the program produced by the same
-atomic instantiation.  References may name old nodes or any resolved node
-draft; concrete application identifiers remain engine-owned. -/
+/-- One scoped application proposed against the atomically extended program. -/
 structure ProposedScope where
   rule : RuleKey
   anchor : NodeRef
@@ -819,8 +377,9 @@ structure ProposedScope where
   writes : List NodeRef
   deriving Repr
 
-/-- Untrusted atomic expression-extension request.  The engine, not the rule,
-recomputes generations and assigns concrete node identifiers. -/
+/-- Experimental atomic append-only expression-extension request. `key` is a
+provisional package/policy family and is deliberately not part of the
+supported action contract. -/
 structure InstantiationRequest where
   key : Nat
   nodes : List ProposedNode
@@ -829,14 +388,7 @@ structure InstantiationRequest where
   payload : PayloadId
   deriving Repr
 
-/-- Cached policy-key surface for one validated instantiation proposal. -/
-def InstantiationRequest.policyItems (request : InstantiationRequest) : Nat :=
-  request.nodes.length + request.equalities.length + request.scopes.length +
-    request.nodes.foldl (fun count node => count + node.args.length) 0 +
-    request.scopes.foldl (fun count scope =>
-      count + 1 + scope.watches.length + scope.writes.length) 0
-
-/-- Why a propagator recommends a proof-state split. -/
+/-- Why an experimental package recommends a proof-state split. -/
 inductive SplitReason where
   | singularity
   | totalityBoundary
@@ -848,12 +400,19 @@ inductive SplitReason where
   | custom (code : Nat)
   deriving DecidableEq, Repr
 
-/-- A proof-split suggestion.  The rule supplies only a node, cut, and reason;
-a checked branch manager creates complementary child scopes and facts. -/
+/-- An experimental split suggestion. A checked branch manager owns child
+scopes and facts. -/
 structure SplitRequest where
   node : NodeId
   point : Dyadic
   reason : SplitReason
+
+/-- Cached policy-key surface for one validated instantiation proposal. -/
+def instantiationPolicyItems (request : InstantiationRequest) : Nat :=
+  request.nodes.length + request.equalities.length + request.scopes.length +
+    request.nodes.foldl (fun count node => count + node.args.length) 0 +
+    request.scopes.foldl (fun count scope =>
+      count + 1 + scope.watches.length + scope.writes.length) 0
 
 /-- Non-fact information returned to the search policy. -/
 inductive Suggestion where
@@ -963,30 +522,11 @@ structure Reply (Fact : Type) where
   application : ApplicationId
   outcome : Outcome Fact
 
-def Action.reply (action : Action) (outcome : Outcome Fact) : Reply Fact :=
+def _root_.Hex.Interval.Action.reply (action : Action) (outcome : Outcome Fact) : Reply Fact :=
   { serial := action.serial
     programVersion := action.programVersion
     application := action.application
     outcome }
-
-/-! # Fact intersection boundary -/
-
-/-- Result of intersecting an untrusted candidate with the current strongest
-fact.  The explicit record passed to `submit` supplies this operation; the
-scheduler is independent of endpoint representation. -/
-inductive NarrowResult (Fact : Type) where
-  | noChange
-  | improved (fact : Fact)
-  | contradiction (fact : Fact)
-  | malformed (code : Nat)
-  | resourceLimit (budget : Nat)
-
-/-- The only fact-domain behavior needed by propagation scheduling.
-`narrow` enforces the fact representation's intersection discipline; it does
-not authenticate the semantic claim carried by a candidate. -/
-structure FactDomain (Fact : Type) where
-  top : DomainId -> Fact
-  narrow : DomainId -> Fact -> Fact -> NarrowResult Fact
 
 /-- Bounded list check which inspects at most one constructor beyond the
 trusted limit. -/
@@ -1323,12 +863,12 @@ def preflightStart (program : Program) (rules : Array Registration)
   let some depths := program.depths? | throw .invalidProgram
   if depths.any (fun depth => limits.maxNodeDepth < depth) then
     throw (.resourceLimit .nodeDepth)
-  if !registrationsCheck program rules then
+  if !Registration.check program rules then
     throw .invalidRegistrations
   if limits.matcherBatchSize == 0 &&
       rules.any (fun rule => rule.matchWatch == .network) then
     throw .invalidRegistrations
-  if !scopeBindingsCheck program rules bindings then
+  if !ScopeBinding.checkAll program rules bindings then
     throw .invalidBindings
 
 /-- Validate and compile an engine.  The caller supplies one initial fact per
@@ -1783,22 +1323,18 @@ def suggestionsEffortBounded (limit : Nat) (suggestions : List Suggestion) : Boo
 
 /-! # Structural proposal validation -/
 
-namespace Node
-
 /-- Exact syntactic node equality used by the experiment's linear CSE table. -/
-def same (left right : Node) : Bool :=
+def sameNode (left right : Node) : Bool :=
   left.domain == right.domain && left.op == right.op && left.args == right.args
-
-end Node
 
 /-- Linear reference CSE lookup.  The experiment measures this against indexed
 tables before selecting a production representation. -/
 def findNodeFrom : Nat -> List Node -> Node -> Option NodeId
   | _, [], _ => none
   | index, node :: nodes, target =>
-      if node.same target then some { index } else findNodeFrom (index + 1) nodes target
+      if sameNode node target then some { index } else findNodeFrom (index + 1) nodes target
 
-def Program.findNode? (program : Program) (target : Node) : Option NodeId :=
+def findNode? (program : Program) (target : Node) : Option NodeId :=
   findNodeFrom 0 program.nodes.toList target
 
 /-- Resolve a draft reference.  `existing` IDs are restricted to the immutable
@@ -1834,7 +1370,7 @@ def resolveDrafts (baseSize : Nat) :
         throw .badReferenceOrShape
       let some candidateDepth := Program.nodeDepth? depths args
         | throw .badReferenceOrShape
-      match program.findNode? candidate with
+      match findNode? program candidate with
       | some id =>
           let some storedDepth := depths[id.index]? | throw .badReferenceOrShape
           if storedDepth != candidateDepth then throw .badReferenceOrShape
@@ -1879,7 +1415,7 @@ def resolveRequestedScopes (baseSize : Nat) (resolved : List NodeId)
       let watches <- resolveRefs? baseSize resolved proposal.watches
       let writes <- resolveRefs? baseSize resolved proposal.writes
       let binding : ScopeBinding := { rule := proposal.rule, anchor, watches, writes }
-      if !binding.valid program rules then none else pure ()
+      if !ScopeBinding.check program rules binding then none else pure ()
       let rest <- resolveRequestedScopes baseSize resolved program rules proposals
       some (binding :: rest)
 
@@ -2008,7 +1544,7 @@ def retainSuggestion (state : Engine Fact) (action : Action)
       | .retry _ | .instantiate _ => none
     policyItems := action.structuralInputs.length +
       match suggestion with
-      | .instantiate request => request.policyItems
+      | .instantiate request => instantiationPolicyItems request
       | .retry _ | .split _ => 0 }
 
 def candidateNodesUnique (candidates : List (Candidate Fact)) : Bool :=

--- a/HexInterval/Fact.lean
+++ b/HexInterval/Fact.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Program
+
+@[expose] public section
+
+/-!
+# Function-agnostic fact contracts
+
+Facts remain an opaque caller-selected type. The controller owns exact node
+versions and supplies packages only immutable, explicitly projected fact
+views. Narrowing validates the fact representation and monotone intersection;
+it does not authenticate a candidate's mathematical meaning.
+-/
+
+namespace Hex.Interval
+
+/-- Exact monotone fact version observed at one program node. -/
+structure SeenVersion where
+  node : NodeId
+  version : Nat
+  deriving DecidableEq, Repr
+
+/-- Immutable whole-state fact snapshot. This is controller data, not proof
+evidence. Package callbacks receive the narrower `FactView` projection. -/
+structure Snapshot (Fact : Type) where
+  facts : Array Fact
+  versions : Array Nat
+  contradictory : Bool
+
+namespace Snapshot
+
+/-- Validate exact fact/version alignment with one checked program. The
+contradiction marker remains runtime state and has no evidentiary force. -/
+def check (snapshot : Snapshot Fact) (program : Program) : Bool :=
+  program.check && snapshot.facts.size == program.nodes.size &&
+    snapshot.versions.size == program.nodes.size
+
+/-- Exact optional fact lookup. -/
+def fact? (snapshot : Snapshot Fact) (node : NodeId) : Option Fact :=
+  snapshot.facts[node.index]?
+
+/-- Exact optional version lookup. -/
+def version? (snapshot : Snapshot Fact) (node : NodeId) : Option Nat :=
+  snapshot.versions[node.index]?
+
+end Snapshot
+
+/-- One declared rule input. Packages receive these projected views rather
+than unrestricted fact state, so every semantic dependency has a watcher. -/
+structure FactView (Fact : Type) where
+  node : NodeId
+  fact : Fact
+  version : Nat
+
+/-- Result of intersecting an untrusted candidate with the current strongest
+fact. Refusal and malformed input are distinct from contradiction. -/
+inductive NarrowResult (Fact : Type) where
+  | noChange
+  | improved (fact : Fact)
+  | contradiction (fact : Fact)
+  | malformed (code : Nat)
+  | resourceLimit (budget : Nat)
+
+/-- The fact behavior required by the generic controller. `narrow` preserves
+the domain's representation and intersection discipline; replay, not this
+callback, establishes mathematical soundness. -/
+structure FactDomain (Fact : Type) where
+  top : DomainId -> Fact
+  narrow : DomainId -> Fact -> Fact -> NarrowResult Fact
+
+end Hex.Interval

--- a/HexInterval/Program.lean
+++ b/HexInterval/Program.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Basic
+
+@[expose] public section
+
+/-!
+# Function-agnostic expression programs
+
+This module is the supported structural boundary between a frontend and an
+interval controller. Operations are opaque stable keys; the Mathlib-free
+program layer knows only their typed signatures. `Program.check` validates
+operation-key uniqueness, exact arities and domains, and strict SSA topology.
+
+`Program` is intentionally plain decoded data. Constructing a value does not
+assert that it is valid, and no mathematical evidence follows from it. A
+controller must run `Program.check` before building dependency state or
+invoking a package. This keeps certificate decoding inspectable without
+giving untrusted runtime data proof authority.
+-/
+
+namespace Hex.Interval
+
+/-- Compact domain identifier. The controller does not interpret domains. -/
+structure DomainId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Stable, versioned semantic operation name. Compact operation identifiers
+are snapshot-local; this key is the identity retained across snapshots. -/
+structure OpKey where
+  name : String
+  version : Nat := 1
+  deriving DecidableEq, Repr
+
+/-- Compact index into one program's operation table. -/
+structure OpId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Compact index into one program's node table. -/
+structure NodeId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- An opaque operation signature known to the typed frontend. -/
+structure Operation where
+  key : OpKey
+  inputs : List DomainId
+  output : DomainId
+  deriving DecidableEq, Repr
+
+/-- One instruction in a typed single-assignment expression DAG. -/
+structure Node where
+  domain : DomainId
+  op : OpId
+  args : List NodeId
+  deriving DecidableEq, Repr
+
+/-- Immutable decoded expression program. Validated consumers require
+`Program.check program = true`. -/
+structure Program where
+  operations : Array Operation
+  nodes : Array Node
+  deriving DecidableEq, Repr
+
+namespace Program
+
+/-- Exact optional operation lookup. -/
+def operation? (program : Program) (operation : OpId) : Option Operation :=
+  program.operations[operation.index]?
+
+/-- Exact optional node lookup. -/
+def node? (program : Program) (node : NodeId) : Option Node :=
+  program.nodes[node.index]?
+
+/-- Resolve a stable operation key in this exact program snapshot. -/
+def operationWithKey? (program : Program) (key : OpKey) : Option Operation :=
+  program.operations.toList.find? fun operation => operation.key == key
+
+/-- Resolve a stable operation key together with its snapshot-local compact
+identifier. -/
+def operationEntry? (program : Program) (key : OpKey) : Option (OpId × Operation) := do
+  for index in [0:program.operations.size] do
+    let operation <- program.operations[index]?
+    if operation.key == key then return ({ index }, operation)
+  none
+
+def uniqueOpKeys : List Operation -> Bool
+  | [] => true
+  | operation :: operations =>
+      !(operations.any fun other => other.key == operation.key) &&
+        uniqueOpKeys operations
+
+def argsCheck (program : Program) (outputIndex : Nat) :
+    List NodeId -> List DomainId -> Bool
+  | [], [] => true
+  | argument :: arguments, domain :: domains =>
+      argument.index < outputIndex &&
+        (program.node? argument).any (fun node => node.domain == domain) &&
+        argsCheck program outputIndex arguments domains
+  | _, _ => false
+
+def nodeCheck (program : Program) (outputIndex : Nat) (node : Node) : Bool :=
+  match program.operation? node.op with
+  | none => false
+  | some operation =>
+      node.domain == operation.output &&
+        argsCheck program outputIndex node.args operation.inputs
+
+def nodesCheckFrom (program : Program) : Nat -> List Node -> Bool
+  | _, [] => true
+  | outputIndex, node :: nodes =>
+      nodeCheck program outputIndex node && nodesCheckFrom program (outputIndex + 1) nodes
+
+/-- Validate operation-key uniqueness, operation references, arities, domains,
+and strict SSA topology. In particular, every argument precedes its consumer,
+so a checked program is acyclic. -/
+def check (program : Program) : Bool :=
+  uniqueOpKeys program.operations.toList && nodesCheckFrom program 0 program.nodes.toList
+
+/-- Structural expression depth, with nullary nodes at depth zero. -/
+def nodeDepth? (depths : Array Nat) (arguments : List NodeId) : Option Nat := do
+  if arguments.isEmpty then
+    pure 0
+  else
+    let mut greatest := 0
+    for argument in arguments do
+      let depth <- depths[argument.index]?
+      greatest := Nat.max greatest depth
+    pure (greatest + 1)
+
+/-- Reconstruct the structural depth of every node in a validated SSA
+program. This measure is independent of theorem-instantiation generation. -/
+def depths? (program : Program) : Option (Array Nat) := do
+  let mut depths := #[]
+  for index in [0:program.nodes.size] do
+    let node <- program.nodes[index]?
+    let depth <- nodeDepth? depths node.args
+    depths := depths.push depth
+  pure depths
+
+end Program
+end Hex.Interval

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -63,6 +63,18 @@ keys. Dyadic, rational, elementary-function, and Mathlib theorem backends plug
 into that framework; backend-specific replay experiments do not block or
 define the scheduler architecture.
 
+The current supported Mathlib-free boundary now includes the structural half
+of that milestone: checked typed SSA `Program`s; versioned fact snapshots and
+projected views; stable operation/rule keys; registrations and explicit scope
+bindings; and immutable actions and package requests. These records
+deliberately contain neither function callbacks nor proof evidence. Concrete
+dependency storage, worklists, resource counters, package assembly, callback
+outcomes and proposals, scheduling, policy, branch search, payload storage,
+and replay are still experimental; their current types are not supported APIs
+and do not determine the eventual storage or default policy. In particular,
+the current instantiation proposal's package-supplied numeric policy family is
+not part of the supported action contract.
+
 The active implementation gate is to harden and compare the first complete
 arbitrary-function vertical: independently assembled forward and backward
 propagators, function-owned retries and split suggestions, structural
@@ -923,11 +935,13 @@ operation key to infer that, for example, addition reads two arguments or a
 contractor writes one of them. Later shape rules may propose validated
 cross-node applications without changing the scheduler protocol.
 
-The current arbitrary-propagator experiment gives each request a bounded,
-immutable `ProgramView` containing the exact program version, operation table,
+The supported request contract gives each action a bounded, immutable
+`ProgramView` containing the exact program version, operation table,
 SSA node table, per-node theorem-instantiation generations, and per-node
 structural expression depths. It contains no facts.
-The engine constructs it only from a validated state already covered by the
+`ProgramView.check` validates the decoded SSA program and exact alignment of
+the generation/depth side tables; the experimental engine constructs it only
+from a validated state already covered by the
 operation, node, arity, generation, and structural-depth limits. Thus an
 external shape rule can follow a product argument to a nested difference,
 compare opaque operation keys, recover the repeated `NodeId`, and construct a
@@ -1414,6 +1428,16 @@ Rules are explicit registrations, not typeclass instances. Typeclass search
 must not recursively decide which algorithm computes an expression's bound.
 The registry may contain several rules for one head symbol, and the policy may
 try or combine all of them.
+
+`Registration.check` is supported and validates exact versioned heads,
+duplicate-free keys, binding shapes, and local slot ranges against a checked
+program. `ScopeBinding.check` validates ordered concrete ports and exact
+anchor heads without interpreting a function. `RuleRequest.accepts` validates
+the immutable program view plus the registration's exact stable key, action
+kind, fact versions, and ordered read/write projection. Compact rule and
+application identifiers, action serials, fact values, and pending-state
+ownership can only be authenticated by the controller that issued the action;
+these structural checks neither claim that authority nor create evidence.
 
 A registry snapshot is assembled from independently upgradeable function
 packages. The current canary chooses an ordered `Array (Package Fact)`. Each
@@ -4909,13 +4933,24 @@ their declared cost inside a scheduler bound.
   semantics and the one-way total-real-division enclosure theorem.
 - `HexIntervalMathlib/Regularize.lean`: exact normalized rounded-cut semantics,
   outward containment, and raw-cut idempotence without a grid-tightest claim.
-- `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
-- `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
-- `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
-- `HexInterval/State.lean`: branch state and incremental worklists.
-- `HexInterval/Policy.lean`: policy interface and `balancedV1`.
-- `HexInterval/Search.lean`: budgeted branch search and derivation slicing.
-- `HexInterval/Trace.lean`: diagnostics and machine-readable telemetry.
+- `HexInterval/Program.lean`: supported stable operation/domain/node
+  identifiers, decoded typed SSA programs, fail-closed validation, and
+  structural depths.
+- `HexInterval/Fact.lean`: supported versioned fact snapshots, projected fact
+  views, narrowing results, and the function-agnostic fact-domain interface.
+- `HexInterval/Action.lean`: supported stable rule/action identities,
+  registrations, scope bindings, validated immutable program/request views,
+  and exact read/write projections. It has no callbacks, outcomes, policy, or
+  proof evidence.
+- `HexInterval/Experiment/Propagator.lean`: current experimental concrete
+  applications, dependency indexes, worklists, counters, callback outcomes
+  and untrusted proposals, replies, extension admission, and engine state,
+  consuming the supported contracts.
+- `HexInterval/Experiment/{PackageRegistry,PolicyDriver,PolicySession,
+  StagedPolicy,AdaptivePolicy,FeaturePolicy,BranchTree}.lean`: current
+  provisional package callback, policy, session, and branch-search designs.
+   Future supported state/policy/search/trace modules will be selected from
+   measurements; no storage representation or default policy is frozen yet.
 - `conformance/HexInterval/{Conformance,MinMaxConformance,EmitFixtures}.lean`:
   Lean-only checks and oracle fixtures.
 - `HexInterval/Experiment/PntFks2FamilyData*.lean` and
@@ -4953,6 +4988,11 @@ The required Lean-only profile covers every interval shape and operation with
 typical, boundary, and adversarial inputs. In particular it includes:
 
 - all four finite endpoint closure combinations;
+- malformed structural programs, including duplicate operation keys, wrong
+  arity/domain, unknown operations, and self/forward SSA references;
+- malformed registration, scope, and request snapshots, including wrong
+  operation/rule versions, duplicate or out-of-range ports, misaligned side
+  tables, changed fact versions, and changed ordered write authority;
 - equal endpoints in all closure combinations;
 - empty, singleton, one-sided unbounded, and whole intervals;
 - table-driven empty laws: every unary operation and `regularize` preserve

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -948,6 +948,11 @@ compare opaque operation keys, recover the repeated `NodeId`, and construct a
 proposal without duplicating either engine-owned depth calculation. It still
 receives facts only for its registration's declared watch slots. Structural
 inspection does not become a hidden fact dependency.
+The current package-boundary dispatch deliberately runs this complete check
+again through `RuleRequest.accepts` for every selected request. This is a
+fail-closed structural authentication boundary, not a hot-path complexity
+claim: it scans the whole program and reconstructs its depth array before the
+package callback runs.
 `ProgramView.findOp?` resolves a stable `OpKey` to this snapshot's local
 `OpId` and exact signature; package assembly order is never authoritative for
 frontend node identifiers.
@@ -4857,10 +4862,15 @@ design with its own SPEC.
 ## Complexity contract
 
 Let `n` be the number of program nodes, `e` the number of argument-to-consumer
-edges, `q` the number of queued candidates, and `b` the number of live branch
-states.
+edges, `k` the number of registered operations, `q` the number of queued
+candidates, and `b` the number of live branch states.
 
-- Program validation and initial dependency construction are `O(n + e)`.
+- `Program.check` is `O(n + e + k²)`: it checks the SSA nodes and edges and
+  performs the current pairwise operation-key uniqueness check. Initial
+  dependency construction is `O(n + e)`. `RuleRequest.accepts` deliberately
+  revalidates the complete `ProgramView` per selected request, including depth
+  reconstruction, so the current package-boundary dispatch performs this
+  whole-program work before each callback.
 - One worklist update is proportional to the number of rules attached to the
   changed node and its consumers. The scheduler does not scan all `n` nodes
   after every fact.

--- a/HexIntervalMathlib/Experiment/CosBillion.lean
+++ b/HexIntervalMathlib/Experiment/CosBillion.lean
@@ -23,6 +23,7 @@ the ordinary cosine periodicity theorem.
 
 namespace Hex.IntervalMathlib.Experiment.CosBillion
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator SemanticReplay ChronologicalReplay ProofEmitter ProofRegistry
 open GenericInstanceReconstruction OperationSemantics

--- a/HexIntervalMathlib/Experiment/LogTablePrecision.lean
+++ b/HexIntervalMathlib/Experiment/LogTablePrecision.lean
@@ -17,6 +17,7 @@ public import HexInterval.Experiment.OperationSemantics
 namespace Hex.IntervalMathlib.Experiment.LogTablePrecision
 
 open Finset
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator SemanticReplay ChronologicalReplay ProofEmitter ProofRegistry
 open GenericInstanceReconstruction OperationSemantics

--- a/HexIntervalMathlib/Experiment/SinTenInterval.lean
+++ b/HexIntervalMathlib/Experiment/SinTenInterval.lean
@@ -23,6 +23,7 @@ ordinary real semantics.
 
 namespace Hex.IntervalMathlib.Experiment.SinTenInterval
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator SemanticReplay ChronologicalReplay ProofEmitter ProofRegistry
 open GenericInstanceReconstruction OperationSemantics

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -2148,4 +2148,158 @@ example {limit : EndpointLimit} {raw : Raw} {interval : Hex.Interval}
 example (left right : Hex.Interval) (h : left.view = right.view) : left = right :=
   Hex.Interval.ext h
 
+/-! # Supported controller contracts -/
+
+namespace Contracts
+
+def realDomain : DomainId := { index := 0 }
+def otherDomain : DomainId := { index := 1 }
+
+def sourceKey : OpKey := { name := "contracts.source", version := 1 }
+def sourceV2Key : OpKey := { name := "contracts.source", version := 2 }
+def unaryKey : OpKey := { name := "contracts.unary", version := 3 }
+
+def sourceOp : Operation := { key := sourceKey, inputs := [], output := realDomain }
+def sourceV2Op : Operation := { key := sourceV2Key, inputs := [], output := realDomain }
+def unaryOp : Operation := { key := unaryKey, inputs := [realDomain], output := realDomain }
+
+def contractNode (index : Nat) : NodeId := { index }
+
+def contractProgram : Program :=
+  { operations := #[sourceOp, unaryOp]
+    nodes :=
+      #[{ domain := realDomain, op := { index := 0 }, args := [] },
+        { domain := realDomain, op := { index := 1 }, args := [contractNode 0] }] }
+
+#guard contractProgram.check
+#guard contractProgram.depths? == some #[0, 1]
+
+-- Stable operation versions are part of uniqueness and lookup identity.
+#guard ({ contractProgram with operations := #[sourceOp, unaryOp, sourceV2Op] }).check
+#guard !({ contractProgram with operations := #[sourceOp, sourceOp, unaryOp] }).check
+
+-- Arity, output domains, operation identifiers, and strict SSA order are all
+-- checked before a controller may build dependency state.
+#guard !({ contractProgram with nodes :=
+  #[{ domain := realDomain, op := { index := 0 }, args := [contractNode 0] }] }).check
+#guard !({ contractProgram with nodes :=
+  #[{ domain := realDomain, op := { index := 9 }, args := [] }] }).check
+#guard !({ contractProgram with nodes :=
+  #[{ domain := otherDomain, op := { index := 0 }, args := [] }] }).check
+#guard !({ contractProgram with nodes :=
+  #[{ domain := realDomain, op := { index := 0 }, args := [] },
+    { domain := realDomain, op := { index := 1 }, args := [contractNode 1] }] }).check
+#guard !({ contractProgram with nodes :=
+  #[{ domain := realDomain, op := { index := 0 }, args := [] },
+    { domain := realDomain, op := { index := 1 }, args := [] }] }).check
+
+def localKey : RuleKey := { name := "contracts.local", schema := 4 }
+def scopedKey : RuleKey := { name := "contracts.scoped", schema := 2 }
+
+def localRule : Registration :=
+  { key := localKey
+    head := unaryKey
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def scopeRule : Registration :=
+  { key := scopedKey
+    head := unaryKey
+    kind := .improve
+    watches := []
+    writes := []
+    binding := .scoped }
+
+def wrongHeadRule : Registration :=
+  { localRule with
+    key := { name := "contracts.local", schema := 5 }
+    head := { name := "contracts.unary", version := 2 } }
+
+#guard Registration.check contractProgram #[localRule, scopeRule]
+#guard !Registration.check contractProgram #[localRule, localRule]
+#guard !Registration.check contractProgram #[wrongHeadRule]
+#guard !Registration.check contractProgram #[{ localRule with watches := [.argument 1] }]
+#guard !Registration.check contractProgram #[{ localRule with writes := [.result, .result] }]
+#guard !Registration.check contractProgram #[{ localRule with binding := .global }]
+
+def binding : ScopeBinding :=
+  { rule := scopedKey
+    anchor := contractNode 1
+    watches := [contractNode 0]
+    writes := [contractNode 1] }
+
+#guard ScopeBinding.check contractProgram #[localRule, scopeRule] binding
+#guard ScopeBinding.checkAll contractProgram #[localRule, scopeRule] #[binding]
+#guard !ScopeBinding.checkAll contractProgram #[localRule, scopeRule] #[binding, binding]
+#guard !ScopeBinding.check contractProgram #[localRule, scopeRule]
+  { binding with rule := localKey }
+#guard !ScopeBinding.check contractProgram #[localRule, scopeRule]
+  { binding with anchor := contractNode 0 }
+#guard !ScopeBinding.check contractProgram #[localRule, scopeRule]
+  { binding with watches := [contractNode 0, contractNode 0] }
+#guard !ScopeBinding.check contractProgram #[localRule, scopeRule]
+  { binding with writes := [contractNode 2] }
+
+def view : ProgramView :=
+  { programVersion := 7
+    operations := contractProgram.operations
+    nodes := contractProgram.nodes
+    generations := #[0, 2]
+    depths := #[0, 1] }
+
+#guard view.check
+#guard !({ view with generations := #[0] }).check
+#guard !({ view with depths := #[0, 2] }).check
+
+def action : Action :=
+  { serial := 11
+    programVersion := 7
+    application := { index := 3 }
+    rule := { index := 0 }
+    key := localKey
+    node := contractNode 1
+    kind := .forward
+    effort := 0
+    generation := 2
+    inputs := [{ node := contractNode 0, version := 5 }]
+    writes := [contractNode 1] }
+
+def request : RuleRequest Nat :=
+  { action
+    program := view
+    inputs := [{ node := contractNode 0, fact := 23, version := 5 }]
+    writes := [contractNode 1] }
+
+#guard RuleRequest.accepts localRule request
+#guard request.fact? (contractNode 0) == some 23
+
+-- Compact identifiers and serials are authenticated by controller state, but
+-- every stable key, program/fact version, and ordered port is checked here.
+#guard !RuleRequest.accepts localRule
+  { request with action := { action with programVersion := 8 } }
+#guard !RuleRequest.accepts localRule
+  { request with action := { action with key := { localKey with schema := 5 } } }
+#guard !RuleRequest.accepts localRule
+  { request with action :=
+      { action with inputs := [{ node := contractNode 0, version := 6 }] } }
+#guard !RuleRequest.accepts localRule
+  { request with inputs := [{ node := contractNode 0, fact := 23, version := 6 }] }
+#guard !RuleRequest.accepts localRule { request with action := { action with writes := [] } }
+#guard !RuleRequest.accepts localRule { request with writes := [] }
+#guard !RuleRequest.accepts localRule
+  { request with program := { view with depths := #[0, 2] } }
+
+def snapshot : Snapshot Nat :=
+  { facts := #[13, 23], versions := #[4, 5], contradictory := false }
+
+#guard snapshot.check contractProgram
+#guard !({ snapshot with versions := #[4] }).check contractProgram
+#guard snapshot.fact? (contractNode 1) == some 23
+#guard snapshot.version? (contractNode 1) == some 5
+#guard ({ node := contractNode 1, version := 5 : SeenVersion }) !=
+  ({ node := contractNode 1, version := 6 : SeenVersion })
+
+end Contracts
+
 end Hex.Interval.Conformance

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -89,7 +89,7 @@ def exactFact (state : Engine Fact) (index : Nat) (expected : Raw) : Bool :=
 
 def registryChecks (program : Program) : Bool :=
   match registry? with
-  | some registry => registrationsCheck program registry.registrations
+  | some registry => Registration.check program registry.registrations
   | none => false
 
 /-! ## Exact backward singleton multiplication -/
@@ -410,7 +410,8 @@ def plannedRequest? (registry : ConcreteRegistry) (serial : Nat)
           node := anchor
           kind
           effort := 0
-          inputs := [] }
+          inputs := []
+          writes }
       program := payloadView
       inputs := []
       writes }

--- a/conformance/HexInterval/GenericInstanceReconstructionConformance.lean
+++ b/conformance/HexInterval/GenericInstanceReconstructionConformance.lean
@@ -16,6 +16,7 @@ operation key, or package registry.
 
 namespace Hex.Interval.GenericInstanceReconstructionConformance
 
+open Hex.Interval
 open Experiment Propagator SemanticReplay ChronologicalReplay
 open GenericInstanceReconstruction
 
@@ -44,7 +45,7 @@ def finalProgram : Program :=
 def baseProgram : Program :=
   programPrefix finalProgram 1
 
-theorem baseSnapshot : Snapshot finalProgram baseProgram :=
+theorem baseSnapshot : GenericInstanceReconstruction.Snapshot finalProgram baseProgram :=
   { finalChecked := by rfl
     currentChecked := by rfl
     finalPrefix :=

--- a/conformance/HexInterval/MatcherSchedulerConformance.lean
+++ b/conformance/HexInterval/MatcherSchedulerConformance.lean
@@ -107,7 +107,7 @@ def started? : Option (Engine Rank) :=
   | .error _ => none
 
 #guard program.check
-#guard registrationsCheck program #[matcherRule, contractRule]
+#guard Registration.check program #[matcherRule, contractRule]
 
 -- A whole-network matcher is compiled once for the registration, even though
 -- its declared head can occur many times after instantiation.

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -20,6 +20,7 @@ frontiers differ on live pending work.
 namespace Hex.Interval.NestedBranchConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Experiment
 open Propagator PolicySession SemanticReplay TargetRun BranchStart BranchTree
 open BranchProof ExpSign
@@ -108,7 +109,7 @@ private def run? (order : Order) (fuel : Nat) : Option (State Bound Route) := do
   let .ok state := BranchTree.runFrom (config order) fuel state | none
   some state
 
-private def leafReached? (entry : Node Bound Route) : Bool :=
+private def leafReached? (entry : BranchTree.Node Bound Route) : Bool :=
   match entry with
   | .leaf source (.result result) =>
       source.input.target == target &&

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -209,7 +209,8 @@ def unaryRequest (rule application : Nat) (key : RuleKey) (anchor : NodeId)
         node := anchor
         kind
         effort := 0
-        inputs := [{ node := node 0, version := 0 }] }
+        inputs := [{ node := node 0, version := 0 }]
+        writes }
     program := view
     inputs := [{ node := node 0, fact := 0, version := 0 }]
     writes }

--- a/conformance/HexInterval/SemanticReplayConformance.lean
+++ b/conformance/HexInterval/SemanticReplayConformance.lean
@@ -236,7 +236,8 @@ def action (serial application rule : Nat) (key : RuleKey)
     node := target
     kind := .forward
     effort := 0
-    inputs := [{ node := input, version := 0 }] }
+    inputs := [{ node := input, version := 0 }]
+    writes := [target] }
 
 def leftAction : Action :=
   action 0 0 0 leftRuleKey (node 1) (node 0)

--- a/conformance/HexIntervalAlgebraic/PolynomialDispatchConformance.lean
+++ b/conformance/HexIntervalAlgebraic/PolynomialDispatchConformance.lean
@@ -21,6 +21,7 @@ generic proof frontend can construct evidence.
 namespace Hex.IntervalAlgebraic.PolynomialDispatchConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ProofEmitter ProofRegistry Frontend
 open Hex.Interval.Experiment.PolynomialDispatch

--- a/conformance/HexIntervalMathlib/CosBillionConformance.lean
+++ b/conformance/HexIntervalMathlib/CosBillionConformance.lean
@@ -20,6 +20,7 @@ ordinary theorem `0 < Real.cos (10^10)`.
 namespace Hex.IntervalMathlib.CosBillionConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -26,6 +26,7 @@ ordinary kernel-checked theorem.
 namespace Hex.IntervalMathlib.ExpSignConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend ExpSign

--- a/conformance/HexIntervalMathlib/IntegralCanaryConformance.lean
+++ b/conformance/HexIntervalMathlib/IntegralCanaryConformance.lean
@@ -20,6 +20,7 @@ Its ordinary conclusion bounds `∫ x in 0..1, exp (-x²)` to four decimals.
 namespace Hex.IntervalMathlib.IntegralCanaryConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry IntegralCanary

--- a/conformance/HexIntervalMathlib/LogTablePrecisionConformance.lean
+++ b/conformance/HexIntervalMathlib/LogTablePrecisionConformance.lean
@@ -20,6 +20,7 @@ frontend to an ordinary theorem about `Real.log 2`.
 namespace Hex.IntervalMathlib.LogTablePrecisionConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry

--- a/conformance/HexIntervalMathlib/MixedFunctionsConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedFunctionsConformance.lean
@@ -23,6 +23,7 @@ The generic scheduler and proof frontend contain no cases for either function.
 namespace Hex.IntervalMathlib.MixedFunctionsConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend GoalClosure

--- a/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedInstantiationConformance.lean
@@ -24,6 +24,7 @@ that fact back to `sin (-x)`; and the exponential package consumes it.
 namespace Hex.IntervalMathlib.MixedInstantiationConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend GoalClosure

--- a/conformance/HexIntervalMathlib/PntBKLNWExpConformance.lean
+++ b/conformance/HexIntervalMathlib/PntBKLNWExpConformance.lean
@@ -20,6 +20,7 @@ floor, exact/table-tail split, rational scale, and both output cuts.
 namespace Hex.IntervalMathlib.PntBKLNWExpConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntBKLNWExp

--- a/conformance/HexIntervalMathlib/PntBKLNWPowConformance.lean
+++ b/conformance/HexIntervalMathlib/PntBKLNWPowConformance.lean
@@ -21,6 +21,7 @@ source `pow*_upper` declarations without importing LeanCert.
 namespace Hex.IntervalMathlib.PntBKLNWPowConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntBKLNWPow

--- a/conformance/HexIntervalMathlib/PntExpNegativeConformance.lean
+++ b/conformance/HexIntervalMathlib/PntExpNegativeConformance.lean
@@ -22,6 +22,7 @@ run through the same bounded sixth-power provider; the tight representative
 namespace Hex.IntervalMathlib.PntExpNegativeConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntExpNegative
@@ -204,8 +205,8 @@ theorem closeRepresentative
 
 private def sourceExpr (value : Source) : Expr :=
   mkApp2 (mkConst ``Source.mk) (mkNatLit value.sourceIndex) (mkNatLit value.sixths)
-private def upperExpr (value : Upper) : Expr :=
-  mkApp3 (mkConst ``Upper.mk) (mkNatLit value.sourceIndex)
+private def upperExpr (value : PntExpNegative.Upper) : Expr :=
+  mkApp3 (mkConst ``PntExpNegative.Upper.mk) (mkNatLit value.sourceIndex)
     (mkNatLit value.numerator) (mkNatLit value.scale)
 private def boundExpr : Bound → Expr
   | .all => mkConst ``Bound.all

--- a/conformance/HexIntervalMathlib/PntExpPointConformance.lean
+++ b/conformance/HexIntervalMathlib/PntExpPointConformance.lean
@@ -21,6 +21,7 @@ chronology and `ProofFrontend` replay.
 namespace Hex.IntervalMathlib.PntExpPointConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntExpPoint

--- a/conformance/HexIntervalMathlib/PntExpTailConformance.lean
+++ b/conformance/HexIntervalMathlib/PntExpTailConformance.lean
@@ -23,6 +23,7 @@ This fixture covers the numerical leaf inside
 namespace Hex.IntervalMathlib.PntExpTailConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntExpTail

--- a/conformance/HexIntervalMathlib/PntFks2FamilyConformance.lean
+++ b/conformance/HexIntervalMathlib/PntFks2FamilyConformance.lean
@@ -19,6 +19,7 @@ representative cells from both sides of shard boundaries.
 
 namespace Hex.IntervalMathlib.PntFks2FamilyConformance
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay
 open Frontend PntFks2Family

--- a/conformance/HexIntervalMathlib/PntFks2ShardConformance.lean
+++ b/conformance/HexIntervalMathlib/PntFks2ShardConformance.lean
@@ -19,6 +19,7 @@ large-payload `ProofFrontend` fold is deliberately not part of this probe.
 
 namespace Hex.IntervalMathlib.PntFks2ShardConformance
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay
 open Frontend PntFks2Shard

--- a/conformance/HexIntervalMathlib/PntLogNaturalConformance.lean
+++ b/conformance/HexIntervalMathlib/PntLogNaturalConformance.lean
@@ -22,6 +22,7 @@ row.  The generic proof frontend is exercised at representative row 29.
 namespace Hex.IntervalMathlib.PntLogNaturalConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntLogNatural

--- a/conformance/HexIntervalMathlib/PntLogRationalConformance.lean
+++ b/conformance/HexIntervalMathlib/PntLogRationalConformance.lean
@@ -22,6 +22,7 @@ chronology and `ProofFrontend` replay.
 namespace Hex.IntervalMathlib.PntLogRationalConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntLogRational

--- a/conformance/HexIntervalMathlib/PntLogTableConformance.lean
+++ b/conformance/HexIntervalMathlib/PntLogTableConformance.lean
@@ -21,6 +21,7 @@ chronology through the package schema and closes the original real theorem.
 namespace Hex.IntervalMathlib.PntLogTableConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntLogTable

--- a/conformance/HexIntervalMathlib/PntNestedLogConformance.lean
+++ b/conformance/HexIntervalMathlib/PntNestedLogConformance.lean
@@ -22,6 +22,7 @@ Mathlib-free log package twice.  Replay first checks a positive enclosure for
 namespace Hex.IntervalMathlib.PntNestedLogConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntNestedLog

--- a/conformance/HexIntervalMathlib/PntNestedLogTwoConformance.lean
+++ b/conformance/HexIntervalMathlib/PntNestedLogTwoConformance.lean
@@ -20,6 +20,7 @@ of its endpoints.
 namespace Hex.IntervalMathlib.PntNestedLogTwoConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntNestedLogTwo

--- a/conformance/HexIntervalMathlib/PntPiPointConformance.lean
+++ b/conformance/HexIntervalMathlib/PntPiPointConformance.lean
@@ -20,6 +20,7 @@ proved `Real.pi_lt_d2`; no Chudnovsky or LeanCert theorem is imported.
 namespace Hex.IntervalMathlib.PntPiPointConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntPiPoint

--- a/conformance/HexIntervalMathlib/PntTable10A2Conformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10A2Conformance.lean
@@ -20,6 +20,7 @@ representative source theorem through `ProofFrontend`.
 namespace Hex.IntervalMathlib.PntTable10A2Conformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10A2

--- a/conformance/HexIntervalMathlib/PntTable10ConvexConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10ConvexConformance.lean
@@ -20,6 +20,7 @@ without a draft or precision retry.
 namespace Hex.IntervalMathlib.PntTable10ConvexConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10Convex

--- a/conformance/HexIntervalMathlib/PntTable10LargePointwiseConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10LargePointwiseConformance.lean
@@ -19,6 +19,7 @@ Endpoint and coordinate mutations reject without a draft or retry.
 namespace Hex.IntervalMathlib.PntTable10LargePointwiseConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10LargePointwise

--- a/conformance/HexIntervalMathlib/PntTable10LogCoupledConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10LogCoupledConformance.lean
@@ -20,6 +20,7 @@ mutations all reject without producing a draft or retry.
 namespace Hex.IntervalMathlib.PntTable10LogCoupledConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10LogCoupled

--- a/conformance/HexIntervalMathlib/PntTable10PointwiseConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10PointwiseConformance.lean
@@ -20,6 +20,7 @@ a draft or precision retry.
 namespace Hex.IntervalMathlib.PntTable10PointwiseConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10Pointwise

--- a/conformance/HexIntervalMathlib/PntTable10ShardConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable10ShardConformance.lean
@@ -21,6 +21,7 @@ that the un-margined endpoint inequality is false.
 namespace Hex.IntervalMathlib.PntTable10ShardConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable10Shard

--- a/conformance/HexIntervalMathlib/PntTable12Conformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable12Conformance.lean
@@ -22,6 +22,7 @@ outside this fixture.
 namespace Hex.IntervalMathlib.PntTable12Conformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable12

--- a/conformance/HexIntervalMathlib/PntTable12LogConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable12LogConformance.lean
@@ -19,6 +19,7 @@ the ten logarithmic leaves that follow the 120-cell ordinary fixture.
 namespace Hex.IntervalMathlib.PntTable12LogConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable12Log

--- a/conformance/HexIntervalMathlib/PntTable12OrdinaryConformance.lean
+++ b/conformance/HexIntervalMathlib/PntTable12OrdinaryConformance.lean
@@ -21,6 +21,7 @@ logarithmic-row leaves remain separate acceptance work.
 namespace Hex.IntervalMathlib.PntTable12OrdinaryConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend ProofRegistry PntTable12Ordinary

--- a/conformance/HexIntervalMathlib/ReluConformance.lean
+++ b/conformance/HexIntervalMathlib/ReluConformance.lean
@@ -26,6 +26,7 @@ theorem is unconditional and does not mathematically require branching.
 namespace Hex.IntervalMathlib.ReluConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend ExpSign

--- a/conformance/HexIntervalMathlib/SinTenIntervalConformance.lean
+++ b/conformance/HexIntervalMathlib/SinTenIntervalConformance.lean
@@ -19,6 +19,7 @@ instantiation through the generic runtime chronology and proof frontend.
 namespace Hex.IntervalMathlib.SinTenIntervalConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry

--- a/conformance/HexIntervalMathlib/SineProofConformance.lean
+++ b/conformance/HexIntervalMathlib/SineProofConformance.lean
@@ -19,6 +19,7 @@ is not an oracle used by the proof.
 
 namespace Hex.IntervalMathlib.SineProofConformance
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PayloadArena SemanticReplay ChronologicalReplay ProofEmitter
 open SineSign SineSignConformance

--- a/conformance/HexIntervalMathlib/SineSignConformance.lean
+++ b/conformance/HexIntervalMathlib/SineSignConformance.lean
@@ -17,6 +17,7 @@ against the Mathlib theorem schemas.
 
 namespace Hex.IntervalMathlib.SineSignConformance
 
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay TraceReplay
   ProofRegistry

--- a/conformance/HexIntervalMathlib/SineTacticConformance.lean
+++ b/conformance/HexIntervalMathlib/SineTacticConformance.lean
@@ -26,6 +26,7 @@ assigned to the goal is checked by Lean's kernel.
 namespace Hex.IntervalMathlib.SineTacticConformance
 
 open Lean Elab Tactic Meta
+open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PayloadArena SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend ProofFrontend

--- a/progress/20260815T141635Z.md
+++ b/progress/20260815T141635Z.md
@@ -1,0 +1,46 @@
+# Accomplished
+
+- Extracted the function-agnostic typed SSA program, versioned fact, and
+  immutable action/request contracts from `HexInterval/Experiment` into the
+  supported Mathlib-free `HexInterval/{Program,Fact,Action}.lean` modules.
+- Moved exact operation/rule key lookup, registration and explicit-scope
+  validation, local slot resolution, program-view alignment, and exact request
+  projection checks to that supported boundary. Runtime data still grants no
+  theorem evidence, and compact identifiers/serials remain controller-owned.
+- Migrated the existing experimental engine, registry, policies, frontends,
+  branches, and proof experiments to consume the supported types without
+  moving callbacks, outcomes/proposals, payloads, storage, scheduling, policy,
+  or replay into the supported API. The package-supplied numeric instantiation
+  family therefore remains provisional rather than becoming a public action
+  field.
+- Added load-bearing conformance guards for malformed operation/rule versions,
+  duplicate keys and ports, invalid arity/domain/SSA dependencies, bad scope
+  anchors, misaligned fact/program side tables, and changed fact versions or
+  write authority.
+- Updated the umbrella and central SPEC to distinguish the supported
+  structural contracts from the still-experimental controller implementation
+  and future storage/default-policy choices.
+- Built the supported umbrella, the complete 59-module Mathlib-free controller
+  experiment, and focused program/registry/scope/matcher/payload/trace
+  conformance. The complete Mathlib experiment umbrella also builds after
+  making three affected proof modules explicitly open the supported namespace.
+  The full 9,484-job shared conformance target builds after migrating its
+  hand-built request fixtures to explicit write authority and making affected
+  consumers open or qualify the supported contracts. Trust, PNT inventory,
+  factor freshness, diff hygiene, and banned proof-mechanism checks pass.
+
+# Current frontier
+
+The supported library now has a checked decoded-data boundary suitable for a
+future production controller. The controller implementation itself remains an
+acceptance experiment, deliberately behind `HexInterval/Experiment`.
+
+# Next step
+
+Select and extract production state/dependency/worklist/resource accounting
+only after measuring the prepared controller policies and branch storage. Keep
+package callbacks and theorem replay in independently upgradeable layers.
+
+# Blockers
+
+None.

--- a/progress/20260816T030410Z.md
+++ b/progress/20260816T030410Z.md
@@ -1,0 +1,36 @@
+# Supported controller-contract restack
+
+## Accomplished
+
+- Replayed the preserved supported `Program` / `Fact` / `Action` extraction
+  patch-identically onto exact #9240 candidate
+  `99f30d9ca4d6c7484d9db5825168f9ad6fe1bf44`.
+- Audited the supported boundary against the current arithmetic, controller,
+  mixed-function, and PNT tree.  Structural validation remains Mathlib-free
+  and carries no callback, runtime contradiction, or proof authority.
+- Migrated fourteen PNT conformance modules added after the original
+  extraction to open the supported `Hex.Interval` contract namespace.  The
+  negative-exponential fixture additionally qualifies its package-local
+  `Upper` type to avoid collision with the public interval cut type.
+- Rebuilt the supported and Mathlib-free dependent controller graph, the
+  mixed sine/exp instantiation vertical, and representative current PNT
+  theorem paths.
+
+## Current frontier
+
+- The local candidate contains the extraction commit plus one narrow
+  current-tree namespace integration repair.  No remote branch or PR has been
+  changed.
+- Concrete engine state, provenance records, callback outcomes and proposals,
+  package assembly, policy, search, payload storage, and replay remain under
+  `HexInterval/Experiment` as intended.
+
+## Next step
+
+- After #9240 merges, mechanically restack these two local commits onto its
+  exact merge commit, refresh additive integration metadata if necessary, and
+  publish only after repeating focused and static gates.
+
+## Blockers
+
+- None.

--- a/progress/20260816T030656Z.md
+++ b/progress/20260816T030656Z.md
@@ -1,0 +1,28 @@
+# Supported controller-contract publication restack
+
+## Accomplished
+
+- Replayed the prepared supported `Program` / `Fact` / `Action` extraction and
+  current PNT namespace integration commits onto exact #9240 merge commit
+  `83b49aae8a2250470803477b36d5fafdb53fb964`.
+- Verified both replayed commits are patch-identical to the prepared local
+  candidate and preserve the merged mixed-instantiation, public interval, and
+  PNT tree byte-for-byte.
+- Rebuilt the Mathlib-free controller dependency graph and the mixed/current
+  representative PNT conformance targets in the publication worktree.
+
+## Current frontier
+
+- The branch is ready for final static gates and direct-main publication.
+- Supported APIs stop at structural programs, facts, registrations, scopes,
+  actions, and immutable requests.  Concrete applications, provenance state,
+  callbacks, search, and proof replay remain experimental.
+
+## Next step
+
+- Publish the exact branch to a new non-draft upstream PR against `main`, then
+  monitor the automatically launched exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T014324Z.md
+++ b/progress/20260821T014324Z.md
@@ -1,0 +1,26 @@
+# Supported controller contract final restack
+
+## Accomplished
+
+- Replayed the reviewed `Program`/`Fact`/`Action` extraction as an exact
+  three-commit range onto current `main` at `dd224652`, preserving the
+  intervening finite-field work and all current interval/PNT registrations.
+- Rebuilt the supported controller/conformance graph and the mixed-function
+  and current PNT consumers.
+- Re-ran DAG, trust-surface, factor-freshness, PNT-inventory, diff, and banned
+  proof-mechanism checks.
+
+## Current frontier
+
+- The structural Mathlib-free contracts are ready for publication as the
+  direct child of `dd224652`; concrete applications, callbacks, search, and
+  proof replay remain in `Experiment`.
+
+## Next step
+
+- Extract checked supported `State` and `Trace` contracts atop this edge,
+  migrating experimental controller consumers to the actual supported types.
+
+## Blockers
+
+- None.

--- a/progress/20260821T015525Z.md
+++ b/progress/20260821T015525Z.md
@@ -1,0 +1,24 @@
+# Supported contract complexity clarification
+
+## Accomplished
+
+- Audited the live `PackageRegistry.invokePlanned` dispatch path and confirmed
+  that `RuleRequest.accepts` rechecks the complete `ProgramView` before every
+  package callback.
+- Corrected the SPEC complexity contract: `Program.check` is
+  `O(n + e + k²)` with the current pairwise operation-key uniqueness check,
+  and current package dispatch performs that whole-program validation plus
+  depth reconstruction per request.
+
+## Current frontier
+
+- The code remains unchanged; this is an honesty repair for the supported
+  structural authentication boundary.
+
+## Next step
+
+- Let exact-head CI validate the repaired publication candidate.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
## Summary

- add Mathlib-free supported Program, Fact, and Action modules for typed SSA expression graphs, exact fact versions/views, stable operation and rule keys, registrations, scopes, actions, and immutable package requests
- validate operation-key uniqueness, typed arities/domains, strict SSA topology, structural depths, registration/scope shapes, and exact ordered request projections fail-closed
- migrate the existing experimental engine and package registry to consume these supported contracts without aliases or compatibility shims
- add malformed program, registration, scope, version, and request conformance guards
- preserve current mixed-instantiation and PNT consumers, including namespace integration for conformances added after the original extraction

## Trust boundary

These are structural contracts only. Checked runtime data does not become proof evidence, and the contradiction flag has no evidentiary authority. Concrete applications and provenance records, callbacks and proposals, dependency/worklist storage, policy, search, payload storage, and proof replay remain experimental. No storage representation or default policy is frozen here.

## Validation

- focused Mathlib-free controller build: 51 jobs
- mixed-function and representative current PNT build: 2,302 jobs
- DAG and trust-surface checks
- factor-sweep freshness
- PNT inventory tests and inventory validation
- exact main ancestry, unchanged Lake blob, diff, and banned-construct checks

No native_decide, axiom, or sorry is introduced.