### PR TITLE
feat(interval): support checked controller state and traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,10 @@ jobs:
             hexrealroots_bench hexrcf_bench hexroots_bench \
             hexresultant_bench hexnumberfield_bench \
             hexnumberfieldtower_bench
-          # The policy-frontier spike is an exact logical-count canary rather
-          # than a lean-bench timing registration. Build it above and exercise
-          # all three representation fixtures directly here.
+          # These interval scheduler spikes are exact logical-count canaries
+          # rather than lean-bench timing registrations. Build them above and
+          # exercise their fixtures directly here.
+          .lake/build/bin/hex_interval_scheduler_spike canary
           .lake/build/bin/hex_interval_policy_frontier_spike canary
           touch "$RUNNER_TEMP/bench.ok"
       - name: Conformance oracles + BZ gates

--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -9,6 +9,8 @@ module
 public import HexInterval.Interval
 public import HexInterval.Multiplication
 public import HexInterval.Action
+public import HexInterval.State
+public import HexInterval.Trace
 
 public section
 
@@ -30,7 +32,8 @@ cuts for two nonzero finite singletons, exact empty and total-zero cases, and a
 sound whole-line fallback for every other nonempty shape. Raw cuts remain
 visible as the explicit decoder and inspection boundary. The public structural
 contracts also cover checked typed SSA programs, versioned fact projections,
-registrations, scoped bindings, actions, and immutable package requests.
-Concrete state, callback outcomes and proposals, scheduling, policy, search,
-and replay remain experimental.
+registrations, scoped bindings, actions, immutable package requests, checked
+immutable branch state, dependency/work queues, authoritative chronology, and
+bounded diagnostics. Concrete callbacks and proposals, policy selection,
+search, proof replay, and measurement-selected storage remain experimental.
 -/

--- a/HexInterval/Experiment/ChronologicalReplay.lean
+++ b/HexInterval/Experiment/ChronologicalReplay.lean
@@ -314,7 +314,7 @@ def replayRuleStep {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics)
     (input : CheckerInput Fact) (arena : Arena)
-    (event : FactEvent Fact) (program : Program)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) (program : Program)
     (basePrefix : ProgramPrefix input.baseProgram program)
     (base assumptions : List (NodeFact Fact)) (previous : Fact)
     (previousSound :
@@ -347,7 +347,7 @@ def replayResolvedRule {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics)
     (input : CheckerInput Fact) (arena : Arena)
-    (event : FactEvent Fact) (program : Program)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) (program : Program)
     (basePrefix : ProgramPrefix input.baseProgram program)
     (base : List (NodeFact Fact))
     (resolve : (seen : SeenVersion) ->
@@ -416,7 +416,7 @@ accepted event. -/
 private def push {Fact : Type} {semantics : Semantics Fact}
     {program : Program} {base : List (NodeFact Fact)}
     (checked : Prefix semantics program base)
-    (event : FactEvent Fact)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact))
     (within : event.node.index < program.nodes.size)
     (sound :
       Evidence
@@ -438,7 +438,7 @@ private def push {Fact : Type} {semantics : Semantics Fact}
 
 /-- Result of one accepted rule event. -/
 structure Step {Fact : Type} (semantics : Semantics Fact) (program : Program)
-    (base : List (NodeFact Fact)) (event : FactEvent Fact) where
+    (base : List (NodeFact Fact)) (event : Hex.Interval.State.Update Fact (FactCause Fact)) where
   next : Prefix semantics program base
   sound :
     Evidence
@@ -454,7 +454,7 @@ opaque replayRule {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics)
     (input : CheckerInput Fact) (arena : Arena)
-    (event : FactEvent Fact)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact))
     (basePrefix : ProgramPrefix input.baseProgram program) :
     Option (Step semantics program base event) := do
   if within : event.node.index < program.nodes.size then
@@ -629,7 +629,7 @@ opaque replayRule {Fact : Type} {semantics : Semantics Fact}
     (checked : Cursor semantics input base version program)
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (arena : Arena)
-    (event : FactEvent Fact) :
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) :
     Option (Cursor semantics input base version program) := do
   if event.programVersion != version then none else pure ()
   let step ←
@@ -696,7 +696,7 @@ def replayTransportStep {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (laws : Laws semantics)
     (input : CheckerInput Fact) (arena : Arena)
-    (event : FactEvent Fact) (edge : EqualityEdge) (program : Program)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) (edge : EqualityEdge) (program : Program)
     (basePrefix : ProgramPrefix input.baseProgram program)
     (base equalityAssumptions : List (NodeFact Fact))
     (previous sourceFact : Fact)
@@ -755,7 +755,7 @@ opaque replayTransport {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (laws : Laws semantics)
     (input : CheckerInput Fact) (arena : Arena)
-    (event : FactEvent Fact) (edge : EqualityEdge)
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) (edge : EqualityEdge)
     (basePrefix : ProgramPrefix input.baseProgram program) :
     Option (Step semantics program base event) := do
   if within : event.node.index < program.nodes.size then
@@ -802,7 +802,7 @@ opaque replayTransport {Fact : Type} {semantics : Semantics Fact}
     (checked : Cursor semantics input base version program)
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (laws : Laws semantics)
-    (arena : Arena) (event : FactEvent Fact) (edge : EqualityEdge) :
+    (arena : Arena) (event : Hex.Interval.State.Update Fact (FactCause Fact)) (edge : EqualityEdge) :
     Option (Cursor semantics input base version program) := do
   if event.programVersion != version then none else pure ()
   let step ←

--- a/HexInterval/Experiment/CosBillion.lean
+++ b/HexInterval/Experiment/CosBillion.lean
@@ -280,7 +280,7 @@ def negationPackage : Package Bound :=
 def packages : Array (Package Bound) :=
   #[sourcePackage, localPackage, constantPackage, reductionPackage, negationPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 5, maxNodes := 6, maxRules := 5, maxRegistryEntries := 24,
     maxReplayFormats := 8, maxArity := 2, maxScopeNodes := 1,
     maxApplications := 12, maxQueueEntries := 96, maxActions := 80,

--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -719,7 +719,7 @@ def importInitialFacts (limit : EndpointLimit) :
 canonical and nonempty; malformed cuts, empty cuts, and resource failures are
 reported before the generic scheduler can observe them. -/
 def start (endpointLimit : EndpointLimit) (program : Program)
-    (rules : Array Registration) (rawFacts : Array Raw) (limits : Limits) :
+    (rules : Array Registration) (rawFacts : Array Raw) (limits : Hex.Interval.State.Limits) :
     Except StartError (Engine Fact) := do
   -- Bound the raw-fact scan with the same resource-first validation used by
   -- the generic engine.  In particular, no oversized program, registry, or

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -517,7 +517,7 @@ def centeredPackage (config : Config) (real : DomainId) : Package Fact :=
         limits.maxOperations ≤ limits.maxObservationValue &&
         limits.maxNodes ≤ limits.maxObservationValue - limits.maxOperations }
 
-def buildRegistry (config : Config) (real : DomainId) (limits : Limits) :
+def buildRegistry (config : Config) (real : DomainId) (limits : Hex.Interval.State.Limits) :
     Except RegistryError (Propagator.Registry Fact) :=
   Propagator.Registry.buildWithin limits
     #[arithmeticPackage config real, centeredPackage config real]
@@ -545,7 +545,7 @@ inductive StartError where
 /-- The checked entry point binds the exact flattened registrations to their
 callbacks and retains the existential registry as the driver's cache. -/
 def start (config : Config) (real : DomainId) (program : Program)
-    (rawFacts : Array Raw) (limits : Limits) :
+    (rawFacts : Array Raw) (limits : Hex.Interval.State.Limits) :
     Except StartError (Engine Fact × Propagator.Registry Fact) :=
   match buildRegistry config real limits with
   | .error error => .error (.registry error)

--- a/HexInterval/Experiment/ExpSign.lean
+++ b/HexInterval/Experiment/ExpSign.lean
@@ -163,7 +163,7 @@ def packages : Array (Package Bound) := #[sourcePackage, expPackage]
 def splitPackages : Array (Package Bound) :=
   #[sourcePackage, expPackage, splitPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 3
     maxNodes := 5
     maxRules := 3

--- a/HexInterval/Experiment/Frontend.lean
+++ b/HexInterval/Experiment/Frontend.lean
@@ -45,27 +45,27 @@ in its already-established prefix. -/
 def resolveFacts? (engine : Engine Fact) (inputs : List SeenVersion) :
     Option (List (NodeFact Fact)) :=
   inputs.mapM fun input => do
-    let fact ← engine.factAt? input
+    let fact ← engine.toBranch.factAt? input
     pure { node := input.node, fact }
 
 /-- Quote one rule-produced fact record and its immutable payload entry. -/
 def ruleStep? (engine : Engine Fact) (arena : Arena)
-    (event : FactEvent Fact) : Option (RuleStep Fact) := do
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) : Option (RuleStep Fact) := do
   let .rule action _ payload := event.cause | none
   let entry ← arena.entry? payload .fact
   let assumptions ← resolveFacts? engine action.inputs
-  let previous ← engine.factAt? event.previous
+  let previous ← engine.toBranch.factAt? event.previous
   pure { event, payload, entry, assumptions, previous }
 
 /-- Quote one equality-transport fact record, retained edge, and payload. -/
 def transportStep? (engine : Engine Fact) (arena : Arena)
-    (event : FactEvent Fact) : Option (TransportStep Fact) := do
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) : Option (TransportStep Fact) := do
   let .transport equality source := event.cause | none
   let edge ← engine.equalities[equality.index]?
   let entry ← arena.entry? edge.payload .equality
   let assumptions ← resolveFacts? engine edge.origin.inputs
-  let previous ← engine.factAt? event.previous
-  let sourceFact ← engine.factAt? source
+  let previous ← engine.toBranch.factAt? event.previous
+  let sourceFact ← engine.toBranch.factAt? source
   pure
     { event
       equality
@@ -83,7 +83,7 @@ must exhaust both detailed histories.  Cross-role causal checks deliberately
 belong to the dependent proof fold, which has the evidence and program state
 needed to validate them. -/
 def quote? (engine : Engine Fact) (arena : Arena) :
-    List HistoryEvent → Nat → Nat → Option (List (Event Fact))
+    List Hex.Interval.Trace.Ref → Nat → Nat → Option (List (Event Fact))
   | [], nextFact, nextInstance =>
       if nextFact == engine.history.size &&
           nextInstance == engine.instanceHistory.size then

--- a/HexInterval/Experiment/FrontendEncoder.lean
+++ b/HexInterval/Experiment/FrontendEncoder.lean
@@ -169,8 +169,8 @@ def factCauseExpr (factType : Expr) (factExpr : Fact → MetaM Expr) :
         (← equalityExpr equality) (← seenExpr source)
 
 def factEventExpr (factType : Expr) (factExpr : Fact → MetaM Expr)
-    (event : FactEvent Fact) : MetaM Expr := do
-  mkAppM ``FactEvent.mk
+    (event : Hex.Interval.State.Update Fact (FactCause Fact)) : MetaM Expr := do
+  mkAppM ``Hex.Interval.State.Update.mk
     #[mkNatLit event.programVersion,
       ← nodeIdExpr event.node,
       ← seenExpr event.previous,

--- a/HexInterval/Experiment/IntegralCanary.lean
+++ b/HexInterval/Experiment/IntegralCanary.lean
@@ -150,7 +150,7 @@ def integrationPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[integrationPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 1
     maxNodes := 1
     maxRules := 1

--- a/HexInterval/Experiment/LogTablePrecision.lean
+++ b/HexInterval/Experiment/LogTablePrecision.lean
@@ -198,7 +198,7 @@ def decimal20Input : SemanticReplay.CheckerInput Bound :=
 def decimal50Input : SemanticReplay.CheckerInput Bound :=
   checkerInput 50 decimal50Certificate
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 3, maxNodes := 3, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 2, maxScopeNodes := 1,
     maxApplications := 2, maxQueueEntries := 16, maxActions := 8,

--- a/HexInterval/Experiment/MixedFunctions.lean
+++ b/HexInterval/Experiment/MixedFunctions.lean
@@ -161,7 +161,7 @@ def expPackage : Package Bound :=
 def packages : Array (Package Bound) :=
   #[sourcePackage, sinePackage, expPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 3
     maxNodes := 8
     maxRules := 2

--- a/HexInterval/Experiment/MixedInstantiation.lean
+++ b/HexInterval/Experiment/MixedInstantiation.lean
@@ -238,7 +238,7 @@ def expPackage : Package Bound :=
 def packages : Array (Package Bound) :=
   #[sourcePackage, negationPackage, sinePackage, expPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 4
     maxNodes := 6
     maxRules := 4

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -184,7 +184,7 @@ structure Package (Fact : Type) where
   operations : Array Operation := #[]
   requiredOperations : Array Operation := #[]
   handlers : Array (Handler Fact Cache)
-  acceptsLimits : Program -> Limits -> PayloadArena.Limits -> Bool :=
+  acceptsLimits : Program -> Hex.Interval.State.Limits -> PayloadArena.Limits -> Bool :=
     fun _ _ _ => true
   /-- Non-semantic routing telemetry used to check that only the selected
   package snapshot changes. -/
@@ -235,7 +235,7 @@ inductive RegistryError where
   | duplicateRule (key : RuleKey)
   | duplicateFormat (key : PayloadArena.ReplayKey)
   | undeclaredHead (rule : RuleKey) (head : OpKey)
-  | resourceLimit (resource : Resource)
+  | resourceLimit (resource : Hex.Interval.State.Resource)
   deriving DecidableEq, Repr
 
 namespace Registry
@@ -300,7 +300,7 @@ def flatten : Nat -> List (Package Fact) -> Array Operation ->
         addHandlers packageIndex 0 package.handlers.toList registrations routes
       flatten (packageIndex + 1) rest operations registrations routes
 
-def preflight (limits : Limits) (packages : Array (Package Fact)) :
+def preflight (limits : Hex.Interval.State.Limits) (packages : Array (Package Fact)) :
     Except RegistryError Unit := do
   if limits.maxRegistryEntries < packages.size then
     throw (.resourceLimit .registryEntries)
@@ -339,7 +339,7 @@ array allocation. Dedicated caps bound total metadata and replay-format
 declarations without borrowing executable operation headroom. Assembly order
 is package-major and then handler-major; exact operation and rule keys are
 unique in the snapshot. -/
-opaque buildWithin (limits : Limits) (packages : Array (Package Fact)) :
+opaque buildWithin (limits : Hex.Interval.State.Limits) (packages : Array (Package Fact)) :
     Except RegistryError (Registry Fact) :=
   match preflight limits packages with
   | .error error => .error error
@@ -370,7 +370,7 @@ def acceptsProgram (registry : Registry Fact) (program : Program) : Bool :=
 /-- Run every package-owned configuration preflight over the final program,
 engine resource envelope, and proof-payload arena envelope. -/
 def acceptsLimits (registry : Registry Fact) (program : Program)
-    (limits : Limits) (arenaLimits : PayloadArena.Limits) : Bool :=
+    (limits : Hex.Interval.State.Limits) (arenaLimits : PayloadArena.Limits) : Bool :=
   DispatchCode.requestMismatch ≤ limits.maxDiagnosticValue &&
     registry.packages.all fun package =>
       package.acceptsLimits program limits arenaLimits

--- a/HexInterval/Experiment/PayloadSession.lean
+++ b/HexInterval/Experiment/PayloadSession.lean
@@ -76,7 +76,7 @@ private def make (engine : Engine Fact) (registry : Registry Fact)
 /-- A sound upper bound on payload-arena work in any engine-valid reply:
 every candidate, every suggestion constructor, and at most
 `maxProposalItems` nested equalities for each suggestion. -/
-def requiredUses (limits : Propagator.Limits) : Nat :=
+def requiredUses (limits : Hex.Interval.State.Limits) : Nat :=
   limits.maxOutcomeCandidates +
     limits.maxOutcomeSuggestions * (limits.maxProposalItems + 1)
 
@@ -85,7 +85,7 @@ payload use. `maxDrafts ≤ maxUses` also bounds malformed pre-coverage draft
 lists by the use-traversal envelope, while the local draft and cell caps must
 fit an empty arena. Therefore only capacity consumed by earlier commits can
 produce a whole-run exhaustion. -/
-def limitsCoherent (limits : Propagator.Limits)
+def limitsCoherent (limits : Hex.Interval.State.Limits)
     (arenaLimits : PayloadArena.Limits) : Bool :=
   requiredUses limits ≤ arenaLimits.maxDrafts &&
     arenaLimits.maxDrafts ≤ arenaLimits.maxUses &&
@@ -98,7 +98,7 @@ The generic engine preflight precedes any package callback which may traverse
 the program. -/
 opaque Session.start (factDomain : FactDomain Fact) (program : Program)
     (packages : Array (Package Fact)) (facts : Array Fact)
-    (limits : Propagator.Limits) (arenaLimits : PayloadArena.Limits) :
+    (limits : Hex.Interval.State.Limits) (arenaLimits : PayloadArena.Limits) :
     Except StartError (Session Fact) :=
   match Registry.buildWithin limits packages with
   | .error error => .error (.registry error)
@@ -123,7 +123,7 @@ inductive Step (Fact : Type) where
   | saturated (session : Session Fact)
   | incomplete (session : Session Fact)
   | contradiction (session : Session Fact)
-  | engineResource (resource : Propagator.Resource) (session : Session Fact)
+  | engineResource (resource : Hex.Interval.State.Resource) (session : Session Fact)
   | factResource (budget : Nat) (session : Session Fact)
   | invalidReply (error : ReplyError) (session : Session Fact)
   | invalidPayload (error : PayloadArena.Invalid) (session : Session Fact)
@@ -171,7 +171,7 @@ private def outcomeDropsWork : Outcome Fact -> Bool
 before the arena traverses payload uses or drafts. Nested instantiation lists
 remain bounded by the arena cap here and by `maxProposalItems` during engine
 admission. -/
-private def outcomeListsBounded (limits : Propagator.Limits) : Outcome Fact -> Bool
+private def outcomeListsBounded (limits : Hex.Interval.State.Limits) : Outcome Fact -> Bool
   | .success candidates suggestions _ =>
       listWithin limits.maxOutcomeCandidates candidates &&
         listWithin limits.maxOutcomeSuggestions suggestions
@@ -292,7 +292,7 @@ inductive Stop where
   | saturated
   | incomplete
   | contradiction
-  | engineResource (resource : Propagator.Resource)
+  | engineResource (resource : Hex.Interval.State.Resource)
   | factResource (budget : Nat)
   | invalidReply (error : ReplyError)
   | payloadResource (resource : PayloadArena.Resource)

--- a/HexInterval/Experiment/PntBKLNWExp.lean
+++ b/HexInterval/Experiment/PntBKLNWExp.lean
@@ -361,7 +361,7 @@ def packageFor (value : Certificate) : Package Bound :=
 
 def packagesFor (value : Certificate) : Array (Package Bound) := #[packageFor value]
 
-def engineLimitsFor (value : Certificate) : Propagator.Limits :=
+def engineLimitsFor (value : Certificate) : State.Limits :=
   { maxOperations := 1
     maxNodes := 1
     maxRules := 1

--- a/HexInterval/Experiment/PntBKLNWPow.lean
+++ b/HexInterval/Experiment/PntBKLNWPow.lean
@@ -168,7 +168,7 @@ def package : Package Bound :=
 
 def packages : Array (Package Bound) := #[package]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 1
     maxNodes := 1
     maxRules := 1

--- a/HexInterval/Experiment/PntExpNegative.lean
+++ b/HexInterval/Experiment/PntExpNegative.lean
@@ -263,7 +263,7 @@ def representative : Certificate :=
 def representativeInput : SemanticReplay.CheckerInput Bound :=
   checkerInput representative
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 2, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 2,
     maxQueueEntries := 8, maxActions := 4, maxMatcherVisits := 2,

--- a/HexInterval/Experiment/PntExpPoint.lean
+++ b/HexInterval/Experiment/PntExpPoint.lean
@@ -232,7 +232,7 @@ def checkerInput (value : Certificate) : SemanticReplay.CheckerInput Bound :=
 
 def representativeInput : SemanticReplay.CheckerInput Bound := checkerInput rowTwenty
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 2, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 2,
     maxQueueEntries := 8, maxActions := 4, maxMatcherVisits := 2,

--- a/HexInterval/Experiment/PntExpTail.lean
+++ b/HexInterval/Experiment/PntExpTail.lean
@@ -158,7 +158,7 @@ def expPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, expPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 3
     maxRules := 1

--- a/HexInterval/Experiment/PntFks2Family.lean
+++ b/HexInterval/Experiment/PntFks2Family.lean
@@ -117,7 +117,7 @@ def batchPackage : Package Bound :=
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
 /-- Explicit global and per-action resource envelope for the local profile. -/
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 14000
     maxRules := 700

--- a/HexInterval/Experiment/PntFks2Shard.lean
+++ b/HexInterval/Experiment/PntFks2Shard.lean
@@ -193,7 +193,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 1001
     maxRules := 50

--- a/HexInterval/Experiment/PntLogNatural.lean
+++ b/HexInterval/Experiment/PntLogNatural.lean
@@ -151,7 +151,7 @@ def checkerInput (row : Certificate) : SemanticReplay.CheckerInput Bound :=
 
 def representativeInput : SemanticReplay.CheckerInput Bound := checkerInput row29
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 2, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 2,
     maxQueueEntries := 8, maxActions := 4, maxMatcherVisits := 2, matcherBatchSize := 2,

--- a/HexInterval/Experiment/PntLogRational.lean
+++ b/HexInterval/Experiment/PntLogRational.lean
@@ -184,7 +184,7 @@ def checkerInput (value : Certificate) : SemanticReplay.CheckerInput Bound :=
 
 def representativeInput : SemanticReplay.CheckerInput Bound := checkerInput row32e12
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 2, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 2,
     maxQueueEntries := 8, maxActions := 4, maxMatcherVisits := 2,

--- a/HexInterval/Experiment/PntLogTable.lean
+++ b/HexInterval/Experiment/PntLogTable.lean
@@ -145,7 +145,7 @@ def logPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, logPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 3
     maxRules := 1

--- a/HexInterval/Experiment/PntNestedLog.lean
+++ b/HexInterval/Experiment/PntNestedLog.lean
@@ -177,7 +177,7 @@ def logPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, logPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 4
     maxRules := 1

--- a/HexInterval/Experiment/PntNestedLogTwo.lean
+++ b/HexInterval/Experiment/PntNestedLogTwo.lean
@@ -114,7 +114,7 @@ def checkerInput : SemanticReplay.CheckerInput Bound :=
   { baseProgram := program, initialFacts := #[.two, .all, .all],
     target := { node := node 2, fact := .outerWindow } }
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 4, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 3,
     maxQueueEntries := 12, maxActions := 8, maxMatcherVisits := 4,

--- a/HexInterval/Experiment/PntPiPoint.lean
+++ b/HexInterval/Experiment/PntPiPoint.lean
@@ -105,7 +105,7 @@ def checkerInput : SemanticReplay.CheckerInput Bound :=
   { baseProgram := program, initialFacts := #[.request, .all],
     target := { node := node 1, fact := .upper certificate.cut } }
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2, maxNodes := 2, maxRules := 1, maxRegistryEntries := 8,
     maxReplayFormats := 2, maxArity := 1, maxScopeNodes := 1, maxApplications := 2,
     maxQueueEntries := 8, maxActions := 4, maxMatcherVisits := 2,

--- a/HexInterval/Experiment/PntTable10A2.lean
+++ b/HexInterval/Experiment/PntTable10A2.lean
@@ -234,7 +234,7 @@ def packageFor (value : Certificate) : Package Bound :=
 
 def packagesFor (value : Certificate) : Array (Package Bound) := #[packageFor value]
 
-def engineLimitsFor (value : Certificate) : Propagator.Limits :=
+def engineLimitsFor (value : Certificate) : State.Limits :=
   { maxOperations := 1
     maxNodes := 1
     maxRules := 1

--- a/HexInterval/Experiment/PntTable10Convex.lean
+++ b/HexInterval/Experiment/PntTable10Convex.lean
@@ -207,7 +207,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 31
     maxRules := 1

--- a/HexInterval/Experiment/PntTable10LargePointwise.lean
+++ b/HexInterval/Experiment/PntTable10LargePointwise.lean
@@ -174,7 +174,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 6
     maxRules := 1

--- a/HexInterval/Experiment/PntTable10LogCoupled.lean
+++ b/HexInterval/Experiment/PntTable10LogCoupled.lean
@@ -249,7 +249,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 11
     maxRules := 1

--- a/HexInterval/Experiment/PntTable10Pointwise.lean
+++ b/HexInterval/Experiment/PntTable10Pointwise.lean
@@ -192,7 +192,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 11
     maxRules := 1

--- a/HexInterval/Experiment/PntTable10Shard.lean
+++ b/HexInterval/Experiment/PntTable10Shard.lean
@@ -298,7 +298,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : State.Limits :=
   { maxOperations := 2
     maxNodes := 6
     maxRules := 1

--- a/HexInterval/Experiment/PntTable12.lean
+++ b/HexInterval/Experiment/PntTable12.lean
@@ -276,7 +276,7 @@ def rowPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, rowPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 6
     maxRules := 1

--- a/HexInterval/Experiment/PntTable12Log.lean
+++ b/HexInterval/Experiment/PntTable12Log.lean
@@ -317,7 +317,7 @@ def rowPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, logPackage, rowPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 4, maxNodes := 16, maxRules := 3, maxRegistryEntries := 12,
     maxReplayFormats := 4, maxArity := 6, maxScopeNodes := 1, maxApplications := 4,
     maxQueueEntries := 40, maxActions := 8, maxMatcherVisits := 8, matcherBatchSize := 4,

--- a/HexInterval/Experiment/PntTable12Ordinary.lean
+++ b/HexInterval/Experiment/PntTable12Ordinary.lean
@@ -240,7 +240,7 @@ def batchPackage : Package Bound :=
 
 def packages : Array (Package Bound) := #[sourcePackage, batchPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 2
     maxNodes := 116
     maxRules := 1

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -677,10 +677,10 @@ contract. Policy order may differ from FIFO order, so the retained entry
 becomes a tombstone rather than moving the FIFO cursor. -/
 private def clearWork? (engine : Engine Fact) (work : Hex.Interval.State.Work) :
     Option (Engine Fact) := do
-  let dependencies <-
-    (engine.toQueue.deactivate engine.limits.maxQueueEntries engine.applications.size
-      engine.equalities.size engine.toDependencies work).toOption
-  pure { engine with toDependencies := dependencies }
+  let (dependencies, queue) <-
+    (engine.toQueue.deactivate engine.limits.maxQueueEntries engine.program.nodes.size
+      engine.applications.size engine.equalities.size engine.toDependencies work).toOption
+  pure { engine with toDependencies := dependencies, toQueue := queue }
 
 private def prepareApplication (state : State Fact) (applicationId : ApplicationId)
     (effort : Option Nat) (clearDirty : Bool) (decision : DecisionClass)

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -497,7 +497,7 @@ opaque State.view (state : State Fact) : Except ViewError (View Fact × State Fa
        serial := state.serial
        programVersion := state.engine.programVersion
        offers
-       facts := state.engine.snapshot
+       facts := state.engine.toBranch.snapshot
        incomplete := state.incomplete
        remaining :=
         { actions := remaining state.engine.limits.maxActions state.engine.metrics.queuePops
@@ -553,7 +553,7 @@ inductive EqualityOutcome where
   | noChange
   | improved
   | contradiction
-  | engineResource (resource : Resource)
+  | engineResource (resource : Hex.Interval.State.Resource)
   | factResource (budget : Nat)
   | invalid (fault : EqualityFault)
   deriving DecidableEq, Repr
@@ -591,7 +591,7 @@ inductive SelectResult (Fact : Type) where
   | completed (completion : Completed) (state : State Fact)
   | split (plan : SplitPlan Fact) (state : State Fact)
   | rejected (reason : Rejection) (state : State Fact)
-  | engineResource (resource : Resource) (state : State Fact)
+  | engineResource (resource : Hex.Interval.State.Resource) (state : State Fact)
   | factResource (budget : Nat) (state : State Fact)
 
 private inductive DecisionClass where
@@ -672,6 +672,16 @@ private def prepareMatchForPolicy (state : State Fact) (applicationId : Applicat
               .invalid
         | _, _ => .invalid
 
+/-- Consume one policy-selected dirty item through the supported queue
+contract. Policy order may differ from FIFO order, so the retained entry
+becomes a tombstone rather than moving the FIFO cursor. -/
+private def clearWork? (engine : Engine Fact) (work : Hex.Interval.State.Work) :
+    Option (Engine Fact) := do
+  let dependencies <-
+    (engine.toQueue.deactivate engine.limits.maxQueueEntries engine.applications.size
+      engine.equalities.size engine.toDependencies work).toOption
+  pure { engine with toDependencies := dependencies }
+
 private def prepareApplication (state : State Fact) (applicationId : ApplicationId)
     (effort : Option Nat) (clearDirty : Bool) (decision : DecisionClass)
     (source : Option Action := none) : SelectResult Fact :=
@@ -709,25 +719,25 @@ private def prepareApplication (state : State Fact) (applicationId : Application
                 writes := application.writes
                 structuralInputs
                 matcherEpoch }
-            let queued :=
-              if clearDirty then state.engine.queued.set! applicationId.index false
-              else state.engine.queued
-            let engine : Engine Fact :=
-              { state.engine with
-                queued
-                pending := some action
-                pendingMatcher
-                metrics :=
-                  { state.engine.metrics with
-                    queuePops := state.engine.metrics.queuePops + 1
-                    requests := state.engine.metrics.requests + 1 } }
-            let state := advanceState (chargeDecision state decision) engine
-            .request
-              { action
-                program := state.engine.programView
-                inputs := views
-                writes := application.writes }
-              state
+            match if clearDirty then clearWork? state.engine (.application applicationId)
+                else some state.engine with
+            | none => reject state .malformedState
+            | some base =>
+                let engine : Engine Fact :=
+                  { base with
+                    pending := some action
+                    pendingMatcher
+                    metrics :=
+                      { base.metrics with
+                        queuePops := state.engine.metrics.queuePops + 1
+                        requests := state.engine.metrics.requests + 1 } }
+                let state := advanceState (chargeDecision state decision) engine
+                .request
+                  { action
+                    program := state.engine.programView
+                    inputs := views
+                    writes := application.writes }
+                  state
         | _, _, _ => reject state .malformedState
 
 private def consumeSuggestion (state : State Fact) (suggestion : SuggestionId) : State Fact :=
@@ -747,39 +757,40 @@ def equalityObservation (key : EqualityWorkKey) (before after : Engine Fact)
 private def selectEquality (state : State Fact) (key : EqualityWorkKey) : SelectResult Fact :=
   if state.engine.limits.maxActions <= state.engine.metrics.queuePops then
     reject state .actionLimit
-  else
-    let running : Engine Fact :=
-      { state.engine with
-        equalityQueued := state.engine.equalityQueued.set! key.equality.index false
-        metrics :=
-          { state.engine.metrics with
-            queuePops := state.engine.metrics.queuePops + 1
-            equalityRuns := state.engine.metrics.equalityRuns + 1 } }
-    let selectedClock :=
-      match state.equalities[key.equality.index]? with
-      | some clock =>
-          { state with equalities :=
-              state.equalities.set! key.equality.index { clock with active := false } }
-      | none => state
-    match running.contractEquality key.equality with
-    | .advanced narrowCalls engine =>
-        let outcome :=
-          if engine.contradictory && !state.engine.contradictory then .contradiction
-          else if engine.history.size == state.engine.history.size then .noChange
-          else .improved
-        let observation := equalityObservation key state.engine engine outcome narrowCalls
-        .equality observation (advanceState (chargeDecision selectedClock .equality) engine)
-    | .invalid fault narrowCalls engine =>
-        .equality (equalityObservation key state.engine engine (.invalid fault) narrowCalls)
-          (chargeDecision state .equality)
-    | .resourceLimit resource narrowCalls engine =>
-        .equality (equalityObservation key state.engine engine
-            (.engineResource resource) narrowCalls)
-          (chargeDecision state .equality)
-    | .factResourceLimit budget narrowCalls engine =>
-        .equality (equalityObservation key state.engine engine
-            (.factResource budget) narrowCalls)
-          (chargeDecision state .equality)
+  else match clearWork? state.engine (.equality key.equality) with
+  | none => reject state .malformedState
+  | some base =>
+      let running : Engine Fact :=
+        { base with
+          metrics :=
+            { base.metrics with
+              queuePops := state.engine.metrics.queuePops + 1
+              equalityRuns := state.engine.metrics.equalityRuns + 1 } }
+      let selectedClock :=
+        match state.equalities[key.equality.index]? with
+        | some clock =>
+            { state with equalities :=
+                state.equalities.set! key.equality.index { clock with active := false } }
+        | none => state
+      match running.contractEquality key.equality with
+      | .advanced narrowCalls engine =>
+          let outcome :=
+            if engine.contradictory && !state.engine.contradictory then .contradiction
+            else if engine.history.size == state.engine.history.size then .noChange
+            else .improved
+          let observation := equalityObservation key state.engine engine outcome narrowCalls
+          .equality observation (advanceState (chargeDecision selectedClock .equality) engine)
+      | .invalid fault narrowCalls engine =>
+          .equality (equalityObservation key state.engine engine (.invalid fault) narrowCalls)
+            (chargeDecision state .equality)
+      | .resourceLimit resource narrowCalls engine =>
+          .equality (equalityObservation key state.engine engine
+              (.engineResource resource) narrowCalls)
+            (chargeDecision state .equality)
+      | .factResourceLimit budget narrowCalls engine =>
+          .equality (equalityObservation key state.engine engine
+              (.factResource budget) narrowCalls)
+            (chargeDecision state .equality)
 
 private def selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
     (key : OfferKey) : SelectResult Fact :=
@@ -853,26 +864,29 @@ opaque State.dismiss (state : State Fact) (selection : Selection) : SelectResult
   match state.validate selection with
   | .error reason => reject state reason
   | .ok _ =>
-      let next := match selection.id with
-        | .application application =>
-            let engine :=
-              { state.engine with queued := state.engine.queued.set! application.index false }
-            { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
-        | .equality equality =>
-            let engine :=
-              { state.engine with
-                equalityQueued := state.engine.equalityQueued.set! equality.index false }
-            { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
-        | .suggestion suggestion =>
-            let next := chargeDecision (consumeSuggestion state suggestion) .dismissal
-            match state.engine.suggestions[suggestion.index]? with
-            | some retained =>
+      match selection.id with
+      | .application application =>
+          match clearWork? state.engine (.application application) with
+          | none => reject state .malformedState
+          | some engine =>
+              .completed .dismissed
+                { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
+      | .equality equality =>
+          match clearWork? state.engine (.equality equality) with
+          | none => reject state .malformedState
+          | some engine =>
+              .completed .dismissed
+                { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
+      | .suggestion suggestion =>
+          let next := chargeDecision (consumeSuggestion state suggestion) .dismissal
+          match state.engine.suggestions[suggestion.index]? with
+          | some retained =>
+              .completed .dismissed <|
                 if Suggestion.affectsClosure retained.suggestion then
                   { next with incomplete := true }
                 else
                   next
-            | none => { next with incomplete := true }
-      .completed .dismissed next
+          | none => reject state .malformedState
 
 /-! # Exact rule observations -/
 
@@ -913,7 +927,7 @@ def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
 inductive SubmitResult (Fact : Type) where
   | accepted (observation : RuleObservation Fact) (state : State Fact)
   | invalid (error : ReplyError) (state : State Fact)
-  | engineResource (resource : Resource) (state : State Fact)
+  | engineResource (resource : Hex.Interval.State.Resource) (state : State Fact)
   | factResource (budget : Nat) (state : State Fact)
   | malformedState (state : State Fact)
 

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -62,7 +62,7 @@ inductive Event (Fact : Type)
   | dismissal (selection : Selection) (halts : Bool) (causesIncomplete : Bool)
   | splitPrepared (selection : Selection) (plan : SplitPlan Fact)
   | choiceRejected (selection : Selection) (reason : Rejection)
-  | engineResource (origin : ResourceOrigin) (resource : Resource)
+  | engineResource (origin : ResourceOrigin) (resource : Hex.Interval.State.Resource)
   | factResource (origin : ResourceOrigin) (budget : Nat)
   | decisionResource
   | viewResource (error : ViewError)
@@ -95,7 +95,7 @@ inductive Stop (Fact : Type)
   | contradiction
   | split (plan : SplitPlan Fact)
   | unknown (reason : UnknownReason)
-  | engineResource (resource : Resource)
+  | engineResource (resource : Hex.Interval.State.Resource)
   | factResource (budget : Nat)
   | decisionResource
   | viewResource (error : ViewError)

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -147,7 +147,7 @@ def rankDomain : FactDomain Rank where
   narrow _ current candidate :=
     if current < candidate then .improved candidate else .noChange
 
-def engineLimits (workload : Workload) : Experiment.Propagator.Limits :=
+def engineLimits (workload : Workload) : Hex.Interval.State.Limits :=
   let arity := Nat.max workload.roots (sinkArity workload)
   let applications := applicationCount workload
   { maxOperations := 3
@@ -632,7 +632,7 @@ structure Index where
   suggestionCursor : Nat
   deriving Repr
 
-def offerIdOfWork : WorkItem -> OfferId
+def offerIdOfWork : Hex.Interval.State.Work -> OfferId
   | .application application => .application application
   | .equality equality => .equality equality
 

--- a/HexInterval/Experiment/PolicySession.lean
+++ b/HexInterval/Experiment/PolicySession.lean
@@ -39,7 +39,7 @@ open Propagator
 
 /-- All deterministic envelopes used to assemble one policy session. -/
 structure Limits where
-  engine : Propagator.Limits
+  engine : Hex.Interval.State.Limits
   policy : Propagator.Policy.Limits
   arena : PayloadArena.Limits
   deriving DecidableEq, Repr
@@ -79,7 +79,7 @@ private def make (state : Propagator.Policy.State Fact)
 /-- A sound upper bound on proof-payload traversal for any engine-valid
 reply.  It charges every candidate and suggestion and the maximum number of
 equalities which may be nested below each suggestion. -/
-def requiredUses (limits : Propagator.Limits) : Nat :=
+def requiredUses (limits : Hex.Interval.State.Limits) : Nat :=
   limits.maxOutcomeCandidates +
     limits.maxOutcomeSuggestions * (limits.maxProposalItems + 1)
 
@@ -206,7 +206,7 @@ inductive Step (Fact : Type) where
   | rejected (selection : Propagator.Policy.Selection)
       (reason : Propagator.Policy.Rejection) (session : Session Fact)
   | contradiction (session : Session Fact)
-  | engineResource (resource : Propagator.Resource) (session : Session Fact)
+  | engineResource (resource : Hex.Interval.State.Resource) (session : Session Fact)
   | factResource (budget : Nat) (session : Session Fact)
   | invalidReply (error : ReplyError) (session : Session Fact)
   | invalidPayload (error : PayloadArena.Invalid) (session : Session Fact)
@@ -217,7 +217,7 @@ inductive Step (Fact : Type) where
   | payloadResource (resource : PayloadArena.Resource) (session : Session Fact)
   | invalidSession (session : Session Fact)
 
-private def outcomeListsBounded (limits : Propagator.Limits) : Outcome Fact -> Bool
+private def outcomeListsBounded (limits : Hex.Interval.State.Limits) : Outcome Fact -> Bool
   | .success candidates suggestions _ =>
       listWithin limits.maxOutcomeCandidates candidates &&
         listWithin limits.maxOutcomeSuggestions suggestions

--- a/HexInterval/Experiment/ProofEmitter.lean
+++ b/HexInterval/Experiment/ProofEmitter.lean
@@ -42,7 +42,7 @@ open Propagator PayloadArena SemanticReplay ChronologicalReplay
 the quote, rather than retaining the opaque arena lookup, is what makes the
 proof-side reduction independent of the compiled search implementation. -/
 structure RuleStep (Fact : Type) where
-  event : FactEvent Fact
+  event : Hex.Interval.State.Update Fact (FactCause Fact)
   payload : PayloadId
   entry : Entry
   assumptions : List (NodeFact Fact)
@@ -56,7 +56,7 @@ structure InstanceQuote where
 
 /-- Plain data quoted for one equality-caused fact improvement. -/
 structure TransportStep (Fact : Type) where
-  event : FactEvent Fact
+  event : Hex.Interval.State.Update Fact (FactCause Fact)
   equality : EqualityId
   edge : EqualityEdge
   payload : PayloadId

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexInterval.Action
+public import HexInterval.State
 public import HexInterval.Experiment.StructuralCursor
 
 @[expose] public section
@@ -46,13 +46,6 @@ abbrev MatcherCursor := StructuralCursor.Cursor
 abbrev MatcherLimits := StructuralCursor.Limits
 abbrev MatcherError := StructuralCursor.Error
 abbrev MatcherStep := StructuralCursor.Step StructuralInput
-
-/-- A single scheduler queue carries both companion-backed rule applications
-and engine-owned equality contractors. -/
-inductive WorkItem where
-  | application (application : ApplicationId)
-  | equality (equality : EqualityId)
-  deriving DecidableEq, Repr
 
 /-- A registration resolved against one concrete program node. -/
 structure Application where
@@ -535,97 +528,7 @@ def listWithin {alpha : Type} : Nat -> List alpha -> Bool
   | 0, _ :: _ => false
   | limit + 1, _ :: items => listWithin limit items
 
-/-! # Deterministic engine resources -/
-
-/-- Solver-owned resource whose trusted limit was exhausted. -/
-inductive Resource where
-  | operations
-  | nodes
-  | rules
-  | arity
-  | scopes
-  | applications
-  | queueEntries
-  | actions
-  | matcherVisits
-  | effort
-  | registryEntries
-  | replayFormats
-  | acceptedFacts
-  | retainedSuggestions
-  | outcomeCandidates
-  | outcomeSuggestions
-  | instances
-  | generation
-  | nodeDepth
-  | equalities
-  deriving DecidableEq, Repr
-
-/-- Independent structural and work limits. -/
-structure Limits where
-  maxOperations : Nat
-  maxNodes : Nat
-  maxRules : Nat
-  /-- Total package metadata cells, independent of executable program size. -/
-  maxRegistryEntries : Nat
-  /-- Total cache-independent proof-replay format declarations. -/
-  maxReplayFormats : Nat
-  maxArity : Nat
-  /-- Maximum ordered read or write ports of one arbitrary-scope application.
-  Local operation slots remain governed by `maxArity`. -/
-  maxScopeNodes : Nat := 0
-  maxApplications : Nat
-  maxQueueEntries : Nat
-  maxActions : Nat
-  /-- Global number of engine-enumerated structural inputs. -/
-  maxMatcherVisits : Nat := 0
-  /-- Maximum structural inputs exposed by one matcher invocation. -/
-  matcherBatchSize : Nat := 0
-  maxAcceptedFacts : Nat
-  maxRetainedSuggestions : Nat
-  maxEffort : Nat
-  maxObservationValue : Nat
-  maxDiagnosticValue : Nat
-  maxOutcomeCandidates : Nat
-  maxOutcomeSuggestions : Nat
-  maxProposalItems : Nat
-  maxInstances : Nat
-  maxGeneration : Nat
-  maxNodeDepth : Nat
-  maxEqualities : Nat
-  splitEndpointLimit : EndpointLimit
-  deriving DecidableEq, Repr
-
-/-- Logical counters used both by conformance fixtures and later policy
-experiments. -/
-structure Metrics where
-  queueInsertions : Nat := 0
-  suppressedInsertions : Nat := 0
-  queuePops : Nat := 0
-  requests : Nat := 0
-  matcherVisits : Nat := 0
-  replies : Nat := 0
-  candidates : Nat := 0
-  improvements : Nat := 0
-  contradictions : Nat := 0
-  ruleNoChange : Nat := 0
-  ruleInapplicable : Nat := 0
-  ruleResourceLimits : Nat := 0
-  ruleFailures : Nat := 0
-  admittedInstances : Nat := 0
-  duplicateInstances : Nat := 0
-  /-- Total suggestions omitted from retained policy state. -/
-  droppedSuggestions : Nat := 0
-  /-- Suggestions omitted because the retained array was full. -/
-  capacityDrops : Nat := 0
-  /-- Structurally valid instantiations omitted by `maxNodeDepth`. -/
-  depthDrops : Nat := 0
-  generatedNodes : Nat := 0
-  generatedScopes : Nat := 0
-  generatedEqualities : Nat := 0
-  equalityRuns : Nat := 0
-  equalityImprovements : Nat := 0
-  deriving DecidableEq, Repr
+/-! # Experimental provenance and structural arenas -/
 
 /-- Why one narrowed fact was admitted.  Rule provenance retains the proposed
 fact separately from the narrowed fact installed in the event.  Equality
@@ -635,15 +538,6 @@ inductive FactCause (Fact : Type) where
   | rule (action : Action) (proposed : Fact) (payload : PayloadId)
   | transport (equality : EqualityId) (source : SeenVersion)
   deriving Repr
-
-/-- One retained fact provenance record. -/
-structure FactEvent (Fact : Type) where
-  programVersion : Nat
-  node : NodeId
-  previous : SeenVersion
-  fact : Fact
-  version : Nat
-  cause : FactCause Fact
 
 /-- Canonical unordered endpoint pair for one generated equality. -/
 structure EqualityPair where
@@ -712,25 +606,13 @@ structure InstanceEvent where
   newEqualities : List EqualityId := []
   payload : PayloadId
 
-/-- One entry in the engine's authoritative cross-history order. The detailed
-records remain in their role-specific arrays; this compact log says exactly
-when each committed fact or program extension became available. Equalities are
-introduced by their owning instance event. -/
-inductive HistoryEvent where
-  | fact (index : Nat)
-  | instance (index : Nat)
-  deriving DecidableEq, Repr
-
-/-- Live state of the function-agnostic scheduler. -/
-structure Engine (Fact : Type) where
-  programVersion : Nat
+/-- Live state of the function-agnostic scheduler. Its branch facts,
+dependency bits, append-only work queue, and chronology order are the supported
+plain-data contracts; package callbacks and structural arenas remain here. -/
+structure Engine (Fact : Type) extends
+    Hex.Interval.State.Branch Fact (FactCause Fact), Hex.Interval.State.Dependencies, Hex.Interval.State.Queue,
+      Hex.Interval.Trace.Order where
   factDomain : FactDomain Fact
-  /-- Validated caller program before any search-time instantiation. -/
-  baseProgram : Program
-  /-- Caller-supplied version-zero facts. Replay never recovers these from the
-  mutable current fact slots. -/
-  initialFacts : Array Fact
-  program : Program
   rules : Array Registration
   /-- Concrete scoped bindings in admission order.  Start-time bindings form
   the initial prefix; dynamically proposed bindings append without moving any
@@ -747,29 +629,16 @@ structure Engine (Fact : Type) where
   Ordinary applications carry `none`; matcher applications carry their
   append-stable cursor. -/
   matcherCursors : Array (Option MatcherCursor)
-  watchers : Array (List WorkItem)
-  facts : Array Fact
-  versions : Array Nat
-  generations : Array Nat
-  depths : Array Nat
-  queue : Array WorkItem
-  queueHead : Nat
-  queued : Array Bool
-  equalityQueued : Array Bool
   pending : Option Action
   /-- Prepared matcher progress for the pending action.  This cursor never
   crosses the registry request boundary and commits only with a valid reply. -/
   pendingMatcher : Option MatcherCursor
-  history : Array (FactEvent Fact)
   suggestions : Array RetainedSuggestion
   instances : List InstanceKey
   instanceHistory : Array InstanceEvent
-  /-- Authoritative interleaving of `history` and `instanceHistory`. -/
-  chronology : Array HistoryEvent
   equalities : Array EqualityEdge
-  contradictory : Bool
-  metrics : Metrics
-  limits : Limits
+  metrics : Hex.Interval.State.Metrics
+  limits : Hex.Interval.State.Limits
 
 /-- Failure while validating and compiling an initial engine snapshot. -/
 inductive StartError where
@@ -777,13 +646,13 @@ inductive StartError where
   | invalidRegistrations
   | invalidBindings
   | wrongFactCount
-  | resourceLimit (resource : Resource)
+  | resourceLimit (resource : Hex.Interval.State.Resource)
   deriving DecidableEq, Repr
 
 /-- Build the dependency index in application order followed by equality order.
 Each equality is one undirected contractor watching both endpoints. -/
 def buildWatchers (nodeCount : Nat) (applications : Array Application)
-    (equalities : Array EqualityEdge) : Option (Array (List WorkItem)) := do
+    (equalities : Array EqualityEdge) : Option (Array (List Hex.Interval.State.Work)) := do
   let mut watchers := Array.replicate nodeCount []
   for applicationIndex in [0:applications.size] do
     let application <- applications[applicationIndex]?
@@ -797,13 +666,6 @@ def buildWatchers (nodeCount : Nat) (applications : Array Application)
       let current <- watchers[node.index]?
       watchers := watchers.set! node.index (.equality { index := equalityIndex } :: current)
   some (watchers.map List.reverse)
-
-/-- Initial queue containing every compiled application exactly once. -/
-def initialQueue (applicationCount : Nat) : Array WorkItem := Id.run do
-  let mut queue := #[]
-  for index in [0:applicationCount] do
-    queue := queue.push (.application { index })
-  queue
 
 /-- Freeze the three append-only structural arena sizes without copying their
 contents. -/
@@ -836,7 +698,7 @@ def matcherCursorSuffix? (rules : Array Registration)
 /-- Resource-first validation shared by checked frontends and `Engine.start`.
 Size caps precede every traversal of untrusted program or registry metadata. -/
 def preflightStart (program : Program) (rules : Array Registration)
-    (factCount : Nat) (limits : Limits) (bindings : Array ScopeBinding := #[]) :
+    (factCount : Nat) (limits : Hex.Interval.State.Limits) (bindings : Array ScopeBinding := #[]) :
     Except StartError Unit := do
   if limits.maxOperations < program.operations.size then
     throw (.resourceLimit .operations)
@@ -874,13 +736,18 @@ def preflightStart (program : Program) (rules : Array Registration)
 /-- Validate and compile an engine.  The caller supplies one initial fact per
 node, ordinarily the domain top refined by source hypotheses. -/
 def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Array Registration)
-    (facts : Array Fact) (limits : Limits) (bindings : Array ScopeBinding := #[])
+    (facts : Array Fact) (limits : Hex.Interval.State.Limits) (bindings : Array ScopeBinding := #[])
     (acceptsScope : Program -> ScopeBinding -> Bool := fun _ _ => true) :
     Except StartError (Engine Fact) := do
   preflightStart program rules facts.size limits bindings
   if !bindings.all (acceptsScope program) then
     throw .invalidBindings
-  let some depths := program.depths? | throw .invalidProgram
+  let branch : Hex.Interval.State.Branch Fact (FactCause Fact) <-
+    match Hex.Interval.State.Branch.startWithin limits program facts with
+    | .ok branch => pure branch
+    | .error .wrongFactCount => throw .wrongFactCount
+    | .error (.resource resource) => throw (.resourceLimit resource)
+    | .error _ => throw .invalidProgram
   let applications <-
     match compileApplicationsWithin limits.maxApplications program rules bindings with
     | .ok applications => pure applications
@@ -894,63 +761,40 @@ def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Arr
     matcherViewOf 0 program.nodes.size 0 applications.size
   let some matcherCursors := matcherCursorSuffix? rules applications 0 matcherView
     | throw .invalidRegistrations
+  let dependencies : Hex.Interval.State.Dependencies :=
+    { watchers
+      queued := Array.replicate applications.size true
+      equalityQueued := #[] }
+  let queue <-
+    match Hex.Interval.State.Queue.initialWithin limits.maxQueueEntries applications.size with
+    | .ok queue => pure queue
+    | .error resource => throw (.resourceLimit resource)
+  if !dependencies.check program.nodes.size applications.size 0 ||
+      !queue.check dependencies applications.size 0 limits.maxQueueEntries then
+    throw .invalidRegistrations
   pure
-    { factDomain
-      baseProgram := program
-      initialFacts := facts
-      program
-      programVersion := 0
+    { toBranch := branch
+      toDependencies := dependencies
+      toQueue := queue
+      toOrder := Hex.Interval.Trace.Order.empty
+      factDomain
       rules
       bindings
       acceptsScope
       applications
       matcherCursors
-      watchers
-      facts
-      versions := Array.replicate facts.size 0
-      generations := Array.replicate facts.size 0
-      depths
-      queue := initialQueue applications.size
-      queueHead := 0
-      queued := Array.replicate applications.size true
-      equalityQueued := #[]
       pending := none
       pendingMatcher := none
-      history := #[]
       suggestions := #[]
       instances := []
       instanceHistory := #[]
-      chronology := #[]
       equalities := #[]
-      contradictory := false
       metrics := { queueInsertions := applications.size }
       limits }
 
 /-! # Incremental scheduling -/
 
 namespace Engine
-
-/-- Immutable view supplied to the companion registry. -/
-def snapshot (state : Engine Fact) : Snapshot Fact :=
-  { facts := state.facts
-    versions := state.versions
-    contradictory := state.contradictory }
-
-/-- Resolve one immutable fact version for replay.  Version zero comes from
-the caller's initial fact array for base nodes and from the domain top for
-search-generated nodes.  Every later version must name an exact history
-event, never the mutable current fact slot. -/
-def factAt? (state : Engine Fact) (seen : SeenVersion) : Option Fact :=
-  if seen.version == 0 then
-    if seen.node.index < state.baseProgram.nodes.size then
-      state.initialFacts[seen.node.index]?
-    else do
-      let node ← state.program.node? seen.node
-      pure (state.factDomain.top node.domain)
-  else
-    (state.history.find? fun event =>
-      event.node == seen.node && event.version == seen.version).map
-        (fun event => event.fact)
 
 /-- Freeze the current bounded expression structure for one registry request. -/
 def programView (state : Engine Fact) : ProgramView :=
@@ -1085,38 +929,32 @@ def actionFresh (state : Engine Fact) (action : Action) : Bool :=
 
 /-- Insert work unless it is already dirty.  The queue is an append-only work
 log in this experiment, so its trusted cap also bounds total dependency churn. -/
-def enqueue (state : Engine Fact) (work : WorkItem) : Except Resource (Engine Fact) := do
-  let alreadyQueued <- match work with
-    | .application application =>
-        let some queued := state.queued[application.index]? | throw .applications
-        pure queued
-    | .equality equality =>
-        let some queued := state.equalityQueued[equality.index]? | throw .equalities
-        pure queued
-  if alreadyQueued then
-    pure
-      { state with
-        metrics :=
+def enqueue (state : Engine Fact) (work : Hex.Interval.State.Work) : Except Hex.Interval.State.Resource (Engine Fact) := do
+  let suppressed := (Hex.Interval.State.Queue.dirty? state.toDependencies work).getD false
+  let (dependencies, queue) <-
+    match state.toQueue.enqueueWithin state.limits.maxQueueEntries
+        state.applications.size state.equalities.size state.toDependencies work with
+    | .ok result => pure result
+    | .error (.resource resource) => throw resource
+    | .error .malformed =>
+        throw <| match work with
+          | .application _ => .applications
+          | .equality _ => .equalities
+  pure
+    { state with
+      toDependencies := dependencies
+      toQueue := queue
+      metrics :=
+        if suppressed then
           { state.metrics with
-            suppressedInsertions := state.metrics.suppressedInsertions + 1 } }
-  else if state.limits.maxQueueEntries <= state.queue.size then
-    throw .queueEntries
-  else
-    let state <- match work with
-      | .application application =>
-          pure { state with queued := state.queued.set! application.index true }
-      | .equality equality =>
-          pure { state with equalityQueued := state.equalityQueued.set! equality.index true }
-    pure
-      { state with
-        queue := state.queue.push work
-        metrics :=
+            suppressedInsertions := state.metrics.suppressedInsertions + 1 }
+        else
           { state.metrics with
             queueInsertions := state.metrics.queueInsertions + 1 } }
 
 /-- Wake precisely the applications registered on one changed node. -/
 def wakeNode (state : Engine Fact) (node : NodeId) :
-    Except Resource (Engine Fact) := do
+    Except Hex.Interval.State.Resource (Engine Fact) := do
   let some applications := state.watchers[node.index]?
     | throw .nodes
   applications.foldlM enqueue state
@@ -1125,7 +963,7 @@ def wakeNode (state : Engine Fact) (node : NodeId) :
 installed.  Queue suppression ensures that a multi-output contractor creates
 at most one pending call per affected application. -/
 def wakeNodes (state : Engine Fact) (nodes : List NodeId) :
-    Except Resource (Engine Fact) :=
+    Except Hex.Interval.State.Resource (Engine Fact) :=
   nodes.foldlM wakeNode state
 
 end Engine
@@ -1138,7 +976,7 @@ inductive Poll (Fact : Type) where
   | saturated (state : Engine Fact)
   | contradiction (state : Engine Fact)
   | awaitingReply (state : Engine Fact)
-  | resourceLimit (resource : Resource) (state : Engine Fact)
+  | resourceLimit (resource : Hex.Interval.State.Resource) (state : Engine Fact)
   | invalidState (state : Engine Fact)
 
 namespace Engine
@@ -1167,13 +1005,10 @@ def issueApplication (state : Engine Fact) (applicationId : ApplicationId)
       matcherEpoch }
   let next : Engine Fact :=
     { state with
-      queueHead := state.queueHead + 1
-      queued := state.queued.set! applicationId.index false
       pending := some action
       pendingMatcher := matcherNext
       metrics :=
         { state.metrics with
-          queuePops := state.metrics.queuePops + 1
           requests := state.metrics.requests + 1 } }
   .request
     { action
@@ -1189,42 +1024,48 @@ def poll (state : Engine Fact) : Poll Fact :=
     .awaitingReply state
   else if state.contradictory then
     .contradiction state
-  else if state.queue.size <= state.queueHead then
-    .saturated state
-  else if state.limits.maxActions <= state.metrics.queuePops then
-    .resourceLimit .actions state
   else
-    match state.queue[state.queueHead]? with
-    | none => .invalidState state
-    | some (.equality equalityId) =>
-        match state.equalities[equalityId.index]?, state.equalityQueued[equalityId.index]? with
-        | some _, some true =>
-            .equality equalityId
-              { state with
-                queueHead := state.queueHead + 1
-                equalityQueued := state.equalityQueued.set! equalityId.index false
-                metrics :=
-                  { state.metrics with
-                    queuePops := state.metrics.queuePops + 1
-                    equalityRuns := state.metrics.equalityRuns + 1 } }
-        | _, _ => .invalidState state
-    | some (.application applicationId) =>
-        match state.applications[applicationId.index]?,
-            state.queued[applicationId.index]? with
-        | some application, some true =>
-            match state.rules[application.rule.index]?, state.seenVersions? application.watches,
-                state.factViews? application.watches with
-            | some rule, some inputs, some views =>
-                match state.prepareMatch applicationId rule with
-                | .ordinary =>
-                    issueApplication state applicationId application rule inputs views
-                | .batch structuralInputs epoch next =>
-                    issueApplication state applicationId application rule inputs views
-                      structuralInputs (some epoch) (some next)
-                | .resourceLimit => .resourceLimit .matcherVisits state
-                | .invalid => .invalidState state
-            | _, _, _ => .invalidState state
-        | _, _ => .invalidState state
+    match state.toQueue.pop state.limits.maxQueueEntries state.applications.size
+        state.equalities.size state.toDependencies with
+    | .error _ => .invalidState state
+    | .ok (none, dependencies, queue) =>
+        .saturated { state with toDependencies := dependencies, toQueue := queue }
+    | .ok (some work, dependencies, queue) =>
+        if state.limits.maxActions <= state.metrics.queuePops then
+          .resourceLimit .actions state
+        else
+          let popped : Engine Fact :=
+            { state with
+              toDependencies := dependencies
+              toQueue := queue
+              metrics := { state.metrics with queuePops := state.metrics.queuePops + 1 } }
+          match work with
+          | .equality equalityId =>
+              match state.equalities[equalityId.index]? with
+              | some _ =>
+                  .equality equalityId
+                    { popped with
+                      metrics :=
+                        { popped.metrics with
+                          equalityRuns := popped.metrics.equalityRuns + 1 } }
+              | none => .invalidState state
+          | .application applicationId =>
+              match state.applications[applicationId.index]? with
+              | some application =>
+                  match state.rules[application.rule.index]?,
+                      state.seenVersions? application.watches,
+                      state.factViews? application.watches with
+                  | some rule, some inputs, some views =>
+                      match state.prepareMatch applicationId rule with
+                      | .ordinary =>
+                          issueApplication popped applicationId application rule inputs views
+                      | .batch structuralInputs epoch next =>
+                          issueApplication popped applicationId application rule inputs views
+                            structuralInputs (some epoch) (some next)
+                      | .resourceLimit => .resourceLimit .matcherVisits state
+                      | .invalid => .invalidState state
+                  | _, _, _ => .invalidState state
+              | none => .invalidState state
 
 end Engine
 
@@ -1251,7 +1092,7 @@ inductive ReplyError where
 inductive ReplyResult (Fact : Type) where
   | accepted (plan : SuggestionPlan) (state : Engine Fact)
   | invalid (error : ReplyError) (state : Engine Fact)
-  | resourceLimit (resource : Resource) (state : Engine Fact)
+  | resourceLimit (resource : Hex.Interval.State.Resource) (state : Engine Fact)
   | factResourceLimit (budget : Nat) (state : Engine Fact)
 
 /-- One endpoint update computed by an equality contractor from a common
@@ -1281,7 +1122,7 @@ inductive EqualityFault where
 inductive EqualityResult (Fact : Type) where
   | advanced (narrowCalls : Nat) (state : Engine Fact)
   | invalid (fault : EqualityFault) (narrowCalls : Nat) (state : Engine Fact)
-  | resourceLimit (resource : Resource) (narrowCalls : Nat) (state : Engine Fact)
+  | resourceLimit (resource : Hex.Interval.State.Resource) (narrowCalls : Nat) (state : Engine Fact)
   | factResourceLimit (budget : Nat) (narrowCalls : Nat) (state : Engine Fact)
 
 def existingRefBounded (nodeCount : Nat) : NodeRef -> Bool
@@ -1302,7 +1143,7 @@ def proposalBounded (nodeCount itemLimit scopeLimit : Nat)
         scope.watches.all (existingRefBounded nodeCount) &&
         scope.writes.all (existingRefBounded nodeCount))
 
-def suggestionBounded (limits : Limits) (nodeCount : Nat) : Suggestion -> Bool
+def suggestionBounded (limits : Hex.Interval.State.Limits) (nodeCount : Nat) : Suggestion -> Bool
   | .retry effort => effort <= limits.maxEffort
   | .split request =>
       request.node.index < nodeCount &&
@@ -1310,7 +1151,7 @@ def suggestionBounded (limits : Limits) (nodeCount : Nat) : Suggestion -> Bool
   | .instantiate request =>
       proposalBounded nodeCount limits.maxProposalItems limits.maxScopeNodes request
 
-def suggestionsBounded (limits : Limits) (nodeCount : Nat)
+def suggestionsBounded (limits : Hex.Interval.State.Limits) (nodeCount : Nat)
     (suggestions : List Suggestion) : Bool :=
   suggestions.all (suggestionBounded limits nodeCount)
 
@@ -1463,7 +1304,7 @@ unseen inputs, or became exhausted while the network grew past its frozen
 limit, requeue the same global matcher through the ordinary bounded worklist. -/
 def commitMatcher (state : Engine Fact) (action : Action)
     (matcherNext : Option MatcherCursor) :
-    Except Resource (Engine Fact) := do
+    Except Hex.Interval.State.Resource (Engine Fact) := do
   match matcherNext with
   | none =>
       if action.structuralInputs.isEmpty && action.matcherEpoch.isNone then
@@ -1558,26 +1399,36 @@ def candidatesAuthorized (writes : List NodeId) (candidates : List (Candidate Fa
 
 def installImprovement (action : Action) (candidate : Candidate Fact)
     (fact : Fact) (contradiction : Bool) (state : Engine Fact) :
-    Except (ReplyError × Option Nat × Option Resource) (Engine Fact) := do
+    Except (ReplyError × Option Nat × Option Hex.Interval.State.Resource) (Engine Fact) := do
   if state.limits.maxAcceptedFacts <= state.history.size then
     throw (.malformedFact 0, none, some .acceptedFacts)
   else
     let version := state.versions[candidate.node.index]! + 1
     let previous : SeenVersion :=
       { node := candidate.node, version := state.versions[candidate.node.index]! }
+    let event : Hex.Interval.State.Update Fact (FactCause Fact) :=
+      { programVersion := action.programVersion
+        node := candidate.node
+        previous
+        fact
+        version
+        cause := .rule action candidate.fact candidate.payload }
+    let branch <-
+      match state.toBranch.pushWithin state.limits event contradiction with
+      | .ok branch => pure branch
+      | .error _ => throw (.malformedFact 0, none, none)
+    let order <-
+      match state.toOrder.appendFact
+          { maxFacts := state.limits.maxAcceptedFacts
+            maxInstances := state.limits.maxInstances }
+          state.history.size with
+      | .ok order => pure order
+      | .error .facts => throw (.malformedFact 0, none, some .acceptedFacts)
+      | .error _ => throw (.malformedFact 0, none, none)
     pure
       { state with
-        facts := state.facts.set! candidate.node.index fact
-        versions := state.versions.set! candidate.node.index version
-        history := state.history.push
-          { programVersion := action.programVersion
-            node := candidate.node
-            previous
-            fact
-            version
-            cause := .rule action candidate.fact candidate.payload }
-        chronology := state.chronology.push (.fact state.history.size)
-        contradictory := state.contradictory || contradiction
+        toBranch := branch
+        toOrder := order
         metrics :=
           { state.metrics with
             improvements := state.metrics.improvements + 1
@@ -1588,7 +1439,7 @@ def installImprovement (action : Action) (candidate : Candidate Fact)
 discards the returned working state and keeps the reply-cleared base state. -/
 def installCandidates (action : Action) :
     Engine Fact -> List (Candidate Fact) ->
-      Except (ReplyError × Option Nat × Option Resource) (Engine Fact × List NodeId)
+      Except (ReplyError × Option Nat × Option Hex.Interval.State.Resource) (Engine Fact × List NodeId)
   | state, [] => pure (state, [])
   | state, candidate :: candidates => do
       let some current := state.facts[candidate.node.index]?
@@ -1757,26 +1608,31 @@ def transportUpdate (target source : NodeId) (targetVersion sourceVersion : Nat)
 
 /-- Install one already-preflighted transport update without waking. -/
 def installTransport (equality : EqualityId) (update : TransportUpdate Fact)
-    (state : Engine Fact) : Engine Fact :=
+    (state : Engine Fact) : Option (Engine Fact) := do
   let version := update.previous.version + 1
-  { state with
-    facts := state.facts.set! update.target.index update.fact
-    versions := state.versions.set! update.target.index version
-    history := state.history.push
-      { programVersion := state.programVersion
-        node := update.target
-        previous := update.previous
-        fact := update.fact
-        version
-        cause := .transport equality update.source }
-    chronology := state.chronology.push (.fact state.history.size)
-    contradictory := state.contradictory || update.contradiction
-    metrics :=
-      { state.metrics with
-        improvements := state.metrics.improvements + 1
-        equalityImprovements := state.metrics.equalityImprovements + 1
-        contradictions :=
-          state.metrics.contradictions + if update.contradiction then 1 else 0 } }
+  let event : Hex.Interval.State.Update Fact (FactCause Fact) :=
+    { programVersion := state.programVersion
+      node := update.target
+      previous := update.previous
+      fact := update.fact
+      version
+      cause := .transport equality update.source }
+  let branch <- (state.toBranch.pushWithin state.limits event update.contradiction).toOption
+  let order <-
+    (state.toOrder.appendFact
+      { maxFacts := state.limits.maxAcceptedFacts
+        maxInstances := state.limits.maxInstances }
+      state.history.size).toOption
+  pure
+    { state with
+      toBranch := branch
+      toOrder := order
+      metrics :=
+        { state.metrics with
+          improvements := state.metrics.improvements + 1
+          equalityImprovements := state.metrics.equalityImprovements + 1
+          contradictions :=
+            state.metrics.contradictions + if update.contradiction then 1 else 0 } }
 
 /-- Contract both endpoints of one admitted equality against the same facts,
 commit all improvements together, then wake their dependency union. -/
@@ -1825,12 +1681,14 @@ def contractEquality (state : Engine Fact) (equalityId : EqualityId) :
                     if state.limits.maxAcceptedFacts < state.history.size + updates.length then
                       .resourceLimit .acceptedFacts 2 state
                     else
-                      let working := updates.foldl
-                        (fun state update => installTransport equalityId update state) state
-                      let changed := updates.map fun update => update.target
-                      match working.wakeNodes changed with
-                      | .error resource => .resourceLimit resource 2 state
-                      | .ok next => .advanced 2 next
+                      match updates.foldlM
+                          (fun state update => installTransport equalityId update state) state with
+                      | none => .invalid .missingState 2 state
+                      | some working =>
+                          let changed := updates.map fun update => update.target
+                          match working.wakeNodes changed with
+                          | .error resource => .resourceLimit resource 2 state
+                          | .ok next => .advanced 2 next
       | _, _, _, _, _, _ => .invalid .missingState 0 state
 
 end Engine
@@ -1846,7 +1704,7 @@ point. -/
 inductive RunStop where
   | saturated
   | contradiction
-  | engineResource (resource : Resource)
+  | engineResource (resource : Hex.Interval.State.Resource)
   | factResource (budget : Nat)
   | invalidReply (error : ReplyError)
   | invalidEngine
@@ -1914,7 +1772,7 @@ inductive AdmissionResult (Fact : Type) where
   | admitted (newNodes : List NodeId) (state : Engine Fact)
   | duplicate (state : Engine Fact)
   | invalid (error : AdmissionError) (state : Engine Fact)
-  | resourceLimit (resource : Resource) (state : Engine Fact)
+  | resourceLimit (resource : Hex.Interval.State.Resource) (state : Engine Fact)
 
 /-- Existing references named directly by one draft reference list. -/
 def existingRefs (refs : List NodeRef) : List NodeId :=
@@ -2015,7 +1873,7 @@ def newTopFacts (domain : FactDomain Fact) (baseSize : Nat)
 
 /-- Queue every newly compiled concrete application. -/
 def enqueueNewApplications (oldCount newCount : Nat) (state : Engine Fact) :
-    Except Resource (Engine Fact) :=
+    Except Hex.Interval.State.Resource (Engine Fact) :=
   (List.range newCount).foldlM
     (fun state offset => state.enqueue (.application { index := oldCount + offset })) state
 
@@ -2033,13 +1891,13 @@ def dormantProgramWatchers? (state : Engine Fact) : Option (List ApplicationId) 
   pure watchers.reverse
 
 def enqueueApplications (applications : List ApplicationId) (state : Engine Fact) :
-    Except Resource (Engine Fact) :=
+    Except Hex.Interval.State.Resource (Engine Fact) :=
   applications.foldlM
     (fun state application => state.enqueue (.application application)) state
 
 /-- Queue every newly admitted equality contractor. -/
 def enqueueNewEqualities (oldCount newCount : Nat) (state : Engine Fact) :
-    Except Resource (Engine Fact) :=
+    Except Hex.Interval.State.Resource (Engine Fact) :=
   (List.range newCount).foldlM
     (fun state offset => state.enqueue (.equality { index := oldCount + offset })) state
 
@@ -2179,97 +2037,111 @@ def admitRetained (state : Engine Fact)
                                                           state.applications.size then
                                                         .invalid .invalidCompiledProgram state
                                                       else
-                                                      let generated :=
-                                                        newNodeIds baseSize program.nodes.size
-                                                      let freshScopeIds : List ApplicationId :=
-                                                        (List.range addedScopes).map fun offset =>
-                                                          { index :=
-                                                              state.applications.size + offset }
-                                                      let freshEqualityIds : List EqualityId :=
-                                                        (List.range equalities.length).map fun offset =>
-                                                          { index :=
-                                                              state.equalities.size + offset }
-                                                      let queued := state.queued ++
-                                                        Array.replicate addedApplications false
-                                                      let equalityQueued := state.equalityQueued ++
-                                                        Array.replicate equalities.length false
-                                                      let prospective : Engine Fact :=
-                                                        { state with
-                                                          programVersion :=
-                                                            state.programVersion + 1
-                                                          program
-                                                          bindings := state.bindings ++
-                                                            scopeResolution.freshBindings.toArray
-                                                          applications
-                                                          matcherCursors :=
-                                                            state.matcherCursors ++ matcherSuffix
-                                                          watchers
-                                                          facts := state.facts ++ newTopFacts
-                                                            state.factDomain baseSize program.nodes
-                                                          versions := state.versions ++
-                                                            Array.replicate addedNodes 0
-                                                          generations := state.generations ++
-                                                            Array.replicate addedNodes generation
-                                                          depths
-                                                          queued
-                                                          equalityQueued
-                                                          instances :=
-                                                            instanceKey :: state.instances
-                                                          instanceHistory :=
-                                                            state.instanceHistory.push
-                                                              { programVersion :=
-                                                                  state.programVersion + 1
-                                                                origin := retained.action
-                                                                family := request.key
-                                                                substitution
-                                                                products := resolved
-                                                                newNodes := generated
-                                                                bindings := requestedScopes
-                                                                newBindings :=
-                                                                  scopeResolution.freshBindings
-                                                                applications :=
-                                                                  scopeResolution.outputs
-                                                                newApplications := freshScopeIds
-                                                                generation
-                                                                equalities := equalityIds
-                                                                newEqualities := freshEqualityIds
-                                                                payload := request.payload }
-                                                          chronology :=
-                                                            state.chronology.push
-                                                              (.instance
-                                                                state.instanceHistory.size)
-                                                          equalities := allEqualities
-                                                          metrics :=
-                                                            { state.metrics with
-                                                              admittedInstances :=
-                                                                state.metrics.admittedInstances + 1
-                                                              generatedNodes :=
-                                                                state.metrics.generatedNodes +
-                                                                  addedNodes
-                                                              generatedScopes :=
-                                                                state.metrics.generatedScopes +
-                                                                  addedScopes
-                                                              generatedEqualities :=
-                                                                state.metrics.generatedEqualities +
-                                                                  equalities.length } }
-                                                      match enqueueNewEqualities
-                                                          state.equalities.size equalities.length
-                                                          prospective with
-                                                      | .error resource =>
-                                                          .resourceLimit resource state
-                                                      | .ok prospective =>
-                                                          match enqueueNewApplications
-                                                              state.applications.size
-                                                              addedApplications prospective with
-                                                          | .error resource =>
-                                                              .resourceLimit resource state
-                                                          | .ok prospective =>
-                                                              match enqueueApplications
-                                                                  programWatchers prospective with
-                                                              | .error resource =>
-                                                                  .resourceLimit resource state
-                                                              | .ok next =>
-                                                                  .admitted generated next
+                                                        let generated :=
+                                                          newNodeIds baseSize program.nodes.size
+                                                        let freshScopeIds : List ApplicationId :=
+                                                          (List.range addedScopes).map fun offset =>
+                                                            { index :=
+                                                                state.applications.size + offset }
+                                                        let freshEqualityIds : List EqualityId :=
+                                                          (List.range equalities.length).map fun offset =>
+                                                            { index :=
+                                                                state.equalities.size + offset }
+                                                        let queued := state.queued ++
+                                                          Array.replicate addedApplications false
+                                                        let equalityQueued := state.equalityQueued ++
+                                                          Array.replicate equalities.length false
+                                                        let freshFacts := newTopFacts
+                                                          state.factDomain baseSize program.nodes
+                                                        match state.toBranch.extendWithin state.limits
+                                                            program freshFacts generation with
+                                                        | .error _ =>
+                                                            .invalid .invalidCompiledProgram state
+                                                        | .ok branch =>
+                                                          match state.toOrder.appendInstance
+                                                              { maxFacts :=
+                                                                  state.limits.maxAcceptedFacts
+                                                                maxInstances :=
+                                                                  state.limits.maxInstances }
+                                                              state.instanceHistory.size with
+                                                          | .error .instances =>
+                                                              .resourceLimit .instances state
+                                                          | .error _ =>
+                                                              .invalid .invalidCompiledProgram state
+                                                          | .ok order =>
+                                                            let prospective : Engine Fact :=
+                                                              { state with
+                                                                toBranch := branch
+                                                                bindings := state.bindings ++
+                                                                  scopeResolution.freshBindings.toArray
+                                                                applications
+                                                                matcherCursors :=
+                                                                  state.matcherCursors ++ matcherSuffix
+                                                                watchers
+                                                                queued
+                                                                equalityQueued
+                                                                instances :=
+                                                                  instanceKey :: state.instances
+                                                                instanceHistory :=
+                                                                  state.instanceHistory.push
+                                                                    { programVersion :=
+                                                                        state.programVersion + 1
+                                                                      origin := retained.action
+                                                                      family := request.key
+                                                                      substitution
+                                                                      products := resolved
+                                                                      newNodes := generated
+                                                                      bindings := requestedScopes
+                                                                      newBindings :=
+                                                                        scopeResolution.freshBindings
+                                                                      applications :=
+                                                                        scopeResolution.outputs
+                                                                      newApplications := freshScopeIds
+                                                                      generation
+                                                                      equalities := equalityIds
+                                                                      newEqualities := freshEqualityIds
+                                                                      payload := request.payload }
+                                                                toOrder := order
+                                                                equalities := allEqualities
+                                                                metrics :=
+                                                                  { state.metrics with
+                                                                    admittedInstances :=
+                                                                      state.metrics.admittedInstances + 1
+                                                                    generatedNodes :=
+                                                                      state.metrics.generatedNodes +
+                                                                        addedNodes
+                                                                    generatedScopes :=
+                                                                      state.metrics.generatedScopes +
+                                                                        addedScopes
+                                                                    generatedEqualities :=
+                                                                      state.metrics.generatedEqualities +
+                                                                        equalities.length } }
+                                                            if !prospective.toDependencies.check
+                                                                program.nodes.size applications.size
+                                                                  allEqualities.size ||
+                                                                !prospective.toQueue.check
+                                                                  prospective.toDependencies
+                                                                  applications.size allEqualities.size
+                                                                    prospective.limits.maxQueueEntries then
+                                                              .invalid .invalidCompiledProgram state
+                                                            else match enqueueNewEqualities
+                                                                state.equalities.size equalities.length
+                                                                  prospective with
+                                                            | .error resource =>
+                                                                .resourceLimit resource state
+                                                            | .ok prospective =>
+                                                                match enqueueNewApplications
+                                                                    state.applications.size
+                                                                    addedApplications prospective with
+                                                                | .error resource =>
+                                                                    .resourceLimit resource state
+                                                                | .ok prospective =>
+                                                                    match enqueueApplications
+                                                                        programWatchers prospective with
+                                                                    | .error resource =>
+                                                                        .resourceLimit resource state
+                                                                    | .ok next =>
+                                                                        .admitted generated next
 
 /-- Select one proposal retained in this concrete engine snapshot.  This
 experiment keeps `Engine` inspectable for benchmarks, so callers can still

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -612,6 +612,10 @@ plain-data contracts; package callbacks and structural arenas remain here. -/
 structure Engine (Fact : Type) extends
     Hex.Interval.State.Branch Fact (FactCause Fact), Hex.Interval.State.Dependencies, Hex.Interval.State.Queue,
       Hex.Interval.Trace.Order where
+  /-- Eager runtime cache of the current facts. The supported branch keeps
+  seeds and history authoritative; this experimental cache never becomes
+  proof evidence. Engine transitions update both together. -/
+  facts : Array Fact
   factDomain : FactDomain Fact
   rules : Array Registration
   /-- Concrete scoped bindings in admission order.  Start-time bindings form
@@ -770,13 +774,14 @@ def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Arr
     | .ok queue => pure queue
     | .error resource => throw (.resourceLimit resource)
   if !dependencies.check program.nodes.size applications.size 0 ||
-      !queue.check dependencies applications.size 0 limits.maxQueueEntries then
+      !queue.check dependencies program.nodes.size applications.size 0 limits.maxQueueEntries then
     throw .invalidRegistrations
   pure
     { toBranch := branch
       toDependencies := dependencies
       toQueue := queue
       toOrder := Hex.Interval.Trace.Order.empty
+      facts
       factDomain
       rules
       bindings
@@ -933,7 +938,8 @@ def enqueue (state : Engine Fact) (work : Hex.Interval.State.Work) : Except Hex.
   let suppressed := (Hex.Interval.State.Queue.dirty? state.toDependencies work).getD false
   let (dependencies, queue) <-
     match state.toQueue.enqueueWithin state.limits.maxQueueEntries
-        state.applications.size state.equalities.size state.toDependencies work with
+        state.program.nodes.size state.applications.size state.equalities.size
+          state.toDependencies work with
     | .ok result => pure result
     | .error (.resource resource) => throw resource
     | .error .malformed =>
@@ -1025,8 +1031,8 @@ def poll (state : Engine Fact) : Poll Fact :=
   else if state.contradictory then
     .contradiction state
   else
-    match state.toQueue.pop state.limits.maxQueueEntries state.applications.size
-        state.equalities.size state.toDependencies with
+    match state.toQueue.pop state.limits.maxQueueEntries state.program.nodes.size
+        state.applications.size state.equalities.size state.toDependencies with
     | .error _ => .invalidState state
     | .ok (none, dependencies, queue) =>
         .saturated { state with toDependencies := dependencies, toQueue := queue }
@@ -1428,6 +1434,7 @@ def installImprovement (action : Action) (candidate : Candidate Fact)
     pure
       { state with
         toBranch := branch
+        facts := state.facts.set! candidate.node.index fact
         toOrder := order
         metrics :=
           { state.metrics with
@@ -1626,6 +1633,7 @@ def installTransport (equality : EqualityId) (update : TransportUpdate Fact)
   pure
     { state with
       toBranch := branch
+      facts := state.facts.set! update.target.index update.fact
       toOrder := order
       metrics :=
         { state.metrics with
@@ -2072,6 +2080,7 @@ def admitRetained (state : Engine Fact)
                                                             let prospective : Engine Fact :=
                                                               { state with
                                                                 toBranch := branch
+                                                                facts := state.facts ++ freshFacts
                                                                 bindings := state.bindings ++
                                                                   scopeResolution.freshBindings.toArray
                                                                 applications
@@ -2121,7 +2130,8 @@ def admitRetained (state : Engine Fact)
                                                                   allEqualities.size ||
                                                                 !prospective.toQueue.check
                                                                   prospective.toDependencies
-                                                                  applications.size allEqualities.size
+                                                                  program.nodes.size applications.size
+                                                                    allEqualities.size
                                                                     prospective.limits.maxQueueEntries then
                                                               .invalid .invalidCompiledProgram state
                                                             else match enqueueNewEqualities

--- a/HexInterval/Experiment/SemanticReplay.lean
+++ b/HexInterval/Experiment/SemanticReplay.lean
@@ -540,17 +540,17 @@ end Registry
 facts, and target are intentionally absent; they remain in `CheckerInput`. -/
 structure Trace (Fact : Type) where
   program : Program
-  events : Array (FactEvent Fact)
+  events : Array (Hex.Interval.State.Update Fact (FactCause Fact))
   arena : Arena
 
 namespace Trace
 
 /-- Read an event only when its index is strictly before the replay cursor.
 Even if the untrusted array contains a future entry, it is inaccessible. -/
-def eventAt? (trace : Trace Fact) (cursor index : Nat) : Option (FactEvent Fact) :=
+def eventAt? (trace : Trace Fact) (cursor index : Nat) : Option (Hex.Interval.State.Update Fact (FactCause Fact)) :=
   if index < cursor then trace.events[index]? else none
 
-def findVersionPrefix? (events : Array (FactEvent Fact)) (seen : SeenVersion) :
+def findVersionPrefix? (events : Array (Hex.Interval.State.Update Fact (FactCause Fact))) (seen : SeenVersion) :
     Nat -> Nat -> Option Fact
   | 0, _ => none
   | cursor + 1, index =>

--- a/HexInterval/Experiment/SinTenInterval.lean
+++ b/HexInterval/Experiment/SinTenInterval.lean
@@ -266,7 +266,7 @@ def negationPackage : Package Bound :=
 def packages : Array (Package Bound) :=
   #[sourcePackage, localPackage, constantPackage, reductionPackage, negationPackage]
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 5, maxNodes := 6, maxRules := 5, maxRegistryEntries := 24,
     maxReplayFormats := 8, maxArity := 2, maxScopeNodes := 1,
     maxApplications := 12, maxQueueEntries := 96, maxActions := 80,

--- a/HexInterval/Experiment/SineSign.lean
+++ b/HexInterval/Experiment/SineSign.lean
@@ -303,7 +303,7 @@ def packages : Array (Package Range) :=
 
 /-! ## A bounded proof-producing session -/
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 3
     maxNodes := 5
     maxRules := 3

--- a/HexInterval/Experiment/TargetRun.lean
+++ b/HexInterval/Experiment/TargetRun.lean
@@ -67,7 +67,7 @@ inductive Stop (Fact : Type)
   | policyStop (liveOffers : Nat)
   | incomplete
   | viewResource (error : Propagator.Policy.ViewError)
-  | engineResource (resource : Propagator.Resource)
+  | engineResource (resource : Hex.Interval.State.Resource)
   | factResource (budget : Nat)
   | payloadResource (resource : PayloadArena.Resource)
   | invalidReply (error : ReplyError)

--- a/HexInterval/Experiment/TraceReplay.lean
+++ b/HexInterval/Experiment/TraceReplay.lean
@@ -33,9 +33,9 @@ open Propagator PayloadArena SemanticReplay ChronologicalReplay
 structure Trace (Fact : Type) where
   programVersion : Nat
   program : Program
-  facts : Array (FactEvent Fact)
+  facts : Array (Hex.Interval.State.Update Fact (FactCause Fact))
   instances : Array InstanceEvent
-  chronology : Array HistoryEvent
+  chronology : Array Hex.Interval.Trace.Ref
   equalities : Array EqualityEdge
   arena : Arena
 
@@ -162,7 +162,7 @@ def replayEvent {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (laws : Laws semantics)
     (buildInstance : InstanceBuilder semantics) (trace : Trace Fact)
-    (checked : State semantics input base) (entry : HistoryEvent) :
+    (checked : State semantics input base) (entry : Hex.Interval.Trace.Ref) :
     Option (State semantics input base) := do
   match entry with
   | .fact index =>
@@ -211,7 +211,7 @@ def replayEvents {Fact : Type} {semantics : Semantics Fact}
     (registry : SemanticReplay.Registry semantics)
     (domain : FactDomainSchema semantics) (laws : Laws semantics)
     (buildInstance : InstanceBuilder semantics) (trace : Trace Fact) :
-    List HistoryEvent -> State semantics input base ->
+    List Hex.Interval.Trace.Ref -> State semantics input base ->
       Option (State semantics input base)
   | [], checked => some checked
   | entry :: entries, checked => do

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -63,17 +63,19 @@ keys. Dyadic, rational, elementary-function, and Mathlib theorem backends plug
 into that framework; backend-specific replay experiments do not block or
 define the scheduler architecture.
 
-The current supported Mathlib-free boundary now includes the structural half
-of that milestone: checked typed SSA `Program`s; versioned fact snapshots and
-projected views; stable operation/rule keys; registrations and explicit scope
-bindings; and immutable actions and package requests. These records
-deliberately contain neither function callbacks nor proof evidence. Concrete
-dependency storage, worklists, resource counters, package assembly, callback
-outcomes and proposals, scheduling, policy, branch search, payload storage,
-and replay are still experimental; their current types are not supported APIs
-and do not determine the eventual storage or default policy. In particular,
-the current instantiation proposal's package-supplied numeric policy family is
-not part of the supported action contract.
+The current supported Mathlib-free boundary includes checked typed SSA
+`Program`s; versioned fact snapshots and projected views; stable
+operation/rule keys; registrations and explicit scope bindings; immutable
+actions and package requests; and checked immutable branch, dependency,
+work-queue, chronology, and bounded diagnostic snapshots. These records
+deliberately contain neither function callbacks nor proof evidence. The state
+records are a stable decoded interchange and validation contract; they do not
+select the eventual mutable, persistent, paged, or trail-backed implementation
+used inside a high-performance branch search. Package assembly, callback
+outcomes and proposals, policy choice, sessions, branch search, payload
+storage, proof replay, and that optimized backing store remain experimental.
+In particular, the current instantiation proposal's package-supplied numeric
+policy family is not part of the supported action contract.
 
 The active implementation gate is to harden and compare the first complete
 arbitrary-function vertical: independently assembled forward and backward
@@ -971,6 +973,47 @@ Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
 which reads the whole view declares `watchesProgram`, making program extension
 an explicit dependency.
 
+### Supported state and trace snapshots
+
+`State.Branch Fact Cause` is the function-independent decoded branch contract.
+It retains the exact base program and caller facts, current append-only
+program, an immutable version-zero seed for every base or generated node,
+current facts and versions, structural generations and depths, exact updates,
+and the contradiction search flag. `Cause` is opaque data at this layer.
+`Branch.check` reconstructs every current version from the ordered predecessor
+links and validates the base/program prefix and all aligned arrays. It does not
+interpret a fact or provenance cause as evidence.
+
+`Branch.startWithin`, `pushWithin`, and `extendWithin` are transactional.
+Structural count/arity/depth/generation caps are checked before allocating
+aligned arrays; fact-history capacity is checked before appending an update;
+and a stale node/version, wrong program version, malformed current branch, or
+non-prefix extension returns no replacement branch. Generated version-zero
+facts are retained in the seed array rather than reconstructed by a later
+callback. This makes quotation independent of mutable package state.
+
+`State.Dependencies` retains node-aligned watcher lists and separate dirty bits
+for application and equality work. `State.Queue` is an append-only bounded work
+log plus its FIFO cursor. A policy may consume work out of FIFO order through
+`Queue.deactivate`, leaving a checked tombstone. A later wake appends a fresh
+occurrence; `Queue.pop` skips tombstones and clears exactly the next still-dirty
+item. Queue construction, enqueue, deactivation, and pop validate reference,
+array, live-bit, cursor, and retained-count alignment before returning a new
+snapshot. The append-only array is the current decoded/reference
+representation, not a decision against a compacting or persistent production
+queue with the same behavior.
+
+`Trace.Order` is the authoritative interleaving of fact updates and program
+instances. Its checked append operations require the exact next role-local
+index and independent fact/instance history caps. The role-specific histories
+retain payload and provenance; the order alone carries no proof authority.
+`Trace.Log` is a separate diagnostic stream with exact event-count,
+already-allocated payload-byte, declared-work, and code limits. Refusal marks
+the diagnostic stream truncated without changing any branch or chronology.
+Because byte admission occurs after an event exists, arbitrary callback and
+Lean-object construction is explicitly non-preemptible and remains the
+package's bounded responsibility.
+
 The transparent structural-cursor module is the reference semantics for
 bounded whole-network matching. Within each epoch it enumerates the
 append-only node, equality, and concrete-application identifier spaces in that
@@ -1237,8 +1280,8 @@ dependency item is therefore a sum:
 structure EqualityId where
   index : Nat
 
-inductive WorkItem
-  | rule     (application : ApplicationId)
+inductive State.Work
+  | application (application : ApplicationId)
   | equality (edge : EqualityId)
 ```
 
@@ -3234,7 +3277,14 @@ is merely the current bounded aggregate derived from earlier events, not a
 second observation channel. Successful and fixed-point cost components are
 checked against `maxObservationValue`; candidate, suggestion, and proposal
 counts have separate structural caps, and negative identifiers have their own
-diagnostic cap. The current event protocol has no general encoded-byte cap.
+diagnostic cap. The supported `Trace.Log` contract provides exact retained
+event-count, payload-byte, logical-work, and code limits with explicit
+truncation. The current experimental `PolicyEvent` protocol does not yet
+encode into that log: it retains exact fact values and therefore still has no
+general byte cap. `Trace.Log.append` sees an already allocated byte payload,
+so it cannot preempt arbitrary callback, `Fact`, `String`, or Lean-object
+construction. Packages must bound that explicitly non-preemptible construction
+envelope before returning; controller retention begins only afterward.
 
 It may be cleaner to normalize the registry result as one bounded `RuleReport`
 containing an outcome tag, candidate list, suggestion list, and cost. That
@@ -4952,15 +5002,25 @@ their declared cost inside a scheduler bound.
   registrations, scope bindings, validated immutable program/request views,
   and exact read/write projections. It has no callbacks, outcomes, policy, or
   proof evidence.
+- `HexInterval/Trace.lean`: supported exact fact/instance chronology and
+  bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
+  payload cells after callback construction; they do not claim to preempt
+  arbitrary Lean allocation.
+- `HexInterval/State.lean`: supported immutable branch seeds, current facts,
+  exact version/provenance history, structural/generation side tables,
+  dependency watchers, dirty bits, append-only work queues with policy
+  tombstones, controller resources, and transactional checked builders. These
+  decoded arrays do not select the optimized branch-storage implementation.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
-  applications, dependency indexes, worklists, counters, callback outcomes
-  and untrusted proposals, replies, extension admission, and engine state,
-  consuming the supported contracts.
+  applications, callbacks, outcomes, untrusted proposals and replies, and
+  extension admission. Its engine extends and mutates only through the
+  supported state/trace contracts, while its public record remains an
+  inspectable experimental storage candidate.
 - `HexInterval/Experiment/{PackageRegistry,PolicyDriver,PolicySession,
   StagedPolicy,AdaptivePolicy,FeaturePolicy,BranchTree}.lean`: current
   provisional package callback, policy, session, and branch-search designs.
-   Future supported state/policy/search/trace modules will be selected from
-   measurements; no storage representation or default policy is frozen yet.
+   Optimized storage, policy/search APIs, and a default policy will be selected
+   from measurements; none is frozen by the decoded supported snapshots.
 - `conformance/HexInterval/{Conformance,MinMaxConformance,EmitFixtures}.lean`:
   Lean-only checks and oracle fixtures.
 - `HexInterval/Experiment/PntFks2FamilyData*.lean` and
@@ -5003,6 +5063,14 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - malformed registration, scope, and request snapshots, including wrong
   operation/rule versions, duplicate or out-of-range ports, misaligned side
   tables, changed fact versions, and changed ordered write authority;
+- malformed or over-budget state snapshots, including stale/cross-node update
+  predecessors, wrong program versions, non-prefix extensions, exact generated
+  version-zero seed restoration, dependency/watcher misalignment, stale dirty
+  bits, policy tombstones, queue and chronology one-over limits, and reordered
+  fact/instance chronology;
+- diagnostic event count, payload-byte, logical-work, and code refusal,
+  malformed cached totals, and a truncation canary showing that diagnostic
+  loss cannot change branch facts, versions, provenance, or contradiction;
 - equal endpoints in all closure combinations;
 - empty, singleton, one-sided unbounded, and whole intervals;
 - table-driven empty laws: every unary operation and `regularize` preserve

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -977,11 +977,17 @@ an explicit dependency.
 
 `State.Branch Fact Cause` is the function-independent decoded branch contract.
 It retains the exact base program and caller facts, current append-only
-program, an immutable version-zero seed for every base or generated node,
-current facts and versions, structural generations and depths, exact updates,
-and the contradiction search flag. `Cause` is opaque data at this layer.
-`Branch.check` reconstructs every current version from the ordered predecessor
-links and validates the base/program prefix and all aligned arrays. It does not
+program, immutable version-zero seeds for the generated-node suffix, current
+versions, structural generation/depth metadata, exact updates, and the
+contradiction search flag. Base facts plus generated-node seeds and ordered
+updates are authoritative: `Branch.snapshot` reconstructs current facts rather
+than trusting an independently mutable fact cache. `Cause` is opaque data at
+this layer. `Branch.check` reconstructs every current fact and version,
+validates the base/program prefix and all aligned arrays, requires base-node
+generations to be zero, and rejects an appended generation after the current
+program version. Exact dependency-derived creation generation remains the
+experimental engine transition's responsibility; the supported decoded table
+does not independently authenticate that semantic relation. It does not
 interpret a fact or provenance cause as evidence.
 
 `Branch.startWithin`, `pushWithin`, and `extendWithin` are transactional.
@@ -989,23 +995,34 @@ Structural count/arity/depth/generation caps are checked before allocating
 aligned arrays; fact-history capacity is checked before appending an update;
 and a stale node/version, wrong program version, malformed current branch, or
 non-prefix extension returns no replacement branch. Generated version-zero
-facts are retained in the seed array rather than reconstructed by a later
-callback. This makes quotation independent of mutable package state.
+facts are retained in the suffix seed array rather than reconstructed by a
+later callback. This makes quotation independent of mutable package state.
+The experimental engine separately caches current facts for scheduler speed;
+that cache is runtime data and never replaces branch history during replay.
+Checked branch mutation preflights both the decoded base and current program
+sizes before `Branch.check` traverses either program. `restoredFacts?` checks
+the base/suffix/current size relation before concatenating the two seed arrays.
 
 `State.Dependencies` retains node-aligned watcher lists and separate dirty bits
 for application and equality work. `State.Queue` is an append-only bounded work
 log plus its FIFO cursor. A policy may consume work out of FIFO order through
-`Queue.deactivate`, leaving a checked tombstone. A later wake appends a fresh
-occurrence; `Queue.pop` skips tombstones and clears exactly the next still-dirty
-item. Queue construction, enqueue, deactivation, and pop validate reference,
-array, live-bit, cursor, and retained-count alignment before returning a new
-snapshot. The append-only array is the current decoded/reference
+`Queue.deactivate`, clearing that exact occurrence's live bit and leaving a
+checked tombstone. A later wake appends a fresh live occurrence and cannot
+resurrect the earlier tombstone; `Queue.pop` skips tombstones and clears exactly
+the next live item. Initial queue construction preflights its retained count; queue
+validation, enqueue, deactivation, and pop additionally receive the exact
+program-node count and validate watcher/reference arrays, live bits, cursor,
+and retained-count alignment before returning a new snapshot. The append-only
+array is the current decoded/reference
 representation, not a decision against a compacting or persistent production
 queue with the same behavior.
 
 `Trace.Order` is the authoritative interleaving of fact updates and program
 instances. Its checked append operations require the exact next role-local
-index and independent fact/instance history caps. The role-specific histories
+index and independent fact/instance history caps. The target-role index and
+combined retained-count cap are preflighted before scanning chronology; after
+that scan the exact role-local order and separate retained counts are checked.
+The role-specific histories
 retain payload and provenance; the order alone carries no proof authority.
 `Trace.Log` is a separate diagnostic stream with exact event-count,
 already-allocated payload-byte, declared-work, and code limits. Refusal marks
@@ -4921,9 +4938,17 @@ candidates, and `b` the number of live branch states.
   revalidates the complete `ProgramView` per selected request, including depth
   reconstruction, so the current package-boundary dispatch performs this
   whole-program work before each callback.
-- One worklist update is proportional to the number of rules attached to the
-  changed node and its consumers. The scheduler does not scan all `n` nodes
-  after every fact.
+- Dependency discovery for one changed fact visits only the rules attached to
+  that node. The current decoded/reference state does **not** yet turn this
+  semantic locality into a local mutation cost: every `Queue.enqueueWithin`,
+  deactivation, and pop revalidates the complete dependency/dirty arrays and
+  retained queue, including all watcher lists and `q` entries. Every accepted
+  fact through `Branch.pushWithin` revalidates both base and current programs,
+  reconstructs current facts and versions from the retained history, and
+  checks the complete generation/depth tables; chronology append separately
+  scans its retained order. Avoiding these whole-state scans is a requirement
+  for the selected production store and queue, not a property of the current
+  transparent reference builders.
 - Fact comparison and contradiction checks use exact endpoint comparison. For
   the dyadic candidate, integer cost is proportional to effective endpoint
   height and the permitted exponent-alignment shift; a rational candidate must
@@ -5006,8 +5031,9 @@ their declared cost inside a scheduler bound.
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt
   arbitrary Lean allocation.
-- `HexInterval/State.lean`: supported immutable branch seeds, current facts,
-  exact version/provenance history, structural/generation side tables,
+- `HexInterval/State.lean`: supported immutable base and generated-node seeds,
+  reconstructed current facts, exact version/provenance history, and bounded
+  structural/generation side tables,
   dependency watchers, dirty bits, append-only work queues with policy
   tombstones, controller resources, and transactional checked builders. These
   decoded arrays do not select the optimized branch-storage implementation.

--- a/HexInterval/State.lean
+++ b/HexInterval/State.lean
@@ -124,16 +124,18 @@ structure Update (Fact Cause : Type) where
   version : Nat
   cause : Cause
 
-/-- Immutable fact state for one search branch. Generations and depths are
-aligned with the exact current program; history is append-only. -/
+/-- Immutable fact state for one search branch. Base facts and appended-node
+seeds are the authoritative version-zero facts; later current facts are
+reconstructed from append-only history. Generation values are aligned bounded
+metadata supplied by the controller, not independently authenticated theorem
+provenance. -/
 structure Branch (Fact Cause : Type) where
   programVersion : Nat
   baseProgram : Program
   initialFacts : Array Fact
   program : Program
-  /-- Exact version-zero fact for every current node, including extensions. -/
+  /-- Exact version-zero facts for the appended node suffix only. -/
   seeds : Array Fact
-  facts : Array Fact
   versions : Array Nat
   generations : Array Nat
   depths : Array Nat
@@ -145,6 +147,7 @@ inductive BranchError where
   | wrongFactCount
   | staleVersion (node : NodeId)
   | wrongProgramVersion
+  | invalidGeneration
   | nonExtension
   | resource (resource : Resource)
   deriving DecidableEq, Repr
@@ -177,17 +180,30 @@ def startWithin (limits : Limits) (program : Program) (facts : Array Fact) :
       baseProgram := program
       initialFacts := facts
       program
-      seeds := facts
-      facts
+      seeds := #[]
       versions := Array.replicate facts.size 0
       generations := Array.replicate facts.size 0
       depths
       history := #[]
       contradictory := false }
 
-/-- Immutable callback-facing current fact snapshot. -/
+/-- Reconstruct current facts from the authoritative base/suffix seeds and
+ordered update history. An out-of-range retained update is malformed. -/
+def restoredFacts? (branch : Branch Fact Cause) : Option (Array Fact) := do
+  if branch.initialFacts.size != branch.baseProgram.nodes.size ||
+      branch.program.nodes.size < branch.baseProgram.nodes.size ||
+      branch.seeds.size != branch.program.nodes.size - branch.baseProgram.nodes.size then
+    none
+  let mut facts := branch.initialFacts ++ branch.seeds
+  for event in branch.history do
+    if branch.program.nodes[event.node.index]?.isNone then none
+    facts := facts.set! event.node.index event.fact
+  pure facts
+
+/-- Immutable callback-facing current fact snapshot. A malformed decoded
+branch produces an empty fact array and consequently fails `Branch.check`. -/
 def snapshot (branch : Branch Fact Cause) : Snapshot Fact :=
-  { facts := branch.facts
+  { facts := branch.restoredFacts?.getD #[]
     versions := branch.versions
     contradictory := branch.contradictory }
 
@@ -195,7 +211,10 @@ def snapshot (branch : Branch Fact Cause) : Snapshot Fact :=
 seed array; later versions come only from append-only update history. -/
 def factAt? (branch : Branch Fact Cause) (seen : SeenVersion) : Option Fact :=
   if seen.version == 0 then
-    branch.seeds[seen.node.index]?
+    if seen.node.index < branch.initialFacts.size then
+      branch.initialFacts[seen.node.index]?
+    else
+      branch.seeds[seen.node.index - branch.initialFacts.size]?
   else
     (branch.history.find? fun event =>
       event.node == seen.node && event.version == seen.version).map (·.fact)
@@ -211,15 +230,31 @@ def restoredVersions? (branch : Branch Fact Cause) : Option (Array Nat) := do
     versions := versions.set! event.node.index event.version
   pure versions
 
+/-- Validate the generation facts that this generic state layer can establish:
+base nodes are generation zero, and no appended node claims a generation after
+the current append-only program version. Exact dependency-derived generation
+is authenticated by the controller's instance transition, not by this table. -/
+def generationsCheck (branch : Branch Fact Cause) : Bool := Id.run do
+  if branch.generations.size != branch.program.nodes.size then return false
+  for index in [0:branch.generations.size] do
+    let some generation := branch.generations[index]? | return false
+    if index < branch.baseProgram.nodes.size then
+      if generation != 0 then return false
+    else if branch.programVersion < generation then
+      return false
+  return true
+
 /-- Validate all immutable array alignments, append-only program structure,
 depths, and exact per-node update chronology. -/
 def check (branch : Branch Fact Cause) : Bool :=
+  let snapshot := branch.snapshot
   branch.baseProgram.check && branch.program.check &&
     programPrefix branch.baseProgram branch.program &&
     branch.initialFacts.size == branch.baseProgram.nodes.size &&
-    branch.seeds.size == branch.program.nodes.size &&
-    branch.snapshot.check branch.program &&
-    branch.generations.size == branch.program.nodes.size &&
+    branch.seeds.size == branch.program.nodes.size - branch.baseProgram.nodes.size &&
+    snapshot.facts.size == branch.program.nodes.size &&
+    snapshot.versions.size == branch.program.nodes.size &&
+    branch.generationsCheck &&
     branch.program.depths? == some branch.depths &&
     branch.restoredVersions? == some branch.versions
 
@@ -229,6 +264,9 @@ def pushWithin (limits : Limits) (branch : Branch Fact Cause) (event : Update Fa
     (contradiction : Bool := false) : Except BranchError (Branch Fact Cause) := do
   if limits.maxAcceptedFacts <= branch.history.size then
     throw (.resource .acceptedFacts)
+  if limits.maxOperations < branch.baseProgram.operations.size then
+    throw (.resource .operations)
+  if limits.maxNodes < branch.baseProgram.nodes.size then throw (.resource .nodes)
   if limits.maxOperations < branch.program.operations.size then
     throw (.resource .operations)
   if limits.maxNodes < branch.program.nodes.size then throw (.resource .nodes)
@@ -240,7 +278,6 @@ def pushWithin (limits : Limits) (branch : Branch Fact Cause) (event : Update Fa
     throw (.staleVersion event.node)
   pure
     { branch with
-      facts := branch.facts.set! event.node.index event.fact
       versions := branch.versions.set! event.node.index event.version
       history := branch.history.push event
       contradictory := branch.contradictory || contradiction }
@@ -248,8 +285,13 @@ def pushWithin (limits : Limits) (branch : Branch Fact Cause) (event : Update Fa
 /-- Append one checked program suffix and its version-zero top facts. -/
 def extendWithin (limits : Limits) (branch : Branch Fact Cause) (program : Program)
     (freshFacts : Array Fact) (generation : Nat) : Except BranchError (Branch Fact Cause) := do
+  if limits.maxAcceptedFacts < branch.history.size then
+    throw (.resource .acceptedFacts)
   if limits.maxOperations < program.operations.size then throw (.resource .operations)
   if limits.maxNodes < program.nodes.size then throw (.resource .nodes)
+  if limits.maxOperations < branch.baseProgram.operations.size then
+    throw (.resource .operations)
+  if limits.maxNodes < branch.baseProgram.nodes.size then throw (.resource .nodes)
   if limits.maxOperations < branch.program.operations.size then
     throw (.resource .operations)
   if limits.maxNodes < branch.program.nodes.size then throw (.resource .nodes)
@@ -261,6 +303,8 @@ def extendWithin (limits : Limits) (branch : Branch Fact Cause) (program : Progr
   if !program.check || !programPrefix branch.program program then throw .nonExtension
   let added := program.nodes.size - branch.program.nodes.size
   if freshFacts.size != added then throw .wrongFactCount
+  if 0 < added && (generation == 0 || branch.programVersion + 1 < generation) then
+    throw .invalidGeneration
   let some depths := program.depths? | throw .invalidProgram
   if depths.any (fun depth => limits.maxNodeDepth < depth) then
     throw (.resource .nodeDepth)
@@ -269,7 +313,6 @@ def extendWithin (limits : Limits) (branch : Branch Fact Cause) (program : Progr
       programVersion := branch.programVersion + 1
       program
       seeds := branch.seeds ++ freshFacts
-      facts := branch.facts ++ freshFacts
       versions := branch.versions ++ Array.replicate added 0
       generations := branch.generations ++ Array.replicate added generation
       depths }
@@ -298,9 +341,12 @@ def check (dependencies : Dependencies) (nodeCount applicationCount equalityCoun
 
 end Dependencies
 
-/-- Append-only work log plus the first live position. -/
+/-- Append-only work log, per-occurrence liveness, and the first unconsumed
+position. A cleared occurrence stays a tombstone even if the same work is
+woken and appended again later. -/
 structure Queue where
   queue : Array Work
+  live : Array Bool
   queueHead : Nat
 
 namespace Queue
@@ -312,30 +358,43 @@ inductive Error where
 
 def containsAfter (queue : Queue) (work : Work) : Bool := Id.run do
   for index in [queue.queueHead:queue.queue.size] do
-    if queue.queue[index]? == some work then return true
+    if queue.live[index]? == some true && queue.queue[index]? == some work then return true
   return false
 
 def dirty? (dependencies : Dependencies) : Work -> Option Bool
   | .application application => dependencies.queued[application.index]?
   | .equality equality => dependencies.equalityQueued[equality.index]?
 
-/-- Validate the retained cap, cursor, compact references, and that every dirty
-bit has a retained suffix occurrence. A false bit may leave a policy-created
-tombstone which `pop` skips. -/
+/-- Validate the retained cap, cursor, compact references, and the bijection
+between dirty bits and live retained suffix occurrences. Per-occurrence live
+bits keep a policy-created tombstone dead after later re-enqueue. -/
 def check (queue : Queue) (dependencies : Dependencies)
-    (applicationCount equalityCount maxEntries : Nat) : Bool := Id.run do
+    (nodeCount applicationCount equalityCount maxEntries : Nat) : Bool := Id.run do
   if maxEntries < queue.queue.size || queue.queue.size < queue.queueHead ||
-      !dependencies.check dependencies.watchers.size applicationCount equalityCount then
+      queue.live.size != queue.queue.size ||
+      !dependencies.check nodeCount applicationCount equalityCount then
     return false
-  for work in queue.queue do
+  let mut seenApplications := Array.replicate applicationCount false
+  let mut seenEqualities := Array.replicate equalityCount false
+  for index in [0:queue.queue.size] do
+    let some work := queue.queue[index]? | return false
     if !Dependencies.workValid applicationCount equalityCount work then return false
-  for index in [0:applicationCount] do
-    if dependencies.queued[index]? == some true &&
-        !queue.containsAfter (.application { index }) then return false
-  for index in [0:equalityCount] do
-    if dependencies.equalityQueued[index]? == some true &&
-        !queue.containsAfter (.equality { index }) then return false
-  return true
+    let some live := queue.live[index]? | return false
+    if index < queue.queueHead && live then return false
+    if live then
+      match work with
+      | .application application =>
+          if seenApplications[application.index]? != some false ||
+              dependencies.queued[application.index]? != some true then
+            return false
+          seenApplications := seenApplications.set! application.index true
+      | .equality equality =>
+          if seenEqualities[equality.index]? != some false ||
+              dependencies.equalityQueued[equality.index]? != some true then
+            return false
+          seenEqualities := seenEqualities.set! equality.index true
+  return seenApplications == dependencies.queued &&
+    seenEqualities == dependencies.equalityQueued
 
 /-- Construct the initial application queue only after its retained-count
 limit has admitted the entire allocation. -/
@@ -344,14 +403,14 @@ def initialWithin (maxEntries applicationCount : Nat) : Except Resource Queue :=
   let mut queue := #[]
   for index in [0:applicationCount] do
     queue := queue.push (.application { index })
-  pure { queue, queueHead := 0 }
+  pure { queue, live := Array.replicate applicationCount true, queueHead := 0 }
 
 /-- Transactionally enqueue one valid work item, suppressing an already-live
 item and setting exactly its aligned dirty bit. -/
-def enqueueWithin (maxEntries applicationCount equalityCount : Nat)
+def enqueueWithin (maxEntries nodeCount applicationCount equalityCount : Nat)
     (dependencies : Dependencies) (queue : Queue) (work : Work) :
     Except Error (Dependencies × Queue) := do
-  if !queue.check dependencies applicationCount equalityCount maxEntries ||
+  if !queue.check dependencies nodeCount applicationCount equalityCount maxEntries ||
       !Dependencies.workValid applicationCount equalityCount work then
     throw Error.malformed
   let some dirty := dirty? dependencies work | throw Error.malformed
@@ -363,42 +422,50 @@ def enqueueWithin (maxEntries applicationCount equalityCount : Nat)
     | .equality equality =>
         { dependencies with
           equalityQueued := dependencies.equalityQueued.set! equality.index true }
-  pure (dependencies, { queue with queue := queue.queue.push work })
+  pure (dependencies,
+    { queue with queue := queue.queue.push work, live := queue.live.push true })
 
 /-- Transactionally clear one selected work item. Its retained queue-log entry
 may become a tombstone; a later enqueue appends a fresh occurrence. -/
-def deactivate (maxEntries applicationCount equalityCount : Nat)
+def deactivate (maxEntries nodeCount applicationCount equalityCount : Nat)
     (dependencies : Dependencies) (queue : Queue) (work : Work) :
-    Except Error Dependencies := do
-  if !queue.check dependencies applicationCount equalityCount maxEntries ||
+    Except Error (Dependencies × Queue) := do
+  if !queue.check dependencies nodeCount applicationCount equalityCount maxEntries ||
       !Dependencies.workValid applicationCount equalityCount work then
     throw Error.malformed
   let some dirty := dirty? dependencies work | throw Error.malformed
   if !dirty then throw Error.malformed
-  pure <| match work with
+  let mut liveIndex? := none
+  for index in [queue.queueHead:queue.queue.size] do
+    if queue.live[index]? == some true && queue.queue[index]? == some work then
+      liveIndex? := some index
+      break
+  let some liveIndex := liveIndex? | throw Error.malformed
+  let dependencies := match work with
     | .application application =>
         { dependencies with queued := dependencies.queued.set! application.index false }
     | .equality equality =>
         { dependencies with
           equalityQueued := dependencies.equalityQueued.set! equality.index false }
+  pure (dependencies, { queue with live := queue.live.set! liveIndex false })
 
 /-- Transactionally pop the next still-dirty work item, skipping retained
 tombstones created by policy selection. `none` denotes a checked empty suffix;
 the returned queue still commits the cursor advance across those tombstones. -/
-def pop (maxEntries applicationCount equalityCount : Nat)
+def pop (maxEntries nodeCount applicationCount equalityCount : Nat)
     (dependencies : Dependencies) (queue : Queue) :
     Except Error (Option Work × Dependencies × Queue) := do
-  if !queue.check dependencies applicationCount equalityCount maxEntries then
+  if !queue.check dependencies nodeCount applicationCount equalityCount maxEntries then
     throw Error.malformed
   let mut queue := queue
   while queue.queueHead < queue.queue.size do
     let some work := queue.queue[queue.queueHead]? | throw Error.malformed
-    let some dirty := dirty? dependencies work | throw Error.malformed
-    if dirty then
-      let dependencies <- queue.deactivate maxEntries applicationCount equalityCount
-        dependencies work
-      queue := { queue with queueHead := queue.queueHead + 1 }
-      if !queue.check dependencies applicationCount equalityCount maxEntries then
+    let some live := queue.live[queue.queueHead]? | throw Error.malformed
+    if live then
+      let (dependencies, deactivated) <-
+        queue.deactivate maxEntries nodeCount applicationCount equalityCount dependencies work
+      queue := { deactivated with queueHead := deactivated.queueHead + 1 }
+      if !queue.check dependencies nodeCount applicationCount equalityCount maxEntries then
         throw Error.malformed
       return (some work, dependencies, queue)
     queue := { queue with queueHead := queue.queueHead + 1 }

--- a/HexInterval/State.lean
+++ b/HexInterval/State.lean
@@ -1,0 +1,408 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Trace
+
+@[expose] public section
+
+/-!
+# Function-agnostic controller state
+
+These contracts describe immutable branch facts, exact versioned updates,
+dependency/queue alignment, and explicit controller limits. They deliberately
+do not choose persistent storage, rollback, a priority policy, callbacks, or a
+proof format. A value is plain decoded data until its `check` succeeds.
+
+All builders are transactional: malformed, stale, or over-budget inputs return
+an error and no replacement state. Runtime facts and provenance remain
+untrusted data; only later theorem replay can establish their meaning.
+-/
+
+namespace Hex.Interval.State
+
+/-- A single scheduler queue carries rule applications and equality
+contractors without interpreting either. -/
+inductive Work where
+  | application (application : ApplicationId)
+  | equality (equality : EqualityId)
+  deriving DecidableEq, Repr
+
+/-- Solver-owned resource whose checked limit was exhausted. -/
+inductive Resource where
+  | operations
+  | nodes
+  | rules
+  | arity
+  | scopes
+  | applications
+  | queueEntries
+  | actions
+  | matcherVisits
+  | effort
+  | registryEntries
+  | replayFormats
+  | acceptedFacts
+  | retainedSuggestions
+  | outcomeCandidates
+  | outcomeSuggestions
+  | instances
+  | generation
+  | nodeDepth
+  | equalities
+  deriving DecidableEq, Repr
+
+/-- Independent structural and logical-work limits. Byte-bounded retained
+diagnostics use `Hex.Interval.Trace.Limit`; arbitrary callback/Fact allocation is outside
+this preemptible envelope. -/
+structure Limits where
+  maxOperations : Nat
+  maxNodes : Nat
+  maxRules : Nat
+  maxRegistryEntries : Nat
+  maxReplayFormats : Nat
+  maxArity : Nat
+  maxScopeNodes : Nat := 0
+  maxApplications : Nat
+  maxQueueEntries : Nat
+  maxActions : Nat
+  maxMatcherVisits : Nat := 0
+  matcherBatchSize : Nat := 0
+  maxAcceptedFacts : Nat
+  maxRetainedSuggestions : Nat
+  maxEffort : Nat
+  maxObservationValue : Nat
+  maxDiagnosticValue : Nat
+  maxOutcomeCandidates : Nat
+  maxOutcomeSuggestions : Nat
+  maxProposalItems : Nat
+  maxInstances : Nat
+  maxGeneration : Nat
+  maxNodeDepth : Nat
+  maxEqualities : Nat
+  splitEndpointLimit : EndpointLimit
+  deriving DecidableEq, Repr
+
+/-- Logical counters; these are telemetry and resource state, never proof
+evidence. -/
+structure Metrics where
+  queueInsertions : Nat := 0
+  suppressedInsertions : Nat := 0
+  queuePops : Nat := 0
+  requests : Nat := 0
+  matcherVisits : Nat := 0
+  replies : Nat := 0
+  candidates : Nat := 0
+  improvements : Nat := 0
+  contradictions : Nat := 0
+  ruleNoChange : Nat := 0
+  ruleInapplicable : Nat := 0
+  ruleResourceLimits : Nat := 0
+  ruleFailures : Nat := 0
+  admittedInstances : Nat := 0
+  duplicateInstances : Nat := 0
+  droppedSuggestions : Nat := 0
+  capacityDrops : Nat := 0
+  depthDrops : Nat := 0
+  generatedNodes : Nat := 0
+  generatedScopes : Nat := 0
+  generatedEqualities : Nat := 0
+  equalityRuns : Nat := 0
+  equalityImprovements : Nat := 0
+  deriving DecidableEq, Repr
+
+/-- One exact fact update with opaque caller-selected provenance. -/
+structure Update (Fact Cause : Type) where
+  programVersion : Nat
+  node : NodeId
+  previous : SeenVersion
+  fact : Fact
+  version : Nat
+  cause : Cause
+
+/-- Immutable fact state for one search branch. Generations and depths are
+aligned with the exact current program; history is append-only. -/
+structure Branch (Fact Cause : Type) where
+  programVersion : Nat
+  baseProgram : Program
+  initialFacts : Array Fact
+  program : Program
+  /-- Exact version-zero fact for every current node, including extensions. -/
+  seeds : Array Fact
+  facts : Array Fact
+  versions : Array Nat
+  generations : Array Nat
+  depths : Array Nat
+  history : Array (Update Fact Cause)
+  contradictory : Bool
+
+inductive BranchError where
+  | invalidProgram
+  | wrongFactCount
+  | staleVersion (node : NodeId)
+  | wrongProgramVersion
+  | nonExtension
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+def programPrefix (before after : Program) : Bool := Id.run do
+  if before.operations != after.operations || after.nodes.size < before.nodes.size then
+    return false
+  for index in [0:before.nodes.size] do
+    if before.nodes[index]? != after.nodes[index]? then return false
+  return true
+
+namespace Branch
+
+/-- Construct an exact version-zero branch. Structural caps are checked before
+the depth, generation, and version arrays are allocated. -/
+def startWithin (limits : Limits) (program : Program) (facts : Array Fact) :
+    Except BranchError (Branch Fact Cause) := do
+  if limits.maxOperations < program.operations.size then throw (.resource .operations)
+  if limits.maxNodes < program.nodes.size then throw (.resource .nodes)
+  if program.operations.any (fun operation => limits.maxArity < operation.inputs.length) ||
+      program.nodes.any (fun node => limits.maxArity < node.args.length) then
+    throw (.resource .arity)
+  if facts.size != program.nodes.size then throw .wrongFactCount
+  if !program.check then throw .invalidProgram
+  let some depths := program.depths? | throw .invalidProgram
+  if depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (.resource .nodeDepth)
+  pure
+    { programVersion := 0
+      baseProgram := program
+      initialFacts := facts
+      program
+      seeds := facts
+      facts
+      versions := Array.replicate facts.size 0
+      generations := Array.replicate facts.size 0
+      depths
+      history := #[]
+      contradictory := false }
+
+/-- Immutable callback-facing current fact snapshot. -/
+def snapshot (branch : Branch Fact Cause) : Snapshot Fact :=
+  { facts := branch.facts
+    versions := branch.versions
+    contradictory := branch.contradictory }
+
+/-- Resolve an exact retained version. Version zero comes from the immutable
+seed array; later versions come only from append-only update history. -/
+def factAt? (branch : Branch Fact Cause) (seen : SeenVersion) : Option Fact :=
+  if seen.version == 0 then
+    branch.seeds[seen.node.index]?
+  else
+    (branch.history.find? fun event =>
+      event.node == seen.node && event.version == seen.version).map (·.fact)
+
+/-- Reconstruct current node versions from exact predecessor links. -/
+def restoredVersions? (branch : Branch Fact Cause) : Option (Array Nat) := do
+  let mut versions := Array.replicate branch.program.nodes.size 0
+  for event in branch.history do
+    if branch.programVersion < event.programVersion || event.previous.node != event.node then
+      none
+    let current <- versions[event.node.index]?
+    if event.previous.version != current || event.version != current + 1 then none
+    versions := versions.set! event.node.index event.version
+  pure versions
+
+/-- Validate all immutable array alignments, append-only program structure,
+depths, and exact per-node update chronology. -/
+def check (branch : Branch Fact Cause) : Bool :=
+  branch.baseProgram.check && branch.program.check &&
+    programPrefix branch.baseProgram branch.program &&
+    branch.initialFacts.size == branch.baseProgram.nodes.size &&
+    branch.seeds.size == branch.program.nodes.size &&
+    branch.snapshot.check branch.program &&
+    branch.generations.size == branch.program.nodes.size &&
+    branch.program.depths? == some branch.depths &&
+    branch.restoredVersions? == some branch.versions
+
+/-- Install one already-computed update only when it names the exact live
+predecessor and current program version. -/
+def pushWithin (limits : Limits) (branch : Branch Fact Cause) (event : Update Fact Cause)
+    (contradiction : Bool := false) : Except BranchError (Branch Fact Cause) := do
+  if limits.maxAcceptedFacts <= branch.history.size then
+    throw (.resource .acceptedFacts)
+  if limits.maxOperations < branch.program.operations.size then
+    throw (.resource .operations)
+  if limits.maxNodes < branch.program.nodes.size then throw (.resource .nodes)
+  if !branch.check then throw .invalidProgram
+  if event.programVersion != branch.programVersion then throw .wrongProgramVersion
+  let some current := branch.versions[event.node.index]? | throw (.staleVersion event.node)
+  if event.previous.node != event.node || event.previous.version != current ||
+      event.version != current + 1 then
+    throw (.staleVersion event.node)
+  pure
+    { branch with
+      facts := branch.facts.set! event.node.index event.fact
+      versions := branch.versions.set! event.node.index event.version
+      history := branch.history.push event
+      contradictory := branch.contradictory || contradiction }
+
+/-- Append one checked program suffix and its version-zero top facts. -/
+def extendWithin (limits : Limits) (branch : Branch Fact Cause) (program : Program)
+    (freshFacts : Array Fact) (generation : Nat) : Except BranchError (Branch Fact Cause) := do
+  if limits.maxOperations < program.operations.size then throw (.resource .operations)
+  if limits.maxNodes < program.nodes.size then throw (.resource .nodes)
+  if limits.maxOperations < branch.program.operations.size then
+    throw (.resource .operations)
+  if limits.maxNodes < branch.program.nodes.size then throw (.resource .nodes)
+  if limits.maxGeneration < generation then throw (.resource .generation)
+  if program.operations.any (fun operation => limits.maxArity < operation.inputs.length) ||
+      program.nodes.any (fun node => limits.maxArity < node.args.length) then
+    throw (.resource .arity)
+  if !branch.check then throw .invalidProgram
+  if !program.check || !programPrefix branch.program program then throw .nonExtension
+  let added := program.nodes.size - branch.program.nodes.size
+  if freshFacts.size != added then throw .wrongFactCount
+  let some depths := program.depths? | throw .invalidProgram
+  if depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (.resource .nodeDepth)
+  pure
+    { branch with
+      programVersion := branch.programVersion + 1
+      program
+      seeds := branch.seeds ++ freshFacts
+      facts := branch.facts ++ freshFacts
+      versions := branch.versions ++ Array.replicate added 0
+      generations := branch.generations ++ Array.replicate added generation
+      depths }
+
+end Branch
+
+/-- Dependency watchers and exact dirty bits. -/
+structure Dependencies where
+  watchers : Array (List Work)
+  queued : Array Bool
+  equalityQueued : Array Bool
+
+namespace Dependencies
+
+def workValid (applicationCount equalityCount : Nat) : Work -> Bool
+  | .application application => application.index < applicationCount
+  | .equality equality => equality.index < equalityCount
+
+/-- Validate node alignment and every compact dependency reference. -/
+def check (dependencies : Dependencies) (nodeCount applicationCount equalityCount : Nat) : Bool :=
+  dependencies.watchers.size == nodeCount &&
+    dependencies.queued.size == applicationCount &&
+    dependencies.equalityQueued.size == equalityCount &&
+    dependencies.watchers.all fun items =>
+      items.all (workValid applicationCount equalityCount)
+
+end Dependencies
+
+/-- Append-only work log plus the first live position. -/
+structure Queue where
+  queue : Array Work
+  queueHead : Nat
+
+namespace Queue
+
+inductive Error where
+  | malformed
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+def containsAfter (queue : Queue) (work : Work) : Bool := Id.run do
+  for index in [queue.queueHead:queue.queue.size] do
+    if queue.queue[index]? == some work then return true
+  return false
+
+def dirty? (dependencies : Dependencies) : Work -> Option Bool
+  | .application application => dependencies.queued[application.index]?
+  | .equality equality => dependencies.equalityQueued[equality.index]?
+
+/-- Validate the retained cap, cursor, compact references, and that every dirty
+bit has a retained suffix occurrence. A false bit may leave a policy-created
+tombstone which `pop` skips. -/
+def check (queue : Queue) (dependencies : Dependencies)
+    (applicationCount equalityCount maxEntries : Nat) : Bool := Id.run do
+  if maxEntries < queue.queue.size || queue.queue.size < queue.queueHead ||
+      !dependencies.check dependencies.watchers.size applicationCount equalityCount then
+    return false
+  for work in queue.queue do
+    if !Dependencies.workValid applicationCount equalityCount work then return false
+  for index in [0:applicationCount] do
+    if dependencies.queued[index]? == some true &&
+        !queue.containsAfter (.application { index }) then return false
+  for index in [0:equalityCount] do
+    if dependencies.equalityQueued[index]? == some true &&
+        !queue.containsAfter (.equality { index }) then return false
+  return true
+
+/-- Construct the initial application queue only after its retained-count
+limit has admitted the entire allocation. -/
+def initialWithin (maxEntries applicationCount : Nat) : Except Resource Queue := do
+  if maxEntries < applicationCount then throw .queueEntries
+  let mut queue := #[]
+  for index in [0:applicationCount] do
+    queue := queue.push (.application { index })
+  pure { queue, queueHead := 0 }
+
+/-- Transactionally enqueue one valid work item, suppressing an already-live
+item and setting exactly its aligned dirty bit. -/
+def enqueueWithin (maxEntries applicationCount equalityCount : Nat)
+    (dependencies : Dependencies) (queue : Queue) (work : Work) :
+    Except Error (Dependencies × Queue) := do
+  if !queue.check dependencies applicationCount equalityCount maxEntries ||
+      !Dependencies.workValid applicationCount equalityCount work then
+    throw Error.malformed
+  let some dirty := dirty? dependencies work | throw Error.malformed
+  if dirty then return (dependencies, queue)
+  if maxEntries <= queue.queue.size then throw (Error.resource .queueEntries)
+  let dependencies := match work with
+    | .application application =>
+        { dependencies with queued := dependencies.queued.set! application.index true }
+    | .equality equality =>
+        { dependencies with
+          equalityQueued := dependencies.equalityQueued.set! equality.index true }
+  pure (dependencies, { queue with queue := queue.queue.push work })
+
+/-- Transactionally clear one selected work item. Its retained queue-log entry
+may become a tombstone; a later enqueue appends a fresh occurrence. -/
+def deactivate (maxEntries applicationCount equalityCount : Nat)
+    (dependencies : Dependencies) (queue : Queue) (work : Work) :
+    Except Error Dependencies := do
+  if !queue.check dependencies applicationCount equalityCount maxEntries ||
+      !Dependencies.workValid applicationCount equalityCount work then
+    throw Error.malformed
+  let some dirty := dirty? dependencies work | throw Error.malformed
+  if !dirty then throw Error.malformed
+  pure <| match work with
+    | .application application =>
+        { dependencies with queued := dependencies.queued.set! application.index false }
+    | .equality equality =>
+        { dependencies with
+          equalityQueued := dependencies.equalityQueued.set! equality.index false }
+
+/-- Transactionally pop the next still-dirty work item, skipping retained
+tombstones created by policy selection. `none` denotes a checked empty suffix;
+the returned queue still commits the cursor advance across those tombstones. -/
+def pop (maxEntries applicationCount equalityCount : Nat)
+    (dependencies : Dependencies) (queue : Queue) :
+    Except Error (Option Work × Dependencies × Queue) := do
+  if !queue.check dependencies applicationCount equalityCount maxEntries then
+    throw Error.malformed
+  let mut queue := queue
+  while queue.queueHead < queue.queue.size do
+    let some work := queue.queue[queue.queueHead]? | throw Error.malformed
+    let some dirty := dirty? dependencies work | throw Error.malformed
+    if dirty then
+      let dependencies <- queue.deactivate maxEntries applicationCount equalityCount
+        dependencies work
+      queue := { queue with queueHead := queue.queueHead + 1 }
+      if !queue.check dependencies applicationCount equalityCount maxEntries then
+        throw Error.malformed
+      return (some work, dependencies, queue)
+    queue := { queue with queueHead := queue.queueHead + 1 }
+  pure (none, dependencies, queue)
+
+end Queue
+end Hex.Interval.State

--- a/HexInterval/State.lean
+++ b/HexInterval/State.lean
@@ -63,14 +63,20 @@ structure Limits where
   maxOperations : Nat
   maxNodes : Nat
   maxRules : Nat
+  /-- Total package metadata cells, independent of executable program size. -/
   maxRegistryEntries : Nat
+  /-- Total cache-independent proof-replay format declarations. -/
   maxReplayFormats : Nat
   maxArity : Nat
+  /-- Maximum ordered read or write ports of one arbitrary-scope application.
+  Local operation slots remain governed by `maxArity`. -/
   maxScopeNodes : Nat := 0
   maxApplications : Nat
   maxQueueEntries : Nat
   maxActions : Nat
+  /-- Global number of engine-enumerated structural inputs. -/
   maxMatcherVisits : Nat := 0
+  /-- Maximum structural inputs exposed by one matcher invocation. -/
   matcherBatchSize : Nat := 0
   maxAcceptedFacts : Nat
   maxRetainedSuggestions : Nat
@@ -105,8 +111,11 @@ structure Metrics where
   ruleFailures : Nat := 0
   admittedInstances : Nat := 0
   duplicateInstances : Nat := 0
+  /-- Total suggestions omitted from retained policy state. -/
   droppedSuggestions : Nat := 0
+  /-- Suggestions omitted because the retained array was full. -/
   capacityDrops : Nat := 0
+  /-- Structurally valid instantiations omitted by `maxNodeDepth`. -/
   depthDrops : Nat := 0
   generatedNodes : Nat := 0
   generatedScopes : Nat := 0

--- a/HexInterval/Trace.lean
+++ b/HexInterval/Trace.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Action
+
+@[expose] public section
+
+/-!
+# Bounded controller traces
+
+This module contains function-independent retained-order and diagnostic-log
+contracts. Trace data is operational data, never theorem evidence. In
+particular, truncating diagnostics cannot authorize a fact or remove an entry
+from the proof chronology.
+
+The byte bound below is an exact bound on retained `UInt8` payload cells. It
+does not preempt construction of a callback result, a `Fact`, a `String`, or
+another Lean object. Such values already exist when `Log.append` inspects
+them. Callbacks therefore remain an explicitly non-preemptible envelope; a
+package must enforce its own construction limits before returning. The
+controller checks returned counts, retained bytes, and declared logical work
+before mutating its log.
+-/
+
+namespace Hex.Interval.Trace
+
+/-- One exact position in the authoritative interleaving of fact updates and
+program-instance events. -/
+inductive Ref where
+  | fact (index : Nat)
+  | instance (index : Nat)
+  deriving DecidableEq, Repr
+
+/-- Authoritative event order, stored separately from role-specific arrays. -/
+structure Order where
+  chronology : Array Ref
+  deriving DecidableEq, Repr
+
+namespace Order
+
+/-- Separate caps for the two authoritative history roles. -/
+structure Limit where
+  maxFacts : Nat
+  maxInstances : Nat
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | malformed
+  | facts
+  | instances
+  deriving DecidableEq, Repr
+
+/-- Check exact append order and exhaustion of both role-specific arrays. Each
+index occurs once, at the only point where it becomes available. -/
+def check (order : Order) (factCount instanceCount : Nat) : Bool := Id.run do
+  if order.chronology.size != factCount + instanceCount then return false
+  let mut nextFact := 0
+  let mut nextInstance := 0
+  for entry in order.chronology do
+    match entry with
+    | .fact index =>
+        if index != nextFact then return false
+        nextFact := nextFact + 1
+    | .instance index =>
+        if index != nextInstance then return false
+        nextInstance := nextInstance + 1
+  return nextFact == factCount && nextInstance == instanceCount
+
+def empty : Order := { chronology := #[] }
+
+def counts? (order : Order) : Option (Nat × Nat) := do
+  let mut facts := 0
+  let mut instances := 0
+  for entry in order.chronology do
+    match entry with
+    | .fact index =>
+        if index != facts then none
+        facts := facts + 1
+    | .instance index =>
+        if index != instances then none
+        instances := instances + 1
+  pure (facts, instances)
+
+/-- Append the exact next fact-history position after validating the retained
+chronology and both independent count caps. -/
+def appendFact (limit : Limit) (order : Order) (index : Nat) : Except Error Order := do
+  let some (facts, instances) := order.counts? | throw .malformed
+  if index != facts || limit.maxInstances < instances then throw .malformed
+  if limit.maxFacts <= facts then throw .facts
+  pure { chronology := order.chronology.push (.fact index) }
+
+/-- Append the exact next instance-history position after validating the
+retained chronology and both independent count caps. -/
+def appendInstance (limit : Limit) (order : Order) (index : Nat) : Except Error Order := do
+  let some (facts, instances) := order.counts? | throw .malformed
+  if index != instances || limit.maxFacts < facts then throw .malformed
+  if limit.maxInstances <= instances then throw .instances
+  pure { chronology := order.chronology.push (.instance index) }
+
+end Order
+
+/-- Independent retained diagnostic limits. `maxBytes` counts payload bytes;
+`maxWork` counts controller-declared logical work, not wall-clock time. -/
+structure Limit where
+  maxEvents : Nat
+  maxBytes : Nat
+  maxWork : Nat
+  maxCode : Nat
+  deriving DecidableEq, Repr
+
+/-- One plain diagnostic event. Payload bytes have no semantic or proof
+interpretation at this layer. -/
+structure Event where
+  code : Nat
+  payload : Array UInt8 := #[]
+  work : Nat := 0
+  deriving DecidableEq, Repr
+
+/-- Bounded retained diagnostics. Cached totals make admission constant-time
+after inspecting the returned event's already-allocated payload size. -/
+structure Log where
+  events : Array Event := #[]
+  bytes : Nat := 0
+  work : Nat := 0
+  truncated : Bool := false
+  deriving DecidableEq, Repr
+
+namespace Log
+
+/-- Recompute and validate exact totals and every retained event limit. -/
+def check (limit : Limit) (log : Log) : Bool := Id.run do
+  if limit.maxEvents < log.events.size then return false
+  let mut bytes := 0
+  let mut work := 0
+  for event in log.events do
+    if limit.maxCode < event.code then return false
+    if limit.maxBytes - bytes < event.payload.size then return false
+    if limit.maxWork - work < event.work then return false
+    bytes := bytes + event.payload.size
+    work := work + event.work
+  return bytes == log.bytes && work == log.work
+
+/-- Result of retaining one diagnostic. Truncation is a successful, explicit
+loss of diagnostics; malformed input means the preceding log itself was not a
+valid snapshot. -/
+inductive Append where
+  | retained (log : Log)
+  | truncated (log : Log)
+  | malformed
+  deriving DecidableEq, Repr
+
+/-- Transactionally retain one event, or mark the diagnostic stream truncated
+without retaining the event. No proof-state object is an argument or result. -/
+def append (limit : Limit) (log : Log) (event : Event) : Append :=
+  if !log.check limit then
+    .malformed
+  else if limit.maxEvents <= log.events.size || limit.maxCode < event.code ||
+      limit.maxBytes - log.bytes < event.payload.size ||
+      limit.maxWork - log.work < event.work then
+    .truncated { log with truncated := true }
+  else
+    .retained
+      { events := log.events.push event
+        bytes := log.bytes + event.payload.size
+        work := log.work + event.work
+        truncated := log.truncated }
+
+end Log
+end Hex.Interval.Trace

--- a/HexInterval/Trace.lean
+++ b/HexInterval/Trace.lean
@@ -89,17 +89,22 @@ def counts? (order : Order) : Option (Nat × Nat) := do
 /-- Append the exact next fact-history position after validating the retained
 chronology and both independent count caps. -/
 def appendFact (limit : Limit) (order : Order) (index : Nat) : Except Error Order := do
+  if limit.maxFacts <= index || limit.maxFacts + limit.maxInstances <= order.chronology.size then
+    throw .facts
   let some (facts, instances) := order.counts? | throw .malformed
-  if index != facts || limit.maxInstances < instances then throw .malformed
-  if limit.maxFacts <= facts then throw .facts
+  if limit.maxFacts < facts || limit.maxInstances < instances || index != facts then
+    throw .malformed
   pure { chronology := order.chronology.push (.fact index) }
 
 /-- Append the exact next instance-history position after validating the
 retained chronology and both independent count caps. -/
 def appendInstance (limit : Limit) (order : Order) (index : Nat) : Except Error Order := do
+  if limit.maxInstances <= index ||
+      limit.maxFacts + limit.maxInstances <= order.chronology.size then
+    throw .instances
   let some (facts, instances) := order.counts? | throw .malformed
-  if index != instances || limit.maxFacts < facts then throw .malformed
-  if limit.maxInstances <= instances then throw .instances
+  if limit.maxFacts < facts || limit.maxInstances < instances || index != instances then
+    throw .malformed
   pure { chronology := order.chronology.push (.instance index) }
 
 end Order
@@ -121,8 +126,9 @@ structure Event where
   work : Nat := 0
   deriving DecidableEq, Repr
 
-/-- Bounded retained diagnostics. Cached totals make admission constant-time
-after inspecting the returned event's already-allocated payload size. -/
+/-- Bounded retained diagnostics. `append` first revalidates the complete
+retained event array; cached totals make only the subsequent accepted-event
+increment constant-time after inspecting the already-allocated payload size. -/
 structure Log where
   events : Array Event := #[]
   bytes : Nat := 0

--- a/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
+++ b/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
@@ -357,7 +357,7 @@ def complexProgram : Program :=
         instruction 6 [node 2, node 0], instruction 5 [node 3, node 0],
         instruction 5 [node 4, node 1], instruction 9 [node 0, node 5]] }
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 10
     maxNodes := 8
     maxRules := 2

--- a/bench/HexInterval/IntervalSchedulerSpike.lean
+++ b/bench/HexInterval/IntervalSchedulerSpike.lean
@@ -329,7 +329,7 @@ def canary : Comparison := compare 4 8
 /-- Suggested logical-count corpus.  Increasing the disconnected-tree count
 leaves incremental work fixed at `depth`, while structural work grows as
 `2 * trees * depth`. -/
-def corpus : Array (Nat × Nat × Comparison) :=
+def corpus (_ : Unit) : Array (Nat × Nat × Comparison) :=
   #[(1, 64, compare 1 64),
     (8, 64, compare 8 64),
     (64, 64, compare 64 64),

--- a/bench/HexInterval/IntervalSchedulerSpike.lean
+++ b/bench/HexInterval/IntervalSchedulerSpike.lean
@@ -29,7 +29,9 @@ this file exercises no rational or endpoint arithmetic.
 The primary measurements are deterministic rule-invocation and improvement
 counts.  A position-sensitive checksum pins the final facts, so a lower count
 cannot be obtained by silently skipping propagation.  Wall-clock timing can be
-layered on this module later without changing the logical workload.
+layered on this module later without changing the logical workload, but current
+timings include the transparent reference engine's whole-state validation and
+queue-history costs rather than measuring dependency discovery alone.
 -/
 
 namespace Hex.Interval.Experiment.Propagator.Bench
@@ -95,7 +97,7 @@ def refineFirstRoot (facts : Array Nat) : Option (Array Nat) := do
 
 def applicationCount (trees depth : Nat) : Nat := trees * depth
 
-def generousLimits (trees depth : Nat) : Limits :=
+def generousLimits (trees depth : Nat) : Hex.Interval.State.Limits :=
   let nodeCount := trees * (depth + 1)
   let applications := applicationCount trees depth
   { maxOperations := operations.size
@@ -176,24 +178,25 @@ def stopOfRun : RunStop -> Stop
   | .contradiction | .engineResource _ | .factResource _ | .invalidReply _ |
       .invalidEngine => .engineFailure
 
-/-- Clear the initial all-rules queue to model an old fixed point, install one
-new source fact, and wake exactly that source's watchers. -/
+/-- Start from a canonical version-zero source refinement, clear the initial
+all-rules queue through checked per-occurrence deactivation to model an old
+fixed point, and wake exactly that source's watchers. -/
 def prepareIncremental (trees depth : Nat) : Option (Engine Nat) := do
   if trees = 0 then none else pure ()
+  let facts <- refineFirstRoot (saturatedFacts trees depth)
   let initial <-
-    match Engine.start factDomain (forestProgram trees depth) rules (saturatedFacts trees depth)
+    match Engine.start factDomain (forestProgram trees depth) rules facts
         (generousLimits trees depth) with
     | .ok state => some state
     | .error _ => none
-  let facts <- refineFirstRoot initial.facts
-  let idle : Engine Nat :=
-    { initial with
-      facts
-      versions := initial.versions.set! firstRoot.index 1
-      queue := #[]
-      queueHead := 0
-      queued := Array.replicate initial.applications.size false
-      metrics := {} }
+  let mut idle := initial
+  for index in [0:initial.applications.size] do
+    let (dependencies, queue) <-
+      (idle.toQueue.deactivate idle.limits.maxQueueEntries idle.program.nodes.size
+        idle.applications.size idle.equalities.size idle.toDependencies
+          (.application { index })).toOption
+    idle := { idle with toDependencies := dependencies, toQueue := queue }
+  idle := { idle with metrics := {} }
   match idle.wakeNode firstRoot with
   | .ok ready => some ready
   | .error _ => none

--- a/conformance/HexInterval/ChronologicalReplayConformance.lean
+++ b/conformance/HexInterval/ChronologicalReplayConformance.lean
@@ -108,7 +108,7 @@ def rankFacts : FactDomainSchema functionSemantics :=
         else none
       else none }
 
-def replaysStep (mutate : FactEvent Rank -> FactEvent Rank := id)
+def replaysStep (mutate : Hex.Interval.State.Update Rank (FactCause Rank) -> Hex.Interval.State.Update Rank (FactCause Rank) := id)
     (inputNode : NodeId := node 0) : Bool :=
   match semanticFixture? with
   | none => false
@@ -157,7 +157,7 @@ def replaysStep (mutate : FactEvent Rank -> FactEvent Rank := id)
       | .transport _ _ => event) &&
     !replaysStep (fun event => { event with fact := 0 })
 
-def replaysResolved (mutate : FactEvent Rank -> FactEvent Rank := id) : Bool :=
+def replaysResolved (mutate : Hex.Interval.State.Update Rank (FactCause Rank) -> Hex.Interval.State.Update Rank (FactCause Rank) := id) : Bool :=
   match semanticFixture? with
   | none => false
   | some fixture =>
@@ -646,7 +646,7 @@ theorem callerSinNegRange :
     functionSemantics.Entails program base { node := node 2, fact := 1 } := by
   simpa [rangeTargetInput, checkerInput] using emittedTarget.proof
 
-def transportEvent (source : NodeId := node 4) : FactEvent Rank :=
+def transportEvent (source : NodeId := node 4) : Hex.Interval.State.Update Rank (FactCause Rank) :=
   { programVersion := 1
     node := node 2
     previous := { node := node 2, version := 0 }

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -2353,8 +2353,29 @@ def secondUpdate : Hex.Interval.State.Update Nat Nat :=
       | .error _ => false
       | .ok next =>
           next.check && next.restoredVersions? == some #[0, 1] &&
+            next.restoredFacts? == some #[13, 29] &&
+            next.snapshot.facts == #[13, 29] &&
             next.factAt? { node := contractNode 1, version := 0 } == some 23 &&
             next.factAt? { node := contractNode 1, version := 1 } == some 29
+
+-- Base facts are authoritative and appended-node seeds retain only the exact
+-- suffix. A forged duplicate base seed cannot enter a checked branch.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      branch.seeds.isEmpty &&
+        ({ branch with seeds := #[999, 23] }).restoredFacts?.isNone &&
+        !({ branch with seeds := #[999, 23] }).check &&
+        branch.factAt? { node := contractNode 0, version := 0 } == some 13
+
+-- There is no independently mutable current-fact field. A forged retained
+-- fact event changes the reconstructed snapshot, but without its matching
+-- version transition the decoded branch is rejected.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      let malformed := { branch with history := #[{ firstUpdate with fact := 999 }] }
+      !malformed.check && malformed.snapshot.facts == #[13, 999]
 
 -- Stale, cross-node, and wrong-program provenance fail without a replacement
 -- branch. A malformed current snapshot cannot be repaired by appending to it.
@@ -2378,7 +2399,7 @@ def secondUpdate : Hex.Interval.State.Update Nat Nat :=
   | some branch =>
       let malformed := { branch with versions := #[0] }
       match malformed.pushWithin stateLimits firstUpdate with
-      | .error .invalidProgram => malformed.facts == #[13, 23]
+      | .error .invalidProgram => malformed.snapshot.facts == #[13, 23]
       | _ => false
 
 -- The history limit is checked before the second event is retained.
@@ -2391,13 +2412,33 @@ def secondUpdate : Hex.Interval.State.Update Nat Nat :=
       | .ok next =>
           match next.pushWithin one secondUpdate with
           | .error (.resource .acceptedFacts) =>
-              next.history.size == 1 && next.facts[1]? == some 29
+              next.history.size == 1 && next.snapshot.facts[1]? == some 29
           | _ => false
 
 def extendedProgram : Program :=
   { contractProgram with
     nodes := contractProgram.nodes.push
       { domain := realDomain, op := { index := 1 }, args := [contractNode 1] } }
+
+-- Decoded base-program limits are checked before the malformed prefix is
+-- traversed by `Branch.check`.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      let malformed := { branch with baseProgram := extendedProgram }
+      let tiny := { stateLimits with maxNodes := 2 }
+      match malformed.pushWithin tiny firstUpdate with
+      | .error (.resource .nodes) => malformed.history.isEmpty
+      | _ => false
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      let overHistory := { branch with history := #[firstUpdate] }
+      let none := { stateLimits with maxAcceptedFacts := 0 }
+      match overHistory.extendWithin none extendedProgram #[37] 1 with
+      | .error (.resource .acceptedFacts) => overHistory.program == contractProgram
+      | _ => false
 
 -- Extension retains the exact generated version-zero seed rather than asking
 -- a later callback to reconstruct it. Non-prefix and wrong-count extensions
@@ -2408,8 +2449,21 @@ def extendedProgram : Program :=
       match branch.extendWithin stateLimits extendedProgram #[37] 1 with
       | .error _ => false
       | .ok next =>
-          next.check && next.programVersion == 1 && next.seeds == #[13, 23, 37] &&
+          next.check && next.programVersion == 1 && next.seeds == #[37] &&
+            next.generations == #[0, 0, 1] &&
             next.factAt? { node := contractNode 2, version := 0 } == some 37
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.extendWithin stateLimits extendedProgram #[37] 2 with
+      | .error .invalidGeneration => branch.programVersion == 0
+      | _ => false
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      !({ branch with generations := #[1, 0] }).check
 
 #guard match branch? with
   | none => false
@@ -2429,8 +2483,18 @@ def initialQueue? : Option Hex.Interval.State.Queue :=
 #guard dependencies.check 2 1 1
 #guard !({ dependencies with watchers := #[[], [.application { index := 1 }]] }).check 2 1 1
 #guard match initialQueue? with
-  | some queue => queue.check dependencies 1 1 1
+  | some queue => queue.check dependencies 2 1 1 1
   | none => false
+
+-- Queue builders receive the exact node count; watcher alignment is not
+-- inferred tautologically from the malformed watcher array itself.
+#guard match initialQueue? with
+  | none => false
+  | some queue =>
+      !queue.check dependencies 1 1 1 1 &&
+        match queue.enqueueWithin 2 1 1 1 dependencies (.equality { index := 0 }) with
+        | .error .malformed => true
+        | _ => false
 
 -- Count refusal precedes initial queue allocation. Enqueue and pop preserve
 -- exact live-suffix/dirty-bit agreement for both work roles.
@@ -2441,17 +2505,17 @@ def initialQueue? : Option Hex.Interval.State.Queue :=
 #guard match initialQueue? with
   | none => false
   | some queue =>
-      match queue.enqueueWithin 2 1 1 dependencies (.equality { index := 0 }) with
+      match queue.enqueueWithin 2 2 1 1 dependencies (.equality { index := 0 }) with
       | .error _ => false
       | .ok (dependencies, queue) =>
-          queue.check dependencies 1 1 2 &&
-            match queue.pop 2 1 1 dependencies with
+          queue.check dependencies 2 1 1 2 &&
+            match queue.pop 2 2 1 1 dependencies with
             | .error _ | .ok (none, _, _) => false
             | .ok (some (.application _), dependencies, queue) =>
-                queue.check dependencies 1 1 2 &&
-                  match queue.pop 2 1 1 dependencies with
+                queue.check dependencies 2 1 1 2 &&
+                  match queue.pop 2 2 1 1 dependencies with
                   | .ok (some (.equality _), dependencies, queue) =>
-                      queue.check dependencies 1 1 2 && queue.queueHead == 2
+                      queue.check dependencies 2 1 1 2 && queue.queueHead == 2
                   | _ => false
             | _ => false
 
@@ -2459,21 +2523,49 @@ def initialQueue? : Option Hex.Interval.State.Queue :=
   | none => false
   | some queue =>
       let misaligned := { dependencies with queued := #[] }
-      match queue.enqueueWithin 2 1 1 misaligned (.equality { index := 0 }) with
+      match queue.enqueueWithin 2 2 1 1 misaligned (.equality { index := 0 }) with
       | .error .malformed => queue.queue.size == 1
       | _ => false
 
 #guard match initialQueue? with
   | none => false
   | some queue =>
-      match queue.deactivate 1 1 1 dependencies (.application { index := 0 }) with
+      match queue.deactivate 1 2 1 1 dependencies (.application { index := 0 }) with
       | .error _ => false
-      | .ok dependencies =>
-          match queue.pop 1 1 1 dependencies with
+      | .ok (dependencies, queue) =>
+          match queue.pop 1 2 1 1 dependencies with
           | .ok (none, dependencies, queue) =>
               queue.queueHead == 1 && dependencies.queued == #[false] &&
-                queue.check dependencies 1 1 1
+                queue.check dependencies 2 1 1 1
           | _ => false
+
+def twoDependencies : Hex.Interval.State.Dependencies :=
+  { watchers := #[[]]
+    queued := #[true, true]
+    equalityQueued := #[] }
+
+def twoQueue? : Option Hex.Interval.State.Queue :=
+  (Hex.Interval.State.Queue.initialWithin 3 2).toOption
+
+-- Deactivating the first occurrence leaves an occurrence-local tombstone.
+-- Re-enqueueing that work cannot resurrect it ahead of the still-live second
+-- application, so FIFO order remains load-bearing.
+#guard match twoQueue? with
+  | none => false
+  | some queue =>
+      match queue.deactivate 3 1 2 0 twoDependencies (.application { index := 0 }) with
+      | .error _ => false
+      | .ok (dependencies, queue) =>
+          match queue.enqueueWithin 3 1 2 0 dependencies (.application { index := 0 }) with
+          | .error _ => false
+          | .ok (dependencies, queue) =>
+              queue.live == #[false, true, true] &&
+                match queue.pop 3 1 2 0 dependencies with
+                | .ok (some (.application application), dependencies, queue) =>
+                    application.index == 1 && queue.queueHead == 2 &&
+                      queue.live == #[false, false, true] &&
+                      queue.check dependencies 1 2 0 3
+                | _ => false
 
 def orderLimit : Hex.Interval.Trace.Order.Limit :=
   { maxFacts := 1, maxInstances := 1 }
@@ -2486,7 +2578,8 @@ def exactOrder? : Option Hex.Interval.Trace.Order := do
   | some order => order.check 1 1
   | none => false
 
-#guard match Hex.Interval.Trace.Order.empty.appendFact orderLimit 1 with
+#guard match Hex.Interval.Trace.Order.empty.appendFact
+    { maxFacts := 2, maxInstances := 1 } 1 with
   | .error .malformed => true
   | _ => false
 
@@ -2496,6 +2589,19 @@ def exactOrder? : Option Hex.Interval.Trace.Order := do
       match order.appendFact orderLimit 1 with
       | .error .facts => order.check 1 1
       | _ => false
+
+-- Total-cap refusal precedes traversal of malformed retained chronology.
+-- Without the size preflight these bad local indices would report malformed.
+def overCapOrder : Hex.Interval.Trace.Order :=
+  { chronology := #[.fact 7, .instance 9, .fact 11] }
+
+#guard match overCapOrder.appendFact orderLimit 0 with
+  | .error .facts => true
+  | _ => false
+
+#guard match overCapOrder.appendInstance orderLimit 0 with
+  | .error .instances => true
+  | _ => false
 
 def traceLimit : Hex.Interval.Trace.Limit :=
   { maxEvents := 1, maxBytes := 2, maxWork := 3, maxCode := 4 }

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -2300,6 +2300,253 @@ def snapshot : Snapshot Nat :=
 #guard ({ node := contractNode 1, version := 5 : SeenVersion }) !=
   ({ node := contractNode 1, version := 6 : SeenVersion })
 
+def stateLimits : Hex.Interval.State.Limits :=
+  { maxOperations := 4
+    maxNodes := 4
+    maxRules := 4
+    maxRegistryEntries := 4
+    maxReplayFormats := 4
+    maxArity := 2
+    maxScopeNodes := 2
+    maxApplications := 2
+    maxQueueEntries := 4
+    maxActions := 4
+    maxMatcherVisits := 4
+    matcherBatchSize := 1
+    maxAcceptedFacts := 2
+    maxRetainedSuggestions := 2
+    maxEffort := 4
+    maxObservationValue := 8
+    maxDiagnosticValue := 8
+    maxOutcomeCandidates := 2
+    maxOutcomeSuggestions := 2
+    maxProposalItems := 4
+    maxInstances := 2
+    maxGeneration := 2
+    maxNodeDepth := 3
+    maxEqualities := 2
+    splitEndpointLimit := smallLimit }
+
+def branch? : Option (Hex.Interval.State.Branch Nat Nat) :=
+  (Hex.Interval.State.Branch.startWithin stateLimits contractProgram #[13, 23]).toOption
+
+def firstUpdate : Hex.Interval.State.Update Nat Nat :=
+  { programVersion := 0
+    node := contractNode 1
+    previous := { node := contractNode 1, version := 0 }
+    fact := 29
+    version := 1
+    cause := 71 }
+
+def secondUpdate : Hex.Interval.State.Update Nat Nat :=
+  { firstUpdate with
+    previous := { node := contractNode 1, version := 1 }
+    fact := 31
+    version := 2 }
+
+-- Version zero and every later version are immutable retained facts. Exact
+-- predecessor links reconstruct the live version array.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.pushWithin stateLimits firstUpdate with
+      | .error _ => false
+      | .ok next =>
+          next.check && next.restoredVersions? == some #[0, 1] &&
+            next.factAt? { node := contractNode 1, version := 0 } == some 23 &&
+            next.factAt? { node := contractNode 1, version := 1 } == some 29
+
+-- Stale, cross-node, and wrong-program provenance fail without a replacement
+-- branch. A malformed current snapshot cannot be repaired by appending to it.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.pushWithin stateLimits
+          { firstUpdate with previous := { node := contractNode 0, version := 0 } } with
+      | .error (.staleVersion node) => node == contractNode 1
+      | _ => false
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.pushWithin stateLimits { firstUpdate with programVersion := 1 } with
+      | .error .wrongProgramVersion => true
+      | _ => false
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      let malformed := { branch with versions := #[0] }
+      match malformed.pushWithin stateLimits firstUpdate with
+      | .error .invalidProgram => malformed.facts == #[13, 23]
+      | _ => false
+
+-- The history limit is checked before the second event is retained.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      let one := { stateLimits with maxAcceptedFacts := 1 }
+      match branch.pushWithin one firstUpdate with
+      | .error _ => false
+      | .ok next =>
+          match next.pushWithin one secondUpdate with
+          | .error (.resource .acceptedFacts) =>
+              next.history.size == 1 && next.facts[1]? == some 29
+          | _ => false
+
+def extendedProgram : Program :=
+  { contractProgram with
+    nodes := contractProgram.nodes.push
+      { domain := realDomain, op := { index := 1 }, args := [contractNode 1] } }
+
+-- Extension retains the exact generated version-zero seed rather than asking
+-- a later callback to reconstruct it. Non-prefix and wrong-count extensions
+-- are rejected before branch arrays change.
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.extendWithin stateLimits extendedProgram #[37] 1 with
+      | .error _ => false
+      | .ok next =>
+          next.check && next.programVersion == 1 && next.seeds == #[13, 23, 37] &&
+            next.factAt? { node := contractNode 2, version := 0 } == some 37
+
+#guard match branch? with
+  | none => false
+  | some branch =>
+      match branch.extendWithin stateLimits extendedProgram #[] 1 with
+      | .error .wrongFactCount => branch.programVersion == 0
+      | _ => false
+
+def dependencies : Hex.Interval.State.Dependencies :=
+  { watchers := #[[], [.application { index := 0 }, .equality { index := 0 }]]
+    queued := #[true]
+    equalityQueued := #[false] }
+
+def initialQueue? : Option Hex.Interval.State.Queue :=
+  (Hex.Interval.State.Queue.initialWithin 1 1).toOption
+
+#guard dependencies.check 2 1 1
+#guard !({ dependencies with watchers := #[[], [.application { index := 1 }]] }).check 2 1 1
+#guard match initialQueue? with
+  | some queue => queue.check dependencies 1 1 1
+  | none => false
+
+-- Count refusal precedes initial queue allocation. Enqueue and pop preserve
+-- exact live-suffix/dirty-bit agreement for both work roles.
+#guard match Hex.Interval.State.Queue.initialWithin 0 1 with
+  | .error .queueEntries => true
+  | _ => false
+
+#guard match initialQueue? with
+  | none => false
+  | some queue =>
+      match queue.enqueueWithin 2 1 1 dependencies (.equality { index := 0 }) with
+      | .error _ => false
+      | .ok (dependencies, queue) =>
+          queue.check dependencies 1 1 2 &&
+            match queue.pop 2 1 1 dependencies with
+            | .error _ | .ok (none, _, _) => false
+            | .ok (some (.application _), dependencies, queue) =>
+                queue.check dependencies 1 1 2 &&
+                  match queue.pop 2 1 1 dependencies with
+                  | .ok (some (.equality _), dependencies, queue) =>
+                      queue.check dependencies 1 1 2 && queue.queueHead == 2
+                  | _ => false
+            | _ => false
+
+#guard match initialQueue? with
+  | none => false
+  | some queue =>
+      let misaligned := { dependencies with queued := #[] }
+      match queue.enqueueWithin 2 1 1 misaligned (.equality { index := 0 }) with
+      | .error .malformed => queue.queue.size == 1
+      | _ => false
+
+#guard match initialQueue? with
+  | none => false
+  | some queue =>
+      match queue.deactivate 1 1 1 dependencies (.application { index := 0 }) with
+      | .error _ => false
+      | .ok dependencies =>
+          match queue.pop 1 1 1 dependencies with
+          | .ok (none, dependencies, queue) =>
+              queue.queueHead == 1 && dependencies.queued == #[false] &&
+                queue.check dependencies 1 1 1
+          | _ => false
+
+def orderLimit : Hex.Interval.Trace.Order.Limit :=
+  { maxFacts := 1, maxInstances := 1 }
+
+def exactOrder? : Option Hex.Interval.Trace.Order := do
+  let order ← (Hex.Interval.Trace.Order.empty.appendFact orderLimit 0).toOption
+  (order.appendInstance orderLimit 0).toOption
+
+#guard match exactOrder? with
+  | some order => order.check 1 1
+  | none => false
+
+#guard match Hex.Interval.Trace.Order.empty.appendFact orderLimit 1 with
+  | .error .malformed => true
+  | _ => false
+
+#guard match exactOrder? with
+  | none => false
+  | some order =>
+      match order.appendFact orderLimit 1 with
+      | .error .facts => order.check 1 1
+      | _ => false
+
+def traceLimit : Hex.Interval.Trace.Limit :=
+  { maxEvents := 1, maxBytes := 2, maxWork := 3, maxCode := 4 }
+
+def traceEvent : Hex.Interval.Trace.Event :=
+  { code := 4, payload := #[7, 8], work := 3 }
+
+def retainedLog? : Option Hex.Interval.Trace.Log :=
+  match ({} : Hex.Interval.Trace.Log).append traceLimit traceEvent with
+  | .retained log => some log
+  | _ => none
+
+#guard match retainedLog? with
+  | some log => log.check traceLimit && log.bytes == 2 && log.work == 3
+  | none => false
+
+-- Each one-over count/byte/work refusal is explicit truncation and retains
+-- neither the event nor its totals. Malformed cached totals are distinct.
+#guard match retainedLog? with
+  | none => false
+  | some log =>
+      match log.append traceLimit { code := 0 } with
+      | .truncated next =>
+          next.truncated && next.events.size == 1 && next.bytes == 2 && next.work == 3
+      | _ => false
+
+#guard match ({} : Hex.Interval.Trace.Log).append
+    { traceLimit with maxBytes := 1 } traceEvent with
+  | .truncated log => log.events.isEmpty && log.truncated
+  | _ => false
+
+#guard match ({} : Hex.Interval.Trace.Log).append
+    { traceLimit with maxWork := 2 } traceEvent with
+  | .truncated log => log.events.isEmpty && log.truncated
+  | _ => false
+
+#guard match ({ bytes := 1 } : Hex.Interval.Trace.Log).append traceLimit traceEvent with
+  | .malformed => true
+  | _ => false
+
+-- Diagnostic loss has no branch-state argument and therefore cannot alter
+-- facts, versions, provenance, or contradiction state.
+#guard match branch?, retainedLog? with
+  | some branch, some log =>
+      match log.append traceLimit { code := 0 } with
+      | .truncated _ =>
+          branch.snapshot.facts == #[13, 23] && branch.snapshot.versions == #[0, 0] &&
+            branch.history.isEmpty && !branch.contradictory
+      | _ => false
+  | _, _ => false
+
 end Contracts
 
 end Hex.Interval.Conformance

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -490,7 +490,7 @@ private def sourceProgram : Program :=
   { operations := #[{ key := sourceOp, inputs := [], output := real }]
     nodes := #[{ domain := real, op := { index := 0 }, args := [] }] }
 
-private def engineLimits : Limits :=
+private def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 4
     maxNodes := 4
     maxRules := 0

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -37,7 +37,7 @@ def config : Config :=
 
 abbrev ConcreteRegistry := Propagator.Registry Fact
 
-def limits : Experiment.Propagator.Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 16
     maxNodes := 32
     maxRules := 16
@@ -509,26 +509,26 @@ def ownsV0 (arena : PayloadArena.Arena) (payload : PayloadId)
       | _ => false
   | none => false
 
-def lowEffortLimits : Experiment.Propagator.Limits :=
+def lowEffortLimits : Hex.Interval.State.Limits :=
   { limits with maxEffort := 3 }
 
-def lowDiagnosticLimits : Experiment.Propagator.Limits :=
+def lowDiagnosticLimits : Hex.Interval.State.Limits :=
   { limits with maxDiagnosticValue := 70 }
 
-def noCandidateLimits : Experiment.Propagator.Limits :=
+def noCandidateLimits : Hex.Interval.State.Limits :=
   { limits with maxOutcomeCandidates := 0 }
 
-def noSuggestionLimits : Experiment.Propagator.Limits :=
+def noSuggestionLimits : Hex.Interval.State.Limits :=
   { limits with maxOutcomeSuggestions := 0 }
 
-def shortProposalLimits : Experiment.Propagator.Limits :=
+def shortProposalLimits : Hex.Interval.State.Limits :=
   { limits with maxProposalItems := 3 }
 
-def tinySplitLimits : Experiment.Propagator.Limits :=
+def tinySplitLimits : Hex.Interval.State.Limits :=
   { limits with
     splitEndpointLimit := { maxEndpointHeight := 0, maxAlignmentShift := 0 } }
 
-def rejectsPackageLimits (candidateLimits : Experiment.Propagator.Limits) : Bool :=
+def rejectsPackageLimits (candidateLimits : Hex.Interval.State.Limits) : Bool :=
   match DyadicRules.start config real centeredProgram
       #[finite 0 false 1 false, finite 1 false 1 false, whole, whole]
       candidateLimits with

--- a/conformance/HexInterval/MatcherSchedulerConformance.lean
+++ b/conformance/HexInterval/MatcherSchedulerConformance.lean
@@ -72,7 +72,7 @@ def contractRule : Registration :=
     writes := []
     binding := .scoped }
 
-def limits : Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 4
     maxNodes := 8
     maxRules := 2
@@ -297,7 +297,7 @@ def afterOddness? : Option (Engine Rank) := do
 
 /-! ## Growth before a frozen matcher epoch is exhausted -/
 
-def earlyLimits : Limits :=
+def earlyLimits : Hex.Interval.State.Limits :=
   { limits with matcherBatchSize := 1 }
 
 def earlyStarted? : Option (Engine Rank) :=
@@ -512,7 +512,7 @@ def package : Package Rank :=
         { Handler.bareDroppingDrafts contractRule packageContract with
           acceptsScope := fun _ binding => binding.rule == contractKey }] }
 
-def packageLimits : Limits :=
+def packageLimits : Hex.Interval.State.Limits :=
   { limits with maxDiagnosticValue := 300 }
 
 def payloadLimits : Experiment.PayloadArena.Limits :=

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -235,7 +235,7 @@ def factDomain : FactDomain Nat where
   narrow _ current candidate :=
     if current < candidate then .improved candidate else .noChange
 
-def limits : Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 8
     maxNodes := 8
     maxRules := 8
@@ -280,22 +280,22 @@ def externalRegistry? : Option (Registry Nat) :=
   | .ok registry => some registry
   | .error _ => none
 
-def lowDiagnosticLimits : Limits :=
+def lowDiagnosticLimits : Hex.Interval.State.Limits :=
   { limits with maxDiagnosticValue := 999999 }
 
 def shortArenaLimits : Experiment.PayloadArena.Limits :=
   { arenaLimits with maxEntries := 3 }
 
-def shortRuleLimits : Limits :=
+def shortRuleLimits : Hex.Interval.State.Limits :=
   { limits with maxRules := 3 }
 
-def shortOperationLimits : Limits :=
+def shortOperationLimits : Hex.Interval.State.Limits :=
   { limits with maxOperations := 3 }
 
-def shortMetadataLimits : Limits :=
+def shortMetadataLimits : Hex.Interval.State.Limits :=
   { limits with maxRegistryEntries := 8 }
 
-def nullaryLimits : Limits :=
+def nullaryLimits : Hex.Interval.State.Limits :=
   { limits with maxArity := 0 }
 
 def run? : Option (RunResult Nat (Registry Nat)) :=

--- a/conformance/HexInterval/PayloadSessionConformance.lean
+++ b/conformance/HexInterval/PayloadSessionConformance.lean
@@ -104,7 +104,7 @@ def resourceDomain : FactDomain Nat where
   top _ := 0
   narrow _ _ _ := .resourceLimit 6
 
-def limits : Propagator.Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 4
     maxNodes := 4
     maxRules := 2
@@ -775,7 +775,7 @@ def opaqueProgram : Program :=
         instruction 1 [node 0],
         instruction 2 [node 0]] }
 
-def opaqueLimits : Propagator.Limits :=
+def opaqueLimits : Hex.Interval.State.Limits :=
   { limits with maxOperations := 6, maxRules := 4 }
 
 def start (package : Package Nat)
@@ -784,19 +784,19 @@ def start (package : Package Nat)
   PayloadSession.Session.start factDomain program #[package] #[3, 0, 0]
     limits payloadLimits
 
-def startWithin (package : Package Nat) (engineLimits : Propagator.Limits)
+def startWithin (package : Package Nat) (engineLimits : Hex.Interval.State.Limits)
     (payloadLimits : PayloadArena.Limits) :
     Except PayloadSession.StartError (PayloadSession.Session Nat) :=
   PayloadSession.Session.start factDomain program #[package] #[3, 0, 0]
     engineLimits payloadLimits
 
-def matcherLimits : Propagator.Limits :=
+def matcherLimits : Hex.Interval.State.Limits :=
   { limits with
     maxScopeNodes := 2
     maxMatcherVisits := 8
     matcherBatchSize := 2 }
 
-def oneMatcherUseLimits : Propagator.Limits :=
+def oneMatcherUseLimits : Hex.Interval.State.Limits :=
   { matcherLimits with
     maxOutcomeCandidates := 0
     maxOutcomeSuggestions := 1
@@ -809,18 +809,18 @@ def oneMatcherEntryArena : PayloadArena.Limits :=
     maxUses := 1 }
 
 def startMatcher (package : Package Nat)
-    (engineLimits : Propagator.Limits := matcherLimits)
+    (engineLimits : Hex.Interval.State.Limits := matcherLimits)
     (payloadLimits : PayloadArena.Limits := arenaLimits) :
     Except PayloadSession.StartError (PayloadSession.Session Nat) :=
   startWithin package engineLimits payloadLimits
 
-def oneReplyLimits : Propagator.Limits :=
+def oneReplyLimits : Hex.Interval.State.Limits :=
   { limits with
     maxOutcomeCandidates := 1
     maxOutcomeSuggestions := 0
     maxProposalItems := 0 }
 
-def twoUseLimits : Propagator.Limits :=
+def twoUseLimits : Hex.Interval.State.Limits :=
   { oneReplyLimits with maxOutcomeCandidates := 2 }
 
 def lateExtraArena : PayloadArena.Limits :=
@@ -839,7 +839,7 @@ def lateMalformedArena : PayloadArena.Limits :=
     maxDraftCells := 2
     maxUses := 1 }
 
-def nestedUsesLimits : Propagator.Limits :=
+def nestedUsesLimits : Hex.Interval.State.Limits :=
   { limits with
     maxOutcomeCandidates := 0
     maxOutcomeSuggestions := 1
@@ -850,7 +850,7 @@ def nestedUsesArena : PayloadArena.Limits :=
     maxDrafts := PayloadSession.requiredUses nestedUsesLimits
     maxUses := PayloadSession.requiredUses nestedUsesLimits }
 
-def overflowLimits : Propagator.Limits :=
+def overflowLimits : Hex.Interval.State.Limits :=
   { limits with maxOutcomeSuggestions := 3 }
 
 def overflowArenaLimits : PayloadArena.Limits :=

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -69,7 +69,7 @@ def gRule : Registration :=
     watches := [.argument 0]
     writes := [.result] }
 
-def engineLimits : Experiment.Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 8
     maxNodes := 8
     maxRules := 8
@@ -99,7 +99,7 @@ def policyLimits : Experiment.Propagator.Policy.Limits :=
     maxTraversal := 512
     maxLiveOffers := 32 }
 
-def initialWithLimits? (engineLimit : Experiment.Propagator.Limits)
+def initialWithLimits? (engineLimit : Hex.Interval.State.Limits)
     (policyLimit : Experiment.Propagator.Policy.Limits) : Option (State Rank) := do
   let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimit with
     | .ok engine => some engine
@@ -392,7 +392,7 @@ def afterInitial? : Option (State Rank) := do
   let (_, state) <- submit? state request
   some state
 
-def afterReplyWith? (engineLimit : Experiment.Propagator.Limits)
+def afterReplyWith? (engineLimit : Hex.Interval.State.Limits)
     (reply : RuleRequest Rank -> Outcome Rank) : Option (State Rank) := do
   let state <- initialWithLimits? engineLimit policyLimits
   let (request, state) <- request? state (.application (application 0))
@@ -400,7 +400,7 @@ def afterReplyWith? (engineLimit : Experiment.Propagator.Limits)
   | .accepted _ next => some next
   | _ => none
 
-def observedWith? (engineLimit : Experiment.Propagator.Limits)
+def observedWith? (engineLimit : Hex.Interval.State.Limits)
     (reply : RuleRequest Rank -> Outcome Rank) :
     Option (RuleObservation Rank × State Rank) := do
   let state <- initialWithLimits? engineLimit policyLimits
@@ -409,7 +409,7 @@ def observedWith? (engineLimit : Experiment.Propagator.Limits)
   | .accepted observation next => some (observation, next)
   | _ => none
 
-def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (State Rank) :=
+def afterInitialWith? (engineLimit : Hex.Interval.State.Limits) : Option (State Rank) :=
   afterReplyWith? engineLimit invoke
 
 -- Adopting a snapshot with an open reply latch cannot reconstruct the selected
@@ -553,7 +553,7 @@ def oneDecisionState? : Option (State Rank) :=
 
 /-! # Resource preservation and exact equality observations -/
 
-def retainedEngineWith? (limits : Experiment.Propagator.Limits) : Option (Engine Rank) := do
+def retainedEngineWith? (limits : Hex.Interval.State.Limits) : Option (Engine Rank) := do
   let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] limits with
     | .ok engine => some engine
     | .error _ => none
@@ -564,7 +564,7 @@ def retainedEngineWith? (limits : Experiment.Propagator.Limits) : Option (Engine
       | _ => none
   | _ => none
 
-def equalityReadyWith? (limits : Experiment.Propagator.Limits)
+def equalityReadyWith? (limits : Hex.Interval.State.Limits)
     (domain : FactDomain Rank) : Option (State Rank) := do
   let engine <- retainedEngineWith? limits
   let state := State.start { engine with factDomain := domain } policyLimits

--- a/conformance/HexInterval/PolicyFunctionConformance.lean
+++ b/conformance/HexInterval/PolicyFunctionConformance.lean
@@ -198,7 +198,7 @@ def packageWith (plan : RuleRequest Rank -> Plan Rank) : Package Rank :=
 def package : Package Rank := packageWith matcherPlan
 def rejectedPackage : Package Rank := packageWith rejectedMatcherPlan
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 3
     maxNodes := 5
     maxRules := 2

--- a/conformance/HexInterval/PolicySessionConformance.lean
+++ b/conformance/HexInterval/PolicySessionConformance.lean
@@ -36,7 +36,7 @@ def config : Config :=
     reciprocalBasePrecision := 2
     maxReciprocalEffort := 4 }
 
-def engineLimits : Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 24
     maxNodes := 32
     maxRules := 16
@@ -434,7 +434,7 @@ def capacityFacts? : Option (Array Fact) :=
   | .ok facts => some facts.toArray
   | .error _ => none
 
-def capacityEngineLimits : Propagator.Limits :=
+def capacityEngineLimits : Hex.Interval.State.Limits :=
   { engineLimits with
     maxOutcomeCandidates := 1
     maxOutcomeSuggestions := 0

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -49,7 +49,7 @@ def operations : Array Operation :=
   #[{ key := sourceOp, inputs := [], output := real },
     { key := unaryOp, inputs := [real], output := real }]
 
-def generous : Limits :=
+def generous : Hex.Interval.State.Limits :=
   { maxOperations := 16
     maxNodes := 64
     maxRules := 16
@@ -99,7 +99,7 @@ def copyInvoke (calls : List Nat) (request : RuleRequest Rank) :
   | none => (.failed 1, calls)
 
 def start? (program : Program) (rules : Array Registration) (facts : Array Rank)
-    (limits : Limits := generous) : Option (Engine Rank) :=
+    (limits : Hex.Interval.State.Limits := generous) : Option (Engine Rank) :=
   match Engine.start rankDomain program rules facts limits with
   | .ok state => some state
   | .error _ => none
@@ -366,7 +366,7 @@ def dynamicInvoke (calls : List String) (request : RuleRequest Rank) :
   else
     (.failed 7, calls)
 
-def dynamicInitial? (limits : Limits := generous) :
+def dynamicInitial? (limits : Hex.Interval.State.Limits := generous) :
     Option (RunResult Rank (List String)) := do
   let program : Program :=
     { operations := dynamicOperations, nodes := #[sourceNode, unaryNode 0] }
@@ -402,12 +402,12 @@ def dynamicFinal? : Option (RunResult Rank (List String) × SuggestionId) := do
 #guard
   match dynamicAdmitted? with
   | some (state, _, _) =>
-      state.factAt? { node := node 0, version := 0 } == some 4 &&
-        state.factAt? { node := node 1, version := 0 } == some 0 &&
-        state.factAt? { node := node 1, version := 1 } == some 4 &&
-        state.factAt? { node := node 2, version := 0 } == some 0 &&
-        state.factAt? { node := node 2, version := 1 } == none &&
-        state.factAt? { node := node 3, version := 0 } == none
+      state.toBranch.factAt? { node := node 0, version := 0 } == some 4 &&
+        state.toBranch.factAt? { node := node 1, version := 0 } == some 0 &&
+        state.toBranch.factAt? { node := node 1, version := 1 } == some 4 &&
+        state.toBranch.factAt? { node := node 2, version := 0 } == some 0 &&
+        state.toBranch.factAt? { node := node 2, version := 1 } == none &&
+        state.toBranch.factAt? { node := node 3, version := 0 } == none
   | none => false
 
 #guard
@@ -416,9 +416,9 @@ def dynamicFinal? : Option (RunResult Rank (List String) × SuggestionId) := do
       result.stop == .saturated && result.state.facts.toList == [4, 4, 4] &&
         result.state.metrics.requests == 3 && result.state.metrics.improvements == 2 &&
         result.state.history.size == 2 &&
-        result.state.factAt? { node := node 2, version := 0 } == some 0 &&
-        result.state.factAt? { node := node 2, version := 1 } == some 4 &&
-        result.state.factAt? { node := node 2, version := 2 } == none
+        result.state.toBranch.factAt? { node := node 2, version := 0 } == some 0 &&
+        result.state.toBranch.factAt? { node := node 2, version := 1 } == some 4 &&
+        result.state.toBranch.factAt? { node := node 2, version := 2 } == none
   | none => false
 
 -- Selecting the same structural extension twice allocates nothing.
@@ -649,7 +649,7 @@ def ladderInvoke (calls : List String) (request : RuleRequest Rank) :
   else
     (.failed 9, calls)
 
-def ladderInitial? (limits : Limits := generous) :
+def ladderInitial? (limits : Hex.Interval.State.Limits := generous) :
     Option (RunResult Rank (List String)) := do
   let program : Program :=
     { operations := ladderOperations, nodes := #[sourceNode, unaryNode 0] }
@@ -658,7 +658,7 @@ def ladderInitial? (limits : Limits := generous) :
   let state <- start? program rules #[4, 0] limits
   pure (drive ladderInvoke 8 state [])
 
-def ladderAfterFirst? (limits : Limits := generous) :
+def ladderAfterFirst? (limits : Hex.Interval.State.Limits := generous) :
     Option (RunResult Rank (List String)) := do
   let initial <- ladderInitial? limits
   match initial.state.admitInstantiation (suggestion 0) with
@@ -829,20 +829,20 @@ def pairEqualityInvoke (calls : Nat) (_request : RuleRequest PairRank) :
 def pairProgram : Program :=
   { operations, nodes := #[sourceNode, sourceNode, unaryNode 0] }
 
-def pairInitial? (limits : Limits := generous) : Option (RunResult PairRank Nat) := do
+def pairInitial? (limits : Hex.Interval.State.Limits := generous) : Option (RunResult PairRank Nat) := do
   let state <- match Engine.start pairDomain pairProgram #[pairEqualityRule]
       #[pair 4 0, pair 0 5, pair 0 0] limits with
     | .ok state => some state
     | .error _ => none
   pure (drive pairEqualityInvoke 8 state 0)
 
-def pairAdmitted? (limits : Limits := generous) : Option (Engine PairRank) := do
+def pairAdmitted? (limits : Hex.Interval.State.Limits := generous) : Option (Engine PairRank) := do
   let initial <- pairInitial? limits
   match initial.state.admitInstantiation (suggestion 0) with
   | .admitted [] state => some state
   | _ => none
 
-def pairFinal? (limits : Limits := generous) : Option (RunResult PairRank Nat) := do
+def pairFinal? (limits : Hex.Interval.State.Limits := generous) : Option (RunResult PairRank Nat) := do
   let state <- pairAdmitted? limits
   pure (drive pairEqualityInvoke 8 state 1)
 
@@ -979,19 +979,19 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
             edge.origin.key == pairEqualityKey && edge.origin.node == node 2 &&
               left.node == node 0 && left.previous == { node := node 0, version := 0 } &&
               right.node == node 1 && right.previous == { node := node 1, version := 0 } &&
-              result.state.factAt? left.previous == some (pair 4 0) &&
-              result.state.factAt? right.previous == some (pair 0 5) &&
-              result.state.factAt? { node := left.node, version := left.version } ==
+              result.state.toBranch.factAt? left.previous == some (pair 4 0) &&
+              result.state.toBranch.factAt? right.previous == some (pair 0 5) &&
+              result.state.toBranch.factAt? { node := left.node, version := left.version } ==
                 some (pair 4 5) &&
-              result.state.factAt? { node := right.node, version := right.version } ==
+              result.state.toBranch.factAt? { node := right.node, version := right.version } ==
                 some (pair 4 5) &&
               match left.cause, right.cause with
               | .transport leftEquality leftSource, .transport rightEquality rightSource =>
                   leftEquality == { index := 0 } && rightEquality == { index := 0 } &&
                     leftSource == { node := node 1, version := 0 } &&
                     rightSource == { node := node 0, version := 0 } &&
-                    result.state.factAt? leftSource == some (pair 0 5) &&
-                    result.state.factAt? rightSource == some (pair 4 0)
+                    result.state.toBranch.factAt? leftSource == some (pair 0 5) &&
+                    result.state.toBranch.factAt? rightSource == some (pair 4 0)
               | _, _ => false
         | _, _, _ => false
   | none => false
@@ -1087,14 +1087,14 @@ def alternateEqualityInvoke (calls : List String) (request : RuleRequest Rank) :
   else
     (.failed 12, calls)
 
-def alternateEqualityInitial? (limits : Limits := generous) :
+def alternateEqualityInitial? (limits : Hex.Interval.State.Limits := generous) :
     Option (RunResult Rank (List String)) := do
   let program : Program :=
     { operations := ladderOperations, nodes := #[sourceNode, unaryNode 0] }
   let state <- start? program #[alternateEqualityRule, nextCopyRule] #[4, 4] limits
   pure (drive alternateEqualityInvoke 8 state [])
 
-def alternateEqualityAdmitted? (limits : Limits := generous) :
+def alternateEqualityAdmitted? (limits : Hex.Interval.State.Limits := generous) :
     Option (Engine Rank × List String) := do
   let initial <- alternateEqualityInitial? limits
   match initial.state.admitInstantiation (suggestion 0) with

--- a/conformance/HexInterval/ScopeConformance.lean
+++ b/conformance/HexInterval/ScopeConformance.lean
@@ -90,7 +90,7 @@ def scope : ScopeBinding :=
 def writeOnlyScope : ScopeBinding :=
   { scope with watches := [node 0, node 1] }
 
-def limits : Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 8
     maxNodes := 16
     maxRules := 8
@@ -264,7 +264,7 @@ def writeOnlyRun? : Option (RunResult Rank Nat) := do
       | .error _ => false
   | none => false
 
-def firstRequest? (customLimits : Limits := limits) :
+def firstRequest? (customLimits : Hex.Interval.State.Limits := limits) :
     Option (RuleRequest Rank × Engine Rank) := do
   let state <- match Engine.start rankDomain program #[scopedRule]
       #[4, 6, 0, 0, 0, 9] customLimits #[scope] with
@@ -438,7 +438,7 @@ def dynamicRequest : InstantiationRequest :=
     scopes := [proposedDynamicScope, proposedDynamicScope]
     payload := { index := 7 } }
 
-def retainedDynamic? (customLimits : Limits := limits) : Option (Engine Rank) := do
+def retainedDynamic? (customLimits : Hex.Interval.State.Limits := limits) : Option (Engine Rank) := do
   let state <- match Engine.start rankDomain program
       #[localRule, scopedRule, dynamicRule] #[4, 6, 0, 0, 0, 9]
       customLimits #[scope] with
@@ -452,7 +452,7 @@ def retainedDynamic? (customLimits : Limits := limits) : Option (Engine Rank) :=
   | .accepted _ state => some state
   | _ => none
 
-def admittedDynamic? (customLimits : Limits := limits) : Option (Engine Rank) := do
+def admittedDynamic? (customLimits : Hex.Interval.State.Limits := limits) : Option (Engine Rank) := do
   let state <- retainedDynamic? customLimits
   match state.admitInstantiation { index := 0 } with
   | .admitted [fresh] state => if fresh == node 6 then some state else none
@@ -526,7 +526,7 @@ def scopeOnlyRequest : InstantiationRequest :=
     scopes := [existingDynamicScope, existingDynamicScope]
     payload := { index := 9 } }
 
-def scopeOnlyInitial? (customLimits : Limits := limits) : Option (Engine Rank) := do
+def scopeOnlyInitial? (customLimits : Hex.Interval.State.Limits := limits) : Option (Engine Rank) := do
   let state <- match Engine.start rankDomain program
       #[localRule, scopedRule, dynamicRule] #[4, 6, 0, 0, 0, 9]
       customLimits #[scope] with
@@ -540,7 +540,7 @@ def scopeOnlyInitial? (customLimits : Limits := limits) : Option (Engine Rank) :
   | .accepted _ state => some state
   | _ => none
 
-def scopeOnlyAdmitted? (customLimits : Limits := limits) :
+def scopeOnlyAdmitted? (customLimits : Hex.Interval.State.Limits := limits) :
     Option (Engine Rank × SuggestionId) := do
   let state <- scopeOnlyInitial? customLimits
   let selected : SuggestionId := { index := 0 }
@@ -854,7 +854,7 @@ def listSubsequence [DecidableEq alpha] (old new : List alpha) : Bool :=
       else listSubsequence (previous :: old) new
 termination_by old.length + new.length
 
-def watcherSubsequences (old new : Array (List WorkItem)) : Bool := Id.run do
+def watcherSubsequences (old new : Array (List Hex.Interval.State.Work)) : Bool := Id.run do
   if new.size < old.size then return false
   for index in [0:old.size] do
     match old[index]?, new[index]? with
@@ -1028,7 +1028,7 @@ def cseEqualityRetained? : Option (Engine Rank × RetainedSuggestion) := do
   | none => false
 
 def startError (rules : Array Registration) (bindings : Array ScopeBinding)
-    (customLimits : Limits := limits) : Option StartError :=
+    (customLimits : Hex.Interval.State.Limits := limits) : Option StartError :=
   match Engine.start rankDomain program rules #[4, 6, 0, 0, 0, 9]
       customLimits bindings with
   | .ok _ => none

--- a/conformance/HexInterval/SemanticReplayConformance.lean
+++ b/conformance/HexInterval/SemanticReplayConformance.lean
@@ -308,7 +308,7 @@ def rightRuntime : Propagator.Package Fact :=
           (registration rightRuleKey rightOpKey) rightPlan
           #[rightFormat, rightEqualityFormat]] }
 
-def limits : Propagator.Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 3
     maxNodes := 3
     maxRules := 2
@@ -600,7 +600,7 @@ example : (factDomain.proveMeet program (node 1) .top (.exact 4) (.exact 4)).isS
     true := by
   decide
 
-def event (version value : Nat) : FactEvent Fact :=
+def event (version value : Nat) : Hex.Interval.State.Update Fact (FactCause Fact) :=
   { programVersion := 0
     node := node 1
     previous := { node := node 1, version := version - 1 }

--- a/conformance/HexInterval/StructuralMatcherConformance.lean
+++ b/conformance/HexInterval/StructuralMatcherConformance.lean
@@ -338,7 +338,7 @@ def sinContractRule : Registration :=
     writes := []
     binding := .scoped }
 
-def engineLimits : Experiment.Propagator.Limits :=
+def engineLimits : Hex.Interval.State.Limits :=
   { maxOperations := 4
     maxNodes := 8
     maxRules := 4
@@ -448,7 +448,7 @@ def fingerprint (state : Engine Rank) : Fingerprint :=
     suggestions := state.suggestions.size
     pending := state.pending.isSome }
 
-def refusedUnchanged (resource : Resource) (limits : Experiment.Propagator.Limits) : Bool :=
+def refusedUnchanged (resource : Hex.Interval.State.Resource) (limits : Hex.Interval.State.Limits) : Bool :=
   match retained? with
   | none => false
   | some state =>

--- a/conformance/HexInterval/StructureViewConformance.lean
+++ b/conformance/HexInterval/StructureViewConformance.lean
@@ -70,7 +70,7 @@ def factDomain : FactDomain Fact where
   narrow _ current candidate :=
     if current < candidate then .improved candidate else .noChange
 
-def limits : Limits :=
+def limits : Hex.Interval.State.Limits :=
   { maxOperations := 16
     maxNodes := 32
     maxRules := 8

--- a/conformance/HexIntervalMathlib/ArithmeticConformance.lean
+++ b/conformance/HexIntervalMathlib/ArithmeticConformance.lean
@@ -77,7 +77,7 @@ private def differenceRange : DyadicInterval.Fact :=
   rw [show (-2 : Dyadic) = ((-2 : Int) : Dyadic) from rfl, toReal_intCast]
   norm_num
 
-private def limits : Propagator.Limits :=
+private def limits : Hex.Interval.State.Limits :=
   { maxOperations := 8
     maxNodes := 4
     maxRules := 16
@@ -135,7 +135,7 @@ private def action : Action :=
     inputs := [{ node := node 0, version := 0 }, { node := node 1, version := 0 }]
     writes := [node 2] }
 
-private def event : FactEvent DyadicInterval.Fact :=
+private def event : Hex.Interval.State.Update DyadicInterval.Fact (FactCause DyadicInterval.Fact) :=
   { programVersion := 0
     node := node 2
     previous := { node := node 2, version := 0 }
@@ -158,7 +158,7 @@ private def sameEntry (left right : Entry) : Bool :=
   left.origin == right.origin && left.role == right.role &&
     left.schema == right.schema && left.body == right.body
 
-private def sameEvent (left right : FactEvent DyadicInterval.Fact) : Bool :=
+private def sameEvent (left right : Hex.Interval.State.Update DyadicInterval.Fact (FactCause DyadicInterval.Fact)) : Bool :=
   left.programVersion == right.programVersion && left.node == right.node &&
     left.previous == right.previous && left.fact == right.fact &&
     left.version == right.version &&
@@ -173,7 +173,7 @@ private def quoteMatchesLive : Bool :=
   match run? with
   | some run =>
       run.stop == .saturated && run.session.engine.history.size == 1 &&
-        run.session.engine.factAt? { node := node 2, version := 1 } ==
+        run.session.engine.toBranch.factAt? { node := node 2, version := 1 } ==
           some differenceRange &&
         match run.session.engine.history[0]?,
             run.session.arena.entry? (payload 0) .fact with

--- a/conformance/HexIntervalMathlib/CenteredConformance.lean
+++ b/conformance/HexIntervalMathlib/CenteredConformance.lean
@@ -44,7 +44,7 @@ private def config : Config :=
     reciprocalBasePrecision := 2
     maxReciprocalEffort := 0 }
 
-private def limits : Propagator.Limits :=
+private def limits : Hex.Interval.State.Limits :=
   { maxOperations := 16
     maxNodes := 8
     maxRules := 8
@@ -105,7 +105,7 @@ private def action : Action :=
     inputs := [{ node := node 0, version := 0 }]
     writes := [node 1] }
 
-private def event : FactEvent DyadicInterval.Fact :=
+private def event : Hex.Interval.State.Update DyadicInterval.Fact (FactCause DyadicInterval.Fact) :=
   { programVersion := 0
     node := node 1
     previous := { node := node 1, version := 0 }
@@ -130,7 +130,7 @@ private def sameEntry (left right : Entry) : Bool :=
   left.origin == right.origin && left.role == right.role &&
     left.schema == right.schema && left.body == right.body
 
-private def sameEvent (left right : FactEvent DyadicInterval.Fact) : Bool :=
+private def sameEvent (left right : Hex.Interval.State.Update DyadicInterval.Fact (FactCause DyadicInterval.Fact)) : Bool :=
   left.programVersion == right.programVersion && left.node == right.node &&
     left.previous == right.previous && left.fact == right.fact &&
     left.version == right.version &&
@@ -151,7 +151,7 @@ private def quotesMatchLive : Bool :=
         run.session.engine.history.size == 1 &&
         run.session.arena.entries.size == 1 &&
         run.session.arena.bodyCells == 0 &&
-        run.session.engine.factAt? { node := node 1, version := 1 } ==
+        run.session.engine.toBranch.factAt? { node := node 1, version := 1 } ==
           some quarterRange &&
         match run.session.engine.history[0]?,
             run.session.arena.entry? (payload 0) .fact with
@@ -327,7 +327,7 @@ private def backwardAction : Action :=
     inputs := [{ node := node 1, version := 0 }]
     writes := [node 0] }
 
-private def backwardEvent : FactEvent DyadicInterval.Fact :=
+private def backwardEvent : Hex.Interval.State.Update DyadicInterval.Fact (FactCause DyadicInterval.Fact) :=
   { programVersion := 0
     node := node 0
     previous := { node := node 0, version := 0 }
@@ -355,7 +355,7 @@ private def backwardMatchesLive : Bool :=
         run.session.engine.history.size == 1 &&
         run.session.arena.entries.size == 3 &&
         run.session.arena.bodyCells == 0 &&
-        run.session.engine.factAt? { node := node 0, version := 1 } ==
+        run.session.engine.toBranch.factAt? { node := node 0, version := 1 } ==
           some middleRange &&
         match run.session.engine.history[0]?,
             run.session.arena.entry? (payload 1) .fact with

--- a/conformance/HexIntervalMathlib/ExactBranchConformance.lean
+++ b/conformance/HexIntervalMathlib/ExactBranchConformance.lean
@@ -448,7 +448,7 @@ private def proofPackage : ProofRegistry.Package semantics Name :=
 private def proofPackages : Array (ProofRegistry.Package semantics Name) :=
   #[proofPackage]
 
-private def limits : Propagator.Limits :=
+private def limits : Hex.Interval.State.Limits :=
   { maxOperations := 8
     maxNodes := 8
     maxRules := 8

--- a/conformance/HexIntervalMathlib/MixedFunctionsConformance.lean
+++ b/conformance/HexIntervalMathlib/MixedFunctionsConformance.lean
@@ -233,7 +233,7 @@ private structure MixedSummary where
   reached : SeenVersion
   fact : Bound
   facts : Array Bound
-  chronology : Array HistoryEvent
+  chronology : Array Hex.Interval.Trace.Ref
 
 private def mixedSummary? : Option MixedSummary := do
   let .ok session := PolicySession.Session.start factDomain mixedProgram

--- a/conformance/HexIntervalMathlib/SineProofConformance.lean
+++ b/conformance/HexIntervalMathlib/SineProofConformance.lean
@@ -344,12 +344,12 @@ def sameFactCause {Fact : Type} [BEq Fact]
   | _, _ => false
 
 def sameFactEvent {Fact : Type} [BEq Fact]
-    (left right : FactEvent Fact) : Bool :=
+    (left right : Hex.Interval.State.Update Fact (FactCause Fact)) : Bool :=
   left.programVersion == right.programVersion && left.node == right.node &&
     left.previous == right.previous && left.fact == right.fact &&
     left.version == right.version && sameFactCause left.cause right.cause
 
-def mutatedTransportEvent : FactEvent Range :=
+def mutatedTransportEvent : Hex.Interval.State.Update Range (FactCause Range) :=
   { transportStep.event with
     cause := .transport { index := 0 } { node := node 3, version := 1 } }
 

--- a/progress/20260815T151223Z.md
+++ b/progress/20260815T151223Z.md
@@ -1,0 +1,47 @@
+# Accomplished
+
+- Added supported Mathlib-free `HexInterval.State` contracts for immutable
+  branch seeds/current facts, exact versioned provenance, structural side
+  tables, dependency watchers, dirty bits, bounded append-only work queues,
+  controller resources, and transactional checked construction/update.
+- Added supported `HexInterval.Trace` contracts for exact fact/instance
+  chronology and diagnostic logs with independent event, byte, logical-work,
+  and code limits. Callback and arbitrary Lean-object allocation is explicitly
+  outside the preemptible retained-byte envelope.
+- Migrated the experimental engine and policy scheduler to extend and update
+  the supported state/trace types directly. FIFO polling now skips checked
+  policy tombstones, while policy selection deactivates exact work through the
+  supported queue transition and a later wake appends a fresh occurrence.
+- Retained exact version-zero seeds for generated nodes, so replay quotation no
+  longer asks a later fact-domain callback to reconstruct historical data.
+- Added supported-contract conformance for version restoration, stale and
+  cross-node provenance, wrong program versions, malformed snapshots,
+  extension seeds, dependency/queue alignment, FIFO and policy consumption,
+  count limits, chronology order, diagnostic truncation, and proof-state
+  independence.
+- Updated the umbrella and central SPEC with the supported decoded-state
+  boundary, exact non-preemptibility disclosure, file map, and the distinction
+  between stable interchange semantics and still-experimental optimized
+  storage, callbacks, policies, sessions, search, and replay.
+- Built the full 9,486-job conformance target and both complete controller
+  experiment umbrellas after migration.
+
+# Current frontier
+
+The supported layer now owns the checked state and trace invariants, while the
+experimental engine owns concrete applications, callbacks, proposals, policy
+selection, sessions, branch search, and proof replay. Its transparent decoded
+arrays remain a reference/storage experiment, not the selected optimized
+branch representation.
+
+# Next step
+
+Extract the smallest sealed production controller which composes these
+contracts with package invocation, while measuring whether branch facts,
+chronology, and queue tombstones should use arrays, persistent pages, or a
+trail-backed implementation. Keep callback construction limits explicit and
+package-owned.
+
+# Blockers
+
+None.

--- a/progress/20260821T015210Z.md
+++ b/progress/20260821T015210Z.md
@@ -1,0 +1,30 @@
+# Supported State/Trace preparation
+
+## Accomplished
+
+- Replayed the supported Mathlib-free `State` and `Trace` extraction directly
+  atop the final #9294 contract candidate.
+- Preserved immutable branch seeds, exact update chronology, checked program
+  extension, dependency/dirty-bit alignment, append-only work queues with
+  policy tombstones, and bounded diagnostic retention.
+- Migrated current experimental controller and proof consumers to the actual
+  supported types. Current PNT additions that postdated the preserved patch
+  now name `State.Limits` directly instead of the removed experimental type.
+- Rebuilt the supported state/controller conformance graph and current
+  mixed-function and PNT consumers, and reran structural and trust checks.
+
+## Current frontier
+
+- Supported state is decoded immutable data with transactional checked
+  builders; supported trace data is operational diagnostics and chronology,
+  never proof evidence. Callback construction and concrete storage remain an
+  explicit non-preemptible/experimental boundary.
+
+## Next step
+
+- After #9294 merges, replay this local edge onto its exact merge commit and
+  publish the supported State/Trace extraction for review.
+
+## Blockers
+
+- None.

--- a/progress/20260821T024739Z.md
+++ b/progress/20260821T024739Z.md
@@ -1,0 +1,49 @@
+# Supported state invariant hardening
+
+## Accomplished
+
+- Removed the independently mutable current-fact cache from supported
+  `State.Branch`; base facts, generated-node seed suffixes, and ordered update
+  history now reconstruct the current snapshot.
+- Kept the eager current-fact cache explicitly experimental in `Engine` and
+  updated every accepted fact/transport/extension transition in lockstep.
+- Added fail-closed seed, fact-history, and generation guards. Supported state
+  now checks base generation zero and rejects a generation after the current
+  program version while documenting that dependency-derived generation remains
+  controller-owned metadata.
+- Threaded the exact node count through checked queue operations, making
+  watcher alignment load-bearing instead of self-derived.
+- Added per-occurrence queue liveness, so policy tombstones remain dead after
+  the same work is re-enqueued and FIFO order cannot be resurrected.
+- Preflighted trace-order index/combined count caps before retained chronology
+  traversal, with exact role/order validation following the scan.
+- Corrected diagnostic-log complexity wording: cached totals accelerate only
+  the post-validation increment because `append` rechecks the retained log.
+- Kept the scheduler benchmark on the supported controller limits explicitly
+  after removal of the experimental unqualified `Propagator.Limits` name.
+- Rebuilt the scheduler canary fixture from a canonical version-zero source
+  refinement and checked queue deactivation/wake transitions, and made CI run
+  the executable canary rather than merely compile it.
+- Preflighted decoded base-program and seed-array sizes before branch traversal
+  or fact-array concatenation.
+- Corrected the complexity contract: local watcher discovery currently crosses
+  whole decoded queue/dependency and branch/program/history validation, which
+  remains a production-store optimization target. Removed the redundant
+  snapshot-level program check and preflighted extension history size.
+- Rebuilt supported/controller and mixed/current-PNT consumers and reran the
+  structural and trust gates.
+
+## Current frontier
+
+- Supported branch facts have one authoritative representation. Concrete
+  scheduler caches, callbacks, exact dependency-derived generation, policy,
+  search, and proof replay remain outside this supported state layer.
+
+## Next step
+
+- Publish the repaired exact head of PR #9311 and let exact-head CI and fresh
+  review validate the narrowed invariants.
+
+## Blockers
+
+- None.

--- a/progress/20260821T044300Z.md
+++ b/progress/20260821T044300Z.md
@@ -1,0 +1,22 @@
+# Supported state review polish
+
+## Accomplished
+
+- Restored the established descriptions of supported scheduler limits and
+  telemetry fields after their extraction from the experimental controller.
+- Made the benchmark's optional logical-count corpus explicitly callable so
+  importing the executable module does not construct it eagerly.
+- Preserved the scheduler canary and supported State/Trace behavior.
+
+## Current frontier
+
+- PR #9311 remains the supported State/Trace extraction; concrete callbacks,
+  policies, search, and proof replay remain experimental.
+
+## Next step
+
+- Rebuild the focused supported/controller targets and run exact-head CI.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
## Summary

- add Mathlib-free supported `HexInterval.State` contracts for immutable base facts, generated-node seed suffixes, current versions, exact version/provenance history, checked program extension, structural side tables, dependencies, dirty bits, and append-only work queues with policy tombstones
- reconstruct supported current-fact snapshots from the authoritative seeds and ordered history instead of retaining an independently mutable cache
- give each queue occurrence its own live bit, so policy deactivation leaves a permanent tombstone and later re-enqueue cannot resurrect an older FIFO position
- add supported `HexInterval.Trace` contracts for exact fact/instance chronology and bounded diagnostic retention whose truncation cannot alter proof state; preflight order index/count caps before chronology traversal
- migrate the experimental controller stack to consume these actual supported types, without aliases or compatibility shims; its eager current-fact cache remains explicitly experimental runtime data and is updated in lockstep
- update current PNT controller configurations and the scheduler benchmark to name supported `State.Limits` directly; rebuild the scheduler canary through supported state/queue transitions and execute it in CI

## Scope, cost, and trust boundary

Concrete callbacks, packages, policy choice, search, proof replay, optimized storage, and exact dependency-derived generation authentication remain experimental. Supported state checks base generation zero and rejects appended generations after the current program version, but does not overclaim that its decoded generation table independently proves controller dependency semantics. Runtime facts, state, queues, callbacks, caches, and diagnostics remain untrusted data and never become proof evidence. Callback and arbitrary Lean-object construction remains explicitly outside the preemptible byte envelope.

Queue validation and mutation receive the exact program-node count, making watcher alignment fail closed, and authenticate a bijection between global dirty bits and per-occurrence live entries. Checked branch mutation preflights decoded base/current program and retained-history sizes before traversal, and fact restoration validates seed-array sizes before concatenation. `Trace.Log.append` revalidates the full retained log; cached totals accelerate only the accepted post-validation increment.

The current transparent decoded/reference builders favor auditability over local update cost: each queue mutation revalidates the complete dependency/dirty/queue state, and each accepted fact revalidates the base/current programs and reconstructs retained branch history. Only watcher discovery is local. Avoiding these whole-state scans is explicitly left to the selected production store/queue.

## Validation

- supported/controller and mixed/current-PNT focused builds
- full dependent `HexIntervalExperiment` + `HexIntervalMathlibExperiment` build
- exact scheduler and policy-frontier executable canaries; scheduler canary is now in the existing CI bench tail
- discriminating seed-prefix, fact-history, generation, base/history-size preflight, watcher-alignment, FIFO tombstone/re-enqueue, chronology preflight, and diagnostic truncation guards
- DAG and published trust-surface checks
- factor-sweep freshness and Mathlib-free bench graph
- PNT inventory unit tests and exact inventory check
- diff whitespace and added `native_decide`/`axiom`/`sorry` scan
