### PR TITLE
docs: make Hermite and Smith specs implementable

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -89,7 +89,7 @@ Each library with its immediate dependencies:
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
 - **hex-bareiss**: hex-determinant, hex-matrix
-- **hex-hermite**: hex-row-reduce, hex-arith, hex-bareiss
+- **hex-hermite**: hex-row-reduce, hex-arith, hex-determinant
 - **hex-smith**: hex-hermite
 - **hex-mod-arith**: hex-arith
 - **hex-modular**: hex-arith
@@ -140,7 +140,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
 - **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
 - **hex-bareiss-mathlib**: hex-determinant-mathlib
-- **hex-hermite-mathlib**: hex-hermite, hex-row-reduce-mathlib, hex-bareiss-mathlib
+- **hex-hermite-mathlib**: hex-hermite, hex-row-reduce-mathlib, hex-determinant-mathlib
 - **hex-smith-mathlib**: hex-smith, hex-hermite-mathlib
 - **hex-gram-schmidt-mathlib**: hex-gram-schmidt, hex-bareiss-mathlib
 - **hex-lll-mathlib**: hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib
@@ -173,18 +173,18 @@ and [hex-poly-z-gcd §Why this is not hex-mv-gcd at arity one](hex-poly-z-gcd.md
 The matrix family splits internally. `hex-matrix` is the dense base.
 `hex-row-reduce`, `hex-determinant`, and `hex-bareiss` build on it
 (`hex-bareiss` also on `hex-determinant`), `hex-gram-schmidt` uses all
-three, and `hex-lll` builds on `hex-gram-schmidt`. `hex-hermite` is the
-one member with a dependency outside the family, on `hex-arith` for the
-extended GCD, and `hex-smith` sits on top of it. Each has a matching
-`*-mathlib` companion of the same shape. In the diagram below,
-`hex-matrix` stands for that whole family.
+three, and `hex-lll` builds on `hex-gram-schmidt`. `hex-hermite` reuses
+the row-echelon and determinant layers and is the one member with a dependency
+outside the family, on `hex-arith` for the extended GCD; `hex-smith` sits
+on top of it. Each has a matching `*-mathlib` companion of the same shape.
+In the diagram below, `hex-matrix` stands for that whole family.
 
 The integer normal forms within it:
 
 ```text
-hex-row-reduce ──┐
-hex-arith ───────┼── hex-hermite ── hex-smith
-hex-bareiss ─────┘
+hex-row-reduce ───┐
+hex-arith ─────────┼── hex-hermite ── hex-smith
+hex-determinant ───┘
 ```
 
 The algebraic graph has three independent roots: hex-poly, hex-arith,

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -1,8 +1,8 @@
-# hex-hermite (Hermite normal form over `Int`, depends on hex-row-reduce, hex-arith, hex-bareiss)
+# hex-hermite (Hermite normal form over `Int`, depends on hex-row-reduce, hex-arith, hex-determinant)
 
 The Hermite normal form of an integer matrix: a canonical row-echelon
-representative of the integer row lattice, together with the unimodular
-transform that produces it and the transform's inverse. Mathlib-free;
+representative of the integer row lattice, together with an optional
+unimodular transform and explicitly accumulated inverse. Mathlib-free;
 the companion `hex-hermite-mathlib` relates the executable output to
 `Submodule.span ℤ`, `Matrix.rank`, and the general linear group over `ℤ`.
 
@@ -30,7 +30,7 @@ What the library delivers, none of which is currently reachable:
   same dimensions* have the same integer row lattice exactly when their
   Hermite normal forms are equal, so lattice equality is decided by one
   comparison. Across dimensions the comparison is on `hnfBasis`, the
-  nonzero rows alone. See "Canonicity is per shape" below.
+  nonzero rows alone; see "Canonicity is per shape" below.
 - **Lattice membership with completeness.** `latticeContains A v` is
   `true` exactly when `v` is an integer combination of the rows of `A`.
   The `Field`-based `spanContains` answers the rational question and
@@ -56,11 +56,11 @@ Named consumers:
   exactly the pivot product above.
 - **hex-lll**, which can canonicalise a reduced basis and drop
   dependent generators. The dependency runs from this library to
-  `hex-lll`'s vocabulary rather than the other way. See "Prerequisite
+  `hex-lll`'s vocabulary rather than the other way; see "Prerequisite
   changes in other libraries".
 - The **polynomial-matrix invariant factors** item in
   [future-work](../future-work.md), which needs the same algorithm shape
-  over `F[x]`. That is not this library. See "Why `Int` and not a
+  over `F[x]`. That is not this library; see "Why `Int` and not a
   Euclidean domain class".
 
 ## The convention this library fixes
@@ -86,7 +86,7 @@ or HNF)".
 
 **`H` is unique; `U` is not.** Uniqueness of `H` is the property the
 whole library rests on: its nonzero rows depend only on the integer row
-lattice of `A`. `U` is determined only when `A` has full row rank. When
+lattice of `A`. `U` is determined only when `A` has full row rank; when
 `rank < n` the rows of `U` that map to zero can be changed by any
 unimodular transformation of the kernel lattice. No uniqueness theorem
 for `U` is stated or should be expected.
@@ -171,7 +171,7 @@ example : IsRowReduced cexM cexD where
 
 Every field is vacuous or immediate, yet `5` sits to the left of the
 declared pivot, so this is not a row echelon form under any standard
-definition. `rowReduce` of course produces leading pivots. The point is
+definition. `rowReduce` of course produces leading pivots; the point is
 that the *contract* does not say so, and a downstream proof may not
 assume it.
 
@@ -183,10 +183,8 @@ normal forms of `[[5, 1]]` with pivot column `1`, and they are different
 matrices. The condition is clause 2 above, and it appears as
 `pivot_leading` below.
 
-**The clause list in [future-work](../future-work.md) is wrong in both
-directions.** It proposes three HNF-specific fields, of which
-`det transform = 1 ∨ det transform = -1` is redundant, and it omits the
-leading-entry condition, which is required. Redundant because
+**Determinant unimodularity is a theorem, not a contract field.** A field
+`det transform = 1 ∨ det transform = -1` would be redundant because
 `IsEchelonForm.transform_inv` already supplies an integer matrix `Tinv`
 with `Tinv * transform = 1`, and `det_mul` (Mathlib-free, in
 `HexDeterminant/Adjugate.lean`) turns that into
@@ -211,8 +209,8 @@ structure IsHNF {n m : Nat} (M : Matrix Int n m) (D : RowEchelonData Int n m) : 
 
 This elaborates as written against the current tree. `above_nonneg` and
 `above_lt` are separate fields rather than one conjunction so that each
-can be cited on its own. Together they are the "reduced into
-`[0, pivot)`" condition. The `D.echelon[i]` access with `i : Fin D.rank` is the same
+can be cited on its own; the pair is the "reduced into `[0, pivot)`"
+condition. The `D.echelon[i]` access with `i : Fin D.rank` is the same
 shape `IsRowReduced.pivot_one` already uses.
 
 The unimodularity of `D.transform` is inherited from
@@ -247,13 +245,17 @@ is now wanted by two libraries, it should move to `hex-arith` next to
 (s * a + t * b) / g = 1`, and the displayed `E⁻¹` is its inverse by
 direct computation, so *the inverse transform is available at every step
 without a determinant or an adjugate*. Accumulating `U` and `W` together
-costs one extra row update per step and makes
+costs one additional two-column update of `W` per row update of `U` and makes
 `IsEchelonForm.transform_inv` data rather than an existence proof to be
 recovered later.
 
-`extGcd` returns `g : Nat`, so `g` is nonnegative by construction and
-the pivot-positivity clause needs no separate sign fixup except when the
-whole column is zero, where the step is skipped.
+`extGcd` returns `g : Nat`, so every 2x2 elimination step leaves a
+nonnegative pivot. That does not remove the need for explicit sign
+normalisation: the selected pivot may have no lower row, so no 2x2 step may
+run at all. After clearing the pivot column and before reducing above it, if
+the pivot is negative, negate the pivot row. On the transform path this also
+negates the corresponding row of `U`; on the inverse path it negates the
+corresponding column of `W`, since the row-negation matrix is its own inverse.
 
 Reduction above a pivot `p > 0`: for each row `k < i`, subtract
 `(H[k][jᵢ] / p)` times row `i`. Lean's `Int` division and modulus are
@@ -271,10 +273,10 @@ answer: the output is bounded (for square nonsingular `A`, every entry
 of `H` is at most `|det A|`, and the pivot product is exactly `|det A|`)
 while the intermediate matrices are not. This is the classical
 observation that makes integer elimination a different subject from
-elimination over a field, and it is the same phenomenon `hex-bareiss`
-addresses for determinants by exact division.
+elimination over a field.
 
-Three responses, all standard, and this SPEC takes the first two.
+Three responses are standard. V1 takes the first and records objective
+triggers for specifying the other two later.
 
 **The default is total, and is the one the public `hnf` runs.** Process
 the columns left to right, and after each new pivot is fixed, reduce
@@ -284,6 +286,24 @@ pivots instead of letting it accumulate across the run. The rows not yet
 consumed are not bounded by anything, which is the honest statement, and
 is why the input families under "Benchmarking" measure entry size and not
 only time.
+
+The control flow is entirely bounded. For each of the `m` columns, scan the
+rows at or below the current pivot row. If they are all zero, advance only
+the column. Otherwise move the first nonzero entry to the pivot row, then
+fold the 2x2 `extGcd` step once over each lower row. Each application clears
+that row's entry in the pivot column; later applications touch only the pivot
+row and a later row, so an entry already cleared is not reintroduced. Negate
+the pivot row if the resulting pivot is negative, then use a final fixed scan
+to reduce the entries above it and advance both the pivot row and column. Thus
+the implementation is nested structural iteration over
+the remaining columns and rows (or equivalent fuel bounded by `m` and `n`),
+with no value-dependent recursive call and no unreachable exhaustion branch.
+Implement this as one loop parameterised by a companion accumulator: `Unit`
+for `hnf`, `U` for `hnfData`, and `(U, W)` for `hnfWithInv`. The accumulator's
+row-step operation is inlined, so the `Unit` instantiation allocates no matrix.
+The shared loop makes the schedule and pivot selection identical and lets the
+agreement theorems follow from accumulator-parametric step lemmas rather than
+three independent correctness inductions.
 
 This is deliberately *not* called Kannan-Bachem. Kannan-Bachem maintains
 Hermite normal forms of leading *nonsingular* minors and reorders rows
@@ -297,11 +317,12 @@ and the transform is real work and is listed under "Open questions" as
 the optimisation to measure against the total algorithm, not smuggled in
 as the default.
 
-**A modular variant for square nonsingular input.** For square
+**The modular variant is not a v1 declaration.** For square
 nonsingular `A` with `d = |det A|`, the row lattice `L` contains `d·ℤⁿ`
 (because `d · A⁻¹` is `± adj A`, an integer matrix), so `L = L + d·ℤⁿ`
-and the Hermite normal form of `A` is the Hermite normal form of the
-`(2n) × n` matrix `[A; d·I]`. That augmented lattice is what makes
+and the `(2n) × n` matrix `[A; d·I]` has the same nonzero HNF rows as `A`
+(equivalently, the two `hnfBasis` values agree after transporting across their
+rank equality). That augmented lattice is what makes
 modular arithmetic legitimate, and the statement has to be made in that
 form rather than as "reduce every entry modulo `d`":
 
@@ -313,10 +334,12 @@ What is legitimate is to compute in `ℤ/dℤ` while the generators of
 `d·ℤⁿ` remain present, which is what the Domich-Kannan-Trotter algorithm
 does: each pivot is `gcd` of the column entries *with `d`*, and a pivot
 may equal `d` itself, so entries live in `[0, d]` rather than `[0, d)`.
-The SPEC for `hnfSquare` is the DKT recurrence on `[A; d·I]`, not
-elimination with a modulus bolted on, and the implementation must
-represent the pivot value `d` rather than reducing it to `0`. `d` comes
-from `hex-bareiss`, which is why this library depends on it.
+That observation is a prerequisite for a future DKT SPEC, not enough to
+implement one: the recurrence, state invariant, termination argument, and
+agreement theorem with `hnf` are not written here. Consequently v1 has no
+`hnfSquare` or `Modular.lean`. A later change may add them only with the
+complete algorithm and a theorem `hnfSquare_eq_hnf`; a name plus a citation
+is not an implementation specification.
 
 **LLL-based reduction is deliberately not in v1.** The
 Havas-Majewski-Matthews algorithm controls growth by LLL-reducing the
@@ -334,14 +357,21 @@ determinant while `U ≈ H · A⁻¹` is bounded by the determinant times the
 size of `A⁻¹`. FLINT's separate `fmpz_mat_hnf` and
 `fmpz_mat_hnf_transform` entry points are evidence that production
 implementations treat this as two operations, and this SPEC does the
-same: `hnf` returns the form alone and `hnfData` returns the form with
-the transform and its inverse. A caller who only wants lattice equality,
-rank, or the index must not be made to pay for `U`.
+same. `hnf` returns the form alone. `hnfData` accumulates `U` but not its
+inverse, which is enough for lattice coefficients and the kernel basis.
+`hnfWithInv` is the explicitly more expensive entry point that accumulates
+both `U` and `W`. A caller who only wants lattice equality, rank, the index,
+coefficients, or a kernel basis pays for no transform it does not consume.
 
 ## API
 
 ```lean
 namespace Hex.Matrix
+
+/-- Hermite data with the inverse transform accumulated on the value path. -/
+structure HermiteData (n m : Nat) where
+  rowData : RowEchelonData Int n m
+  inverse : Matrix Int n n
 
 /-- The Hermite normal form of `A`. Does not compute the transform. -/
 def hnf (A : Matrix Int n m) : Matrix Int n m
@@ -354,15 +384,12 @@ independent of how many generators `A` supplied. -/
 def hnfBasis (A : Matrix Int n m) : Matrix Int (hnfRank A) m
 
 /-- The Hermite normal form with the unimodular transform, the pivot
-columns, and the rank, in the shared echelon-data shape. -/
+columns, and the rank, in the shared echelon-data shape. This path
+accumulates `U` but does not compute its inverse. -/
 def hnfData (A : Matrix Int n m) : RowEchelonData Int n m
 
-/-- The inverse of `(hnfData A).transform`, accumulated alongside it. -/
-def hnfInv (A : Matrix Int n m) : Matrix Int n n
-
-/-- Hermite normal form of a square matrix, by the Domich-Kannan-Trotter
-recurrence on `[A; d·I]` when `d = |det A|` is nonzero. -/
-def hnfSquare (A : Matrix Int n n) : Matrix Int n n
+/-- Hermite data with `U` and `U⁻¹` accumulated in one traversal. -/
+def hnfWithInv (A : Matrix Int n m) : HermiteData n m
 
 /-- Integer coefficients expressing `v` as a combination of the rows of
 `A`, or `none` when `v` is not in the row lattice. -/
@@ -375,23 +402,44 @@ def latticeContains (A : Matrix Int n m) (v : Vector Int m) : Bool
 rows of an `(n - hnfRank A) × n` matrix. -/
 def kernelBasis (A : Matrix Int n m) : Matrix Int (n - hnfRank A) n
 
-/-- The pivot entries of `hnf A`, in column order. -/
-def pivots (A : Matrix Int n m) : Vector Int (hnfRank A)
+/-- The positive pivot entries of `hnf A`, in column order. -/
+def pivots (A : Matrix Int n m) : Vector Nat (hnfRank A)
 
 /-- The index `[ℤᵐ : L]` of the row lattice of `A`, or `0` when the row
 lattice does not have finite index. -/
-def latticeIndex (A : Matrix Int n m) : Int
+def latticeIndex (A : Matrix Int n m) : Nat
 
 end Hex.Matrix
 ```
 
 Contracts an implementer would otherwise have to guess. `hnf` and
 `hnfData` agree on the form. `hnfRank A` is `(hnfData A).rank` and is
-computed without building the transform. `latticeCoeffs` returns
+computed without building the transform. `hnfWithInv` runs the same
+deterministic row algorithm while also updating the inverse, and its
+`rowData` agrees with `hnfData`; callers needing both matrices call it once.
+After a left row step `U' = E * U`, the inverse update is
+`W' = W * E⁻¹`, a right multiplication (equivalently, a two-column update),
+not another row update.
+`hnfData_isHNF` proves the existential inverse fields by induction over the
+elementary steps; proof erasure keeps that witness off the value path.
+`hnfData` must not be implemented as a projection of `hnfWithInv`, because
+Lean's eager evaluation would then allocate the inverse it promises to avoid.
+`hnfBasis` is definitionally the first `hnfRank A` rows of `hnf A`, and
+`pivots` is definitionally the `natAbs` of the entries in those rows at the
+corresponding `(hnfData A).pivotCols` positions (transported along
+`hnfRank_eq`). These are definition contracts, so neither function has an
+independent choice that could satisfy only the index theorem accidentally.
+
+`latticeCoeffs` returns
 coefficients against the rows of `A`, not against the rows of `hnf A`,
-which is why it needs the transform: solve against `hnf A` by
-back-substitution with exact division at each pivot, then map the answer
-through `(hnfData A).transform`. `kernelBasis` is the last `n - r` rows
+which is why it needs the transform. Starting with residual `v`, traverse
+the pivot rows in increasing order, require exact divisibility at the current
+pivot, record the quotient, and subtract that multiple of the whole row.
+After the final pivot, return `some` only if the *entire* residual vector is
+zero; pivot divisibility alone is insufficient in a non-pivot column (for
+example `H = [[1, 0]]` and `v = [0, 1]`). Map the coefficients for `hnf A`
+through `(hnfData A).transform` to obtain coefficients for `A`.
+`kernelBasis` is the last `n - r` rows
 of `(hnfData A).transform`, and its dependent type follows `nullspace`
 in `hex-row-reduce`, which is already indexed by `rowReduce_rank M`.
 `latticeIndex` returns the pivot product when `hnfRank A = m` and `0`
@@ -401,35 +449,33 @@ already takes in the square case. Note that finite index needs
 `hnfRank A = m`, the number of *columns*, so a wide matrix never has one
 however many independent rows it has.
 
-`hnfSquare` chooses between the modular algorithm and the general one on
-the determinant returned by `hex-bareiss`. Both branches are complete
-algorithms, so this is a dispatch and not a total form of a partial
-helper in the sense of design principle 8. No fallback classification is
-required, and none should be written.
-
 ## Correctness theorems
 
 ```lean
 theorem hnfData_isHNF (A : Matrix Int n m) : IsHNF A (hnfData A)
 theorem hnf_eq_hnfData_echelon (A : Matrix Int n m) : hnf A = (hnfData A).echelon
 theorem hnfRank_eq (A : Matrix Int n m) : hnfRank A = (hnfData A).rank
-theorem hnfInv_mul (A : Matrix Int n m) :
-    hnfInv A * (hnfData A).transform = Matrix.identity n
-theorem mul_hnfInv (A : Matrix Int n m) :
-    (hnfData A).transform * hnfInv A = Matrix.identity n
+theorem hnfWithInv_data (A : Matrix Int n m) :
+    (hnfWithInv A).rowData = hnfData A
+theorem hnfWithInv_inv_mul (A : Matrix Int n m) :
+    (hnfWithInv A).inverse * (hnfWithInv A).rowData.transform = Matrix.identity n
+theorem hnfWithInv_mul_inv (A : Matrix Int n m) :
+    (hnfWithInv A).rowData.transform * (hnfWithInv A).inverse = Matrix.identity n
 
 -- Uniqueness, in the two forms callers want.
 theorem IsHNF.eq (h : IsHNF A D) (h' : IsHNF A D') :
-    D.rank = D'.rank ∧ D.echelon = D'.echelon
+    D.rank = D'.rank ∧ D.echelon = D'.echelon ∧ HEq D.pivotCols D'.pivotCols
 theorem IsHNF.eq_of_memLattice (h : IsHNF A D) (h' : IsHNF B D')
     (hL : ∀ v, A.memLattice v ↔ B.memLattice v) :
-    D.rank = D'.rank ∧ D.echelon = D'.echelon
+    D.rank = D'.rank ∧ D.echelon = D'.echelon ∧ HEq D.pivotCols D'.pivotCols
 theorem hnf_idem (A : Matrix Int n m) : hnf (hnf A) = hnf A
 
 -- Canonicity across presentations, where the shapes need not agree.
 theorem hnfBasis_eq_of_memLattice (A : Matrix Int n m) (B : Matrix Int n' m)
     (hL : ∀ v, A.memLattice v ↔ B.memLattice v) :
     hnfRank A = hnfRank B ∧ HEq (hnfBasis A) (hnfBasis B)
+theorem hnfBasis_memLattice_iff (A : Matrix Int n m) (v : Vector Int m) :
+    (hnfBasis A).memLattice v ↔ A.memLattice v
 
 -- Lattice statements.
 theorem hnf_memLattice_iff (A : Matrix Int n m) (v : Vector Int m) :
@@ -445,12 +491,15 @@ theorem latticeContains_iff {A : Matrix Int n m} {v} :
 theorem kernelBasis_mul (A : Matrix Int n m) : kernelBasis A * A = 0
 theorem kernelBasis_complete {A : Matrix Int n m} {x : Vector Int n} :
     vecMul x A = 0 → ∃ c, vecMul c (kernelBasis A) = x
+theorem kernelBasis_independent {A : Matrix Int n m}
+    {c : Vector Int (n - hnfRank A)} :
+    vecMul c (kernelBasis A) = 0 → c = 0
 
 -- Determinant and index.
 theorem latticeIndex_eq_prod_pivots (A : Matrix Int n m) (h : hnfRank A = m) :
     latticeIndex A = (pivots A).foldl (· * ·) 1
 theorem latticeIndex_eq_det (A : Matrix Int n n) :
-    latticeIndex A = ((det A).natAbs : Int)
+    latticeIndex A = (det A).natAbs
 ```
 
 `IsHNF.eq_of_memLattice` is the substantive one and `IsHNF.eq` is its
@@ -460,20 +509,23 @@ that across presentations, so those two are the theorems to prove first
 and the ones a `sorry` must not survive in.
 `kernelBasis_complete` is the saturation statement: it says the returned
 rows generate the whole kernel lattice, and it is what a rational
-nullspace computation cannot give.
+nullspace computation cannot give. `kernelBasis_independent` supplies the
+other half of the word "basis" and is the theorem the Mathlib
+`Module.Basis` construction consumes.
 
 `latticeIndex_eq_det` is the square specialisation of
 `latticeIndex_eq_prod_pivots`, and is worth stating separately because it
-gives a second determinant algorithm to cross-check `hex-bareiss`
+gives a second determinant algorithm to cross-check the determinant stack
 against.
 
 `memLattice` is `Hex.Matrix.memLattice`, currently defined in
-`HexLLL/Lattice.lean`. See the next section.
+`HexLLL/Lattice.lean`; see the next section.
 
 ## Certificates and certified dispatch
 
 `hex-lll` already has the machinery this library needs, and it should be
-reused rather than reinvented. `Hex.Internal.mulEqCert U A C` decides
+relocated and reused rather than reinvented. After the prerequisite move,
+`Hex.Matrix.mulEqCert U A C` decides
 `U * A = C` through a Kronecker-substitution digit packing, so the
 product matrix is never formed, and `mulEqCert_iff` proves it correct.
 `Hex.Matrix.sameLatticeCert` composes two of those into a same-lattice
@@ -486,18 +538,21 @@ The Hermite certificate is three checks:
 `U` and inverse transform `W`. -/
 def hnfCert (A H : Matrix Int n m) (U W : Matrix Int n n)
     (r : Nat) (piv : Vector (Fin m) r) : Bool :=
-  Hex.Internal.mulEqCert U A H
-    && Hex.Internal.mulEqCert U W (Matrix.identity n)
+  Hex.Matrix.mulEqCert U A H
+    && Hex.Matrix.mulEqCert U W (Matrix.identity n)
     && isHNFForm H r piv
 
 theorem hnfCert_sound :
     hnfCert A H U W r piv = true → IsHNF A ⟨r, H, U, piv⟩
 ```
 
-`isHNFForm` is the decidable shape test for the four clauses, written
-directly on the entries. Note what the three checks buy. `U * W = I`
+`isHNFForm` is the decidable shape test written directly on the entries. It
+checks `r ≤ n`, `r ≤ m`, that `piv` is strictly increasing, all leading and
+zero-row conditions inherited from `IsEchelonForm`, and the HNF positivity
+and residue conditions; it is not only a pivot-entry predicate. Note what the
+three certificate checks buy. `U * W = I`
 over a commutative ring gives `W * U = I` as well, through the adjugate,
-so unimodularity of `U` follows from one product check. The reverse
+so unimodularity of `U` follows from one product check; the reverse
 product need not be certified separately. The same-lattice statement
 then follows from `U * A = H` and `W * H = W * U * A = A`. So
 `sameLatticeCert`'s second check is redundant here and should not be
@@ -523,20 +578,24 @@ is designed for it now (the checker takes `W` as an argument rather than
 recomputing an inverse, which is the one decision that would be
 expensive to change later).
 
-The lemma this rests on is `Hex.Matrix.mul_eq_one_comm` in
-`HexDeterminant/Adjugate.lean`:
+One obligation that belongs in `hex-determinant` rather than here:
 
 ```lean
-theorem mul_eq_one_comm {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
+theorem Matrix.mul_eq_one_comm {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    {U W : Matrix R n n} (h : U * W = Matrix.identity n) :
     W * U = Matrix.identity n
 ```
 
-for a commutative ring, proved by applying `adjugate_mul` twice. It
-is adjugate theory rather than Hermite theory, which is why it lives there.
+For a commutative ring this follows from determinant and adjugate theory, so it
+belongs in `hex-determinant`, not here. The current Mathlib-free file has
+`det_mul`, matrix-level `mul_adjugate` only in the `(n + 1) × (n + 1)` shape,
+and entrywise `adjugate_mul_apply`; the prerequisite change must add the
+matrix-level `adjugate_mul`, handle the `0 × 0` case (or generalise the shape),
+and then prove the displayed lemma. Two other libraries would use it.
 
 ## Prerequisite changes in other libraries
 
-Three small relocations, each with a reason independent of this library.
+Four prerequisite relocations, each with a reason independent of this library.
 
 **`memLattice` should move to `hex-matrix`.** `Hex.Matrix.memLattice b v`
 is `∃ c, vecMul c b = v`. It mentions nothing from `hex-lll` and nothing
@@ -545,32 +604,35 @@ from `hex-gram-schmidt`, but it lives in `HexLLL/Lattice.lean` alongside
 statement in this SPEC is phrased with it, and `hex-hermite` should not
 acquire a dependency on `hex-lll` (and through it `hex-gram-schmidt`,
 `hex-bareiss`, `hex-determinant`) to say "is an integer combination of
-the rows". Move `memLattice`, `vecMul_mul`, `memLattice_of_mul_eq`, and
-`memLattice_iff_of_mul_eq` into `HexMatrix/Lattice.lean`, and leave
+the rows". Move `memLattice` from `Hex.Matrix` and `vecMul_mul`,
+`memLattice_of_mul_eq`, and `memLattice_iff_of_mul_eq` from `Hex.Internal`
+into their final public namespace in `HexMatrix/Lattice.lean`; leave
 `independent` where it is.
 
-**`mulEqCert` should be public.** It is in `Hex.Internal`, so it is
+**`mulEqCert` should be public.** It is currently in `Hex.Internal`, so it is
 reachable but marked as an implementation detail. The packed product
 check is the right primitive for any certificate that asserts a matrix
 identity without forming the product, and this library plus `hex-smith`
 are two more consumers. Promote it to `Hex.Matrix` next to
 `sameLatticeCert`, and move both to `hex-matrix` with `memLattice`.
 
-**`mul_eq_one_comm`** is done: it and the matrix-level `adjugate_mul` are in
-`HexDeterminant/Adjugate.lean`, with `smul_mul` added to `hex-matrix`
-underneath them.
+**`mul_eq_one_comm` belongs in `hex-determinant`**, as above.
 
 **`exactDiv` should move to `hex-arith`.** `HexBareiss/Bareiss.lean`
 defines the proof-free `exactDiv` with its `@[extern]` binding and proves
 `exactDiv_eq_divExact` beside it. This library and `hex-smith` both want
 exactly that primitive, and copying it into two more places is how three
 slightly different versions appear. It is integer arithmetic, so it
-belongs next to `extGcd`, with `hex-bareiss` re-exporting or importing
-it.
+belongs next to `extGcd` as `HexArith.Int.exactDiv`, with a compatibility
+alias in `Hex.Matrix` while existing Bareiss and Gram--Schmidt callers are
+migrated.
 
-None of the four blocks starting work here: each can be done as a
-separate change before or alongside the first Hermite commit, and until
-they are, this library can name the existing paths.
+These are prerequisites, not work to hide in the first Hermite commit. They
+cross released-repository boundaries, so land them here in dependency order,
+rebuild the monorepo, and publish them through the normal release-sync flow
+before activating Hermite; do not delete an old public name until its released
+consumers have moved, and keep compatibility aliases where the topological sync
+requires them. The new Hermite source uses only the final public names.
 
 ## Why `Int` and not a Euclidean domain class
 
@@ -587,7 +649,7 @@ elimination step. What does not: the canonical form of a pivot is
 above a pivot is `%` into `[0, p)` over `ℤ` and remainder of lower
 degree over `F[x]`; the termination measure is absolute value in one
 case and degree in the other; and the growth problem that motivates
-the eager reduction and the modular variant is a coefficient-size problem over
+the eager reduction and a possible future modular variant is a coefficient-size problem over
 `ℤ` and a degree-growth problem over `F[x]`, with different remedies.
 A class that abstracts only the elimination step buys one function and
 costs an indirection on a path that has to reduce cheaply. The
@@ -613,11 +675,12 @@ derived. See "Benchmarking".
 | operation | algorithm | matrix updates and `extGcd` calls | operand size |
 |---|---|---|---|
 | `hnf` | column sweep with eager reduction above each pivot | `O(r · n · m)` | processed part bounded by its own pivots, unprocessed part unbounded |
-| `hnfSquare` (nonsingular) | elimination modulo the determinant `d` | `O(n³)` | `< d` throughout |
-| `hnfData` | `hnf` plus accumulation of `U` and `W` | `+ O(r · n²)` | larger than `H`; see "Entry growth" |
-| `latticeCoeffs` | back-substitution with exact division, then one `vecMul` through `U` | `O(n · m)` | bounded by the entries of `H` and `U` |
-| `kernelBasis` | row slice of `U` | none | `U`'s |
-| `latticeIndex` | pivot product | `O(m)` | bounded by the index |
+| `hnfData` | `hnf` plus accumulation of `U` only | `+ O(r · n²)` | `U` may be much larger than `H` |
+| `hnfWithInv` | `hnfData` plus right-updates of `W = U⁻¹` | `+ O(r · n²)` beyond `hnfData` | `U`'s and `W`'s |
+| `latticeCoeffs` | `hnfData`, forward pivot solve, residual check, one `vecMul` through `U` | as `hnfData`, plus `O(n · m)` | bounded by `H`, `U`, and the residual |
+| `latticeContains` | `latticeCoeffs` followed by `Option.isSome` | as `latticeCoeffs` | as `latticeCoeffs` |
+| `kernelBasis` | `hnfData` plus a row slice of `U` | as `hnfData`, plus `O((n-r) · n)` | `U`'s |
+| `latticeIndex` | `hnf` plus pivot scan and product | as `hnf`, plus `O(m)` | bounded by the form and index |
 
 ## The Mathlib layer
 
@@ -631,9 +694,9 @@ theorem span_hnf (A : Matrix Int n m) :
 
 /-- The transform is an element of the general linear group over `ℤ`. -/
 theorem isUnit_transform (A : Matrix Int n m) :
-    IsUnit (Matrix.det (matrixEquiv (hnfData A).transform))
+    IsUnit (matrixEquiv (hnfData A).transform)
 
-/-- The integer rank agrees with the rank over `ℚ`. -/
+/-- The executable integer rank agrees with Mathlib's module rank over `ℤ`. -/
 theorem hnfRank_eq_rank (A : Matrix Int n m) :
     hnfRank A = (matrixEquiv A).rank
 
@@ -647,6 +710,13 @@ noncomputable def kernelBasisEquiv (A : Matrix Int n m) :
     Module.Basis (Fin (n - hnfRank A)) ℤ
       (LinearMap.ker (Matrix.vecMulLinear (matrixEquiv A)))
 ```
+
+`hnfRank_eq_rank` needs a genuine row-rank/column-rank bridge. Mathlib's
+`Matrix.rank` is the `finrank` of the range of `mulVecLin`, while HNF counts
+nonzero rows. Since `Matrix.rank_transpose` is field-only, the proof either
+base-changes the integer matrix to `ℚ` and transports both ranks, or first
+identifies `hnfRank` with the rank of the row-span submodule and proves that it
+equals the column rank. It is not discharged merely by `span_hnf`.
 
 The last is the payoff and the reason the layer is more than a
 restatement: Mathlib's basis for a submodule of a free module over a PID
@@ -691,7 +761,7 @@ No new job, no matrix, no new workflow file, per [SPEC/CI.md](../CI.md).
 exposes `fmpz_mat_hnf` and `fmpz_mat_hnf_transform` in the row-style
 convention this SPEC fixes. The python-flint binding for the
 transform-returning form must be confirmed against the version CI
-installs before the driver is written. If it is not exposed, the
+installs before the driver is written; if it is not exposed, the
 fallback is PARI's `mathnf(M, 1)` through `cypari2`, which is already a
 CI dependency. The column-style-to-row-style conversion is then done in
 the driver, and it is not just a transpose: reversing rows or columns on
@@ -709,13 +779,16 @@ produce spurious failures.
 **Cases that must be present**, since these are what a plausible
 implementation gets wrong:
 
-- the zero matrix, and a matrix with a zero column at the left, where
+- the `0 × 0`, `0 × m`, and `n × 0` edge cases, the zero matrix, and a
+  matrix with a zero column at the left, where
   the first pivot is not in column `0`;
 - rank-deficient input, including duplicated and negated rows, checking
   that the zero rows land at the bottom and `rank` is right;
 - more rows than columns and more columns than rows;
 - negative entries in every position that feeds a pivot, since the sign
   handling of `extGcd` and of `%` is where an implementation goes wrong;
+- `[[1, 0], [0, -1]]`, whose last pivot has no lower row and therefore catches
+  an implementation that relies on an `extGcd` step to normalise every sign;
 - an input already in Hermite normal form, checking idempotence;
 - a pivot of `1`, where the reduction above it must produce zeros;
 - an input whose naive elimination blows up (a random `20 × 20` matrix
@@ -726,16 +799,24 @@ implementation gets wrong:
   checking that their `hnfBasis` values agree. This case is on
   `hnfBasis`, not on `hnf`, because `hnf` of an `n × m` and an `n' × m`
   matrix are different types and differ in their trailing zero rows;
-- for `hnfSquare`, an input whose Hermite normal form contains a pivot
-  equal to `d = |det A|` (the `1 × 1` matrix `[2]` is the smallest), which
-  is the case that catches a modular implementation reducing that pivot to
-  zero.
+- `H = [[1, 0]]` and `v = [0, 1]` as a lattice non-member, which catches
+  a solver that checks pivot divisibility but forgets the final residual.
 
 The property checks in `conformance/HexHermite/Conformance.lean` assert
-`U * A = H`, `U * W = I`, the four shape clauses, the pivot product
-against `hex-bareiss`'s determinant on square nonsingular input,
+`U * A = H`, both inverse identities from `hnfWithInv`, the four shape
+clauses, the pivot product against `hex-determinant` on square nonsingular input,
 `latticeContains` on both a member and a non-member of the lattice, and
-`kernelBasis A * A = 0`.
+`kernelBasis A * A = 0`. A small exhaustive coefficient range also checks
+that no nonzero coefficient vector annihilates `kernelBasis A`; the theorem,
+not this bounded check, supplies full independence.
+
+The direct `hex-determinant` pivot-product cross-check is restricted to
+dimensions at most `6`, because that library's public determinant is the
+Leibniz formula. The `20 × 20` growth fixture checks the HNF form against the
+external oracle and the transform identities, but does not invoke the Leibniz
+determinant. A conformance driver may instead import `HexBareiss` for larger
+determinant cross-checks; that test-only import does not become a Hermite
+library dependency.
 
 ## Benchmarking
 
@@ -746,10 +827,10 @@ Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
 a single family would hide:
 
 - `random-dense-hermite`: uniform entries in `[-B, B]`, square and
-  nonsingular, the case where the modular algorithm should win.
+  nonsingular.
 - `rank-deficient-hermite`: rows drawn as integer combinations of a
-  smaller independent set, where the determinant is zero and the modular
-  path is unavailable.
+  smaller independent set, exercising zero-row reconstruction and kernel
+  extraction.
 - `tall-hermite`: many more rows than columns, the shape a number-field
   module basis has, where most rows are redundant.
 - `unimodular-conjugate`: `V * D` for a random unimodular `V` and a
@@ -766,34 +847,23 @@ PARI is column-style and its timing includes the convention conversion.
 Both are recorded for orientation in
 `reports/hex-hermite-performance.md`.
 
-**Two decision rules written down in advance.** Both are stated over a
-range rather than at one ladder endpoint, because a single-point ratio
-mostly reports where the crossover was placed.
-
-1. `hnfSquare` (modular) is kept only if it beats the default over a
-   named production range: the crossover curve in dimension and entry
-   bit-size is measured, and the modular path must win across the whole
-   upper half of both ladders, not merely at the last rung. If the
-   crossover sits outside the sizes the named consumers produce, the
-   modular path is not carrying its complexity and should be removed
-   rather than kept as an unmeasured alternative.
-2. The LLL-based Havas-Majewski-Matthews algorithm is justified only if
-   growth rather than operation count is what limits the default. The
-   evidence is a divergence: the peak intermediate entry bit-size must
-   grow faster in the dimension than the output entry bit-size does on
-   `unimodular-conjugate`, with the time spent in big-integer arithmetic
-   rising as a share of total time. Instrument entry size and allocation
-   in the bench, not just wallclock. A time ratio alone cannot separate
-   these two causes.
+**Growth trigger written down in advance.** An LLL-based
+Havas-Majewski-Matthews follow-up is justified only if peak intermediate
+entry bit-size grows faster in the dimension than output entry bit-size on
+`unimodular-conjugate`, and wallclock follows that divergence across the
+upper half of the dimension ladder. The implementation provides a separate
+untimed diagnostic runner that scans the working matrix after every
+elementary update and returns `peakBits`; ordinary benchmark timings run the
+uninstrumented API. No claim is made about "time spent in big-integer
+arithmetic", which the benchmark harness cannot isolate.
 
 ## File organisation
 
 ```
 HexHermite/
   Contracts.lean     -- IsHNF, isHNFForm, IsHNF.det_transform
-  Step.lean          -- the 2x2 elimination step, its inverse, exact division
-  Hermite.lean       -- hnf, hnfData, hnfInv, hnfRank, hnfBasis
-  Modular.lean       -- hnfSquare, the DKT recurrence on [A; d·I]
+  Step.lean          -- 2x2 elimination, row-sign normalisation, inverses, exact division
+  Hermite.lean       -- hnf, hnfData, hnfWithInv, hnfRank, hnfBasis
   Unique.lean        -- IsHNF.eq, IsHNF.eq_of_memLattice, hnf_idem
   Lattice.lean       -- latticeCoeffs, latticeContains, kernelBasis, latticeIndex
   Cert.lean          -- hnfCert and its soundness
@@ -809,25 +879,42 @@ HexHermiteMathlib.lean
 
 ```yaml
   HexHermite:
-    deps: [HexRowReduce, HexArith, HexBareiss]
+    deps: [HexRowReduce, HexArith, HexDeterminant]
     mathlib: false
     done_through: 0
     status: draft
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_mat_hnf via python-flint
+          class: informational
+          rationale: FLINT dispatches to asymptotically faster algorithms outside this SPEC
+        - tool: PARI mathnf via cypari2
+          class: informational
+          rationale: PARI is column-style and the timing includes convention conversion
+      input_families:
+        - name: random-dense-hermite
+          description: dense square nonsingular integer matrices with uniformly bounded entries
+        - name: rank-deficient-hermite
+          description: rows drawn as integer combinations of a smaller independent set
+        - name: tall-hermite
+          description: tall matrices with many redundant row generators
+        - name: unimodular-conjugate
+          description: random unimodular left factors times a known diagonal form
   HexHermiteMathlib:
-    deps: [HexHermite, HexRowReduceMathlib, HexBareissMathlib]
+    deps: [HexHermite, HexRowReduceMathlib, HexDeterminantMathlib]
     mathlib: true
     done_through: 0
     status: draft
 ```
 
 `HexRowReduce` supplies `RowEchelonData` and `IsEchelonForm`, `HexArith`
-supplies `extGcd`, and `HexBareiss` supplies the determinant for the
-modular algorithm and (through `HexDeterminant`) `det_mul` and the
-adjugate identities. `HexMatrix` arrives through all three.
+supplies `extGcd` and `exactDiv`, and `HexDeterminant` supplies `det_mul`,
+the adjugate identities, and `mul_eq_one_comm`. `HexMatrix` arrives through
+the first and third dependencies.
 
 ## Open questions
 
-- **Where the rectangular modular algorithm stops.** The modular
+- **Whether to write a modular follow-up SPEC.** The modular
   argument needs `d·ℤᵐ ⊆ L` for the row lattice `L ⊆ ℤᵐ`, which needs `L`
   to have finite index, which needs `hnfRank A = m`: full **column**
   rank, with `n ≥ m`. It is not full row rank. A wide matrix with
@@ -836,8 +923,10 @@ adjugate identities. `HexMatrix` arrives through all three.
   independent rows it has. For `n ≥ m` of full column rank, the
   determinant of any nonsingular `m × m` row submatrix is a positive
   multiple of the index and is a valid modulus. Whether that extra
-  machinery pays is a benchmark question against `tall-hermite`, and
-  until it is answered `hnfSquare` is the only modular entry point.
+  machinery pays is a benchmark question against `tall-hermite`. Any future
+  public entry point starts with a complete square DKT recurrence and
+  `hnfSquare_eq_hnf`; rectangular generalisation is a later extension, not a
+  premise hidden in that first API.
 - **Whether the rank-profile preprocessing is worth writing.** The
   default algorithm is total but its unprocessed rows are unbounded. The
   Kannan-Bachem arrangement bounds them, at the cost of rank-profile
@@ -846,13 +935,6 @@ adjugate identities. `HexMatrix` arrives through all three.
   variant of the default, and it should be specified only if the entry
   instrumentation under "Benchmarking" shows the unprocessed rows are
   what hurts.
-- **Whether `hnfData` should return `W`.** This SPEC returns the inverse
-  transform from a separate function, `hnfInv`, so that `RowEchelonData`
-  is unchanged. The alternative is a Hermite-specific data structure
-  carrying both. The existing shape is preferred because it keeps the
-  span and column-partition operations in `hex-row-reduce` usable
-  directly, but if the two are always called together the extra
-  traversal is waste and the structure should be reconsidered.
 - **Kernel reduction.** Nothing in this SPEC is on a `decide +kernel`
   path today. If the Hermite certificate is ever checked in the kernel,
   the exposure analysis in the `hex-mv-poly` SPEC applies verbatim, and

--- a/SPEC/Libraries/hex-smith.md
+++ b/SPEC/Libraries/hex-smith.md
@@ -4,7 +4,7 @@ The Smith normal form of an integer matrix: a diagonal matrix `S` with
 `S = U * A * V` for unimodular `U` and `V`, whose diagonal entries are
 positive and form a divisibility chain `d₁ ∣ d₂ ∣ ⋯ ∣ d_r`. Those
 entries are the invariant factors of `A`, and they determine the
-structure of the abelian group presented by `A`. Mathlib-free. The
+structure of the abelian group presented by `A`. Mathlib-free; the
 companion `hex-smith-mathlib` builds Mathlib's
 `Module.Basis.SmithNormalForm` from the executable output and relates
 the invariant factors to the structure theorem for finitely generated
@@ -17,9 +17,10 @@ this library extends. Read that one first.
 
 ## Why this library exists
 
-Hermite normal form answers questions about one lattice. Smith normal
-form answers questions about a lattice *inside* another, which is a
-different and larger class of question:
+Hermite normal form already decides membership, produces one solution of
+`vecMul x A = b`, gives the integer kernel, and computes the index. Smith
+normal form adds canonical invariant factors and simultaneous source/target
+coordinates. Its genuinely new uses are:
 
 - **The structure of a finitely generated abelian group.** Given
   relations as the rows of `A : Matrix Int n m`, the group
@@ -28,22 +29,24 @@ different and larger class of question:
   headline consumer and the reason the divisibility chain matters:
   without it the diagonal is not canonical and the summands are not the
   invariant factors.
-- **Integer linear systems.** `A x = b` over `ℤ` becomes a diagonal
-  system after the change of basis, so solvability is a divisibility
-  test per coordinate and the full solution set is a coset of the kernel
-  lattice.
-- **The index and the order of a quotient.** `[ℤᵐ : rowlattice A]` is
-  `∏ dᵢ` when `r = m`, and infinite otherwise.
+- **Diagonal coordinates for integer linear systems.** The existing
+  `latticeCoeffs` API remains the efficient way to obtain one solution.
+  Smith data additionally proves that solvability is a coordinatewise
+  divisibility/zero test after applying `V`, and exposes both changes of
+  basis for consumers that need the diagonal presentation itself.
+- **A canonical factorisation of the index.** Hermite already computes the
+  index. Smith proves that a finite index is `∏ dᵢ`, recording how that
+  order decomposes rather than introducing a second index algorithm.
 - **Invariant factors of a module map**, which is what the polynomial
   matrix item in [future-work](../future-work.md) wants over `F[x]`
-  rather than `ℤ`. That item is not this library. See "Why `Int`" in
+  rather than `ℤ`. That item is not this library; see "Why `Int`" in
   [hex-hermite](hex-hermite.md).
 
 The dependency on `hex-hermite` is real rather than organisational: the
 `extGcd` elimination step with its explicit inverse, the exact-division
-discipline, the certificate machinery, the conventions, and the reliance on
-`mul_eq_one_comm` are all shared. Note that the default
-algorithm below does *not* call `hnf`. The Kannan-Bachem variant under
+discipline, the certificate machinery, the conventions, and the
+`mul_eq_one_comm` obligation are all shared. Note that the default
+algorithm below does *not* call `hnf`; the Kannan-Bachem variant under
 "Open questions" would, which is the other reason to keep the two
 libraries adjacent.
 
@@ -94,7 +97,8 @@ structure SmithData (n m : Nat) where
   right : Matrix Int m m
   rightInv : Matrix Int m m
 
-/-- The `n × m` matrix carrying `d` down the leading diagonal. -/
+/-- Prerequisite API from `HexMatrix/Diagonal.lean`: the `n × m` matrix
+carrying `d` down the leading diagonal. -/
 def diagMatrix {r : Nat} (d : Vector Int r) (n m : Nat) : Matrix Int n m :=
   Matrix.ofFn fun i j => if h : i.val = j.val ∧ i.val < r then d[i.val]'h.2 else 0
 
@@ -115,27 +119,29 @@ differently.
 
 **One-sided inverse fields.** `left_inv` and `right_inv` record only
 `U * W = I` and `V * X = I`. The other side follows over a commutative
-ring through the adjugate, by `Hex.Matrix.mul_eq_one_comm` in
-`HexDeterminant/Adjugate.lean`. Carrying both
+ring through the adjugate, by the `mul_eq_one_comm` lemma
+[hex-hermite](hex-hermite.md) asks `hex-determinant` for. Carrying both
 directions as fields would make every construction discharge a
 redundant obligation.
 
-**The inverses are data, not existence.** As in the Hermite case, every
-elementary step has an explicit inverse, so accumulating `W` and `X`
-alongside `U` and `V` costs one extra update per step and removes any
-need to invert a matrix afterwards.
+**The inverses are data on the full path, not on the form-only path.** Every
+elementary step has an explicit inverse, so `snfData` accumulates `W` and `X`
+alongside `U` and `V`. For a left row step `U' = E * U`, update
+`W' = W * E⁻¹`; for a right column step `V' = V * F`, update
+`X' = F⁻¹ * X`. The public `snf` and `snfRank` paths accumulate none of
+these four matrices.
 
-**`diagMatrix` should probably move to `hex-matrix`.** It is a general
-constructor, `hex-matrix` has no `diagonal` of any kind today, and a
-second consumer would immediately want it. It is specified here because
-this is the library that needs it first.
+**`diagMatrix` moves to `hex-matrix` before this library starts.** It is a
+general constructor and is also used by the Mathlib bridge and tests. The
+signature above is the prerequisite API; `hex-smith` does not own a second
+copy.
 
 ## Algorithms
 
 **The default is the classical Euclidean pivot algorithm**, and it is
 called that rather than Kannan-Bachem. Kannan-Bachem controls growth by
 alternating row and column Hermite normal forms on trailing submatrices,
-and its entry bound comes from that repetition. The pivot loop below does
+and its entry bound comes from that repetition; the pivot loop below does
 not inherit those bounds merely by shrinking the pivot, and saying it
 does would be an unearned claim. What the loop below has is a
 straightforward correctness argument and a termination measure. What it
@@ -159,13 +165,17 @@ The pivot loop, which is where the mathematics lives:
    operations, using the same `extGcd` 2x2 step as
    [hex-hermite](hex-hermite.md). Each step replaces the pivot by
    `gcd(pivot, entry)`, so the pivot never grows.
-4. If some entry `a[i][j]` of the remaining block is not divisible by
+4. If the pivot is negative, negate its row. On the full-data path also
+   negate the matching row of `U` and column of `W`; the row-negation matrix
+   is its own inverse. Perform this inline without a recursive call; it leaves
+   both components of the termination measure below unchanged.
+5. If some entry `a[i][j]` of the remaining block is not divisible by
    the pivot `p`, add row `i` to the pivot row **and immediately run the
    column-`j` elimination against the new entry**, which replaces `p` by
    `gcd(p, a[i][j])`, then return to step 3. This is the step that
    produces the divisibility chain, and it is the step a naive
    implementation omits.
-5. Otherwise advance to the next diagonal position.
+6. Otherwise advance to the next diagonal position.
 
 **Termination measure.** The pair `(|pivot|, c)` ordered
 lexicographically, where `c` is the number of nonzero entries in the
@@ -174,7 +184,7 @@ pivot row and column other than the pivot itself. Step 3 either leaves
 the step is a plain subtraction) or strictly decreases `|pivot|` (when
 it does not).
 
-Step 4 is why it is stated as one fused step rather than two. Adding row
+Step 5 is why it is stated as one fused step rather than two. Adding row
 `i` to the pivot row on its own decreases nothing: `|pivot|` is unchanged
 and `c` rises from `0`, so the measure *increases*, and "it decreases on
 the next pass" is not a termination argument, since Lean needs the
@@ -193,35 +203,24 @@ value that a sufficiency theorem proves unreachable on public API
 inputs, and that classification is written down. Design principle 8
 allows nothing weaker.
 
-**A modular variant, for the form only.** Iliopoulos's algorithm runs
-the elimination modulo a positive multiple of the largest invariant
-factor, keeping entries bounded. Two restrictions have to be in the
-signature rather than in the prose. It applies to nonsingular square
-input, where `hex-bareiss` supplies the modulus. And it computes the
-diagonal, not the transforms: the multipliers are not a by-product of the
-modular recurrence, and recovering them is a separate algorithm (FLINT
-uses an iterated-Hermite routine for the transform case rather than its
-modular one). So the entry point is
-
-```lean
-/-- The invariant factors of a nonsingular square matrix, computed
-modulo a multiple of the largest one. Returns the diagonal only. -/
-def snfSquareDiag (A : Matrix Int n n) : Option (Vector Int n)
-```
-
-returning `none` on singular input, and it does **not** sit on the
-`SmithData` path. Putting it there would mean specifying and proving a
-multiplier-reconstruction algorithm, which is not in this SPEC. It is
-subject to the same measured decision rule as `hnfSquare` in
-[hex-hermite](hex-hermite.md) before it is kept at all.
+**The modular variant is not a v1 declaration.** Iliopoulos's algorithm
+runs elimination modulo a positive multiple of the largest invariant
+factor, applies to nonsingular square input, and computes only the diagonal;
+multiplier reconstruction is a separate algorithm. Those facts do not
+specify its recurrence, modulus invariant, singular classification, or
+agreement theorem. V1 therefore has no `snfSquareDiag` or `Modular.lean`.
+A future proposal must give the complete algorithm and prove that its `some`
+result equals `invariantFactors` and that `none` is equivalent to singularity
+before adding a public declaration.
 
 **A fast path for diagonal input.** A diagonal matrix is already almost
 in Smith normal form and needs only normalisation and the chain. The
 normalisation is not skippable, because the input diagonal may contain
-zeros and negatives: negate the row of each negative entry, move the
-nonzero entries stably before the zeros, and take the rank to be the
-number of nonzero entries. Every sign change and transposition is
-accumulated into all four transform matrices. The gcd and lcm sweep then
+zeros and negatives: negate each negative entry, move the nonzero entries
+stably before the zeros, and take the rank to be the number of nonzero
+entries. `snfDiagonalData` accumulates the corresponding row and column
+operations and their inverses; form-only `snfDiagonal` does not. The gcd
+and lcm sweep then
 runs on the positive prefix alone, which is what makes the divisions by
 `g` below defined: `[0, 0]` has no `g` to divide by, and `[0, 2]` is not
 in Smith normal form despite being diagonal.
@@ -238,8 +237,11 @@ sends `diag(a, b)` to `diag(g, l)`: adding the second row to the first
 gives `[[a, b], [0, b]]`, right-multiplying by `V` (which has
 determinant `(s·a + t·b)/g = 1`) gives `[[g, 0], [b·t, l]]`, and the
 second row operation clears the `b·t` entry, which is divisible by `g`
-because `g` divides `b`. Sweeping this over adjacent pairs until no pair
-changes yields the chain in `O(r²)` gcd steps. This is FLINT's
+because `g` divides `b`. Run a fixed bubble network of `r` full adjacent
+passes. On each prime valuation, `(gcd, lcm)` is `(min, max)`, so the same
+network sorts every valuation and yields the divisibility chain after at
+most `r · (r - 1)` pair steps. This fixed schedule makes both termination
+and the `O(r²)` bound immediate. This is FLINT's
 `snf_diagonal`, and it is the path a direct-sum presentation of an
 abelian group takes, which is the common case for the headline consumer.
 
@@ -253,71 +255,106 @@ pretending the ratio against FLINT measures the same algorithm.
 ```lean
 namespace Hex.Matrix
 
-/-- Smith normal form data for `A`. -/
-def snf (A : Matrix Int n m) : SmithData n m
+/-- Named structure-theorem data for `ℤᵐ / rowlattice A`. -/
+structure AbelianStructure where
+  freeRank : Nat
+  torsionFactors : Array Nat
+
+/-- The canonical `n × m` Smith matrix. Does not compute transforms. -/
+def snf (A : Matrix Int n m) : Matrix Int n m
+
+/-- The number of nonzero diagonal entries of `snf A`. -/
+def snfRank (A : Matrix Int n m) : Nat
+
+/-- Smith form with all four change-of-basis matrices. -/
+def snfData (A : Matrix Int n m) : SmithData n m
 
 /-- The invariant factors of `A`, positive and in a divisibility chain. -/
-def invariantFactors (A : Matrix Int n m) : Vector Int (snf A).rank
+def invariantFactors (A : Matrix Int n m) : Vector Int (snfRank A)
 
-/-- Smith normal form of a diagonal matrix, given its diagonal. -/
-def snfDiagonal {r : Nat} (d : Vector Int r) : SmithData r r
+/-- Form-only Smith normal form of a diagonal matrix. -/
+def snfDiagonal {r : Nat} (d : Vector Int r) : Matrix Int r r
+
+/-- Smith normal form data of a diagonal matrix, including transforms. -/
+def snfDiagonalData {r : Nat} (d : Vector Int r) : SmithData r r
 
 /-- The structure of `ℤᵐ / rowlattice A`: the free rank, and the
 torsion invariants in a divisibility chain with the units dropped. -/
-def abelianStructure (A : Matrix Int n m) : Nat × Array Int
+def abelianStructure (A : Matrix Int n m) : AbelianStructure
 
-/-- The order of `ℤᵐ / rowlattice A`, or `0` when it is infinite. -/
-def quotientOrder (A : Matrix Int n m) : Int
-
-/-- An integer solution of `vecMul x A = b`, or `none` when there is
-none. -/
-def solveInt (A : Matrix Int n m) (b : Vector Int m) : Option (Vector Int n)
-
-/-- The `k`-th determinantal divisor: the gcd of the determinants of all
-`k × k` submatrices of `A`, taken over every choice of `k` rows and `k`
+/-- The `k`-th determinantal divisor: the gcd of the `natAbs` values of
+the determinants of all `k × k` submatrices of `A`, taken over every
+choice of `k` rows and `k`
 columns. `detDivisor A 0 = 1`, and `detDivisor A k = 0` when
 `k > min n m` or when every such minor vanishes.
 
 This is the specification function. Its definition is the gcd above and
-mentions nothing about `snf`. `detDivisor_eq_prod` is what says the
+mentions nothing about `snf`; `IsSNF.detDivisor_eq` is what says the
 invariant factors compute it. -/
 noncomputable def detDivisor (A : Matrix Int n m) (k : Nat) : Nat
 
 end Hex.Matrix
 ```
 
-Contracts to state explicitly. `invariantFactors` drops nothing, so its
-leading entries may be `1`. `abelianStructure` drops them, because a
-`ℤ/1` summand is not part of anyone's answer, and returns the free rank
-`m - rank` separately. `quotientOrder` returns `0` when the free rank is
-positive, which is the same convention `latticeIndex` uses in
-[hex-hermite](hex-hermite.md) and is a correct value rather than a
-fallback.
+Contracts to state explicitly. `snf`, `snfRank`, `invariantFactors`, and
+`abelianStructure` use a form-only engine and allocate no transform matrix.
+`snfData` runs the same deterministic pivot choices while accumulating all
+four transforms, and its diagonal matrix and rank agree with the form-only
+results. `invariantFactors` drops nothing, so its leading entries may be `1`;
+`abelianStructure.torsionFactors` converts the entries greater than `1` to
+`Nat`, and `freeRank = m - snfRank A`.
+The form-only definitions must not be projections of `snfData`: eager
+evaluation would allocate the discarded transforms. Implement the general
+pivot loop once, parameterised by a companion accumulator that is `Unit` for
+`snf` and `(U, W, V, X)` for `snfData`; likewise parameterise the fixed
+diagonal network by `Unit` versus the four transforms. Inline the accumulator
+operations so the `Unit` instances allocate no matrices. Agreement then comes
+from accumulator-parametric step lemmas rather than duplicated correctness
+inductions.
 
-`solveInt` needs both transforms, not one. From `S = U * A * V`, the
-system `vecMul x A = b` becomes `vecMul z S = vecMul b V` with
-`z = vecMul x U⁻¹`, so the right-hand side is transformed by `V` before
-the diagonal solve, and the answer is mapped back by `x = vecMul z U`.
-Solving the diagonal system against `b` directly is wrong whenever
-`V ≠ I`, which is the usual case, and the transformed right-hand side
-gets its own lemma in the theorem list.
+There is deliberately no second integer solver or quotient-order function in
+this library. `latticeCoeffs` and `latticeIndex` in `hex-hermite` already own
+those executable operations. Smith supplies the diagonal solvability theorem
+and invariant-factor product theorem below. In particular, for
+`S = snfData A`, a transformed right-hand side `bV` is solvable exactly when
+its first `S.rank` coordinates are divisible by the corresponding diagonal
+entries and every remaining coordinate is zero. Omitting the trailing zero
+test is the Smith analogue of omitting Hermite's final residual check.
 
 `detDivisor` is `noncomputable` under design principle 11: its definition
 enumerates exponentially many minors and there is no runtime twin. It is
 **defined by that enumeration and not through `snf`**. Defining it
-through `snf` would make `detDivisor_eq_prod` circular, since the
+through `snf` would make `IsSNF.detDivisor_eq` circular, since the
 invariant used to prove that `snf`'s output is canonical would already
 contain that output. The executable route to its *value* is the product
-of the first `k` invariant factors, which is what `detDivisor_eq_prod`
+of the first `k` invariant factors, which is what `IsSNF.detDivisor_eq`
 states. It returns `Nat` so that "the gcd" needs no separate
 normalisation clause.
 
 ## Correctness theorems
 
 ```lean
-theorem snf_isSNF (A : Matrix Int n m) : IsSNF A (snf A)
-theorem snfDiagonal_isSNF {r : Nat} (d : Vector Int r) :
-    IsSNF (diagMatrix d r r) (snfDiagonal d)
+theorem snfData_isSNF (A : Matrix Int n m) : IsSNF A (snfData A)
+theorem snf_eq_data (A : Matrix Int n m) :
+    snf A = diagMatrix (snfData A).diag n m
+theorem snfRank_eq_data (A : Matrix Int n m) :
+    snfRank A = (snfData A).rank
+theorem snf_idem (A : Matrix Int n m) : snf (snf A) = snf A
+theorem snfRank_le_n (A : Matrix Int n m) : snfRank A ≤ n
+theorem snfRank_le_m (A : Matrix Int n m) : snfRank A ≤ m
+theorem invariantFactors_pos (A : Matrix Int n m) (i : Fin (snfRank A)) :
+    0 < (invariantFactors A)[i]
+theorem invariantFactors_chain (A : Matrix Int n m) (i : Nat)
+    (h : i + 1 < snfRank A) :
+    (invariantFactors A)[⟨i, by omega⟩] ∣
+      (invariantFactors A)[⟨i + 1, h⟩]
+
+theorem snfDiagonalData_isSNF {r : Nat} (d : Vector Int r) :
+    IsSNF (diagMatrix d r r) (snfDiagonalData d)
+theorem snfDiagonal_eq_data {r : Nat} (d : Vector Int r) :
+    snfDiagonal d = diagMatrix (snfDiagonalData d).diag r r
+theorem snfDiagonal_eq_snf {r : Nat} (d : Vector Int r) :
+    snfDiagonal d = snf (diagMatrix d r r)
 
 -- The determinantal-divisor characterisation, which is the specification.
 -- Stated for every k, including k > S.rank, where both sides are zero.
@@ -330,23 +367,32 @@ theorem IsSNF.detDivisor_eq {A : Matrix Int n m} {S : SmithData n m}
 theorem IsSNF.rank_eq (h : IsSNF A S) (h' : IsSNF A S') : S.rank = S'.rank
 theorem IsSNF.diag_eq (h : IsSNF A S) (h' : IsSNF A S') (i : Nat)
     (hi : i < S.rank) (hi' : i < S'.rank) : S.diag[i] = S'.diag[i]
+theorem IsSNF.form_eq (h : IsSNF A S) (h' : IsSNF A S') :
+    diagMatrix S.diag n m = diagMatrix S'.diag n m
 
 -- Agreement with the Hermite rank, and with the determinant.
 theorem IsSNF.rank_eq_hnfRank (h : IsSNF A S) : S.rank = hnfRank A
-theorem prod_invariantFactors (A : Matrix Int n n) (h : (snf A).rank = n) :
-    (invariantFactors A).foldl (· * ·) 1 = ((det A).natAbs : Int)
+theorem snfRank_eq_hnfRank (A : Matrix Int n m) : snfRank A = hnfRank A
+theorem prod_invariantFactors (A : Matrix Int n n) (h : snfRank A = n) :
+    (invariantFactors A).foldl (· * ·) 1 = Int.ofNat ((det A).natAbs)
 
 -- The consumer-facing statements.
-theorem solveInt_iff_diagonal {A : Matrix Int n m} {b} (S := snf A) :
+theorem solvable_iff_diagonal {A : Matrix Int n m} {S : SmithData n m}
+    (hS : IsSNF A S) {b : Vector Int m} :
     (∃ x, vecMul x A = b) ↔
       ∃ z, vecMul z (diagMatrix S.diag n m) = vecMul b S.right
-theorem solveInt_sound {A : Matrix Int n m} {b x} :
-    solveInt A b = some x → vecMul x A = b
-theorem solveInt_complete {A : Matrix Int n m} {b} :
-    (∃ x, vecMul x A = b) → (solveInt A b).isSome
-theorem quotientOrder_eq (A : Matrix Int n m) :
-    quotientOrder A =
-      if (snf A).rank = m then (invariantFactors A).foldl (· * ·) 1 else 0
+theorem solvable_iff_dvd {A : Matrix Int n m} {S : SmithData n m}
+    (hS : IsSNF A S) (b : Vector Int m) :
+    (∃ x, vecMul x A = b) ↔
+      (∀ i : Fin S.rank,
+          S.diag[i] ∣ (vecMul b S.right)[
+            ⟨i.val, Nat.lt_of_lt_of_le i.isLt hS.rank_le_m⟩]) ∧
+      (∀ j : Fin m, S.rank ≤ j.val → (vecMul b S.right)[j] = 0)
+theorem latticeIndex_eq_invariantFactors (A : Matrix Int n m) :
+    latticeIndex A =
+      if snfRank A = m then
+        (invariantFactors A).foldl (fun acc d => acc * d.natAbs) 1
+      else 0
 ```
 
 `IsSNF.detDivisor_eq` is the theorem to prove first, and it must be
@@ -357,6 +403,11 @@ statement does not apply. With the all-`k` form, `S.rank` is the largest
 `k` whose determinantal divisor is nonzero, which gives `rank_eq`, and
 cancelling the positive product of the preceding factors gives
 `diag_eq`. Everything the library claims about canonicity rests on it.
+`IsSNF.form_eq` packages the dependent rank and diagonal equalities into the
+fixed `n × m` matrix equality callers usually want. It also proves
+`snfDiagonal_eq_snf`: the diagonal-specific data and the general data both
+satisfy `IsSNF` for the same input, while `snfDiagonal_eq_data` and
+`snf_eq_data` connect the two form-only paths to those data.
 
 **Its prerequisite is a phase of work in `hex-determinant`, and that
 work does not exist.** The argument needs each `k × k` minor of a product
@@ -381,9 +432,17 @@ So `hex-determinant` needs, as a named prerequisite:
 - the gcd and divisibility lemmas that turn that expansion into
   invariance of `detDivisor` under unimodular multiplication.
 
-Smith implementation should not be scheduled before that lands. Nothing
-else in this SPEC depends on it, so the executable parts and the
-certificate can proceed in parallel with it.
+The same selected-minor infrastructure closes `IsSNF.rank_eq_hnfRank`
+without importing Mathlib. If `r = hnfRank A`, the HNF pivot rows and pivot
+columns select a triangular `r × r` minor with nonzero determinant, while
+every `(r + 1) × (r + 1)` minor vanishes because the remaining HNF rows are
+zero. Invariance under the HNF transform transfers those statements back to
+`A`; the all-`k` Smith characterisation then identifies `S.rank` with `r`.
+
+The executable pivot loop can be prototyped after Hermite lands, but the
+library cannot be activated or claim canonical output until this prerequisite
+and `IsSNF.detDivisor_eq` are complete. Schedule the determinant work before
+the Smith proof phase rather than treating uniqueness as optional follow-up.
 
 ## Certificates
 
@@ -393,11 +452,11 @@ The same shape as [hex-hermite](hex-hermite.md), with one more product:
 /-- Accepts `(S, U, W, V, X, T)` as a Smith normal form of `A`, where
 `T = U * A` is the intermediate product. -/
 def snfCert (A : Matrix Int n m) (S : SmithData n m) (T : Matrix Int n m) : Bool :=
-  Hex.Internal.mulEqCert S.left A T
-    && Hex.Internal.mulEqCert S.right.transpose T.transpose
+  Hex.Matrix.mulEqCert S.left A T
+    && Hex.Matrix.mulEqCert S.right.transpose T.transpose
           (diagMatrix S.diag n m).transpose
-    && Hex.Internal.mulEqCert S.left S.leftInv (Matrix.identity n)
-    && Hex.Internal.mulEqCert S.right S.rightInv (Matrix.identity m)
+    && Hex.Matrix.mulEqCert S.left S.leftInv (Matrix.identity n)
+    && Hex.Matrix.mulEqCert S.right S.rightInv (Matrix.identity m)
     && isSNFShape S
 
 theorem snfCert_sound : snfCert A S T = true → IsSNF A S
@@ -416,7 +475,7 @@ clauses with unimodular transforms has the rank and the diagonal of the
 Smith normal form, so an accepted candidate is the answer and no second
 witness for canonicity is needed. Note that this completeness is
 downstream of the uniqueness theorem, which is downstream of the
-`hex-determinant` prerequisite above. Until that chain is closed, the
+`hex-determinant` prerequisite above; until that chain is closed, the
 checker is sound but the "it is the answer" claim is not yet proved.
 That makes certified dispatch to an external implementation possible in
 the shape `hex-lll`'s `certCheck` already uses. It is not part of v1.
@@ -430,16 +489,17 @@ the shape `hex-lll`'s `certCheck` already uses. It is not part of v1.
 submodule spanned by the rows of `A`. -/
 noncomputable def smithNormalForm (A : Matrix Int n m) :
     Module.Basis.SmithNormalForm
-      (Submodule.span ℤ (Set.range (matrixEquiv A))) (Fin m) (snf A).rank
+      (Submodule.span ℤ (Set.range (matrixEquiv A))) (Fin m) (snfRank A)
 
 /-- The divisibility chain, which Mathlib's structure does not carry. -/
-theorem smithNormalForm_chain (A : Matrix Int n m) (i : Nat) (h : i + 1 < (snf A).rank) :
+theorem smithNormalForm_chain (A : Matrix Int n m) (i : Nat) (h : i + 1 < snfRank A) :
     (smithNormalForm A).a ⟨i, by omega⟩ ∣ (smithNormalForm A).a ⟨i + 1, h⟩
 
 /-- The structure theorem, instantiated at the executable output. -/
 noncomputable def quotientEquiv (A : Matrix Int n m) :
     (Fin m → ℤ) ⧸ Submodule.span ℤ (Set.range (matrixEquiv A)) ≃ₗ[ℤ]
-      (Fin (m - (snf A).rank) → ℤ) × ⨁ i, ℤ ⧸ Ideal.span {invariantFactors A i}
+      (Fin (m - snfRank A) → ℤ) ×
+        ⨁ i : Fin (snfRank A), ℤ ⧸ Ideal.span {(invariantFactors A)[i]}
 ```
 
 Two things are worth knowing about the Mathlib side before this is
@@ -460,6 +520,13 @@ transport, and the executable library is the only source of canonicity.
 existence argument over a PID. Supplying an executable witness with the
 identity proved is the same payoff `hex-hermite`'s `kernelBasisEquiv`
 delivers, one level up.
+
+The pinned Mathlib quotient helper directly covers only a full-rank
+submodule. The displayed `quotientEquiv` is rank-general: its proof must use
+the explicit Smith ambient basis, split the complement of the leading
+`Fin (snfRank A)` embedding to produce the free factor, and apply the cyclic
+quotient equivalence on the occupied coordinates. It is not merely an
+application of the existing full-rank helper.
 
 Upstreaming the chain field to Mathlib's structure, or adding invariant
 factors alongside it, is a reasonable later contribution and is out of
@@ -482,12 +549,6 @@ the route to rational canonical form and the minimal polynomial, and it
 shares the algorithm shape and none of the normalisation, growth
 control, or termination measure.
 
-**Anything Berlekamp-Zassenhaus needs.** Nothing in the existing tree
-depends on this library. Integer factoring of polynomials reaches its
-answer without a Smith normal form, so this is new capability rather than
-a missing piece of something already built, and it can be scheduled
-purely on the strength of its own consumers.
-
 **Sparse input.** Relation matrices from group presentations are often
 very sparse, and dense elimination fills them in immediately. The sparse
 matrix item in [future-work](../future-work.md) names this as one of the
@@ -499,17 +560,20 @@ revisited there rather than worked around here.
 `A` is `n × m` with rank `r`. As in [hex-hermite](hex-hermite.md), these
 are **matrix-update counts** rather than worst-case complexity, and they
 are parameterised by `P`, the number of times the pivot loop repeats at
-one diagonal position. `P` is bounded by the bit length of the entries,
-not by any matrix dimension, since each repetition strictly shrinks the
-pivot. There is no proven bound on operand size for this algorithm, which
+one diagonal position. `P` is bounded by the bit length of the pivot when
+that diagonal stage begins, not by a matrix dimension, since each strict
+replacement is by a proper divisor. There is no input-only bound on that
+bit length or on the other intermediate operands for this algorithm, which
 is the point made under "Algorithms".
 
 | operation | algorithm | matrix updates and `extGcd` calls | operand size |
 |---|---|---|---|
-| `snf` | classical Euclidean pivot loop | `O(P · r · (n + m) · max n m)` | unbounded; measured, not proved |
-| `snfDiagonal` | normalisation plus adjacent-pair sweep | `O(r²)` | bounded by the product of the input diagonal |
+| `snf` | form-only classical Euclidean pivot loop | `O(P · r · (n + m) · max n m)` | unbounded; measured, not proved |
+| `snfRank`, `invariantFactors` | projections of the form-only run | as `snf` | as `snf` |
+| `snfData` | `snf` plus accumulation of `U`, `W`, `V`, and `X` | `+ O(P · r · (n + m) · max n m)` | transforms may exceed the form substantially |
+| `snfDiagonal` | form-only normalisation plus fixed adjacent-pair network | `O(r²)` | bounded by the product of the input diagonal |
+| `snfDiagonalData` | `snfDiagonal` plus four transform updates | `O(r³)` scalar entry updates in the dense matrices | transform-dependent |
 | `abelianStructure` | `snf` plus a filter | as `snf` | as `snf` |
-| `solveInt` | `snf`, one diagonal solve, two `vecMul`s | `+ O(n · m)` | as `snf` |
 
 ## Conformance
 
@@ -531,7 +595,8 @@ identities instead.
 
 **Cases that must be present:**
 
-- the zero matrix, and a matrix of rank `1`;
+- the `0 × 0`, `0 × m`, and `n × 0` cases, the zero matrix, and a matrix
+  of rank `1`;
 - input where the first invariant factor is not the smallest entry, for
   example `[[2, 0], [0, 3]]`, whose Smith normal form is
   `diag(1, 6)`. An implementation that omits the divisibility step in
@@ -542,17 +607,24 @@ identities instead.
 - rank-deficient input, checking the trailing zeros and the rank;
 - rectangular input in both orientations;
 - negative and mixed-sign entries;
+- `[-1]` and a matrix whose final diagonal stage is negative, checking that
+  the general pivot loop normalises a pivot even when no elimination step runs;
 - a presentation of a known abelian group, checked against
-  `abelianStructure`: `[[2, 0], [0, 2]]` gives `(0, #[2, 2])` and
-  `[[1, 1], [0, 2]]` gives `(0, #[2])`;
-- input already in Smith normal form, checking idempotence;
-- diagonal input through `snfDiagonal` containing zeros and negatives,
+  `abelianStructure`: `[[2, 0], [0, 2]]` gives free rank `0` and torsion
+  `#[2, 2]`, while `[[1, 1], [0, 2]]` gives free rank `0` and torsion
+  `#[2]`;
+- input already in Smith normal form, checking `snf (snf A) = snf A`;
+- agreement of `snf`/`snfData` and `snfDiagonal`/`snfDiagonalData` on every
+  fixture, plus `snfDiagonal d = snf (diagMatrix d r r)` on every diagonal
+  fixture;
+- diagonal input through both diagonal paths containing zeros and negatives,
   including `[0, 2]`, `[-2, 0]`, and `[0, 0]`, which is where an
   implementation that skips the normalisation phase divides by zero or
   returns a non-normal form;
-- an unsolvable and a solvable integer system through `solveInt`, with
-  the solvable one chosen so that `V ≠ I`, which is what catches a
-  `solveInt` that forgets to transform the right-hand side.
+- an unsolvable and a solvable integer system checked through
+  `solvable_iff_dvd (snfData_isSNF A)`, with `V ≠ I`; the unsolvable case
+  has a zero-tail violation so it catches both failure to transform `b` and
+  failure to check coordinates after the rank.
 
 ## Benchmarking
 
@@ -575,38 +647,31 @@ specified here, so the ratio compares different algorithms and does not
 hold a required threshold. PARI `matsnf` through `cypari2`, also
 `informational`.
 
-**The decision rules written down in advance.** As in
-[hex-hermite](hex-hermite.md), each is stated over a range rather than at
-one ladder endpoint.
+**The diagonal decision rule written down in advance.** `snfDiagonal` must
+be faster than `snf` on diagonal input by a margin that grows with `r`, since
+it skips elimination entirely. A flat or shrinking margin means the fast
+path is not being taken, which is a bug rather than a benchmark result. The
+report also measures `snfData / snf` and `snfDiagonalData / snfDiagonal`
+separately so transform cost is visible rather than charged to form-only
+consumers.
 
-1. `snfSquareDiag` (modular, form only) is kept only if it wins across
-   the upper half of both the dimension and the entry-bit-size ladders on
-   `random-dense-smith`, and only if a named consumer wants the diagonal
-   without the transforms. It answers a strictly smaller question than
-   `snf`, so a win at one point does not justify carrying it.
-2. `snfDiagonal` must be faster than `snf` on diagonal input by a margin
-   that grows with `r`, since it skips the elimination entirely. A flat
-   or shrinking margin means the fast path is not being taken, which is a
-   bug rather than a benchmark result. It is not stated as a fixed
-   multiple, because at small `r` the two are legitimately comparable.
-
-**Growth instrumentation is required, not optional.** The default
-algorithm ships with no proven entry bound, so the bench records peak
-intermediate entry bit-size and time spent in big-integer arithmetic
-alongside wallclock on every family. Those numbers are the evidence for
-or against specifying Kannan-Bachem, per "Open questions".
+**Growth instrumentation is required, not optional.** A separate untimed
+diagnostic runner scans the working matrix after each elementary update and
+returns peak intermediate entry bit-size. Timed runs use the ordinary
+uninstrumented API and report wallclock. The growth curve and wallclock curve,
+not an unavailable attribution of time to individual `Int` primitives, are
+the evidence for or against specifying Kannan-Bachem.
 
 ## File organisation
 
 ```
 HexSmith/
-  Contracts.lean     -- SmithData, diagMatrix, IsSNF, isSNFShape
-  Smith.lean         -- snf, the classical Euclidean pivot loop
-  Diagonal.lean      -- snfDiagonal: normalisation and the adjacent-pair sweep
-  Modular.lean       -- snfSquareDiag, the Iliopoulos variant
+  Contracts.lean     -- SmithData, AbelianStructure, IsSNF, isSNFShape
+  Smith.lean         -- snf, snfRank, snfData, the classical pivot loop
+  Diagonal.lean      -- snfDiagonal, snfDiagonalData, fixed gcd/lcm network
   Divisor.lean       -- detDivisor and IsSNF.detDivisor_eq
   Unique.lean        -- IsSNF.rank_eq, IsSNF.diag_eq
-  Structure.lean     -- invariantFactors, abelianStructure, quotientOrder, solveInt
+  Structure.lean     -- invariantFactors, abelianStructure, solvability and index theorems
   Cert.lean          -- snfCert and its soundness
 HexSmith.lean        -- umbrella
 HexSmithMathlib/
@@ -624,6 +689,21 @@ HexSmithMathlib.lean
     mathlib: false
     done_through: 0
     status: draft
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_mat_snf via python-flint
+          class: informational
+          rationale: FLINT dispatches to algorithms and crossover policies outside this SPEC
+        - tool: PARI matsnf via cypari2
+          class: informational
+          rationale: PARI uses a separately tuned implementation and is recorded for orientation
+      input_families:
+        - name: random-dense-smith
+          description: dense square nonsingular integer matrices with uniformly bounded entries
+        - name: chain-conjugate
+          description: known divisibility chains conjugated by random unimodular matrices
+        - name: presentation-smith
+          description: sparse abelian-group relation matrices run through the dense implementation
   HexSmithMathlib:
     deps: [HexSmith, HexHermiteMathlib]
     mathlib: true
@@ -651,12 +731,17 @@ Everything else arrives through `HexHermite`.
   forms on trailing submatrices and does have one, at the cost of block
   embeddings, rank-deficient handling, and accumulating the transforms
   through all of it. The growth instrumentation under "Benchmarking" is
-  what decides whether that work is called for. It should not be started
+  what decides whether that work is called for; it should not be started
   on the strength of the name.
+- **Whether to write an Iliopoulos follow-up SPEC.** A public modular path
+  needs the complete recurrence, its modulus invariant, a singularity
+  theorem for the `Option` boundary, and agreement with `invariantFactors`.
+  It is proposed only if the form-only `snf` growth curve shows a production
+  range where bounded modular operands are likely to repay that complexity.
 - **Whether `detDivisor` should be public at all.** It is the
   specification function and it has no efficient direct evaluation. The
   argument for exporting it is that the statement `d₁ ⋯ d_k = D_k` is
-  the thing a mathematician wants to cite. The argument against is that
+  the thing a mathematician wants to cite; the argument against is that
   a `noncomputable` definition with an exponential unfolding invites
   misuse. It is exported here with its docstring saying so.
 - **Sparse relation matrices**, as above. The dense algorithm is

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -36,10 +36,10 @@ representative of an integer row lattice with lattice membership,
 integer kernel bases, and integer rank on top of it, and Smith normal
 form as the diagonal form with the divisibility chain `d₁ ∣ d₂ ∣ ⋯ ∣ dᵣ`,
 the invariant factors, and the structure of a finitely generated abelian
-group. Both are separate libraries rather than additions to hex-matrix,
-because both need the extended GCD from hex-arith and the echelon
-contracts from hex-row-reduce, and Hermite normal form needs a
-determinant from hex-bareiss for its modular algorithm.
+group. Both are separate libraries rather than additions to hex-matrix.
+Hermite uses the extended GCD from hex-arith, the echelon contracts from
+hex-row-reduce, and determinant/adjugate theory from hex-determinant; Smith
+builds on that library and its shared elimination step.
 
 Two corrections to what this file said before those SPECs were written,
 recorded because they are easy to make again. The `IsHNF` field list

--- a/progress/2026-08-21T05-58-26Z.md
+++ b/progress/2026-08-21T05-58-26Z.md
@@ -1,0 +1,36 @@
+# Hermite/Smith pre-merge corrections
+
+## Accomplished
+
+- Rebased the Hermite/Smith SPEC rewrite onto the current upstream
+  `main` in an isolated worktree, leaving unrelated concurrent edits untouched.
+- Corrected missing negative-pivot normalisation in both classical algorithms,
+  including transform/inverse updates and regression fixtures.
+- Repaired the Smith solvability theorem binders and all `Vector` indexing
+  forms, and made the matrix one-sided-inverse prerequisite elaborate against
+  the Mathlib-free matrix API.
+- Clarified the shared accumulator implementation strategy, feasible
+  determinant cross-check sizes, the row-rank/column-rank proof obligation,
+  released-repository prerequisite sequencing, and cross-shape modular claims.
+- Updated the library index and future-work summary to match the revised
+  Hermite dependency and v1 algorithm.
+- Added machine-readable Phase-4 metadata to both proposed library snippets.
+- Ran the DAG checker and Markdown structural, link, fence, and whitespace
+  checks successfully.
+
+## Current frontier
+
+- The focused branch contains only the two SPEC rewrites, their two consistency
+  updates, and this progress note.
+- The documentation changes are ready for commit, PR creation, and CI.
+
+## Next step
+
+- Push the focused branch, open the upstream PR, inspect every Actions job
+  directly, resolve any review or CI failures, and merge when green.
+
+## Blockers
+
+- No design blocker remains in the SPEC rewrite.
+- Smith implementation still intentionally depends on the documented selected
+  minor and rectangular Cauchy--Binet prerequisites in `hex-determinant`.


### PR DESCRIPTION
## Summary

- split form-only, transform, and inverse-transform APIs with explicit cost and agreement contracts
- defer underspecified modular algorithms and repair pivot normalization, integer-solvability, kernel, index, and canonical-form contracts
- name determinant/minor, public matrix-helper, and released-library sequencing prerequisites
- align the library index and future-work summary with the revised v1 dependency graph

## Validation

- independent pre-merge specification review, with all blocking findings resolved
- `python3 scripts/check_dag.py`
- Markdown local-link, fence, trailing-whitespace, and `git diff --check` validation

Documentation only; no Lean source changed.