### PR TITLE
test: cross-check every compiled clmul path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: python3 scripts/release/check_manual_split.py
       - run: python3 -m unittest scripts/release/test_sync_released.py
       - run: python3 scripts/release/check_trust_surface.py
+      - name: Cross-check every compiled clmul path (HexGF2/SPEC/hex-gf2.md)
+        run: bash scripts/ci/check_clmul_paths.sh
       - run: python3 scripts/check_phase4.py
       - name: Check Phase 7 chapters and anchored tutorials (PLAN/Phase7.md)
         run: |

--- a/HexGF2/SPEC/hex-gf2.md
+++ b/HexGF2/SPEC/hex-gf2.md
@@ -72,8 +72,28 @@ runtime CPU detection): x86-64 `__PCLMUL__` uses
 `vmull_p64`; otherwise it runs a portable shift-and-XOR mirroring
 `Hex.pureClmul`. Correctness of the intrinsic paths is trusted, same
 as the GMP externs in hex-arith. Tests must exercise each compiled
-wrapper path and the pure-Lean body (built without the extern
-attached) to catch divergence.
+wrapper path and the pure-Lean body to catch divergence.
+
+Because the choice is made at compile time, one build runs exactly one
+path, and the Lake target passes only `-O3`, so ordinary builds compile
+the portable fallback. Covering the requirement therefore needs two
+compilations rather than one:
+
+- `scripts/ci/check_clmul_paths.sh` compiles `HexGF2/ffi/clmul_selftest.c`
+  against `clmul.c` twice, plain and with the flag that enables the host's
+  intrinsic (`-mpclmul` on x86-64, `-march=armv8-a+crypto` on aarch64),
+  and cross-checks the intrinsic against the portable reference on 100000
+  deterministic pairs. A build that asked for an intrinsic and did not get
+  one fails rather than passing quietly.
+- `conformance/HexGF2/CrossCheck.lean` compares the extern against
+  `Hex.pureClmul` over a pseudorandom stream, which is the Lean half: it
+  checks the compiled wrapper against the logical definition the proofs
+  use.
+
+`clmul.c` exposes `hex_clmul_portable`, `hex_clmul_intrinsic`, and
+`hex_clmul_uses_intrinsic` so both halves can address the paths
+individually; `HEX_CLMUL_NO_LEAN` drops the export wrapper so the
+self-test needs no Lean runtime.
 
 **GF(2^n) elements.** Elements of `GF(2^n)` are polynomials of degree
 < n over F_2, reduced modulo an irreducible of degree n. This library

--- a/HexGF2/ffi/clmul.c
+++ b/HexGF2/ffi/clmul.c
@@ -1,15 +1,32 @@
+/* `HEX_CLMUL_NO_LEAN` compiles only the arithmetic, without the Lean export
+   wrapper and so without the Lean runtime. The self-test uses it: it wants to
+   compare the two implementations, not to link a Lean binary. */
+#ifndef HEX_CLMUL_NO_LEAN
 #include <lean/lean.h>
+#endif
 #include <stdint.h>
 
+/* Which implementation this translation unit selects is a compile-time
+   decision made by the guards below, not runtime CPU detection.
+   `HEX_CLMUL_HAVE_INTRINSIC` records that decision so the self-test can report
+   which path a given build exercised, and so a build that expected an
+   intrinsic can tell that it did not get one. */
 #if defined(__PCLMUL__) && (defined(__x86_64__) || defined(_M_X64))
+#define HEX_CLMUL_HAVE_INTRINSIC 1
+#define HEX_CLMUL_INTRINSIC_X86 1
 #include <immintrin.h>
-#endif
-
-#if defined(__ARM_FEATURE_CRYPTO) && (defined(__aarch64__) || defined(_M_ARM64))
+#elif defined(__ARM_FEATURE_CRYPTO) && (defined(__aarch64__) || defined(_M_ARM64))
+#define HEX_CLMUL_HAVE_INTRINSIC 1
+#define HEX_CLMUL_INTRINSIC_ARM 1
 #include <arm_neon.h>
+#else
+#define HEX_CLMUL_HAVE_INTRINSIC 0
 #endif
 
-static inline void hex_clmul_portable(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
+/* The portable reference, mirroring `Hex.pureClmul`, which is the logical
+   definition every proof reasons about. Exported rather than `static` so the
+   self-test can compare it against an intrinsic path inside one binary. */
+void hex_clmul_portable(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
     uint64_t out_hi = 0;
     uint64_t out_lo = 0;
     for (unsigned bit = 0; bit < 64; ++bit) {
@@ -27,16 +44,17 @@ static inline void hex_clmul_portable(uint64_t a, uint64_t b, uint64_t* hi, uint
     *lo = out_lo;
 }
 
-#if defined(__PCLMUL__) && (defined(__x86_64__) || defined(_M_X64))
-static inline void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
+#if HEX_CLMUL_HAVE_INTRINSIC
+#ifdef HEX_CLMUL_INTRINSIC_X86
+void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
     __m128i lhs = _mm_set_epi64x(0, (long long)a);
     __m128i rhs = _mm_set_epi64x(0, (long long)b);
     __m128i prod = _mm_clmulepi64_si128(lhs, rhs, 0x00);
     *lo = (uint64_t)_mm_cvtsi128_si64(prod);
     *hi = (uint64_t)_mm_extract_epi64(prod, 1);
 }
-#elif defined(__ARM_FEATURE_CRYPTO) && (defined(__aarch64__) || defined(_M_ARM64))
-static inline void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
+#else
+void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo) {
     poly64_t lhs = (poly64_t)a;
     poly64_t rhs = (poly64_t)b;
     poly128_t prod = vmull_p64(lhs, rhs);
@@ -44,13 +62,18 @@ static inline void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uin
     *hi = (uint64_t)(prod >> 64);
 }
 #endif
+#endif
 
+/* Whether this build compiled an intrinsic path at all. */
+int hex_clmul_uses_intrinsic(void) {
+    return HEX_CLMUL_HAVE_INTRINSIC;
+}
+
+#ifndef HEX_CLMUL_NO_LEAN
 LEAN_EXPORT lean_obj_res lean_hex_clmul_u64(uint64_t a, uint64_t b) {
     uint64_t hi;
     uint64_t lo;
-#if defined(__PCLMUL__) && (defined(__x86_64__) || defined(_M_X64))
-    hex_clmul_intrinsic(a, b, &hi, &lo);
-#elif defined(__ARM_FEATURE_CRYPTO) && (defined(__aarch64__) || defined(_M_ARM64))
+#if HEX_CLMUL_HAVE_INTRINSIC
     hex_clmul_intrinsic(a, b, &hi, &lo);
 #else
     hex_clmul_portable(a, b, &hi, &lo);
@@ -60,3 +83,4 @@ LEAN_EXPORT lean_obj_res lean_hex_clmul_u64(uint64_t a, uint64_t b) {
     lean_ctor_set(pair, 1, lean_box_uint64(lo));
     return pair;
 }
+#endif

--- a/HexGF2/ffi/clmul_selftest.c
+++ b/HexGF2/ffi/clmul_selftest.c
@@ -1,0 +1,100 @@
+/* Cross-check of the carry-less multiply implementations in clmul.c.
+ *
+ * `HexGF2/SPEC/hex-gf2.md` requires that tests exercise each compiled wrapper
+ * path, not merely whichever one the host happens to select. A build picks its
+ * path with preprocessor guards, so a single build can only ever run one of
+ * them; `scripts/ci/check_clmul_paths.sh` therefore compiles this twice, once
+ * plain and once with the flags that enable an intrinsic, and this program
+ * reports which path it got.
+ *
+ * When an intrinsic is compiled it is compared against the portable reference
+ * on every vector, which is the divergence the SPEC is worried about. When it
+ * is not, the portable path is still checked against known-answer vectors, so
+ * a plain build is not vacuous.
+ *
+ * The Lean side of the same obligation is `conformance/HexGF2/CrossCheck.lean`,
+ * which compares the extern against `Hex.pureClmul` over a pseudorandom stream.
+ */
+#include <stdint.h>
+#include <stdio.h>
+
+void hex_clmul_portable(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo);
+int hex_clmul_uses_intrinsic(void);
+#if defined(HEX_CLMUL_SELFTEST_EXPECT_INTRINSIC)
+void hex_clmul_intrinsic(uint64_t a, uint64_t b, uint64_t* hi, uint64_t* lo);
+#endif
+
+/* Known answers, computed independently of this C code: the first three are
+   hand-derived, the rest come from `Hex.pureClmul` evaluated in Lean. */
+struct known { uint64_t a, b, hi, lo; };
+static const struct known KNOWN[] = {
+    { 0u, 0u, 0u, 0u },
+    { 1u, 1u, 0u, 1u },
+    { 2u, 2u, 0u, 4u },
+    { 3u, 3u, 0u, 5u },
+    { 0xFFu, 0xFFu, 0u, 0x5555u },
+    { 0x8000000000000000ull, 2u, 1u, 0u },
+    { 0x8000000000000000ull, 0x8000000000000000ull, 0x4000000000000000ull, 0u },
+};
+
+/* Deterministic MMIX linear congruential generator, the same one the Lean
+   cross-check uses, so the two halves sweep comparable input shapes. */
+static uint64_t next(uint64_t* state) {
+    *state = *state * 6364136223846793005ull + 1442695040888963407ull;
+    return *state;
+}
+
+int main(void) {
+    int intrinsic = hex_clmul_uses_intrinsic();
+    printf("clmul self-test: intrinsic path %s\n",
+           intrinsic ? "compiled" : "not compiled (portable fallback)");
+
+#if defined(HEX_CLMUL_SELFTEST_EXPECT_INTRINSIC)
+    if (!intrinsic) {
+        fprintf(stderr,
+                "clmul self-test: expected an intrinsic build, but the guards "
+                "selected the portable path; the flags did not take effect\n");
+        return 2;
+    }
+#endif
+
+    for (unsigned i = 0; i < sizeof(KNOWN) / sizeof(KNOWN[0]); ++i) {
+        uint64_t hi, lo;
+        hex_clmul_portable(KNOWN[i].a, KNOWN[i].b, &hi, &lo);
+        if (hi != KNOWN[i].hi || lo != KNOWN[i].lo) {
+            fprintf(stderr,
+                    "clmul self-test: portable disagrees with known answer at "
+                    "vector %u: got (%llx, %llx), want (%llx, %llx)\n",
+                    i, (unsigned long long)hi, (unsigned long long)lo,
+                    (unsigned long long)KNOWN[i].hi,
+                    (unsigned long long)KNOWN[i].lo);
+            return 1;
+        }
+    }
+
+#if defined(HEX_CLMUL_SELFTEST_EXPECT_INTRINSIC)
+    uint64_t state = 0x243F6A8885A308D3ull;
+    for (unsigned i = 0; i < 100000u; ++i) {
+        uint64_t a = next(&state);
+        uint64_t b = next(&state);
+        uint64_t phi, plo, ihi, ilo;
+        hex_clmul_portable(a, b, &phi, &plo);
+        hex_clmul_intrinsic(a, b, &ihi, &ilo);
+        if (phi != ihi || plo != ilo) {
+            fprintf(stderr,
+                    "clmul self-test: intrinsic and portable disagree on "
+                    "(%llx, %llx): portable (%llx, %llx), intrinsic (%llx, %llx)\n",
+                    (unsigned long long)a, (unsigned long long)b,
+                    (unsigned long long)phi, (unsigned long long)plo,
+                    (unsigned long long)ihi, (unsigned long long)ilo);
+            return 1;
+        }
+    }
+    printf("clmul self-test: intrinsic agrees with portable on 100000 pairs\n");
+#else
+    (void)next;
+#endif
+
+    printf("clmul self-test: OK\n");
+    return 0;
+}

--- a/scripts/ci/check_clmul_paths.sh
+++ b/scripts/ci/check_clmul_paths.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Exercise every compiled carry-less-multiply path in HexGF2/ffi/clmul.c.
+#
+# `HexGF2/SPEC/hex-gf2.md` requires that tests exercise each compiled wrapper
+# path. A build selects its path with preprocessor guards, so one build runs
+# exactly one of them: the Lake target passes only `-O3`, which means ordinary
+# builds compile the portable fallback and never the intrinsic. This script
+# compiles the self-test a second time with the flags that enable an intrinsic,
+# so both paths are checked on every CI run rather than each machine silently
+# testing whichever one it happens to select.
+#
+# Extends the existing single job (SPEC/CI.md "no parallelism in CI"); it is a
+# few seconds of `cc`, not a new runner.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+CC="${CC:-cc}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SRC="HexGF2/ffi/clmul.c"
+TEST="HexGF2/ffi/clmul_selftest.c"
+
+# `HEX_CLMUL_NO_LEAN` drops the Lean export wrapper, so the self-test compiles
+# the arithmetic alone and needs neither Lean's headers nor its runtime.
+COMMON=(-DHEX_CLMUL_NO_LEAN -O2)
+
+build_and_run() {
+  local label="$1"; shift
+  local out="$WORK/selftest_$label"
+  echo "--- $label ---"
+  if ! "$CC" "${COMMON[@]}" "$@" "$SRC" "$TEST" -o "$out" 2>"$WORK/err_$label"; then
+    if [ "$label" = "portable" ]; then
+      cat "$WORK/err_$label" >&2
+      echo "check_clmul_paths: the portable build must compile" >&2
+      exit 1
+    fi
+    echo "check_clmul_paths: $label did not compile on this host; skipping"
+    sed 's/^/    /' "$WORK/err_$label" | head -5
+    return 0
+  fi
+  "$out"
+}
+
+# The path ordinary builds take.
+build_and_run portable
+
+# The intrinsic paths. Which one applies depends on the host architecture, so
+# try the one that matches and let the other be skipped. A host that cannot
+# build either still gets the portable check, and says so rather than passing
+# silently.
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64 | amd64)
+    build_and_run pclmul -mpclmul -DHEX_CLMUL_SELFTEST_EXPECT_INTRINSIC
+    ;;
+  aarch64 | arm64)
+    build_and_run pmull -march=armv8-a+crypto -DHEX_CLMUL_SELFTEST_EXPECT_INTRINSIC
+    ;;
+  *)
+    echo "check_clmul_paths: no intrinsic path defined for $ARCH; portable only"
+    ;;
+esac
+
+echo "check_clmul_paths: OK"


### PR DESCRIPTION
This PR makes `hex-gf2`'s carry-less multiply meet the testing requirement its own SPEC states.

`HexGF2/SPEC/hex-gf2.md` says tests must exercise each compiled wrapper path. Nothing did. The path is chosen by preprocessor guards, so a build runs exactly one, and `lakefile.lean` passes only `-O3`: x86-64 builds compile the portable shift-and-XOR fallback and never `_mm_clmulepi64_si128`, while Apple silicon compiles `vmull_p64` and never the fallback. Each machine tested one path and neither tested the other, so a divergence between them would have gone unnoticed until it produced a wrong answer on someone's hardware.

`scripts/ci/check_clmul_paths.sh` compiles `HexGF2/ffi/clmul_selftest.c` against `clmul.c` twice, plain and with the flag that enables the host's intrinsic (`-mpclmul` on x86-64, `-march=armv8-a+crypto` on aarch64), and cross-checks the intrinsic against the portable reference on 100000 deterministic pairs from the same MMIX generator the Lean cross-check uses. The portable build is separately checked against known answers so a host with no intrinsic still runs a real test, and a build that asked for an intrinsic but did not get one fails rather than reporting success. It runs in the existing lint job: a few seconds of `cc`, not a new runner.

Making the paths individually addressable meant exporting `hex_clmul_portable`, `hex_clmul_intrinsic`, and `hex_clmul_uses_intrinsic` rather than keeping the implementations `static inline`. `HEX_CLMUL_NO_LEAN` drops the export wrapper so the self-test compiles the arithmetic alone, needing neither Lean's headers nor its runtime. The dispatcher's behaviour is unchanged.

The SPEC now records how the requirement is met and by which half. `conformance/HexGF2/CrossCheck.lean` already compares the extern against `Hex.pureClmul`, covering the compiled wrapper against the logical definition the proofs use; this script covers the wrapper's own paths against each other.

Locally both halves pass: the portable build reports the fallback and matches its known answers, and the `pclmul` build reports the intrinsic and agrees with the portable reference on all 100000 pairs. Verified with `lake build HexGF2 HexConformance` (9530 jobs, clean) and the five lint scripts.

🤖 Prepared with Claude Code