### PR TITLE
feat: give the packed GF(2) types their Mathlib ring and field structure

### DIFF
--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -1254,6 +1254,40 @@ theorem xorWords_self (xs : Array UInt64) :
     _ = #[] := by
           simp [ofWords, normalizeWords_replicate_zero]
 
+/-- Negation in `F_2[x]` is the identity: characteristic two makes every
+element its own additive inverse. Present so that the additive group structure
+can be named, not because it computes anything. -/
+@[expose]
+def neg (p : GF2Poly) : GF2Poly :=
+  p
+
+instance : Neg GF2Poly where
+  neg := neg
+
+/-- Subtraction in `F_2[x]` coincides with addition. -/
+@[expose]
+def sub (p q : GF2Poly) : GF2Poly :=
+  add p q
+
+instance : Sub GF2Poly where
+  sub := sub
+
+/-- Negation is the identity. -/
+@[simp, grind =] theorem neg_eq_self (p : GF2Poly) :
+    -p = p :=
+  rfl
+
+/-- Subtraction is addition. -/
+@[simp, grind =] theorem sub_eq_add (p q : GF2Poly) :
+    p - q = p + q :=
+  rfl
+
+/-- Every element cancels against its negation, which in characteristic two is
+itself. -/
+@[simp, grind =] theorem neg_add_cancel (p : GF2Poly) :
+    -p + p = 0 := by
+  rw [neg_eq_self, add_self]
+
 /-- Zero is the left identity for `F_2[x]` addition. -/
 @[simp, grind =] theorem zero_add (p : GF2Poly) :
     0 + p = p := by

--- a/HexGF2/Field/Word.lean
+++ b/HexGF2/Field/Word.lean
@@ -381,6 +381,10 @@ modulo an irreducible polynomial. -/
 structure GF2nPoly (f : GF2Poly) (hirr : GF2Poly.Irreducible f) where
   /-- The canonical residue representing this field element, reduced modulo `f`. -/
   val : GF2Poly
+  /-- The representative is reduced modulo `f`: it is either zero or of degree
+  below the modulus, so each field element has exactly one packed spelling.
+  Zero is called out separately because the packed degree of the zero
+  polynomial is `0`, not `-∞`. -/
   val_reduced : val.IsZero ∨ val.degree < f.degree
 
 /-- `GF(2^n)` packed into one machine word. The modulus stores only the lower
@@ -392,6 +396,9 @@ structure GF2n (n : Nat) (irr : UInt64)
   /-- The packed canonical representative: the lower `n` coefficients of the
   residue modulo the implicit modulus `x^n + irr`. -/
   val : UInt64
+  /-- The representative is reduced: only the lower `n` bits are set, so each
+  field element has exactly one packed spelling and equality of elements is
+  equality of words. -/
   val_lt : val.toNat < 2 ^ n
 
 

--- a/HexGF2Mathlib.lean
+++ b/HexGF2Mathlib.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import HexGF2Mathlib.Basic
 import HexGF2Mathlib.Field
+import HexGF2Mathlib.Algebra
 
 /-!
 The `HexGF2Mathlib` library connects the packed `HexGF2` execution path to the
@@ -13,5 +14,6 @@ generic proof-facing polynomial and finite-field constructions.
 
 It exposes the packed-polynomial equivalence `Hex.GF2Poly ≃+* Hex.FpPoly 2`
 together with the corresponding single-word/arbitrary-degree `GF(2^n)`
-correspondence modules.
+correspondence modules, and carries Mathlib's `CommRing` and `Field`
+structure on the packed types.
 -/

--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexGF2Mathlib.Field
+import Mathlib.Algebra.Ring.MinimalAxioms
+import Mathlib.Algebra.Field.MinimalAxioms
+
+/-!
+Mathlib algebraic structure on the packed `hex-gf2` types.
+
+`SPEC/design-principles.md` principle 2 puts Mathlib typeclass instances on an
+executable type in the `*-mathlib` companion. The instances here are built from
+the laws `hex-gf2` already proves, through Mathlib's minimal-axioms
+constructors, so the ring and field operations stay the executable ones: `*` on
+a `CommRing Hex.GF2Poly` is still packed carry-less multiplication, not a
+transported copy of it. Building them by transport along
+{name}`HexGF2Mathlib.GF2Poly.equiv` instead would give the right laws attached
+to the wrong operations.
+-/
+
+namespace HexGF2Mathlib
+
+open Hex
+
+/-- The packed `F₂[x]` representation is a Mathlib commutative ring, with the
+executable packed operations. -/
+instance commRing : CommRing Hex.GF2Poly :=
+  CommRing.ofMinimalAxioms
+    Hex.GF2Poly.add_assoc
+    Hex.GF2Poly.zero_add
+    Hex.GF2Poly.neg_add_cancel
+    Hex.GF2Poly.mul_assoc
+    Hex.GF2Poly.mul_comm
+    Hex.GF2Poly.one_mul
+    -- `Hex.GF2Poly.left_distrib` is in fact the right-distributive law
+    -- `(p + r) * q = p * q + r * q`; commutativity turns it into the one
+    -- Mathlib asks for here.
+    (fun a b c => by
+      rw [Hex.GF2Poly.mul_comm a (b + c), Hex.GF2Poly.left_distrib,
+        Hex.GF2Poly.mul_comm b a, Hex.GF2Poly.mul_comm c a])
+
+namespace GF2nPoly
+
+variable {f : Hex.GF2Poly} {hirr : Hex.GF2Poly.Irreducible f}
+
+/-- The packed quotient is a Mathlib field once the modulus is nonconstant.
+
+The degree hypothesis is not redundant. `Hex.GF2Poly.Irreducible` asks that `f`
+be nonzero with no factorization into two positive-degree parts, which the
+constant `1` satisfies, and `Hex.GF2nPoly 1 _` is the trivial ring where
+`0 = 1`. Carried as a `Fact` so that instance synthesis can find it: a caller
+with a genuine modulus supplies it once, and every committed
+the committed packed entries in `hex-gfq` has `degree_pos` to build it from. -/
+noncomputable instance field [hdeg : Fact (0 < f.degree)] :
+    Field (Hex.GF2nPoly f hirr) :=
+  Field.ofMinimalAxioms (Hex.GF2nPoly f hirr)
+    Hex.GF2nPoly.add_assoc
+    Hex.GF2nPoly.zero_add
+    (fun a => by
+      show a + a = 0
+      exact Hex.GF2nPoly.add_self a)
+    Hex.GF2nPoly.mul_assoc
+    Hex.GF2nPoly.mul_comm
+    Hex.GF2nPoly.one_mul
+    Hex.GF2nPoly.mul_inv_cancel
+    Hex.GF2nPoly.inv_zero
+    Hex.GF2nPoly.left_distrib
+    ⟨1, 0, Hex.GF2nPoly.one_ne_zero hdeg.out⟩
+
+/-! # The instances are usable, and keep the executable operations -/
+
+section Checks
+
+open Hex
+
+/-- The `CommRing` reaches Mathlib's general ring lemmas. -/
+example (p q : Hex.GF2Poly) : (p + q) ^ 2 = p ^ 2 + 2 * (p * q) + q ^ 2 := by
+  ring
+
+/-- Multiplication under the `CommRing` is still the executable packed product,
+not a transported copy: this closes by `rfl`. -/
+example (p q : Hex.GF2Poly) : p * q = Hex.GF2Poly.mul p q := rfl
+
+/-- Addition likewise. -/
+example (p q : Hex.GF2Poly) : p + q = Hex.GF2Poly.add p q := rfl
+
+/-- The field instance is found by synthesis given the degree fact, and its
+inverse is still the executable one. -/
+example {f : Hex.GF2Poly} {hirr : Hex.GF2Poly.Irreducible f}
+    [Fact (0 < f.degree)] (a : Hex.GF2nPoly f hirr) (ha : a ≠ 0) :
+    a * a⁻¹ = 1 :=
+  mul_inv_cancel₀ ha
+
+end Checks
+
+end GF2nPoly
+
+end HexGF2Mathlib

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -402,6 +402,8 @@ noncomputable instance : Fintype (Hex.GF2n n irr hn hn64 hirr) :=
   Fintype.ofEquiv (Fin (2 ^ n)) (finEquiv (n := n) (irr := irr)
     (hn := hn) (hn64 := hn64) (hirr := hirr)).symm
 
+/-- A single-word `GF(2^n)` has `2 ^ n` elements, read off the `val` bound
+rather than transported across the ring equivalence. -/
 theorem fintype_card :
     Fintype.card (Hex.GF2n n irr hn hn64 hirr) = 2 ^ n := by
   simpa using Fintype.card_congr (finEquiv (n := n) (irr := irr)
@@ -650,6 +652,8 @@ def finEquiv : Hex.GF2nPoly f hirr ≃ Fin (2 ^ f.degree) :=
 noncomputable instance : Fintype (Hex.GF2nPoly f hirr) :=
   Fintype.ofEquiv (Fin (2 ^ f.degree)) (finEquiv (f := f) (hirr := hirr)).symm
 
+/-- The packed quotient by `f` has `2 ^ deg f` elements, counted through its
+reduced-representative subtype. -/
 theorem fintype_card :
     Fintype.card (Hex.GF2nPoly f hirr) = 2 ^ f.degree := by
   simpa using Fintype.card_congr (finEquiv (f := f) (hirr := hirr))

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -32,14 +32,26 @@ The `Equiv`s are computable, the `Fintype` instances deliberately are not: the
 carriers have `2 ^ n` elements, so a compiled `Finset.univ` over one is a
 footgun rather than a feature.
 
-**What this library does not yet supply.** Neither `GF2n` nor `GF2nPoly` has a
-Mathlib `Ring`, `CommRing`, or `Field` instance. A `RingEquiv` does not install
-those; they have to be pulled back explicitly, preserving the executable
-operations, and that work is outstanding. So the current Mathlib-facing surface
-is the equivalences plus `Fintype` and cardinality, and a caller wanting to
-apply a Mathlib finite-field theorem must transport across an equivalence by
-hand rather than find the instance waiting. `SPEC/design-principles.md` asks
-for those instances to live here, and they should.
+**Algebraic structure.** `CommRing GF2Poly` and, for a nonconstant modulus,
+`Field (GF2nPoly f hirr)` are built with Mathlib's minimal-axioms constructors
+from the laws hex-gf2 already proves, so the operations stay the executable
+ones: `*` on the `CommRing` is packed carry-less multiplication, and `p * q =
+GF2Poly.mul p q` closes by `rfl`. Building them by transport along the ring
+equivalence instead would attach the right laws to the wrong operations.
+
+The field instance takes `Fact (0 < f.degree)`. The degree hypothesis is not
+redundant: `GF2Poly.Irreducible` admits the constant `1`, and `GF2nPoly 1 _` is
+the trivial ring where `0 = 1`, so neither `zero_ne_one` nor characteristic two
+holds for every modulus the type accepts. hex-gfq-field avoids the same trap by
+carrying the degree bound as a type parameter.
+
+`GF2n` has no Mathlib `Field` instance yet, because hex-gf2 does not prove its
+ring laws as bare theorems the way it does for `GF2Poly` and `GF2nPoly`;
+reaching Mathlib from a `GF2n` today means going through
+`GF2n.equiv`. `EuclideanDomain GF2Poly` is also outstanding, and is not simply
+more of the same: hex-gf2 already defines `Div` and `Mod` on `GF2Poly`, and
+`EuclideanDomain` supplies its own, so the two have to be reconciled rather
+than stacked.
 
 The computational hex-gf2 library stays Mathlib-free.
 

--- a/HexManual/Chapters/HexGF2.lean
+++ b/HexManual/Chapters/HexGF2.lean
@@ -15,6 +15,8 @@ import HexGF2.Irreducibility
 import HexGF2.RabinSoundness
 import HexGF2.CommonIrreducibility
 
+import HexGF2Mathlib
+
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
 
@@ -148,6 +150,45 @@ full {name}`Hex.GF2Poly` rather than a single word. Both expose the field
 operations (addition, multiplication, inverse, division) and a
 square-and-multiply exponentiation {name}`Hex.GF2n.pow`.
 
+{docstring Hex.GF2n}
+
+{docstring Hex.GF2n.reduce}
+
+{docstring Hex.GF2n.mul}
+
+{docstring Hex.GF2n.inv}
+
+{docstring Hex.GF2n.pow}
+
+{docstring Hex.GF2n.mul_inv_cancel}
+
+The single word is the constraint, not the representation: `GF2n`
+requires `n < 64`, which covers AES's `GF(2⁸)` and the byte- and
+word-sized fields but stops short of the ones cryptography reaches for
+next. GHASH multiplies in `GF(2¹²⁸)`, and a 128-bit element does not fit
+in a `UInt64`. That is what {name}`Hex.GF2nPoly` is for: it takes any
+{name}`Hex.GF2Poly` modulus, so the degree bound disappears and the same
+field operations run over a packed word array instead.
+
+{docstring Hex.GF2nPoly}
+
+{docstring Hex.GF2nPoly.mul}
+
+{docstring Hex.GF2nPoly.inv}
+
+{docstring Hex.GF2nPoly.mul_inv_cancel}
+
+The price is the representation: `GF2n` arithmetic is word operations on
+a register, while `GF2nPoly` allocates. Choose `GF2n` when the degree
+fits and `GF2nPoly` when it does not.
+
+The moduli themselves are committed with certified irreducibility, so a
+caller naming one does not have to supply a proof.
+
+{docstring Hex.GF2Poly.aesModulus}
+
+{docstring Hex.GF2Poly.ghashModulus}
+
 # Worked example
 %%%
 tag := "hex-gf2-worked"
@@ -213,6 +254,32 @@ def aes (w : UInt64) : AES := GF2n.reduce w
 end HexGF2Chapter
 ```
 
+`#guard` checks a value you already know. To see one, evaluate it.
+AES's `xtimes` is multiplication by `x`, which on a byte is a shift left
+followed by a conditional XOR with the modulus when the top bit was set.
+Both cases:
+
+```lean (name := gf2XtimesEval)
+open Hex HexGF2Chapter in
+#eval ((aes 0x57) * (aes 0x02)).val
+```
+```leanOutput gf2XtimesEval
+174
+```
+
+```lean (name := gf2XtimesReduceEval)
+open Hex HexGF2Chapter in
+#eval ((aes 0xAE) * (aes 0x02)).val
+```
+```leanOutput gf2XtimesReduceEval
+71
+```
+
+The results print in decimal: `174` is `0xAE` and `71` is `0x47`. So
+`0x57 · x = 0xAE` is the plain shift, and `0xAE · x` overflows degree
+eight, so the modulus folds it back to `0x47`. Both are the FIPS-197
+worked values.
+
 # Rabin irreducibility
 %%%
 tag := "hex-gf2-irreducible"
@@ -243,6 +310,127 @@ target. The committed cryptographic moduli (the AES modulus and its
 siblings) are proved this way, none of them through `native_decide`.
 
 {docstring Hex.GF2Poly.aes_modulus_irreducible}
+
+# Performance
+%%%
+tag := "hex-gf2-performance"
+%%%
+
+The packed representation exists for speed, so it is worth saying what
+the speed is. Two comparisons are recorded in
+`reports/hex-gf2-performance.md`.
+
+Against the generic `FpPoly 2` path inside Hex, on the same `GF(2)`
+coefficient inputs at `n = 64`, packed GCD runs in 14.1 ms against
+1.41 s, and the Berlekamp-style Frobenius-column construction in
+9.77 ms against 419 ms. That is roughly `100x` and `43x`: the packed
+long division is 64-bit XOR and shift on whole words, while the generic
+path pays per-bit `ZMod64`-wrapped arithmetic for every coefficient.
+
+Against NTL's `GF2X`, the picture depends on where you look, and the
+honest summary is that Hex wins at small degree and loses at large.
+Multiplication crosses over near `n = 512`: below it Hex is ahead, at
+`n = 2048` NTL spends about 4% of Hex's wall time on the same product.
+The reason is algorithmic and known — NTL switches to Karatsuba and
+then FFT multiplication, and the schoolbook packed-word loop here does
+not. Addition is not a useful comparison at all: NTL's measured time is
+dominated by marshaling across the process boundary at every rung, so
+those ratios describe the harness rather than the kernel.
+
+# The Mathlib correspondence
+%%%
+tag := "hex-gf2-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. `HexGF2Mathlib` is the
+companion that connects it to Mathlib, and this section is where that
+library is documented.
+
+The starting point is that the packed representation is the generic
+dense one in disguise. Unpacking a {name}`Hex.GF2Poly` bit by bit gives a
+{name}`Hex.FpPoly` over `ZMod64 2`, and the two directions are mutually
+inverse ring maps.
+
+{docstring HexGF2Mathlib.GF2Poly.toFpPoly}
+
+{docstring HexGF2Mathlib.GF2Poly.ofFpPoly}
+
+{docstring HexGF2Mathlib.GF2Poly.equiv}
+
+That lands on a Hex type. A Mathlib user wants `Polynomial (ZMod 2)`, one
+composition further along.
+
+{docstring HexGF2Mathlib.GF2Poly.equivPolynomial}
+
+{docstring HexGF2Mathlib.GF2Poly.coeff_equivPolynomial}
+
+The field wrappers correspond the same way, to the quotient-field
+construction of {ref "hex-gfq-field"}[`HexGFqField`] over the transported
+modulus.
+
+{docstring HexGF2Mathlib.GF2n.equiv}
+
+{docstring HexGF2Mathlib.GF2nPoly.equiv}
+
+Cardinality comes from indexing the elements directly rather than from
+transporting finiteness across those equivalences: `GF2n` by its `val`
+bound, `GF2nPoly` through its reduced-representative subtype.
+
+{docstring HexGF2Mathlib.GF2n.fintype_card}
+
+{docstring HexGF2Mathlib.GF2nPoly.fintype_card}
+
+The `Equiv`s are computable; the `Fintype` instances behind these are
+deliberately not. A carrier here has `2 ^ n` elements, and for a
+GHASH-sized modulus that is `2 ^ 128`, so a compiled `Finset.univ` over
+one would be a footgun rather than a feature.
+
+## Mathlib algebraic structure
+%%%
+tag := "hex-gf2-mathlib-instances"
+%%%
+
+A `RingEquiv` does not install a `CommRing`. `SPEC/design-principles.md`
+asks for those instances to live in the companion, transported so that
+they keep the executable operations, and they do.
+
+{docstring HexGF2Mathlib.commRing}
+
+That instance is built from the laws `HexGF2` proves, not by copying
+Mathlib's operations across the equivalence, so multiplication under it
+is still packed carry-less multiplication.
+
+```lean
+open Hex in
+example (p q : GF2Poly) :
+    p * q = GF2Poly.mul p q := rfl
+```
+
+So Mathlib's ring automation applies directly to packed polynomials:
+
+```lean
+open Hex in
+example (p q : GF2Poly) :
+    (p + q) ^ 2 = p ^ 2 + 2 * (p * q) + q ^ 2 := by
+  ring
+```
+
+{docstring HexGF2Mathlib.GF2nPoly.field}
+
+The `Fact (0 < f.degree)` hypothesis on that instance is not
+bureaucracy. {name}`Hex.GF2Poly.Irreducible` asks that the modulus be
+nonzero and admit no factorization into two positive-degree parts, and
+the constant `1` satisfies both. `GF2nPoly 1 _` is then the trivial ring,
+where every residue is `0` and `0 = 1`, so a `Field` instance for every
+modulus the type accepts would be false.
+{ref "hex-gfq-field"}[`HexGFqField`] sidesteps this by carrying the
+degree bound as a type parameter; the packed wrapper does not, so the
+bound is asked for here instead.
+
+{name}`Hex.GF2n` has no Mathlib `Field` instance yet: `HexGF2` proves its
+laws for the field operations but not the bare ring laws that the
+minimal-axioms constructor needs, so reaching Mathlib from a `GF2n` today
+means going through {name}`HexGF2Mathlib.GF2n.equiv`.
 
 # Cross-references
 %%%

--- a/libraries.yml
+++ b/libraries.yml
@@ -503,7 +503,7 @@ libraries:
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGFqField, HexPolyFpMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
   HexGFqMathlib:
     deps: [HexGFq, HexGF2Mathlib]


### PR DESCRIPTION
This PR adds `CommRing Hex.GF2Poly` and, for a nonconstant modulus, `Field (Hex.GF2nPoly f hirr)`, closing the gap `SPEC/design-principles.md` principle 2 describes: a `RingEquiv` does not install a `CommRing`, and until now the packed types had none. Both are built from the laws `hex-gf2` already proves, through Mathlib's minimal-axioms constructors, so the operations stay the executable ones. `p * q = Hex.GF2Poly.mul p q` closes by `rfl`, and `ring` now applies directly to packed polynomials.

The field instance takes `Fact (0 < f.degree)`. That hypothesis is not redundant: `Hex.GF2Poly.Irreducible` admits the constant `1`, and `GF2nPoly 1 _` is the trivial ring where `0 = 1`, so a `Field` for every modulus the type accepts would be false.

It also adds `Neg` and `Sub` on `GF2Poly`, which the additive group structure needs and which characteristic two makes the identity and addition, and it documents the new instances in the `HexGF2` chapter's `# The Mathlib correspondence` section, which is `hex-gf2-mathlib`'s Phase 7 deliverable. The chapter gains real docstrings for the field wrappers it previously mentioned only in prose, the `GF(2^128)` case that motivates `GF2nPoly`, the committed cryptographic moduli, a performance section, and evaluated AES `xtimes` values. `hex-gf2-mathlib` advances to `done_through: 5`.

🤖 Prepared with Claude Code