### PR TITLE
doc: state the prime hypothesis behind PolyQuotient canonicality

### DIFF
--- a/HexGFqRing/PolynomialQuotient.lean
+++ b/HexGFqRing/PolynomialQuotient.lean
@@ -69,7 +69,18 @@ theorem reduceMod_eq_self_of_degree_lt (f g : FpPoly p) :
 def IsReduced (f : FpPoly p) (g : FpPoly p) : Prop :=
   ∃ h : FpPoly p, g = reduceMod f h
 
-/-- Executable quotient elements represented by canonical reduced polynomials. -/
+/-- Executable quotient elements, carrying the reducedness invariant in the type.
+
+A value of this type is a polynomial *together with* a proof that it lies in the
+image of `reduceMod f`, so a raw `FpPoly p` cannot be supplied where one of these
+is expected.
+
+That representative is the canonical one for its residue class only when `p` is
+prime, which is what makes `reduceMod` a genuine remainder; see
+`isReduced_iff_degree_lt`. For composite `p` the division step divides by a
+leading coefficient that need not be a unit, `reduceMod` is then not a canonical
+form, and two values of this type can represent the same class. Every ring
+operation and every canonicality result below assumes `ZMod64.PrimeModulus p`. -/
 abbrev PolyQuotient (f : FpPoly p) (_hf : 0 < FpPoly.degree f) :=
   { g : FpPoly p // IsReduced f g }
 
@@ -137,6 +148,23 @@ variable [ZMod64.PrimeModulus p]
   rcases x.2 with ⟨g, hx⟩
   simpa [repr, hx, IsReduced, reduceMod, FpPoly.degree, DensePoly.mod_eq_divMod]
     using DensePoly.mod_degree_lt_of_pos_degree g f hf
+
+/-- Reducedness is exactly a degree bound, so the representative a
+{name}`PolyQuotient` stores is the unique one of its residue class.
+
+This is the theorem behind the "equality is equality of canonical
+representatives" contract, and it is where primality is load-bearing: the
+right-to-left direction needs `reduceMod` to fix every polynomial below the
+modulus, which fails when the leading coefficient of `f` is not a unit. -/
+theorem isReduced_iff_degree_lt {f : FpPoly p} (hf : 0 < FpPoly.degree f)
+    (g : FpPoly p) :
+    IsReduced f g ↔ FpPoly.degree g < FpPoly.degree f := by
+  constructor
+  · rintro ⟨h, rfl⟩
+    simpa [IsReduced, reduceMod, FpPoly.degree, DensePoly.mod_eq_divMod]
+      using DensePoly.mod_degree_lt_of_pos_degree h f hf
+  · intro hdeg
+    exact ⟨g, (reduceMod_eq_self_of_degree_lt f g hdeg).symm⟩
 
 /-- Applying {name}`reduceMod` to a reduced representative is a no-op. -/
 @[simp, grind =] theorem reduceMod_idem (f : FpPoly p) (g : FpPoly p) :

--- a/HexGFqRing/SPEC/hex-gfq-ring.md
+++ b/HexGFqRing/SPEC/hex-gfq-ring.md
@@ -23,11 +23,21 @@ API.
   `n+1 ↦ pred + 1` recursion is forbidden.
 - `Lean.Grind.CommRing (PolyQuotient p f hf)` instance
 
-Representation choice: the stored representative is always canonical.
-Callers do not manage reduction manually; `ofPoly` and all ring
-operations normalize through `reduceMod`. Equality of quotient elements
-is therefore equality of canonical representatives, not a separate
-setoid-style relation.
+Representation choice: the stored representative is canonical, and the
+type says so — `PolyQuotient` is a subtype carrying `IsReduced`, so a raw
+`FpPoly` cannot be passed where a quotient element is expected. Callers
+do not manage reduction manually; `ofPoly` and all ring operations
+normalize through `reduceMod`. Equality of quotient elements is therefore
+equality of canonical representatives, not a separate setoid-style
+relation.
+
+Canonicality requires `p` prime, and the operations require it too. The
+`PolyQuotient` type itself asks only for `ZMod64.Bounds p`, but at
+composite `p` the long-division step divides by a leading coefficient
+that need not be a unit, `reduceMod` is not a canonical form, and two
+values can represent one residue class. `isReduced_iff_degree_lt` states
+the canonicality contract under `ZMod64.PrimeModulus p`, which is the
+only regime this library supports.
 
 This does NOT require `f` to be irreducible — the quotient is always a
 ring. When `f` is irreducible, the same underlying representation


### PR DESCRIPTION
This PR corrects an unconditional canonicality claim on `HexGFqRing.PolyQuotient` and adds the theorem that states the contract.

`reduceMod` is a canonical form only when `p` is prime. At composite `p` the long-division step computes `rem.leadingCoeff / q.leadingCoeff` against a leading coefficient that need not be a unit, and `ZMod64.inv` is a Bézout coefficient with no invertibility check, so the elimination step can subtract zero and leave the remainder unchanged. At `p = 4` with `f = 2X` this gives `reduceMod f f = f` while `reduceMod f 0 = 0`, so `f` and `0` are congruent modulo `f` yet inhabit `PolyQuotient f hf` as distinct values.

Nothing proved in the library was wrong and no consumer is affected, since every ring instance and every canonicality theorem already requires `ZMod64.PrimeModulus p`, and the source comment above the prime `variable` already said as much. But the `PolyQuotient` docstring and `hex-gfq-ring.md` both promised canonical representatives with no hypothesis at all.

`isReduced_iff_degree_lt` now states the contract directly under `PrimeModulus`: reducedness is exactly a degree bound, which is what makes the stored representative the unique one of its residue class. The docstring and the SPEC say where primality is load-bearing.

Whether to move the restriction into the type is a separate design decision, tracked in https://github.com/kim-em/hex-dev/issues/9309.

🤖 Prepared with Claude Code