### PR TITLE
doc: reconcile the finite-field SPECs with the shipped API

### DIFF
--- a/HexConway/SPEC/hex-conway.md
+++ b/HexConway/SPEC/hex-conway.md
@@ -111,12 +111,29 @@ benchmarking, or user-facing expectations.
 
 **API:**
 ```lean
-def conwayPoly (p n : Nat) : FpPoly p
+/-- A committed table hit, packaging the polynomial with its primality witness
+    and a proof that the lookup resolves to it. Unconstructible for an
+    uncommitted pair, which is how `conwayPoly` stays total only where the
+    table covers. -/
+structure SupportedEntry (p n : Nat) [ZMod64.Bounds p]
 
-theorem conwayPoly_nonconstant (p n : Nat) : 0 < (conwayPoly p n).degree
-theorem conwayPoly_irreducible (p n : Nat) : Irreducible (conwayPoly p n)
+def conwayPoly (p n : Nat) [ZMod64.Bounds p] (h : SupportedEntry p n) : FpPoly p
+
+theorem conwayPoly_nonconstant (p n) [ZMod64.Bounds p] (h : SupportedEntry p n) :
+    0 < (conwayPoly p n h).degree
+theorem conwayPoly_irreducible (p n) [ZMod64.Bounds p] (h : SupportedEntry p n) :
+    Irreducible (conwayPoly p n h)
+theorem conwayPoly_monic (p n) [ZMod64.Bounds p] (h : SupportedEntry p n) :
+    Monic (conwayPoly p n h)
+
+-- Tier 2, not yet implemented:
 theorem conwayPoly_compat (p m n : Nat) (h : m ∣ n) : ...
 ```
+
+The `SupportedEntry` argument is how "total only for committed entries" is
+enforced. It carries the table hit as a proof, so an uncommitted pair cannot
+produce one and the constructor cannot be applied. There is no fallback
+modulus and no `Option`.
 
 The API should expose the tiers explicitly rather than hiding them all
 behind one partial-performance promise. Concretely:

--- a/HexConway/Table.lean
+++ b/HexConway/Table.lean
@@ -17,10 +17,22 @@ per-entry polynomial literals with their monic/degree/table-hit lemmas.
 namespace Hex
 
 namespace Conway
+
+/-! # Word bounds for the committed primes
+
+`ZMod64.Bounds p` is what lets coefficient arithmetic modulo `p` stay in a
+machine word. Every prime the table commits to needs one in scope, so they are
+declared here beside the table rather than at each use site. -/
+
+/-- Word bound for the committed prime `3`. -/
 instance boundsThree : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
+/-- Word bound for the committed prime `5`. -/
 instance boundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+/-- Word bound for the committed prime `7`. -/
 instance boundsSeven : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
+/-- Word bound for the committed prime `11`. -/
 instance boundsEleven : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
+/-- Word bound for the committed prime `13`. -/
 instance boundsThirteen : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
 
 -- Regenerate this definition with the command on the next line, which

--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -18,7 +18,14 @@ separate declarations so the representation choice remains explicit.
 -/
 namespace Hex
 
-namespace Conway
+namespace GFq
+
+-- Everything in this block is `hex-gfq`'s own material: the two
+-- instance-synthesis classes that select a committed table entry, the packed
+-- binary modulus they name, and their certificates. The Conway table itself
+-- stays in `hex-conway`, and is opened here rather than qualified at each of
+-- the forty-odd instances.
+open Conway
 
 /-- A committed Conway-table entry available through instance synthesis.
 
@@ -489,7 +496,7 @@ instance packedGF2Entry_2_8 : PackedGF2Entry 8 where
   degree_lt_word := by decide
   packed_irreducible := packedGF2Entry_2_8_irreducible
 
-end Conway
+end GFq
 
 /-- Canonical finite field with `p^n` elements for a committed Conway-table
 entry, using the generic quotient-field representation. -/
@@ -762,12 +769,12 @@ end GFq
 
 Use `GFqC p n` when the committed entry should be inferred from the current
 Conway table. Use explicit `GFq p n h` when a proof needs to name the witness. -/
-abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : Conway.CommittedEntry p n] : Type :=
+abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : GFq.CommittedEntry p n] : Type :=
   GFq p n h.entry
 
 namespace GFqC
 
-variable {p n : Nat} [ZMod64.Bounds p] [h : Conway.CommittedEntry p n]
+variable {p n : Nat} [ZMod64.Bounds p] [h : GFq.CommittedEntry p n]
 
 /-- The committed Conway-table entry selected for `GFqC p n`. -/
 abbrev entry : Conway.SupportedEntry p n :=
@@ -848,12 +855,12 @@ end GFqC
 
 /-- Optimized canonical binary field for committed Conway entries that have a
 single-word packed modulus. -/
-abbrev GF2q (n : Nat) [h : Conway.PackedGF2Entry n] : Type :=
+abbrev GF2q (n : Nat) [h : GFq.PackedGF2Entry n] : Type :=
   GF2n n h.lower h.degree_pos h.degree_lt_word h.packed_irreducible
 
 namespace GF2q
 
-variable {n : Nat} [h : Conway.PackedGF2Entry n]
+variable {n : Nat} [h : GFq.PackedGF2Entry n]
 
 /-- The supported Conway-table entry backing this optimized binary field. -/
 def supportedEntry : Conway.SupportedEntry 2 n :=
@@ -887,13 +894,13 @@ def modulus : GF2Poly :=
 /-- The packed modulus, viewed through the generic `FpPoly 2` representation,
 is the committed Conway polynomial for this entry. -/
 theorem conway_eq_packed :
-    Conway.conwayPoly 2 n h.entry = Conway.packedGF2FpPoly h.lower n :=
+    Conway.conwayPoly 2 n h.entry = GFq.packedGF2FpPoly h.lower n :=
   h.conway_eq_packed
 
 /-- The generic `GFq` modulus for a packed binary entry agrees with the packed
 modulus viewed as an `FpPoly 2`. -/
 theorem gfq_modulus_eq_packedFpPoly :
-    GFq.modulus h.entry = Conway.packedGF2FpPoly (lower (n := n)) n := by
+    GFq.modulus h.entry = GFq.packedGF2FpPoly (lower (n := n)) n := by
   simpa [GFq.modulus, lower] using h.conway_eq_packed
 
 /-- The selected packed modulus has positive extension degree. -/

--- a/HexGFq/SPEC/hex-gfq.md
+++ b/HexGFq/SPEC/hex-gfq.md
@@ -9,39 +9,58 @@ polynomial from `hex-conway`. For `p = 2`, this library additionally
 provides an optimized convenience constructor built on `hex-gf2`.
 
 ```lean
-/-- Canonical finite field with `p^n` elements, always using the generic
-    quotient-field representation from `hex-gfq-field`. In particular,
+/-- Canonical finite field for a committed Conway-table entry, always using the
+    generic quotient-field representation from `hex-gfq-field`. In particular
     `GFq 2 n` does NOT switch to the packed `hex-gf2` representation. -/
-def GFq (p n : Nat) :=
-  FiniteField p (conwayPoly p n) (conwayPoly_nonconstant p n)
-    (conwayPoly_irreducible p n)
+abbrev GFq (p n : Nat) [ZMod64.Bounds p] (h : Conway.SupportedEntry p n) : Type
 
-/-- Optimized canonical GF(2^n), using the Conway polynomial chosen by
+/-- The same field with the committed entry found by instance synthesis, which
+    is the spelling users want. -/
+abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : Conway.CommittedEntry p n] : Type
+
+/-- Optimized canonical `GF(2^n)`, using the Conway polynomial chosen by
     `hex-conway` but represented with the packed `hex-gf2` backend. -/
-def GF2q (n : Nat) := ...
-
-/-- The optimized `p = 2` constructor is mathematically the same field
-    as the generic canonical constructor. -/
-def GF2q.equivGFq (n : Nat) : GF2q n ≃+* GFq 2 n := ...
+abbrev GF2q (n : Nat) [h : Conway.PackedGF2Entry n] : Type
 ```
+
+The evidence is explicit in the type rather than assumed. `GFq` takes a
+`Conway.SupportedEntry p n`, which packages the table hit with its primality
+and irreducibility proofs and cannot be constructed for an uncommitted pair.
+`GFqC` and `GF2q` take the same evidence through instance synthesis, so the
+user writes the pair and the instance supplies the witness.
+
+That is why there is no `conwayPoly p n` with two arguments: a total function
+would have to invent a modulus for pairs the table does not cover, and
+`hex-conway` is explicit that `conwayPoly` should be total only for committed
+entries.
+
+**Coverage.** The committed table runs over `p` in `2, 3, 5, 7, 11, 13`, to
+degree `6` for the odd primes and to degree `8` for `p = 2`. Every one of those
+pairs has a `CommittedEntry` instance; the binary column additionally has
+`PackedGF2Entry` instances, so `GF2q n` resolves for `n` in `1` to `8`. Outside
+that range the constructors fail at instance synthesis, which is the intended
+behaviour: there is no junk field.
 
 API intent:
 
-- `GFq p n` is the canonical, always-available constructor, with a
-  uniform generic representation for every `p`.
-- `GF2q n` is the specialized `p = 2` constructor using the optimized
-  representation from `hex-gf2`.
-- `GF2q n ≃+* GFq 2 n`, so users can move between the optimized and
-  generic `p = 2` models without changing the mathematics.
-- Both constructors choose the modulus automatically via Conway
-  polynomials, so the user supplies neither a polynomial nor an
-  irreducibility proof.
+- `GFqC p n` is the spelling to reach for; `GFq p n h` is for proofs that need
+  to name the witness.
+- `GF2q n` is the specialized `p = 2` constructor using the packed
+  representation.
+- `GF2q n ≃+* GFq 2 n`, so users can move between the optimized and generic
+  `p = 2` models without changing the mathematics. That equivalence is
+  `GF2q.equivGFq` and it lives in `hex-gfq-mathlib`, not here: `≃+*` is
+  Mathlib's `RingEquiv`, and this library is Mathlib-free. The Mathlib-free
+  one-way map `GF2q.toGFq` lives here.
+- Both constructors choose the modulus automatically via Conway polynomials, so
+  the user supplies neither a polynomial nor an irreducibility proof.
 
-The user writes `GFq 3 5` and gets the canonical `GF(3^5)`. The user
-writes `GF2q 8` and gets the optimized canonical `GF(2^8)` backed by
-packed bitwise arithmetic. For non-Conway models (e.g. AES's
-`x^8 + x^4 + x^3 + x + 1`), use `FiniteField` directly from
-hex-gfq-field or `GF2n`/`GF2nPoly` directly from hex-gf2.
+The user writes `GFqC 3 5` and gets the canonical `GF(3^5)`. The user writes
+`GF2q 8` and gets the optimized canonical `GF(2^8)` backed by packed bitwise
+arithmetic. For non-Conway models, including AES's `x^8 + x^4 + x^3 + x + 1`,
+which is a different irreducible from the Conway polynomial at degree 8, use
+`FiniteField` directly from hex-gfq-field or `GF2n`/`GF2nPoly` directly from
+hex-gf2.
 
 ## External comparators
 

--- a/HexGFq/SPEC/hex-gfq.md
+++ b/HexGFq/SPEC/hex-gfq.md
@@ -16,11 +16,11 @@ abbrev GFq (p n : Nat) [ZMod64.Bounds p] (h : Conway.SupportedEntry p n) : Type
 
 /-- The same field with the committed entry found by instance synthesis, which
     is the spelling users want. -/
-abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : Conway.CommittedEntry p n] : Type
+abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : GFq.CommittedEntry p n] : Type
 
 /-- Optimized canonical `GF(2^n)`, using the Conway polynomial chosen by
     `hex-conway` but represented with the packed `hex-gf2` backend. -/
-abbrev GF2q (n : Nat) [h : Conway.PackedGF2Entry n] : Type
+abbrev GF2q (n : Nat) [h : GFq.PackedGF2Entry n] : Type
 ```
 
 The evidence is explicit in the type rather than assumed. `GFq` takes a

--- a/HexGFqField/Basic.lean
+++ b/HexGFqField/Basic.lean
@@ -33,6 +33,9 @@ structure FiniteField
   /-- The underlying reduced quotient-ring residue backing this field element. -/
   toQuotient : GFqRing.PolyQuotient f hf
 
+/-- Field equality is decidable, and decided by comparing canonical
+representatives: elements are wrappers around reduced quotient values, so
+equality of the wrapped values is equality of the elements. -/
 instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f} :
     DecidableEq (FiniteField f hf hp hirr) := by
   intro x y

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -226,7 +226,13 @@ private theorem dvd_trans_poly {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c
 
 This normalizes the extended-GCD left coefficient by the gcd's constant-unit
 factor, producing a polynomial whose residue is the multiplicative inverse
-whenever the quotient element is nonzero. -/
+whenever the quotient element is nonzero.
+
+At zero this is not an inverse and does not claim to be: the extended GCD of `0`
+and `f` returns `f` itself, so the result is `f` scaled by the inverse of its own
+constant coefficient. It stays public because `inv` is `@[expose]` and mentions
+it, but `inv` decides the zero case before reaching it, and callers should
+reason through the field-level lemmas below rather than by unfolding this. -/
 @[expose]
 def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : GFqRing.PolyQuotient f hf) : FpPoly p :=
@@ -840,6 +846,7 @@ theorem inv_mul_cancel
     _ = (x * x⁻¹ : FiniteField f hf hp hirr).toQuotient := rfl
     _ = (1 : FiniteField f hf hp hirr).toQuotient := congrArg FiniteField.toQuotient hleft
 
+/-- The additive-identity representative is the reduced form of `0`. -/
 @[simp, grind =] theorem repr_zero
     (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p) (hirr : FpPoly.Irreducible f) :
     repr (0 : FiniteField f hf hp hirr) = GFqRing.reduceMod f 0 :=

--- a/HexGFqField/SPEC/hex-gfq-field.md
+++ b/HexGFqField/SPEC/hex-gfq-field.md
@@ -12,9 +12,19 @@ canonical reduction function, and one equality story across the ring and
 field libraries.
 
 **Contents:**
-- `FiniteField p f hf hirr` — the field `F_p[x]/(f)`, where `hf : 0 <
-  f.degree` and `hirr : Irreducible f`
-- Coercions or conversion functions to and from `PolyQuotient p f hf`
+- `FiniteField f hf hp hirr` — the field `F_p[x]/(f)`, where `hf : 0 <
+  f.degree`, `hp : Hex.Nat.Prime p`, and `hirr : Irreducible f`, with `p`
+  implicit and `[ZMod64.Bounds p]` ambient. The prime witness is a type
+  parameter rather than a typeclass so the field type carries its own
+  evidence: `ZMod64.PrimeModulus p` is derived from `hp` where the operations
+  need it, instead of being demanded again at every call site.
+
+  Both `hf` and `hirr` are needed. Irreducibility alone does not give a field,
+  since the predicate admits nonzero constants, and the quotient by a constant
+  is trivial. `hex-gf2`'s packed types omit `hf` from their structures and pay
+  for it: their field laws have to take the degree hypothesis separately.
+- Conversion functions `ofQuotient` and the `toQuotient` projection to and from
+  `PolyQuotient f hf`. These are plain functions rather than coercions.
 - Multiplicative inverse via extended GCD in `F_p[x]`
 - Division and exponentiation. `pow x n` is square-and-multiply
   (`O(log n)` field multiplications); the textbook `n+1 ↦ pow n * x`

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -17,7 +17,7 @@ namespace Hex
 
 namespace GF2q
 
-variable {n : Nat} [h : Conway.PackedGF2Entry n]
+variable {n : Nat} [h : GFq.PackedGF2Entry n]
 
 
 private theorem cast_symm_cast {α β : Type u} (h : α = β) (x : α) :
@@ -89,11 +89,11 @@ private theorem bit_and_one_eq_zero_iff (w : UInt64) {i : Nat} (hi : i < 64) :
 /-- Coefficients of the packed binary modulus polynomial: the implicit leading
 `x^n` term, with lower degrees reading the bits of `lower`. -/
 private theorem coeff_packedGF2FpPoly (lower : UInt64) (n i : Nat) :
-    (Conway.packedGF2FpPoly lower n).coeff i =
+    (GFq.packedGF2FpPoly lower n).coeff i =
       if i = n then (1 : Hex.ZMod64 2)
       else if i < n then (if (lower >>> i.toUInt64 &&& 1) = 0 then 0 else 1)
       else 0 := by
-  unfold Conway.packedGF2FpPoly
+  unfold GFq.packedGF2FpPoly
   rw [Hex.FpPoly.ofCoeffs, Hex.DensePoly.coeff_ofCoeffs, Array.getD_eq_getD_getElem?,
     Array.getElem?_push]
   have hsz : (((List.range n).map fun j =>
@@ -119,7 +119,7 @@ theorem modulusFpPoly_eq_conway :
   apply Hex.DensePoly.ext_coeff
   intro i
   show (HexGF2Mathlib.GF2Poly.toFpPoly (Hex.GF2Poly.ofUInt64Monic h.lower n)).coeff i =
-      (Conway.packedGF2FpPoly h.lower n).coeff i
+      (GFq.packedGF2FpPoly h.lower n).coeff i
   have hn64 : n < 64 := h.degree_lt_word
   rw [HexGF2Mathlib.GF2Poly.coeff_toFpPoly,
     Hex.GF2Poly.coeff_ofUInt64Monic h.lower h.degree_lt_word,
@@ -190,6 +190,24 @@ def equivGFq : RingEquiv (GF2q n) (GFq 2 n h.entry) :=
       (hn := h.degree_pos) (hn64 := h.degree_lt_word)
       (hirr := h.packed_irreducible)).trans
     (genericEquivGFq (n := n))
+
+/-- The optimized packed binary Conway field is ring-equivalent to Mathlib's
+{name}`GaloisField` of the same order.
+
+This is the composite the `hex-gfq-mathlib` SPEC describes: {name}`Hex.GF2q.equivGFq`
+carries the packed representation onto the generic one, and
+{name}`HexGFqMathlib.GFq.equivGaloisField` carries that onto Mathlib. It is the
+statement a user reaches for when they want to discharge a `GaloisField 2 n`
+goal by computing in the packed representation.
+
+Noncomputable because the second leg goes through
+`FiniteField.ringEquivOfCardEq`, which chooses an isomorphism rather than
+constructing one; {name}`Hex.GF2q.equivGFq`, the leg that does the packing work,
+is computable. -/
+noncomputable def equivGaloisField : RingEquiv (GF2q n) (GaloisField 2 n) :=
+  haveI : Fact (_root_.Nat.Prime 2) := ⟨_root_.Nat.prime_two⟩
+  (equivGFq (n := n)).trans
+    (HexGFqMathlib.GFq.equivGaloisField h.entry (Nat.pos_iff_ne_zero.mp h.degree_pos))
 
 end GF2q
 

--- a/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
+++ b/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
@@ -1,21 +1,56 @@
-# hex-gfq-mathlib (depends on hex-gfq + Mathlib)
+# hex-gfq-mathlib (depends on hex-gfq + hex-gf2-mathlib + Mathlib)
 
-Provides the finiteness/cardinality layer for the quotient-field
-construction and proves `GFq p n ≃+* GaloisField p n` (Mathlib's Galois
-field).
+Supplies the finiteness and cardinality layer for the quotient-field
+construction, the Mathlib `Field` instance on it, and the correspondence with
+Mathlib's `GaloisField`.
 
-Important representation choice:
+**Contents:**
 
-- `GFq p n` is always the generic quotient-field construction from
-  `hex-gfq-field`, even when `p = 2`.
-- The optimized `p = 2` constructor is `GF2q n` from `hex-gfq`.
-- The `p = 2` optimized path relates to Mathlib by composing
-  `GF2q n ≃+* GFq 2 n` with `GFq 2 n ≃+* GaloisField 2 n`.
+- `FiniteField.field` — the Mathlib `Field` instance on
+  `GFqField.FiniteField f hf hp hirr`, built through `Field.ofMinimalAxioms`
+  from the executable `Lean.Grind.Field`, so the operations stay the executable
+  ones.
+- `FiniteField.fintype` and `FiniteField.fintype_card :
+  Fintype.card (FiniteField f hf hp hirr) = p ^ f.degree`, indexed through the
+  reduced-representative subtype.
+- `GFq.fintype_card_eq_pow : Fintype.card (GFq p n h) = p ^ n`, which composes
+  the above with `conwayPoly_degree`.
+- `GFq.equivGaloisField : GFq p n h ≃+* GaloisField p n`.
+- `GF2q.equivGFq : GF2q n ≃+* GFq 2 n h.entry`, the packed-to-generic leg.
 
-In particular, this is where `FiniteField p f hf hirr` gets its
-`Fintype` instance and cardinality theorem `card = p ^ f.degree`.
+The `Fintype` instances are deliberately `noncomputable`. The carriers have
+`p ^ degree f` elements, so a compiled `Finset.univ` over one is a footgun
+rather than a feature; the underlying `Equiv`s are computable, which is the
+part callers want.
 
-Proof strategy: apply `FiniteField.ringEquivOfCardEq` from Mathlib,
-which just needs `Fintype.card (GFq p n) = Fintype.card (GaloisField p n)`.
-Both sides equal `p ^ n` — Mathlib has `GaloisField.card` and we need
-`card_finiteField` from this bridge layer.
+## Representation choice
+
+`GFq p n` is always the generic quotient-field construction from
+hex-gfq-field, even when `p = 2`. The optimized `p = 2` constructor is `GF2q n`
+from hex-gfq, and it reaches Mathlib in two legs: `GF2q n ≃+* GFq 2 n` from
+here, composed with `GFq 2 n ≃+* GaloisField 2 n`, also from here. The first
+leg is built on hex-gf2-mathlib's `GF2n.equiv`, which is why this library
+depends on it.
+
+## Proof strategy
+
+`equivGaloisField` applies Mathlib's `FiniteField.ringEquivOfCardEq`, which
+needs only that the two cardinalities agree. Both are `p ^ n`: Mathlib supplies
+`GaloisField.card`, and this library supplies `GFq.fintype_card_eq_pow`. It
+therefore needs `[Fact p.Prime]` and `n ≠ 0`, both of which `GaloisField.card`
+requires and neither of which the executable side carries, so they are
+hypotheses on the equivalence rather than on the field type.
+
+## Namespaces
+
+Declarations live in `HexGFqMathlib`, except `GF2q.equivGFq`, which extends
+`Hex.GF2q` so that it reads as part of the constructor's API at the call site.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `proof-only-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
+arithmetic algorithm; it transports facts about constructions whose performance
+is measured in hex-gfq-field and hex-gf2.

--- a/HexManual/Chapters/HexGFq.lean
+++ b/HexManual/Chapters/HexGFq.lean
@@ -194,7 +194,7 @@ certificate, never by {tactic}`native_decide`. The degree-one case is small
 enough to prove by exhausting the two monic linear polynomials over
 `𝔽₂`:
 
-{docstring Hex.Conway.packedGF2Entry_2_1_irreducible}
+{docstring Hex.GFq.packedGF2Entry_2_1_irreducible}
 
 Higher-degree committed entries are certified the same way through the
 `HexGF2` certificate checker. Because the check runs at elaboration time,

--- a/HexManual/Chapters/HexGFq.lean
+++ b/HexManual/Chapters/HexGFq.lean
@@ -52,7 +52,7 @@ irreducibility proofs. Passing that witness explicitly everywhere is
 verbose, so `HexGFq` makes it available through instance synthesis with a
 one-method class.
 
-{name}`Hex.Conway.CommittedEntry` carries a single field `entry`, the
+{name}`Hex.GFq.CommittedEntry` carries a single field `entry`, the
 committed {name}`Hex.Conway.SupportedEntry` for the pair `(p, n)`. The
 library commits one instance per committed table cell, named
 `committedEntry_p_n` (for example `committedEntry_2_3`), covering
@@ -72,7 +72,7 @@ The headline type is {name}`Hex.GFq`: given an explicit
 the committed Conway modulus, with the positive-degree, primality, and
 irreducibility hypotheses discharged from the entry. Its ergonomic
 sibling {name}`Hex.GFqC` is the same field with the entry resolved by
-{name}`Hex.Conway.CommittedEntry` synthesis, so `GFqC 2 3` denotes
+{name}`Hex.GFq.CommittedEntry` synthesis, so `GFqC 2 3` denotes
 `GF(8)` with no further arguments.
 
 Each field element is a polynomial over `F_p` of degree below `n`: the
@@ -113,22 +113,22 @@ proves the two agree.
 The translation from a packed single-word modulus to the generic
 `FpPoly 2` view is:
 
-{docstring Hex.Conway.packedGF2FpPoly}
+{docstring Hex.GFq.packedGF2FpPoly}
 
 A committed binary entry that also admits the packed view is recorded by
-the class {name}`Hex.Conway.PackedGF2Entry`. Its fields bundle the
+the class {name}`Hex.GFq.PackedGF2Entry`. Its fields bundle the
 `HexConway` {name}`Hex.Conway.SupportedEntry`, the packed lower-word modulus
-{name}`Hex.Conway.PackedGF2Entry.lower`, the
+{name}`Hex.GFq.PackedGF2Entry.lower`, the
 extension-degree bounds `0 < n < 64`, the certified irreducibility of the
 packed modulus, and (crucially)
-{name}`Hex.Conway.PackedGF2Entry.conway_eq_packed`, the proof that the
+{name}`Hex.GFq.PackedGF2Entry.conway_eq_packed`, the proof that the
 committed Conway polynomial *equals* the packed modulus viewed as an
 {name}`Hex.FpPoly` with modulus `2`. That equality is what lets the optimized field stand in for
 the canonical one without changing the mathematics. The committed
 instances are named `packedGF2Entry_2_n`.
 
 The optimized field itself is {name}`Hex.GF2q`: for a committed
-{name}`Hex.Conway.PackedGF2Entry` at degree `n`, the single-word `HexGF2` field
+{name}`Hex.GFq.PackedGF2Entry` at degree `n`, the single-word `HexGF2` field
 {name}`Hex.GF2n` with that
 modulus. A `UInt64` word becomes a packed element through:
 
@@ -227,7 +227,7 @@ tag := "hex-gfq-cross-references"
 
 * {ref "hex-conway"}[`HexConway`] supplies the committed Conway moduli
   and their {name}`Hex.Conway.SupportedEntry` witnesses; each
-  {name}`Hex.Conway.CommittedEntry` instance wraps one.
+  {name}`Hex.GFq.CommittedEntry` instance wraps one.
 * {ref "hex-gfq-field"}[`HexGFqField`] (over
   {ref "hex-gfq-ring"}[`HexGFqRing`]) is the generic quotient field
   backing {name}`Hex.GFq` and {name}`Hex.GFqC`; every generic operation

--- a/bench/HexGFq/Bench.lean
+++ b/bench/HexGFq/Bench.lean
@@ -18,8 +18,8 @@ arithmetic underneath it is measured by `hex-gfq-field` and `hex-gf2`.
 
 The committed table is wider than what is exercised here: `hex-conway` commits
 36 generic entries (`p` in `2, 3, 5, 7, 11, 13`, `n` in `1` to `6`), all
-reachable through `Conway.CommittedEntry` instances, and this library exposes
-`Conway.PackedGF2Entry` instances for `n` in `1` to `6`. Sweeping the bench
+reachable through `GFq.CommittedEntry` instances, and this library exposes
+`GFq.PackedGF2Entry` instances for `n` in `1` to `6`. Sweeping the bench
 across that range is outstanding work, not a limit of the public API.
 
 * `runGFqOfPolyReprChecksum`: generic `GFq.ofPoly` plus `GFq.repr` on a

--- a/conformance/HexGFq/Conformance.lean
+++ b/conformance/HexGFq/Conformance.lean
@@ -13,8 +13,8 @@ Core conformance checks for the canonical finite-field constructors in
 Oracle: none
 Mode: always
 Covered operations:
-- `Conway.packedGF2FpPoly`
-- `Conway.PackedGF2Entry`
+- `GFq.packedGF2FpPoly`
+- `GFq.PackedGF2Entry`
 - `GFq.modulus`, `GFq.ofPoly`, and `GFq.repr`
 - `GFqC.modulus`, `GFqC.ofPoly`, `GFqC.repr`, and `GFqC.frob`
 - `GF2q.supportedEntry`, `GF2q.lower`, `GF2q.modulus`,
@@ -76,38 +76,38 @@ private def packedAsGenericCoeffNats (w : UInt64) : List Nat :=
   else
     [(GF2q.repr (packed w)).toNat]
 
-#guard coeffNats (Conway.packedGF2FpPoly 1 1) = [1, 1]
+#guard coeffNats (GFq.packedGF2FpPoly 1 1) = [1, 1]
 -- `PackedGF2Entry` excludes degree zero; this checks only the raw helper's
 -- leading-coefficient convention at the lower boundary.
-#guard coeffNats (Conway.packedGF2FpPoly 0 0) = [1]
-#guard coeffNats (Conway.packedGF2FpPoly 0b101 3) = [1, 0, 1, 1]
-#guard coeffNats (Conway.packedGF2FpPoly ((1 : UInt64) <<< 63) 1) = [0, 1]
+#guard coeffNats (GFq.packedGF2FpPoly 0 0) = [1]
+#guard coeffNats (GFq.packedGF2FpPoly 0b101 3) = [1, 0, 1, 1]
+#guard coeffNats (GFq.packedGF2FpPoly ((1 : UInt64) <<< 63) 1) = [0, 1]
 
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 1).entry.poly = [1, 1]
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 1).entry.poly = [1, 1]
 #guard Conway.luebeckConwayPolynomial? 2 1 =
-  some (inferInstance : Conway.PackedGF2Entry 1).entry.poly
-#guard (inferInstance : Conway.PackedGF2Entry 1).lower = 1
+  some (inferInstance : GFq.PackedGF2Entry 1).entry.poly
+#guard (inferInstance : GFq.PackedGF2Entry 1).lower = 1
 example : 0 < 1 :=
-  (inferInstance : Conway.PackedGF2Entry 1).degree_pos
+  (inferInstance : GFq.PackedGF2Entry 1).degree_pos
 
 example : 1 < 64 :=
-  (inferInstance : Conway.PackedGF2Entry 1).degree_lt_word
-#guard coeffNats (Conway.conwayPoly 2 1 (inferInstance : Conway.PackedGF2Entry 1).entry) =
-  coeffNats (Conway.packedGF2FpPoly (inferInstance : Conway.PackedGF2Entry 1).lower 1)
+  (inferInstance : GFq.PackedGF2Entry 1).degree_lt_word
+#guard coeffNats (Conway.conwayPoly 2 1 (inferInstance : GFq.PackedGF2Entry 1).entry) =
+  coeffNats (GFq.packedGF2FpPoly (inferInstance : GFq.PackedGF2Entry 1).lower 1)
 
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 2).entry.poly = [1, 1, 1]
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 3).entry.poly = [1, 1, 0, 1]
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 4).entry.poly = [1, 1, 0, 0, 1]
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 5).entry.poly = [1, 0, 1, 0, 0, 1]
-#guard coeffNats (inferInstance : Conway.PackedGF2Entry 6).entry.poly = [1, 1, 0, 1, 1, 0, 1]
-#guard (inferInstance : Conway.PackedGF2Entry 2).lower = 0x3
-#guard (inferInstance : Conway.PackedGF2Entry 3).lower = 0x3
-#guard (inferInstance : Conway.PackedGF2Entry 4).lower = 0x3
-#guard (inferInstance : Conway.PackedGF2Entry 5).lower = 0x5
-#guard (inferInstance : Conway.PackedGF2Entry 6).lower = 0x1B
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 2).entry.poly = [1, 1, 1]
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 3).entry.poly = [1, 1, 0, 1]
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 4).entry.poly = [1, 1, 0, 0, 1]
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 5).entry.poly = [1, 0, 1, 0, 0, 1]
+#guard coeffNats (inferInstance : GFq.PackedGF2Entry 6).entry.poly = [1, 1, 0, 1, 1, 0, 1]
+#guard (inferInstance : GFq.PackedGF2Entry 2).lower = 0x3
+#guard (inferInstance : GFq.PackedGF2Entry 3).lower = 0x3
+#guard (inferInstance : GFq.PackedGF2Entry 4).lower = 0x3
+#guard (inferInstance : GFq.PackedGF2Entry 5).lower = 0x5
+#guard (inferInstance : GFq.PackedGF2Entry 6).lower = 0x1B
 
 example :
-    (Conway.CommittedEntry.entry (p := 2) (n := 1)) = Conway.supportedEntry_2_1 :=
+    (GFq.CommittedEntry.entry (p := 2) (n := 1)) = Conway.supportedEntry_2_1 :=
   rfl
 #guard coeffNats (GFqC.modulus (p := 2) (n := 1)) = [1, 1]
 #guard GFqC.modulus (p := 2) (n := 1) =
@@ -168,7 +168,7 @@ example (x y z : Generic21) :
 #guard GF2q.lower (n := 1) = 1
 #guard wordArray (GF2q.modulus (n := 1)) = #[3]
 #guard coeffNats (GFqC.modulus (p := 2) (n := 1)) =
-  coeffNats (Conway.packedGF2FpPoly (GF2q.lower (n := 1)) 1)
+  coeffNats (GFq.packedGF2FpPoly (GF2q.lower (n := 1)) 1)
 #guard wordArray (GF2q.modulus (n := 1)) =
   wordArray (GF2Poly.ofUInt64Monic (GF2q.lower (n := 1)) 1)
 
@@ -183,9 +183,9 @@ example (x y z : Generic21) :
 #guard GF2q.repr (GF2q.ofWord (n := 1) 2) =
   (GF2n.reduce
     (n := 1) (irr := GF2q.lower (n := 1))
-    (hn := Conway.PackedGF2Entry.degree_pos)
-    (hn64 := Conway.PackedGF2Entry.degree_lt_word)
-    (hirr := Conway.PackedGF2Entry.packed_irreducible) 2).val
+    (hn := GFq.PackedGF2Entry.degree_pos)
+    (hn64 := GFq.PackedGF2Entry.degree_lt_word)
+    (hirr := GFq.PackedGF2Entry.packed_irreducible) 2).val
 
 #guard wordArray (GF2q.modulus (n := 4)) = #[0x13]
 #guard GF2q.lower (n := 4) = 0x3

--- a/conformance/HexGFq/CrossCheck.lean
+++ b/conformance/HexGFq/CrossCheck.lean
@@ -161,15 +161,15 @@ set_option maxRecDepth 4096 in
 packed degree-4 `GF(2)` modulus `0x3`. -/
 private theorem genericN4Cert_check :
     Berlekamp.checkIrreducibilityCertificateLinear
-        (Conway.packedGF2FpPoly 0x3 4)
-        (by unfold Conway.packedGF2FpPoly; rfl)
+        (GFq.packedGF2FpPoly 0x3 4)
+        (by unfold GFq.packedGF2FpPoly; rfl)
         genericN4Cert = true := by
   simp [Berlekamp.checkIrreducibilityCertificateLinear,
     genericN4Cert,
     Berlekamp.IrreducibilityCertificate.toAmbient?,
     Berlekamp.checkPowChainLinear, Berlekamp.checkRabinBezoutWitnesses,
     Berlekamp.checkRabinBezoutWitness, Berlekamp.certifiedFrobeniusDiffMod,
-    maxProperDiv_4, Conway.packedGF2FpPoly, polyP2]
+    maxProperDiv_4, GFq.packedGF2FpPoly, polyP2]
   constructor
   · constructor
     · constructor
@@ -183,12 +183,12 @@ private theorem genericN4Cert_check :
 /-- The packed degree-4 `GF(2)` modulus `0x3` is irreducible, certified via
 `genericN4Cert`. -/
 private theorem genericN4_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x3 4) :=
-  Berlekamp.rabinTest_imp_irreducible (Conway.packedGF2FpPoly 0x3 4)
-    (by unfold Conway.packedGF2FpPoly; rfl)
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x3 4) :=
+  Berlekamp.rabinTest_imp_irreducible (GFq.packedGF2FpPoly 0x3 4)
+    (by unfold GFq.packedGF2FpPoly; rfl)
     (Berlekamp.checkIrreducibilityCertificateLinear_rabinTest
-      (Conway.packedGF2FpPoly 0x3 4)
-      (by unfold Conway.packedGF2FpPoly; rfl)
+      (GFq.packedGF2FpPoly 0x3 4)
+      (by unfold GFq.packedGF2FpPoly; rfl)
       genericN4Cert
       genericN4Cert_check)
 
@@ -211,8 +211,8 @@ set_option maxRecDepth 4096 in
 against the packed degree-8 `GF(2)` modulus `0x1B`. -/
 private theorem genericN8Cert_check :
     Berlekamp.checkIrreducibilityCertificateLinearIncremental
-        (Conway.packedGF2FpPoly 0x1B 8)
-        (by unfold Conway.packedGF2FpPoly; rfl)
+        (GFq.packedGF2FpPoly 0x1B 8)
+        (by unfold GFq.packedGF2FpPoly; rfl)
         genericN8Cert = true := by
   simp [Berlekamp.checkIrreducibilityCertificateLinearIncremental,
     genericN8Cert,
@@ -221,7 +221,7 @@ private theorem genericN8Cert_check :
     Berlekamp.checkPowChainLinearIncrementalStep,
     Berlekamp.checkRabinBezoutWitnesses,
     Berlekamp.checkRabinBezoutWitness, Berlekamp.certifiedFrobeniusDiffMod,
-    maxProperDiv_8, Conway.packedGF2FpPoly, polyP2]
+    maxProperDiv_8, GFq.packedGF2FpPoly, polyP2]
   constructor
   · constructor
     · constructor
@@ -238,12 +238,12 @@ private theorem genericN8Cert_check :
 /-- The packed degree-8 `GF(2)` modulus `0x1B` is irreducible, certified via
 `genericN8Cert`. -/
 private theorem genericN8_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x1B 8) :=
-  Berlekamp.rabinTest_imp_irreducible (Conway.packedGF2FpPoly 0x1B 8)
-    (by unfold Conway.packedGF2FpPoly; rfl)
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x1B 8) :=
+  Berlekamp.rabinTest_imp_irreducible (GFq.packedGF2FpPoly 0x1B 8)
+    (by unfold GFq.packedGF2FpPoly; rfl)
     (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
-      (Conway.packedGF2FpPoly 0x1B 8)
-      (by unfold Conway.packedGF2FpPoly; rfl)
+      (GFq.packedGF2FpPoly 0x1B 8)
+      (by unfold GFq.packedGF2FpPoly; rfl)
       genericN8Cert
       genericN8Cert_check)
 
@@ -274,16 +274,16 @@ private def genericN16Cert : Berlekamp.IrreducibilityCertificate where
 
 /-- The packed degree-16 `GF(2)` modulus `0x100B` as an `FpPoly 2`. -/
 private def genericN16Mod : FpPoly 2 :=
-  Conway.packedGF2FpPoly 0x100B 16
+  GFq.packedGF2FpPoly 0x100B 16
 
 /-- The packed degree-16 `GF(2)` modulus `genericN16Mod` is monic. -/
 private theorem genericN16Mod_monic : DensePoly.Monic genericN16Mod := by
-  unfold genericN16Mod Conway.packedGF2FpPoly
+  unfold genericN16Mod GFq.packedGF2FpPoly
   rfl
 
 /-- The packed degree-16 `GF(2)` modulus `genericN16Mod` has degree 16. -/
 private theorem genericN16Mod_degree_eq : genericN16Mod.degree?.getD 0 = 16 := by
-  unfold genericN16Mod Conway.packedGF2FpPoly DensePoly.degree? DensePoly.size
+  unfold genericN16Mod GFq.packedGF2FpPoly DensePoly.degree? DensePoly.size
   rfl
 
 /-- The packed degree-16 `GF(2)` modulus `genericN16Mod` has positive degree. -/
@@ -347,7 +347,7 @@ private theorem genericN16_step0_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -368,7 +368,7 @@ private theorem genericN16_step1_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -389,7 +389,7 @@ private theorem genericN16_step2_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -410,7 +410,7 @@ private theorem genericN16_step3_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -431,7 +431,7 @@ private theorem genericN16_step4_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -452,7 +452,7 @@ private theorem genericN16_step5_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -473,7 +473,7 @@ private theorem genericN16_step6_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -494,7 +494,7 @@ private theorem genericN16_step7_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -515,7 +515,7 @@ private theorem genericN16_step8_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -536,7 +536,7 @@ private theorem genericN16_step9_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -557,7 +557,7 @@ private theorem genericN16_step10_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -578,7 +578,7 @@ private theorem genericN16_step11_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -599,7 +599,7 @@ private theorem genericN16_step12_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -620,7 +620,7 @@ private theorem genericN16_step13_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -641,7 +641,7 @@ private theorem genericN16_step14_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -662,7 +662,7 @@ private theorem genericN16_step15_check :
   · exact polyP2_size_le_16 (by decide)
   · exact polyP2_size_le_16 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericN16Mod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -679,7 +679,7 @@ private theorem genericN16QuotientWitnesses_check :
   · apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnesses_first_of_coeffs
       (first := polyP2 #[0, 1])
     · rfl
-    · simp [genericN16Mod, Conway.packedGF2FpPoly, polyP2, FpPoly.X,
+    · simp [genericN16Mod, GFq.packedGF2FpPoly, polyP2, FpPoly.X,
         DensePoly.monomial, FpPoly.modByMonic, DensePoly.modByMonic_eq_mod]
       decide
   · intro k hk
@@ -721,7 +721,7 @@ private theorem genericN16_bezout :
   unfold Berlekamp.checkRabinBezoutWitnesses Berlekamp.checkRabinBezoutWitness
     Berlekamp.certifiedFrobeniusDiffMod
   simp [genericN16SamePrimeCert, genericN16Cert, maxProperDiv_16,
-    genericN16Mod, Conway.packedGF2FpPoly, polyP2]
+    genericN16Mod, GFq.packedGF2FpPoly, polyP2]
   decide
 
 /-- `genericN16SamePrimeCert.n` equals the Berlekamp basis size of `genericN16Mod`. -/
@@ -761,8 +761,8 @@ set_option maxHeartbeats 1000000 in
 for the degree-16 packed modulus `0x100B`. -/
 private theorem genericN16Cert_check :
     Berlekamp.checkIrreducibilityCertificateLinearIncremental
-        (Conway.packedGF2FpPoly 0x100B 16)
-        (by unfold Conway.packedGF2FpPoly; rfl)
+        (GFq.packedGF2FpPoly 0x100B 16)
+        (by unfold GFq.packedGF2FpPoly; rfl)
         genericN16Cert = true := by
   simp [Berlekamp.checkIrreducibilityCertificateLinearIncremental,
     genericN16Cert, Berlekamp.IrreducibilityCertificate.toAmbient?]
@@ -773,12 +773,12 @@ private theorem genericN16Cert_check :
 
 /-- The degree-16 packed modulus `0x100B` is irreducible over `FpPoly 2`. -/
 theorem genericN16_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x100B 16) :=
-  Berlekamp.rabinTest_imp_irreducible (Conway.packedGF2FpPoly 0x100B 16)
-    (by unfold Conway.packedGF2FpPoly; rfl)
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x100B 16) :=
+  Berlekamp.rabinTest_imp_irreducible (GFq.packedGF2FpPoly 0x100B 16)
+    (by unfold GFq.packedGF2FpPoly; rfl)
     (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
-      (Conway.packedGF2FpPoly 0x100B 16)
-      (by unfold Conway.packedGF2FpPoly; rfl)
+      (GFq.packedGF2FpPoly 0x100B 16)
+      (by unfold GFq.packedGF2FpPoly; rfl)
       genericN16Cert
       genericN16Cert_check)
 
@@ -786,7 +786,7 @@ theorem genericN16_irr :
 
 For each extension degree `n` we fix a known irreducible packed
 modulus, declare the matching `FpPoly 2` modulus via
-`Conway.packedGF2FpPoly`, and provide irreducibility plus positive-degree
+`GFq.packedGF2FpPoly`, and provide irreducibility plus positive-degree
 witnesses for both representations.  The four `#guard`s
 per degree compare 50 pseudorandom shared inputs across addition,
 multiplication, inversion, and Frobenius (`a ↦ a^2`).
@@ -807,7 +807,7 @@ private theorem packed_irr :
   exact GF2Poly.gf16_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
@@ -864,7 +864,7 @@ private theorem packed_irr :
   exact GF2Poly.aes_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
@@ -922,7 +922,7 @@ private theorem packed_irr :
   exact GF2Poly.gf65k_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
@@ -1005,11 +1005,11 @@ private theorem packed_irr :
 
 /-- The packed degree-32 `GF(2)` modulus `x^32 + x^7 + x^3 + x^2 + 1` as an `FpPoly 2`. -/
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 /-- The packed degree-32 `GF(2)` modulus `genericMod` is monic. -/
 private theorem genericMod_monic : DensePoly.Monic genericMod := by
-  unfold genericMod Conway.packedGF2FpPoly
+  unfold genericMod GFq.packedGF2FpPoly
   rfl
 
 /-- The Frobenius power chain `x^(2^k) mod genericMod` for the degree-32 certificate. -/
@@ -1113,7 +1113,7 @@ private def genericN32Cert : Berlekamp.IrreducibilityCertificate where
 
 /-- The packed degree-32 `GF(2)` modulus `genericMod` has degree 32. -/
 private theorem genericMod_degree_eq : genericMod.degree?.getD 0 = 32 := by
-  unfold genericMod Conway.packedGF2FpPoly DensePoly.degree? DensePoly.size
+  unfold genericMod GFq.packedGF2FpPoly DensePoly.degree? DensePoly.size
   rfl
 
 /-- The packed degree-32 `GF(2)` modulus `genericMod` has positive degree. -/
@@ -1150,7 +1150,7 @@ private theorem genericN32_step0_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1171,7 +1171,7 @@ private theorem genericN32_step1_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1192,7 +1192,7 @@ private theorem genericN32_step2_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1213,7 +1213,7 @@ private theorem genericN32_step3_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1234,7 +1234,7 @@ private theorem genericN32_step4_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1255,7 +1255,7 @@ private theorem genericN32_step5_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1276,7 +1276,7 @@ private theorem genericN32_step6_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1297,7 +1297,7 @@ private theorem genericN32_step7_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1318,7 +1318,7 @@ private theorem genericN32_step8_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1339,7 +1339,7 @@ private theorem genericN32_step9_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1360,7 +1360,7 @@ private theorem genericN32_step10_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1381,7 +1381,7 @@ private theorem genericN32_step11_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1402,7 +1402,7 @@ private theorem genericN32_step12_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1423,7 +1423,7 @@ private theorem genericN32_step13_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1444,7 +1444,7 @@ private theorem genericN32_step14_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1465,7 +1465,7 @@ private theorem genericN32_step15_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1486,7 +1486,7 @@ private theorem genericN32_step16_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1507,7 +1507,7 @@ private theorem genericN32_step17_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1528,7 +1528,7 @@ private theorem genericN32_step18_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1549,7 +1549,7 @@ private theorem genericN32_step19_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1570,7 +1570,7 @@ private theorem genericN32_step20_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1591,7 +1591,7 @@ private theorem genericN32_step21_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1612,7 +1612,7 @@ private theorem genericN32_step22_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1633,7 +1633,7 @@ private theorem genericN32_step23_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1654,7 +1654,7 @@ private theorem genericN32_step24_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1675,7 +1675,7 @@ private theorem genericN32_step25_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1696,7 +1696,7 @@ private theorem genericN32_step26_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1717,7 +1717,7 @@ private theorem genericN32_step27_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1738,7 +1738,7 @@ private theorem genericN32_step28_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1759,7 +1759,7 @@ private theorem genericN32_step29_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1780,7 +1780,7 @@ private theorem genericN32_step30_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 set_option maxRecDepth 65536 in
@@ -1801,7 +1801,7 @@ private theorem genericN32_step31_check :
   · exact polyP2_size_le_32 (by decide)
   · exact polyP2_size_le_32 (by decide)
   · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
-      Conway.packedGF2FpPoly]
+      GFq.packedGF2FpPoly]
     decide
 
 /-- `FpPoly.X` reduced modulo the monic `genericMod` is `FpPoly.X` itself, its
@@ -1891,7 +1891,7 @@ private theorem genericN32_bezout :
     Berlekamp.certifiedFrobeniusDiffMod
   rw [genericMod_modByMonic_X]
   simp [genericN32SamePrimeCert, genericN32PowChain, maxProperDiv_32,
-    genericMod, Conway.packedGF2FpPoly, lower, n, polyP2]
+    genericMod, GFq.packedGF2FpPoly, lower, n, polyP2]
   decide
 
 /-- `genericN32SamePrimeCert.n` equals the Berlekamp basis size of `genericMod`. -/

--- a/conformance/HexGFq/EmitFixtures.lean
+++ b/conformance/HexGFq/EmitFixtures.lean
@@ -87,15 +87,15 @@ private def genericN4Cert : Berlekamp.IrreducibilityCertificate where
 set_option maxRecDepth 4096 in
 private theorem genericN4Cert_check :
     Berlekamp.checkIrreducibilityCertificateLinear
-        (Conway.packedGF2FpPoly 0x3 4)
-        (by unfold Conway.packedGF2FpPoly; rfl)
+        (GFq.packedGF2FpPoly 0x3 4)
+        (by unfold GFq.packedGF2FpPoly; rfl)
         genericN4Cert = true := by
   simp [Berlekamp.checkIrreducibilityCertificateLinear,
     genericN4Cert,
     Berlekamp.IrreducibilityCertificate.toAmbient?,
     Berlekamp.checkPowChainLinear, Berlekamp.checkRabinBezoutWitnesses,
     Berlekamp.checkRabinBezoutWitness, Berlekamp.certifiedFrobeniusDiffMod,
-    maxProperDiv_4, Conway.packedGF2FpPoly, polyP2]
+    maxProperDiv_4, GFq.packedGF2FpPoly, polyP2]
   constructor
   · constructor
     · constructor
@@ -107,12 +107,12 @@ private theorem genericN4Cert_check :
   · rfl
 
 private theorem genericN4_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x3 4) :=
-  Berlekamp.rabinTest_imp_irreducible (Conway.packedGF2FpPoly 0x3 4)
-    (by unfold Conway.packedGF2FpPoly; rfl)
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x3 4) :=
+  Berlekamp.rabinTest_imp_irreducible (GFq.packedGF2FpPoly 0x3 4)
+    (by unfold GFq.packedGF2FpPoly; rfl)
     (Berlekamp.checkIrreducibilityCertificateLinear_rabinTest
-      (Conway.packedGF2FpPoly 0x3 4)
-      (by unfold Conway.packedGF2FpPoly; rfl)
+      (GFq.packedGF2FpPoly 0x3 4)
+      (by unfold GFq.packedGF2FpPoly; rfl)
       genericN4Cert
       genericN4Cert_check)
 
@@ -131,8 +131,8 @@ private def genericN8Cert : Berlekamp.IrreducibilityCertificate where
 set_option maxRecDepth 4096 in
 private theorem genericN8Cert_check :
     Berlekamp.checkIrreducibilityCertificateLinearIncremental
-        (Conway.packedGF2FpPoly 0x1B 8)
-        (by unfold Conway.packedGF2FpPoly; rfl)
+        (GFq.packedGF2FpPoly 0x1B 8)
+        (by unfold GFq.packedGF2FpPoly; rfl)
         genericN8Cert = true := by
   simp [Berlekamp.checkIrreducibilityCertificateLinearIncremental,
     genericN8Cert,
@@ -141,7 +141,7 @@ private theorem genericN8Cert_check :
     Berlekamp.checkPowChainLinearIncrementalStep,
     Berlekamp.checkRabinBezoutWitnesses,
     Berlekamp.checkRabinBezoutWitness, Berlekamp.certifiedFrobeniusDiffMod,
-    maxProperDiv_8, Conway.packedGF2FpPoly, polyP2]
+    maxProperDiv_8, GFq.packedGF2FpPoly, polyP2]
   constructor
   · constructor
     · constructor
@@ -156,17 +156,17 @@ private theorem genericN8Cert_check :
   · rfl
 
 private theorem genericN8_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x1B 8) :=
-  Berlekamp.rabinTest_imp_irreducible (Conway.packedGF2FpPoly 0x1B 8)
-    (by unfold Conway.packedGF2FpPoly; rfl)
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x1B 8) :=
+  Berlekamp.rabinTest_imp_irreducible (GFq.packedGF2FpPoly 0x1B 8)
+    (by unfold GFq.packedGF2FpPoly; rfl)
     (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
-      (Conway.packedGF2FpPoly 0x1B 8)
-      (by unfold Conway.packedGF2FpPoly; rfl)
+      (GFq.packedGF2FpPoly 0x1B 8)
+      (by unfold GFq.packedGF2FpPoly; rfl)
       genericN8Cert
       genericN8Cert_check)
 
 private theorem genericN16_irr :
-    FpPoly.Irreducible (Conway.packedGF2FpPoly 0x100B 16) :=
+    FpPoly.Irreducible (GFq.packedGF2FpPoly 0x100B 16) :=
   Hex.GfqCrossCheck.genericN16_irr
 
 /-- Mask the low `n` bits of `w`, matching the canonical packed-form
@@ -209,7 +209,7 @@ private def fp2Coeffs (f : FpPoly 2) : List Int :=
 /-! # Per-degree case bundles
 
 Each namespace fixes a known irreducible packed modulus, packages the
-matching generic `FpPoly 2` modulus via `Conway.packedGF2FpPoly`, and
+matching generic `FpPoly 2` modulus via `GFq.packedGF2FpPoly`, and
 provides irreducibility plus positive-degree witnesses for both
 representations.  This mirrors `conformance/HexGFq/CrossCheck.lean`.
 -/
@@ -225,7 +225,7 @@ private theorem packed_irr :
   exact GF2Poly.gf16_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
@@ -294,7 +294,7 @@ private theorem packed_irr :
   exact GF2Poly.aes_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
@@ -364,7 +364,7 @@ private theorem packed_irr :
   exact GF2Poly.gf65k_modulus_irreducible
 
 private def genericMod : FpPoly 2 :=
-  Conway.packedGF2FpPoly lower n
+  GFq.packedGF2FpPoly lower n
 
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide


### PR DESCRIPTION
This PR rewrites the `hex-gfq`, `hex-conway`, and `hex-gfq-field` SPEC API blocks to the signatures that actually ship, states the committed-table coverage limit outright, and brings `hex-gfq-mathlib`'s SPEC up to the depth of the computational ones. The SPECs had drifted behind the implementation: the shipped `FiniteField` takes an extra prime witness and an ambient `ZMod64.Bounds`, `conwayPoly` takes a `SupportedEntry`, and `GFq`/`GFqC`/`GF2q` are three constructors rather than one.

It also defines the composite `GF2q n ≃+* GaloisField 2 n`, which both SPECs named and neither library provided; the two legs already existed. The two committed-entry classes move out of the `Conway` namespace into `GFq`, where they are declared and where a reader will look for them, along with the packed binary modulus and certificate they name. The committed-prime word bounds and two other public declarations gain docstrings, and `invPoly` now says what it returns at zero rather than leaving it unspecified.

🤖 Prepared with Claude Code