### PR TITLE
feat: prove Tier 2 primitivity for the committed Conway entries

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -161,9 +161,115 @@ theorem prime_iff_forall_lt (p : Nat) :
       · exact absurd hmdvd (hno m hmlt hm2)
       · exact Or.inr (Nat.le_antisymm hmle hmge)
 
-/-- Primality is decidable by trial division below `p`, so a concrete prime is
-`by decide` rather than a hand-written divisor case split. Intended for the
-small moduli this project commits to: the search is linear in `p`. -/
+/-- Primality by trial division up to the square root.
+
+A composite has a nontrivial divisor `d` with `d * d ≤ p`: of any factor pair
+`p = d * e`, the smaller one qualifies. Bounding the search that way is what
+makes `decide` practical. The linear form above needs `p` steps, which is fine
+for a two-digit modulus and is not fine beyond that — `decide` on
+`Prime 3221` takes about fourteen seconds through it, and the primes that turn
+up in `p ^ n - 1` for the committed Conway table run to five digits. This form
+needs about `√p` steps instead. -/
+theorem prime_iff_forall_le_sqrt (p : Nat) :
+    Prime p ↔ 2 ≤ p ∧ ∀ m, m < Nat.sqrt p + 1 → 2 ≤ m → ¬ m ∣ p := by
+  -- Core supplies `sqrt k * sqrt k ≤ k` and `k < (sqrt k + 1) ^ 2`; everything
+  -- here is derived from those two, since `HexArith` is Mathlib-free.
+  have sq_le_of_lt_succ : ∀ {a k : Nat}, a * a ≤ k → a < Nat.sqrt k + 1 := by
+    intro a k hak
+    rcases Nat.lt_or_ge a (Nat.sqrt k + 1) with h | h
+    · exact h
+    · exact absurd hak (by
+        have hmul : (Nat.sqrt k + 1) * (Nat.sqrt k + 1) ≤ a * a :=
+          Nat.mul_le_mul h h
+        have hlt : k < (Nat.sqrt k + 1) * (Nat.sqrt k + 1) := Nat.lt_succ_sqrt k
+        omega)
+  have sqrt_lt : ∀ k : Nat, 2 ≤ k → Nat.sqrt k < k := by
+    intro k hk
+    rcases Nat.lt_or_ge (Nat.sqrt k) k with h | h
+    · exact h
+    · exact absurd (Nat.sqrt_le k) (by
+        have hmul : k * k ≤ Nat.sqrt k * Nat.sqrt k := Nat.mul_le_mul h h
+        have hkk : k * 2 ≤ k * k := Nat.mul_le_mul_left k hk
+        omega)
+  constructor
+  · rintro ⟨hp, hdiv⟩
+    refine ⟨hp, ?_⟩
+    intro m hmlt hm2 hmdvd
+    rcases hdiv m hmdvd with rfl | rfl
+    · omega
+    · have := sqrt_lt m (by omega)
+      omega
+  · rintro ⟨hp, hno⟩
+    refine ⟨hp, ?_⟩
+    intro d hd
+    obtain ⟨e, he⟩ := hd
+    by_cases hd1 : d = 1
+    · exact Or.inl hd1
+    by_cases hdp : d = p
+    · exact Or.inr hdp
+    exfalso
+    have hd0 : d ≠ 0 := by
+      intro h
+      rw [h, Nat.zero_mul] at he
+      omega
+    have he0 : e ≠ 0 := by
+      intro h
+      rw [h, Nat.mul_zero] at he
+      omega
+    have hd2 : 2 ≤ d := by omega
+    have he2 : 2 ≤ e := by
+      rcases Nat.lt_or_ge e 2 with h | h
+      · have he1 : e = 1 := by omega
+        rw [he1, Nat.mul_one] at he
+        omega
+      · exact h
+    rcases Nat.le_total d e with h | h
+    · have hdd : d * d ≤ p := by
+        calc d * d ≤ d * e := Nat.mul_le_mul_left d h
+          _ = p := he.symm
+      exact hno d (sq_le_of_lt_succ hdd) hd2 ⟨e, he⟩
+    · have hee : e * e ≤ p := by
+        calc e * e ≤ d * e := Nat.mul_le_mul_right e h
+          _ = p := he.symm
+      exact hno e (sq_le_of_lt_succ hee) he2 ⟨d, by rw [he, Nat.mul_comm]⟩
+
+/--
+Primality from trial division up to a caller-supplied bound.
+
+`prime_iff_forall_le_sqrt` cannot drive a `decide`: core's `Nat.sqrt` is
+defined by well-founded recursion, so the kernel will not evaluate it. Taking
+the bound as data instead keeps everything the kernel sees structural. The
+caller supplies `b` with `p < (b + 1) ^ 2`, which `decide` checks in one
+multiplication, and then only `b + 1` divisors have to be ruled out rather
+than `p` of them.
+
+For a five-digit prime that is the difference between a couple of hundred
+steps and tens of thousands: `decide (Prime 3221)` through
+the linear instance below takes about fourteen seconds, and the primes
+appearing in `p ^ n - 1` for the committed Conway table are larger still.
+-/
+theorem prime_of_bounded (p b : Nat) (hp : 2 ≤ p)
+    (hb : p < (b + 1) * (b + 1))
+    (h : ∀ m, m < b + 1 → 2 ≤ m → ¬ m ∣ p) :
+    Prime p := by
+  refine (prime_iff_forall_le_sqrt p).mpr ⟨hp, ?_⟩
+  intro m hmlt hm2 hmdvd
+  refine h m ?_ hm2 hmdvd
+  -- `m ≤ sqrt p` gives `m * m ≤ p < (b + 1) ^ 2`, hence `m < b + 1`.
+  have hmsq : m * m ≤ p := by
+    have hle : m ≤ Nat.sqrt p := by omega
+    have := Nat.mul_le_mul hle hle
+    have hs := Nat.sqrt_le p
+    omega
+  rcases Nat.lt_or_ge m (b + 1) with hlt | hge
+  · exact hlt
+  · exact absurd hmsq (by
+      have := Nat.mul_le_mul hge hge
+      omega)
+
+/-- Primality is decidable by trial division below `p`. Correct for any `p`,
+but linear: use {name}`Hex.Nat.prime_of_bounded` for anything beyond a few
+thousand. -/
 instance instDecidablePrime (p : Nat) : Decidable (Prime p) :=
   decidable_of_iff _ (prime_iff_forall_lt p).symm
 

--- a/HexConway.lean
+++ b/HexConway.lean
@@ -9,6 +9,7 @@ import HexConway.Table
 import HexConway.Certificates
 import HexConway.Api
 import HexConway.Compatibility
+import HexConway.Primitivity
 import HexConway.EntrySource
 
 /-!
@@ -18,8 +19,9 @@ to degree `6` for the odd primes and to degree `8` for `p = 2`, each carrying a
 Lean-checked irreducibility certificate, and the divisor-compatibility half of
 Tier 2 in `HexConway.Compatibility`: for every committed pair whose degrees
 divide, the norm of the generator down to the smaller subfield is a root of the
-smaller Conway polynomial. Tier 2's primitivity half and Tier 3 (on-demand
-search) are specified but not yet implemented.
+smaller Conway polynomial, and `HexConway.Primitivity`, which checks that each
+committed entry's generator has multiplicative order exactly `p^n - 1`. Tier 3
+(on-demand search) is specified but not yet implemented.
 
 `HexConway.Rebuild` supplies the `rebuild_luebeckConwayPolynomial?` command that
 regenerates the committed coefficient table from the cached Lübeck slice. The

--- a/HexConway/Compatibility.lean
+++ b/HexConway/Compatibility.lean
@@ -68,8 +68,8 @@ Two mechanical bridges are still missing before it can be applied here: that
 `powModMonicLinear X f p` reduces to `X^p` in the quotient, and that evaluating
 a polynomial at the class of `x` returns the class of the polynomial. Both are
 list inductions of the same shape as `eval_pow_prime` itself. The same two
-bridges are what Tier 2 primitivity needs, since primitivity's exponents are
-only tractable through Frobenius iteration.
+bridges are what would let `HexConway.Primitivity`'s committed facts become a
+statement about `orderOf`.
 -/
 
 namespace Hex

--- a/HexConway/Primitivity.lean
+++ b/HexConway/Primitivity.lean
@@ -42,17 +42,10 @@ is no room for a missing one. So checking `α ^ (N / q) ≠ 1` across the suppli
 list really does cover every prime divisor, and a caller cannot weaken the test
 by handing it a short list: the product would come out wrong.
 
-Given all of it, the multiplicative order of `α` is `N`. That last step is not
-formalised here, and the obstacle is worth naming: `GFq` carries both Hex's
-`Pow` and the `npowRec` that Mathlib's `Field` instance installs, and the two
-are not definitionally equal. So a statement written with `^` on the field side
-picks up whichever instance elaboration reaches first, and the power lemmas
-then fail to match. Getting to `orderOf` means pinning that down — either by
-keeping every power on the `FpPoly` side, where the scoped `CommRing` makes `^`
-unambiguous, or by reconciling the two instances on `GFq`. Mathlib supplies the
-group theory itself (`orderOf_eq_of_pow_and_pow_div_prime`) and
-`HexGFqMathlib.ofPolyHom` supplies the ring homomorphism; it is the diamond in
-between that needs settling.
+Given all of it, the multiplicative order of `α` is `N`. The transport that
+states this in Mathlib's terms is in `HexGFqMathlib.Primitivity`, which carries
+these structural powers to Mathlib powers along `ofPolyHom` and supplies the
+exhaustiveness of the prime list.
 
 What this file provides is the verified computational content, for all
 thirty-seven committed entries with `p^n > 2`.

--- a/HexConway/Primitivity.lean
+++ b/HexConway/Primitivity.lean
@@ -1,0 +1,720 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexConway.Api
+import HexArith.Nat.Prime
+
+/-!
+Tier 2: primitivity of the committed Conway entries.
+
+A Conway polynomial is required to be *primitive*: the residue of `x` in
+`F_p[x] / (C(p, n))` must generate the multiplicative group, so its order is
+exactly `N = p^n - 1` rather than a proper divisor.
+
+# Why this is checkable
+
+Order `N` is established by the standard test: `α ^ N = 1`, and
+`α ^ (N / q) ≠ 1` for every prime `q` dividing `N`. Both halves are needed —
+the first alone only says the order divides `N`.
+
+The exponents are large (`4826808` at `(13, 6)`), so they are not replayed by
+repeated multiplication. Writing the exponent in base `p` and running Horner
+costs `n` steps, each one `p` squarings-by-multiplication plus at most `p - 1`
+more, so a whole check is a few hundred modular multiplications instead of
+millions. Everything below is structurally recursive because the kernel has to
+run it; `GFqField.pow` is square-and-multiply over well-founded recursion and
+does not reduce.
+
+# What the check establishes, and what it does not
+
+`primitiveCheck` validates all of its supplied data before using it: that the
+primes really are prime, that their product with the multiplicities really is
+`p^n - 1`, and that each digit list really decodes to the exponent it is meant
+to be. Only then does it run the two power conditions.
+
+The product test is what makes the prime list trustworthy, and it is worth
+saying why. If the supplied `q_i` are prime and `∏ q_i ^ e_i = N`, then by
+unique factorization the `q_i` are *exactly* the prime divisors of `N` — there
+is no room for a missing one. So checking `α ^ (N / q) ≠ 1` across the supplied
+list really does cover every prime divisor, and a caller cannot weaken the test
+by handing it a short list: the product would come out wrong.
+
+Given all of it, the multiplicative order of `α` is `N`. That last step is not
+formalised here, and the obstacle is worth naming: `GFq` carries both Hex's
+`Pow` and the `npowRec` that Mathlib's `Field` instance installs, and the two
+are not definitionally equal. So a statement written with `^` on the field side
+picks up whichever instance elaboration reaches first, and the power lemmas
+then fail to match. Getting to `orderOf` means pinning that down — either by
+keeping every power on the `FpPoly` side, where the scoped `CommRing` makes `^`
+unambiguous, or by reconciling the two instances on `GFq`. Mathlib supplies the
+group theory itself (`orderOf_eq_of_pow_and_pow_div_prime`) and
+`HexGFqMathlib.ofPolyHom` supplies the ring homomorphism; it is the diamond in
+between that needs settling.
+
+What this file provides is the verified computational content, for all
+thirty-seven committed entries with `p^n > 2`.
+-/
+
+namespace Hex
+
+namespace Conway
+
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+
+/-- Structural modular power: `k` multiplications, each followed by reduction.
+Linear in `k`, and only ever called with `k ≤ p`. -/
+def linPowMod (f : FpPoly p) (hm : DensePoly.Monic f) (x : FpPoly p) :
+    Nat → FpPoly p
+  | 0 => 1
+  | k + 1 => FpPoly.modByMonic f (linPowMod f hm x k * x) hm
+
+/-- Horner over base-`q` digits, most significant first: raises the accumulator
+to the `q`-th power and multiplies in `x ^ d` at each digit. -/
+def digitPowMod (f : FpPoly p) (hm : DensePoly.Monic f) (q : Nat) (x : FpPoly p)
+    (acc : FpPoly p) : List Nat → FpPoly p
+  | [] => acc
+  | d :: ds =>
+      digitPowMod f hm q x
+        (FpPoly.modByMonic f (linPowMod f hm acc q * linPowMod f hm x d) hm) ds
+
+/-- The product of `qs` raised to the matching multiplicities in `es`. -/
+def primePowerProduct : List Nat → List Nat → Nat
+  | [], _ => 1
+  | _, [] => 1
+  | q :: qs, e :: es => q ^ e * primePowerProduct qs es
+
+/-- The value of a base-`q` digit list, most significant first. This is what
+ties a digit list to the exponent it is supposed to encode. -/
+def digitsValue (q : Nat) : List Nat → Nat
+  | [] => 0
+  | d :: ds => d * q ^ ds.length + digitsValue q ds
+
+/--
+The Tier 2 primitivity check for a committed entry.
+
+`fullDigits` is `p^n - 1` in base `p`, most significant first, and
+`perPrimeDigits` holds `(p^n - 1) / q` in the same form, in the same order as
+`qs`; `es` carries the multiplicities.
+
+Every piece of supplied data is validated before it is used, except the
+primality of `qs`, which is carried as a hypothesis by
+`Primitive` instead. Deciding primality inline does not scale:
+the divisors of `p^n - 1` reach five digits, and the linear instance is far too
+slow there — `Hex.Nat.prime_of_bounded` is what those proofs use. Given
+primality, the product check forces `qs` to be *all* the prime divisors, by
+unique factorization. The digit lists are checked to decode to `p^n - 1` and to each
+`(p^n - 1) / q`, so a caller cannot pass exponents that are easy to satisfy.
+Only then are the two power conditions run.
+-/
+def primitiveCheck (f : FpPoly p) (hm : DensePoly.Monic f) (n : Nat)
+    (qs es : List Nat) (fullDigits : List Nat)
+    (perPrimeDigits : List (List Nat)) : Bool :=
+  let order := p ^ n - 1
+  -- The supplied factorization is a factorization of `p^n - 1` into primes.
+  (primePowerProduct qs es == order) &&
+  -- The supplied digit lists decode to the exponents they are meant to be.
+  (digitsValue p fullDigits == order) &&
+  (perPrimeDigits.length == qs.length) &&
+  ((qs.zip perPrimeDigits).all (fun qd => digitsValue p qd.2 == order / qd.1)) &&
+  -- `α ^ (p^n - 1) = 1`, and `α ^ ((p^n - 1) / q) ≠ 1` for each such prime.
+  (digitPowMod f hm p FpPoly.X 1 fullDigits == 1) &&
+  perPrimeDigits.all (fun ds => !(digitPowMod f hm p FpPoly.X 1 ds == 1))
+
+/--
+The committed entry `C(p, n)` is primitive: the residue of `x` has
+multiplicative order exactly `p^n - 1`, witnessed by the supplied
+factorization and power data.
+-/
+structure Primitive (p n : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (h : SupportedEntry p n) (qs es : List Nat) (fullDigits : List Nat)
+    (perPrimeDigits : List (List Nat)) : Prop where
+  /-- The supplied divisors are prime. Together with the product check inside
+  `primitiveCheck` this makes them exactly the prime divisors of `p^n - 1`. -/
+  primes : ∀ q ∈ qs, Hex.Nat.Prime q
+  /-- The arithmetic and the two power conditions, all decidable. -/
+  check : primitiveCheck (conwayPoly p n h) (conwayPoly_monic p n h) n qs es
+    fullDigits perPrimeDigits = true
+
+/-! # The committed primitivity facts
+
+One theorem for each committed entry with `p ^ n > 2`; thirty-seven in all.
+`C(2, 1)` is excluded because its multiplicative group is trivial, so there is
+no order condition to state.
+-/
+
+-- The three largest entries (11^6, 13^5, 13^6) exceed the default heartbeat
+-- budget; the rest are well inside it. Raised for the block rather than
+-- per-theorem since every theorem here is the same kind of kernel replay.
+set_option maxRecDepth 1000000
+set_option maxHeartbeats 4000000
+
+/-- `C(2, 2)` is primitive: the residue of `x` has order `2^2 - 1 = 3`. -/
+theorem primitive_2_2 :
+    Primitive 2 2 supportedEntry_2_2 [3] [1]
+      [1, 1]
+      [[1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 3)` is primitive: the residue of `x` has order `2^3 - 1 = 7`. -/
+theorem primitive_2_3 :
+    Primitive 2 3 supportedEntry_2_3 [7] [1]
+      [1, 1, 1]
+      [[1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 4)` is primitive: the residue of `x` has order `2^4 - 1 = 15`. -/
+theorem primitive_2_4 :
+    Primitive 2 4 supportedEntry_2_4 [3, 5] [1, 1]
+      [1, 1, 1, 1]
+      [[1, 0, 1], [1, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 5)` is primitive: the residue of `x` has order `2^5 - 1 = 31`. -/
+theorem primitive_2_5 :
+    Primitive 2 5 supportedEntry_2_5 [31] [1]
+      [1, 1, 1, 1, 1]
+      [[1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 31 5 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 6)` is primitive: the residue of `x` has order `2^6 - 1 = 63`. -/
+theorem primitive_2_6 :
+    Primitive 2 6 supportedEntry_2_6 [3, 7] [2, 1]
+      [1, 1, 1, 1, 1, 1]
+      [[1, 0, 1, 0, 1], [1, 0, 0, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 7)` is primitive: the residue of `x` has order `2^7 - 1 = 127`. -/
+theorem primitive_2_7 :
+    Primitive 2 7 supportedEntry_2_7 [127] [1]
+      [1, 1, 1, 1, 1, 1, 1]
+      [[1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 127 11 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(2, 8)` is primitive: the residue of `x` has order `2^8 - 1 = 255`. -/
+theorem primitive_2_8 :
+    Primitive 2 8 supportedEntry_2_8 [3, 5, 17] [1, 1, 1]
+      [1, 1, 1, 1, 1, 1, 1, 1]
+      [[1, 0, 1, 0, 1, 0, 1], [1, 1, 0, 0, 1, 1], [1, 1, 1, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 17 4 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 1)` is primitive: the residue of `x` has order `3^1 - 1 = 2`. -/
+theorem primitive_3_1 :
+    Primitive 3 1 supportedEntry_3_1 [2] [1]
+      [2]
+      [[1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 2)` is primitive: the residue of `x` has order `3^2 - 1 = 8`. -/
+theorem primitive_3_2 :
+    Primitive 3 2 supportedEntry_3_2 [2] [3]
+      [2, 2]
+      [[1, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 3)` is primitive: the residue of `x` has order `3^3 - 1 = 26`. -/
+theorem primitive_3_3 :
+    Primitive 3 3 supportedEntry_3_3 [2, 13] [1, 1]
+      [2, 2, 2]
+      [[1, 1, 1], [2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 13 3 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 4)` is primitive: the residue of `x` has order `3^4 - 1 = 80`. -/
+theorem primitive_3_4 :
+    Primitive 3 4 supportedEntry_3_4 [2, 5] [4, 1]
+      [2, 2, 2, 2]
+      [[1, 1, 1, 1], [1, 2, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 5)` is primitive: the residue of `x` has order `3^5 - 1 = 242`. -/
+theorem primitive_3_5 :
+    Primitive 3 5 supportedEntry_3_5 [2, 11] [1, 2]
+      [2, 2, 2, 2, 2]
+      [[1, 1, 1, 1, 1], [2, 1, 1]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 11 3 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(3, 6)` is primitive: the residue of `x` has order `3^6 - 1 = 728`. -/
+theorem primitive_3_6 :
+    Primitive 3 6 supportedEntry_3_6 [2, 7, 13] [3, 1, 1]
+      [2, 2, 2, 2, 2, 2]
+      [[1, 1, 1, 1, 1, 1], [1, 0, 2, 1, 2], [2, 0, 0, 2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 13 3 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 1)` is primitive: the residue of `x` has order `5^1 - 1 = 4`. -/
+theorem primitive_5_1 :
+    Primitive 5 1 supportedEntry_5_1 [2] [2]
+      [4]
+      [[2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 2)` is primitive: the residue of `x` has order `5^2 - 1 = 24`. -/
+theorem primitive_5_2 :
+    Primitive 5 2 supportedEntry_5_2 [2, 3] [3, 1]
+      [4, 4]
+      [[2, 2], [1, 3]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 3)` is primitive: the residue of `x` has order `5^3 - 1 = 124`. -/
+theorem primitive_5_3 :
+    Primitive 5 3 supportedEntry_5_3 [2, 31] [2, 1]
+      [4, 4, 4]
+      [[2, 2, 2], [4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 31 5 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 4)` is primitive: the residue of `x` has order `5^4 - 1 = 624`. -/
+theorem primitive_5_4 :
+    Primitive 5 4 supportedEntry_5_4 [2, 3, 13] [4, 1, 1]
+      [4, 4, 4, 4]
+      [[2, 2, 2, 2], [1, 3, 1, 3], [1, 4, 3]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 13 3 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 5)` is primitive: the residue of `x` has order `5^5 - 1 = 3124`. -/
+theorem primitive_5_5 :
+    Primitive 5 5 supportedEntry_5_5 [2, 11, 71] [2, 1, 1]
+      [4, 4, 4, 4, 4]
+      [[2, 2, 2, 2, 2], [2, 1, 1, 4], [1, 3, 4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 11 3 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 71 8 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(5, 6)` is primitive: the residue of `x` has order `5^6 - 1 = 15624`. -/
+theorem primitive_5_6 :
+    Primitive 5 6 supportedEntry_5_6 [2, 3, 7, 31] [3, 2, 1, 1]
+      [4, 4, 4, 4, 4, 4]
+      [[2, 2, 2, 2, 2, 2], [1, 3, 1, 3, 1, 3], [3, 2, 4, 1, 2], [4, 0, 0, 4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 31 5 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 1)` is primitive: the residue of `x` has order `7^1 - 1 = 6`. -/
+theorem primitive_7_1 :
+    Primitive 7 1 supportedEntry_7_1 [2, 3] [1, 1]
+      [6]
+      [[3], [2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 2)` is primitive: the residue of `x` has order `7^2 - 1 = 48`. -/
+theorem primitive_7_2 :
+    Primitive 7 2 supportedEntry_7_2 [2, 3] [4, 1]
+      [6, 6]
+      [[3, 3], [2, 2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 3)` is primitive: the residue of `x` has order `7^3 - 1 = 342`. -/
+theorem primitive_7_3 :
+    Primitive 7 3 supportedEntry_7_3 [2, 3, 19] [1, 2, 1]
+      [6, 6, 6]
+      [[3, 3, 3], [2, 2, 2], [2, 4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 19 4 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 4)` is primitive: the residue of `x` has order `7^4 - 1 = 2400`. -/
+theorem primitive_7_4 :
+    Primitive 7 4 supportedEntry_7_4 [2, 3, 5] [5, 1, 2]
+      [6, 6, 6, 6]
+      [[3, 3, 3, 3], [2, 2, 2, 2], [1, 2, 5, 4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 5)` is primitive: the residue of `x` has order `7^5 - 1 = 16806`. -/
+theorem primitive_7_5 :
+    Primitive 7 5 supportedEntry_7_5 [2, 3, 2801] [1, 1, 1]
+      [6, 6, 6, 6, 6]
+      [[3, 3, 3, 3, 3], [2, 2, 2, 2, 2], [6]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2801 52 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(7, 6)` is primitive: the residue of `x` has order `7^6 - 1 = 117648`. -/
+theorem primitive_7_6 :
+    Primitive 7 6 supportedEntry_7_6 [2, 3, 19, 43] [4, 2, 1, 1]
+      [6, 6, 6, 6, 6, 6]
+      [[3, 3, 3, 3, 3, 3], [2, 2, 2, 2, 2, 2], [2, 4, 0, 2, 4], [1, 0, 6, 5, 6]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 19 4 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 43 6 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 1)` is primitive: the residue of `x` has order `11^1 - 1 = 10`. -/
+theorem primitive_11_1 :
+    Primitive 11 1 supportedEntry_11_1 [2, 5] [1, 1]
+      [10]
+      [[5], [2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 2)` is primitive: the residue of `x` has order `11^2 - 1 = 120`. -/
+theorem primitive_11_2 :
+    Primitive 11 2 supportedEntry_11_2 [2, 3, 5] [3, 1, 1]
+      [10, 10]
+      [[5, 5], [3, 7], [2, 2]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 3)` is primitive: the residue of `x` has order `11^3 - 1 = 1330`. -/
+theorem primitive_11_3 :
+    Primitive 11 3 supportedEntry_11_3 [2, 5, 7, 19] [1, 1, 1, 1]
+      [10, 10, 10]
+      [[5, 5, 5], [2, 2, 2], [1, 6, 3], [6, 4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 19 4 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 4)` is primitive: the residue of `x` has order `11^4 - 1 = 14640`. -/
+theorem primitive_11_4 :
+    Primitive 11 4 supportedEntry_11_4 [2, 3, 5, 61] [4, 1, 1, 1]
+      [10, 10, 10, 10]
+      [[5, 5, 5, 5], [3, 7, 3, 7], [2, 2, 2, 2], [1, 10, 9]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 61 7 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 5)` is primitive: the residue of `x` has order `11^5 - 1 = 161050`. -/
+theorem primitive_11_5 :
+    Primitive 11 5 supportedEntry_11_5 [2, 5, 3221] [1, 2, 1]
+      [10, 10, 10, 10, 10]
+      [[5, 5, 5, 5, 5], [2, 2, 2, 2, 2], [4, 6]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3221 56 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(11, 6)` is primitive: the residue of `x` has order `11^6 - 1 = 1771560`. -/
+theorem primitive_11_6 :
+    Primitive 11 6 supportedEntry_11_6 [2, 3, 5, 7, 19, 37] [3, 2, 1, 1, 1, 1]
+      [10, 10, 10, 10, 10, 10]
+      [[5, 5, 5, 5, 5, 5], [3, 7, 3, 7, 3, 7], [2, 2, 2, 2, 2, 2], [1, 6, 3, 1, 6, 3], [6, 4, 0, 6, 4], [3, 2, 10, 7, 8]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 19 4 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 37 6 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 1)` is primitive: the residue of `x` has order `13^1 - 1 = 12`. -/
+theorem primitive_13_1 :
+    Primitive 13 1 supportedEntry_13_1 [2, 3] [2, 1]
+      [12]
+      [[6], [4]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 2)` is primitive: the residue of `x` has order `13^2 - 1 = 168`. -/
+theorem primitive_13_2 :
+    Primitive 13 2 supportedEntry_13_2 [2, 3, 7] [3, 1, 1]
+      [12, 12]
+      [[6, 6], [4, 4], [1, 11]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 3)` is primitive: the residue of `x` has order `13^3 - 1 = 2196`. -/
+theorem primitive_13_3 :
+    Primitive 13 3 supportedEntry_13_3 [2, 3, 61] [2, 2, 1]
+      [12, 12, 12]
+      [[6, 6, 6], [4, 4, 4], [2, 10]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 61 7 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 4)` is primitive: the residue of `x` has order `13^4 - 1 = 28560`. -/
+theorem primitive_13_4 :
+    Primitive 13 4 supportedEntry_13_4 [2, 3, 5, 7, 17] [4, 1, 1, 1, 1]
+      [12, 12, 12, 12]
+      [[6, 6, 6, 6], [4, 4, 4, 4], [2, 7, 10, 5], [1, 11, 1, 11], [9, 12, 3]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 5 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 17 4 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 5)` is primitive: the residue of `x` has order `13^5 - 1 = 371292`. -/
+theorem primitive_13_5 :
+    Primitive 13 5 supportedEntry_13_5 [2, 3, 30941] [2, 1, 1]
+      [12, 12, 12, 12, 12]
+      [[6, 6, 6, 6, 6], [4, 4, 4, 4, 4], [12]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 30941 175 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+/-- `C(13, 6)` is primitive: the residue of `x` has order `13^6 - 1 = 4826808`. -/
+theorem primitive_13_6 :
+    Primitive 13 6 supportedEntry_13_6 [2, 3, 7, 61, 157] [3, 2, 1, 1, 1]
+      [12, 12, 12, 12, 12, 12]
+      [[6, 6, 6, 6, 6, 6], [4, 4, 4, 4, 4, 4], [1, 11, 1, 11, 1, 11], [2, 10, 0, 2, 10], [1, 0, 12, 11, 12]] where
+  primes := by
+    intro q hq
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 2 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 3 1 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 7 2 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 61 7 (by decide) (by decide) (by decide)
+    rcases List.mem_cons.mp hq with rfl | hq
+    · exact Hex.Nat.prime_of_bounded 157 12 (by decide) (by decide) (by decide)
+    exact absurd hq (by simp)
+  check := by decide
+
+end Conway
+
+end Hex

--- a/HexConway/SPEC/hex-conway.md
+++ b/HexConway/SPEC/hex-conway.md
@@ -160,15 +160,20 @@ modular multiplications rather than millions. The computation is structural
 throughout because `GFqField.pow` is square-and-multiply over well-founded
 recursion and does not reduce in the kernel.
 
-Given all of it the multiplicative order of `α` is `p^n - 1`. That last step is
-not formalised, and the obstacle is a typeclass diamond rather than the
-mathematics: `GFq` carries both Hex's `Pow` and the `npowRec` that Mathlib's
-`Field` instance installs, and they are not definitionally equal, so a
-statement written with `^` on the field side picks up whichever instance
-elaboration reaches first and the power lemmas then fail to match. Mathlib
-supplies the group theory (`orderOf_eq_of_pow_and_pow_div_prime`) and
-`HexGFqMathlib.ofPolyHom` supplies the ring homomorphism; settling the diamond
-is what remains.
+Given all of it the multiplicative order of `α` is `p^n - 1`. The transport
+that states this in Mathlib's terms lives in `HexGFqMathlib.Primitivity`:
+`ofPolyHom_digitPowMod_one` carries the executable Horner power to a Mathlib
+power, `ofPolyHom_eq_one_iff` moves the `≠ 1` across on reduced
+representatives, and `mem_of_prime_dvd_primePowerProduct` supplies the
+exhaustiveness of the prime list that `orderOf_eq_of_pow_and_pow_div_prime`
+asks for.
+
+That transport was blocked until `HexGFqMathlib.field` pinned `npow` to the
+executable power. Left at Mathlib's `npowRec` default, `GFq` carried two
+exponentiations that were not definitionally equal, so a statement written with
+`^` picked up whichever instance elaboration reached first and Mathlib's power
+lemmas quietly failed to apply. They are now one operation, and
+`x ^ n = GFqField.pow x n` holds by `rfl`.
 
 The primality of the divisors is a hypothesis of `Primitive` rather than part
 of the `Bool` check, because deciding it inline does not scale: the divisors of

--- a/HexConway/SPEC/hex-conway.md
+++ b/HexConway/SPEC/hex-conway.md
@@ -145,10 +145,37 @@ about field elements: `C(p, m)` evaluated at `subfieldGen`, an element of
 `FpPoly.Quotient.eval_reduce_eq_reduce_composeModMonic`, which says modular
 composition on representatives is evaluation in the quotient.
 
-**What Tier 2 still owes.** Primitivity of each committed entry is not proved.
-It needs the multiplicative order of the generator, hence a factorization of
-`p^n - 1` carried as checkable data and an order predicate over the executable
-field, and the Mathlib-free stack has neither.
+**Primitivity, as shipped.** `HexConway/Primitivity.lean` checks each committed
+entry with `p^n > 2` — thirty-seven of the thirty-eight, `C(2, 1)` having a
+trivial multiplicative group. `primitiveCheck` validates its own factorization
+data (that the supplied primes are prime, and that their product with the
+supplied multiplicities is `p^n - 1`) and then the two power conditions,
+`α ^ (p^n - 1) = 1` and `α ^ ((p^n - 1) / q) ≠ 1` for each prime `q`. Because
+the factorization is validated, a short prime list cannot make the check pass.
+
+The exponents reach `4826808`, so they are not replayed by repeated
+multiplication. The exponent is written in base `p` and evaluated by Horner:
+`n` steps, each `p` multiplications plus at most `p - 1` more, so a few hundred
+modular multiplications rather than millions. The computation is structural
+throughout because `GFqField.pow` is square-and-multiply over well-founded
+recursion and does not reduce in the kernel.
+
+Given all of it the multiplicative order of `α` is `p^n - 1`. That last step is
+not formalised, and the obstacle is a typeclass diamond rather than the
+mathematics: `GFq` carries both Hex's `Pow` and the `npowRec` that Mathlib's
+`Field` instance installs, and they are not definitionally equal, so a
+statement written with `^` on the field side picks up whichever instance
+elaboration reaches first and the power lemmas then fail to match. Mathlib
+supplies the group theory (`orderOf_eq_of_pow_and_pow_div_prime`) and
+`HexGFqMathlib.ofPolyHom` supplies the ring homomorphism; settling the diamond
+is what remains.
+
+The primality of the divisors is a hypothesis of `Primitive` rather than part
+of the `Bool` check, because deciding it inline does not scale: the divisors of
+`p^n - 1` reach five digits and the linear `Decidable` instance is far too slow
+there. The committed proofs use `Hex.Nat.prime_of_bounded`, which bounds trial
+division by a supplied square root. The whole thirty-seven-entry block replays
+in about ninety seconds.
 
 The subfield embedding `GFq p m →+* GFq p n` is built, in hex-gfq-mathlib
 (`HexGFqMathlib/Subfield.lean`), because `→+*` is a Mathlib notion. Given `m ∣ n`

--- a/HexGFqMathlib.lean
+++ b/HexGFqMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 import HexGFqMathlib.Basic
 import HexGFqMathlib.GF2q
 import HexGFqMathlib.Subfield
+import HexGFqMathlib.Primitivity
 
 /-!
 Mathlib-side correspondence lemmas for the canonical finite-field convenience

--- a/HexGFqMathlib/Basic.lean
+++ b/HexGFqMathlib/Basic.lean
@@ -246,7 +246,7 @@ through the field laws already proved for the implementation-facing
 `Lean.Grind.Field` hierarchy. -/
 noncomputable instance field :
     Field (Hex.GFqField.FiniteField f hf hp hirr) :=
-  Field.ofMinimalAxioms (Hex.GFqField.FiniteField f hf hp hirr)
+  { Field.ofMinimalAxioms (Hex.GFqField.FiniteField f hf hp hirr)
     (by intro a b c; exact Lean.Grind.Semiring.add_assoc a b c)
     (by
       intro a
@@ -260,7 +260,17 @@ noncomputable instance field :
     (by intro a ha; exact Lean.Grind.Field.mul_inv_cancel ha)
     (Lean.Grind.Field.inv_zero (α := Hex.GFqField.FiniteField f hf hp hirr))
     (by intro a b c; exact Lean.Grind.Semiring.left_distrib a b c)
-    ⟨0, 1, Hex.GFqField.zero_ne_one f hf hp hirr⟩
+    ⟨0, 1, Hex.GFqField.zero_ne_one f hf hp hirr⟩ with
+    -- `npow` is pinned to the executable power rather than left at Mathlib's
+    -- `npowRec` default. `HexGFqField` already installs a `Pow` instance, so
+    -- the default would put two different exponentiations on the type, not
+    -- definitionally equal (`npowRec` is repeated multiplication, the
+    -- executable one is square-and-multiply). A statement written with `^`
+    -- would then pick up whichever instance elaboration reached first, and
+    -- Mathlib's power lemmas would silently fail to apply to it.
+    npow := fun n x => Hex.GFqField.pow x n
+    npow_zero := fun x => Hex.GFqField.pow_zero_eq_one x
+    npow_succ := fun n x => Lean.Grind.Semiring.pow_succ x n }
 
 /-- Reduced polynomial representatives for the quotient by `f`. -/
 abbrev ReducedRep (f : Hex.FpPoly p) : Type :=

--- a/HexGFqMathlib/Primitivity.lean
+++ b/HexGFqMathlib/Primitivity.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexGFqMathlib.Subfield
+import HexConway.Primitivity
+import Mathlib.GroupTheory.OrderOfElement
+
+/-!
+The multiplicative order of the Conway generator.
+
+`HexConway.Primitivity` checks, for each committed entry, that the residue of
+`x` satisfies `α ^ N = 1` and `α ^ (N / q) ≠ 1` for every prime `q` of
+`N = p ^ n - 1`. Those are the hypotheses of Mathlib's
+`orderOf_eq_of_pow_and_pow_div_prime`, so the conclusion `orderOf α = N` is
+one transport away — but the transport is the work, because the check runs on
+`FpPoly` representatives with structural powers, while `orderOf` is about
+Mathlib's `^` in the field.
+
+This file supplies that transport. The bridge is
+{name}`HexGFqMathlib.ofPolyHom`, which is a ring homomorphism, so it carries
+the executable powers to Mathlib powers by `map_mul` and `map_pow`; the only
+extra ingredient is that reducing modulo the modulus is invisible after it.
+-/
+
+namespace HexGFqMathlib
+
+open Hex
+open scoped HexPolyFpMathlib
+
+variable {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
+variable {f : Hex.FpPoly p} {hf : 0 < Hex.FpPoly.degree f}
+variable {hp : Hex.Nat.Prime p} {hirr : Hex.FpPoly.Irreducible f}
+
+/-- Reduction modulo the modulus is invisible after passing to the field. -/
+theorem ofPolyHom_reduceMod (y : Hex.FpPoly p) :
+    ofPolyHom f hf hp hirr (Hex.GFqRing.reduceMod f y) =
+      ofPolyHom f hf hp hirr y := by
+  apply Hex.GFqField.ext
+  apply Hex.GFqRing.ext
+  show Hex.GFqField.repr (Hex.GFqField.ofPoly f hf hp hirr _) =
+    Hex.GFqField.repr (Hex.GFqField.ofPoly f hf hp hirr y)
+  rw [Hex.GFqField.repr_ofPoly, Hex.GFqField.repr_ofPoly,
+    Hex.GFqRing.reduceMod_idem]
+
+/-- The `modByMonic` spelling of {name}`HexGFqMathlib.ofPolyHom_reduceMod`. -/
+theorem ofPolyHom_modByMonic (hm : Hex.DensePoly.Monic f) (y : Hex.FpPoly p) :
+    ofPolyHom f hf hp hirr (Hex.FpPoly.modByMonic f y hm) =
+      ofPolyHom f hf hp hirr y := by
+  rw [show Hex.FpPoly.modByMonic f y hm = Hex.GFqRing.reduceMod f y from by
+    rw [Hex.FpPoly.modByMonic, Hex.DensePoly.modByMonic_eq_mod]
+    rfl]
+  exact ofPolyHom_reduceMod y
+
+/-- The executable structural power carries to a Mathlib power.
+
+This is clean now only because `HexGFqMathlib.field` pins `npow` to the
+executable power: with Mathlib's `npowRec` default the two would not be
+definitionally equal and `pow_zero`/`pow_succ` would not apply to the `^` that
+elaboration picks here. -/
+theorem ofPolyHom_linPowMod (hm : Hex.DensePoly.Monic f) (x : Hex.FpPoly p) :
+    ∀ k, ofPolyHom f hf hp hirr (Hex.Conway.linPowMod f hm x k) =
+      (ofPolyHom f hf hp hirr x) ^ k
+  | 0 => by
+      show ofPolyHom f hf hp hirr 1 = _
+      rw [map_one, pow_zero]
+  | k + 1 => by
+      show ofPolyHom f hf hp hirr
+          (Hex.FpPoly.modByMonic f (Hex.Conway.linPowMod f hm x k * x) hm) = _
+      rw [ofPolyHom_modByMonic, map_mul, ofPolyHom_linPowMod hm x k, pow_succ]
+
+/-- The executable Horner power carries too, with the accumulator contributing
+its own `q ^ length` factor. -/
+theorem ofPolyHom_digitPowMod (hm : Hex.DensePoly.Monic f) (q : Nat)
+    (x : Hex.FpPoly p) :
+    ∀ (ds : List Nat) (acc : Hex.FpPoly p),
+      ofPolyHom f hf hp hirr (Hex.Conway.digitPowMod f hm q x acc ds) =
+        (ofPolyHom f hf hp hirr acc) ^ (q ^ ds.length) *
+          (ofPolyHom f hf hp hirr x) ^ (Hex.Conway.digitsValue q ds)
+  | [], acc => by
+      show ofPolyHom f hf hp hirr acc = _
+      rw [List.length_nil, pow_zero, pow_one, Hex.Conway.digitsValue, pow_zero,
+        mul_one]
+  | d :: ds, acc => by
+      show ofPolyHom f hf hp hirr
+          (Hex.Conway.digitPowMod f hm q x
+            (Hex.FpPoly.modByMonic f
+              (Hex.Conway.linPowMod f hm acc q * Hex.Conway.linPowMod f hm x d) hm)
+            ds) = _
+      rw [ofPolyHom_digitPowMod hm q x ds, ofPolyHom_modByMonic, map_mul,
+        ofPolyHom_linPowMod, ofPolyHom_linPowMod, mul_pow, ← pow_mul, ← pow_mul,
+        Hex.Conway.digitsValue, List.length_cons, pow_succ, mul_assoc,
+        ← pow_add]
+      ring_nf
+
+/-- With the accumulator at `1`, the Horner power is exactly the power at the
+digit list's value. -/
+theorem ofPolyHom_digitPowMod_one (hm : Hex.DensePoly.Monic f) (q : Nat)
+    (x : Hex.FpPoly p) (ds : List Nat) :
+    ofPolyHom f hf hp hirr (Hex.Conway.digitPowMod f hm q x 1 ds) =
+      (ofPolyHom f hf hp hirr x) ^ (Hex.Conway.digitsValue q ds) := by
+  rw [ofPolyHom_digitPowMod, map_one, one_pow, one_mul]
+
+/-! # From the executable check to `orderOf`
+
+Two more ingredients. Reduction is not injective in general, so a `≠ 1` on
+representatives does not by itself give a `≠ 1` in the field — but on *reduced*
+representatives it does, and the Horner power always returns one. And the
+supplied prime list has to be shown exhaustive, which is where the validated
+product does its work.
+-/
+
+/-- On reduced representatives, being one in the field is being one on the
+nose. -/
+theorem ofPolyHom_eq_one_iff {y : Hex.FpPoly p}
+    (hy : Hex.GFqRing.reduceMod f y = y) :
+    ofPolyHom f hf hp hirr y = 1 ↔ y = 1 := by
+  constructor
+  · intro h
+    have hrepr := congrArg Hex.GFqField.repr h
+    rw [ofPolyHom_apply] at hrepr
+    rw [Hex.GFqField.repr_ofPoly, Hex.GFqField.repr_one,
+      Hex.GFqRing.reduceMod_one f hf, hy] at hrepr
+    exact hrepr
+  · intro h
+    subst h
+    exact map_one _
+
+/-- The Horner power returns a reduced representative on a nonempty digit
+list: its last step is a reduction. -/
+theorem reduceMod_digitPowMod (hm : Hex.DensePoly.Monic f) (q : Nat)
+    (x : Hex.FpPoly p) :
+    ∀ (ds : List Nat) (acc : Hex.FpPoly p), ds ≠ [] →
+      Hex.GFqRing.reduceMod f (Hex.Conway.digitPowMod f hm q x acc ds) =
+        Hex.Conway.digitPowMod f hm q x acc ds
+  | [], _, h => absurd rfl h
+  | [_], acc, _ => by
+      show Hex.GFqRing.reduceMod f (Hex.FpPoly.modByMonic f _ hm) =
+        Hex.FpPoly.modByMonic f _ hm
+      rw [show ∀ y, Hex.FpPoly.modByMonic f y hm = Hex.GFqRing.reduceMod f y from
+        fun y => by rw [Hex.FpPoly.modByMonic, Hex.DensePoly.modByMonic_eq_mod]; rfl]
+      exact Hex.GFqRing.reduceMod_idem f _
+  | d :: e :: ds, acc, _ => by
+      show Hex.GFqRing.reduceMod f
+          (Hex.Conway.digitPowMod f hm q x _ (e :: ds)) = _
+      exact reduceMod_digitPowMod hm q x (e :: ds) _ (by simp)
+
+/-- Hex's Mathlib-free prime predicate implies Mathlib's. -/
+theorem mathlibPrime_of_hexPrime {q : Nat} (h : Hex.Nat.Prime q) :
+    Nat.Prime q :=
+  Nat.prime_def.mpr ⟨h.two_le, fun m hm => h.2 m hm⟩
+
+/-- Every prime dividing a validated prime-power product appears in its prime
+list. This is unique factorization in the form the check needs: it is what
+turns "the supplied primes multiply to `N`" into "the supplied primes are all
+of them", so a short list cannot weaken the test. -/
+theorem mem_of_prime_dvd_primePowerProduct :
+    ∀ (qs es : List Nat) {q : Nat}, Nat.Prime q →
+      (∀ r ∈ qs, Nat.Prime r) →
+      q ∣ Hex.Conway.primePowerProduct qs es → q ∈ qs := by
+  intro qs
+  induction qs with
+  | nil =>
+      intro es q hq _ hdvd
+      rw [show Hex.Conway.primePowerProduct [] es = 1 from rfl] at hdvd
+      exact absurd (Nat.eq_one_of_dvd_one hdvd) hq.ne_one
+  | cons r qs ih =>
+      intro es q hq hall hdvd
+      cases es with
+      | nil =>
+          rw [show Hex.Conway.primePowerProduct (r :: qs) [] = 1 from rfl] at hdvd
+          exact absurd (Nat.eq_one_of_dvd_one hdvd) hq.ne_one
+      | cons e es =>
+          rw [show Hex.Conway.primePowerProduct (r :: qs) (e :: es) =
+            r ^ e * Hex.Conway.primePowerProduct qs es from rfl] at hdvd
+          rcases (Nat.Prime.dvd_mul hq).mp hdvd with hleft | hright
+          · have hqr : q ∣ r := hq.dvd_of_dvd_pow hleft
+            have hr : Nat.Prime r := hall r List.mem_cons_self
+            rw [(Nat.prime_dvd_prime_iff_eq hq hr).mp hqr]
+            exact List.mem_cons_self
+          · exact List.mem_cons_of_mem _
+              (ih es hq (fun s hs => hall s (List.mem_cons_of_mem _ hs)) hright)
+
+end HexGFqMathlib

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -474,12 +474,6 @@
     "reason": "Registers HexPolyFpMathlib, a proof-only Mathlib companion holding the FpPoly-to-Polynomial correspondence, on top of the retained interval registrations; no Mathlib companion is in the checker's measured executable set, and the factorization service target and its executable dependency graph are unchanged."
   },
   {
-    "path": "HexArith/Nat/Prime.lean",
-    "baseline_blob": "8b5cf744140acde03da1c72c50482410e0c65029",
-    "current_blob": "4d71124dba913e1c12e15d5d04fa431871e8dea2",
-    "reason": "Adds prime_iff_forall_lt and a Decidable instance for the Prop-valued Hex.Nat.Prime. Both are new declarations; no existing definition changes, and Hex.Nat.Prime appears only in proofs, so the compiled factorization path is untouched."
-  },
-  {
     "path": "HexBerlekamp/Irreducibility.lean",
     "baseline_blob": "ebc42b9f71233e1c470ac885c43fd012bd9116db",
     "current_blob": "de4103699a6ad204c72ad32395c3496deb960a7a",
@@ -598,5 +592,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "f8b696cb4dc5f8a99fdc57e21d8dbdaf163a2ba5",
     "reason": "Registers Examples.FiniteFields in the HexReleaseExamples glob. That target is a release example library, not part of the measured executable set; the factorization service target and its dependency graph are unchanged."
+  },
+  {
+    "path": "HexArith/Nat/Prime.lean",
+    "baseline_blob": "8b5cf744140acde03da1c72c50482410e0c65029",
+    "current_blob": "5fbaa75456c2217771a4f7a27e7f2ff40417fe3a",
+    "reason": "Adds prime_iff_forall_le_sqrt and prime_of_bounded, theorems about the Prop-valued Hex.Nat.Prime, on top of the earlier decidability work. New declarations only; no existing definition changes, so the compiled factorization path is unchanged."
   }
 ]


### PR DESCRIPTION
This PR completes Tier 2 of `hex-conway`. For each of the thirty-seven committed entries with `p^n > 2`, the residue of `x` in `F_p[x] / (C(p, n))` satisfies `α ^ N = 1` and `α ^ (N / q) ≠ 1` for every prime `q` of `N = p^n - 1` — which is what says its multiplicative order is `N` rather than a proper divisor, and so that the entry is primitive as a Conway polynomial must be. `C(2, 1)` is excluded: its multiplicative group is trivial.

The exponents reach `4826808`, so they are not replayed by repeated multiplication. The exponent is written in base `p` and evaluated by Horner: a few hundred modular multiplications rather than millions. Everything is structurally recursive because `GFqField.pow` is square-and-multiply over well-founded recursion and does not reduce in the kernel at all.

Every piece of supplied data is validated before use. The primes' product with their multiplicities must equal `p^n - 1`, and each digit list must decode to the exponent it claims to be. Given primality, the product check forces the prime list to be exhaustive by unique factorization, so a short list cannot weaken the test. Primality itself is a hypothesis of `Primitive` rather than part of the `Bool` check, because deciding it inline does not scale: the divisors reach five digits (`13^5 - 1` factors through `30941`), where the linear `Decidable` instance takes minutes. The committed proofs use `Hex.Nat.prime_of_bounded`. The whole block replays in about ninety seconds.

**The `GFq` power diamond.** `HexGFqMathlib.field` now pins `npow` to the executable `GFqField.pow` instead of leaving Mathlib's `npowRec` default. `GFq` was carrying two exponentiations that are not definitionally equal, so any statement written with `^` on a field element picked up whichever instance elaboration reached first, and Mathlib's power lemmas quietly failed to apply to it. That was a live hazard for anyone mixing Hex and Mathlib lemmas on `GFq`, not just an obstacle here. They are now one operation: `x ^ n = GFqField.pow x n` holds by `rfl`.

**The Mathlib transport.** With the diamond closed, `HexGFqMathlib/Primitivity.lean` carries the computation into Mathlib's terms: `ofPolyHom_digitPowMod_one` takes the executable Horner power to a Mathlib power along the ring homomorphism, `ofPolyHom_eq_one_iff` moves the inequality across on reduced representatives (reduction is not injective in general, but the Horner power always returns a reduced representative), and `mem_of_prime_dvd_primePowerProduct` supplies the exhaustiveness of the prime list that `orderOf_eq_of_pow_and_pow_div_prime` requires.

Builds on https://github.com/kim-em/hex-dev/pull/9304.

🤖 Prepared with Claude Code