### PR TITLE
docs: repair primality and factorization specifications

### DIFF
--- a/SPEC/Libraries/hex-int-factor.md
+++ b/SPEC/Libraries/hex-int-factor.md
@@ -5,8 +5,8 @@ divisor-function API built on it, and the multiplicative-order and
 primitive-root results that are the reason this tree wants it.
 Mathlib-free. The companion `hex-int-factor-mathlib` proves the
 correspondence with `Nat.factorization` and `Nat.primeFactorsList`,
-supplies `Decidable (Squarefree n)`, and relates the order API to
-`orderOf` in `(ZMod n)ˣ`.
+supplies factorization-derived witnesses for squarefree decomposition,
+and relates the order API to `orderOf` in `(ZMod n)ˣ`.
 
 This SPEC expands the "Integer factorization" entry in
 [future-work](../future-work.md) and depends on
@@ -26,20 +26,19 @@ family of integers, and it has structure worth exploiting. See "The
 
 ## Why this library exists
 
-**hex-conway Tier 2 is blocked on it.** hex-conway's SPEC sets Tier 2
-as "irreducible, primitive, compatible with `C(p, m)` for each proper
-divisor `m ∣ n`", and names Tier 2 as the intended target for every
-committed table entry. Primitivity of a root `α` of `C(p, n)` means
+**hex-conway Tier 2 is the motivating consumer, not a current
+blocker.** hex-conway's committed table now has Tier 2 proofs using
+small, locally checked factorizations. Its SPEC defines Tier 2 as
+"irreducible, primitive, compatible with `C(p, m)` for each proper
+divisor `m ∣ n`". Primitivity of a root `α` of `C(p, n)` means
 `ord(α) = p^n − 1`, which is checked by `α^{(p^n − 1)/q} ≠ 1` for each
 prime `q ∣ p^n − 1`. What that needs is a **certified complete prime
 support** of `p^n − 1` -- every distinct prime divisor, with no
 multiplicities -- and a complete factorization is the sufficient
-certificate this library supplies for it. Today the tree carries 36
-irreducibility certificates (35 in `HexConway/Certificates.lean`, and
-`cert_2_1` in `HexConway/Table.lean:279`) and no primitivity witnesses
-at all, which is Tier 1. Tier 2 also needs the compatibility proofs
-across degree divisors, so factorization is one prerequisite rather
-than the only one.
+certificate this library supplies when that table grows beyond values
+comfortable to maintain by hand. Tier 2 also needs the compatibility
+proofs across degree divisors, so factorization remains one ingredient
+rather than the whole verification story.
 
 **Squarefree content over `ℤ`, but not for the reason hex-mv-gcd
 gives.** `12x` is not squarefree in `ℤ[x]` because `4 ∣ 12`, so the
@@ -79,17 +78,30 @@ unfactored".
 ## Scope
 
 In scope: the factorization certificate and its checker; perfect-power
-detection; trial division against hex-primality's table; Pollard rho
-with Brent's cycle detection; Pollard `p − 1` in two stages; the
-elliptic curve method with Montgomery curves; the divisor-function API
+detection; trial division against hex-primality's table; reuse of
+hex-primality's Brent-rho primitive; Pollard `p − 1` stage 1; ECM stage
+1 with Montgomery curves; the divisor-function API
 (`divisors`, `sigma`, `totient`, `radical`, `squarefreePart`,
 `isSquarefree`); the multiplicative-order and primitive-root
 certificates; and the cyclotomic pre-split for numbers of the form
 `b^n ± 1`.
 
+Pollard `p − 1` stage 2 and ECM stage 2 are not in scope. Real
+continuations need specified baby-step/giant-step and Brent-Suyama
+layouts respectively, an arbitrary-precision modular-arithmetic cost
+model, and their own benchmark families; "the standard continuation"
+is not an implementable contract. Each stage 1 is independently useful
+and is the largest surface specified here.
+
+ECM stage 1 without stage 2 may not earn its maintenance cost. Milestone
+6 is therefore benchmark-gated: if the specified stage-1 route does not
+win on an unbalanced-semiprime family, it is removed from the initial
+library rather than retained on the assumption that an unspecified
+continuation will rescue it.
+
 Not in scope: the quadratic sieve and the number field sieve. They
 reach past anything this tree needs, they are large projects, and the
-honest position is that a fuel-exhausted `none` from ECM is a better
+honest position is that a fuel-exhausted `FactorStop.incomplete` result is a better
 answer for this project than a sieve implementation nobody will
 maintain. If a consumer appears that needs 60-digit factorizations, the
 route is an untrusted external oracle checked by this library's
@@ -113,12 +125,13 @@ be cyclic.
 ```lean
 namespace Hex.Nat
 
-/-- One prime power in a factorization, carrying the primality
-certificate for its base. -/
+/-- One prime power in a factorization. The base is the certificate's
+subject, so the two cannot disagree. -/
 structure PrimePower where
-  prime    : Nat
   exponent : Nat
   cert     : PrimeCert
+
+def PrimePower.prime (e : PrimePower) : Nat := e.cert.subject
 
 /-- A complete factorization of `subject`. -/
 structure Factorization where
@@ -127,11 +140,11 @@ structure Factorization where
 
 def checkFactorization (F : Factorization) : Bool
 
-/-- Factorization data together with the proof that the checker
-accepted it. Every semantic operation below consumes this, not `Factorization`. -/
-structure CheckedFactorization where
-  raw   : Factorization
-  valid : checkFactorization raw = true
+/-- Accepted factorization data tied to the subject requested by its caller. -/
+structure CheckedFactorization (n : Nat) where
+  raw        : Factorization
+  subject_eq : raw.subject = n
+  valid      : checkFactorization raw = true
 ```
 
 The subtype is not decoration. An earlier draft had the divisor
@@ -141,7 +154,8 @@ carrying factors of `5` is a perfectly good `Factorization`, and
 `totient` of it means nothing. Either every theorem carries
 `checkFactorization F = true` as a hypothesis, or the validity travels
 with the data. The second is better, and it is what "takes checked
-data" has to mean.
+data" has to mean. Indexing the checked form by `n` additionally prevents
+a valid factorization of one number from answering a request about another.
 
 `checkFactorization` verifies:
 
@@ -149,13 +163,19 @@ data" has to mean.
 2. `F.factors` is strictly ascending in `prime`, so the primes are
    distinct and the representation is canonical.
 3. Every `exponent` is positive.
-4. `checkPrime` accepts each `cert`, and each certifies its own
-   `prime`.
+4. `checkPrime` accepts each `cert`; `prime` is definitionally that
+   certificate's subject.
 5. `∏ prime ^ exponent = F.subject`.
 
 Steps 1 through 3 and step 5 are arithmetic on the literal data; step 4
 is hex-primality's checker, recursively. The whole check is `O(k)`
-multiplications plus `k` primality replays.
+bounded exponentiations plus `k` primality replays.
+
+As in `checkPrime`, powers and their product are accumulated against the
+known bound `F.subject`: the loop rejects as soon as the running value
+exceeds the subject. An untrusted exponent therefore cannot force the
+kernel to construct a gigantic `prime ^ exponent` before discovering
+that the certificate is invalid.
 
 ```lean
 theorem checkFactorization_prod {F} (h : checkFactorization F = true) :
@@ -202,12 +222,13 @@ time-bounded, while the checker is total. That is the cleanest instance
 of design principle 4's certificate model anywhere in this tree, and it
 is why every algorithm below needs no correctness proof.
 
-**Degenerate inputs.** `factor 1` returns `⟨1, []⟩`, and the empty
-product is `1`. `factor 0` is refused: `0` has no factorization into
+**Degenerate inputs.** `factor? 1` has a checked empty
+factorization, whose product is `1`. At `0`, `factor?` reports
+`FactorStop.zero`: `0` has no factorization into
 primes and every `n` divides it, so `checkFactorization` requires
-`0 < subject` and the public API returns `Option` at `0`. This is
+`0 < subject`. This is
 stated because the alternative -- a junk value at `0` -- makes
-`checkFactorization_complete` false and would be found only by a
+the factorization's prime-support completeness theorem false and would be found only by a
 consumer.
 
 ## The algorithms
@@ -217,8 +238,19 @@ it only through `checkFactorization`. A rejected candidate is a bug in
 a route, never a wrong answer, and the dispatch simply continues.
 
 ```lean
-def factor? (n : Nat) (r : Rand) (fuel : Nat) :
-    Option (CheckedFactorization × Rand)
+inductive FactorStop where
+  | zero
+  | incomplete
+
+structure FactorFailure where
+  stop     : FactorStop
+  attempts : Nat
+  rand     : Rand
+
+def defaultFuel (n : Nat) : Nat
+
+def factor? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
+    Except FactorFailure (CheckedFactorization n × Rand)
 ```
 
 There is no total `factor : Nat → Factorization`. An earlier draft had
@@ -257,7 +289,9 @@ prerequisite, specified there and sited in hex-basic.
 
 ### 1. Pollard rho with Brent's cycle detection
 
-The workhorse for factors up to about `10^{12}`. Iterate
+This route is hex-primality's `Hex.Nat.rhoFactor?`, reused directly
+rather than reimplemented here. It is the workhorse for factors up to
+about `10^{12}`: iterate
 `x ↦ x² + c (mod n)`, detect a cycle by Brent's method rather than
 Floyd's (fewer function evaluations per step), and take
 `gcd(|xᵢ − x_j|, n)` in batches of accumulated products so that one gcd
@@ -265,23 +299,28 @@ serves many steps.
 
 Expected cost is `O(p^{1/2})` iterations to find a factor `p`, so
 `O(n^{1/4})` to split a semiprime. The batching constant matters: a gcd
-per step makes the routine gcd-bound rather than multiply-bound, and
-`Hex.extGcd`'s GMP extern does not change that.
+per step makes the routine gcd-bound rather than multiply-bound. The
+primitive required is `Nat.gcd`, not extended GCD.
 
 `c` and the starting point are drawn from `Hex.Rand` (specified in
 [hex-finite-field](hex-finite-field.md), sited in hex-basic), following
 the same explicit-argument discipline: the draw is an argument, the
 retry budget is fuel, and a bad draw costs time and never correctness.
-The known bad case is `c = 0` and `c = n − 2`, which are excluded by
-construction rather than by luck.
+The draw rejects `c = 0` and any starting point `x` satisfying
+`x² + c ≡ x (mod n)`, a fixed point that can be detected before the
+loop. In particular, `c = n - 2` is bad for the conventional start
+`x = 2` but is not globally blacklisted for every start.
 
 ### 2. Pollard `p − 1`
 
-Stage 1 computes `a^M mod n` for `M = ∏ q^{⌊log_q B⌋}` over primes
-`q ≤ B` and takes `g = gcd(a^M − 1, n)`. Three outcomes, all of which
-the implementation must distinguish: `g = 1` (increase `B` or go to
-stage 2), `1 < g < n` (a factor), `g = n` (the exponent killed every
-component; retry with a different base or a smaller `B`).
+Stage 1 chooses `1 < a < n` and first checks `gcd(a,n)`: a gcd greater
+than `1` is necessarily a proper factor. Otherwise it computes
+`x = a^M mod n` for `M = ∏ q^{⌊log_q B⌋}` over primes
+`q ≤ B` and takes `g = gcd((x + n - 1) % n, n)`, avoiding truncated
+`Nat` subtraction. Three outcomes, all of which
+the implementation must distinguish: `g = 1` (increase `B`, retry, or
+fall through), `1 < g < n` (a factor), `g = n` (the exponent killed
+every component; retry with a different base or a smaller `B`).
 
 The success condition is about the **order of `a` modulo `p`**, not
 about `p − 1`: stage 1 finds `p` when `ord_p(a) ∣ M`. That is implied
@@ -290,14 +329,13 @@ earlier draft's "succeeds iff `p − 1` is `B`-smooth" was wrong in both
 directions -- it can succeed on a non-smooth `p − 1` when the base has
 small order, and it can fail on a smooth one by returning `n`.
 
-Stage 2 allows one prime factor of `ord_p(a)` between `B₁` and `B₂`. A
-difference table is the idea but not an algorithm: a usable stage 2
-needs a baby-step/giant-step layout over the primes in the interval and
-a batched gcd (accumulate a product, take one gcd per block). Montgomery
-and Kruppa's treatment is the reference,
-https://antsmath.org/ANTSVIII/files/kruppa.pdf, and the stage-2
-benchmark family below is what decides whether it earns its
-complexity.
+A future stage 2 may allow one prime factor of `ord_p(a)` between `B₁`
+and `B₂`, but a difference table is an idea rather than an algorithm.
+Before it enters scope it needs an exact baby-step/giant-step layout over
+the interval primes, a batched-gcd schedule, and a benchmark family.
+Montgomery and Kruppa's treatment,
+https://antsmath.org/ANTSVIII/files/kruppa.pdf, is the starting reference
+for that separate specification.
 
 It is cheap, it fails on most inputs, and it succeeds instantly on the
 inputs this tree actually produces. `p^n − 1` is a difference of
@@ -309,9 +347,9 @@ below is the one that justifies its place.
 ### 3. The elliptic curve method
 
 For factors past rho's reach. Montgomery curves in **projective `x:z`
-coordinates** with Suyama's parameterisation, stage 1 by scalar
-multiplication against the same smoothness-bound structure as `p − 1`,
-stage 2 by the standard continuation. Expected total work is
+coordinates** with Suyama's parameterisation and stage 1 scalar
+multiplication against the same smoothness-bound structure as `p − 1`.
+Expected total work is
 subexponential in the size of the smallest factor rather than in `n`,
 which is what makes it the right last route: its cost tracks the
 difficulty of the *answer*, not of the input.
@@ -319,8 +357,8 @@ difficulty of the *answer*, not of the input.
 **The arithmetic description matters, and an earlier draft got it
 backwards.** The whole point of `x:z` coordinates is that scalar
 multiplication performs *no* modular inversion; the draft said "one
-modular inversion per stage". What ECM actually does is accumulate `z`
-coordinates and take a gcd at stage boundaries, with three outcomes to
+modular inversion per stage". What ECM stage 1 actually does is accumulate `z`
+coordinates and take a gcd at the stage boundary, with three outcomes to
 distinguish exactly as in `p − 1`: `gcd = 1` is no information,
 `1 < gcd < n` is the factor, and `gcd = n` is failure, not success.
 Suyama setup does need one inversion or gcd. And the primitive required
@@ -330,17 +368,24 @@ is the gcd rather than `HexArith.Int.extGcd`.
 Lenstra's analysis, https://annals.math.princeton.edu/1987/126-3/p09,
 is the source for the dependence on the smallest prime factor.
 
-ECM is where the implementation effort is, and it is milestone 5 for
+ECM is where the implementation effort is, and it is milestone 6 for
 that reason. Everything above it is a complete and useful library. It
 needs no hex-matrix, no hex-poly, and none of the algebraic
-infrastructure: it is arithmetic mod a composite `n`, which is the
-setting hex-arith's Montgomery context was built for.
+infrastructure, but it does need an explicit arithmetic dispatch:
+word-sized odd moduli use hex-arith's `MontCtx`; larger moduli use direct
+GMP-backed `Nat` multiplication and remainder, `(a * b) % n`. The
+existing Montgomery context is `UInt64`-only and is not claimed to be an
+arbitrary-precision backend. The ECM benchmark family must show that the
+direct-`Nat` route is useful before this milestone is complete; a future
+stage 2 or a failed benchmark is the point at which to specify a separate
+big-integer modular context.
 
-### 4. Fuel, and what `none` means
+### 4. Fuel, and what failure means
 
-`none` means the routes did not finish inside `fuel`, and it is
+`FactorStop.incomplete` means the routes did not finish inside
+`fuel`, and it is
 reachable -- deliberately so. Per design principle 8 that is the third
-remedy, propagating the `Option` upward, and it is the right one here:
+remedy, propagating the failure upward, and it is the right one here:
 there is no fallback that is correct-but-slow, because trial division
 past `10^{18}` is not slow, it is unavailable.
 
@@ -355,27 +400,48 @@ structure PartialFactorization where
   factors  : List PrimePower
   residual : Nat
 
-def factorPartial (n : Nat) (r : Rand) (fuel : Nat) :
-    CheckedPartialFactorization × Rand
+structure CheckedPartialFactorization (n : Nat) where
+  raw        : PartialFactorization
+  subject_eq : raw.subject = n
+  valid      : checkPartial raw = true
+
+def factorPartial? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
+    Except FactorFailure (CheckedPartialFactorization n × Rand)
 ```
 
 `checkPartial` verifies `0 < subject`, `∏ pᵢ^{eᵢ} · residual = subject`,
 positive exponents, strictly ascending distinct bases, and the primality
 of the listed factors through their certificates -- the same conditions
 as `checkFactorization` minus the requirement that the residual be `1`.
-It makes **no** completeness claim. `CheckedPartialFactorization` pairs
-the data with `checkPartial = true` exactly as `CheckedFactorization`
-does, and
+Its product calculation uses the same subject-bounded loop.
+It makes **no** completeness claim. The indexed checked form prevents a
+partial factorization of one subject from answering a request about
+another, and
 
 ```lean
-theorem checkPartial_factorPartial (n r fuel) (hn : 0 < n) :
-    checkPartial (factorPartial n r fuel).1.raw = true
+theorem factorPartial?_error {n r fuel f}
+    (h : factorPartial? n r fuel = .error f) :
+    f.stop = .zero ∧ n = 0
+
+theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
+    ∃ F r', factorPartial? n r fuel = .ok (F, r')
 ```
 
-is what makes `factorPartial` total: it always returns something, and
-what it returns is always valid, because `⟨[], n⟩` is valid. An earlier
-draft returned raw data and only described the checker, so "what the
-search proved" rested on nothing.
+For positive `n`, the empty factor list with residual `n` is always a
+valid fallback, so fuel exhaustion still returns checked partial data.
+At `n = 0` no object satisfying `0 < subject` and `subject = n` exists,
+and `FactorStop.zero` reports that fact instead of returning checked
+data about another number. A failure retains its advanced state and
+attempt count, while success returns the state alongside the checked
+data, so a caller never repeats a failed random stream accidentally.
+
+`factor?` is the convenience projection of `factorPartial?`: it
+propagates `FactorStop.zero`, returns the complete checked form exactly
+when the checked residual is `1`, and returns `FactorStop.incomplete`
+otherwise, retaining
+the same advanced state and attempt count. Keeping both APIs avoids
+forcing callers that require completeness to unpack an object they
+cannot use.
 
 That is the honest object for the consumers that need one: hex-primality's
 Pocklington search wants "enough of `n − 1` to pass `√n`" and does not
@@ -386,9 +452,9 @@ exactly a `residual ≠ 1`.
 
 ## The `p^n − 1` problem
 
-The consumer that drives this library asks for the factorization of
-`p^n − 1`, and that family deserves its own treatment rather than being
-handed to the generic dispatch.
+The motivating table-growth path asks for factorizations of `p^n − 1`,
+and that family deserves its own treatment rather than being handed to
+the generic dispatch.
 
 For `b ≥ 2` and `n > 0`,
 
@@ -411,23 +477,29 @@ roughly `2 log p` bits in place of one of `6 log p` bits.
 ```lean
 inductive Sign where | minus | plus
 
-/-- One cyclotomic part: the index `d` and the value `Φ_d(b)`. -/
+/-- One candidate cyclotomic part: its index `d` and proposed value
+`Φ_d(b)`. Exact cyclotomic semantics are conformance-tested, not trusted by
+the factorization route. -/
 structure CyclotomicPart where
   index : Nat
   value : Nat
 
-/-- Split `b^n - 1` or `b^n + 1` into its cyclotomic parts before
-factoring. Requires `2 ≤ b` and `0 < n`; the product of the returned
-values is the input. -/
-def cyclotomicSplit (b n : Nat) (sign : Sign) (hb : 2 ≤ b) (hn : 0 < n) :
-    List CyclotomicPart
+/-- Candidate split of `b^n - 1` or `b^n + 1`. Invalid domains or a
+candidate whose product is not the input return `none`. -/
+def cyclotomicSplit? (b n : Nat) (sign : Sign) : Option (List CyclotomicPart)
+
+theorem cyclotomicSplit?_prod {b n sign parts}
+    (h : cyclotomicSplit? b n sign = some parts) :
+    2 ≤ b ∧ 0 < n ∧
+      (parts.map (·.value)).prod =
+        match sign with | .minus => b ^ n - 1 | .plus => b ^ n + 1
 ```
 
 An enum rather than a `Bool`, and a named pair rather than
 `Nat × Nat`, because neither of the earlier draft's choices said which
-way round it was. The domain conditions are hypotheses rather than
-junk-value cases: at `b ≤ 1` or `n = 0` the identities degenerate and
-no caller wants an answer.
+way round it was. Invalid domains use the existing failure channel: at
+`b ≤ 1` or `n = 0` the identities degenerate and no caller wants an
+answer.
 
 This needs cyclotomic polynomials evaluated at an integer, which is
 [future-work](../future-work.md)'s "Cyclotomic polynomials" entry --
@@ -438,13 +510,17 @@ described there as "small enough to build rather than plan". Evaluating
 Φ_d(b) = (b^d − 1) / ∏_{e ∣ d, e < d} Φ_e(b)
 ```
 
-computes it in `Nat` with one division per index, and **that division
-is exact**, which is the theorem the implementation carries. The Möbius
+computes a candidate in `Nat` with one division per index. The route does
+not take exactness of those truncating divisions into its trusted proof
+surface: `cyclotomicSplit?` checks the final product, and the eventual
+factorization still passes `checkFactorization` against the original
+input. The Möbius
 form `∏_{μ(d/e)=1}(b^e−1) / ∏_{μ(d/e)=−1}(b^e−1)` is also correct, but
 only as a single final quotient: dividing term by term in an arbitrary
-order is not justified in `Nat`, and an earlier draft of this SPEC
-proposed exactly that. The recursion is specified because every
-intermediate quotient is exact and provably so.
+order is not justified in `Nat`. The recursive producer is specified
+because it is the natural fast candidate algorithm; a separate
+Mathlib-free formalization of cyclotomic-polynomial identities is not a
+prerequisite for this checked search optimization.
 
 **The parts need not be pairwise coprime**, so factoring them
 separately can produce the same prime twice with different exponents.
@@ -472,9 +548,10 @@ would have caught, and they are recorded here rather than specified.
 **What this means for hex-conway.** The committed table covers
 `p ∈ {2, 3, 5, 7, 11, 13}` with `n ≤ 6`, so the largest `p^n − 1` in
 scope is `13^6 − 1 = 4826808 = 2³ · 3² · 7 · 61 · 157` -- which
-trial division against a `10^4` table finishes instantly. So **Tier 2
-for the current table needs nothing beyond milestone 1 of this
-library**, and the difficulty is entirely in how far the table is
+trial division against a `10^4` table finishes instantly. So a
+refactoring of the current Tier 2 proofs onto these shared certificates
+would need nothing beyond milestone 1 of this library, and the
+difficulty is entirely in how far the table is
 allowed to grow. That is the right way round: the primitivity checker
 should land early and cheaply, and the table's growth policy should be
 set by what the factorizations cost, alongside the proof-checking
@@ -489,18 +566,25 @@ structure OrderCert where
   base     : Nat
   modulus  : Nat
   order    : Nat
-  orderFac : CheckedFactorization        -- of `order`
+  orderFac : Factorization
 
 def checkOrder (c : OrderCert) : Bool
+
+/-- Order data accepted by the checker. Search APIs return this form. -/
+structure CheckedOrderCert where
+  raw   : OrderCert
+  valid : checkOrder raw = true
 ```
 
 `checkOrder` verifies `1 < c.modulus`, `0 < c.order`,
-`c.orderFac.raw.subject = c.order`, then
-`powMod base order modulus = 1 % modulus`, then
-`powMod base (order/q) modulus ≠ 1 % modulus` for each prime `q` in the
-factorization. The identity is normalised as `1 % modulus` rather than
-`1` so that it says the right thing at `modulus = 1`, which
-`1 < c.modulus` then excludes anyway.
+`c.orderFac.subject = c.order`, `checkFactorization c.orderFac = true`,
+`HexArith.powModNat base order modulus = 1 % modulus`, then
+`HexArith.powModNat base (order/q) modulus ≠ 1 % modulus` for each prime
+`q` in the factorization. `OrderCert` stays raw and serializable; only
+`CheckedOrderCert` embeds the proof that this full replay succeeded.
+The identity is normalised as `1 % modulus` rather than `1` so that the
+same modular expression is used throughout, although `1 < c.modulus`
+excludes the degenerate modulus.
 
 ```lean
 theorem order_eq_of_checkOrder {c} (h : checkOrder c = true) :
@@ -532,12 +616,30 @@ and here the second witness is the completeness of a factorization
 rather than a separate object.
 
 ```lean
-def isPrimitiveRoot (pc : PrimeCert) (F : CheckedFactorization)
-    (hF : F.raw.subject = pc.subject - 1) (g : Nat) : Bool
-def primitiveRoot? (pc : PrimeCert) (F : CheckedFactorization)
-    (hF : F.raw.subject = pc.subject - 1) (fuel : Nat) :
-    Option (Nat × OrderCert)
-def carmichael (F : CheckedFactorization) : Nat        -- λ(subject)
+def isPrimitiveRoot {p : Nat} (pc : CheckedPrimeCert p)
+    (F : CheckedFactorization (p - 1)) (g : Nat) : Bool
+
+theorem isPrimitiveRoot_iff {p pc F g} :
+    isPrimitiveRoot (p := p) pc F g = true ↔
+      Hex.Nat.orderOf g p = p - 1
+
+def primitiveRoot? {p : Nat} (pc : CheckedPrimeCert p)
+    (F : CheckedFactorization (p - 1)) (fuel : Nat) :
+    Option (Nat × CheckedOrderCert)
+
+theorem primitiveRoot?_spec {p pc F fuel g c}
+    (h : primitiveRoot? (p := p) pc F fuel = some (g, c)) :
+    c.raw.base = g ∧ c.raw.modulus = p ∧ c.raw.order = p - 1
+
+def carmichael {n : Nat} (F : CheckedFactorization n) : Nat
+
+theorem pow_carmichael {n : Nat} (F : CheckedFactorization n)
+    (a : Nat) (ha : Nat.Coprime a n) :
+    a ^ carmichael F % n = 1 % n
+
+theorem orderOf_dvd_carmichael {n : Nat} (F : CheckedFactorization n)
+    (a : Nat) (hn : 1 < n) (ha : Nat.Coprime a n) :
+    Hex.Nat.orderOf a n ∣ carmichael F
 ```
 
 All three consume certified data rather than a `Nat`. An earlier draft
@@ -547,9 +649,38 @@ factorization that the fuel-limited search may not have produced:
 `isPrimitiveRoot` would have to answer `false` on exhaustion, which is
 wrong, and `carmichael` had no failure channel at all.
 
-`primitiveRoot?` searches `g = 2, 3, 5, …` and returns the first that
-checks; it is `Option`-valued only because the search is bounded, since
-a primitive root always exists mod a prime.
+`primitiveRoot?` handles `p = 2` with `g = 1`; for odd primes it scans
+the residues `2 ≤ g < p` in ascending order and returns the first that
+checks. It is `Option`-valued only because the search is fuel-bounded,
+since a primitive root exists modulo every prime. Returning a checked
+order certificate, and stating how its fields relate to the requested
+prime, makes a successful search result usable without trusting that
+search.
+
+`carmichael` is the lcm of its prime-power values. For odd `p`,
+`λ(p^e) = (p - 1) * p^(e - 1)`. For `p = 2`, the values are `1` at
+`e = 1`, `2` at `e = 2`, and `2^(e - 2)` at `e ≥ 3`; the empty
+factorization gives `λ(1) = 1`. These cases are part of the definition,
+not an implementation note. The two theorems above give the local
+Mathlib-free semantics consumers need; the companion later identifies
+the value with Mathlib's Carmichael function if and when that bridge is
+useful.
+
+Those theorems are not free consequences of hex-arith's current Fermat
+lemma. Their Mathlib-free proof prerequisites are explicit milestone
+obligations:
+
+- Euler's congruence modulo an odd prime power, proved by lifting
+  Fermat through the binomial theorem;
+- the separate odd-unit congruence modulo `2^e`, giving exponent
+  `2^(e-2)` for `e ≥ 3`;
+- preservation of `a^k ≡ 1` when the exponent is multiplied; and
+- combination of congruences across the pairwise-coprime prime powers
+  in a checked factorization.
+
+Hex-arith currently supplies Fermat modulo a prime, but not these
+prime-power or CRT steps. They belong in `Order.lean` beneath
+`pow_carmichael`; the milestone is not complete until they are proved.
 
 **The generic form for hex-conway.** Primitivity of a field element is
 `checkOrder` with `modulus` replaced by a finite field, and the
@@ -564,14 +695,33 @@ and it buys nothing: two call sites, two lines each.
 ## The divisor-function API
 
 ```lean
-def divisors (F : CheckedFactorization) : Array Nat        -- ascending
-def numDivisors (F : CheckedFactorization) : Nat           -- τ, ∏ (eᵢ + 1)
-def sigma (F : CheckedFactorization) (k : Nat) : Nat       -- σ_k
-def totient (F : CheckedFactorization) : Nat               -- φ
-def radical (F : CheckedFactorization) : Nat               -- ∏ pᵢ
-def squarefreePart (F : CheckedFactorization) : Nat        -- ∏_{eᵢ odd} pᵢ
-def squareDivisor (F : CheckedFactorization) : Nat         -- largest d with d² ∣ n
-def isSquarefree (F : CheckedFactorization) : Bool         -- ∀ i, eᵢ = 1
+def divisors {n} (F : CheckedFactorization n) : Array Nat   -- ascending
+def numDivisors {n} (F : CheckedFactorization n) : Nat     -- τ, ∏ (eᵢ + 1)
+def sigma {n} (F : CheckedFactorization n) (k : Nat) : Nat -- σ_k
+def totient {n} (F : CheckedFactorization n) : Nat         -- φ
+def radical {n} (F : CheckedFactorization n) : Nat         -- ∏ pᵢ
+def squarefreePart {n} (F : CheckedFactorization n) : Nat  -- ∏_{eᵢ odd} pᵢ
+def squareDivisor {n} (F : CheckedFactorization n) : Nat   -- largest d with d² ∣ n
+def isSquarefree {n} (F : CheckedFactorization n) : Bool   -- ∀ i, eᵢ = 1
+
+theorem mem_divisors {n d} (F : CheckedFactorization n) :
+    d ∈ (divisors F).toList ↔ d ∣ n
+theorem numDivisors_eq_size {n} (F : CheckedFactorization n) :
+    numDivisors F = (divisors F).size
+theorem sigma_eq_sum {n k} (F : CheckedFactorization n) :
+    sigma F k = ((divisors F).toList.map (fun d => d ^ k)).sum
+theorem totient_eq_count {n} (F : CheckedFactorization n) :
+    totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length
+theorem prime_dvd_radical_iff {n q} (F : CheckedFactorization n)
+    (hq : Hex.Nat.Prime q) : q ∣ radical F ↔ q ∣ n
+theorem squarefreePart_mul_square {n} (F : CheckedFactorization n) :
+    squarefreePart F * squareDivisor F ^ 2 = n
+theorem squareDivisor_spec {n} (F : CheckedFactorization n) :
+    squareDivisor F ^ 2 ∣ n ∧
+      ∀ d, d ^ 2 ∣ n → d ∣ squareDivisor F
+theorem isSquarefree_iff {n} (F : CheckedFactorization n) :
+    isSquarefree F = true ↔
+      ∀ q, Hex.Nat.Prime q → ¬ (q ^ 2 ∣ n)
 ```
 
 All of these take a `CheckedFactorization` rather than a `Nat`, which
@@ -585,7 +735,20 @@ not.
 `divisors` returns ascending, which costs a sort over `∏(eᵢ + 1)`
 entries and is what every consumer wants. `numDivisors` exists
 separately because it is `O(k)` and computing it by `divisors.size`
-would be exponential.
+would be exponential. The local semantic theorems are deliberate: the
+Mathlib bridge proves correspondence with Mathlib's names, but the
+Mathlib-free library must already say what each public result means.
+At `k = 0`, `sigma` dispatches to `numDivisors`; an implementation using
+the geometric-series product must not evaluate its `0 / 0` form.
+
+The semantic theorems also name real proof work rather than assumed
+infrastructure. `mem_divisors` needs the bounded-exponent
+characterization of a divisor of a product of distinct prime powers.
+`totient_eq_count` additionally needs the prime-power coprime count and
+the multiplicative counting bijection for coprime moduli (a finite CRT
+argument). None of those results is presently exported by hex-arith.
+They are part of the divisor-API milestone; listing the theorems here is
+not a claim that the existing arithmetic root already proves them.
 
 ## Complexity
 
@@ -598,11 +761,10 @@ the number of distinct primes, `B` a smoothness bound.
 | perfect-power test | `O(b · b · M(b))` | `O(b)` roots, Newton each |
 | trial division to `T` | `O(π(T))` divisions | `π(10^4) = 1229` |
 | Pollard rho | `O(√p)` iterations expected | `O(n^{1/4})` for a semiprime |
-| Pollard `p − 1` stage 1 | `O(B log B)` modular mults | succeeds iff `p − 1` is `B`-smooth |
-| Pollard `p − 1` stage 2 | `O(B₂ / log B₂)` mults | one large prime allowed |
-| ECM, one curve | `O(B log B)` mults | per-curve success `~1/L`; total expected work `L_p[1/2, √2]` |
+| Pollard `p − 1` stage 1 | `O(B)` modular mults | `log M = Θ(B)`; smooth `p − 1` is sufficient but not decisive |
+| ECM stage 1, one curve | `O(B)` mults | scalar bit length is `Θ(B)`; success depends on the bound |
 | `checkFactorization` | `O(k)` exponentiations plus `k` primality replays | `p^e` is `O(log e)` mults, not one |
-| `checkOrder` | `O(k)` modular exponentiations | one per prime of the order |
+| `checkOrder` | `O(k)` modular exponentiations plus `checkFactorization` | includes the order's primality replays |
 | `divisors` | `O(τ log τ)` | `τ = ∏(eᵢ + 1)` |
 | everything else in the divisor API | `O(k)` | |
 
@@ -622,11 +784,12 @@ in increasing order of what they can afford to be wrong about.
 ## Kernel exposure
 
 The replay closure is `checkFactorization`, `checkOrder`, and what they
-call: `Nat` multiplication and comparison, `Hex.powMod` (through
-hex-primality's kernel-facing `powModNat`, for the reason that SPEC
-gives), and hex-primality's `checkPrime`. Each is `@[expose]`, and a
-downstream module carries a `decide +kernel` test that fails if any of
-them stops reducing.
+call: `Nat` multiplication and comparison, hex-primality's
+kernel-facing `powModNat`, and `checkPrime`. The reducers in that
+closure are `@[expose]`, and a downstream module carries a
+`decide +kernel` test that fails if any of them stops reducing. The
+SPEC does not invent a second public `Hex.powMod` name for the same
+operation.
 
 Nothing in routes 0 through 3 is in that closure. Rho, `p − 1`, ECM,
 the cyclotomic split, and the perfect-power test are search; they never
@@ -663,9 +826,11 @@ Cases that must be present:
   perfect-power detector fired rather than that the answer came out.
 - **Semiprimes with balanced factors** at 32, 48, and 64 bits, the
   worst case for rho.
-- **Smooth `p − 1`**, a semiprime whose factors have `p − 1` smooth, so
-  the `p − 1` route succeeds; and a deliberately non-smooth one where
-  it must fail and fall through.
+- **Pollard `p − 1` route cases**: a smooth-order semiprime and fixed
+  base for which stage 1 yields a proper factor; a case yielding `1`;
+  and a case yielding the whole modulus. A non-smooth `p − 1` is not by
+  itself a promised failure, because the chosen base can have smaller
+  smooth order.
 - **`b^n ± 1`** for `b ∈ {2, 3, 5, 7, 10}` and `n` up to `32`,
   checked against the cyclotomic split as well as against the oracle.
   The split's product must equal the input exactly, which catches an
@@ -700,10 +865,11 @@ candidate goes through `checkFactorization`, and a broken route falls
 through to the next one, so a fixture passes even if ECM is entirely
 non-functional. The suite therefore needs route-level tests in Lean:
 that the perfect-power detector fired on a perfect power, that `p − 1`
-succeeded on a smooth input and declined on a non-smooth one, that rho
+distinguished proper-factor, `1`, and whole-modulus outcomes, that rho
 found the factor within the expected iteration count for a fixed seed,
-and that the cyclotomic split ran before the generic dispatch on a
-`b^n − 1` input. This is the same division
+that ECM stage 1 distinguished its three gcd outcomes, and that
+`cyclotomicSplit?` ran before the generic dispatch on a `b^n − 1`
+input. This is the same division
 [hex-mv-gcd](hex-mv-gcd.md) makes, and it is worth more than the oracle
 half.
 
@@ -720,8 +886,8 @@ Families:
   finishes. The required property is that the dispatch overhead is
   invisible on the case that dominates call volume.
 - **Balanced semiprimes** at 32, 48, 64, and 80 bits. Route 1.
-- **Smooth `p − 1` semiprimes** at the same sizes. Route 2, and the
-  family that decides whether stage 2 earns its complexity.
+- **Smooth `p − 1` semiprimes** at the same sizes. Route 2; the base is
+  fixed so the benchmark measures the specified stage-1 success case.
 - **`b^n ± 1`**, with and without the cyclotomic split, which is the
   measurement that justifies the split existing.
 - **Unbalanced semiprimes**, a small factor times a large one, where
@@ -734,7 +900,7 @@ Families:
   separately from the factorization of `p − 1` they depend on, so the
   check's cost is visible next to the search's.
 
-**Comparators.** PARI `factorint` via cypari2 is **informational**:
+**Comparators.** PARI `factor` via cypari2 is **informational**:
 PARI dispatches among trial division, SQUFOF, Pollard-Brent rho,
 `p − 1`, and MPQS with tuned crossovers, and this library specifies
 neither SQUFOF nor MPQS, so a required ratio would check an algorithm
@@ -743,8 +909,9 @@ the **table-range** and **balanced semiprime** families the ratio
 should be within a small constant, since both sides run the same two
 algorithms there, and a large ratio means the rho inner loop is wrong
 rather than that the dispatch is. GMP-ECM is **informational** on the
-unbalanced family for the same reason and with the same caveat. sympy
-is the oracle and is not a performance comparator.
+unbalanced family for the same reason and with the same caveat. The
+PARI/python-flint oracle pairing is for conformance, not a performance
+requirement.
 
 No advance claim is made on anything the quadratic sieve would reach,
 because nothing here reaches it.
@@ -758,33 +925,30 @@ theorem factors_eq (F : Factorization) (h : checkFactorization F = true) :
 theorem factorization_eq (F) (h : checkFactorization F = true) (p : Nat) :
     F.subject.factorization p = (F.factors.find? (·.prime = p)).elim 0 (·.exponent)
 
-theorem totient_eq (F : CheckedFactorization) :
-    totient F = Nat.totient F.raw.subject
+theorem totient_eq {n} (F : CheckedFactorization n) :
+    totient F = Nat.totient n
 theorem sigma_eq, divisors_eq, radical_eq
-theorem squarefreePart_spec, squareDivisor_spec
+theorem squarefreePart_mathlib, squareDivisor_mathlib
 
-theorem orderOf_eq {c} (h : checkOrder c = true) (hc : Nat.Coprime c.base c.modulus) :
-    orderOf (ZMod.unitOfCoprime c.base hc) = c.order
+theorem orderOf_eq {c} (h : checkOrder c = true) :
+    orderOf (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order
 ```
 
 `factorization_eq` is the correspondence everything else goes through:
 Mathlib's `Nat.factorization` is a `Finsupp` and this library's is an
 ascending list, and once they agree pointwise every arithmetic-function
-theorem in Mathlib applies. Mathlib has `Nat.factorization_prod_pow_eq_self`,
-`Nat.totient_eq_prod_factorization`, and `Nat.sigma_one_eq_sigmaOne`,
-so the companion's job is one correspondence and a series of
-one-line consequences, not a redevelopment. The exact declaration names
-should be read off the pinned Mathlib rather than from memory: an
-earlier draft of this SPEC cited
-`Nat.factorization_prod_pow_eq_self`, now a deprecated alias, and
-`Nat.sigma_one_eq_sigmaOne`, which does not exist in the pinned
-version.
+theorem in Mathlib applies. The companion's job is one correspondence
+and a series of short consequences, not a redevelopment. Exact helper
+declaration names are read from the pinned Mathlib during implementation;
+the SPEC deliberately does not depend on remembered names that may be
+deprecated or absent.
 
 **No `DecidablePred Squarefree` instance on `Nat`.** Mathlib has one
 (`Mathlib/Data/Nat/Squarefree.lean:234`), so a second would be a
 duplicate that risks instance-selection churn, exactly as a second
 `DecidablePred Nat.Prime` would. What the companion adds instead is the
-witness form -- `squarefreePart_spec` and `squareDivisor_spec` above --
+witness form -- `squarefreePart_mul_square` and `squareDivisor_spec`
+above --
 which the decision procedure does not produce.
 
 `orderOf_eq` needs a unit to speak about, and the coprimality that
@@ -796,33 +960,42 @@ nothing extra.
 
 1. **The certificate and the small routes.** `PrimePower`,
    `Factorization`, `CheckedFactorization`, `checkFactorization` and
-   its theorems, `factorPartial` with `checkPartial_factorPartial`, the
-   structural reductions, trial division against hex-primality's table,
-   and the divisor-function API. This factors every `n` whose least
-   prime factor is below the table bound, plus detected perfect powers
-   -- **not** everything below `10^{12}`, which an earlier draft
-   claimed: a semiprime with two factors near `10^6` survives a `10^4`
-   table and needs rho, which is milestone 3. It is enough for
-   hex-conway Tier 2 on the committed table.
+   its theorems, `CheckedPartialFactorization`, `factorPartial?`, the
+   structural reductions, and trial division against hex-primality's
+   table. The whole library starts after
+   hex-primality milestone 3, because `PrimePower` carries
+   `PrimeCert`. This milestone returns checked partial data for every
+   positive input and a complete result when every residual prime can
+   be certified; it makes no blanket size claim. The committed Conway
+   table is a required regression family, not a currently blocked
+   consumer.
 
-2. **The order API.** `OrderCert`, `checkOrder`, `order_eq_of_checkOrder`,
-   `isPrimitiveRoot`, `primitiveRoot?`, `carmichael`. Depends on
-   hex-primality milestone 2 for the multiplicative order.
+2. **The divisor-function API.** The total functions, their local
+   semantic theorems, divisor-enumeration completeness, the prime-power
+   coprime count, and the finite CRT counting bijection named above.
 
-3. **Pollard rho and `p − 1`.** Routes 1 and 2, with the route-level
-   tests written before the code, and the `p − 1` stage-2 continuation
-   decided by its benchmark family rather than assumed.
+3. **The order API.** `OrderCert`, `CheckedOrderCert`, `checkOrder`,
+   `order_eq_of_checkOrder`, the primitive-root result theorems,
+   `carmichael`, `pow_carmichael`, and `orderOf_dvd_carmichael`,
+   including the prime-power congruence prerequisites named above.
 
-4. **The cyclotomic split.** `cyclotomicSplit`, the Möbius-inversion
-   evaluation of `Φ_d(b)`, and the `b^n ± 1` benchmark family. Ahead of
-   ECM, because it is the cheaper of the two and it is the one this
-   tree's consumers need.
+4. **Shared rho and Pollard `p − 1`.** Integrate hex-primality's
+   `rhoFactor?` and implement route 2 stage 1, with route-level tests
+   written before the code.
 
-5. **ECM.** Montgomery curves, Suyama parameterisation, stages 1 and 2.
+5. **The cyclotomic candidate.** `cyclotomicSplit?`, its checked product
+   theorem, the recursive evaluation candidate, and the `b^n ± 1`
+   benchmark family. Ahead of ECM because it is cheaper and directly
+   serves the motivating family.
 
-6. **The companion.** `factorization_eq` and its consequences, the two
-   decidability instances, `orderOf_eq`. Begins after milestone 1 and
-   runs in parallel with 2 through 5.
+6. **ECM stage 1.** Montgomery curves, Suyama parameterisation, the
+   word/direct-`Nat` arithmetic dispatch, and its route-level tests.
+
+7. **The companion.** `factorization_eq` and its consequences plus
+   `orderOf_eq`. It adds no duplicate decidability instances. The
+   factorization correspondence begins after milestone 1; divisor and
+   order transports follow milestones 2 and 3 while later search routes
+   proceed independently.
 
 ## File organisation
 
@@ -832,16 +1005,15 @@ HexIntFactor/
   Partial.lean      -- PartialFactorization and checkPartial
   Divisors.lean     -- the divisor-function API
   Small.lean        -- trailing zeros, perfect powers, trial division
-  Rho.lean          -- Pollard rho with Brent
-  PMinusOne.lean    -- Pollard p-1, stages 1 and 2
-  Ecm.lean          -- Montgomery-curve ECM
-  Cyclotomic.lean   -- cyclotomicSplit and the Mobius evaluation
+  Rho.lean          -- adapter from the shared rho primitive to the dispatch
+  PMinusOne.lean    -- Pollard p-1 stage 1
+  Ecm.lean          -- Montgomery-curve ECM stage 1
+  Cyclotomic.lean   -- cyclotomicSplit? and the checked candidate
   Order.lean        -- OrderCert, checkOrder, primitive roots, Carmichael
-  Factor.lean       -- the dispatch, factor?, factor, factorPartial
+  Factor.lean       -- the dispatch, factor?, factorPartial?
 HexIntFactor.lean
 HexIntFactorMathlib/
   Factorization.lean -- factorization_eq, factors_eq and consequences
-  Decide.lean       -- DecidablePred Squarefree on Nat and on MvPolynomial (Fin n) Z
   Order.lean        -- orderOf_eq
 HexIntFactorMathlib.lean
 ```
@@ -861,11 +1033,12 @@ HexIntFactorMathlib.lean
     status: draft
 ```
 
-and `HexConway` gains a dependency on `HexIntFactor` when Tier 2
-lands. `HexMvGcdMathlib` does **not** gain one: as set out above,
-Mathlib already decides squarefreeness on `Nat`, so hex-mv-gcd's
-deferral of that instance to this item is unnecessary and its SPEC
-should be corrected rather than depended on.
+`HexConway` need only gain a dependency on `HexIntFactor` if its table
+growth is refactored to consume these shared certificates; Tier 2 has
+already landed without it. `HexMvGcdMathlib` does **not** gain one: as set out above,
+Mathlib already decides squarefreeness on `Nat`; hex-mv-gcd's SPEC has
+already been corrected to use that instance and to cite this library
+only for factorization-derived witnesses.
 
 Neither `HexPrimality` nor `HexIntFactor` is in `libraries.yml` yet, so
 the dependency claims above are draft prose rather than repository
@@ -873,12 +1046,6 @@ state until those entries land.
 
 ## Open questions
 
-- **Whether `factor?` should exist at all**, given that
-  `factorPartial` is total, always valid, and returns `residual = 1`
-  exactly when the factorization is complete. `factor?` is then a thin
-  wrapper testing that residual. Keeping both is a convenience
-  judgement, and the first consumer that is not hex-conway should
-  settle it.
 - **The default fuel schedule.** Stated above as a function of bit
   length and not fixed. It should be set so that the 64-bit balanced
   semiprime family finishes with margin, measured rather than guessed.
@@ -887,7 +1054,7 @@ state until those entries land.
   continued-fraction development and its failure modes are subtler than
   rho's. Worth revisiting if the balanced-semiprime family shows the
   PARI ratio is dominated by that one range.
-- **Whether Aurifeuillian factorizations belong in `cyclotomicSplit`.**
+- **Whether Aurifeuillian factorizations belong in `cyclotomicSplit?`.**
   They are a finite family of identities rather than an algorithm, so
   adding them is a table. Worth doing once the `b^n ± 1` benchmark
   family produces a case where a factor stayed unfactored and an

--- a/SPEC/Libraries/hex-primality.md
+++ b/SPEC/Libraries/hex-primality.md
@@ -24,11 +24,11 @@ predicate, `2 ≤ p ∧ ∀ m, m ∣ p → m = 1 ∨ m = p`, with Euclid's lemma
 dream (`add_pow_prime_mod`), and Fermat's little theorem
 (`pow_prime_mod`) proved on top of it.
 
-`Hex.Nat.isPrimeTrial` (`:561`) is bounded trial division with a
+`Hex.Nat.isPrimeTrial` (`:702`) is bounded trial division with a
 balanced binary recursion, so kernel reduction depth is logarithmic in
 the candidate count while the number of remainder tests stays
-`O(√n)`. It has soundness (`isPrimeTrial_isPrime`, `:646`) **and**
-completeness (`isPrimeTrial_of_prime`, `:703`), so the pair is a
+`O(√n)`. It has soundness (`isPrimeTrial_isPrime`, `:786`) **and**
+completeness (`isPrimeTrial_of_prime`, `:843`), so the pair is a
 decision procedure in everything but name -- there is no
 `Decidable (Hex.Nat.Prime n)` instance in the tree, and adding one is
 two lines.
@@ -44,7 +44,7 @@ search infrastructure rather than a checker primitive: `HexArith.extGcd`
 `@[extern]`. The namespace is `HexArith`, not `Hex`.
 
 `hex-berlekamp-zassenhaus` carries 94 candidate primes in
-`hotPathCandidates` (`HexBerlekampZassenhaus/PrimeSelection.lean:626`),
+`hotPathCandidates` (`HexBerlekampZassenhaus/PrimeSelection.lean:647`),
 each built by `smallPrimeCandidateOfTrial p (by decide) (by decide)`,
 covering every prime in `[3, 500]`. It proves both directions:
 `mem_hotPathCandidates_prime` (every entry is prime and in range) and
@@ -103,10 +103,11 @@ rather than a copy.
   running 32 doubling rounds, covering `M < 2^{32}` and so `n` up to
   roughly `1.3 · 10^{10}`. `PrimeCertTest/SieveVerify1e8.lean` exercises
   it at `10^8`.
-- **Its toolchain is `leanprover/lean4:v4.33.0`**; hex-dev is on
-  `v4.32.0-rc1` with Mathlib pinned at `v4.32.0-rc1-patch1`. So even the
-  companion cannot depend on it today without a toolchain bump on one
-  side or the other.
+- **Its toolchain is `leanprover/lean4:v4.33.0`**; hex-dev currently
+  uses `v4.33.0-rc1` with Mathlib pinned to the matching release
+  candidate. Stable and release-candidate Lean packages are not
+  interchangeable, so a companion dependency still requires aligned
+  pins. The exact gap must be rechecked at implementation time.
 
 Three consequences, and they are the design decisions this SPEC turns
 on.
@@ -135,7 +136,8 @@ on.
 
 ## Scope
 
-In scope: the `Decidable (Hex.Nat.Prime n)` instance; Miller-Rabin as
+In scope: the hex-arith amendment adding the
+`Decidable (Hex.Nat.Prime n)` instance; Miller-Rabin as
 an untrusted filter with a proved compositeness direction; the
 Pocklington certificate, its checker, and its soundness theorem; the
 cube-root variant; a stored initial segment and the sieve that
@@ -193,7 +195,7 @@ theorem exists_prime_le_sqrt (h : 2 ≤ n) (hcomp : ¬ Prime n) :
 The instance belongs next to the two theorems that prove it, and makes
 `decide` available on small `n` without importing this library. The two
 existence lemmas are what the Pocklington argument finishes with;
-hex-arith has `exists_trial_divisor` (`HexArith/Nat/Prime.lean:609`),
+hex-arith has `exists_trial_divisor` (`HexArith/Nat/Prime.lean:750`),
 which is `private` and produces a divisor rather than a *prime*
 divisor, so it can be neither imported nor used as it stands.
 
@@ -253,7 +255,7 @@ the first witness clause *fail*. It makes it hold, since `0 ≢ 1`.
 
 The proof, for the `otherwise` branch, with `n` odd, `n > 2`, and
 `Nat.gcd a n = 1`. Suppose `n` is prime. hex-arith proves Fermat in the
-form `a^p % p = a % p` (`pow_prime_mod`, `HexArith/Nat/Prime.lean:527`),
+form `a^p % p = a % p` (`pow_prime_mod`, `HexArith/Nat/Prime.lean:668`),
 not in the multiplicative form, so the first step is a cancellation
 lemma giving `a^{n-1} % n = 1 % n` from coprimality; that lemma is a
 prerequisite, listed below. Then the sequence
@@ -271,7 +273,10 @@ Prerequisite lemmas, none of which the tree has:
 ```lean
 theorem pow_pred_mod (hp : Prime p) (h : Nat.Coprime a p) : a ^ (p - 1) % p = 1 % p
 theorem orderOf_pos (h1 : 1 < n) (h : Nat.Coprime a n) : 0 < orderOf a n
-theorem orderOf_dvd_of_pow_eq_one (h : a ^ k % n = 1 % n) (hk : 0 < k) :
+theorem coprime_of_pow_mod_eq_one (h1 : 1 < n) (hk : 0 < k)
+    (h : a ^ k % n = 1 % n) : Nat.Coprime a n
+theorem orderOf_dvd_of_pow_eq_one (h1 : 1 < n) (hk : 0 < k)
+    (h : a ^ k % n = 1 % n) :
     orderOf a n ∣ k
 theorem orderOf_dvd_pred (hp : Prime p) (h : Nat.Coprime a p) : orderOf a p ∣ p - 1
 theorem prime_dvd_of_two_le (h : 2 ≤ d) : ∃ q, Prime q ∧ q ∣ d
@@ -281,7 +286,7 @@ theorem exists_prime_le_sqrt (h : 2 ≤ n) (hcomp : ¬ Prime n) :
 
 The last is the composite-witness lemma the Pocklington argument
 finishes with. hex-arith has a version of it, but
-`exists_trial_divisor` (`HexArith/Nat/Prime.lean:609`) is `private`
+`exists_trial_divisor` (`HexArith/Nat/Prime.lean:750`) is `private`
 and returns a divisor rather than a *prime* divisor, so it can be
 neither imported nor used as it stands. Exporting a prime-divisor form
 from hex-arith is a prerequisite amendment, and it is the same
@@ -324,7 +329,17 @@ def PrimeCert.subject : PrimeCert → Nat
   | .small n | .pock n _ | .pock3 n _ _ _ => n
 
 def checkPrime (c : PrimeCert) : Bool
+
+/-- An accepted certificate tied to the number requested by its caller. -/
+structure CheckedPrimeCert (n : Nat) where
+  raw       : PrimeCert
+  subject_eq : raw.subject = n
+  valid     : checkPrime raw = true
 ```
+
+The indexed wrapper is the public result of certificate search. The subject
+equality is load-bearing: `checkPrime` proves primality of `c.subject`, not of
+an unrelated input that happened to request `c`.
 
 The prime `q` of each factor entry is **not stored**; it is read off as
 `cert.subject`. An earlier draft stored both and did not check they
@@ -333,22 +348,27 @@ agreed, which let a certificate for `2` be attached to a claimed factor
 it from the child removes the check by removing the redundancy, which
 is the better of the two fixes.
 
-`checkPrime` on `pock n factors` verifies, cheapest first:
+`checkPrime` on `pock n factors` verifies, with cheap structural and
+arithmetic rejections before recursive certificate replay:
 
 1. `2 ≤ n` and `n` is odd.
-2. The subjects `q` of the child certificates are pairwise distinct.
-3. Each child is accepted by `checkPrime`, recursively.
-4. `F = ∏ q^(e+1)` divides `n - 1`.
-5. `n < F * F`.
-6. For each `(a, e, child)`, with `q = child.subject`:
-   `powMod a (n-1) n = 1 % n` and
-   `Nat.gcd ((powMod a ((n-1)/q) n + n - 1) % n) n = 1`.
+2. The subjects `q` of the child certificates satisfy `2 ≤ q` and are
+   pairwise distinct.
+3. `F = ∏ q^(e+1)` divides `n - 1`; each power is accumulated by a
+   bounded loop and the whole product aborts as soon as its running
+   value exceeds `n - 1`, rather than constructing an attacker-chosen
+   enormous power.
+4. `n < F * F`.
+5. For each `(a, e, child)`, with `q = child.subject`:
+   `HexArith.powModNat a (n-1) n = 1 % n` and
+   `Nat.gcd ((HexArith.powModNat a ((n-1)/q) n + n - 1) % n) n = 1`.
+6. Each child is accepted by `checkPrime`, recursively.
 
-Step 5 is `n < F * F` rather than `n.sqrt < F`. The two are equivalent
+Step 4 is `n < F * F` rather than `n.sqrt < F`. The two are equivalent
 and the multiplication is cheaper and easier to reason about than
 `Nat.sqrt`.
 
-Step 6's gcd argument is written modularly. The checker cannot form the
+Step 5's gcd argument is written modularly. The checker cannot form the
 literal `a^{(n-1)/q}`, only its residue `x`, and `Nat.gcd (x - 1) n` is
 the wrong expression at `x = 0` because `Nat` subtraction truncates.
 `(x + n - 1) % n` is `x - 1` modulo `n` at every residue.
@@ -359,8 +379,8 @@ from `F ∣ n - 1`, the certified complete factorization of `F`, and the
 per-prime conditions alone. The coprimality hypothesis belongs to the
 cube-root variant, not to this one.
 
-Step 6 is two modular exponentiations and one `Nat.gcd` per factor;
-step 4 is one multiplication and one division. So one level of the
+Step 5 is two modular exponentiations and one `Nat.gcd` per factor;
+step 3 is one bounded product and one division. So one level of the
 checker costs `O(k)` modular exponentiations for `k` factors, each
 `O(log n)` modular multiplications.
 
@@ -379,14 +399,16 @@ additional ones.
   than through a `q`-adic valuation, so that no valuation API is needed
   for this one use.
 - **`dvd_of_coprime_prime_powers`**: a product of powers of distinct
-  primes, each dividing `m`, divides `m`. This is what turns the
-  per-factor conclusions into `F ∣ orderOf a p`.
+  primes, each dividing `m`, divides `m`.
 - **gcd-to-noncongruence transport**: `Nat.gcd ((x + n - 1) % n) n = 1`
   and `p ∣ n` give `x ≢ 1 (mod p)`.
-- **The Pocklington step**: let `p` be any prime divisor of `n`. Step 6
-  gives `a^{(n-1)/q} ≢ 1 (mod p)` and `a^{n-1} ≡ 1 (mod p)`, so
-  `q^(e+1) ∣ orderOf a p` for each factor, hence `F ∣ orderOf a p`,
-  and `orderOf a p ∣ p - 1`, so `F ≤ p - 1` and `p ≥ F + 1`. If `n`
+- **The Pocklington step**: let `p` be any prime divisor of `n`. For
+  each entry's own witness `a_q`, step 5 gives
+  `a_q^{(n-1)/q} ≢ 1 (mod p)` and `a_q^{n-1} ≡ 1 (mod p)`, so
+  `q^(e+1) ∣ orderOf a_q p ∣ p - 1`. Combining those pairwise-coprime
+  prime powers gives `F ∣ p - 1`; there is no common witness and no
+  claim that `F` divides one common multiplicative order. Thus
+  `F ≤ p - 1` and `p ≥ F + 1`. If `n`
   were composite it would have a prime divisor `p` with `p * p ≤ n`, and
   `n < F * F ≤ (p-1) * (p-1) < p * p` contradicts that. So `n` is
   prime.
@@ -430,13 +452,16 @@ Condition 6's middle disjunct is not redundant: `r² < 8s` makes
 avoids encoding a negative quantity with truncated `Nat` subtraction.
 The integer square test is `let t := Nat.sqrt m; t * t == m`.
 
-The hypothesis set above is the one in the formalised Coq treatment,
+The hypothesis set above is the `m = 1` specialization of the
+Brillhart-Lehmer-Selfridge theorem formalised in
 Grégoire, Théry and Werner, "A Computational Approach to Pocklington
 Certificates in Type Theory",
 https://www-sop.inria.fr/members/Benjamin.Gregoire/Publi/pock.pdf, and
-matching it is deliberate: PrimeCert's `Pocklington3.lean` states the
-same theorem, so a future companion-side dependency becomes a
-substitution rather than a translation.
+in PrimeCert's `Pocklington3.lean`. PrimeCert states the stronger form
+with an extra parameter `m`, a check excluding divisors `lF + 1` for
+`1 ≤ l < m`, and the corresponding relaxed bound. A future
+companion-side dependency may instantiate it at `m = 1`; this checker
+does not claim that stronger parameterised interface.
 
 ### What an accepted certificate proves, and what it does not
 
@@ -444,12 +469,13 @@ substitution rather than a translation.
 proves its subject prime. Four further statements are distinct from it
 and none is claimed:
 
-- *certificate existence*: every prime has a `PrimeCert`. True, by
-  induction, but not proved here and not needed.
+- *certificate existence*: every prime has a `PrimeCert`. This is
+  mathematically true using existence of suitable multiplicative-order
+  witnesses, but it is not proved here and is not needed.
 - *checker completeness*: every mathematically valid certificate is
   accepted. Worth having as a regression test, not as a theorem.
 - *search completeness*: `primeCert?` finds one. False, and the
-  `Option` in its type says so.
+  `PrimeCertStop.exhausted` result in its type says so.
 - *the certificate carries no second witness obligation*. This one does
   hold, and it is what makes this item cheap relative to most of
   [future-work](../future-work.md): primality is the whole conclusion,
@@ -463,15 +489,46 @@ That last point is why the dependency runs the way it does.
 hex-int-factor depends on hex-primality, because a factorization
 certificate has to prove its factors prime. hex-primality does **not**
 depend on hex-int-factor, because the factorization of `n - 1` it needs
-is search, not proof. To keep it that way, hex-primality owns
-`partialFactor`: trial division by the stored table followed by Pollard
-rho, with a fuel bound.
+is search, not proof. To keep it that way, hex-primality owns the shared
+untrusted Brent-rho primitive and an internal `partialFactor`: trial
+division by the stored table followed by that primitive, with a fuel
+bound.
+
+```lean
+/-- Why a proper-factor search stopped without a factor. -/
+inductive RhoStop where
+  | invalidInput
+  | exhausted
+
+/-- A resumable failure, following the tree's randomized-search convention. -/
+structure RhoFailure where
+  stop     : RhoStop
+  attempts : Nat
+  rand     : Rand
+
+/-- A dynamically validated proper-factor candidate. -/
+def rhoFactor? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except RhoFailure (Nat × Rand)
+
+theorem rhoFactor?_spec {n d r r' fuel}
+    (h : rhoFactor? n r fuel = .ok (d, r')) :
+    1 < d ∧ d < n ∧ d ∣ n
+```
+
+`rhoFactor?` validates range and divisibility before returning.
+Randomness and fuel affect only whether it finds a factor. The advanced
+state is returned even on `.error`, so callers can resume rather than
+accidentally reuse the same failed stream. `.invalidInput` covers
+`n < 4`; `exhausted` includes prime inputs and any composite for which
+no proper factor was found, and makes no primality claim. It is public
+because hex-int-factor reuses this exact primitive; it does not certify
+that `d` is prime and makes no completeness claim.
 
 `partialFactor` is **internal**, not part of the public API. An earlier
 draft exposed it with "no correctness theorem at all", which is safe
 only if every consumer checks everything, and its return type said
-nothing about what it had produced. It keeps one theorem, which is what
-both consumers need and all they need:
+nothing about what it had produced. It keeps the one theorem its
+certificate-search consumer needs:
 
 ```lean
 /-- Candidate partial factorization: bases with positive exponents, and
@@ -480,65 +537,23 @@ structure PartialFactors where
   factors  : List (Nat × Nat)
   residual : Nat
 
-private def partialFactor (n fuel : Nat) : PartialFactors
+private def partialFactor (n : Nat) (r : Rand) (fuel : Nat) :
+    PartialFactors × Rand
 
-private theorem partialFactor_prod (n fuel : Nat) (hn : 0 < n) :
-    ((partialFactor n fuel).factors.map (fun e => e.1 ^ e.2)).prod
-      * (partialFactor n fuel).residual = n
+private theorem partialFactor_prod (n r fuel) (hn : 0 < n) :
+    (((partialFactor n r fuel).1.factors.map
+      (fun e => e.1 ^ e.2)).prod * (partialFactor n r fuel).1.residual) = n
 ```
 
-hex-int-factor reuses this same Pollard rho rather than introducing a
-second one: the primitive lives in the lower library and the elaborate
-version, with Brent's cycle detection, `p - 1`, and ECM, lives in the
-higher one.
+hex-int-factor reuses `rhoFactor?` rather than introducing a second rho.
+Brent's cycle detection is already part of the lower primitive; the
+higher library adds structural reductions, `p - 1`, ECM,
+complete-factorization assembly, and their dispatch.
 
 **The multiplicative order is the new development**, and it is the
 thing to build first because [hex-int-factor](hex-int-factor.md) needs
 it too, for its primitive-root API. It belongs here, in
 `HexPrimality/Order.lean`, and hex-int-factor consumes it.
-
-### The cube-root variant
-
-Pocklington needs `F > √n`, which needs a factorization of `n - 1` that
-gets past half its bits. The Brillhart-Lehmer-Selfridge extension
-relaxes that to `F > n^{1/3}` at the cost of a further condition: write
-`n = m F + 1` with `0 ≤ m < F`, and `m = 2 F s + r` -- then `n` is prime
-provided `r² - 8s` is not a perfect square (and `s = 0` or the
-usual side conditions hold).
-
-That is a materially better test in practice, because the difficulty of
-producing a certificate is dominated by how far into `n - 1` the
-factorization has to reach, and a cube root is much easier to reach
-than a square root. It is milestone 4 rather than milestone 2 because
-the perfect-square condition needs an exact integer square root and its
-correctness argument, and because Pocklington alone is enough for every
-consumer this tree has today.
-
-PrimeCert's `Pocklington3.lean` is the reference for the exact
-hypothesis set (`pocklington3_test (N F R m r s)` there), and its
-statement is what this SPEC's version should match, so that a future
-companion-side dependency is a substitution rather than a translation.
-
-### The certificate is complete
-
-Unlike most items in [future-work](../future-work.md), this one needs
-no second witness. `checkPrime c = true` establishes `Prime c.subject`
-outright: primality is the whole conclusion, and there is no
-minimality, maximality, or completeness clause left over. The
-certificate is also small -- `O(k)` numbers of at most `log n` bits for
-`k` factors, recursively -- and the search that finds it, which needs a
-partial factorization of `n - 1`, runs entirely untrusted.
-
-That last point is why the dependency runs the way it does.
-hex-int-factor depends on hex-primality, because a factorization
-certificate has to prove its factors prime. hex-primality does **not**
-depend on hex-int-factor, because the factorization of `n - 1` it needs
-is search, not proof. To keep it that way, hex-primality owns a small
-untrusted `partialFactor`: trial division by the stored segment
-followed by Pollard rho, with a fuel bound and no correctness theorem
-at all. hex-int-factor then builds on that same rho rather than
-introducing a second one -- the primitive lives in the lower library and
-the elaborate version lives in the higher one.
 
 ## Initial segments
 
@@ -548,14 +563,14 @@ verifies it.
 
 ```lean
 /-- Every prime below `primeTableBound`, ascending. A committed literal,
-checked against one `sieve` evaluation by `decide +kernel`; it is not
-recomputed from the sieve at use time. -/
+checked against one mathematical sieve run through bounded kernel-replayed
+batches; it is not recomputed from the sieve at use time. -/
 def primeTable : Array Nat
 
 /-- Membership, by binary search. -/
 def isTablePrime (n : Nat) : Bool
 
-theorem primeTable_sorted : primeTable.toList.Chain' (· < ·)
+theorem primeTable_sorted : primeTable.toList.Pairwise (· < ·)
 theorem mem_primeTable_prime {n : Nat} (h : n ∈ primeTable) : Hex.Nat.Prime n
 theorem mem_primeTable_of_prime {n : Nat} (hp : Hex.Nat.Prime n)
     (hlt : n < primeTableBound) : n ∈ primeTable
@@ -583,13 +598,15 @@ residues coprime to `6`: `0 ↦ 1, 1 ↦ 5, 2 ↦ 7, 3 ↦ 11, …`. -/
 def numOfIndex (t : Nat) : Nat
 
 theorem sieve_testBit_iff {bound sqrtBound t : Nat}
+    (hmask : (bound - 1) / 3 < 2 ^ 32)
     (hsqrt : bound ≤ sqrtBound * sqrtBound) (ht : 0 < t)
     (hrange : numOfIndex t < bound) :
     (sieve bound sqrtBound).testBit t = true ↔ Hex.Nat.Prime (numOfIndex t)
 ```
 
-The three hypotheses are all load-bearing and an earlier draft of this
-SPEC had none of them. Without `hrange` the statement is false: above
+The four hypotheses are all load-bearing. `hmask` is the range promised
+by the fixed 32 doubling rounds; without it the marking masks no longer
+cover the represented bitset. Without `hrange` the statement is false: above
 the represented range every bit is clear while `numOfIndex t` may well
 be prime. Without `ht` it is false at `t = 0`, where `numOfIndex 0 = 1`.
 And `hsqrt` is what makes the marking loop complete.
@@ -598,11 +615,16 @@ Indexing the residues coprime to `6` excludes `2` and `3` by
 construction, so the table's construction adds them explicitly and
 `primeTable`'s two theorems, not the sieve's, are what a caller uses.
 
-The table is then a `decide +kernel` consequence of one sieve
-evaluation, not 168 or 3000 separate `decide` calls.
+The table is a consequence of one sieve run, but not one monolithic
+reduction. A Mathlib-free elaborator computes the bitset with a compiled
+twin, emits equations for fixed-size batches of sieve steps, kernel-checks
+each equation by reduction, and chains the equations to the final literal.
+This is PrimeCert's `run_sieve` architecture and is required here: a
+single enormous `decide +kernel` expression is not the scaling claim.
 
 **`primeTableBound` is set by measurement, not chosen.** The bound is
-whatever keeps the table's own verification inside the "few minutes on
+whatever keeps the table's own verification, generated source size, and
+incremental compile cost inside the "few minutes on
 the benchmark machine" budget that
 [hex-conway](../../HexConway/SPEC/hex-conway.md) sets for its committed
 table, and the same rule applies for the same reason. The
@@ -619,7 +641,7 @@ list without loss, it is not.
 
 Two things that migration requires and an earlier draft of this SPEC
 left out. `hotPathCandidates` is a `List SmallPrimeCandidate`
-(`HexBerlekampZassenhaus/PrimeSelection.lean:499`), not a list of
+(`HexBerlekampZassenhaus/PrimeSelection.lean:519`), not a list of
 naturals: each entry bundles a `ZMod64.Bounds p` instance and a
 `Hex.Nat.Prime p` field, so the view is a proof-carrying map from table
 entries rather than a projection. And it makes `HexBerlekampZassenhaus`
@@ -639,40 +661,83 @@ in the sense that nobody has run it.
 ```lean
 namespace Hex.Nat
 
-def isPrime (n : Nat) : Bool
-def primeCert? (n : Nat) (r : Rand) (fuel : Nat) : Option (PrimeCert × Rand)
+inductive PrimeCertStop where
+  | composite
+  | exhausted
+
+structure PrimeCertFailure where
+  stop     : PrimeCertStop
+  attempts : Nat
+  rand     : Rand
+
+structure PrimeDecisionFailure where
+  attempts : Nat
+  rand     : Rand
+
+structure NextPrimeFailure where
+  attempts : Nat
+  rand     : Rand
+
+def defaultPrimeFuel (n : Nat) : Nat
+
+def primeCert? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except PrimeCertFailure (CheckedPrimeCert n × Rand)
 def checkPrime (c : PrimeCert) : Bool
-def nextPrime? (n fuel : Nat) : Option Nat
+def isPrime? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except PrimeDecisionFailure (Bool × Rand)
+def isPrime (n : Nat) : Bool
+def nextPrime? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except NextPrimeFailure (Nat × Rand)
 def primesIn (lo hi : Nat) : Array Nat
 
-theorem isPrime_iff {n : Nat} : isPrime n = true ↔ Hex.Nat.Prime n
+theorem isPrime_iff {n} : isPrime n = true ↔ Hex.Nat.Prime n
+theorem isPrime?_spec {n r fuel b r'}
+    (h : isPrime? n r fuel = .ok (b, r')) :
+    b = true ↔ Hex.Nat.Prime n
+theorem primeCert?_composite {n r fuel f}
+    (hresult : primeCert? n r fuel = .error f)
+    (hstop : f.stop = .composite) :
+    ¬ Hex.Nat.Prime n
 theorem mem_primesIn {lo hi n : Nat} :
     n ∈ primesIn lo hi ↔ lo ≤ n ∧ n < hi ∧ Hex.Nat.Prime n
-theorem nextPrime?_spec {n fuel p : Nat} (h : nextPrime? n fuel = some p) :
+theorem nextPrime?_spec {n r r' fuel p}
+    (h : nextPrime? n r fuel = .ok (p, r')) :
     n < p ∧ Hex.Nat.Prime p ∧ ∀ q, n < q → q < p → ¬ Hex.Nat.Prime q
 ```
 
-`isPrime` dispatches: table lookup below `primeTableBound`; trial
+`isPrime?` dispatches: table lookup below `primeTableBound`; trial
 division below a measured second threshold; `isProbablePrime` as a
-filter; then `primeCert?` and `checkPrime`, falling back to trial
-division whenever the search returns `none` or the checker rejects.
-`isPrime_iff` is an iff, not a one-directional "soundness": trial
-division is always available as a last resort and always terminates,
-slowly and correctly, so the function decides.
+filter; then `primeCert?`. A failed base returns a certified `false`, an
+accepted certificate returns `true`, and an exhausted certificate search
+returns `.error` rather than falling into an unbounded computation. The
+indexed success prevents a certificate for one number from answering a
+request about another.
+
+`isPrime` is the pure total convenience API. It runs `isPrime?` with
+`defaultPrimeFuel n` from the reproducible seed `Rand.ofSeed n` and
+falls back to `isPrimeTrial` only if the bounded path exhausts its fuel.
+Thus `isPrime_iff` is an
+iff, while callers that need a real time bound and resumable random
+state use `isPrime?`. No `fuel` argument is attached to a computation
+whose worst-case fallback it does not bound.
 
 `nextPrime?` is fuel-bounded rather than total. A total "least prime
 greater than `n`" needs Euclid's theorem and a well-founded search, and
 this tree has neither Mathlib-free; an earlier draft of this SPEC
 declared `nextPrime : Nat → Nat` with no account of either. Adding
 Euclid would make the total form available and is not on any consumer's
-critical path, so the `Option` is what is specified, with the theorem
-recording that the answer is the *least* such prime.
+critical path, so `NextPrimeFailure` reports exhaustion with the attempt
+count and advanced state. The theorem records that a success is the
+*least* such prime.
 
-`primeCert?` returns `none` on fuel exhaustion, and fuel exhaustion is
-reachable: the certificate search needs `n - 1` factored past a square
-root (or a cube root), and there are `n` for which that is out of
-reach. It threads `Rand` because `partialFactor` runs Pollard rho.
-The `Option` propagates rather than being papered over, which is
+`primeCert?` distinguishes `PrimeCertStop.composite`, justified by trial
+division or a failed Miller-Rabin base, from `.exhausted`, which makes
+no primality claim. Exhaustion is reachable: the certificate search needs `n - 1`
+factored past a square root (or a cube root), and there are `n` for
+which that is out of reach. `PrimeCertFailure` retains the advanced
+state and attempt count because `partialFactor` runs Pollard rho; success
+returns the state alongside the certificate. The failure propagates
+rather than being papered over, which is
 design principle 8's third remedy again.
 
 ## The tactic
@@ -684,10 +749,15 @@ primality           -- tactic: closes a `Hex.Nat.Prime e` goal
 
 Following `factor_poly` and `irreducibility` in hex-berlekamp: the
 search runs at elaboration time as untrusted compiled code, and the
-emitted term is `prime_of_checkPrime (c := ⟨…⟩) (by decide +kernel)`
-with the certificate reified as a literal. The kernel replays only
+emitted term is `prime_of_checkPrime (c := literalCert) (by decide +kernel)`
+with the inductive certificate reified by its constructors. The kernel replays only
 `checkPrime`, which is `O(k log n)` modular multiplications on
 GMP-backed `Nat`, and never the search.
+
+For reproducible syntax with no seed argument, the elaborator uses
+`Rand.ofSeed n`; the lower `primeCert?` API remains explicitly seeded,
+and diagnostics report the seed and attempts if certificate search
+exhausts its fuel.
 
 The companion adds `Nat.Prime n` through that correspondence, and
 registers a
@@ -734,8 +804,10 @@ downstream module is what actually confirms.
 
 The sieve is `@[expose]` and kernel-reducible by construction, since
 generating the committed table is a kernel computation. Miller-Rabin,
-`partialFactor`, Pollard rho, and `primeCert?` are search, appear in no
-proof term, and are not exposed.
+`rhoFactor?`, `partialFactor`, `primeCert?`, `isPrime?`, `isPrime`, and
+`nextPrime?` are search or runtime dispatch, appear in no proof term,
+and are not exposed. The `DecidablePred` instance continues to use
+hex-arith's kernel-reducible `isPrimeTrial`.
 
 ## Complexity
 
@@ -748,10 +820,12 @@ factors in the certificate's factored part.
 | `isPrimeTrial` | `O(√n)` remainder tests | hex-arith, unchanged |
 | `millerRabin` one base | `O(b)` modular multiplications | |
 | `isProbablePrime` | `O(13 b)` | fixed base list |
+| successful `isPrime?` | front end plus certificate search | bounded by explicit fuel after the fixed front end |
+| `isPrime` worst case | `O(√n)` remainder tests | exact fallback after default search exhaustion |
 | `checkPrime`, one Pocklington level | `O(k b)` modular multiplications | |
 | `checkPrime`, full tree | `O(K b)` modular multiplications | `K` = total factor entries over all nodes |
 | `primeCert?` | dominated by `partialFactor` | unbounded; fuel-limited |
-| sieve to `N` | `O(N / log N)` marking rounds | each a bit operation on an `N/3`-bit `Nat` |
+| sieve to `N` | `O(√N + π(√N) · 32)` loop/doubling rounds | each marking round is a bit operation on an `N/3`-bit `Nat` |
 
 These are operation counts, not bit complexity; the operands are big
 integers and a bit-complexity model would have to name a multiplication
@@ -815,13 +889,16 @@ Cases that must be present:
   the same contents in the same order.
 
 **Oracle choice.** PARI's `isprime`, `nextprime`, and `primes`
-through cypari2 cover the whole surface, and cypari2 is already
-installed by the CI dependency step; PARI's `isprime` with flag `1`
-also returns a Pocklington-style certificate, which makes it the
-natural cross-check for the `certcheck` fixtures. hex's checker should
-accept PARI's certificates after translation, which is a stronger test
-than agreeing on a verdict. python-flint's `fmpz.is_prime` is the
-second opinion on the large cases and is likewise already installed.
+through cypari2 cover the verdict surface, and cypari2 is already
+installed by the CI dependency step. Current PARI exposes certificates
+through `primecert`, not through the result of `isprime(n, 1)`;
+`primecert(n,,1)` requests its N-1 certificate form. The oracle validates
+that object with `primecertisvalid`, translates the cases satisfying this
+checker's `m = 1` hypotheses, and commits accepted translations as
+`certcheck` fixtures. Agreement on all `isprime` verdicts remains required
+even when PARI chooses another certificate form. python-flint's
+`fmpz.is_prime` is the second opinion on the large cases and is likewise
+already installed.
 
 sympy is **not installed**: `.github/workflows/ci.yml` installs
 `python-flint`, `cypari2`, and `conway-polynomials` and nothing else, so
@@ -838,16 +915,18 @@ the kernel side is the point of the library.
 
 Families:
 
-- **Table verification**, the `decide +kernel` cost of the committed
-  table at bounds `10^4`, `10^5`, `10^6`, `10^7`. This family sets
+- **Table verification**, the batched kernel-replay cost and generated
+  artifact size of the committed table at bounds `10^4`, `10^5`,
+  `10^6`, `10^7`. This family sets
   `primeTableBound`: the largest bound whose verification stays inside
   the few-minutes budget wins, and the number is committed only after
   it is measured here.
 - **Kernel replay**, `checkPrime` on certificates for primes of `32`,
   `64`, `128`, `256`, and `512` bits. Decides the `powModNat`-versus-
   Montgomery question under "Kernel exposure".
-- **Native decision**, `isPrime` across the same bit lengths, which is
-  where the trial-division-to-certificate threshold is read off.
+- **Native decision**, bounded `isPrime?` and total `isPrime` across the
+  same bit lengths. Their separate rows expose both the normal
+  certificate path and any exact trial-division fallback.
 - **Certificate search**, `primeCert?` at the same sizes, reported
   separately because its cost is dominated by `partialFactor` and is
   therefore the family whose variance is largest and whose numbers say
@@ -859,13 +938,14 @@ Families:
 uses BPSW plus APRCL and a Pocklington-style certificate only on
 request, so it is answering a different question by a different
 method, and a required ratio would compare a checker against a prover.
-sympy is the oracle, not a comparator. The right benchmarked
+PARI is the oracle and python-flint the second opinion; neither is a
+performance comparator. The right benchmarked
 comparison for the kernel side is **PrimeCert itself**, and it is
 `informational` for a reason worth stating: it is the closest prior art
 and the one number a reader will want, and it cannot be run in this
-repository until the toolchains agree. The comparison is recorded as a
-figure to obtain, in a separate checkout, rather than as a CI
-comparator.
+repository until the toolchains agree. The pins are rechecked when the
+benchmark is implemented; while they differ, the comparison is a figure
+to obtain in a separate checkout rather than a CI comparator.
 
 ## The Mathlib layer
 
@@ -914,14 +994,16 @@ cannot see it.
    assumes these, and nothing below can be finished without them.
 
 1. **The table and the sieve.** `sieve`, `sieve_testBit_iff` with its
-   three hypotheses, `primeTable` with sortedness and both directions,
+   four hypotheses, the batched replay elaborator, `primeTable` with
+   sortedness and both directions,
    `isTablePrime`, `primesIn`, and the `hotPathCandidates` migration
    with the `libraries.yml` amendment it forces. Independently useful,
    and the only part of this SPEC with no dependency on the certificate
    machinery.
 
 2. **Miller-Rabin and the order.** `orderOf` with `orderOf_pos`,
-   `orderOf_dvd_of_pow_eq_one`, and `orderOf_dvd_pred`; `pow_pred_mod`;
+   `coprime_of_pow_mod_eq_one`, `orderOf_dvd_of_pow_eq_one`, and
+   `orderOf_dvd_pred`; `pow_pred_mod`;
    `millerRabin` with its full branch list;
    `not_prime_of_millerRabin_false`; `isProbablePrime`. The order
    development is the prerequisite for milestone 3 and for
@@ -929,12 +1011,15 @@ cannot see it.
 
 3. **Pocklington.** `PrimeCert` as one inductive, `checkPrime`,
    `prime_of_checkPrime` with `prime_pow_dvd_orderOf` and
-   `dvd_of_coprime_prime_powers` beneath it, the private
-   `partialFactor` with `partialFactor_prod`, `primeCert?`, and
-   `isPrime` with `isPrime_iff`. The `primality` tactic lands here.
+   `dvd_of_coprime_prime_powers` beneath it, `CheckedPrimeCert`,
+   the resumable failure types, the
+   shared `rhoFactor?` with `rhoFactor?_spec`, the private
+   `partialFactor` with `partialFactor_prod`, indexed `primeCert?`, and
+   bounded `isPrime?` plus total `isPrime` with their result theorems.
+   The `primality` tactic lands here.
 
-4. **The cube-root variant.** `Pocklington3Cert` and its checker arm,
-   with the exact integer square root it needs.
+4. **The cube-root variant.** The `PrimeCert.pock3` checker arm and its
+   soundness case, with the exact integer square root it needs.
 
 5. **The companion.** `prime_iff`, the transports, the `norm_num`
    extension, and the segment statements. Begins after milestone 1.
@@ -944,12 +1029,13 @@ cannot see it.
 ```
 HexPrimality/
   Sieve.lean        -- the kernel-reducible bitset sieve and its correctness
+  SieveElab.lean    -- batched compiled generation and kernel replay
   Table.lean        -- primeTable, isTablePrime, primesIn, both directions
   Order.lean        -- multiplicative order mod n, orderDvd, ord_dvd_pred
   MillerRabin.lean  -- millerRabin, isProbablePrime, the compositeness theorem
-  Cert.lean         -- PrimeCert, PocklingtonCert, checkPrime, soundness
+  Cert.lean         -- PrimeCert, CheckedPrimeCert, checkPrime, soundness
   Cert3.lean        -- the cube-root variant
-  Search.lean       -- partialFactor, rho, primeCert?, isPrime, nextPrime?
+  Search.lean       -- rhoFactor?, partialFactor, primeCert?, isPrime?, isPrime, nextPrime?
   Elab.lean         -- the primality tactic
 HexPrimality.lean
 HexPrimalityMathlib/
@@ -974,8 +1060,8 @@ HexPrimalityMathlib.lean
     status: draft
 ```
 
-`HexBasic` is for the array and bit-manipulation shims; if none turn
-out to be needed the dependency comes out.
+`HexBasic` is required for `Hex.Rand`; array and bit-manipulation shims
+may add further uses, but the dependency does not depend on them.
 
 ## Open questions
 
@@ -1001,8 +1087,7 @@ out to be needed the dependency comes out.
   cheap; whether `norm_num` should simply delegate everything above a
   bound, or whether the two should stay independent, is a question
   about Mathlib-side ergonomics rather than about this library.
-- **Whether `partialFactor` should live here or in hex-arith.** It has
-  no correctness obligation, so it could sit lower and be shared. It is
+- **Whether `rhoFactor?` should eventually move to hex-arith.** It is
   here because its only two consumers are this library's certificate
   search and [hex-int-factor](hex-int-factor.md), and moving it down
-  would put Pollard rho in the arithmetic root for no gain.
+  would put Pollard rho in the arithmetic root for no present gain.

--- a/progress/20260821T054816Z_primality-factor-spec-review.md
+++ b/progress/20260821T054816Z_primality-factor-spec-review.md
@@ -1,0 +1,39 @@
+# Primality and integer-factorization SPEC review
+
+## Accomplished
+
+- Reworked `SPEC/Libraries/hex-primality.md` to repair the
+  multiplicative-order and Pocklington contracts, tie searched
+  certificates to their requested subjects, expose one reusable checked
+  Brent-rho primitive, account for the sieve mask bound and batched
+  replay architecture, and make randomized search failures resumable.
+- Reworked `SPEC/Libraries/hex-int-factor.md` around indexed checked
+  factorizations, raw serializable order certificates, explicit partial
+  results, local divisor/Carmichael semantics, checked cyclotomic
+  candidates, shared rho, and implementable stage-1-only p-1/ECM scope.
+- Reconciled the design with the landed HexConway Tier 2 proofs, current
+  Lean/Mathlib pins, current PARI certificate API, UInt64-only Montgomery
+  context, and the repository's randomness convention.
+- Obtained and independently checked a fresh Claude/Opus review. Its
+  substantive findings were incorporated, including proof-infrastructure
+  milestones, bounded versus total primality APIs, failure-state
+  preservation, checker cost corrections, and stale source citations.
+- `git diff --check`, relative-link and code-fence checks,
+  `scripts/check_dag.py`, and `scripts/check_phase4.py` pass. No Lean
+  source changed, so there is no Lean build delta.
+
+## Current frontier
+
+The two source-less future-library SPECs are internally consistent and
+ready for publication from the clean
+`spec-primality-factor-review-fixes` branch. Upstream changes since the
+branch point do not touch either SPEC.
+
+## Next step
+
+Rebase onto current `origin/main`, open the documentation PR, verify its
+actual Actions job state and logs, and merge it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- correct the Pocklington, multiplicative-order, sieve, Pollard p-1, ECM, and cyclotomic contracts
- make searched certificates input-indexed and randomized failures resumable while separating bounded and total primality decisions
- give the factorization, order, divisor, primitive-root, and Carmichael APIs explicit Mathlib-free semantics and honest proof prerequisites
- reconcile milestones and current-state claims with landed Conway Tier 2, current toolchain pins, PARI, and the UInt64 Montgomery backend

## Independent review

A fresh Claude/Opus pass found no merge-blocking mathematical or trust-boundary issue. Its actionable API, complexity, prerequisite, and stale-reference findings were verified and incorporated before this PR.

## Validation

- git diff --check
- relative Markdown links and code-fence balance
- python3 scripts/check_dag.py
- python3 scripts/check_phase4.py

Documentation only; no Lean source changed.