### PR TITLE
doc: audit determinant identities and fix Sylvester terminology

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -646,9 +646,10 @@ two-row-replaced cofactor-row pairing is the two-by-two difference of the four
 one-row cofactor-row pairings of `u` and `v`.
 
 This is the two-by-two case of Jacobi's identity for minors of the adjugate,
-written with row replacement rather than row deletion. It is *not* Sylvester's
-determinant identity, which is the `k`-fold statement about a matrix of bordered
-minors and is not proved in this project. -/
+written with row replacement rather than row deletion. It is *not* the general
+Sylvester determinant identity, the statement that an `m` by `m` matrix of
+bordered minors has determinant `det A0 ^ (m - 1) * det A`, which is not proved
+in this project. -/
 theorem cofactorRowPairing_setRow_plucker
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -642,8 +642,13 @@ private theorem det_mul_cofactor_setRow_eq
 
 For matrix `M : Matrix R (n+1) (n+1)`, distinct rows `a` and `b`, and
 replacement vectors `u`, `v`, the determinant of `M` paired with the
-two-row-replaced cofactor-row pairing satisfies the quadratic Sylvester
-relation against the four one-row cofactor-row pairings of `u` and `v`. -/
+two-row-replaced cofactor-row pairing is the two-by-two difference of the four
+one-row cofactor-row pairings of `u` and `v`.
+
+This is the two-by-two case of Jacobi's identity for minors of the adjugate,
+written with row replacement rather than row deletion. It is *not* Sylvester's
+determinant identity, which is the `k`-fold statement about a matrix of bordered
+minors and is not proved in this project. -/
 theorem cofactorRowPairing_setRow_plucker
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)
@@ -670,7 +675,13 @@ theorem cofactorRowPairing_setRow_plucker
   rw [hpre]
   grind
 
-/-- Two-row replacement determinant Plucker identity. -/
+/-- Two-row replacement determinant identity: replacing distinct rows `a` and
+`b` of `M` by `u` and `v` relates `det M` times the doubly-replaced determinant
+to the four singly-replaced determinants.
+
+Substituting standard basis vectors for `u` and `v` turns each singly-replaced
+determinant into a signed one-row/one-column minor, recovering Desnanot-Jacobi
+for an arbitrary row pair and column pair. -/
 theorem det_setRow_setRow_mul_det
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)

--- a/HexDeterminant/README.md
+++ b/HexDeterminant/README.md
@@ -95,13 +95,19 @@ theorem det_setRow_setRow_mul_det
         det (setRow M a v) * det (setRow M b u)
 ```
 
-`det_plucker_three_term_consecutive_top` is the three-term Grassmann-Plücker
-relation among maximal minors of a tall matrix, in the specialisation where the
-two larger of the three distinguished rows are the last two rows of the matrix.
-Desnanot-Jacobi itself, and
-the unrestricted three-term relation, are stated in
-[`hex-determinant-mathlib`](https://github.com/leanprover/hex-determinant-mathlib);
-Sylvester's determinant identity is not proved anywhere in the project.
+`det_plucker_three_term_consecutive_top` is a three-term Grassmann-Plücker
+relation, in the specialisation where the two larger of the three distinguished
+rows are the last two rows. It relates the maximal minors of a tall
+`B : Matrix R (k + 2) k` to those of `B` with a column appended: `nDet B p q`
+deletes two rows of `B`, while `mDet B v p` deletes one row of `[B | v]`. Taking
+`v` a standard basis vector recovers the ordinary six-maximal-minor relation
+among `nDet`s.
+
+Desnanot-Jacobi itself, and the unrestricted three-term relation for any
+`p1 < p2 < p3`, are stated in
+[`hex-determinant-mathlib`](https://github.com/leanprover/hex-determinant-mathlib).
+Sylvester's determinant identity, the general `m × m` bordered-minor statement,
+is not proved anywhere in the project.
 
 The identification of this determinant with Mathlib's `Matrix.det`, and the
 correspondence with the executable Bareiss determinant

--- a/HexDeterminant/README.md
+++ b/HexDeterminant/README.md
@@ -51,7 +51,7 @@ def M : Matrix Int 3 3 := Matrix.ofFn fun i j => if i = j then (2 : Int) else 1
 # Verification
 
 Over a `CommRing` the determinant's behaviour is fully proven, starting with
-`det_one` and the row-operation laws `det_rowSwap`, `det_rowScale`, and
+`det_identity` and the row-operation laws `det_rowSwap`, `det_rowScale`, and
 `det_rowAdd`.
 
 The headline theorem for each of the remaining results (with
@@ -78,9 +78,30 @@ The `List.finRange` reference form `det_eq_foldl_laplace_row` states the same
 expansion as a `List.foldl`, bridged by `Fin.foldl_eq_finRange_foldl`.
 
 We prove the Cauchy-Binet column-tuple product formula (Gram form) as
-`det_gramMatrix_eq_sum_columnTuples`, the adjugate identity
-`M * adjugate M = det M • identity` as `mul_adjugate`, and the three-term
-Plücker / Desnanot-Jacobi identity as `det_plucker_three_term_consecutive_top`.
+`det_gramMatrix_eq_sum_columnTuples` and the adjugate identity
+`M * adjugate M = det M • identity` as `mul_adjugate`.
+
+Two quadratic identities among minors are proved here, and it is worth keeping
+their names apart. `det_setRow_setRow_mul_det` is the two-row replacement
+identity, the `2 × 2` case of Jacobi's adjugate-minor identity: for distinct
+rows `a`, `b` and arbitrary vectors `u`, `v`,
+
+```lean
+theorem det_setRow_setRow_mul_det
+    (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)
+    (u v : Vector R (n + 1)) :
+    det M * det (setRow (setRow M a u) b v) =
+      det (setRow M a u) * det (setRow M b v) -
+        det (setRow M a v) * det (setRow M b u)
+```
+
+`det_plucker_three_term_consecutive_top` is the three-term Grassmann-Plücker
+relation among maximal minors of a tall matrix, in the specialisation where the
+two larger of the three distinguished rows are the last two rows of the matrix.
+Desnanot-Jacobi itself, and
+the unrestricted three-term relation, are stated in
+[`hex-determinant-mathlib`](https://github.com/leanprover/hex-determinant-mathlib);
+Sylvester's determinant identity is not proved anywhere in the project.
 
 The identification of this determinant with Mathlib's `Matrix.det`, and the
 correspondence with the executable Bareiss determinant

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -49,8 +49,9 @@ det M * det M^{1,n+2}_{1,n+2} = det M^1_1 * det M^{n+2}_{n+2}
 ```
 
 Both distinguished rows and both distinguished columns are *deleted*.
-`hex-determinant` does **not** prove this. It is stated only over Mathlib
-matrices, in `hex-determinant-mathlib`.
+`hex-determinant` states no theorem in this deletion form. Deletion-form
+Desnanot-Jacobi exists only over Mathlib matrices, in
+`hex-determinant-mathlib`.
 
 **Jacobi's minor identity for the adjugate**, restricted to `2 × 2` minors. In
 row-replacement rather than row-deletion form: for distinct rows `a`, `b` and
@@ -62,19 +63,27 @@ det M * det (M with rows a, b replaced by u, v)
   - det (M with row a := v) * det (M with row b := u)
 ```
 
-This is what `hex-determinant` proves, as `det_setRow_setRow_mul_det`.
-Substituting standard basis vectors for `u` and `v` turns each one-row
-replacement into a signed one-row/one-column minor and recovers Desnanot-Jacobi
-for an arbitrary row pair and column pair, so the replacement form is at least
-as strong. It is **not** Sylvester's identity.
+This is what `hex-determinant` proves, as `det_setRow_setRow_mul_det`. It is
+equivalent to Desnanot-Jacobi for an arbitrary row pair and column pair, in both
+directions. Forwards, take `u = e_{j1}` and `v = e_{j2}` with `a < b` and
+`j1 < j2`: each one-row replacement becomes a cofactor,
+`det (setRow M a e_j) = cofactorSign a j * det (deleteRowCol M a j)`, and the
+two-row replacement becomes the doubly-deleted minor with sign
+`(-1)^(a + b + j1 + j2)`. That sign is common to all three products, so it
+cancels and leaves Desnanot-Jacobi on rows `{a, b}` and columns `{j1, j2}`.
+Backwards, both sides are bilinear in `(u, v)`, so expanding in the standard
+basis reduces the general case to those basis pairs (the diagonal `j1 = j2`
+terms vanish on both sides). It is **not** the general Sylvester determinant
+identity; via that equivalence it is Sylvester's `2 x 2` case.
 
-**Sylvester's determinant identity** is the `k`-fold generalisation over
-bordered minors, and it is absent from both determinant libraries. Its exact
+**Sylvester's determinant identity** is the general statement that an
+`m x m` matrix of bordered minors has determinant `det A0 ^ (m - 1) * det A`,
+and it is absent from both determinant libraries. Its exact
 statement and proposed home are recorded in
 [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md).
-Nothing already in the tree may be relabelled "Sylvester". The Bareiss
-recurrence uses only the case where the bordered-minor matrix is `2 × 2`, and
-that case *is* Desnanot-Jacobi.
+Nothing already in the tree proves it, so nothing already in the tree may be
+renamed to claim it. The Bareiss recurrence uses only the case where the
+bordered-minor matrix is `2 × 2`, and that case *is* Desnanot-Jacobi.
 
 **Grassmann-Plücker relations** are the quadratic relations among the *maximal*
 minors of a rectangular matrix. The three-term relation is the one this library
@@ -119,11 +128,15 @@ before `det_setRow_eq_cofactorRowPairing` rewrites each side into determinants.
 The only hypothesis is `a ≠ b`. The replacement vectors are unconstrained, and
 there is no nondegeneracy or integral-domain assumption: the proof runs through
 `det_mul_cofactor_setRow_eq`, which evaluates a single entry of
-`adjugate (setRow M a u) * (setRow M a u * adjugate M)` two ways using
-`mul_adjugate` and `adjugate_mul`, so the `det M` factor is *produced* rather
-than cancelled. Mathlib's `desnanot_jacobi` reaches the same generality by a
-different route, proving the identity over an integral domain and then
-transferring it along an `MvPolynomial` evaluation from the universal matrix.
+`adjugate (setRow M a u) * (setRow M a u * adjugate M)` two ways. One
+association uses `adjugate_mul_apply`; the other splits the sum over rows with
+`setRow_mul_adjugate_apply_self` and `_ne`, whose off-replacement case is
+`cofactorRowPairing_self` on the diagonal and `cofactorRowPairing_alien_eq_zero`
+off it. The `det M` factor is *produced* by that split rather than cancelled.
+
+Mathlib's `desnanot_jacobi` reaches the same generality by a different route,
+proving the identity over an integral domain and then transferring it along an
+`MvPolynomial` evaluation from the universal matrix.
 
 Three-term Grassmann-Plücker, in `HexDeterminant/Plucker.lean`:
 
@@ -140,8 +153,9 @@ theorem det_plucker_three_term_consecutive_top
 
 This is the *consecutive-top* specialisation: the three distinguished rows are
 `alpha`, `k`, and `k+1` inside `Fin (k + 2)`, so the largest is the last row of
-`B` and the case `q > p3` cannot arise. That restriction is what keeps the proof
-Mathlib-free. The unrestricted three-term relation, for arbitrary
+`B` and the case `q > p3` cannot arise. Removing that case is what makes the
+Mathlib-free proof tractable; it is a proof-effort restriction, not a
+mathematical one. The unrestricted three-term relation, for arbitrary
 `p1 < p2 < p3`, is `det_plucker_three_term` in `hex-determinant-mathlib`; it is
 not restated here.
 

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -2,38 +2,168 @@
 
 The generic Leibniz-formula determinant for dense square matrices, together with
 the cofactor/adjugate theory, column-tuple (Cauchy-Binet) expansion, and the
-two-row Plücker / Desnanot-Jacobi identities.
+Mathlib-free quadratic determinant identities: the two-row replacement identity
+and the three-term Grassmann-Plücker relation.
 
 **Definition.** Define `det` via the Leibniz formula (signed sum over
 permutations), over any `Ring`. Theorems about `det` generally require
 `CommRing`. The development is split by subject across `HexDeterminant/*`
-(`Leibniz`, `Enumeration`, `Minor`, `Index`, `Permutation`, `ColumnLinear`,
-`Laplace`, `CauchyBinet`, `Expansion`, `Selection`, `Adjugate`, `Plucker`).
+(`Leibniz`, `Enumeration`, `Minor`, `LastRow`, `Permutation`, `RowOps`,
+`ColumnLinear`, `Laplace`, `CauchyBinet`, `Triangular`, `Gram`, `Adjugate`,
+`Plucker`), and `HexDeterminant.lean` re-exports all thirteen.
 
 **Determinant of row operations.** The row-operation laws live here, since they
 are statements about `det`. They are used by `hex-row-reduce` pivot-sign
 tracking and by `hex-bareiss` for composing row swaps into a permutation sign.
 
 **Key properties:**
-- `det_one : det 1 = 1`
+- `det_identity : det (Matrix.identity n) = 1` (there is no matrix `One`
+  instance, so the identity matrix is always written out)
 - `det_rowSwap : i ≠ j → det (rowSwap M i j) = -det M`
 - `det_rowScale : det (rowScale M i c) = c * det M`
-- `det_rowAdd : i ≠ j → det (rowAdd M i j c) = det M`
+- `det_rowAdd : src ≠ dst → det (rowAdd M src dst c) = det M`
+- `det_mul : det (M * N) = det M * det N`
 - column linearity, Laplace cofactor expansion, the Cauchy-Binet column-tuple
   product formula, the adjugate identity on both sides (`mul_adjugate` and
-  `adjugate_mul`), and the Plücker / Desnanot-Jacobi two-row identities
-- `mul_eq_one_comm : U * W = 1 → W * U = 1` for a square matrix over a
-  commutative ring, proved through the adjugate. A one-sided inverse is
+  `adjugate_mul`), and the quadratic identities specified below
+- `mul_eq_one_comm : U * W = identity n → W * U = identity n` for a square
+  matrix over a commutative ring, proved through the adjugate (both
+  `mul_adjugate` and `adjugate_mul` are needed). A one-sided inverse is
   therefore enough to witness invertibility, which is what the integer
   normal-form certificate checkers are specified to rely on.
 
-**Mathlib-free vs. Mathlib-bridge proof surface.** Theorems connecting `Hex.det`
+## Quadratic determinant identities: which name means what
+
+Four classical names circulate for the quadratic relations among minors, and
+they are *not* interchangeable. This SPEC and the sibling SPEC for
+[hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md)
+use each in exactly one sense.
+
+**Desnanot-Jacobi** (also Dodgson condensation, Lewis Carroll identity). For an
+`(n+2) × (n+2)` matrix `M`, with `M^i_j` denoting deletion of row `i` and
+column `j`:
+
+```
+det M * det M^{1,n+2}_{1,n+2} = det M^1_1 * det M^{n+2}_{n+2}
+                              - det M^1_{n+2} * det M^{n+2}_1
+```
+
+Both distinguished rows and both distinguished columns are *deleted*.
+`hex-determinant` does **not** prove this. It is stated only over Mathlib
+matrices, in `hex-determinant-mathlib`.
+
+**Jacobi's minor identity for the adjugate**, restricted to `2 × 2` minors. In
+row-replacement rather than row-deletion form: for distinct rows `a`, `b` and
+arbitrary replacement vectors `u`, `v`,
+
+```
+det M * det (M with rows a, b replaced by u, v)
+  = det (M with row a := u) * det (M with row b := v)
+  - det (M with row a := v) * det (M with row b := u)
+```
+
+This is what `hex-determinant` proves, as `det_setRow_setRow_mul_det`.
+Substituting standard basis vectors for `u` and `v` turns each one-row
+replacement into a signed one-row/one-column minor and recovers Desnanot-Jacobi
+for an arbitrary row pair and column pair, so the replacement form is at least
+as strong. It is **not** Sylvester's identity.
+
+**Sylvester's determinant identity** is the `k`-fold generalisation over
+bordered minors, and it is absent from both determinant libraries. Its exact
+statement and proposed home are recorded in
+[hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md).
+Nothing already in the tree may be relabelled "Sylvester". The Bareiss
+recurrence uses only the case where the bordered-minor matrix is `2 × 2`, and
+that case *is* Desnanot-Jacobi.
+
+**Grassmann-Plücker relations** are the quadratic relations among the *maximal*
+minors of a rectangular matrix. The three-term relation is the one this library
+proves, and it is a statement about a tall matrix rather than about deleting a
+row and a column of a square one.
+
+### Index conventions for the Plücker surface
+
+`HexDeterminant/Plucker.lean` fixes the following encoding, all `@[expose]`:
+
+- `skipIndex2 p q hpq : Fin n → Fin (n + 2)` embeds while skipping two deleted
+  indices `p.val < q.val`. The ordering proof `hpq` is a phantom argument: it
+  pins the precondition at call sites but is not consumed, which deliberately
+  trips the `unusedArguments` linter.
+- `mMatrix B v p : Matrix R (n + 1) (n + 1)` for `B : Matrix R (n + 2) n` and
+  `v : Vector R (n + 2)` is `[B | v]` with row `p` deleted; columns `0..n-1`
+  carry `B`, the last column carries `v`. `mDet B v p := det (mMatrix B v p)`.
+- `nMatrix B p q hpq : Matrix R n n` is `B` with rows `p` and `q` deleted, in
+  increasing-row order. `nDet B p q hpq := det (nMatrix B p q hpq)`.
+- `twoColMatrix B u v` / `twoColDet B u v` append two vector columns instead of
+  one, and expand back onto `mDet` through `twoColDet_eq_sum_mDet`.
+
+### The public identity theorems
+
+Every declaration below is exported by the `HexDeterminant` umbrella, over
+`[Lean.Grind.CommRing R]`.
+
+Two-row replacement, in `HexDeterminant/Adjugate.lean`:
+
+```lean
+theorem det_setRow_setRow_mul_det
+    (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)
+    (u v : Vector R (n + 1)) :
+    det M * det (setRow (setRow M a u) b v) =
+      det (setRow M a u) * det (setRow M b v) -
+        det (setRow M a v) * det (setRow M b u)
+```
+
+with `cofactorRowPairing_setRow_plucker` the same identity one step earlier,
+before `det_setRow_eq_cofactorRowPairing` rewrites each side into determinants.
+
+The only hypothesis is `a ≠ b`. The replacement vectors are unconstrained, and
+there is no nondegeneracy or integral-domain assumption: the proof runs through
+`det_mul_cofactor_setRow_eq`, which evaluates a single entry of
+`adjugate (setRow M a u) * (setRow M a u * adjugate M)` two ways using
+`mul_adjugate` and `adjugate_mul`, so the `det M` factor is *produced* rather
+than cancelled. Mathlib's `desnanot_jacobi` reaches the same generality by a
+different route, proving the identity over an integral domain and then
+transferring it along an `MvPolynomial` evaluation from the universal matrix.
+
+Three-term Grassmann-Plücker, in `HexDeterminant/Plucker.lean`:
+
+```lean
+theorem det_plucker_three_term_consecutive_top
+    (B : Matrix R (k + 2) k) (v : Vector R (k + 2))
+    (alpha : Fin (k + 2)) (halpha : alpha.val < k) :
+    let pk : Fin (k + 2) := ⟨k, _⟩
+    let plast : Fin (k + 2) := Fin.last (k + 1)
+    mDet B v alpha * nDet B pk plast _ -
+      mDet B v pk * nDet B alpha plast _ +
+      mDet B v plast * nDet B alpha pk _ = 0
+```
+
+This is the *consecutive-top* specialisation: the three distinguished rows are
+`alpha`, `k`, and `k+1` inside `Fin (k + 2)`, so the largest is the last row of
+`B` and the case `q > p3` cannot arise. That restriction is what keeps the proof
+Mathlib-free. The unrestricted three-term relation, for arbitrary
+`p1 < p2 < p3`, is `det_plucker_three_term` in `hex-determinant-mathlib`; it is
+not restated here.
+
+Supporting public lemmas, all in `Plucker.lean`, that a consumer of the
+three-term relation is expected to use rather than re-derive:
+`mDet_eq_sum_unit` and `twoColDet_eq_sum_unit_pairs` (basis expansion of the
+appended columns), `det_eq_signed_minor_of_col_basis` (Laplace along a basis
+column), `mDet_unit_eq_signed_nDet_of_lt` / `_of_gt` /
+`mDet_unit_eq_zero_of_eq` and `twoColDet_unit_unit_of_lt` / `_of_gt` / `_of_eq`
+(the ordered basis-pair evaluations, including the sign), and
+`deleteRowCol_mMatrix_at_q_minus_one_eq_nMatrix_of_lt` /
+`deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt` (identifying a deleted `mMatrix`
+with the corresponding `nMatrix`, on the two sides of the `q < p` split).
+
+**Mathlib-free vs. Mathlib proof surface.** Theorems connecting `Hex.det`
 to Mathlib's `Matrix.det` (e.g. `det_eq : Hex.det M = Matrix.det (matrixEquiv M)`)
-live exclusively in the sibling `*-mathlib` bridge layer and **must not** be
-restated, reproven, or specialized inside `hex-determinant`. The bridge that
-connects the executable Bareiss determinant to this Leibniz `det`
+live exclusively in the sibling `*-mathlib` layer and **must not** be
+restated, reproven, or specialized inside `hex-determinant`. The translation
+that connects the executable Bareiss determinant to this Leibniz `det`
 (`bareiss_eq_det` and the Desnanot-Jacobi bordered-minor invariant) is specified
-in `hex-bareiss`; the proof itself lives in the Mathlib bridge layer.
+in `hex-bareiss`; the proof itself lives in `hex-determinant-mathlib` and
+`hex-bareiss-mathlib`.
 
 ## External comparators
 

--- a/HexDeterminantMathlib.lean
+++ b/HexDeterminantMathlib.lean
@@ -13,7 +13,8 @@ public section
 /-!
 The `HexDeterminantMathlib` library is the Mathlib bridge for `hex-determinant`.
 It connects the executable Leibniz determinant `Hex.Matrix.det` to Mathlib's
-`Matrix.det` (`det_eq`), together with the permutation-sign transport and the
-four-row / double-row Plücker and Desnanot-Jacobi assembly used by the Bareiss
-correctness proof. This module re-exports the determinant correspondence core.
+`Matrix.det` (`det_eq`), together with the permutation-sign transport, the
+Desnanot-Jacobi bordered-minor identity used by the Bareiss correctness proof,
+and the four-row / double-row Grassmann-Plücker assembly. This module
+re-exports the determinant correspondence core.
 -/

--- a/HexDeterminantMathlib/DesnanotJacobi.lean
+++ b/HexDeterminantMathlib/DesnanotJacobi.lean
@@ -9,14 +9,16 @@ Copyright (c) 2026 Slava Naprienko. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Slava Naprienko
 
-Inlined into hex-matrix-mathlib from
+Inlined into hex-determinant-mathlib from
 https://github.com/leanprover-community/mathlib4/pull/37716
 ("feat(LinearAlgebra/Matrix/Determinant): Desnanot-Jacobi identity",
-authored by Slava Naprienko, commit `bbe9ab491bc1`). The proof is
-copied verbatim modulo Lean module-system syntax (the upstream version
-uses the new `module`/`public import` declarations; this project still
-uses plain `import`). Delete this file and import the upstream module
-once mathlib4 PR #37716 merges.
+authored by Slava Naprienko, commit `bbe9ab491bc1`). The proof was
+copied verbatim from that commit and has since been migrated to the
+`module`/`public import` system and had two `simp` sets repaired across
+toolchain bumps, so it is no longer character-for-character upstream.
+Delete this file and import the upstream module once mathlib4 PR #37716
+merges; the upstream branch has moved on from `bbe9ab491bc1`, so re-check
+the statement rather than assuming a drop-in swap.
 -/
 module
 

--- a/HexDeterminantMathlib/README.md
+++ b/HexDeterminantMathlib/README.md
@@ -57,9 +57,10 @@ The proof-facing API connects the executable determinant to Mathlib:
   `desnanot_jacobi_deleteRowCol_endpoints`, and in the bordered-minor form
   `desnanot_jacobi_borderedMinor` used by the Bareiss correctness proof.
 
-Sylvester's determinant identity, the `k`-fold generalisation over a matrix of
-bordered minors, is **not** proved here; the Bareiss recurrence needs only its
-`2 × 2` case, which is Desnanot-Jacobi.
+Sylvester's determinant identity, the general statement that an `m × m` matrix
+of bordered minors has determinant `det A₀ ^ (m - 1) * det A`, is **not** proved
+here; the Bareiss recurrence needs only its `2 × 2` case, which is
+Desnanot-Jacobi.
 
 # Verification
 

--- a/HexDeterminantMathlib/README.md
+++ b/HexDeterminantMathlib/README.md
@@ -49,9 +49,17 @@ The proof-facing API connects the executable determinant to Mathlib:
 - submatrix transport: `matrixEquiv_borderedMinor` and the determinant forms
   `det_principalSubmatrix_eq_submatrix_det` and
   `det_borderedMinor_eq_submatrix_det`;
-- the Plücker three-term identity `det_plucker_three_term` and the
-  Desnanot-Jacobi identities `desnanot_jacobi` and
+- the unrestricted three-term Grassmann-Plücker relation
+  `det_plucker_three_term`;
+- the Desnanot-Jacobi identity, over Mathlib matrices as `desnanot_jacobi`,
+  under an arbitrary row/column reindexing as
+  `desnanot_jacobi_matrixEquiv_reindex`, in Hex minor terms as
+  `desnanot_jacobi_deleteRowCol_endpoints`, and in the bordered-minor form
   `desnanot_jacobi_borderedMinor` used by the Bareiss correctness proof.
+
+Sylvester's determinant identity, the `k`-fold generalisation over a matrix of
+bordered minors, is **not** proved here; the Bareiss recurrence needs only its
+`2 × 2` case, which is Desnanot-Jacobi.
 
 # Verification
 
@@ -63,7 +71,9 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
     Hex.Matrix.det M = Matrix.det (matrixEquiv M)
 ```
 
-The Plücker three-term identity, assembled for the Bareiss correctness proof:
+The unrestricted three-term Grassmann-Plücker relation, for any three ordered
+rows `p1 < p2 < p3` (`hex-determinant` proves the Mathlib-free specialisation
+where `p2` and `p3` are the last two rows):
 
 ```lean
 theorem det_plucker_three_term

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -207,10 +207,12 @@ At `m = 0` both sides are `det A`. At `m = 1` the left-hand side is
 `b 0 0 * b 1 1 - b 0 1 * b 1 0` and the right-hand side is `det A₀ * det A`,
 which is Desnanot-Jacobi in bordered-minor form. Instantiating that case with
 `A` the `(k + 2) × (k + 2)` submatrix of `source` on rows `{0, …, k, i}` and
-columns `{0, …, k, j}` reproduces `desnanot_jacobi_borderedMinor` exactly: `A₀`
-becomes `principalSubmatrix source k`, the four `b` entries become the four
+columns `{0, …, k, j}` reproduces `desnanot_jacobi_borderedMinor`: `A₀` becomes
+`principalSubmatrix source k`, the four `b` entries become the four
 `borderedMinor source k` determinants, and `det A` becomes
-`det (borderedMinor source (k + 1) _ i j)`.
+`det (borderedMinor source (k + 1) _ i j)`. That correspondence is
+term-for-term modulo the submatrix transports already in `CoreTransport` and one
+`mul_comm` on the subtracted product.
 
 The statement above is not proved here, but it does elaborate at current `main`,
 and the formula was checked by kernel evaluation over `ℤ` at

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -1,9 +1,10 @@
 # hex-determinant-mathlib (depends on hex-determinant + hex-bareiss + hex-matrix-mathlib + Mathlib)
 
 Mathlib layer for `hex-determinant`: proves that our executable Leibniz
-determinant corresponds to Mathlib's `Matrix.det`, and assembles the
-Desnanot-Jacobi identity and the three-term Grassmann-Plücker relation used by
-the Bareiss correctness proof.
+determinant corresponds to Mathlib's `Matrix.det`, assembles the Desnanot-Jacobi
+identity in the bordered-minor form the Bareiss correctness proof consumes, and
+proves the unrestricted three-term Grassmann-Plücker relation (which nothing in
+the tree consumes yet).
 
 **Determinant correspondence:**
 ```lean
@@ -17,7 +18,11 @@ adjugate identities) transfer to our executable determinant.
 ## Module layout and export chain
 
 Everything lives in the `HexMatrixMathlib` namespace, except `desnanot_jacobi`,
-which is in the root namespace because it is verbatim upstream Mathlib.
+which is in the root namespace because it is upstream Mathlib content. Two
+sub-namespaces sit inside it: `HexMatrixMathlib.PermutationVector` (the
+permutation-sign transport, including `toPerm`, `equivs` and
+`detSign_eq_permSign`) and `HexMatrixMathlib.OrderedFourShift` (the cycle
+helpers for the four-row transport).
 
 | module | contents |
 |---|---|
@@ -30,16 +35,22 @@ The umbrella `HexDeterminantMathlib.lean` imports `Core` only. `DesnanotJacobi`
 reaches it transitively, through `CoreTransport`'s `public import`, so
 `desnanot_jacobi` *is* part of the umbrella's export surface even though no
 module names it in an import list next to `Core`. That chain is load-bearing:
-`DesnanotJacobi` has no other importer, and dropping the `public` from
+`DesnanotJacobi` has no other importer, so dropping the `public` from
 `CoreTransport`'s import of it would silently remove `desnanot_jacobi` from the
-published library.
+umbrella's export surface. The module would still exist and stay directly
+importable as `HexDeterminantMathlib.DesnanotJacobi`, which is exactly what
+makes the regression easy to miss.
 
-`DesnanotJacobi.lean` is a verbatim inline of
+`DesnanotJacobi.lean` was copied verbatim from commit `bbe9ab491bc1` of
 https://github.com/leanprover-community/mathlib4/pull/37716
 ("feat(LinearAlgebra/Matrix/Determinant): Desnanot-Jacobi identity", by Slava
-Naprienko), carrying its own copyright header, and is to be deleted in favour of
-the upstream module once that PR merges. Everything in it except the final
-theorem is `private`.
+Naprienko) and carries its own copyright header. It is no longer verbatim: it
+has since been migrated to the `module` / `public import` system and had two
+`simp` sets repaired across toolchain bumps. It is to be deleted in favour of
+the upstream module once that PR merges, and the upstream branch has itself
+moved on from the pinned commit, so expect to re-check the statement rather
+than assume a drop-in swap. Everything in the file except the final theorem is
+`private`.
 
 ## Desnanot-Jacobi: the four public forms
 
@@ -66,8 +77,11 @@ theorem desnanot_jacobi {R : Type*} [CommRing R] {n : ℕ}
 `desnanot_jacobi_matrixEquiv_reindex` (`CoreTransport`) takes an arbitrary pair
 of `Equiv.Perm`s `row` and `col` and states the same identity for
 `(matrixEquiv M).submatrix row col`. This is the form to use when the two
-distinguished rows and columns are not the endpoints: choose `row` and `col` to
-carry them to `0` and `Fin.last`.
+distinguished rows and columns are not the endpoints. Mind the direction:
+`submatrix` composes, so `row` maps *new* indices to original ones. To
+distinguish original rows `r1` and `r2`, pick `row` with `row 0 = r1` and
+`row (Fin.last (n + 1)) = r2`, equivalently `row.symm` carrying `r1` and `r2`
+to the endpoints.
 
 `desnanot_jacobi_deleteRowCol_endpoints` (`CoreTransport`) is the endpoint case
 restated entirely in Hex terms, with `Hex.Matrix.deleteRowCol` in place of
@@ -167,7 +181,7 @@ consumers of the released library.
 ## Sylvester's determinant identity: absent
 
 The general Sylvester identity is **not** proved anywhere in this project, and
-no existing theorem should be relabelled to suggest otherwise. It states: for
+no existing theorem should be renamed to claim it. It states: for
 `A` square of size `k + m`, let `A₀` be the leading `k × k` principal submatrix
 and let `b i j` for `i j : Fin m` be the bordered minor on rows
 `{0, …, k-1} ∪ {k + i}` and columns `{0, …, k-1} ∪ {k + j}`. Then the `m × m`

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -1,9 +1,9 @@
 # hex-determinant-mathlib (depends on hex-determinant + hex-bareiss + hex-matrix-mathlib + Mathlib)
 
-Mathlib bridge for `hex-determinant`: proves that our executable Leibniz
+Mathlib layer for `hex-determinant`: proves that our executable Leibniz
 determinant corresponds to Mathlib's `Matrix.det`, and assembles the
-permutation-sign transport and the four-row / double-row Plücker and
-Desnanot-Jacobi identities used by the Bareiss correctness proof.
+Desnanot-Jacobi identity and the three-term Grassmann-Plücker relation used by
+the Bareiss correctness proof.
 
 **Determinant correspondence:**
 ```lean
@@ -11,12 +11,208 @@ theorem det_eq (M : Hex.Matrix R n n) :
     Hex.det M = Matrix.det (matrixEquiv M)
 ```
 
-**Internal structure:** the permutation-sign bridge and ordered transport
-helpers (`CoreTransport`), the four-row / double-row Plücker and Desnanot-Jacobi
-assembly (`CorePlucker`, `DesnanotJacobi`), re-exported through `Core`. The
-transport layer imports the executable `hex-bareiss` and `hex-determinant` cores
-so the bordered-minor invariant can be stated against the executable Bareiss
-recurrence; the `bareiss = det` headline theorems live in `hex-bareiss-mathlib`.
-
 Through `det_eq`, Mathlib determinant theorems (Cramer's rule, Cauchy-Binet,
 adjugate identities) transfer to our executable determinant.
+
+## Module layout and export chain
+
+Everything lives in the `HexMatrixMathlib` namespace, except `desnanot_jacobi`,
+which is in the root namespace because it is verbatim upstream Mathlib.
+
+| module | contents |
+|---|---|
+| `DesnanotJacobi` | the pure-Mathlib `desnanot_jacobi`, no Hex dependency |
+| `CoreTransport` | permutation-sign transport, `det_eq`, submatrix transport, the Hex-side Desnanot-Jacobi forms, the one-row and two-row replacement identities, and the ordered four-row `nMatrix` helpers |
+| `CorePlucker` | the three-term Grassmann-Plücker assembly and the Bareiss bordered-minor Desnanot-Jacobi specialisation |
+| `Core` | re-exports `CoreTransport` and `CorePlucker` |
+
+The umbrella `HexDeterminantMathlib.lean` imports `Core` only. `DesnanotJacobi`
+reaches it transitively, through `CoreTransport`'s `public import`, so
+`desnanot_jacobi` *is* part of the umbrella's export surface even though no
+module names it in an import list next to `Core`. That chain is load-bearing:
+`DesnanotJacobi` has no other importer, and dropping the `public` from
+`CoreTransport`'s import of it would silently remove `desnanot_jacobi` from the
+published library.
+
+`DesnanotJacobi.lean` is a verbatim inline of
+https://github.com/leanprover-community/mathlib4/pull/37716
+("feat(LinearAlgebra/Matrix/Determinant): Desnanot-Jacobi identity", by Slava
+Naprienko), carrying its own copyright header, and is to be deleted in favour of
+the upstream module once that PR merges. Everything in it except the final
+theorem is `private`.
+
+## Desnanot-Jacobi: the four public forms
+
+The identity is stated once and then transported. Each form below is public and
+reachable from the umbrella.
+
+`desnanot_jacobi` (root namespace, `DesnanotJacobi`), over any `CommRing`, with
+no hypothesis on `M`. The two distinguished rows and columns are pinned to the
+first and last index of `Fin (n + 2)`; deletion is by `Fin.succAbove`, and the
+interior minor is the double deletion
+`Fin.succAbove 0 ∘ (Fin.last n).succAbove`:
+
+```lean
+theorem desnanot_jacobi {R : Type*} [CommRing R] {n : ℕ}
+    (M : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    M.det * (M.submatrix (Fin.succAbove 0 ∘ (Fin.last n).succAbove)
+      (Fin.succAbove 0 ∘ (Fin.last n).succAbove)).det =
+    (M.submatrix (Fin.succAbove 0) (Fin.succAbove 0)).det *
+      (M.submatrix (Fin.last (n + 1)).succAbove (Fin.last (n + 1)).succAbove).det -
+    (M.submatrix (Fin.succAbove 0) (Fin.last (n + 1)).succAbove).det *
+      (M.submatrix (Fin.last (n + 1)).succAbove (Fin.succAbove 0)).det
+```
+
+`desnanot_jacobi_matrixEquiv_reindex` (`CoreTransport`) takes an arbitrary pair
+of `Equiv.Perm`s `row` and `col` and states the same identity for
+`(matrixEquiv M).submatrix row col`. This is the form to use when the two
+distinguished rows and columns are not the endpoints: choose `row` and `col` to
+carry them to `0` and `Fin.last`.
+
+`desnanot_jacobi_deleteRowCol_endpoints` (`CoreTransport`) is the endpoint case
+restated entirely in Hex terms, with `Hex.Matrix.deleteRowCol` in place of
+`Matrix.submatrix` and the interior minor written as an iterated
+`deleteRowCol M 0 0` then `deleteRowCol _ (Fin.last n) (Fin.last n)`. Note the
+index shift between the two deletions: the outer one indexes into
+`Fin (n + 2)`, the inner into `Fin (n + 1)`.
+
+`desnanot_jacobi_borderedMinor` (`CorePlucker`) is the Bareiss step form, and
+the one every consumer in the tree actually uses:
+
+```lean
+theorem desnanot_jacobi_borderedMinor [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) :
+    det (borderedMinor source (k + 1) hnext i j) *
+        det (principalSubmatrix source k (Nat.le_of_lt hk)) =
+      det (borderedMinor source k hk ⟨k, _⟩ ⟨k, _⟩) *
+          det (borderedMinor source k hk i j) -
+        det (borderedMinor source k hk i ⟨k, _⟩) *
+          det (borderedMinor source k hk ⟨k, _⟩ j)
+```
+
+Writing `b(r, c) := det (borderedMinor source k hk r c)` for the minor on rows
+`{0, …, k-1, r}` and columns `{0, …, k-1, c}`, this says
+
+```
+b'(i, j) * det (principalSubmatrix source k) = b(k, k) * b(i, j) - b(i, k) * b(k, j)
+```
+
+where `b'` is the same construction one level up. The right-hand side is the
+determinant of the `2 × 2` matrix of bordered minors indexed by rows `{k, i}`
+and columns `{k, j}`, so this is exactly the `2 × 2` case of Sylvester's
+identity below.
+
+The reindexing that gets from `desnanot_jacobi` to that shape is
+`bareissDesnanotIndex k : Fin (k + 2) ≃ Fin (k + 2)`, which permutes the
+bordered minor into the order `[k, 0, 1, …, k-1, k+1]` so that Desnanot-Jacobi
+deletes the Bareiss pivot row and column first and the trailing row and column
+last, leaving the previous leading principal minor as the interior.
+`det_borderedMinor_bareissDesnanotIndex` records that the reindexing is
+determinant-preserving, and `desnanot_jacobi_borderedMinor_reindex` is the
+intermediate statement in reindexed Mathlib coordinates.
+
+Consumers: `HexBareissMathlib/Bareiss.lean` (twice) and
+`HexGramSchmidtMathlib/Int/Augmented.lean`. `bareissExactDiv_borderedMinor_of_mul_eq`
+packages the resulting product identity as the `hexact` premise of
+`Hex.Matrix.stepMatrix_borderedMinor_update`; it takes the identity as the
+hypothesis `hdesnanot` and additionally requires `prevPivot ≠ 0`, the only
+nondegeneracy hypothesis anywhere in this surface.
+
+## Two-row replacement and Grassmann-Plücker
+
+`det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub` (one row replaced) and
+`det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub` (two rows replaced)
+restate the adjugate row-replacement identities in Hex terms, obtained from
+Mathlib's `Matrix.adjugate` theory. The two-row one has hypothesis `s ≠ r` and
+is the cofactor-pairing form of the `hex-determinant` theorem
+`det_setRow_setRow_mul_det`; the two are the same mathematical statement proved
+twice, once through Mathlib and once Mathlib-free, with the subtracted products
+written in opposite factor order (equal by `mul_comm`). The Mathlib route landed
+first (PR #6048), the Mathlib-free one shortly after (PR #6111), so the copy here
+is now redundant in principle and could be re-derived from
+`Hex.Matrix.det_setRow_setRow_mul_det`. Doing so is a refactor, not a
+correctness question, and nothing turns on it.
+
+`det_plucker_three_term` is the unrestricted three-term Grassmann-Plücker
+relation, for arbitrary ordered `p1 < p2 < p3`:
+
+```lean
+theorem det_plucker_three_term
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (v : Vector R (n + 3))
+    (p1 p2 p3 : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
+    mDet B v p1 * nDet B p2 p3 h23 -
+      mDet B v p2 * nDet B p1 p3 (Nat.lt_trans h12 h23) +
+      mDet B v p3 * nDet B p1 p2 h12 = 0
+```
+
+The `mDet` / `nDet` index conventions are fixed in `hex-determinant` and are not
+restated here. The dimensions are `(n + 3) × (n + 1)`, one taller and one
+narrower than a square matrix, because `mDet` appends the column `v` and `nDet`
+deletes two rows. `hex-determinant` proves the Mathlib-free
+`det_plucker_three_term_consecutive_top`, which is the specialisation with
+`p2 = k` and `p3 = k + 1` in `Fin (k + 2)`.
+
+The assembly runs, in `CorePlucker`, from the ordered four-row kernel
+`ordered_four_det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub` through
+`det_double_setRow_eq_pow_mul_nDet` and `ordered_four_signed_Plucker_p1_side` to
+`det_plucker_three_term_nDet_of_ordered_four`, then splits on the position of a
+basis-vector row `q` (`det_plucker_three_term_basisVec_of_ne` plus the three
+diagonal cases) and finally expands `v` in the standard basis. Nothing in the
+tree consumes `det_plucker_three_term` yet; it is public API for downstream
+consumers of the released library.
+
+## Sylvester's determinant identity: absent
+
+The general Sylvester identity is **not** proved anywhere in this project, and
+no existing theorem should be relabelled to suggest otherwise. It states: for
+`A` square of size `k + m`, let `A₀` be the leading `k × k` principal submatrix
+and let `b i j` for `i j : Fin m` be the bordered minor on rows
+`{0, …, k-1} ∪ {k + i}` and columns `{0, …, k-1} ∪ {k + j}`. Then the `m × m`
+matrix of bordered minors has determinant `det A₀ ^ (m - 1) * det A`.
+
+Stated at `m + 1` to avoid truncated subtraction, and with the border map
+written out:
+
+```lean
+/-- `Fin (k + 1) → Fin (k + (m + 1))`: the leading `k` indices, then `k + i`. -/
+def borderIndex (k m : ℕ) (i : Fin (m + 1)) (r : Fin (k + 1)) :
+    Fin (k + (m + 1)) :=
+  if h : r.val < k then Fin.castAdd (m + 1) ⟨r.val, h⟩ else Fin.natAdd k i
+
+theorem det_sylvester {R : Type*} [CommRing R] {k m : ℕ}
+    (A : Matrix (Fin (k + (m + 1))) (Fin (k + (m + 1))) R) :
+    (Matrix.of fun i j : Fin (m + 1) =>
+        (A.submatrix (borderIndex k m i) (borderIndex k m j)).det).det =
+      (A.submatrix (Fin.castAdd (m + 1)) (Fin.castAdd (m + 1))).det ^ m * A.det
+```
+
+At `m = 0` both sides are `det A`. At `m = 1` the left-hand side is
+`b 0 0 * b 1 1 - b 0 1 * b 1 0` and the right-hand side is `det A₀ * det A`,
+which is Desnanot-Jacobi in bordered-minor form. Instantiating that case with
+`A` the `(k + 2) × (k + 2)` submatrix of `source` on rows `{0, …, k, i}` and
+columns `{0, …, k, j}` reproduces `desnanot_jacobi_borderedMinor` exactly: `A₀`
+becomes `principalSubmatrix source k`, the four `b` entries become the four
+`borderedMinor source k` determinants, and `det A` becomes
+`det (borderedMinor source (k + 1) _ i j)`.
+
+The statement above is not proved here, but it does elaborate at current `main`,
+and the formula was checked by kernel evaluation over `ℤ` at
+`(k, m) = (1, 1)`, `(1, 2)` and `(2, 1)` before being written down.
+
+**Proposed home.** A new `HexDeterminantMathlib/Sylvester.lean`, stated over
+Mathlib matrices with no Hex dependency, following the `DesnanotJacobi.lean`
+precedent of holding pure-Mathlib content pending an upstream contribution, and
+re-exported by a `public import` from `CoreTransport` so it reaches the
+umbrella. A Hex-side `sylvester_borderedMinor` would then belong next to
+`desnanot_jacobi_borderedMinor` in `CorePlucker.lean`, using the same
+`borderedMinor` / `principalSubmatrix` encoding.
+
+**Not a prerequisite for anything.** Fraction-free elimination needs only the
+`m = 1` case, one step at a time, which is what `desnanot_jacobi_borderedMinor`
+already provides. The general identity would be worth proving as a statement
+about `Matrix.det` in its own right, not to unblock a consumer. It must not be
+folded into the Bareiss correctness path as a substitute for the existing
+Desnanot-Jacobi step, which is strictly cheaper to state and to apply.

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -129,11 +129,12 @@ of a square matrix, times the determinant with two rows replaced, to the
 four determinants with one row replaced; it is the `2 × 2` case of
 Jacobi's identity for minors of the adjugate, and substituting standard
 basis vectors recovers Desnanot-Jacobi. The three-term
-Grassmann-Plücker relation is a statement about the maximal minors of a
-*tall* matrix, proved here in the specialisation where the two larger of
-the three distinguished rows are the last two rows. Sylvester's
-determinant identity, the `k`-fold statement about a matrix of bordered
-minors, is not proved in this project.
+Grassmann-Plücker relation instead relates the maximal minors of a
+*tall* matrix `B` to those of `B` with a column appended, proved here in
+the specialisation where the two larger of the three distinguished rows
+are the last two rows. Sylvester's determinant identity, the general
+statement about an `m × m` matrix of bordered minors, is not proved in
+this project.
 
 The triangular-determinant law gives the determinant of an upper- or
 lower-triangular matrix as the product of its diagonal entries.

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -120,13 +120,27 @@ hypothesis.
 tag := "hex-determinant-identities"
 %%%
 
-The determinant of a Gram matrix expands as a sum over column tuples
-(the Cauchy-Binet formula), and the three-term Plücker /
-Desnanot-Jacobi identity relates the determinants of a matrix and its
-bordered minors. The triangular-determinant law gives the determinant of an upper- or
+The determinant of a Gram matrix expands as a sum over column tuples:
+the Cauchy-Binet formula.
+
+Two quadratic identities among minors follow, and their names are worth
+keeping apart. The two-row replacement identity relates the determinant
+of a square matrix, times the determinant with two rows replaced, to the
+four determinants with one row replaced; it is the `2 × 2` case of
+Jacobi's identity for minors of the adjugate, and substituting standard
+basis vectors recovers Desnanot-Jacobi. The three-term
+Grassmann-Plücker relation is a statement about the maximal minors of a
+*tall* matrix, proved here in the specialisation where the two larger of
+the three distinguished rows are the last two rows. Sylvester's
+determinant identity, the `k`-fold statement about a matrix of bordered
+minors, is not proved in this project.
+
+The triangular-determinant law gives the determinant of an upper- or
 lower-triangular matrix as the product of its diagonal entries.
 
 {docstring Hex.Matrix.det_gramMatrix_eq_sum_columnTuples}
+
+{docstring Hex.Matrix.det_setRow_setRow_mul_det}
 
 {docstring Hex.Matrix.det_plucker_three_term_consecutive_top}
 

--- a/progress/20260821T052839Z_determinant-identity-audit.md
+++ b/progress/20260821T052839Z_determinant-identity-audit.md
@@ -1,0 +1,81 @@
+# Determinant identity audit and Sylvester terminology (issue #9316)
+
+## Accomplished
+
+Audited `HexDeterminant`, `HexDeterminantMathlib`, both umbrellas, and both
+SPECs against the actual declarations, then amended the documentation to match.
+
+**Export surface.** No umbrella export change was needed. `HexDeterminantMathlib.lean`
+imports only `Core`, but `desnanot_jacobi` still reaches the umbrella:
+`Core` publicly imports `CoreTransport`, which publicly imports `DesnanotJacobi`.
+Confirmed by elaborating 55 `#check`s against `import HexDeterminant` and
+`import HexDeterminantMathlib` alone, in a scratch file that was then deleted.
+Every declaration named in the amended SPECs and READMEs resolves that way.
+
+**Terminology.** Four names were being used interchangeably. They are now fixed
+to one sense each:
+
+- *Desnanot-Jacobi* (Dodgson condensation): rows and columns deleted. Proved
+  only over Mathlib matrices, in `DesnanotJacobi.lean`, with three transported
+  forms in `CoreTransport`/`CorePlucker`.
+- *Jacobi's adjugate-minor identity at `2 x 2`*, in row-replacement form. This is
+  `Hex.Matrix.det_setRow_setRow_mul_det`, Mathlib-free, hypothesis `a != b` only.
+  Basis-vector substitution recovers Desnanot-Jacobi for an arbitrary row/column
+  pair, so it is at least as strong.
+- *Grassmann-Plücker three-term relation*: about maximal minors of a tall
+  matrix. `det_plucker_three_term` (arbitrary `p1 < p2 < p3`, Mathlib layer) and
+  `det_plucker_three_term_consecutive_top` (Mathlib-free specialisation).
+- *Sylvester's determinant identity*: absent from the project.
+
+The one place labelling a determinant identity "Sylvester" was the docstring on
+`cofactorRowPairing_setRow_plucker`, which called it "the quadratic Sylvester
+relation". Corrected in place rather than propagated.
+
+**Sylvester specified, not proved.** `HexDeterminantMathlib/SPEC` now carries the
+exact formula, the proposed home (`HexDeterminantMathlib/Sylvester.lean`,
+following the `DesnanotJacobi.lean` upstream-inline precedent), and the finding
+that nothing needs it: fraction-free elimination uses only the `m = 1` case,
+which `desnanot_jacobi_borderedMinor` already provides. The proposed statement
+was checked to elaborate, and the formula checked by `decide +kernel` over `Z` at
+`(k, m) = (1, 1)`, `(1, 2)`, `(2, 1)`.
+
+**Stale documentation found and fixed.**
+
+- The `hex-determinant` SPEC listed modules `Index`, `Expansion`, `Selection`,
+  none of which exist, and omitted `LastRow`, `RowOps`, `Triangular`, `Gram`.
+- The SPEC and README both cited `det_one : det 1 = 1`. The theorem is
+  `det_identity : det (Matrix.identity n) = 1`; there is no matrix `One`
+  instance (dropped in #8437).
+- `HexDeterminant/README.md` and the manual chapter both called
+  `det_plucker_three_term_consecutive_top` a "Plücker / Desnanot-Jacobi"
+  identity, and the manual described it as relating "a matrix and its bordered
+  minors", which is Sylvester's shape, not Plücker's.
+- `HexDeterminantMathlib/README.md` said `det_plucker_three_term` was "assembled
+  for the Bareiss correctness proof". Nothing in the tree consumes it; the
+  Bareiss path uses `desnanot_jacobi_borderedMinor`.
+
+**Recorded, not acted on.** `Hex.Matrix.det_setRow_setRow_mul_det` (Mathlib-free,
+PR #6111) and `HexMatrixMathlib.det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub`
+(via Mathlib's adjugate, PR #6048) are the same statement proved twice, with the
+subtracted products in opposite factor order. The Mathlib-side copy could now be
+re-derived from the Mathlib-free one. That is a refactor with no correctness
+content, so the SPEC records it and the code was left alone.
+
+Added `{docstring Hex.Matrix.det_setRow_setRow_mul_det}` to the manual chapter:
+it is a headline public theorem that had no manual coverage.
+
+## Current frontier
+
+Documentation for the determinant libraries now matches the declarations. No
+`sorry`, `axiom`, or export change was introduced; the only Lean edits are
+docstrings and one manual chapter.
+
+## Next step
+
+If someone wants the general Sylvester identity, the SPEC entry is a complete
+work item: statement, home, and the reason it is not urgent. It is a good
+candidate for upstreaming to Mathlib rather than living here.
+
+## Blockers
+
+None.

--- a/progress/20260821T052839Z_determinant-identity-audit.md
+++ b/progress/20260821T052839Z_determinant-identity-audit.md
@@ -64,6 +64,44 @@ content, so the SPEC records it and the code was left alone.
 Added `{docstring Hex.Matrix.det_setRow_setRow_mul_det}` to the manual chapter:
 it is a headline public theorem that had no manual coverage.
 
+## Second-opinion round
+
+A Codex review confirmed the mathematics (the basis-vector specialisation and
+its signs, the `det_sylvester` statement and its `m = 0` and `m = 1` cases, the
+Grassmann-Plücker naming, the export chain, and the no-nondegeneracy claim) and
+flagged wording that was too absolute or imprecise. Acted on all of it:
+
+- "It is not Sylvester's identity" contradicted the SPEC's own statement that
+  Desnanot-Jacobi *is* Sylvester's `2 × 2` case. Narrowed to "not the general
+  Sylvester determinant identity" throughout.
+- "would remove `desnanot_jacobi` from the published library" overstated private
+  imports. It would remove it from the umbrella's export surface; the module
+  stays directly importable, which is what makes such a regression easy to miss.
+- The reindexing direction in `desnanot_jacobi_matrixEquiv_reindex` was stated
+  backwards. In `A.submatrix row col`, `row` maps *new* indices to original
+  ones, so you want `row 0 = r1` and `row (Fin.last _) = r2`.
+- `DesnanotJacobi.lean`'s header claimed verbatim-upstream status and said this
+  project "still uses plain `import`". Neither is true: the file was migrated to
+  the module system and had two `simp` sets repaired across toolchain bumps
+  (#8436, plus a style pass), and upstream has moved past `bbe9ab491bc1`. The
+  header and SPEC now say so and warn against assuming a drop-in swap.
+- The proof-mechanism paragraph named `mul_adjugate` and `adjugate_mul` as
+  directly used. The code calls `adjugate_mul_apply` on one association and
+  `setRow_mul_adjugate_apply_self`/`_ne` on the other, resting on
+  `cofactorRowPairing_self` and `cofactorRowPairing_alien_eq_zero`.
+- "That restriction is what keeps the proof Mathlib-free" implied a mathematical
+  dependency. It only removes the `q > p3` case.
+- "maximal minors of a tall matrix" hid that the relation mixes `mDet` of
+  `[B | v]` with `nDet` of `B`. Spelled out in both READMEs and the manual.
+- "`k`-fold Sylvester identity" clashed with the proposed statement's use of `k`
+  for the core size. Now "the general `m × m` bordered-minor statement".
+
+The sign claim was independently checked outside Lean over 200 random integer
+matrices of sizes 3, 4 and 5, across every row pair and column pair: the
+replacement identity at basis vectors, the
+`(-1)^(a + b + j1 + j2)` double-replacement sign, and generalized
+Desnanot-Jacobi all hold with no failures.
+
 ## Current frontier
 
 Documentation for the determinant libraries now matches the declarations. No


### PR DESCRIPTION
This PR audits the determinant identity API used by Bareiss and amends the
`hex-determinant` and `hex-determinant-mathlib` SPECs and READMEs so the
documentation matches the declarations. Four names were being used
interchangeably; each is now fixed to one sense. Desnanot-Jacobi deletes two
rows and two columns and is stated only over Mathlib matrices. The two-row
replacement identity `det_setRow_setRow_mul_det` is the `2 × 2` case of
Jacobi's adjugate-minor identity in replacement rather than deletion form,
Mathlib-free, with `a ≠ b` as its only hypothesis; it is equivalent to
Desnanot-Jacobi for an arbitrary row pair and column pair, in both directions,
and the SPEC records the sign `(-1)^(a + b + j1 + j2)` that makes the
basis-vector substitution land. The three-term Grassmann-Plücker relation
connects the maximal minors of a tall `B` to those of `[B | v]`, proved in full
in the Mathlib layer and in a consecutive-top specialisation Mathlib-free.
Sylvester's determinant identity is the general statement that an `m × m` matrix
of bordered minors has determinant `det A₀ ^ (m - 1) * det A`; it is absent from
the project, so the SPEC records its exact formula and proposed home rather than
renaming anything to claim it. The one declaration that called a determinant
identity "Sylvester" was the docstring on `cofactorRowPairing_setRow_plucker`;
it is corrected in place.

The audit also records the exact public theorem names, hypotheses, index
conventions (`skipIndex2`, `mMatrix`/`mDet`, `nMatrix`/`nDet`,
`twoColMatrix`/`twoColDet`), the four transported Desnanot-Jacobi forms and the
`bareissDesnanotIndex` reindexing that connects them, and the export chain
`DesnanotJacobi → CoreTransport → Core → HexDeterminantMathlib`. No umbrella
export change was needed: `desnanot_jacobi` already reaches the umbrella
transitively. The SPEC now says so, because dropping the `public` from
`CoreTransport`'s import would remove it from the umbrella's export surface
while leaving the module directly importable, which is what would make such a
regression easy to miss.

Stale documentation the audit surfaced is fixed along the way: the module list
named `Index`, `Expansion` and `Selection`, none of which exist, and omitted
`LastRow`, `RowOps`, `Triangular` and `Gram`; `det_one` has been
`det_identity` since the matrix `One` instance was dropped in #8437; both
`HexDeterminant/README.md` and the manual chapter attributed Desnanot-Jacobi and
a bordered-minor shape to `det_plucker_three_term_consecutive_top`;
`HexDeterminantMathlib/README.md` said `det_plucker_three_term` was assembled
for the Bareiss correctness proof, which consumes `desnanot_jacobi_borderedMinor`
instead; the `desnanot_jacobi_matrixEquiv_reindex` reindexing direction was
stated backwards, since `submatrix` composes and `row` maps new indices to
original ones; and `DesnanotJacobi.lean`'s header still claimed verbatim-upstream
status, plain `import` syntax, and a `hex-matrix-mathlib` home, none of which
hold now that the file has been migrated to the module system, had two `simp`
sets repaired across toolchain bumps, and been overtaken upstream by fifteen
commits on mathlib4 PR 37716. The manual chapter also gains
`{docstring Hex.Matrix.det_setRow_setRow_mul_det}`, a headline public theorem
that had no coverage.

Verification: every declaration named in the amended documents was elaborated
against `import HexDeterminant` and `import HexDeterminantMathlib` alone, 55
`#check`s in a scratch file since deleted, all resolving with no errors. The
proposed `det_sylvester` statement elaborates, and its formula was checked by
`decide +kernel` over `ℤ` at `(k, m) = (1, 1)`, `(1, 2)` and `(2, 1)`. The
basis-vector specialisation and its sign were checked over 200 random integer
matrices of sizes 3, 4 and 5, across every row pair and column pair, with no
failures. `lake build HexDeterminant HexDeterminantMathlib HexGramSchmidtMathlib
HexBareissMathlib HexManual` is green with no new warnings, and
`git diff --check` is clean.

Closes #9316

🤖 Prepared with Claude Code