### PR TITLE
fix: make PolyQuotient a prime-modulus type

### DIFF
--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -508,7 +508,12 @@ abbrev GFq (p n : Nat) [ZMod64.Bounds p] (h : Conway.SupportedEntry p n) : Type 
 
 namespace GFq
 
-variable {p n : Nat} [ZMod64.Bounds p]
+-- The quotient underlying `GFq` is a prime-modulus type.  A `SupportedEntry`
+-- always carries `h.prime`, but it is an ordinary structure, so it cannot drive
+-- instance search; the hypothesis is taken ambiently instead.  Every committed
+-- prime has a ground instance in `HexConway.Table`, so concrete uses resolve it
+-- automatically and only generic code has to carry it.
+variable {p n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
 
 /-- The Conway modulus selected for a committed `GFq p n` entry. -/
 abbrev modulus (h : Conway.SupportedEntry p n) : FpPoly p :=
@@ -774,7 +779,7 @@ abbrev GFqC (p n : Nat) [ZMod64.Bounds p] [h : GFq.CommittedEntry p n] : Type :=
 
 namespace GFqC
 
-variable {p n : Nat} [ZMod64.Bounds p] [h : GFq.CommittedEntry p n]
+variable {p n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] [h : GFq.CommittedEntry p n]
 
 /-- The committed Conway-table entry selected for `GFqC p n`. -/
 abbrev entry : Conway.SupportedEntry p n :=

--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -519,17 +519,20 @@ variable {p n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
 abbrev modulus (h : Conway.SupportedEntry p n) : FpPoly p :=
   Conway.conwayPoly p n h
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFq.modulus` is the Conway polynomial selected by the committed entry. -/
 @[simp, grind =] theorem modulus_eq_conway (h : Conway.SupportedEntry p n) :
     modulus h = Conway.conwayPoly p n h :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The selected Conway modulus has positive degree. -/
 @[simp]
 theorem modulus_nonconstant (h : Conway.SupportedEntry p n) :
     0 < FpPoly.degree (modulus h) :=
   Conway.conwayPoly_nonconstant p n h
 
+omit [ZMod64.PrimeModulus p] in
 /-- The selected Conway modulus is irreducible. -/
 @[grind =>]
 theorem modulus_irreducible (h : Conway.SupportedEntry p n) :
@@ -538,6 +541,7 @@ theorem modulus_irreducible (h : Conway.SupportedEntry p n) :
 
 grind_pattern modulus_irreducible => Conway.conwayPoly p n h
 
+omit [ZMod64.PrimeModulus p] in
 /-- The selected Conway modulus lives over a prime base field. -/
 theorem modulus_prime (h : Conway.SupportedEntry p n) :
     Hex.Nat.Prime p :=
@@ -545,12 +549,17 @@ theorem modulus_prime (h : Conway.SupportedEntry p n) :
 
 grind_pattern modulus_prime => h.prime
 
+omit [ZMod64.PrimeModulus p] in
 /-- Reduce a polynomial into the canonical field selected by a committed Conway
-entry. -/
+entry.
+
+The entry already carries `h.prime`, so this needs no separate prime-modulus
+instance from the caller. -/
 def ofPoly (h : Conway.SupportedEntry p n) (g : FpPoly p) : GFq p n h :=
   GFqField.ofPoly (modulus h) (modulus_nonconstant h) (modulus_prime h)
     (modulus_irreducible h) g
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFq.ofPoly` delegates to the generic quotient-field constructor with the
 selected Conway modulus. -/
 @[simp, grind =] theorem ofPoly_eq_field_ofPoly (h : Conway.SupportedEntry p n)
@@ -564,12 +573,14 @@ selected Conway modulus. -/
 def repr {h : Conway.SupportedEntry p n} (x : GFq p n h) : FpPoly p :=
   GFqField.repr x
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFq.repr` is the generic quotient-field representative projection. -/
 @[simp, grind =] theorem repr_eq_field_repr {h : Conway.SupportedEntry p n}
     (x : GFq p n h) :
     repr x = GFqField.repr x :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Two canonical `GFq` elements are equal when their reduced polynomial
 representatives agree. -/
 @[ext] theorem ext {h : Conway.SupportedEntry p n} {x y : GFq p n h}
@@ -580,6 +591,7 @@ representatives agree. -/
   apply GFqRing.ext
   simpa [repr, GFqField.repr] using hxy
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of an injected `FpPoly` is that polynomial
 reduced modulo the selected Conway polynomial. Lets a caller normalise a
 `repr (ofPoly h g)` round-trip to a plain `reduceMod`. -/
@@ -599,6 +611,7 @@ the selected Conway polynomial. -/
     repr (1 : GFq p n h) = GFqRing.reduceMod (modulus h) 1 :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a sum in `GFq` reduces from the sum of
 representatives modulo the selected Conway polynomial. -/
 @[simp, grind =] theorem repr_add {h : Conway.SupportedEntry p n}
@@ -606,6 +619,7 @@ representatives modulo the selected Conway polynomial. -/
     repr (x + y) = GFqRing.reduceMod (modulus h) (repr x + repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a product in `GFq` reduces from the product
 of representatives modulo the selected Conway polynomial. -/
 @[simp, grind =] theorem repr_mul {h : Conway.SupportedEntry p n}
@@ -613,11 +627,13 @@ of representatives modulo the selected Conway polynomial. -/
     repr (x * y) = GFqRing.reduceMod (modulus h) (repr x * repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a negation reduces from the negated representative. -/
 @[simp, grind =] theorem repr_neg {h : Conway.SupportedEntry p n} (x : GFq p n h) :
     repr (-x) = GFqRing.reduceMod (modulus h) (-(repr x)) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a subtraction reduces from the difference of
 representatives. -/
 @[simp, grind =] theorem repr_sub {h : Conway.SupportedEntry p n} (x y : GFq p n h) :
@@ -632,6 +648,7 @@ polynomial carrying the literal as a `ZMod64` coefficient. -/
       GFqRing.reduceMod (modulus h) (FpPoly.C (k : ZMod64 p)) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a quotient in `GFq` lifts the
 quotient-ring product of the dividend's representative with the inverse of
 the divisor. -/
@@ -641,6 +658,7 @@ the divisor. -/
       GFqRing.repr (x.toQuotient * (GFqField.inv y).toQuotient) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a natural power in `GFq` lifts the
 quotient-ring power of the underlying quotient representative. -/
 @[simp, grind =] theorem repr_pow {h : Conway.SupportedEntry p n}
@@ -648,6 +666,7 @@ quotient-ring power of the underlying quotient representative. -/
     repr (x ^ k) = GFqRing.repr (x.toQuotient ^ k) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a nonnegative integer power in `GFq` lifts
 the quotient-ring power of the underlying quotient representative. -/
 @[simp, grind =] theorem repr_zpow_ofNat {h : Conway.SupportedEntry p n}
@@ -656,6 +675,7 @@ the quotient-ring power of the underlying quotient representative. -/
       GFqRing.repr (x.toQuotient ^ k) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a negative integer power in `GFq` lifts
 the inverse of the corresponding quotient-ring positive power. -/
 @[simp, grind =] theorem repr_zpow_negSucc {h : Conway.SupportedEntry p n}
@@ -672,6 +692,7 @@ quotient-ring integer-cast representative. -/
         ((i : GFqRing.PolyQuotient (modulus h) (modulus_nonconstant h))) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a natural scalar action lifts the quotient-ring
 action. -/
 @[simp, grind =] theorem repr_nsmul {h : Conway.SupportedEntry p n}
@@ -679,6 +700,7 @@ action. -/
     repr (k • x : GFq p n h) = GFqRing.repr (k • x.toQuotient) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of an integer scalar action lifts the quotient-ring
 action. -/
 @[simp, grind =] theorem repr_zsmul {h : Conway.SupportedEntry p n}
@@ -705,6 +727,7 @@ convention and has zero representative. -/
   exact GFqField.inv_zero (modulus h) (modulus_nonconstant h)
     (modulus_prime h) (modulus_irreducible h)
 
+omit [ZMod64.PrimeModulus p] in
 /-- Division in `GFq` is multiplication by inverse. -/
 @[grind =]
 theorem div_eq_mul_inv {h : Conway.SupportedEntry p n}
@@ -727,6 +750,7 @@ theorem inv_mul_cancel {h : Conway.SupportedEntry p n}
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime h.prime
   exact GFqField.inv_mul_cancel (x := x) hx
 
+omit [ZMod64.PrimeModulus p] in
 /-- Two `GFq.ofPoly` constructors produce the same field element exactly when
 their inputs have the same reduced representative modulo the selected Conway
 polynomial. -/
@@ -742,6 +766,7 @@ theorem ofPoly_eq_ofPoly_iff_reduceMod_eq
     apply ext
     simpa using hred
 
+omit [ZMod64.PrimeModulus p] in
 /-- Injecting an `FpPoly` into `GFq` is invariant under pre-reduction modulo
 the selected Conway polynomial: a caller may drop a `reduceMod` already
 sitting under `ofPoly`. -/
@@ -757,11 +782,13 @@ as the `p`-th power on the underlying quotient representation. -/
 def frob {h : Conway.SupportedEntry p n} (x : GFq p n h) : GFq p n h :=
   GFqField.frob x
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFq.frob` is the `p`-th power map. -/
 theorem frob_eq_pow {h : Conway.SupportedEntry p n} (x : GFq p n h) :
     frob x = x ^ p :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of `GFq.frob` is the quotient-ring `p`-th power
 representative. -/
 @[simp, grind =] theorem repr_frob {h : Conway.SupportedEntry p n} (x : GFq p n h) :
@@ -789,6 +816,7 @@ abbrev entry : Conway.SupportedEntry p n :=
 abbrev modulus : FpPoly p :=
   GFq.modulus (entry (p := p) (n := n))
 
+omit [ZMod64.PrimeModulus p] in
 /-- {name}`Hex.GFqC.modulus` delegates to the explicit-entry
 {name}`Hex.GFq.modulus`. -/
 theorem modulus_eq_gfq :
@@ -800,6 +828,7 @@ theorem modulus_eq_gfq :
 def ofPoly (g : FpPoly p) : GFqC p n :=
   GFq.ofPoly (entry (p := p) (n := n)) g
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFqC.ofPoly` delegates to the explicit-entry `GFq.ofPoly`. -/
 theorem ofPoly_eq_gfq (g : FpPoly p) :
     ofPoly (p := p) (n := n) g =
@@ -810,11 +839,13 @@ theorem ofPoly_eq_gfq (g : FpPoly p) :
 def repr (x : GFqC p n) : FpPoly p :=
   GFq.repr x
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFqC.repr` delegates to the explicit-entry `GFq.repr`. -/
 theorem repr_eq_gfq (x : GFqC p n) :
     repr x = GFq.repr x :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of an injected polynomial is reduction modulo the
 selected committed Conway polynomial. -/
 @[simp, grind =] theorem repr_ofPoly (g : FpPoly p) :
@@ -822,6 +853,7 @@ selected committed Conway polynomial. -/
       GFqRing.reduceMod (modulus (p := p) (n := n)) g :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a sum in `GFqC` reduces from the sum of
 representatives modulo the selected committed Conway polynomial. -/
 @[simp, grind =] theorem repr_add (x y : GFqC p n) :
@@ -829,6 +861,7 @@ representatives modulo the selected committed Conway polynomial. -/
       GFqRing.reduceMod (modulus (p := p) (n := n)) (repr x + repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The canonical representative of a product in `GFqC` reduces from the
 product of representatives modulo the selected committed Conway polynomial. -/
 @[simp, grind =] theorem repr_mul (x y : GFqC p n) :
@@ -840,16 +873,19 @@ product of representatives modulo the selected committed Conway polynomial. -/
 def frob (x : GFqC p n) : GFqC p n :=
   GFq.frob x
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFqC.frob` delegates to the explicit-entry `GFq.frob`. -/
 theorem frob_eq_gfq (x : GFqC p n) :
     frob x = GFq.frob x :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- `GFqC.frob` is the `p`-th power map. -/
 theorem frob_eq_pow (x : GFqC p n) :
     frob x = x ^ p :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of `GFqC.frob` is the quotient-ring `p`-th power
 representative. -/
 @[simp, grind =] theorem repr_frob (x : GFqC p n) :

--- a/HexGFqField/Basic.lean
+++ b/HexGFqField/Basic.lean
@@ -23,15 +23,26 @@ namespace Hex
 
 namespace GFqField
 
-variable {p : Nat} [ZMod64.Bounds p] {hp : Hex.Nat.Prime p}
+-- `GFqRing.PolyQuotient` is a prime-modulus type.  Declarations whose binders
+-- mention it need the instance ambiently; `FiniteField` itself does not, since
+-- it derives one from the `_hp` it already carries.
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] {hp : Hex.Nat.Prime p}
 
 /-- Executable finite-field elements are a thin wrapper around quotient-ring
 residues modulo an irreducible polynomial. -/
 structure FiniteField
     (f : FpPoly p) (hf : 0 < FpPoly.degree f)
     (_hp : Hex.Nat.Prime p) (_hirr : FpPoly.Irreducible f) where
-  /-- The underlying reduced quotient-ring residue backing this field element. -/
-  toQuotient : GFqRing.PolyQuotient f hf
+  /-- The underlying reduced quotient-ring residue backing this field element.
+
+  `GFqRing.PolyQuotient` is a prime-modulus type, and the witness it needs is
+  the `_hp` this structure already carries. Deriving the instance here rather
+  than demanding it from callers keeps `FiniteField`'s signature unchanged;
+  `ZMod64.PrimeModulus` is a `Prop`-valued class, so this instance and any
+  ambient one are definitionally equal. -/
+  toQuotient :
+    haveI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime _hp
+    GFqRing.PolyQuotient f hf
 
 /-- Field equality is decidable, and decided by comparing canonical
 representatives: elements are wrappers around reduced quotient values, so

--- a/HexGFqField/Basic.lean
+++ b/HexGFqField/Basic.lean
@@ -69,11 +69,17 @@ def ofQuotient {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreduci
     (x : GFqRing.PolyQuotient f hf) : FiniteField f hf hp hirr :=
   ⟨x⟩
 
+omit [ZMod64.PrimeModulus p] in
 /-- Reduce a polynomial into the finite field by reusing the quotient-ring
-constructor. -/
+constructor.
+
+The prime-modulus instance the quotient needs is derived from this
+constructor's own `hp`, so callers holding only a primality proof do not have to
+supply it a second time. -/
 @[expose]
 def ofPoly (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
     (hirr : FpPoly.Irreducible f) (g : FpPoly p) : FiniteField f hf hp hirr :=
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   ofQuotient (GFqRing.ofPoly f hf g)
 
 /-- Project a finite-field element to its canonical polynomial representative. -/
@@ -103,6 +109,7 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     repr (ofQuotient x : FiniteField f hf hp hirr) = GFqRing.repr x :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Rewrapping a field element through its quotient projection is the identity. -/
 @[simp, grind =] theorem ofQuotient_toQuotient
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -111,6 +118,7 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
   cases x
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a polynomial coerced into the field is its reduced form. -/
 @[simp, grind =] theorem repr_ofPoly
     (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
@@ -118,6 +126,7 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     repr (ofPoly f hf hp hirr g) = GFqRing.reduceMod f g :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Canonical field representatives are reduced below the modulus degree. -/
 @[simp] theorem degree_repr_lt_degree
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -126,6 +135,7 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   exact GFqRing.degree_repr_lt_degree x.toQuotient
 
+omit [ZMod64.PrimeModulus p] in
 /-- Equality of field elements is equality of their quotient representatives. -/
 @[grind =] theorem toQuotient_inj
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -140,6 +150,7 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
   · intro h
     exact congrArg FiniteField.toQuotient h
 
+omit [ZMod64.PrimeModulus p] in
 /-- Extensionality through quotient representatives. -/
 @[ext] theorem ext
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -99,10 +99,11 @@ def zsmul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f
 
 section InverseInternals
 
--- These helpers are modulus-agnostic (they use the `hp : Hex.Nat.Prime p`
--- hypothesis where primality is needed, not the `ZMod64.PrimeModulus` instance),
--- so they precede the `variable [ZMod64.PrimeModulus p]` that the inverse
--- machinery below relies on.
+-- These helpers are modulus-agnostic: they take the `hp : Hex.Nat.Prime p`
+-- hypothesis where primality is needed, rather than the `ZMod64.PrimeModulus`
+-- instance the quotient type asks for. The ones that never mention the quotient
+-- `omit` that instance, so the namespace binder does not leak into their
+-- signatures.
 
 /-- Nonzero field elements have nonzero quotient representatives. This connects
 field-level hypotheses to the quotient-level helper lemmas. -/
@@ -114,6 +115,7 @@ private theorem toQuotient_ne_zero
   apply hx
   exact GFqField.ext hq
 
+omit [ZMod64.PrimeModulus p] in
 /-- A nonzero `ZMod64 p` scalar is coprime to prime `p`, supplying the unit
 fact needed for constant-scaling inverses. -/
 private theorem zmod64_coprime_of_prime_ne_zero
@@ -151,6 +153,7 @@ private theorem zmod64_coprime_of_prime_ne_zero
     rw [hgcd] at hk
     exact ⟨k, hk⟩
 
+omit [ZMod64.PrimeModulus p] in
 /-- Scaling the unit polynomial by `c` is the constant polynomial `C c`, the base
 case for relating scalar multiplication to constant-polynomial multiplication. -/
 private theorem scale_one_poly (c : ZMod64 p) :
@@ -165,6 +168,7 @@ private theorem scale_one_poly (c : ZMod64 p) :
   | zero => grind
   | succ n => exact hzero
 
+omit [ZMod64.PrimeModulus p] in
 /-- Scaling a constant polynomial multiplies its constant coefficient, providing
 the coefficient-level normalization for constant factors. -/
 private theorem scale_C (c d : ZMod64 p) :
@@ -177,6 +181,7 @@ private theorem scale_C (c d : ZMod64 p) :
   | zero => rfl
   | succ n => exact hzero
 
+omit [ZMod64.PrimeModulus p] in
 /-- A polynomial with degree exactly zero is its constant coefficient polynomial,
 identifying degree-zero xgcd gcd witnesses as constants. -/
 private theorem eq_C_of_degree_eq_zero
@@ -198,6 +203,7 @@ private theorem eq_C_of_degree_eq_zero
     rw [DensePoly.coeff_eq_zero_of_size_le g hle]
     simp [hn]
 
+omit [ZMod64.PrimeModulus p] in
 /-- A degree-zero polynomial has nonzero constant coefficient, supplying the
 nonzero scalar needed to invert a constant xgcd gcd witness. -/
 private theorem coeff_zero_ne_zero_of_degree_eq_zero
@@ -214,6 +220,7 @@ private theorem coeff_zero_ne_zero_of_degree_eq_zero
   simp only [hsize] at h
   exact h
 
+omit [ZMod64.PrimeModulus p] in
 /-- Polynomial divisibility is transitive, chaining xgcd divisibility facts into
 the downstream inverse-soundness argument. -/
 private theorem dvd_trans_poly {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
@@ -241,6 +248,11 @@ def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
   let r := DensePoly.xgcd (GFqRing.repr x) f
   let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹
   DensePoly.scale unitInv r.left
+
+-- The scalar and constant-polynomial helpers below are pure `FpPoly` / `ZMod64`
+-- facts that take their own `hp` argument; none of them mention the quotient,
+-- so the ambient prime-modulus instance is dropped until it is needed again.
+omit [ZMod64.PrimeModulus p]
 
 /-- A nonzero `ZMod64 p` scalar multiplies with its inverse to one, turning the
 coprimality fact into the scalar cancellation used below. -/
@@ -306,6 +318,8 @@ private theorem dvd_left_of_mul_const_right_eq
       exact (DensePoly.mul_assoc_poly g (DensePoly.C c) (DensePoly.C c⁻¹)).symm
     _ = f * DensePoly.C c⁻¹ := by
       rw [hfgC]
+
+variable [ZMod64.PrimeModulus p]
 
 /-- The extended-gcd output gives the unscaled Bezout identity for the reduced
 representative and the modulus. -/
@@ -688,6 +702,7 @@ theorem natCast_eq_natCast_iff_mod_eq
   · intro h
     exact natCast_eq_of_mod_eq f hf hp hirr h
 
+omit [ZMod64.PrimeModulus p] in
 /-- Addition projects to quotient-ring addition. -/
 @[simp, grind =] theorem toQuotient_add
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -696,6 +711,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient + y.toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Multiplication projects to quotient-ring multiplication. -/
 @[simp, grind =] theorem toQuotient_mul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -704,6 +720,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient * y.toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Negation projects to the quotient-ring additive inverse. -/
 @[simp, grind =] theorem toQuotient_neg
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -711,6 +728,7 @@ theorem natCast_eq_natCast_iff_mod_eq
     (-x : FiniteField f hf hp hirr).toQuotient = -x.toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Subtraction projects to the quotient-ring difference. -/
 @[simp, grind =] theorem toQuotient_sub
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -719,6 +737,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient - y.toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Natural scalar multiplication projects to the quotient-ring scalar action. -/
 @[simp, grind =] theorem toQuotient_nsmul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -732,6 +751,7 @@ theorem natCast_eq_natCast_iff_mod_eq
     ((i : FiniteField f hf hp hirr).toQuotient) = (i : GFqRing.PolyQuotient f hf) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Integer scalar multiplication projects to the quotient-ring scalar action. -/
 @[simp, grind =] theorem toQuotient_zsmul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -739,6 +759,7 @@ theorem natCast_eq_natCast_iff_mod_eq
     (i • x : FiniteField f hf hp hirr).toQuotient = i • x.toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Natural powers project to quotient-ring natural powers. -/
 @[simp, grind =] theorem toQuotient_pow
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -747,6 +768,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient ^ n :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Division projects to multiplication by the projected inverse. -/
 @[simp, grind =] theorem toQuotient_div
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -755,6 +777,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient * (inv y).toQuotient :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Nonnegative integer powers project to quotient-ring natural powers. -/
 @[simp, grind =] theorem toQuotient_zpow_ofNat
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -763,6 +786,7 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient ^ n :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Negative integer powers project through inversion of the positive power. -/
 @[simp, grind =] theorem toQuotient_zpow_negSucc
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -780,6 +804,7 @@ theorem natCast_eq_natCast_iff_mod_eq
     ofPoly f hf hp hirr (invPoly ((0 : FiniteField f hf hp hirr).toQuotient))) = 0
   simp
 
+omit [ZMod64.PrimeModulus p] in
 /-- Division is field multiplication by inverse. -/
 @[simp, grind =]
 theorem div_eq_mul_inv
@@ -857,6 +882,7 @@ theorem inv_mul_cancel
     repr (1 : FiniteField f hf hp hirr) = GFqRing.reduceMod f 1 :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a sum is the reduced sum of representatives. -/
 @[simp, grind =] theorem repr_add
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -864,6 +890,7 @@ theorem inv_mul_cancel
     repr (x + y) = GFqRing.reduceMod f (repr x + repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a product is the reduced product of representatives. -/
 @[simp, grind =] theorem repr_mul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -871,6 +898,7 @@ theorem inv_mul_cancel
     repr (x * y) = GFqRing.reduceMod f (repr x * repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a negation reduces from the negated representative. -/
 @[simp, grind =] theorem repr_neg
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -878,6 +906,7 @@ theorem inv_mul_cancel
     repr (-x) = GFqRing.reduceMod f (-(repr x)) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a subtraction reduces from the difference of
 representatives. -/
 @[simp, grind =] theorem repr_sub
@@ -886,6 +915,7 @@ representatives. -/
     repr (x - y) = GFqRing.reduceMod f (repr x - repr y) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a natural power is the quotient-ring power representative. -/
 @[simp, grind =] theorem repr_pow
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -893,6 +923,7 @@ representatives. -/
     repr (x ^ n) = GFqRing.repr (x.toQuotient ^ n) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a quotient is the quotient-ring product with the projected inverse. -/
 @[simp, grind =] theorem repr_div
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -901,6 +932,7 @@ representatives. -/
       GFqRing.repr (x.toQuotient * (inv y).toQuotient) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Nonnegative integer powers share the natural-power representative. -/
 @[simp, grind =] theorem repr_zpow_ofNat
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -909,6 +941,7 @@ representatives. -/
       GFqRing.repr (x.toQuotient ^ n) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Negative integer powers represent the inverse of the corresponding positive power. -/
 @[simp, grind =] theorem repr_zpow_negSucc
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -924,6 +957,7 @@ representatives. -/
       GFqRing.repr ((i : GFqRing.PolyQuotient f hf)) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of a natural scalar action lifts the quotient-ring action. -/
 @[simp, grind =] theorem repr_nsmul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -931,6 +965,7 @@ representatives. -/
     repr (n • x : FiniteField f hf hp hirr) = GFqRing.repr (n • x.toQuotient) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of an integer scalar action lifts the quotient-ring action. -/
 @[simp, grind =] theorem repr_zsmul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -1124,6 +1159,7 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     Lean.Grind.IsCharP (FiniteField f hf hp hirr) p where
   ofNat_ext_iff {x y} := natCast_eq_natCast_iff_mod_eq f hf hp hirr x y
 
+omit [ZMod64.PrimeModulus p] in
 /-- Frobenius is definitionally the `p`-th power map. -/
 theorem frob_eq_pow
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -1131,6 +1167,7 @@ theorem frob_eq_pow
     frob x = x ^ p :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- Frobenius projects to the quotient-ring `p`-th power. -/
 @[simp, grind =] theorem toQuotient_frob
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
@@ -1138,6 +1175,7 @@ theorem frob_eq_pow
     (frob x).toQuotient = x.toQuotient ^ p :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 /-- The representative of Frobenius is the quotient-ring `p`-th power representative. -/
 @[simp, grind =] theorem repr_frob
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -23,7 +23,9 @@ namespace Hex
 
 namespace GFqField
 
-variable {p : Nat} [ZMod64.Bounds p] {hp : Hex.Nat.Prime p}
+-- The quotient type these operations wrap is a prime-modulus type, and the
+-- extended-gcd / inverse machinery needs `ZMod64 p` to be a field besides.
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] {hp : Hex.Nat.Prime p}
 
 /-- Natural-number literals reuse the quotient-ring cast and then rewrap the
 resulting reduced residue. -/
@@ -304,9 +306,6 @@ private theorem dvd_left_of_mul_const_right_eq
       exact (DensePoly.mul_assoc_poly g (DensePoly.C c) (DensePoly.C c⁻¹)).symm
     _ = f * DensePoly.C c⁻¹ := by
       rw [hfgC]
-
--- The extended-gcd / inverse machinery below needs `ZMod64 p` to be a field.
-variable [ZMod64.PrimeModulus p]
 
 /-- The extended-gcd output gives the unscaled Bezout identity for the reduced
 representative and the modulus. -/

--- a/HexGFqMathlib/Basic.lean
+++ b/HexGFqMathlib/Basic.lean
@@ -326,6 +326,7 @@ noncomputable instance fintype :
     Fintype (Hex.GFqField.FiniteField f hf hp hirr) :=
   Fintype.ofEquiv (Fin (p ^ Hex.FpPoly.degree f)) finEquiv.symm
 
+omit [ZMod64.PrimeModulus p] in
 /-- The generic executable finite-field wrapper has the expected cardinality. -/
 @[simp, grind =]
 theorem fintype_card :
@@ -346,6 +347,7 @@ noncomputable instance fintype (h : Hex.Conway.SupportedEntry p n) :
     Fintype (Hex.GFq p n h) :=
   FiniteField.fintype
 
+omit [ZMod64.PrimeModulus p] in
 /-- Cardinality of the canonical Conway-backed `GFq` in terms of its selected
 modulus degree. -/
 theorem fintype_card (h : Hex.Conway.SupportedEntry p n) :
@@ -371,12 +373,14 @@ theorem conwayPoly_degree (h : Hex.Conway.SupportedEntry p n) :
     Hex.FpPoly.degree (Hex.Conway.conwayPoly p n h) = n :=
   modulus_degree h
 
+omit [Hex.ZMod64.PrimeModulus p] in
 /-- Cardinality of canonical `GFq p n` as `p ^ n`. -/
 @[simp]
 theorem fintype_card_eq_pow (h : Hex.Conway.SupportedEntry p n) :
     Fintype.card (Hex.GFq p n h) = p ^ n := by
   rw [fintype_card h, modulus_degree h]
 
+omit [Hex.ZMod64.PrimeModulus p] in
 /-- Canonical {name}`Hex.GFq` and Mathlib's
 {name}`GaloisField` have matching cardinalities. -/
 theorem card_eq_galoisField_card [Fact p.Prime]

--- a/HexGFqRing/Operations.lean
+++ b/HexGFqRing/Operations.lean
@@ -23,7 +23,10 @@ namespace Hex
 
 namespace GFqRing
 
-variable {p : Nat} [ZMod64.Bounds p]
+-- `PolyQuotient` is a prime-modulus type: `reduceMod` is a canonical form only
+-- when the leading coefficient it divides by is a unit.  Every declaration here
+-- mentions the quotient, so the hypothesis is in scope for the whole namespace.
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
 
 /-- The quotient zero element. -/
 @[expose]
@@ -558,10 +561,6 @@ theorem neg_zero_eq {f : FpPoly p} {hf : 0 < FpPoly.degree f} :
     -(0 : PolyQuotient f hf) = 0 := by
   apply ext
   rw [repr_neg, repr_zero, reduceMod_zero f hf, FpPoly.neg_zero, reduceMod_zero f hf]
-
--- From here the quotient-ring algebra rests on `reduceMod` congruence lemmas
--- that need `ZMod64 p` to be a field, so the modulus must be prime.
-variable [ZMod64.PrimeModulus p]
 
 /-- Public alias for {name}`reduceMod_mul_reduceMod_congr`: reducing both factors before quotient
 reduction preserves the canonical representative. -/

--- a/HexGFqRing/Operations.lean
+++ b/HexGFqRing/Operations.lean
@@ -172,6 +172,7 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} : SMul Int (PolyQuotient f hf
     repr (const f hf c) = reduceMod f (FpPoly.C c) :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 private theorem zmod64_eq_zero_of_modulus_one
     (hp : p = 1) (a : ZMod64 p) : a = 0 := by
   apply ZMod64.ext
@@ -180,6 +181,7 @@ private theorem zmod64_eq_zero_of_modulus_one
     exact Nat.lt_one_iff.mp (by simpa [hp] using a.isLt)
   exact ha
 
+omit [ZMod64.PrimeModulus p] in
 private theorem zmod64_zero_ne_one_of_pos_degree
     (f : FpPoly p) (hf : 0 < FpPoly.degree f) :
     (0 : ZMod64 p) ≠ 1 := by
@@ -350,6 +352,7 @@ def linearPow {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     linearPow x (n + 1) = linearPow x n * x :=
   rfl
 
+omit [ZMod64.PrimeModulus p] in
 private theorem fpPoly_C_add (a b : ZMod64 p) :
     FpPoly.C (a + b) = (FpPoly.C a + FpPoly.C b : FpPoly p) := by
   apply DensePoly.ext_coeff

--- a/HexGFqRing/PolynomialQuotient.lean
+++ b/HexGFqRing/PolynomialQuotient.lean
@@ -75,12 +75,18 @@ A value of this type is a polynomial *together with* a proof that it lies in the
 image of `reduceMod f`, so a raw `FpPoly p` cannot be supplied where one of these
 is expected.
 
-The modulus is required to be prime, and that is what makes the representative
-canonical: `reduceMod` is a genuine remainder only when the leading coefficient
-it divides by is a unit. Over a composite modulus the division step can subtract
-zero and leave the remainder untouched, so `reduceMod` is not a canonical form
-and two values would represent one residue class. `isReduced_iff_degree_lt`
-states the contract this hypothesis buys.
+The modulus is required to be prime, which guarantees the representative is
+canonical for every nonconstant `f`: `reduceMod` is a genuine remainder only
+when the leading coefficient it divides by is a unit, and over a prime modulus
+every nonzero coefficient is. Drop the hypothesis and canonicality can fail. At
+`p = 4` with `f = 2X` the division step subtracts zero and leaves the remainder
+untouched, so `f` and `0` are congruent yet both reduced and distinct.
+`isReduced_iff_degree_lt` states the contract this hypothesis buys.
+
+Primality is sufficient, not necessary: a monic `f` needs no coefficient
+inversion and would be canonical over any modulus. The uniform prime hypothesis
+is the deliberate choice here, since every modulus this library serves is over a
+prime field anyway.
 
 `reduceMod` itself, and its degree-short-circuit lemmas above, stay general; it
 is the quotient *type* that is restricted, because that is what carries the
@@ -155,9 +161,11 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} : DecidableEq (PolyQuotient f
 {name}`PolyQuotient` stores is the unique one of its residue class.
 
 This is the theorem behind the "equality is equality of canonical
-representatives" contract, and it is where primality is load-bearing: the
-right-to-left direction needs `reduceMod` to fix every polynomial below the
-modulus, which fails when the leading coefficient of `f` is not a unit. -/
+representatives" contract, and it is where primality is load-bearing. The
+forward direction is the one that needs it: a reduced polynomial is only known
+to sit below the modulus because the remainder-degree law holds over a field,
+and that law is what fails when the leading coefficient of `f` is not a unit.
+The converse is `reduceMod_eq_self_of_degree_lt`, which holds generally. -/
 theorem isReduced_iff_degree_lt {f : FpPoly p} (hf : 0 < FpPoly.degree f)
     (g : FpPoly p) :
     IsReduced f g ↔ FpPoly.degree g < FpPoly.degree f := by

--- a/HexGFqRing/PolynomialQuotient.lean
+++ b/HexGFqRing/PolynomialQuotient.lean
@@ -75,14 +75,20 @@ A value of this type is a polynomial *together with* a proof that it lies in the
 image of `reduceMod f`, so a raw `FpPoly p` cannot be supplied where one of these
 is expected.
 
-That representative is the canonical one for its residue class only when `p` is
-prime, which is what makes `reduceMod` a genuine remainder; see
-`isReduced_iff_degree_lt`. For composite `p` the division step divides by a
-leading coefficient that need not be a unit, `reduceMod` is then not a canonical
-form, and two values of this type can represent the same class. Every ring
-operation and every canonicality result below assumes `ZMod64.PrimeModulus p`. -/
-abbrev PolyQuotient (f : FpPoly p) (_hf : 0 < FpPoly.degree f) :=
+The modulus is required to be prime, and that is what makes the representative
+canonical: `reduceMod` is a genuine remainder only when the leading coefficient
+it divides by is a unit. Over a composite modulus the division step can subtract
+zero and leave the remainder untouched, so `reduceMod` is not a canonical form
+and two values would represent one residue class. `isReduced_iff_degree_lt`
+states the contract this hypothesis buys.
+
+`reduceMod` itself, and its degree-short-circuit lemmas above, stay general; it
+is the quotient *type* that is restricted, because that is what carries the
+canonicality claim. -/
+abbrev PolyQuotient [ZMod64.PrimeModulus p] (f : FpPoly p) (_hf : 0 < FpPoly.degree f) :=
   { g : FpPoly p // IsReduced f g }
+
+variable [ZMod64.PrimeModulus p]
 
 /-- Inject a polynomial into the quotient by reducing it modulo `f`. -/
 @[expose]
@@ -136,10 +142,6 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} : DecidableEq (PolyQuotient f
     exact hx ((eq_zero_iff_repr_eq_zero x).2 hrepr)
   · intro hx hzero
     exact hx ((eq_zero_iff_repr_eq_zero x).1 hzero)
-
--- The remaining `reduceMod` algebra rests on `DensePoly` division laws that
--- require `ZMod64 p` to be a field, so from here the modulus must be prime.
-variable [ZMod64.PrimeModulus p]
 
 /-- Canonical representatives have degree strictly below the modulus. -/
 @[simp] theorem degree_repr_lt_degree {f : FpPoly p} {hf : 0 < FpPoly.degree f}

--- a/HexGFqRing/SPEC/hex-gfq-ring.md
+++ b/HexGFqRing/SPEC/hex-gfq-ring.md
@@ -24,20 +24,24 @@ API.
 - `Lean.Grind.CommRing (PolyQuotient p f hf)` instance
 
 Representation choice: the stored representative is canonical, and the
-type says so — `PolyQuotient` is a subtype carrying `IsReduced`, so a raw
+type says so. `PolyQuotient` is a subtype carrying `IsReduced`, so a raw
 `FpPoly` cannot be passed where a quotient element is expected. Callers
 do not manage reduction manually; `ofPoly` and all ring operations
 normalize through `reduceMod`. Equality of quotient elements is therefore
 equality of canonical representatives, not a separate setoid-style
 relation.
 
-Canonicality requires `p` prime, and the operations require it too. The
-`PolyQuotient` type itself asks only for `ZMod64.Bounds p`, but at
-composite `p` the long-division step divides by a leading coefficient
-that need not be a unit, `reduceMod` is not a canonical form, and two
-values can represent one residue class. `isReduced_iff_degree_lt` states
-the canonicality contract under `ZMod64.PrimeModulus p`, which is the
-only regime this library supports.
+Canonicality requires `p` prime, and `PolyQuotient` says so: it takes
+`[ZMod64.PrimeModulus p]`, so a quotient element cannot be formed over a
+composite modulus at all. That restriction is real rather than
+defensive. At composite `p` the long-division step divides by a leading
+coefficient that need not be a unit, `reduceMod` is then not a canonical
+form, and two values would represent one residue class.
+`isReduced_iff_degree_lt` states the contract the hypothesis buys.
+
+`reduceMod` itself stays general, along with its degree-short-circuit
+lemmas; it is the quotient type that carries the canonicality claim, so
+it is the quotient type that is restricted.
 
 This does NOT require `f` to be irreducible — the quotient is always a
 ring. When `f` is irreducible, the same underlying representation

--- a/HexGFqRing/SPEC/hex-gfq-ring.md
+++ b/HexGFqRing/SPEC/hex-gfq-ring.md
@@ -31,13 +31,20 @@ normalize through `reduceMod`. Equality of quotient elements is therefore
 equality of canonical representatives, not a separate setoid-style
 relation.
 
-Canonicality requires `p` prime, and `PolyQuotient` says so: it takes
-`[ZMod64.PrimeModulus p]`, so a quotient element cannot be formed over a
-composite modulus at all. That restriction is real rather than
-defensive. At composite `p` the long-division step divides by a leading
-coefficient that need not be a unit, `reduceMod` is then not a canonical
-form, and two values would represent one residue class.
-`isReduced_iff_degree_lt` states the contract the hypothesis buys.
+`PolyQuotient` takes `[ZMod64.PrimeModulus p]`, so a quotient element
+cannot be formed over a composite modulus at all. That restriction is
+real rather than defensive: at composite `p` the long-division step
+divides by a leading coefficient that need not be a unit, `reduceMod` is
+then not a canonical form, and two values would represent one residue
+class. `isReduced_iff_degree_lt` states the contract the hypothesis
+buys.
+
+Primality is sufficient rather than necessary. A monic modulus needs no
+coefficient inversion and would be canonical over any `p`; the uniform
+prime hypothesis is the deliberate choice, since every modulus this
+library serves is over a prime field. Generalizing to monic moduli over
+a general coefficient ring would need a division-law package that does
+not exist yet.
 
 `reduceMod` itself stays general, along with its degree-short-circuit
 lemmas; it is the quotient type that carries the canonicality claim, so

--- a/bench/HexGFqRing/Bench.lean
+++ b/bench/HexGFqRing/Bench.lean
@@ -37,6 +37,16 @@ open GFqRing
 
 private instance benchBoundsLarge : ZMod64.Bounds 65537 := ⟨by decide, by decide⟩
 
+-- `PolyQuotient` is a prime-modulus type.  65537 is far too large for the
+-- linear primality decision procedure, so the trial-division bound is supplied
+-- as data: 256 * 256 < 65537 < 257 * 257.
+set_option maxRecDepth 8192 in
+private theorem prime_65537 : Hex.Nat.Prime 65537 :=
+  Hex.Nat.prime_of_bounded 65537 256 (by decide) (by decide) (by decide)
+
+private instance benchPrimeLarge : ZMod64.PrimeModulus 65537 :=
+  ZMod64.primeModulusOfPrime prime_65537
+
 private theorem one_ne_zero_large : (1 : ZMod64 65537) ≠ 0 := by
   intro h
   have hm := (ZMod64.natCast_eq_natCast_iff (p := 65537) 1 0).mp h

--- a/conformance/HexGFqRing/Conformance.lean
+++ b/conformance/HexGFqRing/Conformance.lean
@@ -47,6 +47,11 @@ namespace GFqRing
 
 private instance conformanceBoundsFive : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
 
+-- `PolyQuotient` is a prime-modulus type, so the quotient checks below need
+-- primality of the coefficient modulus, not just its word bound.
+private instance conformancePrimeFive : ZMod64.PrimeModulus 5 :=
+  ZMod64.primeModulusOfPrime (by decide)
+
 private theorem one_ne_zero_five : (1 : ZMod64 5) ≠ 0 := by
   intro h
   have hm := (ZMod64.natCast_eq_natCast_iff (p := 5) 1 0).mp h
@@ -213,6 +218,9 @@ private def x5 : Q := q #[0, 0, 0, 0, 0, 1]
 /-! # Second concrete quotient: `F_7[x] / (x^2 + 1)` -/
 
 private instance conformanceBoundsSeven : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
+
+private instance conformancePrimeSeven : ZMod64.PrimeModulus 7 :=
+  ZMod64.primeModulusOfPrime (by decide)
 
 private theorem one_ne_zero_seven : (1 : ZMod64 7) ≠ 0 := by
   intro h

--- a/conformance/HexGFqRing/EmitFixtures.lean
+++ b/conformance/HexGFqRing/EmitFixtures.lean
@@ -44,6 +44,11 @@ private instance bounds5 : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
 private instance bounds7 : ZMod64.Bounds 7 := ⟨by decide, by decide⟩
 private instance bounds11 : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
 
+-- `PolyQuotient` is a prime-modulus type; every emitted case needs primality.
+private instance prime5 : ZMod64.PrimeModulus 5 := ZMod64.primeModulusOfPrime (by decide)
+private instance prime7 : ZMod64.PrimeModulus 7 := ZMod64.primeModulusOfPrime (by decide)
+private instance prime11 : ZMod64.PrimeModulus 11 := ZMod64.primeModulusOfPrime (by decide)
+
 /-- Lift an `FpPoly p` coefficient list to `List Int` via the canonical
 representative in `[0, p)`.  Used for fixture emission and result
 serialisation. -/
@@ -141,11 +146,11 @@ private def cases11 : List Case :=
       n       := 17 }
   ]
 
-/-- Run one case at a fixed `p` after the `[ZMod64.Bounds p]` instance
-has been resolved by the dispatchers below.  Builds the polynomials,
-constructs canonical quotient elements, and emits one fixture record
-plus the four operation results. -/
-private def emitCaseAt (p : Nat) [ZMod64.Bounds p] (c : Case)
+/-- Run one case at a fixed `p` after the `[ZMod64.Bounds p]` and
+`[ZMod64.PrimeModulus p]` instances have been resolved by the dispatchers
+below.  Builds the polynomials, constructs canonical quotient elements, and
+emits one fixture record plus the four operation results. -/
+private def emitCaseAt (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p] (c : Case)
     (hpos : 0 < FpPoly.degree (mkPoly (p := p) c.modulus)) : IO Unit := do
   let m       : FpPoly p := mkPoly c.modulus
   let aPoly   : FpPoly p := mkPoly c.a


### PR DESCRIPTION
This PR moves the prime-modulus restriction on `HexGFqRing.PolyQuotient` from documentation into the type, closing https://github.com/kim-em/hex-dev/issues/9309.

`reduceMod` is a canonical form only when the leading coefficient it divides by is a unit. Over a composite modulus the long-division step can subtract zero and leave the remainder untouched: at `p = 4` with `f = 2X`, `reduceMod f f = f` while `reduceMod f 0 = 0`, so `f` and `0` are congruent modulo `f` yet both reduced and distinct. Every ring instance and every canonicality theorem already required `ZMod64.PrimeModulus p`, but the type accepted any `ZMod64.Bounds p`, so the restriction was a promise rather than a guarantee.

`PolyQuotient` now takes `[ZMod64.PrimeModulus p]`. `reduceMod` and its degree-short-circuit lemmas stay general, since it is the quotient type that carries the canonicality claim.

The change is smaller than the 105 `PolyQuotient` occurrences in `HexGFqRing/Operations.lean` suggest, because two things absorb it. `ZMod64.PrimeModulus` is `Prop`-valued and therefore proof-irrelevant, so `FiniteField` derives its own witness from the `_hp` it already stores instead of demanding one from callers, leaving its signature and `GFq`/`GFqC`'s unchanged. And `HexConway.Table` already ships ground instances for all six committed primes, so concrete uses resolve automatically and only generic code carries the hypothesis. In the ring and field operation files a single `variable` hoist sufficed, with no per-declaration edits.

The remaining work was the drivers: `PrimeModulus` instances for 5 and 7 in the ring conformance checks, for 5, 7 and 11 plus `[ZMod64.PrimeModulus p]` on `emitCaseAt` in the fixture emitter, and a `prime_of_bounded` witness for 65537 in the bench.

Based on https://github.com/kim-em/hex-dev/pull/9310, which corrected the documentation; review that one first.

🤖 Prepared with Claude Code