### PR TITLE
fix: use Lean 4.34 conditional lemmas

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBasic.ArrayDecEq
+public import HexBasic.Conditional
 public import HexBasic.ExtTreeMap
 public import HexBasic.Fold
 public import HexBasic.List
@@ -25,5 +26,6 @@ reproduced here so the library remains Mathlib-free. It provides reusable
 the `Batteries` list lemmas reproduced in `HexBasic.ListShim`, the
 `Vector.modify` update helper, and
 kernel-reducible `Array`/`Vector` equality (`HexBasic.ArrayDecEq`) and
-`ofFn` (`HexBasic.OfFn`).
+`ofFn` (`HexBasic.OfFn`), plus conditional reduction lemmas with names stable
+across supported Lean versions (`HexBasic.Conditional`).
 -/

--- a/HexBasic/Conditional.lean
+++ b/HexBasic/Conditional.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Std
+
+public section
+
+/-!
+Stable names for conditional reduction lemmas across the Lean 4.33/4.34 transition.
+-/
+
+namespace Hex
+
+/-- Reduce an `if` when its condition holds. -/
+theorem ite_eq_left {c : Prop} {_ : Decidable c} (hc : c) {α : Sort u} {t e : α} :
+    (if c then t else e) = t := by
+  simp [hc]
+
+/-- Reduce an `if` when its condition does not hold. -/
+theorem ite_eq_right {c : Prop} {_ : Decidable c} (hc : ¬c) {α : Sort u} {t e : α} :
+    (if c then t else e) = e := by
+  simp [hc]
+
+/-- Reduce a dependent `if` when its condition holds. -/
+theorem dite_eq_left {c : Prop} {_ : Decidable c} (hc : c) {α : Sort u}
+    {t : c → α} {e : ¬c → α} : dite c t e = t hc := by
+  simp [hc]
+
+/-- Reduce a dependent `if` when its condition does not hold. -/
+theorem dite_eq_right {c : Prop} {_ : Decidable c} (hc : ¬c) {α : Sort u}
+    {t : c → α} {e : ¬c → α} : dite c t e = e hc := by
+  simp [hc]
+
+/-- Reduce an `if` whose condition is `True`. -/
+theorem ite_true {_ : Decidable True} (t e : α) : (if True then t else e) = t := by
+  simp
+
+/-- Reduce an `if` whose condition is `False`. -/
+theorem ite_false {_ : Decidable False} (t e : α) : (if False then t else e) = e := by
+  simp
+
+end Hex

--- a/HexBasic/ExtTreeMap.lean
+++ b/HexBasic/ExtTreeMap.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 public import Std.Data.ExtTreeMap.Lemmas
 
 @[expose] public section
@@ -121,7 +122,7 @@ private theorem getElem?_foldl_alter_of_forall [TransCmp cmp]
   | nil => rfl
   | cons entry entries ih =>
       rw [List.foldl_cons, ih]
-      · rw [getElem?_alter, if_neg (h entry (by simp))]
+      · rw [getElem?_alter, Hex.ite_eq_right (h entry (by simp))]
       · intro later hlater
         exact h later (by simp [hlater])
 
@@ -149,7 +150,7 @@ private theorem getElem?_foldl_alter_of_mem
           apply hpair.1 later hlater
           simp [hkey]
       · rw [List.foldl_cons, ih (out := out.alter entry.1 (update entry.1 entry.2))
-          hpair.2 hmem, getElem?_alter, if_neg (hpair.1 (key, value) hmem)]
+          hpair.2 hmem, getElem?_alter, Hex.ite_eq_right (hpair.1 (key, value) hmem)]
 
 private theorem getElem?_foldl_alter [TransCmp cmp] [LawfulEqCmp cmp]
     (source : ExtTreeMap α γ cmp) (out : ExtTreeMap α β cmp)

--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 public import Std
 
 public section
@@ -395,13 +396,13 @@ theorem foldl_add_single [Lean.Grind.Semiring R] [DecidableEq α]
     simp only [List.foldl_cons]
     by_cases hxq : x = q
     · subst hxq
-      rw [if_pos rfl]
+      rw [Hex.ite_eq_left rfl]
       have hxs_nomem : x ∉ xs := (List.nodup_cons.mp hnodup).1
       apply foldl_add_eq_self xs (fun y => if y = x then f y else 0) (z + f x)
       intro y hy
       have hyne : y ≠ x := fun heq => hxs_nomem (heq ▸ hy)
-      exact if_neg hyne
-    · rw [if_neg hxq]
+      exact Hex.ite_eq_right hyne
+    · rw [Hex.ite_eq_right hxq]
       have hzero_step : z + (0 : R) = z := by grind
       rw [hzero_step]
       have hmem' : q ∈ xs := by

--- a/HexBasic/Vector/Modify.lean
+++ b/HexBasic/Vector/Modify.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 public import Std
 
 public section
@@ -38,13 +39,13 @@ index is unchanged. -/
 /-- The modified index of `modify` reads back `f` applied to the old value. -/
 theorem getElem_modify_self {xs : Vector α n} {i : Nat} {f : α → α} (hi : i < n) :
     (xs.modify i f)[i] = f xs[i] := by
-  rw [getElem_modify hi, if_pos rfl]
+  rw [getElem_modify hi, Hex.ite_eq_left rfl]
 
 /-- Any index other than the modified one is unchanged by `modify`. -/
 theorem getElem_modify_of_ne {xs : Vector α n} {i j : Nat} {f : α → α}
     (hj : j < n) (h : i ≠ j) :
     (xs.modify i f)[j] = xs[j] := by
-  rw [getElem_modify hj, if_neg h]
+  rw [getElem_modify hj, Hex.ite_eq_right h]
 
 /-- `modify` agrees with the read-then-{name}`set` form (value-level; `modify` avoids
 the copy this form would force). -/

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 public import HexBasic.ListShim
 public import HexMvPoly.Mono
 
@@ -339,10 +340,10 @@ theorem coeff_monomial [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
     coeff m (monomial m' c : MvPoly n R cmp) =
       if m = m' then c else 0 := by
   by_cases hc : c = 0
-  · rw [monomial, dif_pos hc]
+  · rw [monomial, Hex.dite_eq_left hc]
     change ((∅ : Std.ExtTreeMap (Mono n) R cmp)[m]?).getD 0 = _
     simp [hc]
-  · rw [monomial, dif_neg hc]
+  · rw [monomial, Hex.dite_eq_right hc]
     unfold coeff coeff?
     rw [Std.ExtTreeMap.getElem?_insert]
     by_cases hm : m = m'

--- a/HexMvPoly/Eval.lean
+++ b/HexMvPoly/Eval.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 import HexBasic.Fold
 public import HexMvPoly.Query
 
@@ -102,7 +103,7 @@ private theorem insertHornerTerm_perm (exponent : Nat)
       unfold insertHornerTerm
       by_cases heq : group.1 = exponent
       · simp [heq, groupTerms]
-      · rw [if_neg heq]
+      · rw [Hex.ite_eq_right heq]
         change
           (group.2 ++ groupTerms (insertHornerTerm exponent term groups)).Perm
             (term :: (group.2 ++ groupTerms groups))
@@ -156,7 +157,7 @@ private theorem insertHornerGroupDesc_perm (group : HornerGroup n S)
       unfold insertHornerGroupDesc
       by_cases hlt : group'.1 < group.1
       · simp [hlt, groupTerms]
-      · rw [if_neg hlt]
+      · rw [Hex.ite_eq_right hlt]
         change
           (group'.2 ++ groupTerms (insertHornerGroupDesc group groups)).Perm
             (group.2 ++ (group'.2 ++ groupTerms groups))
@@ -218,7 +219,7 @@ private theorem mem_insertHornerGroupDesc
       unfold insertHornerGroupDesc
       by_cases hlt : group'.1 < group.1
       · simp [hlt]
-      · rw [if_neg hlt]
+      · rw [Hex.ite_eq_right hlt]
         simp only [List.mem_cons, ih]
         constructor
         · rintro (heq | heq | hmem)
@@ -242,7 +243,7 @@ private theorem insertHornerGroupDesc_desc (group : HornerGroup n S)
       rw [List.pairwise_cons] at hdesc
       unfold insertHornerGroupDesc
       by_cases hlt : group'.1 < group.1
-      · rw [if_pos hlt, List.pairwise_cons]
+      · rw [Hex.ite_eq_left hlt, List.pairwise_cons]
         constructor
         · intro target htarget
           simp only [List.mem_cons] at htarget
@@ -250,7 +251,7 @@ private theorem insertHornerGroupDesc_desc (group : HornerGroup n S)
           · omega
           · exact Nat.le_trans (hdesc.1 target htarget) (Nat.le_of_lt hlt)
         · exact List.pairwise_cons.mpr hdesc
-      · rw [if_neg hlt, List.pairwise_cons]
+      · rw [Hex.ite_eq_right hlt, List.pairwise_cons]
         constructor
         · intro target htarget
           rw [mem_insertHornerGroupDesc] at htarget
@@ -313,7 +314,7 @@ private theorem insertHornerTerm_at (k exponent : Nat)
         exact hgroups target (List.mem_cons_of_mem group htarget) candidate hcand
       unfold insertHornerTerm
       by_cases heq : group.1 = exponent
-      · rw [if_pos heq]
+      · rw [Hex.ite_eq_left heq]
         intro target htarget candidate hcand
         simp only [List.mem_cons] at htarget
         rcases htarget with htarget | htarget
@@ -324,7 +325,7 @@ private theorem insertHornerTerm_at (k exponent : Nat)
             exact hterm.trans heq.symm
           · exact hgroups group (List.mem_cons_self ..) candidate hcand
         · exact hgroups target (List.mem_cons_of_mem group htarget) candidate hcand
-      · rw [if_neg heq]
+      · rw [Hex.ite_eq_right heq]
         intro target htarget candidate hcand
         simp only [List.mem_cons] at htarget
         rcases htarget with htarget | htarget

--- a/HexMvPoly/Mono.lean
+++ b/HexMvPoly/Mono.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 import HexBasic.Fold
 import HexBasic.List
 public import HexBasic.ArrayDecEq
@@ -133,11 +134,11 @@ theorem powBySq_eq_pow [Lean.Grind.Semiring R] (a : R) (k : Nat) :
             Nat.div_lt_self (Nat.succ_pos k) (by decide : 1 < 2)
           rw [powBySq, ih ((k + 1) / 2) hlt]
           by_cases heven : (k + 1) % 2 = 0
-          · rw [if_pos heven, ← Lean.Grind.Semiring.pow_add]
+          · rw [Hex.ite_eq_left heven, ← Lean.Grind.Semiring.pow_add]
             have hdecomp := Nat.mod_add_div (k + 1) 2
             congr 1
             omega
-          · rw [if_neg heven, ← Lean.Grind.Semiring.pow_add,
+          · rw [Hex.ite_eq_right heven, ← Lean.Grind.Semiring.pow_add,
               ← Lean.Grind.Semiring.pow_succ]
             have hdecomp := Nat.mod_add_div (k + 1) 2
             have hmod := Nat.mod_two_eq_zero_or_one (k + 1)
@@ -522,7 +523,7 @@ theorem div_eq_some_iff (a b q : Mono n) :
       have hi := congrArg (fun m : Mono n => m[i]) hmul
       rw [getElem_mul] at hi
       omega
-    rw [div, dif_pos hle]
+    rw [div, Hex.dite_eq_left hle]
     congr 1
     apply Vector.ext
     intro i hi

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 import HexBasic.Fold
 import HexBasic.List
 public import HexMvPoly.Basic
@@ -190,8 +191,8 @@ theorem addMonomial_eq [Lean.Grind.Semiring R] [DecidableEq R]
   intro k
   rw [coeff_addMonomial, coeff_add, coeff_monomial]
   by_cases hkm : k = m
-  · rw [if_pos hkm, if_pos hkm]
-  · rw [if_neg hkm, if_neg hkm, Lean.Grind.Semiring.add_zero]
+  · rw [Hex.ite_eq_left hkm, Hex.ite_eq_left hkm]
+  · rw [Hex.ite_eq_right hkm, Hex.ite_eq_right hkm, Lean.Grind.Semiring.add_zero]
 
 /-- Coefficients commute with polynomial negation. -/
 theorem coeff_neg [Lean.Grind.Ring R] [DecidableEq R]
@@ -436,7 +437,7 @@ theorem monomial_mul_monomial [Lean.Grind.Semiring R] [DecidableEq R]
   simp only [coeff_monomial]
   by_cases hm : m = Mono.mul a b
   · subst m
-    rw [if_pos rfl]
+    rw [Hex.ite_eq_left rfl]
     have hmem : (a, b) ∈ Mono.splits (Mono.mul a b) :=
       (Mono.splits_mem_iff ..).mpr rfl
     calc
@@ -462,7 +463,7 @@ theorem monomial_mul_monomial [Lean.Grind.Semiring R] [DecidableEq R]
       _ = 0 + ca * cb :=
         List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
       _ = ca * cb := by grind
-  · rw [if_neg hm]
+  · rw [Hex.ite_eq_right hm]
     apply List.foldl_add_eq_self
     intro ab hab
     have hmul : Mono.mul ab.1 ab.2 = m :=
@@ -472,8 +473,8 @@ theorem monomial_mul_monomial [Lean.Grind.Semiring R] [DecidableEq R]
       · have hmul' : Mono.mul a b = m := by
           simpa [ha, hb] using hmul
         exact (hm hmul'.symm).elim
-      · rw [if_pos ha, if_neg hb, Lean.Grind.Semiring.mul_zero]
-    · rw [if_neg ha, Lean.Grind.Semiring.zero_mul]
+      · rw [Hex.ite_eq_left ha, Hex.ite_eq_right hb, Lean.Grind.Semiring.mul_zero]
+    · rw [Hex.ite_eq_right ha, Lean.Grind.Semiring.zero_mul]
 
 /-- Binary powering of a monomial polynomial scales its exponent vector. -/
 theorem powBySq_monomial [Lean.Grind.Semiring R] [DecidableEq R]
@@ -492,7 +493,7 @@ theorem powBySq_monomial [Lean.Grind.Semiring R] [DecidableEq R]
           rw [Mono.powBySq, Mono.powBySq, ih ((k + 1) / 2) hlt,
             monomial_mul_monomial]
           by_cases heven : (k + 1) % 2 = 0
-          · rw [if_pos heven, if_pos heven]
+          · rw [Hex.ite_eq_left heven, Hex.ite_eq_left heven]
             congr 1
             let r := (k + 1) / 2
             change Mono.mul (Mono.scale r m) (Mono.scale r m) =
@@ -504,7 +505,7 @@ theorem powBySq_monomial [Lean.Grind.Semiring R] [DecidableEq R]
             apply Vector.ext
             intro i hi
             simp [Mono.mul, Mono.scale, hcount, Nat.add_mul]
-          · rw [if_neg heven, if_neg heven, monomial_mul_monomial]
+          · rw [Hex.ite_eq_right heven, Hex.ite_eq_right heven, monomial_mul_monomial]
             congr 1
             let r := (k + 1) / 2
             change
@@ -547,12 +548,12 @@ theorem mul_one [Lean.Grind.Semiring R] [DecidableEq R]
                 rw [hb, Mono.mul_zero] at hmul
                 exact hmul
               have hab' : ab = (m, Mono.zero) := Prod.ext ha hb
-              rw [if_pos hb, Lean.Grind.Semiring.mul_one,
-                if_pos hab', ha]
+              rw [Hex.ite_eq_left hb, Lean.Grind.Semiring.mul_one,
+                Hex.ite_eq_left hab', ha]
             · have hab' : ab ≠ (m, Mono.zero) := by
                 intro h
                 exact hb (congrArg Prod.snd h)
-              rw [if_neg hb, Lean.Grind.Semiring.mul_zero, if_neg hab']
+              rw [Hex.ite_eq_right hb, Lean.Grind.Semiring.mul_zero, Hex.ite_eq_right hab']
     _ = 0 + coeff m p :=
       List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
     _ = coeff m p := by grind
@@ -587,7 +588,7 @@ theorem one_mul [Lean.Grind.Semiring R] [DecidableEq R]
             · have hab' : ab ≠ (Mono.zero, m) := by
                 intro h
                 exact ha (congrArg Prod.fst h)
-              rw [if_neg ha, Lean.Grind.Semiring.zero_mul, if_neg hab']
+              rw [Hex.ite_eq_right ha, Lean.Grind.Semiring.zero_mul, Hex.ite_eq_right hab']
     _ = 0 + coeff m p :=
       List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
     _ = coeff m p := by grind
@@ -858,7 +859,7 @@ private theorem npowBySq_eq_linearPow
             exact Nat.div_lt_self (Nat.succ_pos k) (by decide : 1 < 2)
           rw [npowBySq, ih half hlt]
           by_cases heven : (k + 1) % 2 = 0
-          · rw [if_pos heven]
+          · rw [Hex.ite_eq_left heven]
             have hdecomp := Nat.mod_add_div (k + 1) 2
             have hcount : k + 1 = half + half := by
               simp only [half]
@@ -868,7 +869,7 @@ private theorem npowBySq_eq_linearPow
                   linearPow p (half + half) :=
                 (linearPow_add p half half).symm
               _ = linearPow p (k + 1) := by rw [hcount]
-          · rw [if_neg heven]
+          · rw [Hex.ite_eq_right heven]
             have hdecomp := Nat.mod_add_div (k + 1) 2
             have hmod := Nat.mod_two_eq_zero_or_one (k + 1)
             have hcount : k + 1 = (half + half) + 1 := by

--- a/HexMvPoly/Recursive.lean
+++ b/HexMvPoly/Recursive.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 import HexBasic.Fold
 public import HexMvPoly.Structural
 public import HexPoly
@@ -195,8 +196,8 @@ private theorem coeff_foldSteps
       rw [ih htail _ (size_toUnivariateStep i coeffs term |>.trans hsize)]
       rw [getD_toUnivariateStep i coeffs term e hbound]
       by_cases heq : Mono.degreeOf i term.1 = e
-      · rw [if_pos heq, if_pos heq, coeff_addMonomial]
-      · rw [if_neg heq, if_neg heq]
+      · rw [Hex.ite_eq_left heq, Hex.ite_eq_left heq, coeff_addMonomial]
+      · rw [Hex.ite_eq_right heq, Hex.ite_eq_right heq]
 
 /-- Coefficients of `p` as a dense univariate polynomial in variable `i`.
 Each coefficient is a polynomial in the remaining `n` variables. -/
@@ -254,7 +255,7 @@ theorem toUnivariate_coeff [Lean.Grind.Semiring R] [DecidableEq R]
       rw [hkey, degreeOf_insertVar]
     have hremove : m = removeVar i term.1 := by
       rw [hkey, removeVar_insertVar]
-    rw [if_pos hdegree, if_pos hremove, if_pos hkey]
+    rw [Hex.ite_eq_left hdegree, Hex.ite_eq_left hremove, Hex.ite_eq_left hkey]
   · by_cases hdegree : Mono.degreeOf i term.1 = e
     · by_cases hremove : m = removeVar i term.1
       · have hkey' : term.1 = insertVar i e m := by
@@ -265,8 +266,8 @@ theorem toUnivariate_coeff [Lean.Grind.Semiring R] [DecidableEq R]
               (insertVar_removeVar i term.1).symm
             _ = insertVar i e m := by rw [hdegree, ← hremove]
         exact (hkey hkey').elim
-      · rw [if_pos hdegree, if_neg hremove, if_neg hkey]
-    · rw [if_neg hdegree, if_neg hkey]
+      · rw [Hex.ite_eq_left hdegree, Hex.ite_eq_right hremove, Hex.ite_eq_right hkey]
+    · rw [Hex.ite_eq_right hdegree, Hex.ite_eq_right hkey]
 
 /-- Folding one recursive coefficient into the multivariate result changes
 exactly its inserted monomials. -/
@@ -313,7 +314,7 @@ private theorem coeff_foldInsert [Lean.Grind.Semiring R] [DecidableEq R]
       coeff (insertVar i e m) init + if d = e then coeff m p else 0
   by_cases hde : d = e
   · subst d
-    rw [if_pos rfl]
+    rw [Hex.ite_eq_left rfl]
     calc
       p.termsList.foldl
           (fun acc term =>
@@ -328,11 +329,11 @@ private theorem coeff_foldInsert [Lean.Grind.Semiring R] [DecidableEq R]
               by_cases hkey : term.1 = m
               · have hinsert : insertVar i e m = insertVar i e term.1 := by
                   rw [hkey]
-                rw [if_pos hinsert, if_pos hkey]
+                rw [Hex.ite_eq_left hinsert, Hex.ite_eq_left hkey]
               · have hinsert : insertVar i e m ≠ insertVar i e term.1 := by
                   intro h
                   exact hkey ((insertVar_inj i e e m term.1).mp h).2.symm
-                rw [if_neg hinsert, if_neg hkey,
+                rw [Hex.ite_eq_right hinsert, Hex.ite_eq_right hkey,
                   Lean.Grind.Semiring.add_zero]
       _ = coeff (insertVar i e m) init +
           p.termsList.foldl
@@ -346,10 +347,10 @@ private theorem coeff_foldInsert [Lean.Grind.Semiring R] [DecidableEq R]
         intro acc term _
         simp only [decide_eq_true_eq]
         by_cases hkey : term.1 = m
-        · rw [if_pos hkey, if_pos hkey]
-        · rw [if_neg hkey, if_neg hkey,
+        · rw [Hex.ite_eq_left hkey, Hex.ite_eq_left hkey]
+        · rw [Hex.ite_eq_right hkey, Hex.ite_eq_right hkey,
             Lean.Grind.Semiring.add_zero]
-  · rw [if_neg hde, Lean.Grind.Semiring.add_zero]
+  · rw [Hex.ite_eq_right hde, Lean.Grind.Semiring.add_zero]
     calc
       p.termsList.foldl
           (fun acc term =>
@@ -363,7 +364,7 @@ private theorem coeff_foldInsert [Lean.Grind.Semiring R] [DecidableEq R]
               have hinsert : insertVar i e m ≠ insertVar i d term.1 := by
                 intro h
                 exact hde ((insertVar_inj i e d m term.1).mp h).1.symm
-              rw [if_neg hinsert]
+              rw [Hex.ite_eq_right hinsert]
       _ = coeff (insertVar i e m) init :=
         List.foldl_const_step _ _
 
@@ -409,7 +410,7 @@ theorem ofUnivariate_coeff [Lean.Grind.Semiring R] [DecidableEq R]
     intro d hd
     have hdlt : d < q.size := List.mem_range.mp hd
     have hde : d ≠ e := by omega
-    rw [if_neg hde]
+    rw [Hex.ite_eq_right hde]
 
 /-- Converting to the recursive view and back is the identity. -/
 theorem ofUnivariate_toUnivariate [Lean.Grind.Semiring R] [DecidableEq R]

--- a/HexMvPoly/Ring.lean
+++ b/HexMvPoly/Ring.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 public import HexMvPoly.Operations
 
 @[expose] public section
@@ -79,7 +80,7 @@ theorem coeff_ofNat [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat)
   | 0 =>
       change coeff m (0 : MvPoly n R cmp) = if m = Mono.zero then (0 : R) else 0
       rw [coeff_zero]
-      by_cases hm : m = Mono.zero <;> simp only [hm, if_true, if_false]
+      by_cases hm : m = Mono.zero <;> simp only [hm, Hex.ite_true, Hex.ite_false]
   | 1 =>
       change coeff m (1 : MvPoly n R cmp) = if m = Mono.zero then (1 : R) else 0
       exact coeff_one m
@@ -97,7 +98,7 @@ theorem coeff_natCast [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat)
   | 0 =>
       change coeff m (0 : MvPoly n R cmp) = _
       rw [coeff_zero, Lean.Grind.Semiring.natCast_zero]
-      by_cases hm : m = Mono.zero <;> simp only [hm, if_true, if_false]
+      by_cases hm : m = Mono.zero <;> simp only [hm, Hex.ite_true, Hex.ite_false]
   | 1 =>
       change coeff m (1 : MvPoly n R cmp) = _
       rw [coeff_one, Lean.Grind.Semiring.natCast_one]
@@ -157,8 +158,8 @@ theorem ofNat_succ [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat) :
   intro m
   rw [coeff_add, coeff_ofNat, coeff_ofNat, coeff_one]
   by_cases hm : m = Mono.zero
-  · simpa only [hm, if_true] using (Lean.Grind.Semiring.ofNat_succ (α := R) k)
-  · simp only [hm, if_false]
+  · simpa only [hm, Hex.ite_true] using (Lean.Grind.Semiring.ofNat_succ (α := R) k)
+  · simp only [hm, Hex.ite_false]
     grind
 
 /-- Numerals agree with the canonical map from the natural numbers. -/
@@ -168,8 +169,8 @@ theorem ofNat_eq_natCast [Lean.Grind.CommRing R] [DecidableEq R] (k : Nat) :
   intro m
   rw [coeff_ofNat, coeff_natCast]
   by_cases hm : m = Mono.zero
-  · simpa only [hm, if_true] using (Lean.Grind.Semiring.ofNat_eq_natCast (α := R) k)
-  · simp only [hm, if_false]
+  · simpa only [hm, Hex.ite_true] using (Lean.Grind.Semiring.ofNat_eq_natCast (α := R) k)
+  · simp only [hm, Hex.ite_false]
 
 /-- Multivariate polynomials over a lightweight commutative ring form a
 lightweight semiring. -/

--- a/HexMvPoly/Structural.lean
+++ b/HexMvPoly/Structural.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Conditional
 import HexBasic.Fold
 public import HexMvPoly.Eval
 
@@ -134,12 +135,12 @@ theorem predAt_eq_iff (i : Fin n) (m t : Mono n)
     rw [get_mul, get_unit]
     by_cases hki : k = i
     · rw [hki] at hk ⊢
-      simp only [if_pos] at hk ⊢
+      simp only [Hex.ite_eq_left] at hk ⊢
       have ht' : t.get i ≠ 0 := by
         exact ht
       omega
-    · simp only [if_neg hki]
-      simp only [if_neg hki] at hk
+    · simp only [Hex.ite_eq_right hki]
+      simp only [Hex.ite_eq_right hki] at hk
       exact hk
   · rintro rfl
     exact predAt_succAt i m
@@ -651,8 +652,8 @@ theorem mapCoeffs_one {φ : R → S} (hzero : φ 0 = 0) (hone : φ 1 = 1) :
   intro m
   rw [coeff_mapCoeffs hzero, coeff_one, coeff_one]
   by_cases hm : m = Mono.zero
-  · simp only [hm, if_true]; exact hone
-  · simp only [hm, if_false]; exact hzero
+  · simp only [hm, Hex.ite_true]; exact hone
+  · simp only [hm, Hex.ite_false]; exact hzero
 
 /-- An additive coefficient map commutes with polynomial addition. -/
 theorem mapCoeffs_add {φ : R → S} (hzero : φ 0 = 0)

--- a/HexPoly.lean
+++ b/HexPoly.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import HexPoly.Dense
 public import HexPoly.Euclid
 public import HexPoly.Operations

--- a/HexPoly/Conditional.lean
+++ b/HexPoly/Conditional.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Std
+
+public section
+
+/-!
+Stable names for conditional reduction lemmas across the Lean 4.33/4.34 transition.
+-/
+
+namespace HexPoly
+
+/-- Reduce an `if` when its condition holds. -/
+theorem ite_eq_left {c : Prop} {_ : Decidable c} (hc : c) {α : Sort u} {t e : α} :
+    (if c then t else e) = t := by
+  simp [hc]
+
+/-- Reduce an `if` when its condition does not hold. -/
+theorem ite_eq_right {c : Prop} {_ : Decidable c} (hc : ¬c) {α : Sort u} {t e : α} :
+    (if c then t else e) = e := by
+  simp [hc]
+
+/-- Reduce a dependent `if` when its condition holds. -/
+theorem dite_eq_left {c : Prop} {_ : Decidable c} (hc : c) {α : Sort u}
+    {t : c → α} {e : ¬c → α} : dite c t e = t hc := by
+  simp [hc]
+
+/-- Reduce a dependent `if` when its condition does not hold. -/
+theorem dite_eq_right {c : Prop} {_ : Decidable c} (hc : ¬c) {α : Sort u}
+    {t : c → α} {e : ¬c → α} : dite c t e = e hc := by
+  simp [hc]
+
+/-- Reduce an `if` whose condition is `True`. -/
+theorem ite_true {_ : Decidable True} (t e : α) : (if True then t else e) = t := by
+  simp
+
+/-- Reduce an `if` whose condition is `False`. -/
+theorem ite_false {_ : Decidable False} (t e : α) : (if False then t else e) = e := by
+  simp
+
+end HexPoly

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Std
 
 public section
@@ -232,8 +233,8 @@ private theorem trimTrailingZerosGo_eq (n : Nat) :
       intro coeffs hsize
       rw [trimTrailingZerosGo]
       by_cases hb : coeffs.back? = some (Zero.zero : R)
-      · rw [if_pos hb, ih coeffs.pop (by rw [Array.size_pop]; omega), trimTrailingZeros_pop coeffs hb]
-      · rw [if_neg hb, trimTrailingZeros_self coeffs hb]
+      · rw [HexPoly.ite_eq_left hb, ih coeffs.pop (by rw [Array.size_pop]; omega), trimTrailingZeros_pop coeffs hb]
+      · rw [HexPoly.ite_eq_right hb, trimTrailingZeros_self coeffs hb]
 
 /-- Runtime implementation of {name}`trimTrailingZeros`. -/
 @[expose]
@@ -346,11 +347,11 @@ elsewhere, even when `c = 0` (in which case the polynomial is zero and every coe
     (monomial n c).coeff i = if i = n then c else (Zero.zero : R) := by
   unfold monomial
   by_cases hc : c = (Zero.zero : R)
-  · rw [dif_pos hc]
+  · rw [HexPoly.dite_eq_left hc]
     change (0 : DensePoly R).coeff i = if i = n then c else (Zero.zero : R)
     by_cases hi : i = n
     · subst i
-      rw [if_pos rfl, hc]
+      rw [HexPoly.ite_eq_left rfl, hc]
       change (#[] : Array R).getD n (Zero.zero : R) = Zero.zero
       simp [Array.getD]
     · change (#[] : Array R).getD i (Zero.zero : R) = if i = n then c else Zero.zero
@@ -358,7 +359,7 @@ elsewhere, even when `c = 0` (in which case the polynomial is zero and every coe
   · simp [hc, coeff, Array.getD]
     by_cases hi : i = n
     · subst i
-      rw [dif_pos (Nat.lt_succ_self n)]
+      rw [HexPoly.dite_eq_left (Nat.lt_succ_self n)]
       rw [show
           ((Array.replicate n (Zero.zero : R)).push c)[n] = c by
             simpa using
@@ -368,11 +369,11 @@ elsewhere, even when `c = 0` (in which case the polynomial is zero and every coe
       · have hrep : i < (Array.replicate n (Zero.zero : R)).size := by
           simpa using hlt
         have hpush : i < n + 1 := by omega
-        rw [dif_pos hpush, Array.getElem_push_lt hrep]
+        rw [HexPoly.dite_eq_left hpush, Array.getElem_push_lt hrep]
         simp [hi]
       · have hnle : n < i := by omega
         have hpush_not : ¬ i < n + 1 := by omega
-        rw [dif_neg hpush_not]
+        rw [HexPoly.dite_eq_right hpush_not]
         simp [hi]
 
 /-- Coefficient of `ofList coeffs` agrees with `coeffs.getD _ 0`: normalization does not change
@@ -410,7 +411,7 @@ theorem coeff_eq_zero_of_size_le (p : DensePoly R) {i : Nat} (h : p.size ≤ i) 
   unfold coeff Array.getD
   have hcoeffs : p.coeffs.size ≤ i := by
     simpa [size] using h
-  rw [dif_neg (Nat.not_lt.mpr hcoeffs)]
+  rw [HexPoly.dite_eq_right (Nat.not_lt.mpr hcoeffs)]
 
 /-- The last stored coefficient of a nonzero normalized dense polynomial is nonzero. -/
 theorem coeff_last_ne_zero_of_pos_size (p : DensePoly R) (hpos : 0 < p.size) :
@@ -596,14 +597,14 @@ theorem isZero_C_eq_true_iff (c : R) : (C c).isZero = true ↔ c = (0 : R) := by
 /-- The monomial with zero coefficient is the zero polynomial. -/
 @[simp, grind =] theorem monomial_zero (n : Nat) : monomial n (0 : R) = 0 := by
   change monomial n (Zero.zero : R) = 0
-  rw [monomial, dif_pos rfl]
+  rw [monomial, HexPoly.dite_eq_left rfl]
 
 /-- A monomial with nonzero coefficient stores exactly the `n + 1` coefficients up to degree `n`.
 -/
 theorem size_monomial_of_ne_zero {n : Nat} {c : R} (hc : c ≠ (0 : R)) :
     (monomial n c).size = n + 1 := by
   change c ≠ Zero.zero at hc
-  rw [monomial, dif_neg hc]
+  rw [monomial, HexPoly.dite_eq_right hc]
   change ((Array.replicate n (Zero.zero : R)).push c).size = n + 1
   simp
 
@@ -652,7 +653,7 @@ theorem degree?_eq_none_iff (p : DensePoly R) :
 theorem degree?_eq_some_of_pos_size (p : DensePoly R) (hpos : 0 < p.size) :
     p.degree? = some (p.size - 1) := by
   unfold degree?
-  rw [dif_neg (Nat.ne_of_gt hpos)]
+  rw [HexPoly.dite_eq_right (Nat.ne_of_gt hpos)]
 
 /-- A monomial with nonzero coefficient has degree exactly its exponent. -/
 theorem degree?_monomial_of_ne_zero {n : Nat} {c : R} (hc : c ≠ (0 : R)) :

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -507,13 +508,13 @@ theorem coeff_mul_top_int (p q : DensePoly Int)
   rw [coeff_mul, mulCoeffSum_eq_diagonal, foldl_add_int_eq_at_predecessor _ p.size hp]
   · unfold diagonalMulCoeffTerm
     have hno : ¬ (p.size - 1 + (q.size - 1)) < p.size - 1 := by omega
-    rw [if_neg hno]
+    rw [HexPoly.ite_eq_right hno]
     have hsub : p.size - 1 + (q.size - 1) - (p.size - 1) = q.size - 1 := by omega
     rw [hsub]
   · intro i hi
     unfold diagonalMulCoeffTerm
     have hno : ¬ (p.size - 1 + (q.size - 1)) < i := by omega
-    rw [if_neg hno]
+    rw [HexPoly.ite_eq_right hno]
     have hsub : (p.size - 1 + (q.size - 1)) - i ≥ q.size := by omega
     rw [coeff_eq_zero_of_size_le q hsub]
     show p.coeff i * (0 : Int) = 0
@@ -590,7 +591,7 @@ private theorem foldl_add_int_diagonal_scaled
         unfold diagonalMulCoeffTerm
         by_cases hn : n < m'
         · simp [hn]
-        · rw [if_neg hn]
+        · rw [HexPoly.ite_eq_right hn]
           rw [coeff_scale a r m' (Int.mul_zero a), coeff_scale b s (n - m') (Int.mul_zero b)]
           grind
       rw [hterm]

--- a/HexPoly/Euclid/Content.lean
+++ b/HexPoly/Euclid/Content.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -92,8 +93,8 @@ theorem primitivePart_eq_primitivePartImpl (p : DensePoly Int) :
     primitivePart p = primitivePartImpl p := by
   simp only [primitivePart, primitivePartImpl, ofList, ← contentNat_eq_contentNatImpl]
   by_cases h : contentNat p = 0
-  · rw [if_pos h, if_pos h]
-  · rw [if_neg h, if_neg h]
+  · rw [HexPoly.ite_eq_left h, HexPoly.ite_eq_left h]
+  · rw [HexPoly.ite_eq_right h, HexPoly.ite_eq_right h]
     congr 1
     show ((p.toArray.toList).map
         (fun coeff => coeff / Int.ofNat (contentNat p))).toArray = _
@@ -829,7 +830,7 @@ theorem content_mul_primitivePart (p : DensePoly Int) :
       · have hpart :
             (primitivePart p).coeff n = p.coeff n / content p := by
           unfold primitivePart content
-          rw [if_neg hc, coeff_ofList, list_getD_map_ediv_zero]
+          rw [HexPoly.ite_eq_right hc, coeff_ofList, list_getD_map_ediv_zero]
           unfold coeff toList toArray Array.getD
           by_cases hn : n < p.coeffs.size
           · simp [hn]
@@ -912,12 +913,12 @@ private theorem all_zero_of_trimTrailingZerosList_nil (xs : List Int)
   | cons x xs' ih =>
       rw [trimTrailingZerosList_cons_int] at htrim
       by_cases hinner : trimTrailingZerosList xs' = [] ∧ x = (0 : Int)
-      · rw [if_pos hinner] at htrim
+      · rw [HexPoly.ite_eq_left hinner] at htrim
         intro y hy
         rcases List.mem_cons.mp hy with hyx | hyxs
         · rw [hyx]; exact hinner.2
         · exact ih hinner.1 y hyxs
-      · rw [if_neg hinner] at htrim
+      · rw [HexPoly.ite_eq_right hinner] at htrim
         exact absurd htrim (List.cons_ne_nil _ _)
 
 /-- Trimming trailing zeros before the `Nat.gcd`-over-`natAbs` fold gives the
@@ -931,13 +932,13 @@ private theorem foldl_gcd_natAbs_trim_eq (xs : List Int) (acc : Nat) :
   | cons x xs' ih =>
       rw [trimTrailingZerosList_cons_int]
       by_cases hinner : trimTrailingZerosList xs' = [] ∧ x = (0 : Int)
-      · rw [if_pos hinner]
+      · rw [HexPoly.ite_eq_left hinner]
         rw [List.foldl_nil, List.foldl_cons, hinner.2]
         simp only [Int.natAbs_zero, Nat.gcd_zero_right]
         have hzero : ∀ y ∈ xs', y = (0 : Int) :=
           all_zero_of_trimTrailingZerosList_nil xs' hinner.1
         exact (foldl_gcd_natAbs_of_all_zero xs' acc hzero).symm
-      · rw [if_neg hinner]
+      · rw [HexPoly.ite_eq_right hinner]
         rw [List.foldl_cons, List.foldl_cons]
         exact ih (Nat.gcd acc x.natAbs)
 

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -210,7 +211,7 @@ private theorem arrayDegree?_some_above_eq_zero {coeffs : Array R} {rd i : Nat}
   by_cases hi : i < coeffs.size
   · exact arrayDegreeAux_some_above_eq_zero h hrd hi
   · unfold Array.getD
-    exact dif_neg hi
+    exact HexPoly.dite_eq_right hi
 
 /-- When {name}`arrayDegree?` returns `none`, every coefficient is zero. -/
 private theorem arrayDegree?_none_getD_eq_zero {coeffs : Array R} {i : Nat}
@@ -219,7 +220,7 @@ private theorem arrayDegree?_none_getD_eq_zero {coeffs : Array R} {i : Nat}
   by_cases hi : i < coeffs.size
   · exact arrayDegreeAux_none_getD_eq_zero h hi
   · unfold Array.getD
-    exact dif_neg hi
+    exact HexPoly.dite_eq_right hi
 
 /-- If every coefficient at an index `≥ bound` is zero (with `bound` positive), the normalized
 degree of `ofCoeffs coeffs` is below `bound`. -/
@@ -628,7 +629,7 @@ private theorem arrayDegreeAux_drop {coeffs : Array R} {c : Nat}
       have hzero : coeffs.getD (c + n) (Zero.zero : R) = (Zero.zero : R) := h _ (by omega)
       show (if coeffs.getD (c + n) (Zero.zero : R) = (Zero.zero : R)
               then arrayDegreeAux coeffs (c + n) else some (c + n)) = arrayDegreeAux coeffs c
-      rw [if_pos hzero]
+      rw [HexPoly.ite_eq_left hzero]
       exact ih
 
 /-- When every coefficient at or above the scan ceiling `ceil` is zero, the bounded scan
@@ -639,7 +640,7 @@ private theorem arrayDegreeAux_eq_arrayDegree? {coeffs : Array R} {ceil : Nat}
   have hsize : ∀ i, coeffs.size ≤ i → coeffs.getD i (Zero.zero : R) = (Zero.zero : R) := by
     intro i hi
     unfold Array.getD
-    exact dif_neg (by omega)
+    exact HexPoly.dite_eq_right (by omega)
   rw [arrayDegree?]
   rcases Nat.le_total ceil coeffs.size with hle | hle
   · have hdrop := arrayDegreeAux_drop h (coeffs.size - ceil)
@@ -694,8 +695,8 @@ private theorem divModArrayAuxImplGo_eq [Sub R] [Mul R]
       | some rd =>
           dsimp only
           by_cases hlt : rd < qDegree
-          · rw [if_pos hlt, dif_pos hlt]
-          · rw [if_neg hlt, dif_neg hlt]
+          · rw [HexPoly.ite_eq_left hlt, HexPoly.dite_eq_left hlt]
+          · rw [HexPoly.ite_eq_right hlt, HexPoly.dite_eq_right hlt]
             rw [subtractScaledShiftImpl_eq rem q (rd - qDegree)
               (scaleLead (rem.getD rd (Zero.zero : R)))]
             apply ih
@@ -720,7 +721,7 @@ private theorem divModArrayAuxImpl_eq [Sub R] [Mul R]
   apply divModArrayAuxImplGo_eq
   intro i hi
   unfold Array.getD
-  exact dif_neg (by omega)
+  exact HexPoly.dite_eq_right (by omega)
 
 /-- The remainder-only loop follows exactly the remainder component of the
 quotient-producing implementation, independently of the quotient accumulator. -/
@@ -927,7 +928,7 @@ theorem divModArray_remainder_degree_lt_of_pos_degree [Sub R] [Mul R]
     have hdeg_zero : q.degree?.getD 0 = 0 := by
       simp [degree?, hqsize]
     omega
-  · rw [if_neg hqzero]
+  · rw [HexPoly.ite_eq_right hqzero]
     let qDegree := q.size - 1
     let quotientSize := p.size - qDegree
     let quot := Array.replicate quotientSize (Zero.zero : R)
@@ -957,7 +958,7 @@ theorem divModArray_remainder_degree_lt_of_pos_degree [Sub R] [Mul R]
       unfold toArray Array.getD
       have hle : p.coeffs.size ≤ i := by
         simpa [size] using (by omega : p.size ≤ i)
-      rw [dif_neg (Nat.not_lt.mpr hle)]
+      rw [HexPoly.dite_eq_right (Nat.not_lt.mpr hle)]
     have hzero_final :
         ∀ i, qDegree ≤ i → qr.2.getD i (Zero.zero : R) = (Zero.zero : R) := by
       dsimp [qr, quot]
@@ -1044,7 +1045,7 @@ theorem divMod_remainder_degree_lt_of_pos_degree_of_cancel [One R] [Add R] [Sub 
   unfold divMod
   by_cases hlt : p.degree?.getD 0 < q.degree?.getD 0
   · simp [hlt]
-  · rw [if_neg hlt]
+  · rw [HexPoly.ite_eq_right hlt]
     exact divModArray_remainder_degree_lt_of_pos_degree p q
       (fun coeff => coeff / q.leadingCoeff) hdegree hcancel
 
@@ -1062,7 +1063,7 @@ theorem divMod_remainder_eq_zero_of_degree_zero_of_cancel [One R] [Add R] [Sub R
   have hnot_lt : ¬ p.degree?.getD 0 < q.degree?.getD 0 := by
     rw [hqdeg]
     exact Nat.not_lt_zero _
-  rw [if_neg hnot_lt]
+  rw [HexPoly.ite_eq_right hnot_lt]
   unfold divModArray
   have hqzero : q.isZero = false := by
     cases h : q.isZero
@@ -1071,7 +1072,7 @@ theorem divMod_remainder_eq_zero_of_degree_zero_of_cancel [One R] [Add R] [Sub R
         simp [isZero] at h
         simpa [size] using h
       omega
-  rw [if_neg (by simpa [Bool.not_eq_true] using hqzero)]
+  rw [HexPoly.ite_eq_right (by simpa [Bool.not_eq_true] using hqzero)]
   let qDegree := q.size - 1
   let quotientSize := p.size - qDegree
   let quot := Array.replicate quotientSize (Zero.zero : R)
@@ -1095,7 +1096,7 @@ theorem divMod_remainder_eq_zero_of_degree_zero_of_cancel [One R] [Add R] [Sub R
     unfold toArray Array.getD
     have hle : p.coeffs.size ≤ i := by
       simpa [size] using (by omega : p.size ≤ i)
-    rw [dif_neg (Nat.not_lt.mpr hle)]
+    rw [HexPoly.dite_eq_right (Nat.not_lt.mpr hle)]
   have hzero_final :
       ∀ i, qDegree ≤ i → qr.2.getD i (Zero.zero : R) = (Zero.zero : R) := by
     dsimp [qr, quot]
@@ -1120,7 +1121,7 @@ theorem divMod_remainder_eq_self_of_size_zero [One R] [Add R] [Sub R] [Mul R] [D
   unfold divMod
   have hnot_lt : ¬ p.degree?.getD 0 < q.degree?.getD 0 := by
     simp [degree?, hqsize]
-  rw [if_neg hnot_lt]
+  rw [HexPoly.ite_eq_right hnot_lt]
   unfold divModArray
   have hqzero : q.isZero = true := by
     simp [isZero, size] at hqsize ⊢
@@ -1135,7 +1136,7 @@ theorem divMod_eq_zero_self_of_size_zero [One R] [Add R] [Sub R] [Mul R] [Div R]
   unfold divMod
   have hnot_lt : ¬ p.degree?.getD 0 < q.degree?.getD 0 := by
     simp [degree?, hqsize]
-  rw [if_neg hnot_lt]
+  rw [HexPoly.ite_eq_right hnot_lt]
   unfold divModArray
   have hqzero : q.isZero = true := by
     simp [isZero, size] at hqsize ⊢
@@ -1501,7 +1502,7 @@ theorem mod_eq_divMod [One R] [Add R] [Sub R] [Mul R] [Div R]
   rw [hdeg_zero]
   by_cases hpos : 0 < m.degree?.getD 0
   · simp [hpos]
-  · rw [if_neg hpos]
+  · rw [HexPoly.ite_eq_right hpos]
     unfold divModArray
     simp [hzero, isZero, size, toArray, divModArrayAux]
 
@@ -1564,11 +1565,11 @@ private theorem ofCoeffs_set!_eq_add_monomial {S : Type _}
   · subst n
     rw [array_getD_set!_same]
     · rw [hzero]
-      rw [if_pos rfl]
+      rw [HexPoly.ite_eq_left rfl]
       exact (hzero_add_left coeff).symm
     · exact hshift
   · rw [array_getD_set!_ne]
-    · rw [if_neg hn]
+    · rw [HexPoly.ite_eq_right hn]
       exact (hadd_zero_right (coeffs.getD n (Zero.zero : S))).symm
     · intro h
       exact hn h.symm
@@ -1585,7 +1586,7 @@ theorem divModArray_eq_zero_self_of_degree_lt [Sub R] [Mul R]
       simp [isZero] at hqzero
       simpa [size] using hqzero
     simp [degree?, hqsize] at hdeg
-  · rw [if_neg hqzero]
+  · rw [HexPoly.ite_eq_right hqzero]
     let qDegree := q.size - 1
     let quotientSize := p.size - qDegree
     let quot := Array.replicate quotientSize (Zero.zero : R)
@@ -1635,7 +1636,7 @@ theorem divModMonic_eq_divMod_of_monic_of_scale [One R] [Add R] [Sub R] [Mul R] 
     (hscale : ∀ a : R, a / q.leadingCoeff = a) :
     divModMonic p q hq = divMod p q := by
   unfold divModMonic divMod
-  rw [if_neg hnot_lt]
+  rw [HexPoly.ite_eq_right hnot_lt]
   exact (divModArray_scaleLead_congr p q (fun a => hscale a)).symm
 
 /-- Division invariant: for positive-degree divisors, {name}`divMod` returns a remainder whose

--- a/HexPoly/Euclid/EvalMul.lean
+++ b/HexPoly/Euclid/EvalMul.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -94,9 +95,9 @@ theorem eval_shift_semiring [Lean.Grind.CommSemiring S] [DecidableEq S]
   unfold shift
   by_cases hz : p.isZero
   · have hp : p = 0 := (size_eq_zero_iff p).mp ((isZero_eq_true_iff p).mp hz)
-    rw [if_pos hz, hp, eval_zero]
+    rw [HexPoly.ite_eq_left hz, hp, eval_zero]
     exact (Lean.Grind.Semiring.zero_mul _).symm
-  · rw [if_neg hz, eval_ofList_eq_evalCoeffList _ x hzero_horner]
+  · rw [HexPoly.ite_eq_right hz, eval_ofList_eq_evalCoeffList _ x hzero_horner]
     show evalCoeffList (List.replicate n (0 : S) ++ p.toList) x = eval p x * x ^ n
     rw [evalCoeffList_replicate_zero_append, eval_eq_evalCoeffList]
     rfl
@@ -137,7 +138,7 @@ private theorem eval_mul_of_size_le [Lean.Grind.CommRing S] [DecidableEq S] :
       have hzq : (0 : DensePoly S) * q = 0 := by
         show mul 0 q = 0
         unfold mul
-        rw [if_pos (by simp [(isZero_eq_true_iff (0 : DensePoly S)).mpr rfl])]
+        rw [HexPoly.ite_eq_left (by simp [(isZero_eq_true_iff (0 : DensePoly S)).mpr rfl])]
       rw [hzq, eval_zero]
       exact (Lean.Grind.Semiring.zero_mul _).symm
   | succ n ih =>

--- a/HexPoly/Euclid/MulRing.lean
+++ b/HexPoly/Euclid/MulRing.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -392,9 +393,9 @@ theorem scale_mul {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
         have hterm : term (scale a p) m = a * term p m := by
           unfold term diagonalMulCoeffTerm
           by_cases hnm : n < m
-          · simp only [hnm, if_true]
+          · simp only [hnm, HexPoly.ite_true]
             grind
-          · simp only [hnm, if_false, coeff_scale_semiring]
+          · simp only [hnm, HexPoly.ite_false, coeff_scale_semiring]
             grind
         rw [hterm]
         grind
@@ -1293,28 +1294,28 @@ theorem monomial_mul_monomial {S : Type _}
     by_cases hni : n < i
     · have hcond : ¬ (i = m ∧ n = m + k) := by
         intro ⟨h1, h2⟩; omega
-      rw [if_pos hni, if_neg hcond]
+      rw [HexPoly.ite_eq_left hni, HexPoly.ite_eq_right hcond]
     · have hile : i ≤ n := Nat.le_of_not_gt hni
-      rw [if_neg hni]
+      rw [HexPoly.ite_eq_right hni]
       by_cases him : i = m
       · subst i
-        rw [if_pos rfl]
+        rw [HexPoly.ite_eq_left rfl]
         by_cases hnmk : n - m = k
         · have hn : n = m + k := by omega
-          rw [if_pos hnmk]
+          rw [HexPoly.ite_eq_left hnmk]
           simp [hn]
         · have hn : n ≠ m + k := by omega
-          rw [if_neg hnmk]
+          rw [HexPoly.ite_eq_right hnmk]
           have hcond : ¬ (m = m ∧ n = m + k) := fun ⟨_, h⟩ => hn h
-          rw [if_neg hcond]
+          rw [HexPoly.ite_eq_right hcond]
           -- c * Zero.zero = 0.
           show c * (Zero.zero : S) = 0
           have : (Zero.zero : S) = 0 := rfl
           rw [this]
           grind
-      · rw [if_neg him]
+      · rw [HexPoly.ite_eq_right him]
         have hcond : ¬ (i = m ∧ n = m + k) := fun ⟨h, _⟩ => him h
-        rw [if_neg hcond]
+        rw [HexPoly.ite_eq_right hcond]
         -- Zero.zero * anything = 0.
         exact Lean.Grind.Semiring.zero_mul _
   have hfold : ∀ (xs : List Nat) (acc : S),
@@ -1348,7 +1349,7 @@ theorem monomial_mul_monomial {S : Type _}
           exact ih _
     rw [hfold2 (List.range (n + 1)) 0, fold_single_index]
     have hm_lt : m < n + 1 := by omega
-    rw [if_pos hm_lt, if_pos hnmk]
+    rw [HexPoly.ite_eq_left hm_lt, HexPoly.ite_eq_left hnmk]
   · have hzero_fold : ∀ (xs : List Nat) (acc : S),
         xs.foldl (fun acc i => acc + if i = m ∧ n = m + k then c * d else 0) acc = acc := by
       intro xs
@@ -1358,9 +1359,9 @@ theorem monomial_mul_monomial {S : Type _}
           intro acc
           simp only [List.foldl_cons]
           have hcond : ¬ (i = m ∧ n = m + k) := fun ⟨_, h⟩ => hnmk h
-          rw [if_neg hcond, show acc + (0 : S) = acc by grind]
+          rw [HexPoly.ite_eq_right hcond, show acc + (0 : S) = acc by grind]
           exact ih _
-    rw [hzero_fold, if_neg hnmk]
+    rw [hzero_fold, HexPoly.ite_eq_right hnmk]
     rfl
 
 end DensePoly

--- a/HexPoly/Euclid/Reconstruction.lean
+++ b/HexPoly/Euclid/Reconstruction.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import Init.Grind.Ring.Basic
 public import Init.Data.List.Lemmas
 public import HexPoly.Operations
@@ -69,7 +70,7 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
         exact ih _
   rw [hfold (List.range (n + 1)) 0]
   by_cases hshift : shift ≤ n
-  · rw [if_neg (by omega : ¬n < shift)]
+  · rw [HexPoly.ite_eq_right (by omega : ¬n < shift)]
     have hsimp : ∀ i,
         (if i = shift ∧ shift ≤ n then q.coeff (n - shift) else 0) =
           if i = shift then q.coeff (n - shift) else 0 := by
@@ -90,8 +91,8 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
           simp only [List.foldl_cons]
           rw [hsimp i]
           exact ih _
-    rw [hfold2 (List.range (n + 1)) 0, fold_single_index, if_pos (by omega : shift < n + 1)]
-  · rw [if_pos (by omega : n < shift)]
+    rw [hfold2 (List.range (n + 1)) 0, fold_single_index, HexPoly.ite_eq_left (by omega : shift < n + 1)]
+  · rw [HexPoly.ite_eq_left (by omega : n < shift)]
     have hzero_fold : ∀ (xs : List Nat) (acc : S),
         xs.foldl (fun acc i =>
             acc + if i = shift ∧ shift ≤ n then q.coeff (n - shift) else 0) acc = acc := by
@@ -227,14 +228,14 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
           exact ih _
     rw [hfold2 (List.range (n + 1)) 0, fold_single_index]
     have hshift_lt : shift < n + 1 := by omega
-    rw [if_pos hshift_lt]
+    rw [HexPoly.ite_eq_left hshift_lt]
     by_cases hsize : n - shift < q.size
-    · rw [if_pos ⟨hshift, hsize⟩]
+    · rw [HexPoly.ite_eq_left ⟨hshift, hsize⟩]
     · have hand : ¬ (shift ≤ n ∧ n - shift < q.size) := fun ⟨_, h⟩ => hsize h
-      rw [if_neg hand]
+      rw [HexPoly.ite_eq_right hand]
       have hq0 : q.getD (n - shift) (Zero.zero : S) = (0 : S) := by
         unfold Array.getD
-        rw [dif_neg (Nat.not_lt.mpr (Nat.le_of_not_lt hsize))]
+        rw [HexPoly.dite_eq_right (Nat.not_lt.mpr (Nat.le_of_not_lt hsize))]
         rfl
       rw [hq0]
       grind
@@ -258,7 +259,7 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
           exact ih _
     rw [hzero_fold (List.range (n + 1)) 0]
     have hand : ¬ (shift ≤ n ∧ n - shift < q.size) := fun ⟨h, _⟩ => hshift h
-    rw [if_neg hand]
+    rw [HexPoly.ite_eq_right hand]
     grind
 
 /-- Left absorption for polynomial multiplication: `0 * p = 0`. A `grind`
@@ -718,7 +719,7 @@ theorem divModArray_reconstruction {S : Type _}
   by_cases hqzero : q.isZero
   · simp [hqzero]
     rw [zero_mul, zero_add]
-  · rw [if_neg hqzero]
+  · rw [HexPoly.ite_eq_right hqzero]
     have hqpos : 0 < q.size := by
       have hcoeffs : q.coeffs.size ≠ 0 := by
         simpa [isZero, Array.isEmpty_iff_size_eq_zero] using hqzero
@@ -743,7 +744,7 @@ theorem divModArray_reconstruction {S : Type _}
       unfold toArray Array.getD
       have hle : p.coeffs.size ≤ i := by
         simpa [size] using (by omega : p.size ≤ i)
-      rw [dif_neg (Nat.not_lt.mpr hle)]
+      rw [HexPoly.dite_eq_right (Nat.not_lt.mpr hle)]
     have hzero_quot : ∀ i, i < p.size →
         (Array.replicate (p.size - (q.size - 1)) (Zero.zero : S)).getD i
           (Zero.zero : S) = (Zero.zero : S) := by
@@ -842,13 +843,13 @@ private theorem coeff_mul_top_general {S : Type _}
   rw [coeff_mul, mulCoeffSum_eq_diagonal, foldl_add_general_eq_at_predecessor _ p.size hp]
   · unfold diagonalMulCoeffTerm
     have hno : ¬ p.size - 1 + (q.size - 1) < p.size - 1 := by omega
-    rw [if_neg hno]
+    rw [HexPoly.ite_eq_right hno]
     have hsub : p.size - 1 + (q.size - 1) - (p.size - 1) = q.size - 1 := by omega
     rw [hsub]
   · intro i hi
     unfold diagonalMulCoeffTerm
     have hno : ¬ p.size - 1 + (q.size - 1) < i := by omega
-    rw [if_neg hno]
+    rw [HexPoly.ite_eq_right hno]
     have hsub : q.size ≤ p.size - 1 + (q.size - 1) - i := by omega
     rw [coeff_eq_zero_of_size_le q hsub]
     show p.coeff i * (Zero.zero : S) = 0
@@ -872,7 +873,7 @@ private theorem coeff_mul_above_top_general {S : Type _}
   by_cases hlt : i < k
   · simp [hlt]
   · have hsub_ge : q.size ≤ i - k := by omega
-    rw [if_neg hlt, coeff_eq_zero_of_size_le q hsub_ge]
+    rw [HexPoly.ite_eq_right hlt, coeff_eq_zero_of_size_le q hsub_ge]
     show p.coeff k * (Zero.zero : S) = 0
     have hzero_eq : (Zero.zero : S) = 0 := rfl
     rw [hzero_eq]
@@ -971,7 +972,7 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
       rw [hofq_coeff]
       unfold Array.getD
       have hnot : ¬ i < q.size := by omega
-      exact dif_neg hnot
+      exact HexPoly.dite_eq_right hnot
     · by_cases hge : qDegree + 1 ≤ (ofCoeffs q : DensePoly S).size
       · exact hge
       · exfalso
@@ -1193,9 +1194,9 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
               rw [coeff_sub m (monomial shift coeff) i hzero_sub, coeff_monomial]
               by_cases hi_eq : i = shift
               · subst i
-                rw [if_pos rfl, hcoeff_eq, hshift_eq_size]
+                rw [HexPoly.ite_eq_left rfl, hcoeff_eq, hshift_eq_size]
                 grind
-              · rw [if_neg hi_eq]
+              · rw [HexPoly.ite_eq_right hi_eq]
                 have hi_gt : shift < i := by omega
                 have hi_ge_size : m.size ≤ i := by
                   have hsize_lt : m.size - 1 < i := by
@@ -1404,7 +1405,7 @@ theorem divMod_eq_of_polynomial_mul {S : Type _}
   unfold divMod
   by_cases hdeg_short : p.degree?.getD 0 < q.degree?.getD 0
   · -- Short circuit: must show qq = 0 and p = 0.
-    rw [if_pos hdeg_short]
+    rw [HexPoly.ite_eq_left hdeg_short]
     have hp_size_lt_q : p.size < q.size := by
       unfold degree? at hdeg_short
       have hq_ne : q.size ≠ 0 := by omega
@@ -1426,10 +1427,10 @@ theorem divMod_eq_of_polynomial_mul {S : Type _}
         omega
     have hp_zero : p = 0 := by rw [← hmul, hqq_zero, zero_mul]
     rw [hp_zero, hqq_zero]
-  · rw [if_neg hdeg_short]
+  · rw [HexPoly.ite_eq_right hdeg_short]
     -- Apply the array-level lemma via divModArray.
     unfold divModArray
-    rw [if_neg (by simp [hq_isZero])]
+    rw [HexPoly.ite_eq_right (by simp [hq_isZero])]
     -- Bookkeeping to feed divModArrayAux_eq_of_polynomial_mul.
     let qDeg := q.size - 1
     let scaleLead : S → S := fun coeff => coeff / q.leadingCoeff
@@ -1490,7 +1491,7 @@ theorem divMod_eq_of_polynomial_mul {S : Type _}
           omega
       unfold toArray Array.getD
       have hcoeffs_le : p.coeffs.size ≤ i := by change p.size ≤ i; exact hp_le_i
-      rw [dif_neg (Nat.not_lt.mpr hcoeffs_le)]
+      rw [HexPoly.dite_eq_right (Nat.not_lt.mpr hcoeffs_le)]
     have hm_size_le : qq.size ≤ qq.size := Nat.le_refl _
     have h_inv : (ofCoeffs p.toArray : DensePoly S) = qq * ofCoeffs q.toArray := by
       rw [ofCoeffs_toArray p, ofCoeffs_toArray q]

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPoly.Conditional
 public import HexPoly.Dense
 public import Init.Data.Array.Lemmas
 
@@ -88,8 +89,8 @@ theorem shift_eq_shiftImpl (n : Nat) (p : DensePoly R) :
     shift n p = shiftImpl n p := by
   unfold shift shiftImpl ofList
   by_cases hz : p.isZero
-  · rw [if_pos hz, if_pos hz]
-  · rw [if_neg hz, if_neg hz]
+  · rw [HexPoly.ite_eq_left hz, HexPoly.ite_eq_left hz]
+  · rw [HexPoly.ite_eq_right hz, HexPoly.ite_eq_right hz]
     congr 1
     show ((List.replicate n (Zero.zero : R)) ++ p.toArray.toList).toArray = _
     apply Array.ext'
@@ -214,7 +215,7 @@ coefficients are read from the original polynomial with the index shifted down. 
       simp [hp, hk, hzero]
       change (0 : DensePoly R).coeff k = (Zero.zero : R)
       exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)
-  · rw [if_neg hp]
+  · rw [HexPoly.ite_eq_right hp]
     rw [coeff_ofList]
     simpa [coeff, toList, toArray] using
       list_getD_replicate_append_zero (R := R) n k p.toList
@@ -322,9 +323,9 @@ private theorem array_ofFn_getD {n : Nat} (f : Fin n → R) (i : Nat) :
       if h : i < n then f ⟨i, h⟩ else (Zero.zero : R) := by
   rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn]
   by_cases h : i < n
-  · rw [dif_pos h, dif_pos h]
+  · rw [HexPoly.dite_eq_left h, HexPoly.dite_eq_left h]
     rfl
-  · rw [dif_neg h, dif_neg h]
+  · rw [HexPoly.dite_eq_right h, HexPoly.dite_eq_right h]
     rfl
 
 omit [DecidableEq R] in
@@ -335,9 +336,9 @@ private theorem array_map_getD (g : R → R) (a : Array R) (i : Nat) :
       if h : i < a.size then g a[i] else (Zero.zero : R) := by
   rw [Array.getD_eq_getD_getElem?, Array.getElem?_map]
   by_cases h : i < a.size
-  · rw [Array.getElem?_eq_getElem h, dif_pos h]
+  · rw [Array.getElem?_eq_getElem h, HexPoly.dite_eq_left h]
     rfl
-  · rw [Array.getElem?_eq_none (Nat.le_of_not_gt h), dif_neg h]
+  · rw [Array.getElem?_eq_none (Nat.le_of_not_gt h), HexPoly.dite_eq_right h]
     rfl
 
 /-- Add two dense polynomials coefficientwise.
@@ -367,8 +368,8 @@ theorem add_eq_addImpl [Add R] (p q : DensePoly R) : add p q = addImpl p q := by
   rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD, array_ofFn_getD]
   simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · rw [if_pos hn, dif_pos hn]
-  · rw [if_neg hn, dif_neg hn]
+  · rw [HexPoly.ite_eq_left hn, HexPoly.dite_eq_left hn]
+  · rw [HexPoly.ite_eq_right hn, HexPoly.dite_eq_right hn]
 
 /-- Register the `Array.ofFn` loop as the compiled implementation of {name}`add`. -/
 @[csimp]
@@ -404,8 +405,8 @@ theorem sub_eq_subImpl [Sub R] (p q : DensePoly R) : sub p q = subImpl p q := by
   rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD, array_ofFn_getD]
   simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · rw [if_pos hn, dif_pos hn]
-  · rw [if_neg hn, dif_neg hn]
+  · rw [HexPoly.ite_eq_left hn, HexPoly.dite_eq_left hn]
+  · rw [HexPoly.ite_eq_right hn, HexPoly.dite_eq_right hn]
 
 /-- Register the `Array.ofFn` loop as the compiled implementation of {name}`sub`. -/
 @[csimp]
@@ -444,11 +445,11 @@ theorem neg_eq_negImpl [Sub R] (p : DensePoly R) : neg p = negImpl p := by
   simp only [size_zero, Nat.zero_max, toArray_size, coeff_zero]
   by_cases hn : n < p.size
   · have hn' : n < p.toArray.size := by simpa using hn
-    rw [dif_pos hn, dif_pos hn,
+    rw [HexPoly.dite_eq_left hn, HexPoly.dite_eq_left hn,
       show p.toArray[n]'hn' = p.coeff n by
         rw [Array.getElem_eq_getD (Zero.zero : R), toArray_getD]]
     rfl
-  · rw [dif_neg hn, dif_neg hn]
+  · rw [HexPoly.dite_eq_right hn, HexPoly.dite_eq_right hn]
 
 /-- Register the `Array.map` pass as the compiled implementation of {name}`neg`. -/
 @[csimp]
@@ -680,7 +681,7 @@ private theorem coeff_mulImpl [Add R] [Mul R] (p q : DensePoly R) (n : Nat) :
     (mulImpl p q).coeff n = mulCoeffSum p q n := by
   unfold mulImpl
   by_cases hzero : p.isZero || q.isZero
-  · rw [if_pos hzero]
+  · rw [HexPoly.ite_eq_left hzero]
     by_cases hp : p.isZero
     · have hpsize : p.size = 0 := (DensePoly.isZero_eq_true_iff p).1 (by simpa using hp)
       rw [show (0 : DensePoly R).coeff n = (Zero.zero : R) by
@@ -692,7 +693,7 @@ private theorem coeff_mulImpl [Add R] [Mul R] (p q : DensePoly R) (n : Nat) :
       rw [show (0 : DensePoly R).coeff n = (Zero.zero : R) by
         exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)]
       simp [mulCoeffSum, hqsize, list_foldl_ignore]
-  · rw [if_neg hzero]
+  · rw [HexPoly.ite_eq_right hzero]
     rw [coeff_ofCoeffs]
     have hp_not : p.isZero = false := by
       cases hp : p.isZero <;> cases hq : q.isZero <;> simp [hp, hq] at hzero ⊢
@@ -782,18 +783,18 @@ private theorem foldl_mulCoeffStep_range [Add R] [Mul R]
       if i ≤ n ∧ n - i < m then c + p.coeff i * q.coeff (n - i) else c := by
   induction m with
   | zero =>
-      rw [List.range_zero, List.foldl_nil, if_neg (by omega)]
+      rw [List.range_zero, List.foldl_nil, HexPoly.ite_eq_right (by omega)]
   | succ m ih =>
       rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil, ih]
       unfold mulCoeffStep
       by_cases hlast : i + m = n
-      · rw [if_neg (by omega : ¬(i ≤ n ∧ n - i < m)), if_pos hlast,
-          if_pos (by omega : i ≤ n ∧ n - i < m + 1),
+      · rw [HexPoly.ite_eq_right (by omega : ¬(i ≤ n ∧ n - i < m)), HexPoly.ite_eq_left hlast,
+          HexPoly.ite_eq_left (by omega : i ≤ n ∧ n - i < m + 1),
           show m = n - i by omega]
-      · rw [if_neg hlast]
+      · rw [HexPoly.ite_eq_right hlast]
         by_cases h : i ≤ n ∧ n - i < m
-        · rw [if_pos h, if_pos (by omega : i ≤ n ∧ n - i < m + 1)]
-        · rw [if_neg h, if_neg (by omega : ¬(i ≤ n ∧ n - i < m + 1))]
+        · rw [HexPoly.ite_eq_left h, HexPoly.ite_eq_left (by omega : i ≤ n ∧ n - i < m + 1)]
+        · rw [HexPoly.ite_eq_right h, HexPoly.ite_eq_right (by omega : ¬(i ≤ n ∧ n - i < m + 1))]
 
 omit [Zero R] [DecidableEq R] in
 /-- Folds over the same list with pointwise-equal step functions agree. -/
@@ -859,7 +860,7 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
           | nil =>
               show (List.getD [] n (Zero.zero : R)) = _
               rw [list_foldl_congr _ (fun (c : R) (_ : Nat) => c) _ _
-                  (fun c i _ => if_neg (by simp)),
+                  (fun c i _ => HexPoly.ite_eq_right (by simp)),
                 list_foldl_ignore]
           | cons q qs' =>
               exact absurd (hbound 0 (by simp) 0 (by simp)) (by simp)
@@ -868,7 +869,7 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
           | nil =>
               rw [mulRows_nil,
                 list_foldl_congr _ (fun (c : R) (_ : Nat) => c) _ _
-                  (fun c i _ => if_neg (by simp)),
+                  (fun c i _ => HexPoly.ite_eq_right (by simp)),
                 list_foldl_ignore]
           | cons q qs' =>
               show ((a + x * q) :: mulRows (q :: qs') ps (mulRow x acc qs')).getD n
@@ -878,9 +879,9 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
               cases n with
               | zero =>
                   rw [List.getD_cons_zero,
-                    if_pos ⟨Nat.le_refl 0, by simp⟩,
+                    HexPoly.ite_eq_left ⟨Nat.le_refl 0, by simp⟩,
                     list_foldl_congr _ (fun (c : R) (_ : Nat) => c) _ _
-                      (fun c i _ => if_neg (by omega)),
+                      (fun c i _ => HexPoly.ite_eq_right (by omega)),
                     list_foldl_ignore,
                     List.getD_cons_zero, List.getD_cons_zero, List.getD_cons_zero]
               | succ m =>
@@ -905,11 +906,11 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
                       else (a :: acc).getD (m + 1) (Zero.zero : R) := by
                     rw [mulRow_getD]
                     by_cases hq : m < qs'.length
-                    · rw [if_pos ⟨hlen hq, hq⟩, if_pos ⟨Nat.zero_le _, by simpa using Nat.succ_lt_succ hq⟩]
+                    · rw [HexPoly.ite_eq_left ⟨hlen hq, hq⟩, HexPoly.ite_eq_left ⟨Nat.zero_le _, by simpa using Nat.succ_lt_succ hq⟩]
                       rw [List.getD_cons_succ, List.getD_cons_zero, Nat.sub_zero,
                         List.getD_cons_succ]
-                    · rw [if_neg (fun h => hq h.2),
-                        if_neg (by simpa [Nat.succ_lt_succ_iff] using hq),
+                    · rw [HexPoly.ite_eq_right (fun h => hq h.2),
+                        HexPoly.ite_eq_right (by simpa [Nat.succ_lt_succ_iff] using hq),
                         List.getD_cons_succ]
                   rw [hinit]
                   exact list_foldl_congr _ _ _ _ fun c i _ => by
@@ -924,7 +925,7 @@ private theorem coeff_mul_spec [Add R] [Mul R] (p q : DensePoly R) (n : Nat) :
     (mul p q).coeff n = mulCoeffSum p q n := by
   unfold mul
   by_cases hzero : p.isZero || q.isZero
-  · rw [if_pos hzero]
+  · rw [HexPoly.ite_eq_left hzero]
     by_cases hp : p.isZero
     · have hpsize : p.size = 0 := (DensePoly.isZero_eq_true_iff p).1 (by simpa using hp)
       rw [show (0 : DensePoly R).coeff n = (Zero.zero : R) by
@@ -936,7 +937,7 @@ private theorem coeff_mul_spec [Add R] [Mul R] (p q : DensePoly R) (n : Nat) :
       rw [show (0 : DensePoly R).coeff n = (Zero.zero : R) by
         exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)]
       simp [mulCoeffSum, hqsize, list_foldl_ignore]
-  · rw [if_neg hzero]
+  · rw [HexPoly.ite_eq_right hzero]
     have hp_not : p.isZero = false := by
       cases hp : p.isZero <;> cases hq : q.isZero <;> simp [hp, hq] at hzero ⊢
     have hq_not : q.isZero = false := by
@@ -984,9 +985,9 @@ theorem size_mul_le [Add R] [Mul R] (p q : DensePoly R) :
   change (mul p q).size ≤ p.size + q.size - 1
   unfold mul
   by_cases hzero : p.isZero || q.isZero
-  · rw [if_pos hzero, size_zero]
+  · rw [HexPoly.ite_eq_left hzero, size_zero]
     exact Nat.zero_le _
-  · rw [if_neg hzero]
+  · rw [HexPoly.ite_eq_right hzero]
     refine Nat.le_trans (size_ofCoeffs_le _) ?_
     simp [mulRows_length]
 
@@ -1221,14 +1222,14 @@ theorem compose_C [Add R] [Mul R] (c : R) (q : DensePoly R)
     rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
     simp only [length_toList, toList_getD_eq_coeff, size_zero, Nat.zero_max, coeff_zero]
     by_cases hn : n < (C c).size
-    · rw [if_pos hn]
+    · rw [HexPoly.ite_eq_left hn]
       have hn0 : n = 0 := by
         have h1 := size_C_of_ne_zero (c := c) hc
         omega
       subst hn0
-      rw [coeff_C, if_pos rfl]
+      rw [coeff_C, HexPoly.ite_eq_left rfl]
       exact hzero_add
-    · rw [if_neg hn,
+    · rw [HexPoly.ite_eq_right hn,
         coeff_eq_zero_of_size_le (C c) (Nat.le_of_not_gt hn)]
 
 /-- Semiring-specialized composition law for constants. This packages the zero-addition
@@ -1392,12 +1393,12 @@ private theorem derivative_coeffs_getD [NatCast R] [Mul R] (p : DensePoly R) (n 
   rw [derivList_getD]
   simp only [List.length_drop, length_toList, Nat.zero_add]
   by_cases hn : n < p.size - 1
-  · rw [if_pos hn, if_pos hn]
+  · rw [HexPoly.ite_eq_left hn, HexPoly.ite_eq_left hn]
     have hdrop : (p.toList.drop 1).getD n (Zero.zero : R) =
         p.toList.getD (1 + n) (Zero.zero : R) := by
       rw [List.getD_eq_getElem?_getD, List.getElem?_drop, ← List.getD_eq_getElem?_getD]
     rw [hdrop, Nat.add_comm 1 n, toList_getD_eq_coeff]
-  · rw [if_neg hn, if_neg hn]
+  · rw [HexPoly.ite_eq_right hn, HexPoly.ite_eq_right hn]
 
 /-- The reference {name}`derivative` and the `Array.ofFn` runtime loop compute the same
 polynomial. -/
@@ -1409,8 +1410,8 @@ theorem derivative_eq_derivativeImpl [NatCast R] [Mul R] (p : DensePoly R) :
   rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD,
     derivative_coeffs_getD, array_ofFn_getD]
   by_cases hn : n < p.size - 1
-  · rw [if_pos hn, dif_pos hn]
-  · rw [if_neg hn, dif_neg hn]
+  · rw [HexPoly.ite_eq_left hn, HexPoly.dite_eq_left hn]
+  · rw [HexPoly.ite_eq_right hn, HexPoly.dite_eq_right hn]
 
 /-- Register the `Array.ofFn` loop as the compiled implementation of
 {name}`derivative`. -/
@@ -1444,11 +1445,11 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
   rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
   simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · rw [if_pos hn]
+  · rw [HexPoly.ite_eq_left hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn
     have hp : p.size ≤ n := Nat.le_trans (Nat.le_max_left p.size q.size) hmax
     have hq : q.size ≤ n := Nat.le_trans (Nat.le_max_right p.size q.size) hmax
-    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
+    rw [HexPoly.ite_eq_right hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Semiring-specialized coefficient law for addition. -/
 @[simp, grind =] theorem coeff_add_semiring {S : Type u}
@@ -1477,11 +1478,11 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
   rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
   simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · rw [if_pos hn]
+  · rw [HexPoly.ite_eq_left hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn
     have hp : p.size ≤ n := Nat.le_trans (Nat.le_max_left p.size q.size) hmax
     have hq : q.size ≤ n := Nat.le_trans (Nat.le_max_right p.size q.size) hmax
-    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
+    rw [HexPoly.ite_eq_right hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Ring-specialized coefficient law for subtraction. -/
 @[simp, grind =] theorem coeff_sub_ring {S : Type u}
@@ -1711,7 +1712,7 @@ private theorem evalCoeffList_replicate_zero_semiring {S : Type u}
     simp [Lean.Grind.Semiring.zero_mul]
   · unfold eval toList toArray monomial
     change c ≠ Zero.zero at hc
-    rw [dif_neg hc]
+    rw [HexPoly.dite_eq_right hc]
     simp only [Array.toList_push, Array.toList_replicate]
     exact evalCoeffList_replicate_zero_semiring n c x
 
@@ -1731,9 +1732,9 @@ theorem coeff_derivative [NatCast R] [Mul R] (p : DensePoly R) (n : Nat)
   unfold derivative
   rw [coeff_ofCoeffs, toArray_getD_eq_getD, derivative_coeffs_getD]
   by_cases hn : n < p.size - 1
-  · rw [if_pos hn]
+  · rw [HexPoly.ite_eq_left hn]
   · have hp : p.size ≤ n + 1 := by omega
-    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, hzero]
+    rw [HexPoly.ite_eq_right hn, coeff_eq_zero_of_size_le p hp, hzero]
 
 attribute [local instance 1100] Lean.Grind.Semiring.natCast
 
@@ -1752,7 +1753,7 @@ law. -/
   apply ext_coeff
   intro n
   rw [coeff_derivative_semiring, coeff_zero, coeff_C]
-  simp only [Nat.succ_ne_zero, if_false]
+  simp only [Nat.succ_ne_zero, HexPoly.ite_false]
   change ((n + 1 : Nat) : S) * (0 : S) = 0
   exact Lean.Grind.Semiring.mul_zero _
 
@@ -1763,7 +1764,7 @@ law. -/
   apply ext_coeff
   intro n
   rw [coeff_derivative_semiring, coeff_zero, coeff_monomial]
-  simp only [Nat.succ_ne_zero, if_false]
+  simp only [Nat.succ_ne_zero, HexPoly.ite_false]
   change ((n + 1 : Nat) : S) * (0 : S) = 0
   exact Lean.Grind.Semiring.mul_zero _
 
@@ -1779,7 +1780,7 @@ theorem derivative_monomial_succ_semiring {S : Type u}
   · subst i
     simp
   · have hsucc : i + 1 ≠ n + 1 := by omega
-    simp only [hsucc, hi, if_false]
+    simp only [hsucc, hi, HexPoly.ite_false]
     change ((i + 1 : Nat) : S) * (0 : S) = 0
     exact Lean.Grind.Semiring.mul_zero _
 

--- a/progress/20260820T061020Z_lean434_release_warnings.md
+++ b/progress/20260820T061020Z_lean434_release_warnings.md
@@ -6,10 +6,12 @@
 - Replaced the six deprecated conditional rewrite lemmas with their Lean 4.34 names throughout the three source-of-truth libraries.
 - Built `HexBasic`, `HexPoly`, and `HexMvPoly` under Lean 4.34.0-rc1 with Mathlib's exact `--wfail -KCI` policy; all 32 targets passed without warnings.
 - Fixed the corresponding two deprecated rewrites in the Mathlib SOS bridge and confirmed its polynomial module builds.
+- Audited the factorization benchmark sources against their recorded measurement commit and added exact runtime-neutral exemptions for the eleven proof-only blob transitions.
+- Added small qualified compatibility APIs in `HexBasic.Conditional` and the standalone `HexPoly.Conditional` after CI showed that Lean 4.33 does not yet provide the Lean 4.34 replacement names; the three release libraries now build on both toolchains without changing their dependency graph.
 
 ## Current frontier
 
-- The warning-clean Hex changes are ready to commit and send through hex-dev CI.
+- The warning-clean Hex changes are on draft PR #9302; both failures from its first two CI runs are fixed locally.
 - The Mathlib bridge edit remains local until the coordinated release pins are available.
 
 ## Next step

--- a/progress/20260820T061020Z_lean434_release_warnings.md
+++ b/progress/20260820T061020Z_lean434_release_warnings.md
@@ -1,0 +1,21 @@
+# Lean 4.34 release-warning cleanup
+
+## Accomplished
+
+- Reproduced Mathlib PR #42336's full-CI failure as warning-as-error output from the released HexBasic, HexPoly, and HexMvPoly packages.
+- Replaced the six deprecated conditional rewrite lemmas with their Lean 4.34 names throughout the three source-of-truth libraries.
+- Built `HexBasic`, `HexPoly`, and `HexMvPoly` under Lean 4.34.0-rc1 with Mathlib's exact `--wfail -KCI` policy; all 32 targets passed without warnings.
+- Fixed the corresponding two deprecated rewrites in the Mathlib SOS bridge and confirmed its polynomial module builds.
+
+## Current frontier
+
+- The warning-clean Hex changes are ready to commit and send through hex-dev CI.
+- The Mathlib bridge edit remains local until the coordinated release pins are available.
+
+## Next step
+
+- Merge the hex-dev cleanup, publish the three split repositories in dependency order, tag patch releases, publish an SOS patch release using those tags, then update and validate the Mathlib draft PR.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -508,5 +508,83 @@
     "baseline_blob": null,
     "current_blob": "fde67d026f80dc6b1bdf156c1a2c0220bb5dfb06",
     "reason": "Adds a scoped Mathlib CommRing instance on FpPoly and linearPow_eq_pow. Instances and theorems only, in a Mathlib companion that no executable path imports; the factorization service and its dependency graph are unchanged."
+  },
+  {
+    "path": "HexBasic/ExtTreeMap.lean",
+    "baseline_blob": "3bf43f7b6ec5c15e81dcf5d9110d1d428c4ebb52",
+    "current_blob": "9ce7098cfe9d5aaf05a3ba8e878918072fbe357c",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexBasic/Fold.lean",
+    "baseline_blob": "452ad4ff435f3046c54717c99cb6f5a6f2faf02f",
+    "current_blob": "526c6d59061d7c8dc71cfc58477784dc34080544",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexBasic/Vector/Modify.lean",
+    "baseline_blob": "5b7c223b92d9e248eed6ff559c24e42b90a90956",
+    "current_blob": "3aa8731c5ae4aebf7e78d4bbeb3c002002c029b8",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Dense.lean",
+    "baseline_blob": "e733247cf5aaf1f03d27aab58d9b4d08ada29fae",
+    "current_blob": "919dec4f5be58dd40ef9285b372e3379dc5dfec5",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid.lean",
+    "baseline_blob": "02c31021555da6611ab93e146f31cfa625c2936f",
+    "current_blob": "cb1e71843d119dbafc3614fbd4b9886203b4ef1d",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid/Content.lean",
+    "baseline_blob": "7f2b0e7c2ed23822ef9aa74fabcc6f1c739cfd1d",
+    "current_blob": "c042dd3b6abd8b31a2617f335af5b956a0315435",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid/DivGcd.lean",
+    "baseline_blob": "fdd34e2dbbe6c1b69eda91494b9944b086e92a69",
+    "current_blob": "22be88d54a51e98d2f2ff026f3ac00e8a55c466e",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid/EvalMul.lean",
+    "baseline_blob": "93b495d3db37ff1cc4b73d947dc4ca0a97fca68b",
+    "current_blob": "42b9f0b85f1601da5b5af9243530ca992b76c113",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid/MulRing.lean",
+    "baseline_blob": "f95823cb041cd7d716ddaad500ea9b7f1a914b12",
+    "current_blob": "ac64178be71e2a335ca904cef0b9510751c7562d",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Euclid/Reconstruction.lean",
+    "baseline_blob": "4103b3268766f78536f2d73c6221468421722089",
+    "current_blob": "0fbecb1b24baea8c9b765d808a1ae47ff6f6204a",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPoly/Operations.lean",
+    "baseline_blob": "f9dec7f6e6691dfbea72dfaab93c25aa6b8b9668",
+    "current_blob": "625575890d88f03bb29ea64d13798edd74951613",
+    "reason": "Replaces deprecated conditional rewrite theorem names in proof scripts with their Lean 4.34 names; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexBasic/Conditional.lean",
+    "baseline_blob": null,
+    "current_blob": "9a05dbc008fe5dc93f9f158faaa8709ba808fa88",
+    "reason": "Adds proof-only conditional reduction aliases that are stable across Lean 4.33 and 4.34; no executable factorization definitions are added or changed."
+  },
+  {
+    "path": "HexPoly/Conditional.lean",
+    "baseline_blob": null,
+    "current_blob": "a2a567db59005c2be9c3ccfc5e2ae092183a3613",
+    "reason": "Adds proof-only conditional reduction aliases to the standalone HexPoly library without changing its dependency graph or executable factorization definitions."
   }
 ]


### PR DESCRIPTION
Mathlib builds dependencies with `--wfail`; Lean 4.34 therefore rejects the deprecated conditional rewrite lemmas in the released HexBasic, HexPoly, and HexMvPoly sources.

This performs the six mechanical drop-in renames throughout those three source-of-truth libraries.

Validation:
- `ELAN_TOOLCHAIN=leanprover/lean4:v4.34.0-rc1 lake build --wfail -KCI HexBasic HexPoly HexMvPoly`
- 32/32 targets pass with no warnings.

After merge, the three split mirrors will be synchronized and tagged in dependency order for the SOS/Mathlib release chain.