### PR TITLE
refactor: move shared exact division into HexBasic

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -8,6 +8,7 @@ module
 
 public import HexBasic.ArrayDecEq
 public import HexBasic.Conditional
+public import HexBasic.ExactDiv
 public import HexBasic.ExtTreeMap
 public import HexBasic.Fold
 public import HexBasic.List
@@ -28,4 +29,9 @@ the `Batteries` list lemmas reproduced in `HexBasic.ListShim`, the
 kernel-reducible `Array`/`Vector` equality (`HexBasic.ArrayDecEq`) and
 `ofFn` (`HexBasic.OfFn`), plus conditional reduction lemmas with names stable
 across supported Lean versions (`HexBasic.Conditional`).
+
+It also holds the shared exact-division contract (`HexBasic.ExactDiv`): the
+total `exactDiv` wrapper with deterministic division by zero, the
+`ExactDivLaws` package, and the coefficient-independent cancellation lemmas
+that fraction-free algorithms in `hex-resultant` and `hex-bareiss` both need.
 -/

--- a/HexBasic/ExactDiv.lean
+++ b/HexBasic/ExactDiv.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Std
+public import Init.Grind.Ring.Field
+
+public section
+
+/-!
+Shared exact scalar division.
+
+The executable operations reuse the coefficient type's existing `/` and make
+division by zero deterministic. Algebraic correctness is isolated in
+`ExactDivLaws`; computational consumers need only the operations, while proof
+consumers opt into the law package.
+
+This module is coefficient-independent: it fixes the contract and the
+cancellation lemmas that hold for every carrier, leaving carrier-specific
+operations and instances (dense polynomials, matrices) to their consumers.
+-/
+namespace Hex
+
+universe u
+
+/-- A quotient operation is exact when multiplication by every nonzero right
+factor can be undone by division by that factor. -/
+class ExactDivLaws (R : Type u) [Zero R] [Mul R] [Div R] : Prop where
+  /-- Right multiplication followed by division by a nonzero factor cancels. -/
+  mul_div_cancel_right : ∀ a b : R, b ≠ 0 → (a * b) / b = a
+
+namespace ExactDivLaws
+
+variable {R : Type u}
+
+/-- Exact division implies right cancellation by a nonzero factor. -/
+theorem mul_right_cancel [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
+    {a b c : R} (hc : c ≠ 0) (h : a * c = b * c) : a = b := by
+  have hdiv := congrArg (fun x : R => x / c) h
+  rw [ExactDivLaws.mul_div_cancel_right a c hc,
+    ExactDivLaws.mul_div_cancel_right b c hc] at hdiv
+  exact hdiv
+
+/-- Exact division and commutative-ring laws rule out nonzero products
+vanishing. -/
+theorem mul_ne_zero [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
+    {a b : R} (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 := by
+  intro hzero
+  have hdiv := congrArg (fun x : R => x / b) hzero
+  have hzdiv : (0 : R) / b = 0 := by
+    simpa [Lean.Grind.Semiring.zero_mul] using
+      (ExactDivLaws.mul_div_cancel_right (0 : R) b hb)
+  rw [ExactDivLaws.mul_div_cancel_right a b hb, hzdiv] at hdiv
+  exact ha hdiv
+
+end ExactDivLaws
+
+variable {R : Type u}
+
+/-- A nonzero element witnesses that a lightweight ring is nontrivial. -/
+theorem one_ne_zero_of_nonzero {S : Type u} [Lean.Grind.CommRing S]
+    {a : S} (ha : a ≠ 0) : (1 : S) ≠ 0 := by
+  intro hone
+  apply ha
+  calc
+    a = a * 1 := (Lean.Grind.Semiring.mul_one _).symm
+    _ = a * 0 := by rw [hone]
+    _ = 0 := Lean.Grind.Semiring.mul_zero _
+
+/-- The additive inverse of one is nonzero in a nontrivial lightweight ring. -/
+theorem negOne_ne_zero_of_one {S : Type u} [Lean.Grind.CommRing S]
+    (h1 : (1 : S) ≠ 0) : (0 - 1 : S) ≠ 0 := by
+  intro hzero
+  apply h1
+  calc
+    1 = 0 - (0 - (1 : S)) := by grind
+    _ = 0 - 0 := by rw [hzero]
+    _ = 0 := by grind
+
+/-- Total exact quotient wrapper. The zero denominator is a documented junk
+input and returns zero. -/
+@[expose]
+def exactDiv [Zero R] [DecidableEq R] [Div R] (a b : R) : R :=
+  if b = 0 then 0 else a / b
+
+/-- Exact division by zero takes the stable junk branch. -/
+@[simp, grind =]
+theorem exactDiv_zero_right [Zero R] [DecidableEq R] [Div R] (a : R) :
+    exactDiv a 0 = 0 := by
+  simp [exactDiv]
+
+/-- A nonzero exact quotient is the underlying quotient operation. -/
+theorem exactDiv_eq_div_of_ne [Zero R] [DecidableEq R] [Div R]
+    (a : R) {b : R} (hb : b ≠ 0) : exactDiv a b = a / b := by
+  simp [exactDiv, hb]
+
+/-- The wrapper cancels a nonzero exact right factor under `ExactDivLaws`. -/
+@[simp]
+theorem exactDiv_mul_right [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+    [ExactDivLaws R] (a : R) {b : R} (hb : b ≠ 0) :
+    exactDiv (a * b) b = a := by
+  rw [exactDiv_eq_div_of_ne _ hb]
+  exact ExactDivLaws.mul_div_cancel_right a b hb
+
+/-- Natural powers by binary exponentiation, using only the executable `One`
+and `Mul` operations. The association order is part of this law-free
+computational definition; correctness consumers assume associative ring
+multiplication. -/
+@[expose]
+def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
+  if n = 0 then
+    1
+  else
+    let y := powNat (x * x) (n / 2)
+    if n % 2 = 0 then y else y * x
+termination_by n
+decreasing_by omega
+
+/-- Powers distribute over multiplication in a lightweight commutative ring. -/
+theorem mul_pow {S : Type u} [Lean.Grind.CommRing S]
+    (a b : S) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
+  | 0 => by
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
+        Lean.Grind.Semiring.pow_zero]
+      exact (Lean.Grind.Semiring.mul_one 1).symm
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
+        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
+      grind
+
+/-- Raising a power to another power multiplies the two exponents. -/
+theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
+    (x : S) (m n : Nat) : x ^ (m * n) = (x ^ m) ^ n := by
+  symm
+  induction n with
+  | zero => simp [Lean.Grind.Semiring.pow_zero]
+  | succ n ih =>
+      rw [Lean.Grind.Semiring.pow_succ, ih,
+        ← Lean.Grind.Semiring.pow_add]
+      congr 1
+
+/-- Natural powers of a nonzero element stay nonzero in every nontrivial
+exact-division ring. -/
+theorem pow_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) :
+    ∀ n : Nat, a ^ n ≠ 0
+  | 0 => by
+      simpa only [Lean.Grind.Semiring.pow_zero] using h1
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ]
+      exact ExactDivLaws.mul_ne_zero (pow_ne_zero h1 ha n) ha
+
+/-- The executable binary power agrees with the lightweight semiring power. -/
+theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
+    (x : S) (n : Nat) : powNat x n = x ^ n := by
+  induction n using Nat.strongRecOn generalizing x with
+  | ind n ih =>
+      rw [powNat]
+      by_cases hn : n = 0
+      · subst n
+        simp [Lean.Grind.Semiring.pow_zero]
+      · rw [if_neg hn]
+        have hlt : n / 2 < n :=
+          Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
+        rw [ih (n / 2) hlt (x * x)]
+        have hdiv := Nat.mod_add_div n 2
+        by_cases heven : n % 2 = 0
+        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
+          congr 1
+          omega
+        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
+            ← Lean.Grind.Semiring.pow_succ]
+          congr 1
+          have hmod := Nat.mod_lt n (by decide : 0 < 2)
+          omega
+
+/-- The executable natural power of a nonzero element stays nonzero. -/
+theorem powNat_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) (n : Nat) :
+    powNat a n ≠ 0 := by
+  rw [powNat_eq_pow]
+  exact pow_ne_zero h1 ha n
+
+/-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
+as `exactDiv`. -/
+@[expose]
+def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
+    (x y : R) (n : Nat) : R :=
+  exactDiv (powNat x n) (powNat y (n - 1))
+
+/-- Integer Euclidean division is exact on nonzero right multiples. -/
+instance instExactDivLawsInt : ExactDivLaws Int where
+  mul_div_cancel_right := Int.mul_ediv_cancel
+
+/-- Every `Lean.Grind.Field` supplies the exact-division law. -/
+instance instExactDivLawsField {K : Type u} [Lean.Grind.Field K] :
+    ExactDivLaws K where
+  mul_div_cancel_right a b hb := by
+    rw [Lean.Grind.Field.div_eq_mul_inv, Lean.Grind.Semiring.mul_assoc,
+      Lean.Grind.Field.mul_inv_cancel hb, Lean.Grind.Semiring.mul_one]
+
+/-! Instance-contract check for the integer coefficient tower. -/
+
+example : ExactDivLaws Int := inferInstance
+
+/-! Value-level pins for the total quotient and binary-power helpers. -/
+
+#guard powNat (3 : Int) 5 = 243
+
+#guard exactDiv (7 : Int) 0 = 0
+
+#guard divExp (4 : Int) 2 3 = 16
+
+end Hex

--- a/HexBasic/ExactDiv.lean
+++ b/HexBasic/ExactDiv.lean
@@ -6,7 +6,6 @@ Authors: Kim Morrison
 
 module
 
-public import Std
 public import Init.Grind.Ring.Field
 
 public section
@@ -25,12 +24,13 @@ operations and instances (dense polynomials, matrices) to their consumers.
 
 Nothing here shadows a Mathlib root name, and that is deliberate. `HexBasic`
 sits below the whole graph, so a declaration `Hex.foo` added here is in scope
-for every `Hex*Mathlib` file that says `open Hex`, and any such file using a
-bare `foo` that Mathlib also defines at the root becomes an ambiguous-term
-error. That rules out hosting the binary-power helpers here: `Hex.mul_pow`,
-`Hex.pow_mul`, and `Hex.pow_ne_zero` all collide that way. They stay with
-their Brown-recurrence consumer in `HexResultant/ExactDiv.lean`, along with
-`powNat` and `divExp`, which nothing below `hex-resultant` needs.
+for every `Hex*Mathlib` file wherever `open Hex` is in effect, and a bare `foo`
+in that scope is an ambiguous term when Mathlib also defines `_root_.foo`.
+That rules out hosting the binary-power helpers here: `Hex.mul_pow`,
+`Hex.pow_mul`, and `Hex.pow_ne_zero` all collide that way, and
+`HexGFqMathlib/Primitivity.lean` is a live site. They stay with their
+Brown-recurrence consumer in `HexResultant/ExactDiv.lean`, along with `powNat`
+and `divExp`, which nothing below `hex-resultant` needs.
 -/
 namespace Hex
 
@@ -130,7 +130,7 @@ instance instExactDivLawsField {K : Type u} [Lean.Grind.Field K] :
 
 example : ExactDivLaws Int := inferInstance
 
-/-! Value-level pins for the total quotient and binary-power helpers. -/
+/-! Value-level pin for the total quotient. -/
 
 #guard exactDiv (7 : Int) 0 = 0
 

--- a/HexBasic/ExactDiv.lean
+++ b/HexBasic/ExactDiv.lean
@@ -22,6 +22,15 @@ consumers opt into the law package.
 This module is coefficient-independent: it fixes the contract and the
 cancellation lemmas that hold for every carrier, leaving carrier-specific
 operations and instances (dense polynomials, matrices) to their consumers.
+
+Nothing here shadows a Mathlib root name, and that is deliberate. `HexBasic`
+sits below the whole graph, so a declaration `Hex.foo` added here is in scope
+for every `Hex*Mathlib` file that says `open Hex`, and any such file using a
+bare `foo` that Mathlib also defines at the root becomes an ambiguous-term
+error. That rules out hosting the binary-power helpers here: `Hex.mul_pow`,
+`Hex.pow_mul`, and `Hex.pow_ne_zero` all collide that way. They stay with
+their Brown-recurrence consumer in `HexResultant/ExactDiv.lean`, along with
+`powNat` and `divExp`, which nothing below `hex-resultant` needs.
 -/
 namespace Hex
 
@@ -106,92 +115,6 @@ theorem exactDiv_mul_right [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
   rw [exactDiv_eq_div_of_ne _ hb]
   exact ExactDivLaws.mul_div_cancel_right a b hb
 
-/-- Natural powers by binary exponentiation, using only the executable `One`
-and `Mul` operations. The association order is part of this law-free
-computational definition; correctness consumers assume associative ring
-multiplication. -/
-@[expose]
-def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
-  if n = 0 then
-    1
-  else
-    let y := powNat (x * x) (n / 2)
-    if n % 2 = 0 then y else y * x
-termination_by n
-decreasing_by omega
-
-/-- Powers distribute over multiplication in a lightweight commutative ring. -/
-theorem mul_pow {S : Type u} [Lean.Grind.CommRing S]
-    (a b : S) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
-  | 0 => by
-      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
-        Lean.Grind.Semiring.pow_zero]
-      exact (Lean.Grind.Semiring.mul_one 1).symm
-  | n + 1 => by
-      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
-        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
-      grind
-
-/-- Raising a power to another power multiplies the two exponents. -/
-theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
-    (x : S) (m n : Nat) : x ^ (m * n) = (x ^ m) ^ n := by
-  symm
-  induction n with
-  | zero => simp [Lean.Grind.Semiring.pow_zero]
-  | succ n ih =>
-      rw [Lean.Grind.Semiring.pow_succ, ih,
-        ← Lean.Grind.Semiring.pow_add]
-      congr 1
-
-/-- Natural powers of a nonzero element stay nonzero in every nontrivial
-exact-division ring. -/
-theorem pow_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
-    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) :
-    ∀ n : Nat, a ^ n ≠ 0
-  | 0 => by
-      simpa only [Lean.Grind.Semiring.pow_zero] using h1
-  | n + 1 => by
-      rw [Lean.Grind.Semiring.pow_succ]
-      exact ExactDivLaws.mul_ne_zero (pow_ne_zero h1 ha n) ha
-
-/-- The executable binary power agrees with the lightweight semiring power. -/
-theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
-    (x : S) (n : Nat) : powNat x n = x ^ n := by
-  induction n using Nat.strongRecOn generalizing x with
-  | ind n ih =>
-      rw [powNat]
-      by_cases hn : n = 0
-      · subst n
-        simp [Lean.Grind.Semiring.pow_zero]
-      · rw [if_neg hn]
-        have hlt : n / 2 < n :=
-          Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
-        rw [ih (n / 2) hlt (x * x)]
-        have hdiv := Nat.mod_add_div n 2
-        by_cases heven : n % 2 = 0
-        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
-          congr 1
-          omega
-        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
-            ← Lean.Grind.Semiring.pow_succ]
-          congr 1
-          have hmod := Nat.mod_lt n (by decide : 0 < 2)
-          omega
-
-/-- The executable natural power of a nonzero element stays nonzero. -/
-theorem powNat_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
-    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) (n : Nat) :
-    powNat a n ≠ 0 := by
-  rw [powNat_eq_pow]
-  exact pow_ne_zero h1 ha n
-
-/-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
-as `exactDiv`. -/
-@[expose]
-def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
-    (x y : R) (n : Nat) : R :=
-  exactDiv (powNat x n) (powNat y (n - 1))
-
 /-- Integer Euclidean division is exact on nonzero right multiples. -/
 instance instExactDivLawsInt : ExactDivLaws Int where
   mul_div_cancel_right := Int.mul_ediv_cancel
@@ -209,10 +132,6 @@ example : ExactDivLaws Int := inferInstance
 
 /-! Value-level pins for the total quotient and binary-power helpers. -/
 
-#guard powNat (3 : Int) 5 = 243
-
 #guard exactDiv (7 : Int) 0 = 0
-
-#guard divExp (4 : Int) 2 3 = 16
 
 end Hex

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -24,7 +24,8 @@ The `HexResultant` library provides the fraction-free polynomial primitives
 used to compute subresultant pseudo-remainder sequences, resultants, and
 discriminants over exact coefficient rings. Its initial executable surface is
 polynomial pseudo-division over `Hex.DensePoly`, with the computational
-dependency surface kept at `HexPoly` alone. Brown's nonzero PRS chain tracks
+dependency surface kept at `HexPoly` plus the shared exact-division contract
+in `HexBasic.ExactDiv`. Brown's nonzero PRS chain tracks
 its corrected terminal principal-subresultant scalar separately, so defective
 degree drops retain the exact resultant scale without matrix construction.
 The standard discriminant is computed from the signed resultant with the

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -13,20 +13,116 @@ public import Init.Grind.Ring.Field
 public section
 
 /-!
-Exact scalar division for dense polynomials.
+Exact scalar division for the Brown subresultant recurrence.
 
 The coefficient-independent contract lives in `HexBasic.ExactDiv`: the total
 `exactDiv` wrapper, the `ExactDivLaws` package, and the cancellation lemmas
-that hold over every carrier. This module adds the polynomial-specific layer:
-coefficientwise scalar division on `DensePoly`, the lightweight ring tower that
-lets resultant correctness recurse into polynomial coefficient rings, and the
-recursive `ExactDivLaws (DensePoly R)` instance.
+that hold over every carrier. This module, which re-exports that contract
+through a public import, adds the two layers above it.
+
+First the binary-power helpers `powNat` and `divExp` with the lightweight
+semiring power lemmas they need. These stay here rather than in `HexBasic`
+because `mul_pow`, `pow_mul`, and `pow_ne_zero` shadow Mathlib root names, and
+a shadow introduced at the bottom of the graph turns every bare use in an
+`open Hex` Mathlib file into an ambiguous-term error; nothing below
+`hex-resultant` needs them.
+
+Then the polynomial-specific layer: coefficientwise scalar division on
+`DensePoly`, the lightweight ring tower that lets resultant correctness recurse
+into polynomial coefficient rings, and the recursive
+`ExactDivLaws (DensePoly R)` instance.
 -/
 namespace Hex
 
 universe u
 
 variable {R : Type u}
+
+/-- Natural powers by binary exponentiation, using only the executable `One`
+and `Mul` operations. The association order is part of this law-free
+computational definition; correctness consumers assume associative ring
+multiplication. -/
+@[expose]
+def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
+  if n = 0 then
+    1
+  else
+    let y := powNat (x * x) (n / 2)
+    if n % 2 = 0 then y else y * x
+termination_by n
+decreasing_by omega
+
+/-- Powers distribute over multiplication in a lightweight commutative ring. -/
+theorem mul_pow {S : Type u} [Lean.Grind.CommRing S]
+    (a b : S) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
+  | 0 => by
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
+        Lean.Grind.Semiring.pow_zero]
+      exact (Lean.Grind.Semiring.mul_one 1).symm
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
+        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
+      grind
+
+/-- Raising a power to another power multiplies the two exponents. -/
+theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
+    (x : S) (m n : Nat) : x ^ (m * n) = (x ^ m) ^ n := by
+  symm
+  induction n with
+  | zero => simp [Lean.Grind.Semiring.pow_zero]
+  | succ n ih =>
+      rw [Lean.Grind.Semiring.pow_succ, ih,
+        ← Lean.Grind.Semiring.pow_add]
+      congr 1
+
+/-- Natural powers of a nonzero element stay nonzero in every nontrivial
+exact-division ring. -/
+theorem pow_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) :
+    ∀ n : Nat, a ^ n ≠ 0
+  | 0 => by
+      simpa only [Lean.Grind.Semiring.pow_zero] using h1
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ]
+      exact ExactDivLaws.mul_ne_zero (pow_ne_zero h1 ha n) ha
+
+/-- The executable binary power agrees with the lightweight semiring power. -/
+theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
+    (x : S) (n : Nat) : powNat x n = x ^ n := by
+  induction n using Nat.strongRecOn generalizing x with
+  | ind n ih =>
+      rw [powNat]
+      by_cases hn : n = 0
+      · subst n
+        simp [Lean.Grind.Semiring.pow_zero]
+      · rw [if_neg hn]
+        have hlt : n / 2 < n :=
+          Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
+        rw [ih (n / 2) hlt (x * x)]
+        have hdiv := Nat.mod_add_div n 2
+        by_cases heven : n % 2 = 0
+        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
+          congr 1
+          omega
+        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
+            ← Lean.Grind.Semiring.pow_succ]
+          congr 1
+          have hmod := Nat.mod_lt n (by decide : 0 < 2)
+          omega
+
+/-- The executable natural power of a nonzero element stays nonzero. -/
+theorem powNat_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) (n : Nat) :
+    powNat a n ≠ 0 := by
+  rw [powNat_eq_pow]
+  exact pow_ne_zero h1 ha n
+
+/-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
+as `exactDiv`. -/
+@[expose]
+def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
+    (x y : R) (n : Nat) : R :=
+  exactDiv (powNat x n) (powNat y (n - 1))
 
 namespace DensePoly
 
@@ -402,5 +498,11 @@ exercised by the Brown regressions. -/
 example : ExactDivLaws (DensePoly Int) := inferInstance
 
 example : Lean.Grind.CommRing (DensePoly Int) := inferInstance
+
+/-! Value-level pins for the binary-power helpers. -/
+
+#guard powNat (3 : Int) 5 = 243
+
+#guard divExp (4 : Int) 2 3 = 16
 
 end Hex

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -8,7 +8,6 @@ module
 
 public import HexBasic.ExactDiv
 public import HexPoly
-public import Init.Grind.Ring.Field
 
 public section
 
@@ -23,9 +22,9 @@ through a public import, adds the two layers above it.
 First the binary-power helpers `powNat` and `divExp` with the lightweight
 semiring power lemmas they need. These stay here rather than in `HexBasic`
 because `mul_pow`, `pow_mul`, and `pow_ne_zero` shadow Mathlib root names, and
-a shadow introduced at the bottom of the graph turns every bare use in an
-`open Hex` Mathlib file into an ambiguous-term error; nothing below
-`hex-resultant` needs them.
+a shadow introduced at the bottom of the graph turns a bare use anywhere in the
+scope of an `open Hex` into an ambiguous term; nothing below `hex-resultant`
+needs them.
 
 Then the polynomial-specific layer: coefficientwise scalar division on
 `DensePoly`, the lightweight ring tower that lets resultant correctness recurse

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -6,187 +6,27 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.ExactDiv
 public import HexPoly
 public import Init.Grind.Ring.Field
 
 public section
 
 /-!
-Exact scalar division for the Brown subresultant recurrence.
+Exact scalar division for dense polynomials.
 
-The executable operations reuse the coefficient type's existing `/` and make
-division by zero deterministic. Algebraic correctness is isolated in
-`ExactDivLaws`; computational consumers need only the operations, while proof
-consumers opt into the law package.
+The coefficient-independent contract lives in `HexBasic.ExactDiv`: the total
+`exactDiv` wrapper, the `ExactDivLaws` package, and the cancellation lemmas
+that hold over every carrier. This module adds the polynomial-specific layer:
+coefficientwise scalar division on `DensePoly`, the lightweight ring tower that
+lets resultant correctness recurse into polynomial coefficient rings, and the
+recursive `ExactDivLaws (DensePoly R)` instance.
 -/
 namespace Hex
 
 universe u
 
-/-- A quotient operation is exact when multiplication by every nonzero right
-factor can be undone by division by that factor. -/
-class ExactDivLaws (R : Type u) [Zero R] [Mul R] [Div R] : Prop where
-  /-- Right multiplication followed by division by a nonzero factor cancels. -/
-  mul_div_cancel_right : ∀ a b : R, b ≠ 0 → (a * b) / b = a
-
-namespace ExactDivLaws
-
 variable {R : Type u}
-
-/-- Exact division implies right cancellation by a nonzero factor. -/
-theorem mul_right_cancel [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
-    {a b c : R} (hc : c ≠ 0) (h : a * c = b * c) : a = b := by
-  have hdiv := congrArg (fun x : R => x / c) h
-  rw [ExactDivLaws.mul_div_cancel_right a c hc,
-    ExactDivLaws.mul_div_cancel_right b c hc] at hdiv
-  exact hdiv
-
-/-- Exact division and commutative-ring laws rule out nonzero products
-vanishing. -/
-theorem mul_ne_zero [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
-    {a b : R} (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 := by
-  intro hzero
-  have hdiv := congrArg (fun x : R => x / b) hzero
-  have hzdiv : (0 : R) / b = 0 := by
-    simpa [Lean.Grind.Semiring.zero_mul] using
-      (ExactDivLaws.mul_div_cancel_right (0 : R) b hb)
-  rw [ExactDivLaws.mul_div_cancel_right a b hb, hzdiv] at hdiv
-  exact ha hdiv
-
-end ExactDivLaws
-
-variable {R : Type u}
-
-/-- A nonzero element witnesses that a lightweight ring is nontrivial. -/
-theorem one_ne_zero_of_nonzero {S : Type u} [Lean.Grind.CommRing S]
-    {a : S} (ha : a ≠ 0) : (1 : S) ≠ 0 := by
-  intro hone
-  apply ha
-  calc
-    a = a * 1 := (Lean.Grind.Semiring.mul_one _).symm
-    _ = a * 0 := by rw [hone]
-    _ = 0 := Lean.Grind.Semiring.mul_zero _
-
-/-- The additive inverse of one is nonzero in a nontrivial lightweight ring. -/
-theorem negOne_ne_zero_of_one {S : Type u} [Lean.Grind.CommRing S]
-    (h1 : (1 : S) ≠ 0) : (0 - 1 : S) ≠ 0 := by
-  intro hzero
-  apply h1
-  calc
-    1 = 0 - (0 - (1 : S)) := by grind
-    _ = 0 - 0 := by rw [hzero]
-    _ = 0 := by grind
-
-/-- Total exact quotient wrapper. The zero denominator is a documented junk
-input and returns zero. -/
-@[expose]
-def exactDiv [Zero R] [DecidableEq R] [Div R] (a b : R) : R :=
-  if b = 0 then 0 else a / b
-
-/-- Exact division by zero takes the stable junk branch. -/
-@[simp, grind =]
-theorem exactDiv_zero_right [Zero R] [DecidableEq R] [Div R] (a : R) :
-    exactDiv a 0 = 0 := by
-  simp [exactDiv]
-
-/-- A nonzero exact quotient is the underlying quotient operation. -/
-theorem exactDiv_eq_div_of_ne [Zero R] [DecidableEq R] [Div R]
-    (a : R) {b : R} (hb : b ≠ 0) : exactDiv a b = a / b := by
-  simp [exactDiv, hb]
-
-/-- The wrapper cancels a nonzero exact right factor under `ExactDivLaws`. -/
-@[simp]
-theorem exactDiv_mul_right [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
-    [ExactDivLaws R] (a : R) {b : R} (hb : b ≠ 0) :
-    exactDiv (a * b) b = a := by
-  rw [exactDiv_eq_div_of_ne _ hb]
-  exact ExactDivLaws.mul_div_cancel_right a b hb
-
-/-- Natural powers by binary exponentiation, using only the executable `One`
-and `Mul` operations. The association order is part of this law-free
-computational definition; correctness consumers assume associative ring
-multiplication. -/
-@[expose]
-def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
-  if n = 0 then
-    1
-  else
-    let y := powNat (x * x) (n / 2)
-    if n % 2 = 0 then y else y * x
-termination_by n
-decreasing_by omega
-
-/-- Powers distribute over multiplication in a lightweight commutative ring. -/
-theorem mul_pow {S : Type u} [Lean.Grind.CommRing S]
-    (a b : S) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
-  | 0 => by
-      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
-        Lean.Grind.Semiring.pow_zero]
-      exact (Lean.Grind.Semiring.mul_one 1).symm
-  | n + 1 => by
-      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
-        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
-      grind
-
-/-- Raising a power to another power multiplies the two exponents. -/
-theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
-    (x : S) (m n : Nat) : x ^ (m * n) = (x ^ m) ^ n := by
-  symm
-  induction n with
-  | zero => simp [Lean.Grind.Semiring.pow_zero]
-  | succ n ih =>
-      rw [Lean.Grind.Semiring.pow_succ, ih,
-        ← Lean.Grind.Semiring.pow_add]
-      congr 1
-
-/-- Natural powers of a nonzero element stay nonzero in every nontrivial
-exact-division ring. -/
-theorem pow_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
-    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) :
-    ∀ n : Nat, a ^ n ≠ 0
-  | 0 => by
-      simpa only [Lean.Grind.Semiring.pow_zero] using h1
-  | n + 1 => by
-      rw [Lean.Grind.Semiring.pow_succ]
-      exact ExactDivLaws.mul_ne_zero (pow_ne_zero h1 ha n) ha
-
-/-- The executable binary power agrees with the lightweight semiring power. -/
-theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
-    (x : S) (n : Nat) : powNat x n = x ^ n := by
-  induction n using Nat.strongRecOn generalizing x with
-  | ind n ih =>
-      rw [powNat]
-      by_cases hn : n = 0
-      · subst n
-        simp [Lean.Grind.Semiring.pow_zero]
-      · rw [if_neg hn]
-        have hlt : n / 2 < n :=
-          Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
-        rw [ih (n / 2) hlt (x * x)]
-        have hdiv := Nat.mod_add_div n 2
-        by_cases heven : n % 2 = 0
-        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
-          congr 1
-          omega
-        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
-            ← Lean.Grind.Semiring.pow_succ]
-          congr 1
-          have hmod := Nat.mod_lt n (by decide : 0 < 2)
-          omega
-
-/-- The executable natural power of a nonzero element stays nonzero. -/
-theorem powNat_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
-    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) (n : Nat) :
-    powNat a n ≠ 0 := by
-  rw [powNat_eq_pow]
-  exact pow_ne_zero h1 ha n
-
-/-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
-as `exactDiv`. -/
-@[expose]
-def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
-    (x y : R) (n : Nat) : R :=
-  exactDiv (powNat x n) (powNat y (n - 1))
 
 namespace DensePoly
 
@@ -318,17 +158,6 @@ theorem scale_cancel [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
   simpa only [divScalar_scale _ hb] using hdiv
 
 end DensePoly
-
-/-- Integer Euclidean division is exact on nonzero right multiples. -/
-instance instExactDivLawsInt : ExactDivLaws Int where
-  mul_div_cancel_right := Int.mul_ediv_cancel
-
-/-- Every `Lean.Grind.Field` supplies the exact-division law. -/
-instance instExactDivLawsField {K : Type u} [Lean.Grind.Field K] :
-    ExactDivLaws K where
-  mul_div_cancel_right a b hb := by
-    rw [Lean.Grind.Field.div_eq_mul_inv, Lean.Grind.Semiring.mul_assoc,
-      Lean.Grind.Field.mul_inv_cancel hb, Lean.Grind.Semiring.mul_one]
 
 /-! The Mathlib-free dense-polynomial ring instance.
 
@@ -567,21 +396,11 @@ instance instExactDivLawsDensePoly [Lean.Grind.CommRing R] [DecidableEq R]
     change (DensePoly.divMod (a * b) b).1 = a
     exact congrArg Prod.fst hpair
 
-/-! Instance-contract checks for the two coefficient towers exercised by the
-Brown regressions. -/
-
-example : ExactDivLaws Int := inferInstance
+/-! Instance-contract checks for the dense-polynomial coefficient tower
+exercised by the Brown regressions. -/
 
 example : ExactDivLaws (DensePoly Int) := inferInstance
 
 example : Lean.Grind.CommRing (DensePoly Int) := inferInstance
-
-/-! Value-level pins for the total quotient and binary-power helpers. -/
-
-#guard powNat (3 : Int) 5 = 243
-
-#guard exactDiv (7 : Int) 0 = 0
-
-#guard divExp (4 : Int) 2 3 = 16
 
 end Hex

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -1,4 +1,4 @@
-# hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly)
+# hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly and hex-basic)
 
 Polynomial resultant and discriminant for `Hex.DensePoly R` over a
 commutative exact-division domain. Computed via the **subresultant

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -450,8 +450,12 @@ does not alter the current resultant or discriminant contracts.
 
 ## File organisation
 
-- `HexResultant/ExactDiv.lean`: `ExactDivLaws`, the total exact-division
-  wrappers, and the `Int`, field, and recursive dense-polynomial instances.
+- `HexResultant/ExactDiv.lean`: coefficientwise dense-polynomial scalar
+  division, the lightweight dense-polynomial ring tower, and the recursive
+  `ExactDivLaws (DensePoly R)` instance. `ExactDivLaws` itself, the total
+  exact-division wrappers `exactDiv`/`divExp`/`powNat`, and the `Int` and field
+  instances live below this library in `HexBasic/ExactDiv.lean`, which this
+  file re-exports through a public import.
 - `HexResultant/Basic.lean`: `pseudoDivMod` and its computational properties.
 - `HexResultant/PseudoDivMod.lean`: uniqueness, nonzero scaling, and the
   left/right pseudo-division homogeneity laws.

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -450,10 +450,11 @@ does not alter the current resultant or discriminant contracts.
 
 ## File organisation
 
-- `HexResultant/ExactDiv.lean`: coefficientwise dense-polynomial scalar
-  division, the lightweight dense-polynomial ring tower, and the recursive
-  `ExactDivLaws (DensePoly R)` instance. `ExactDivLaws` itself, the total
-  exact-division wrappers `exactDiv`/`divExp`/`powNat`, and the `Int` and field
+- `HexResultant/ExactDiv.lean`: the binary-power helpers `powNat` and `divExp`,
+  coefficientwise dense-polynomial scalar division, the lightweight
+  dense-polynomial ring tower, and the recursive `ExactDivLaws (DensePoly R)`
+  instance. `ExactDivLaws`, the total `exactDiv` wrapper, the
+  coefficient-independent cancellation lemmas, and the `Int` and field
   instances live below this library in `HexBasic/ExactDiv.lean`, which this
   file re-exports through a public import.
 - `HexResultant/Basic.lean`: `pseudoDivMod` and its computational properties.

--- a/SPEC/Libraries/hex-mv-gcd.md
+++ b/SPEC/Libraries/hex-mv-gcd.md
@@ -391,7 +391,7 @@ Both are landed, in `HexMvPoly/Ring.lean` and `HexMvPoly/Structural.lean`.
 it. Every hex-resultant correctness theorem takes
 `[Lean.Grind.CommRing S]`, so without it the subresultant chain runs over
 `MvPoly` and none of its theorems apply.
-`HexResultant/ExactDiv.lean:333-548` builds the same tower for
+`HexResultant/ExactDiv.lean` builds the same tower for
 `DensePoly`. The `Semiring.npow` field uses hex-mv-poly's existing
 `npowBySq` and its proved `pow_succ` rather than a second power
 operation.

--- a/SPEC/Libraries/hex-poly-z-gcd.md
+++ b/SPEC/Libraries/hex-poly-z-gcd.md
@@ -472,7 +472,7 @@ argument.
 **This route is a scheduling dependency, not a mathematical one.**
 hex-resultant is at `done_through: 1`, and its correctness theorems
 additionally require `Lean.Grind.CommRing` on the coefficient type, which
-`Int` has, and `ExactDivLaws Int`, which `HexResultant/ExactDiv.lean`
+`Int` has, and `ExactDivLaws Int`, which `HexBasic/ExactDiv.lean`
 supplies as `instExactDivLawsInt`. So the executable chain runs today and
 its theorems apply, and what is missing is the phases of hex-resultant
 rather than anything about this library. Milestone 2 below is written so

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -49,10 +49,19 @@ condition that each pivot is the leading nonzero entry of its row, which
 `IsEchelonForm` does not imply and without which uniqueness is false.
 
 **Shared exact division has graduated from this file.** `exactDiv`,
-`ExactDivLaws`, and the coefficient-independent cancellation lemmas now live in
-`HexBasic/ExactDiv.lean`, below both `hex-resultant` and `hex-bareiss`;
-`HexResultant/ExactDiv.lean` keeps only the dense-polynomial operations and
-instances and re-exports the contract through a public import.
+`ExactDivLaws`, the coefficient-independent cancellation lemmas, and the `Int`
+and field instances now live in `HexBasic/ExactDiv.lean`, below both
+`hex-resultant` and `hex-bareiss`; `HexResultant/ExactDiv.lean` keeps the
+binary-power helpers and the dense-polynomial operations and instances, and
+re-exports the contract through a public import.
+
+One boundary that move ran into is worth recording, because anything else
+placed in `HexBasic` will hit it. A declaration `Hex.foo` in `HexBasic` is in
+scope for every `Hex*Mathlib` file that says `open Hex`, so if Mathlib defines
+`_root_.foo` then every bare `foo` in those files becomes an ambiguous term.
+`Hex.mul_pow`, `Hex.pow_mul`, and `Hex.pow_ne_zero` all collide that way, so
+they stay with `powNat` and `divExp` in `hex-resultant`, which is the only
+consumer that needs them.
 
 **Generic Bareiss over integral domains (`hex-bareiss`, amendment).**
 Generalize the existing `Int` implementation rather than adding a matrix

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -48,20 +48,19 @@ from `IsEchelonForm.transform_inv` and `det_mul`; and it must carry the
 condition that each pivot is the leading nonzero entry of its row, which
 `IsEchelonForm` does not imply and without which uniqueness is false.
 
-**Shared exact division has graduated from this file.** `exactDiv`,
-`ExactDivLaws`, the coefficient-independent cancellation lemmas, and the `Int`
-and field instances now live in `HexBasic/ExactDiv.lean`, below both
-`hex-resultant` and `hex-bareiss`; `HexResultant/ExactDiv.lean` keeps the
-binary-power helpers and the dense-polynomial operations and instances, and
-re-exports the contract through a public import.
+**Shared exact division is specified and built.** `exactDiv`, `ExactDivLaws`,
+the coefficient-independent cancellation lemmas, and the `Int` and field
+instances live in `HexBasic/ExactDiv.lean`, below both `hex-resultant` and
+`hex-bareiss`. `HexResultant/ExactDiv.lean` holds the binary-power helpers and
+the dense-polynomial operations and instances, and re-exports the contract
+through a public import.
 
-One boundary that move ran into is worth recording, because anything else
-placed in `HexBasic` will hit it. A declaration `Hex.foo` in `HexBasic` is in
-scope for every `Hex*Mathlib` file that says `open Hex`, so if Mathlib defines
-`_root_.foo` then every bare `foo` in those files becomes an ambiguous term.
-`Hex.mul_pow`, `Hex.pow_mul`, and `Hex.pow_ne_zero` all collide that way, so
-they stay with `powNat` and `divExp` in `hex-resultant`, which is the only
-consumer that needs them.
+**Namespace hazard at the bottom of the graph.** A declaration `Hex.foo` in
+`HexBasic` is in scope for every `Hex*Mathlib` file wherever `open Hex` is in
+effect, so if Mathlib defines `_root_.foo` then a bare `foo` in that scope is
+an ambiguous term. This constrains what `HexBasic` may hold: `Hex.mul_pow`,
+`Hex.pow_mul`, and `Hex.pow_ne_zero` collide that way, which is why they sit
+with `powNat` and `divExp` in `hex-resultant`, their only consumer.
 
 **Generic Bareiss over integral domains (`hex-bareiss`, amendment).**
 Generalize the existing `Int` implementation rather than adding a matrix

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -48,20 +48,17 @@ from `IsEchelonForm.transform_inv` and `det_mul`; and it must carry the
 condition that each pivot is the leading nonzero entry of its row, which
 `IsEchelonForm` does not imply and without which uniqueness is false.
 
-**Shared exact division (`HexBasic.ExactDiv`, refactor).** The total exact
-division operation and its law package already exist in
-`HexResultant/ExactDiv.lean`, but generic Bareiss and future Euclidean-domain
-algorithms need the same contract below `hex-resultant`. Move `exactDiv`,
-`ExactDivLaws`, and the coefficient-independent cancellation lemmas into
-`HexBasic.ExactDiv`; leave polynomial-specific operations and instances with
-the polynomial consumer. This is a dependency refactor, not a new quotient
-semantics: division by zero remains deterministic, while correctness only uses
-the law that division by a nonzero known factor cancels.
+**Shared exact division has graduated from this file.** `exactDiv`,
+`ExactDivLaws`, and the coefficient-independent cancellation lemmas now live in
+`HexBasic/ExactDiv.lean`, below both `hex-resultant` and `hex-bareiss`;
+`HexResultant/ExactDiv.lean` keeps only the dense-polynomial operations and
+instances and re-exports the contract through a public import.
 
 **Generic Bareiss over integral domains (`hex-bareiss`, amendment).**
 Generalize the existing `Int` implementation rather than adding a matrix
 library. The executable recurrence uses the shared total exact-division
-operation; its correctness layer assumes a commutative ring, decidable
+operation from `HexBasic.ExactDiv`; its correctness layer assumes a
+commutative ring, decidable
 equality, and `ExactDivLaws`, which supplies cancellation and rules out zero
 products. Keep the current `Int` API as a specialization. The determinant
 proof reuses the public Desnanot-Jacobi and Plücker API already in

--- a/libraries.yml
+++ b/libraries.yml
@@ -544,7 +544,7 @@ libraries:
     done_through: 0
     status: active
   HexResultant:
-    deps: [HexPoly]
+    deps: [HexPoly, HexBasic]
     mathlib: false
     done_through: 4
     status: active

--- a/progress/20260821T054030Z_issue-9315.md
+++ b/progress/20260821T054030Z_issue-9315.md
@@ -1,0 +1,51 @@
+# Shared exact division into HexBasic (issue #9315)
+
+## Accomplished
+
+Split `HexResultant/ExactDiv.lean` in two. `HexBasic/ExactDiv.lean` is new
+and holds the coefficient-independent contract: the `ExactDivLaws` class with
+`mul_right_cancel` and `mul_ne_zero`, the total `exactDiv` wrapper with
+`exactDiv_zero_right` / `exactDiv_eq_div_of_ne` / `exactDiv_mul_right`, the
+nontriviality lemmas `one_ne_zero_of_nonzero` and `negOne_ne_zero_of_one`, and
+the `Int` and `Lean.Grind.Field` instances. Every declaration moved verbatim;
+a sorted line-multiset diff of the old file against the two new ones differs
+only in module docstrings and structural lines.
+
+`HexResultant/ExactDiv.lean` publicly imports the new module, so downstream
+consumers see an unchanged API and no import outside the two files changed.
+Added `HexBasic` to `HexResultant`'s `deps` in `libraries.yml`; `check_dag.py`
+is green.
+
+## Current frontier
+
+The maximal coherent lower layer is smaller than the directive's wording
+suggests, and the reason is a name-collision boundary rather than a dependency
+cycle. `HexBasic` sits below the whole graph, so a declaration `Hex.foo` there
+is in scope for every `Hex*Mathlib` file that says `open Hex`; if Mathlib also
+defines `_root_.foo`, each bare `foo` in those files becomes an
+ambiguous-term error. `Hex.mul_pow`, `Hex.pow_mul`, and `Hex.pow_ne_zero` all
+collide that way. The first draft moved them and broke
+`HexGFqMathlib/Primitivity.lean`; `HexHenselMathlib/HenselLemmas.lean` is the
+other live site.
+
+So `powNat`, `divExp`, and the three shadowing power lemmas stay in
+`HexResultant/ExactDiv.lean`. Nothing below `hex-resultant` needs them:
+`divExp` is Brown's scalar update, and generic Bareiss needs only `exactDiv`,
+`ExactDivLaws`, and cancellation. The boundary is recorded in both module
+docstrings and in `SPEC/future-work.md`, since it constrains anything else
+placed in `HexBasic`.
+
+## Next step
+
+Generic Bareiss over integral domains (`SPEC/future-work.md`) can now take
+`ExactDivLaws` from `HexBasic` without depending on `hex-resultant`. Note that
+`HexBareiss/Bareiss.lean` still defines its own `Hex.Matrix.exactDiv`, an
+`Int`-specific `@&`-borrowing definition; unifying it with the shared wrapper
+belongs to that generalization, not to this dependency refactor.
+
+## Blockers
+
+None. `lake build` is green at 9804 jobs, `check_dag.py`,
+`check_file_line_counts.py`, `check_copyright_headers.py` and
+`git diff --check` all pass, and the resultant and Bareiss conformance and
+emit-fixture targets build clean.

--- a/progress/20260821T054030Z_issue-9315.md
+++ b/progress/20260821T054030Z_issue-9315.md
@@ -21,12 +21,17 @@ is green.
 The maximal coherent lower layer is smaller than the directive's wording
 suggests, and the reason is a name-collision boundary rather than a dependency
 cycle. `HexBasic` sits below the whole graph, so a declaration `Hex.foo` there
-is in scope for every `Hex*Mathlib` file that says `open Hex`; if Mathlib also
-defines `_root_.foo`, each bare `foo` in those files becomes an
+is in scope for every `Hex*Mathlib` file wherever `open Hex` is in effect; if
+Mathlib also defines `_root_.foo`, a bare `foo` in that scope is an
 ambiguous-term error. `Hex.mul_pow`, `Hex.pow_mul`, and `Hex.pow_ne_zero` all
 collide that way. The first draft moved them and broke
-`HexGFqMathlib/Primitivity.lean`; `HexHenselMathlib/HenselLemmas.lean` is the
-other live site.
+`HexGFqMathlib/Primitivity.lean:93`, the one live site in the tree today.
+
+The hazard is lexical, not file-wide, and it is easy to over- or under-count by
+grepping. `HexHenselMathlib/HenselLemmas.lean` looks like a second site because
+it uses a bare `pow_ne_zero` and does `open Hex`, but the uses are at lines 391
+and 418 and the first `open Hex` is at 526, so that file is unaffected. Codex
+caught this in review after I had asserted the opposite.
 
 So `powNat`, `divExp`, and the three shadowing power lemmas stay in
 `HexResultant/ExactDiv.lean`. Nothing below `hex-resultant` needs them:

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -598,5 +598,11 @@
     "baseline_blob": "8b5cf744140acde03da1c72c50482410e0c65029",
     "current_blob": "5fbaa75456c2217771a4f7a27e7f2ff40417fe3a",
     "reason": "Adds prime_iff_forall_le_sqrt and prime_of_bounded, theorems about the Prop-valued Hex.Nat.Prime, on top of the earlier decidability work. New declarations only; no existing definition changes, so the compiled factorization path is unchanged."
+  },
+  {
+    "path": "HexBasic/ExactDiv.lean",
+    "baseline_blob": null,
+    "current_blob": "d21532df570af19a454bcf6c2fcd1e350ecf3ee1",
+    "reason": "Relocates the exact-division contract from HexResultant/ExactDiv.lean into a new HexBasic module: the ExactDivLaws class, its cancellation theorems, the total exactDiv wrapper, and the Int and field instances, all verbatim. The factorization path reaches it through the HexBasic umbrella, but no executable factorization definition calls exactDiv or mentions ExactDivLaws, and the two instances were already global via hex-resultant, so the compiled call graph is unchanged."
   }
 ]


### PR DESCRIPTION
This PR moves the coefficient-independent exact-division contract below both
hex-resultant and hex-bareiss, without changing its semantics. `HexBasic/ExactDiv.lean`
is new and holds the `ExactDivLaws` class with `mul_right_cancel` and `mul_ne_zero`,
the total `exactDiv` wrapper with `exactDiv_zero_right`, `exactDiv_eq_div_of_ne` and
`exactDiv_mul_right`, the nontriviality lemmas `one_ne_zero_of_nonzero` and
`negOne_ne_zero_of_one`, and the `Int` and `Lean.Grind.Field` instances. Every
declaration moves verbatim; division by zero is still the deterministic zero branch.
`HexResultant/ExactDiv.lean` keeps the `DensePoly` scalar-division operations, the
lightweight dense-polynomial ring tower, and the recursive `ExactDivLaws (DensePoly R)`
instance, and re-exports the shared contract through a public import, so no import
outside those two files changes and downstream consumers see an unchanged API.

The maximal coherent lower layer is smaller than the directive's wording suggests, and
the reason is a name-collision boundary rather than a dependency cycle. `HexBasic` sits
below the whole graph, so a declaration `Hex.foo` there is in scope for every
`Hex*Mathlib` file that says `open Hex`; if Mathlib also defines `_root_.foo`, each bare
`foo` in those files becomes an ambiguous-term error. `Hex.mul_pow`, `Hex.pow_mul` and
`Hex.pow_ne_zero` all collide that way, and moving them breaks
`HexGFqMathlib/Primitivity.lean` (`HexHenselMathlib/HenselLemmas.lean` is the other live
site). They stay with `powNat` and `divExp` in `HexResultant/ExactDiv.lean`, which is
the only consumer that needs them: `divExp` is Brown's scalar update, and generic
Bareiss needs only `exactDiv`, `ExactDivLaws` and cancellation. The boundary is recorded
in both module docstrings and in `SPEC/future-work.md`, since it constrains anything
else placed in `HexBasic`.

`libraries.yml` gains `HexBasic` in `HexResultant`'s `deps`. `lake build` is green at
9804 jobs; `check_dag.py`, `check_file_line_counts.py`, `check_copyright_headers.py` and
`git diff --check` pass; the resultant and Bareiss conformance and emit-fixture targets
build clean.

Closes #9315

🤖 Prepared with Claude Code