### PR TITLE
feat(interval): support bounded policy contracts

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -11,6 +11,7 @@ public import HexInterval.Multiplication
 public import HexInterval.Action
 public import HexInterval.State
 public import HexInterval.Trace
+public import HexInterval.Policy
 
 public section
 
@@ -34,6 +35,9 @@ visible as the explicit decoder and inspection boundary. The public structural
 contracts also cover checked typed SSA programs, versioned fact projections,
 registrations, scoped bindings, actions, immutable package requests, checked
 immutable branch state, dependency/work queues, authoritative chronology, and
-bounded diagnostics. Concrete callbacks and proposals, policy selection,
-search, proof replay, and measurement-selected storage remain experimental.
+bounded diagnostics. The public policy contract exposes bounded immutable
+offers, exact echoed decisions, and fail-closed revalidation without selecting
+a default policy.
+Concrete callbacks and proposals, policy implementations, search, proof replay,
+and measurement-selected storage remain experimental.
 -/

--- a/HexInterval/Experiment/AdaptivePolicy.lean
+++ b/HexInterval/Experiment/AdaptivePolicy.lean
@@ -27,6 +27,10 @@ The scores choose search order only.  Every selected offer is revalidated by
 namespace Hex.Interval.Experiment.AdaptivePolicy
 
 open Propagator Propagator.Policy TargetRun
+open Hex.Interval.Policy (ScopeId)
+
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView Propagator.Policy.OfferId Propagator.Policy.OfferKey
 
 /-- Replaceable integer coefficients for the first feedback experiment. -/
 structure Config where
@@ -152,12 +156,12 @@ def learnedScore (config : Config) (record : Option Record)
       else gain + ageBonus - config.noChangePenalty * record.stagnant
 
 structure Ranked where
-  offer : OfferView
+  offer : PolicyOffer
   fair : Bool
   stage : Nat
   score : Nat
 
-def rankOffer (state : State) (offer : OfferView) : Ranked :=
+def rankOffer (state : State) (offer : PolicyOffer) : Ranked :=
   let record := (offerKey? offer.key).bind (find? state.records)
   let snapshot := offerSnapshot? offer.key
   { offer
@@ -176,7 +180,7 @@ def better (candidate current : Ranked) : Bool :=
       (current.score < candidate.score ||
         (current.score == candidate.score && current.offer.age < candidate.offer.age)))
 
-def choose? (state : State) (offers : Array OfferView) : Option OfferView :=
+def choose? (state : State) (offers : Array PolicyOffer) : Option PolicyOffer :=
   (offers.foldl (fun best offer =>
     if !StagedPolicy.allowed state.config.staged offer then best
     else

--- a/HexInterval/Experiment/BranchProof.lean
+++ b/HexInterval/Experiment/BranchProof.lean
@@ -72,7 +72,7 @@ def samePlan [DecidableEq Fact] (left right : Propagator.Policy.SplitPlan Fact) 
   left == right
 
 def sameChild [DecidableEq Fact]
-    (scope : Propagator.Policy.ScopeId) (depth : Nat)
+    (scope : Hex.Interval.Policy.ScopeId) (depth : Nat)
     (input : SemanticReplay.CheckerInput Fact)
     (source : BranchTree.Leaf Fact PolicyState) : Bool :=
   source.scope == scope && source.depth == depth && sameInput source.input input

--- a/HexInterval/Experiment/BranchStart.lean
+++ b/HexInterval/Experiment/BranchStart.lean
@@ -42,10 +42,10 @@ structure State where
   private mk ::
   createdScopes : Nat
   nextScope : Nat
-  private scopeDepths : List (Propagator.Policy.ScopeId × Nat)
+  private scopeDepths : List (Hex.Interval.Policy.ScopeId × Nat)
 
 private def makeState (createdScopes nextScope : Nat)
-    (scopeDepths : List (Propagator.Policy.ScopeId × Nat)) : State :=
+    (scopeDepths : List (Hex.Interval.Policy.ScopeId × Nat)) : State :=
   { createdScopes, nextScope, scopeDepths }
 
 namespace State
@@ -68,9 +68,9 @@ structure Children (Fact : Type) where
   plan : Propagator.Policy.SplitPlan Fact
   depth : Nat
   parent : CheckerInput Fact
-  leftScope : Propagator.Policy.ScopeId
+  leftScope : Hex.Interval.Policy.ScopeId
   left : CheckerInput Fact
-  rightScope : Propagator.Policy.ScopeId
+  rightScope : Hex.Interval.Policy.ScopeId
   right : CheckerInput Fact
 
 /-- Fail-closed reasons for refusing to create child sessions. -/
@@ -170,8 +170,8 @@ opaque prepare [DecidableEq Fact] (limits : Limits) (state : State)
   let childDepth := depth + 1
   if childDepth > limits.maxDepth then throw .depthLimit
   if state.createdScopes + 2 > limits.maxScopes then throw .scopeLimit
-  let leftScope : Propagator.Policy.ScopeId := { index := state.nextScope }
-  let rightScope : Propagator.Policy.ScopeId := { index := state.nextScope + 1 }
+  let leftScope : Hex.Interval.Policy.ScopeId := { index := state.nextScope }
+  let rightScope : Hex.Interval.Policy.ScopeId := { index := state.nextScope + 1 }
   let parent : CheckerInput Fact :=
     { baseProgram := engine.program, initialFacts := engine.facts, target }
   let left : CheckerInput Fact :=
@@ -192,7 +192,7 @@ inductive LeafStatus (Fact : Type)
   | unfinished
   | wrongInput
 
-def sameInput [DecidableEq Fact] (scope : Propagator.Policy.ScopeId)
+def sameInput [DecidableEq Fact] (scope : Hex.Interval.Policy.ScopeId)
     (input : CheckerInput Fact)
     (result : TargetRun.Result Fact PolicyState) : Bool :=
   result.session.state.scope == scope &&
@@ -203,7 +203,7 @@ def sameInput [DecidableEq Fact] (scope : Propagator.Policy.ScopeId)
 input.  Target closure is rechecked against the retained current fact and
 version. -/
 def status [DecidableEq Fact] (domain : FactDomain Fact)
-    (scope : Propagator.Policy.ScopeId) (input : CheckerInput Fact)
+    (scope : Hex.Interval.Policy.ScopeId) (input : CheckerInput Fact)
     (result : TargetRun.Result Fact PolicyState) :
     LeafStatus Fact :=
   if !sameInput scope input result then .wrongInput

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -68,14 +68,14 @@ structure TreeId where
 
 /-- Exact input, scope, depth, and private policy state of one leaf. -/
 structure Leaf (Fact PolicyState : Type) where
-  scope : Propagator.Policy.ScopeId
+  scope : Hex.Interval.Policy.ScopeId
   depth : Nat
   input : CheckerInput Fact
   policyState : PolicyState
 
 /-- A leaf whose policy session can still be run. -/
 structure Job (Fact PolicyState : Type) : Type 1 where
-  scope : Propagator.Policy.ScopeId
+  scope : Hex.Interval.Policy.ScopeId
   depth : Nat
   input : CheckerInput Fact
   policyState : PolicyState
@@ -145,7 +145,7 @@ def State.stepLimited (limits : Limits) (state : State Fact PolicyState) : Bool 
   state.steps >= limits.maxSteps && !state.frontier.isEmpty
 
 /-- Build a coherent root session from the exact caller input. -/
-def start (config : Config Fact PolicyState) (scope : Propagator.Policy.ScopeId)
+def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeId)
     (input : CheckerInput Fact) (policyState : PolicyState) :
     Except StartError (State Fact PolicyState) := do
   if config.limits.maxLeaves = 0 then throw .leafLimit
@@ -173,7 +173,7 @@ def schedule (order : Order) (rest fresh : List TreeId) : List TreeId :=
   | .breadthFirst => rest ++ fresh
 
 def childNode (config : Config Fact PolicyState) (side : Side)
-    (scope : Propagator.Policy.ScopeId) (depth : Nat) (input : CheckerInput Fact)
+    (scope : Hex.Interval.Policy.ScopeId) (depth : Nat) (input : CheckerInput Fact)
     (policyState : PolicyState) : Node Fact PolicyState × Bool :=
   let childState := config.forkPolicy policyState side
   let source : Leaf Fact PolicyState := { scope, depth, input, policyState := childState }

--- a/HexInterval/Experiment/FeaturePolicy.lean
+++ b/HexInterval/Experiment/FeaturePolicy.lean
@@ -32,6 +32,9 @@ namespace Hex.Interval.Experiment.FeaturePolicy
 
 open Propagator Propagator.Policy PolicyFeature
 
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView Propagator.Policy.OfferId Propagator.Policy.OfferKey
+
 /-- Globally unambiguous configured feature address. -/
 structure Address where
   provider : ProviderKey
@@ -175,7 +178,7 @@ def featureScore (limits : Limits) (plan : Plan)
   pure score
 
 structure Ranked where
-  offer : OfferView
+  offer : PolicyOffer
   fair : Bool
   stage : Nat
   score : Int
@@ -205,7 +208,7 @@ hand-built experiment data.  The returned value is always the exact
 `FeaturedOffer.base`, and ordinary engine revalidation remains authoritative.
 Unknown and missing configured features contribute zero. -/
 def choose? (limits : Limits) (state : AdaptivePolicy.State) (plan : Plan)
-    (view : PolicyFeature.View Fact) : Except Error (Option OfferView) := do
+    (view : PolicyFeature.View Fact) : Except Error (Option PolicyOffer) := do
   preflight limits plan view
   let mut best : Option Ranked := none
   for offer in view.offers do

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -475,8 +475,7 @@ opaque State.view (state : State Fact) :
 
 /-! # Validated selection -/
 
-/-- A policy echoes the exact engine stamps, remaining budget, identifier,
-semantic key, class, age, and score from one particular view. -/
+/-- Fail-closed reasons why the engine rejected a selected policy offer. -/
 inductive Rejection where
   | decisionLimit
   | wrongScope

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexInterval.Experiment.Propagator
+public import HexInterval.Policy
 
 @[expose] public section
 
@@ -30,17 +31,7 @@ namespace Hex.Interval.Experiment.Propagator.Policy
 
 /-! # Stable semantic offer descriptions -/
 
-/-- Scope identity is explicit even though the first experiment has one root
-scope.  It prevents a later branch-local choice from being transplanted. -/
-structure ScopeId where
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- Versioned name of a deterministic external policy. -/
-structure PolicyKey where
-  name : String
-  version : Nat
-  deriving DecidableEq, Repr
+open Hex.Interval.Policy (ScopeId PolicyKey OfferClass EngineBudgetView)
 
 /-- Collision-free engine identity for each kind of live work. -/
 inductive OfferId where
@@ -121,14 +112,6 @@ def InstantiationSemanticKey.ofRequest
         watches := scope.watches
         writes := scope.writes } }
 
-inductive OfferClass where
-  | invoke
-  | equality
-  | retry
-  | instantiate
-  | split
-  deriving DecidableEq, Repr
-
 /-- Semantic key which a selection must echo exactly.  Split freshness
 includes the target fact version, not an unrelated whole-program version. -/
 inductive OfferKey where
@@ -147,12 +130,8 @@ def OfferKey.offerClass : OfferKey -> OfferClass
   | .instantiate _ _ => .instantiate
   | .split _ _ _ _ => .split
 
-structure OfferView where
-  id : OfferId
-  key : OfferKey
-  offerClass : OfferClass
-  age : Nat
-  deriving DecidableEq
+local notation "OfferView" => Hex.Interval.Policy.OfferView OfferId OfferKey
+local notation "Selection" => Hex.Interval.Policy.Decision OfferId OfferKey
 
 /-! # Engine-owned frontier state -/
 
@@ -460,37 +439,28 @@ private def stateOffers (state : State Fact) : Except ViewError (Array OfferView
   if state.limits.maxLiveOffers < offers.size then throw .liveOfferLimit
   pure (offers, traversal)
 
-structure EngineBudgetView where
-  actions : Nat
-  matcherVisits : Nat
-  acceptedFacts : Nat
-  nodes : Nat
-  applications : Nat
-  equalities : Nat
-  retainedSuggestions : Nat
-  instances : Nat
-  queueEntries : Nat
-  generation : Nat
-  deriving DecidableEq, Repr
-
-structure View (Fact : Type) where
-  scope : ScopeId
-  serial : Nat
-  programVersion : Nat
-  offers : Array OfferView
-  facts : Snapshot Fact
-  remaining : EngineBudgetView
-  incomplete : Bool
-
 def remaining (limit used : Nat) : Nat := limit - used
 
-/-- Highest theorem-instantiation generation already committed in this
-branch.  Instance events cover node-, equality-, and scope-only extensions. -/
-private def usedGeneration (state : State Fact) : Nat :=
-  state.engine.instanceHistory.foldl
+/-- Exact remaining engine budget echoed by a policy decision. -/
+def State.budgetView (state : State Fact) : EngineBudgetView :=
+  let generation := state.engine.instanceHistory.foldl
     (fun greatest event => Nat.max greatest event.generation) 0
+  { actions := remaining state.engine.limits.maxActions state.engine.metrics.queuePops
+    matcherVisits :=
+      remaining state.engine.limits.maxMatcherVisits state.engine.metrics.matcherVisits
+    acceptedFacts := remaining state.engine.limits.maxAcceptedFacts state.engine.history.size
+    nodes := remaining state.engine.limits.maxNodes state.engine.program.nodes.size
+    applications :=
+      remaining state.engine.limits.maxApplications state.engine.applications.size
+    equalities := remaining state.engine.limits.maxEqualities state.engine.equalities.size
+    retainedSuggestions :=
+      remaining state.engine.limits.maxRetainedSuggestions state.engine.suggestions.size
+    instances := remaining state.engine.limits.maxInstances state.engine.instances.length
+    queueEntries := remaining state.engine.limits.maxQueueEntries state.engine.queue.size
+    generation := remaining state.engine.limits.maxGeneration generation }
 
-opaque State.view (state : State Fact) : Except ViewError (View Fact × State Fact) := do
+opaque State.view (state : State Fact) :
+    Except ViewError (Hex.Interval.Policy.View Fact OfferId OfferKey × State Fact) := do
   let (offers, traversal) <- stateOffers state
   pure
     ({ scope := state.scope
@@ -499,24 +469,7 @@ opaque State.view (state : State Fact) : Except ViewError (View Fact × State Fa
        offers
        facts := state.engine.toBranch.snapshot
        incomplete := state.incomplete
-       remaining :=
-        { actions := remaining state.engine.limits.maxActions state.engine.metrics.queuePops
-          matcherVisits :=
-            remaining state.engine.limits.maxMatcherVisits
-              state.engine.metrics.matcherVisits
-          acceptedFacts := remaining state.engine.limits.maxAcceptedFacts state.engine.history.size
-          nodes := remaining state.engine.limits.maxNodes state.engine.program.nodes.size
-          applications :=
-            remaining state.engine.limits.maxApplications state.engine.applications.size
-          equalities := remaining state.engine.limits.maxEqualities state.engine.equalities.size
-          retainedSuggestions :=
-            remaining state.engine.limits.maxRetainedSuggestions state.engine.suggestions.size
-          instances := remaining state.engine.limits.maxInstances state.engine.instances.length
-          queueEntries :=
-            remaining state.engine.limits.maxQueueEntries state.engine.queue.size
-          generation :=
-            remaining state.engine.limits.maxGeneration
-              (usedGeneration state) } },
+       remaining := state.budgetView },
      { state with
        metrics := { state.metrics with traversal := state.metrics.traversal + traversal } })
 
@@ -524,13 +477,6 @@ opaque State.view (state : State Fact) : Except ViewError (View Fact × State Fa
 
 /-- A policy echoes both the engine identity and the semantic key from one
 particular view. -/
-structure Selection where
-  scope : ScopeId
-  serial : Nat
-  programVersion : Nat
-  id : OfferId
-  expected : OfferKey
-
 inductive Rejection where
   | decisionLimit
   | wrongScope

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -475,15 +475,17 @@ opaque State.view (state : State Fact) :
 
 /-! # Validated selection -/
 
-/-- A policy echoes both the engine identity and the semantic key from one
-particular view. -/
+/-- A policy echoes the exact engine stamps, remaining budget, identifier,
+semantic key, class, age, and score from one particular view. -/
 inductive Rejection where
   | decisionLimit
   | wrongScope
   | staleSerial
   | staleProgram
+  | staleBudget
   | missingOffer
   | wrongKey
+  | mutatedOffer
   | actionLimit
   | malformedState
   deriving DecidableEq, Repr
@@ -576,13 +578,19 @@ private def reject (state : State Fact) (reason : Rejection) : SelectResult Fact
   | .decisionLimit => .rejected reason state
   | _ => .rejected reason (chargeDecision state .rejected)
 
+/-- Authenticate every supported decision field against the current retained
+state and return the engine-owned offer rather than the policy's copy. -/
 def State.validate (state : State Fact) (selection : Selection) : Except Rejection OfferView := do
   if state.limits.maxDecisions <= state.metrics.decisions then throw .decisionLimit
   if selection.scope != state.scope then throw .wrongScope
   if selection.serial != state.serial then throw .staleSerial
   if selection.programVersion != state.engine.programVersion then throw .staleProgram
+  if selection.remaining != state.budgetView then throw .staleBudget
   let some offer := state.offer? selection.id | throw .missingOffer
   if selection.expected != offer.key then throw .wrongKey
+  if selection.offerClass != offer.offerClass || selection.age != offer.age ||
+      selection.score != offer.score then
+    throw .mutatedOffer
   pure offer
 
 def deltasFor (before after : Engine Fact) (nodes : List NodeId) : Array (FactDelta Fact) := Id.run do

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -30,13 +30,22 @@ namespace Hex.Interval.Experiment.Propagator.Policy.Driver
 
 universe u
 
+open Hex.Interval.Policy (ScopeId PolicyKey OfferClass)
+
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView OfferId OfferKey
+local notation "PolicyDecision" =>
+  Hex.Interval.Policy.Decision OfferId OfferKey
+local notation "PolicyView" =>
+  Hex.Interval.Policy.View
+
 /-! ## External policy protocol -/
 
 /-- One external policy decision.  Policy-private state has an arbitrary Lean
 type and remains outside the trusted engine. -/
 inductive Step (PolicyState : Type)
-  | select (selection : Selection) (next : PolicyState)
-  | dismiss (selection : Selection) (next : PolicyState)
+  | select (selection : PolicyDecision) (next : PolicyState)
+  | dismiss (selection : PolicyDecision) (next : PolicyState)
   | stop (next : PolicyState)
 
 /-- Outcome of selecting one retained instantiation offer. -/
@@ -48,20 +57,20 @@ inductive InstanceOutcome
 
 /-- The engine transition which exhausted a resource. -/
 inductive ResourceOrigin
-  | choice (selection : Selection)
-  | invocation (selection : Selection) (invocation : InvocationKey)
+  | choice (selection : PolicyDecision)
+  | invocation (selection : PolicyDecision) (invocation : InvocationKey)
 
 /-- One ordered policy observation.  Successful choices retain the exact
 selection as well as the engine-produced semantic observation. -/
 inductive Event (Fact : Type)
-  | rule (selection : Selection) (observation : RuleObservation Fact)
-  | replyRejected (selection : Selection) (invocation : InvocationKey)
+  | rule (selection : PolicyDecision) (observation : RuleObservation Fact)
+  | replyRejected (selection : PolicyDecision) (invocation : InvocationKey)
       (error : ReplyError)
-  | equality (selection : Selection) (observation : EqualityObservation Fact)
-  | instance (selection : Selection) (outcome : InstanceOutcome)
-  | dismissal (selection : Selection) (halts : Bool) (causesIncomplete : Bool)
-  | splitPrepared (selection : Selection) (plan : SplitPlan Fact)
-  | choiceRejected (selection : Selection) (reason : Rejection)
+  | equality (selection : PolicyDecision) (observation : EqualityObservation Fact)
+  | instance (selection : PolicyDecision) (outcome : InstanceOutcome)
+  | dismissal (selection : PolicyDecision) (halts : Bool) (causesIncomplete : Bool)
+  | splitPrepared (selection : PolicyDecision) (plan : SplitPlan Fact)
+  | choiceRejected (selection : PolicyDecision) (reason : Rejection)
   | engineResource (origin : ResourceOrigin) (resource : Hex.Interval.State.Resource)
   | factResource (origin : ResourceOrigin) (budget : Nat)
   | decisionResource
@@ -79,13 +88,14 @@ external code cannot establish a theorem. -/
 structure Controller (Fact PolicyState : Type) where
   key : PolicyKey
   update : PolicyState -> Event Fact -> PolicyState
-  choose : PolicyState -> View Fact -> Step PolicyState
+  choose : PolicyState ->
+    PolicyView Fact OfferId OfferKey -> Step PolicyState
 
 /-! ## Driver result -/
 
 inductive UnknownReason
   | policyStop (liveOffers : Nat)
-  | requiredDismissal (selection : Selection)
+  | requiredDismissal (selection : PolicyDecision)
   | incomplete
 
 /-- Why policy execution stopped.  A prepared split is returned rather than
@@ -138,7 +148,7 @@ def dismissalAffects : OfferClass -> Bool
 /-- Whether this dismissal is responsible for completeness being unavailable.
 The offer class remains visible even if an earlier transition had already
 made the state incomplete. -/
-def dismissalCauses (before : State Fact) (selection : Selection)
+def dismissalCauses (before : State Fact) (selection : PolicyDecision)
     (after : State Fact) : Bool :=
   after.incomplete &&
     (!before.incomplete || dismissalAffects selection.expected.offerClass)

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -286,8 +286,8 @@ def driveFrom {Cache : Type u} (controller : Controller Fact PolicyState)
                           | .malformedState =>
                               finish controller .invalidState .invalidState
                                 afterRejection cache next events
-                          | .wrongScope | .staleSerial | .staleProgram |
-                              .missingOffer | .wrongKey =>
+                          | .wrongScope | .staleSerial | .staleProgram | .staleBudget |
+                              .missingOffer | .wrongKey | .mutatedOffer =>
                               driveFrom controller invoke remaining afterRejection cache next events
                       | .engineResource resource afterResource =>
                           finish controller (.engineResource (.choice selection) resource)
@@ -326,8 +326,8 @@ def driveFrom {Cache : Type u} (controller : Controller Fact PolicyState)
                           | .malformedState =>
                               finish controller .invalidState .invalidState
                                 afterRejection cache next events
-                          | .wrongScope | .staleSerial | .staleProgram |
-                              .missingOffer | .wrongKey =>
+                          | .wrongScope | .staleSerial | .staleProgram | .staleBudget |
+                              .missingOffer | .wrongKey | .mutatedOffer =>
                               driveFrom controller invoke remaining afterRejection cache next events
                       | .request _ invalid | .equality _ invalid | .completed _ invalid |
                           .split _ invalid | .engineResource _ invalid |

--- a/HexInterval/Experiment/PolicyFeature.lean
+++ b/HexInterval/Experiment/PolicyFeature.lean
@@ -30,6 +30,11 @@ validation of the trace that search eventually generates.
 namespace Hex.Interval.Experiment.PolicyFeature
 
 open Propagator Propagator.Policy
+open Hex.Interval.Policy (ScopeId EngineBudgetView)
+
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView Propagator.Policy.OfferId Propagator.Policy.OfferKey
+local notation "PolicyView" => Hex.Interval.Policy.View
 
 /-- Versioned identity of one independently registered feature provider.
 Changing the meaning of any local feature requires a new provider version. -/
@@ -64,7 +69,7 @@ structure Request (Fact : Type) where
   facts : Snapshot Fact
   remaining : EngineBudgetView
   incomplete : Bool
-  offer : OfferView
+  offer : PolicyOffer
 
 /-- Stateless companion contribution from one interval or frontend package.
 Returning an empty array means this provider contributes nothing for the offer. -/
@@ -132,7 +137,7 @@ end Registry
 /-- One engine offer decorated with package data.  `base` is returned unchanged
 when a policy selects this item. -/
 structure FeaturedOffer where
-  base : OfferView
+  base : PolicyOffer
   features : Array Feature
 
 /-- Deterministic callback/output counts reported by one successful decoration. -/
@@ -144,11 +149,13 @@ structure Metrics where
 /-- A policy view plus aligned featured offers.  The base view remains the
 freshness authority. -/
 structure View (Fact : Type) where
-  base : Policy.View Fact
+  base : PolicyView Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey
   offers : Array FeaturedOffer
   metrics : Metrics
 
-private def request (view : Policy.View Fact) (offer : OfferView) : Request Fact :=
+private def request
+    (view : PolicyView Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey)
+    (offer : PolicyOffer) : Request Fact :=
   { scope := view.scope
     serial := view.serial
     programVersion := view.programVersion
@@ -166,7 +173,8 @@ The complete provider/offer cross product is preflight-counted before any
 callback is entered.  Returned arrays are then checked incrementally against
 per-provider, per-offer, whole-view, key, and value limits. -/
 opaque decorate (limits : Limits) (registry : Registry Fact)
-    (view : Policy.View Fact) : Except Error (View Fact) := do
+    (view : PolicyView Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey) :
+    Except Error (View Fact) := do
   if limits.maxProviders < registry.providers.size then throw .providerLimit
   let checks := registry.providers.size * view.offers.size
   if limits.maxProviderChecks < checks then throw .providerCheckLimit

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -32,7 +32,13 @@ it does not by itself choose a production representation.
 
 namespace Hex.Interval.Experiment.Propagator.PolicyFrontier
 
-open Policy
+open _root_.Hex.Interval.Experiment.Propagator.Policy
+open Hex.Interval.Policy (OfferClass)
+
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView Policy.OfferId Policy.OfferKey
+local notation "PolicyDecision" =>
+  Hex.Interval.Policy.Decision Policy.OfferId Policy.OfferKey
 
 abbrev Rank := Nat
 
@@ -252,21 +258,21 @@ def offerIndex : OfferId -> Nat
   | .equality equality => equality.index
   | .suggestion suggestion => suggestion.index
 
-def priorityOf (offer : OfferView) : Priority :=
+def priorityOf (offer : PolicyOffer) : Priority :=
   { tier := classPriority offer.offerClass, index := offerIndex offer.id }
 
 def Priority.higher (left right : Priority) : Bool :=
   right.tier < left.tier ||
     (left.tier == right.tier && right.index < left.index)
 
-def offerHigher (left right : OfferView) : Bool :=
+def offerHigher (left right : PolicyOffer) : Bool :=
   (priorityOf left).higher (priorityOf right)
 
 /-- Select the maximum semantic offer and report exact policy comparisons.
 This is intentionally not `offers[0]?`: both representations exercise a real
 choice over the frontier. -/
-def chooseMaximum (offers : Array OfferView) : Option OfferView × Nat := Id.run do
-  let mut best : Option OfferView := none
+def chooseMaximum (offers : Array PolicyOffer) : Option PolicyOffer × Nat := Id.run do
+  let mut best : Option PolicyOffer := none
   let mut comparisons := 0
   for offer in offers do
     match best with
@@ -355,7 +361,7 @@ def Heap.pop (heap : Heap) : Option (Entry × Heap × HeapCost) :=
       let (entries, cost) := siftDown entries 0 { moves := 2 }
       some (first, { entries }, cost)
 
-def Heap.ofOffers (offers : Array OfferView) : Heap × HeapCost := Id.run do
+def Heap.ofOffers (offers : Array PolicyOffer) : Heap × HeapCost := Id.run do
   let mut heap : Heap := {}
   let mut cost : HeapCost := {}
   for offer in offers do
@@ -411,7 +417,7 @@ def offerSemanticItems (state : Policy.State Fact) : OfferId -> Nat
   | .suggestion suggestion =>
       (state.engine.suggestions[suggestion.index]?).map retainedSemanticItems |>.getD 0
 
-def offersSemanticItems (state : Policy.State Fact) (offers : Array OfferView) : Nat :=
+def offersSemanticItems (state : Policy.State Fact) (offers : Array PolicyOffer) : Nat :=
   offers.foldl (fun count offer => count + offerSemanticItems state offer.id) 0
 
 def pruneSemanticItems (state : Policy.State Fact) : Nat := Id.run do
@@ -426,7 +432,7 @@ def pruneSemanticItems (state : Policy.State Fact) : Nat := Id.run do
 def frontierBacking (state : Policy.State Fact) : Nat :=
   state.applications.size + state.equalities.size + state.suggestions.size
 
-def Work.view (work : Work) (state : Policy.State Fact) (offers : Array OfferView) : Work :=
+def Work.view (work : Work) (state : Policy.State Fact) (offers : Array PolicyOffer) : Work :=
   { work with
     frontierSlots := work.frontierSlots + frontierBacking state
     frontierEmits := work.frontierEmits + offers.size
@@ -451,12 +457,16 @@ def Work.dependencies (work : Work) (before after : Engine Rank) : Work :=
     metricDelta before.metrics.suppressedInsertions after.metrics.suppressedInsertions
   { work with dependencyVisits := work.dependencyVisits + inserted + suppressed }
 
-def selectionFor (state : Policy.State Rank) (offer : OfferView) : Selection :=
+def selectionFor (state : Policy.State Rank) (offer : PolicyOffer) : PolicyDecision :=
   { scope := state.scope
     serial := state.serial
     programVersion := state.engine.programVersion
     id := offer.id
-    expected := offer.key }
+    expected := offer.key
+    offerClass := offer.offerClass
+    age := offer.age
+    score := offer.score
+    remaining := state.budgetView }
 
 structure Step where
   state : Policy.State Rank
@@ -466,7 +476,7 @@ structure Step where
 arbitrary registry, instantiations go through engine-owned structural
 admission, and only optional split suggestions are dismissed. -/
 def execute (workload : Workload) (state : Policy.State Rank)
-    (offer : OfferView) (work : Work) : Option Step :=
+    (offer : PolicyOffer) (work : Work) : Option Step :=
   let selection := selectionFor state offer
   let work :=
     { work with

--- a/HexInterval/Experiment/PolicySession.lean
+++ b/HexInterval/Experiment/PolicySession.lean
@@ -37,6 +37,11 @@ namespace Hex.Interval.Experiment.PolicySession
 
 open Propagator
 
+local notation "PolicyDecision" =>
+  Hex.Interval.Policy.Decision Propagator.Policy.OfferId Propagator.Policy.OfferKey
+local notation "PolicyView" =>
+  Hex.Interval.Policy.View
+
 /-- All deterministic envelopes used to assemble one policy session. -/
 structure Limits where
   engine : Hex.Interval.State.Limits
@@ -97,7 +102,7 @@ def limitsCoherent (limits : Limits) : Bool :=
 configuration, then compile the engine and put it under policy control. -/
 opaque Session.start (factDomain : FactDomain Fact) (program : Program)
     (packages : Array (Package Fact)) (facts : Array Fact) (limits : Limits)
-    (scope : Propagator.Policy.ScopeId := { index := 0 }) :
+    (scope : Hex.Interval.Policy.ScopeId := { index := 0 }) :
     Except StartError (Session Fact) :=
   match Registry.buildWithin limits.engine packages with
   | .error error => .error (.registry error)
@@ -166,13 +171,14 @@ opaque Session.complete (session : Session Fact) : Bool :=
 
 /-- A policy can select any checked offer or explicitly dismiss it. -/
 inductive Choice where
-  | select (selection : Propagator.Policy.Selection)
-  | dismiss (selection : Propagator.Policy.Selection)
+  | select (selection : PolicyDecision)
+  | dismiss (selection : PolicyDecision)
 
 /-- A bounded policy view also returns the same owned session with traversal
 accounting committed. -/
 inductive ViewStep (Fact : Type) where
-  | ready (view : Propagator.Policy.View Fact) (session : Session Fact)
+  | ready (view : PolicyView Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey)
+      (session : Session Fact)
   | resource (error : Propagator.Policy.ViewError) (session : Session Fact)
   | contradiction (session : Session Fact)
   | invalidSession (session : Session Fact)
@@ -192,18 +198,18 @@ opaque Session.view (session : Session Fact) : ViewStep Fact :=
 /-- Result of one policy-owned choice.  Every successful constructor returns
 the next coherent session rather than separable components. -/
 inductive Step (Fact : Type) where
-  | rule (selection : Propagator.Policy.Selection)
+  | rule (selection : PolicyDecision)
       (observation : Propagator.Policy.RuleObservation Fact)
       (session : Session Fact)
-  | equality (selection : Propagator.Policy.Selection)
+  | equality (selection : PolicyDecision)
       (observation : Propagator.Policy.EqualityObservation Fact)
       (session : Session Fact)
-  | instance (selection : Propagator.Policy.Selection)
+  | instance (selection : PolicyDecision)
       (completion : Propagator.Policy.Completed) (session : Session Fact)
-  | dismissed (selection : Propagator.Policy.Selection) (session : Session Fact)
-  | split (selection : Propagator.Policy.Selection)
+  | dismissed (selection : PolicyDecision) (session : Session Fact)
+  | split (selection : PolicyDecision)
       (plan : Propagator.Policy.SplitPlan Fact) (session : Session Fact)
-  | rejected (selection : Propagator.Policy.Selection)
+  | rejected (selection : PolicyDecision)
       (reason : Propagator.Policy.Rejection) (session : Session Fact)
   | contradiction (session : Session Fact)
   | engineResource (resource : Hex.Interval.State.Resource) (session : Session Fact)
@@ -287,7 +293,7 @@ private def rejectedSession (session : Session Fact)
       withState session state
 
 private def finishEquality (session : Session Fact)
-    (selection : Propagator.Policy.Selection)
+    (selection : PolicyDecision)
     (observation : Propagator.Policy.EqualityObservation Fact)
     (state : Propagator.Policy.State Fact) : Step Fact :=
   match observation.outcome with
@@ -301,7 +307,7 @@ private def finishEquality (session : Session Fact)
       .equality selection observation (withState session state)
 
 private def submitInvocation (session : Session Fact)
-    (selection : Propagator.Policy.Selection)
+    (selection : PolicyDecision)
     (request : RuleRequest Fact) (state : Propagator.Policy.State Fact)
     (invocation : Invocation Fact) (registry : Registry Fact) : Step Fact :=
   let plan := invocation.plan
@@ -343,7 +349,7 @@ private def submitInvocation (session : Session Fact)
             .invalidSession (halt session next registry)
 
 private def select (session : Session Fact)
-    (selection : Propagator.Policy.Selection) : Step Fact :=
+    (selection : PolicyDecision) : Step Fact :=
   match session.state.select selection with
   | .request request state =>
       let (invocation, registry) := session.registry.invokePlanned request
@@ -365,7 +371,7 @@ private def select (session : Session Fact)
       .factResource budget (halt session state)
 
 private def dismiss (session : Session Fact)
-    (selection : Propagator.Policy.Selection) : Step Fact :=
+    (selection : PolicyDecision) : Step Fact :=
   match session.state.dismiss selection with
   | .completed .dismissed state =>
       .dismissed selection (withState session state)

--- a/HexInterval/Experiment/PolicySession.lean
+++ b/HexInterval/Experiment/PolicySession.lean
@@ -289,7 +289,8 @@ private def rejectedSession (session : Session Fact)
   match reason with
   | .decisionLimit | .actionLimit | .malformedState =>
       halt session state
-  | .wrongScope | .staleSerial | .staleProgram | .missingOffer | .wrongKey =>
+  | .wrongScope | .staleSerial | .staleProgram | .staleBudget | .missingOffer |
+      .wrongKey | .mutatedOffer =>
       withState session state
 
 private def finishEquality (session : Session Fact)

--- a/HexInterval/Experiment/StagedPolicy.lean
+++ b/HexInterval/Experiment/StagedPolicy.lean
@@ -26,6 +26,9 @@ namespace Hex.Interval.Experiment.StagedPolicy
 
 open Propagator Propagator.Policy TargetRun
 
+local notation "PolicyOffer" =>
+  Hex.Interval.Policy.OfferView Propagator.Policy.OfferId Propagator.Policy.OfferKey
+
 /-- Replaceable feature gates for the staged baseline. -/
 structure Config where
   allowInstantiation : Bool := true
@@ -67,7 +70,7 @@ def splitReasonRank : SplitReason -> Nat
 
 /-- Coarse replaceable stages. Lower values run first. An invocation which
 discovers an instantiation or split precedes the resulting semantic offer. -/
-def rank : OfferView -> Nat
+def rank : PolicyOffer -> Nat
   | { key := .equality _, .. } => 0
   | { key := .invoke invocation, .. } =>
       match invocation.kind with
@@ -79,7 +82,7 @@ def rank : OfferView -> Nat
   | { key := .retry _ _, .. } => 21
   | { key := .split _ _ _ reason, .. } => 40 + splitReasonRank reason
 
-def allowed (config : Config) (offer : OfferView) : Bool :=
+def allowed (config : Config) (offer : PolicyOffer) : Bool :=
   match offer.key with
   | .retry _ effort => config.allowRetries && effort <= config.maxRetryEffort
   | .instantiate _ _ => config.allowInstantiation
@@ -91,13 +94,13 @@ def allowed (config : Config) (offer : OfferView) : Bool :=
       | .forward | .backward | .improve | .shave | .rewrite | .regularize => true
   | .equality _ => true
 
-def better (candidate current : OfferView) : Bool :=
+def better (candidate current : PolicyOffer) : Bool :=
   rank candidate < rank current ||
     (rank candidate == rank current && current.age < candidate.age)
 
 /-- Select the oldest offer in the earliest enabled stage. Array order is the
 final deterministic tie-breaker. -/
-def choose? (config : Config) (offers : Array OfferView) : Option OfferView :=
+def choose? (config : Config) (offers : Array PolicyOffer) : Option PolicyOffer :=
   offers.foldl (fun best candidate =>
     if !allowed config candidate then best
     else

--- a/HexInterval/Experiment/TargetRun.lean
+++ b/HexInterval/Experiment/TargetRun.lean
@@ -31,12 +31,12 @@ namespace Hex.Interval.Experiment.TargetRun
 
 open Propagator PolicySession
 
-/-- One external policy decision.  The driver fills in the view identity and
-uses the chosen offer's complete semantic key when constructing a selection. -/
-inductive Decision (PolicyState : Type)
-  | select (offer : Propagator.Policy.OfferView) (next : PolicyState)
-  | dismiss (offer : Propagator.Policy.OfferView) (next : PolicyState)
-  | stop (next : PolicyState)
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView Propagator.Policy.OfferId Propagator.Policy.OfferKey
+local notation "PolicyView" =>
+  Hex.Interval.Policy.View
+local notation "PolicyDecision" =>
+  Hex.Interval.Policy.Decision Propagator.Policy.OfferId Propagator.Policy.OfferKey
 
 /-- Observations delivered back to the external policy in execution order. -/
 inductive Event (Fact : Type)
@@ -49,9 +49,10 @@ inductive Event (Fact : Type)
   | rejectedPayload (resource : PayloadArena.Resource)
 
 /-- An arbitrary upgradeable policy over bounded engine-owned views. -/
-structure Controller (Fact PolicyState : Type) where
+structure Controller (Fact PolicyState : Type) extends
+    Hex.Interval.Policy.Interface Fact PolicyState
+      Propagator.Policy.OfferId Propagator.Policy.OfferKey where
   update : PolicyState -> Event Fact -> PolicyState
-  choose : PolicyState -> Propagator.Policy.View Fact -> Decision PolicyState
 
 /-- The exact retained fact version which triggered target stopping. -/
 structure Reached (Fact : Type) where
@@ -84,13 +85,9 @@ structure Result (Fact PolicyState : Type) where
   events : Array (Event Fact)
   stop : Stop Fact
 
-def selection (view : Propagator.Policy.View Fact)
-    (offer : Propagator.Policy.OfferView) : Propagator.Policy.Selection :=
-  { scope := view.scope
-    serial := view.serial
-    programVersion := view.programVersion
-    id := offer.id
-    expected := offer.key }
+def selection (view : PolicyView Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey)
+    (offer : OfferView) : PolicyDecision :=
+  Hex.Interval.Policy.select view offer
 
 /-- Check whether the installed fact entails the requested target.  This is a
 runtime search test, not proof evidence. -/

--- a/HexInterval/Policy.lean
+++ b/HexInterval/Policy.lean
@@ -106,21 +106,22 @@ structure View (Fact Id SemanticKey : Type) where
   programVersion : Nat
   offers : Array (OfferView Id SemanticKey)
   facts : Snapshot Fact
-  remaining : EngineBudgetView := {}
+  remaining : EngineBudgetView
   incomplete : Bool
 
-/-- One exact echoed policy choice.  `expected` includes every exposed offer
-field, so mutating its class, age, score, identifier, or semantic key is stale. -/
+/-- One exact echoed policy choice. The scope, serial, program version,
+remaining budget, identifier, semantic key, class, age, and score must all
+match the view and retained offer from which the choice was constructed. -/
 structure Decision (Id SemanticKey : Type) where
   scope : ScopeId
   serial : Nat
   programVersion : Nat
   id : Id
   expected : SemanticKey
-  offerClass : OfferClass := .invoke
-  age : Nat := 0
-  score : Int := 0
-  remaining : EngineBudgetView := {}
+  offerClass : OfferClass
+  age : Nat
+  score : Int
+  remaining : EngineBudgetView
   deriving DecidableEq
 
 /-- External policy result.  Only an exact view member can later pass

--- a/HexInterval/Policy.lean
+++ b/HexInterval/Policy.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.State
+
+@[expose] public section
+
+/-!
+# Bounded search-policy contracts
+
+This module is the supported, function-agnostic boundary between an interval
+controller and a replaceable search policy.  The controller supplies an exact
+immutable view of already-authenticated offers.  A policy can retain private
+state and return one unchanged offer, dismiss one unchanged offer, or stop; it
+cannot construct an action or authorize a state transition.
+
+The checked adapter bounds retained offer count, declared score magnitude, and
+package-defined key size, pair, and logical-work measures.  The measurement
+callbacks and equality on arbitrary identifiers and semantic keys are an
+explicit non-preemptible envelope: they may traverse nested Lean objects before
+returning a bounded number.  Successful checking bounds only the retained
+decoded view and subsequent controller work, not callback allocation or time.
+-/
+
+namespace Hex.Interval.Policy
+
+/-- Branch-local policy scope.  A compact index is meaningful only in the
+controller state which issued it. -/
+structure ScopeId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Versioned identity of an external policy implementation.  No implementation
+is selected as the supported default. -/
+structure PolicyKey where
+  name : String
+  version : Nat
+  deriving DecidableEq, Repr
+
+/-- Coarse controller-owned classification available to generic policies. -/
+inductive OfferClass where
+  | invoke
+  | equality
+  | retry
+  | instantiate
+  | split
+  deriving DecidableEq, Repr
+
+/-- Logical retained cost returned by package-owned measurement callbacks. -/
+structure Cost where
+  bytes : Nat := 0
+  pairs : Nat := 0
+  work : Nat := 0
+  deriving DecidableEq, Repr
+
+def Cost.add (left right : Cost) : Cost :=
+  { bytes := left.bytes + right.bytes
+    pairs := left.pairs + right.pairs
+    work := left.work + right.work }
+
+/-- Independent caps for one policy view. -/
+structure Limits where
+  maxOffers : Nat
+  maxBytes : Nat
+  maxPairs : Nat
+  maxWork : Nat
+  maxScore : Nat
+  deriving DecidableEq, Repr
+
+/-- Complete immutable policy-facing description of one engine-owned offer.
+`Id` and `SemanticKey` remain controller-selected stable types. -/
+structure OfferView (Id SemanticKey : Type) where
+  id : Id
+  key : SemanticKey
+  offerClass : OfferClass
+  age : Nat
+  /-- Optional bounded generic score.  Zero leaves scoring entirely to an
+  experimental or package-owned policy. -/
+  score : Int := 0
+  deriving DecidableEq
+
+/-- Remaining engine resources exposed opaquely to the policy contract. -/
+structure EngineBudgetView where
+  actions : Nat := 0
+  matcherVisits : Nat := 0
+  acceptedFacts : Nat := 0
+  nodes : Nat := 0
+  applications : Nat := 0
+  equalities : Nat := 0
+  retainedSuggestions : Nat := 0
+  instances : Nat := 0
+  queueEntries : Nat := 0
+  generation : Nat := 0
+  deriving DecidableEq, Repr
+
+/-- Exact immutable input to one policy callback. -/
+structure View (Fact Id SemanticKey : Type) where
+  scope : ScopeId
+  serial : Nat
+  programVersion : Nat
+  offers : Array (OfferView Id SemanticKey)
+  facts : Snapshot Fact
+  remaining : EngineBudgetView := {}
+  incomplete : Bool
+
+/-- One exact echoed policy choice.  `expected` includes every exposed offer
+field, so mutating its class, age, score, identifier, or semantic key is stale. -/
+structure Decision (Id SemanticKey : Type) where
+  scope : ScopeId
+  serial : Nat
+  programVersion : Nat
+  id : Id
+  expected : SemanticKey
+  offerClass : OfferClass := .invoke
+  age : Nat := 0
+  score : Int := 0
+  remaining : EngineBudgetView := {}
+  deriving DecidableEq
+
+/-- External policy result.  Only an exact view member can later pass
+`revalidate`; `stop` is always conservative. -/
+inductive Step (PolicyState Id SemanticKey : Type)
+  | select (offer : OfferView Id SemanticKey) (next : PolicyState)
+  | dismiss (offer : OfferView Id SemanticKey) (next : PolicyState)
+  | stop (next : PolicyState)
+
+/-- Replaceable policy callback.  Its implementation is outside the
+preemptible resource envelope and has no state-transition or proof authority. -/
+structure Interface (Fact PolicyState Id SemanticKey : Type) where
+  choose : PolicyState -> View Fact Id SemanticKey -> Step PolicyState Id SemanticKey
+
+/-- Package-owned exact logical measurements.  Both callbacks, and equality on
+their inputs during validation, are non-preemptible. -/
+structure Measure (Id SemanticKey : Type) where
+  id : Id -> Cost
+  key : SemanticKey -> Cost
+
+inductive Error where
+  | invalidProgram
+  | malformedState
+  | offerLimit
+  | byteLimit
+  | pairLimit
+  | workLimit
+  | scoreLimit
+  | duplicateId
+  | wrongScope
+  | staleSerial
+  | staleProgram
+  | staleBudget
+  | missingOffer
+  | mutatedOffer
+  deriving DecidableEq, Repr
+
+def addWithin (limits : Limits) (left right : Cost) : Except Error Cost := do
+  if limits.maxBytes < right.bytes || limits.maxBytes - right.bytes < left.bytes then
+    throw .byteLimit
+  if limits.maxPairs < right.pairs || limits.maxPairs - right.pairs < left.pairs then
+    throw .pairLimit
+  if limits.maxWork < right.work || limits.maxWork - right.work < left.work then
+    throw .workLimit
+  pure (left.add right)
+
+variable {Fact Id SemanticKey Cause PolicyState : Type}
+
+/-- Validate all bounded retained dimensions of a complete view.  No prefix is
+returned on failure. -/
+def checkViewWithin [DecidableEq Id] (limits : Limits) (measure : Measure Id SemanticKey)
+    (program : Program) (view : View Fact Id SemanticKey) : Except Error Cost := do
+  if !program.check then throw .invalidProgram
+  if !view.facts.check program then throw .malformedState
+  if limits.maxOffers < view.offers.size then throw .offerLimit
+  let mut total : Cost := {}
+  for index in [0:view.offers.size] do
+    let some offer := view.offers[index]? | throw .malformedState
+    for prior in [0:index] do
+      let some previous := view.offers[prior]? | throw .malformedState
+      if previous.id == offer.id then throw .duplicateId
+    if limits.maxScore < offer.score.natAbs then throw .scoreLimit
+    total <- addWithin limits total (measure.id offer.id)
+    total <- addWithin limits total (measure.key offer.key)
+  pure total
+
+/-- Construct the exact decision which an external policy must return. -/
+def select (view : View Fact Id SemanticKey) (offer : OfferView Id SemanticKey) :
+    Decision Id SemanticKey :=
+  { scope := view.scope
+    serial := view.serial
+    programVersion := view.programVersion
+    id := offer.id
+    expected := offer.key
+    offerClass := offer.offerClass
+    age := offer.age
+    score := offer.score
+    remaining := view.remaining
+  }
+
+/-- Transactionally revalidate a policy choice against the complete current
+view.  Success returns the controller-owned offer, never the policy's copy. -/
+def revalidate [DecidableEq Id] [DecidableEq SemanticKey]
+    (view : View Fact Id SemanticKey) (decision : Decision Id SemanticKey) :
+    Except Error (OfferView Id SemanticKey) := do
+  if decision.scope != view.scope then throw .wrongScope
+  if decision.serial != view.serial then throw .staleSerial
+  if decision.programVersion != view.programVersion then throw .staleProgram
+  if decision.remaining != view.remaining then throw .staleBudget
+  let some offer := view.offers.find? fun offer => offer.id == decision.id
+    | throw .missingOffer
+  if decision.expected != offer.key || decision.offerClass != offer.offerClass ||
+      decision.age != offer.age || decision.score != offer.score then
+    throw .mutatedOffer
+  pure offer
+
+/-- Validate state/program alignment as well as bounded view retention before
+accepting a choice.  Runtime success remains data, never theorem evidence. -/
+def checkDecisionWithin [DecidableEq Fact] [DecidableEq Id] [DecidableEq SemanticKey]
+    (limits : Limits) (measure : Measure Id SemanticKey)
+    (branch : State.Branch Fact Cause) (view : View Fact Id SemanticKey)
+    (decision : Decision Id SemanticKey) : Except Error (OfferView Id SemanticKey) := do
+  let snapshot := branch.snapshot
+  if !branch.check || branch.programVersion != view.programVersion ||
+      snapshot.facts != view.facts.facts || snapshot.versions != view.facts.versions ||
+      snapshot.contradictory != view.facts.contradictory then
+    throw .malformedState
+  let _ <- checkViewWithin limits measure branch.program view
+  revalidate view decision
+
+end Hex.Interval.Policy

--- a/HexInterval/Policy.lean
+++ b/HexInterval/Policy.lean
@@ -21,10 +21,11 @@ cannot construct an action or authorize a state transition.
 
 The checked adapter bounds retained offer count, declared score magnitude, and
 package-defined key size, pair, and logical-work measures.  The measurement
-callbacks and equality on arbitrary identifiers and semantic keys are an
-explicit non-preemptible envelope: they may traverse nested Lean objects before
-returning a bounded number.  Successful checking bounds only the retained
-decoded view and subsequent controller work, not callback allocation or time.
+callbacks and equality on arbitrary identifiers, semantic keys, and
+reconstructed facts are an explicit non-preemptible envelope: they may traverse
+nested Lean objects before returning a bounded number.  Successful checking
+bounds only the retained decoded view and subsequent controller work, not
+callback allocation or time.
 -/
 
 namespace Hex.Interval.Policy
@@ -168,12 +169,10 @@ def addWithin (limits : Limits) (left right : Cost) : Except Error Cost := do
 
 variable {Fact Id SemanticKey Cause PolicyState : Type}
 
-/-- Validate all bounded retained dimensions of a complete view.  No prefix is
-returned on failure. -/
-def checkViewWithin [DecidableEq Id] (limits : Limits) (measure : Measure Id SemanticKey)
-    (program : Program) (view : View Fact Id SemanticKey) : Except Error Cost := do
-  if !program.check then throw .invalidProgram
-  if !view.facts.check program then throw .malformedState
+/-- Validate the bounded offer portion of a view whose program and fact-array
+alignment have already been authenticated by the caller. -/
+def checkOffersWithin [DecidableEq Id] (limits : Limits)
+    (measure : Measure Id SemanticKey) (view : View Fact Id SemanticKey) : Except Error Cost := do
   if limits.maxOffers < view.offers.size then throw .offerLimit
   let mut total : Cost := {}
   for index in [0:view.offers.size] do
@@ -185,6 +184,16 @@ def checkViewWithin [DecidableEq Id] (limits : Limits) (measure : Measure Id Sem
     total <- addWithin limits total (measure.id offer.id)
     total <- addWithin limits total (measure.key offer.key)
   pure total
+
+/-- Validate all bounded retained dimensions of a complete view.  No prefix is
+returned on failure. -/
+def checkViewWithin [DecidableEq Id] (limits : Limits) (measure : Measure Id SemanticKey)
+    (program : Program) (view : View Fact Id SemanticKey) : Except Error Cost := do
+  if !program.check then throw .invalidProgram
+  if view.facts.facts.size != program.nodes.size ||
+      view.facts.versions.size != program.nodes.size then
+    throw .malformedState
+  checkOffersWithin limits measure view
 
 /-- Construct the exact decision which an external policy must return. -/
 def select (view : View Fact Id SemanticKey) (offer : OfferView Id SemanticKey) :
@@ -217,17 +226,19 @@ def revalidate [DecidableEq Id] [DecidableEq SemanticKey]
   pure offer
 
 /-- Validate state/program alignment as well as bounded view retention before
-accepting a choice.  Runtime success remains data, never theorem evidence. -/
+accepting a choice.  Branch reconstruction and program validation happen once;
+comparison of arbitrary reconstructed facts remains non-preemptible.  Runtime
+success remains data, never theorem evidence. -/
 def checkDecisionWithin [DecidableEq Fact] [DecidableEq Id] [DecidableEq SemanticKey]
     (limits : Limits) (measure : Measure Id SemanticKey)
     (branch : State.Branch Fact Cause) (view : View Fact Id SemanticKey)
     (decision : Decision Id SemanticKey) : Except Error (OfferView Id SemanticKey) := do
-  let snapshot := branch.snapshot
-  if !branch.check || branch.programVersion != view.programVersion ||
+  let some snapshot := branch.checkedSnapshot? | throw .malformedState
+  if branch.programVersion != view.programVersion ||
       snapshot.facts != view.facts.facts || snapshot.versions != view.facts.versions ||
       snapshot.contradictory != view.facts.contradictory then
     throw .malformedState
-  let _ <- checkViewWithin limits measure branch.program view
+  let _ <- checkOffersWithin limits measure view
   revalidate view decision
 
 end Hex.Interval.Policy

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3092,7 +3092,7 @@ never the policy's copy. In the sketch below,
 engine-computed generation, proposed-operation/reference graph, and unordered
 equality-pair key. Replay-facing trigger metadata is deliberately absent;
 `PolicyFeature` is a bounded exact integer key/value; and frontier events are
-engine-issued additions, refreshes, tombstones, and observations:
+engine-issued additions, refreshes, tombstones, and observations.
 
 The current Mathlib-free `HexInterval/Policy.lean` contract implements the
 generic part of this boundary. `OfferView Id SemanticKey` retains the complete
@@ -3120,6 +3120,9 @@ The concrete `OfferId`,
 package callbacks, event history, sessions, and branch-search loop remain under
 `HexInterval/Experiment`. In particular no `balancedV1`, score model, storage
 layout, scheduler, or default policy is selected by the supported contract.
+
+The implemented generic records and current concrete experimental keys are
+sketched below:
 
 ```lean
 structure PolicyKey where
@@ -3177,11 +3180,16 @@ structure PolicyBudget where
   noteBytes : Nat
 
 structure EngineBudgetView where
-  actions       : Nat
-  acceptedFacts : Nat
-  nodes         : Nat
-  equalities    : Nat
-  branches      : Nat
+  actions             : Nat
+  matcherVisits       : Nat
+  acceptedFacts       : Nat
+  nodes               : Nat
+  applications        : Nat
+  equalities          : Nat
+  retainedSuggestions : Nat
+  instances           : Nat
+  queueEntries        : Nat
+  generation          : Nat
 
 structure FactDelta (Fact : Type) where
   node          : NodeId
@@ -3236,12 +3244,16 @@ structure PolicyView (Fact : Type) where
   goalFeatures   : Array PolicyFeature
   remaining      : EngineBudgetView
 
-structure Selection where
+structure Decision where
   scope          : ScopeId
   serial         : Nat
   programVersion : Nat
   id             : OfferId
   expected       : OfferKey
+  offerClass     : OfferClass
+  age            : Nat
+  score          : Int
+  remaining      : EngineBudgetView
 
 inductive PolicyEvent (Fact : Type)
   | frontier (added : Array OfferView) (removed : Array OfferId)
@@ -3249,7 +3261,7 @@ inductive PolicyEvent (Fact : Type)
   | equality (observation : EqualityObservation Fact)
   | instanceAdmitted (programVersion : Nat) (added : Array OfferView)
   | splitPrepared (scope : ScopeId) (node : NodeId) (point : Dyadic)
-  | choiceRejected (choice : Selection) (reason : Nat)
+  | choiceRejected (choice : Decision) (reason : Nat)
   | engineResource (resource : Resource)
 
 structure DecisionNote where
@@ -3258,8 +3270,8 @@ structure DecisionNote where
   score  : Nat
 
 inductive PolicyStep (State : Type)
-  | select  (choice : Selection) (note : DecisionNote) (next : State)
-  | dismiss (choice : Selection) (note : DecisionNote) (next : State)
+  | select  (choice : Decision) (note : DecisionNote) (next : State)
+  | dismiss (choice : Decision) (note : DecisionNote) (next : State)
   | stop    (reason : Nat) (next : State)
 
 structure Policy (Fact : Type) where

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3085,8 +3085,9 @@ conditional fact into the parent scope.
 The policy affects success and performance, never validity. In particular it
 does not construct an `Action`: action serials, program snapshots, concrete
 applications, and input versions are engine-owned authority. The engine owns a
-bounded frontier of offers and the policy returns only the stable identity and
-canonical key of one offer it observed. In the sketch below,
+bounded frontier of offers and the policy echoes the complete controller-owned
+description of one offer it observed; selection returns the retained offer,
+never the policy's copy. In the sketch below,
 `InstantiationSemanticKey` is the payload-erased canonical family,
 engine-computed generation, proposed-operation/reference graph, and unordered
 equality-pair key. Replay-facing trigger metadata is deliberately absent;
@@ -3101,15 +3102,20 @@ age, and bounded score. `checkViewWithin`, `revalidate`, and
 `checkDecisionWithin` fail transactionally on malformed program/fact state,
 duplicate identifiers, stale stamps or budgets, changed offer fields, and
 independent offer-count, byte, pair, logical-work, and score caps. Identifier
-and semantic-key measurement callbacks, and equality on nested key values,
-remain an explicit non-preemptible envelope; the cap governs accepted retained
-data and subsequent adapter work, not arbitrary callback allocation or time.
-The returned runtime value has no theorem authority.
+and semantic-key measurement callbacks, equality on nested key values, and
+equality on arbitrary reconstructed facts remain an explicit non-preemptible
+envelope; the cap governs accepted retained data and subsequent adapter work,
+not arbitrary callback allocation or time. Branch-backed decision validation
+reconstructs and validates the branch snapshot once, then checks bounded offers
+without repeating whole-program validation. The returned runtime value has no
+theorem authority.
 
 The experimental target controller now implements the supported `Interface`
 and returns the actual supported `Step`; it stamps a selected supported offer
-into a supported decision before the policy session performs the existing
-engine-owned key/freshness transition checks. The concrete `OfferId`,
+into a supported decision before the policy session authenticates the exact
+scope, serial, program version, remaining budget, identifier, semantic key,
+class, age, and score and performs the existing engine-owned freshness checks.
+The concrete `OfferId`,
 `OfferKey`, instantiation/split encodings, staged/adaptive/feature policies,
 package callbacks, event history, sessions, and branch-search loop remain under
 `HexInterval/Experiment`. In particular no `balancedV1`, score model, storage
@@ -5069,7 +5075,8 @@ their declared cost inside a scheduler bound.
   generic bounded offer/view/decision/step/interface contracts, exact retained
   offer revalidation, and checked count/byte/pair/work/score admission. Concrete
   semantic offer keys and policies remain experimental; package measurement
-  and nested-key equality callbacks are explicitly non-preemptible.
+  callbacks and equality on nested identifiers, keys, and reconstructed facts
+  are explicitly non-preemptible.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and
   extension admission. Its engine extends and mutates only through the

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -71,9 +71,15 @@ work-queue, chronology, and bounded diagnostic snapshots. These records
 deliberately contain neither function callbacks nor proof evidence. The state
 records are a stable decoded interchange and validation contract; they do not
 select the eventual mutable, persistent, paged, or trail-backed implementation
-used inside a high-performance branch search. Package assembly, callback
-outcomes and proposals, policy choice, sessions, branch search, payload
-storage, proof replay, and that optimized backing store remain experimental.
+used inside a high-performance branch search. The supported boundary also
+includes generic bounded policy offers/views, exact echoed decisions, a
+replaceable choice interface, package-measured byte/pair/work caps, and
+transactional revalidation against exact program, fact snapshot, scope,
+serial, program version, remaining budget, and complete offer fields. It does
+not choose a semantic offer-key encoding or a default policy. Package assembly,
+callback outcomes and proposals, concrete policy algorithms, sessions, branch
+search, payload storage, proof replay, and that optimized backing store remain
+experimental.
 In particular, the current instantiation proposal's package-supplied numeric
 policy family is not part of the supported action contract.
 
@@ -3087,6 +3093,28 @@ equality-pair key. Replay-facing trigger metadata is deliberately absent;
 `PolicyFeature` is a bounded exact integer key/value; and frontier events are
 engine-issued additions, refreshes, tombstones, and observations:
 
+The current Mathlib-free `HexInterval/Policy.lean` contract implements the
+generic part of this boundary. `OfferView Id SemanticKey` retains the complete
+controller-issued offer, and `Decision Id SemanticKey` echoes its scope,
+serial, program version, remaining budget, identifier, semantic key, class,
+age, and bounded score. `checkViewWithin`, `revalidate`, and
+`checkDecisionWithin` fail transactionally on malformed program/fact state,
+duplicate identifiers, stale stamps or budgets, changed offer fields, and
+independent offer-count, byte, pair, logical-work, and score caps. Identifier
+and semantic-key measurement callbacks, and equality on nested key values,
+remain an explicit non-preemptible envelope; the cap governs accepted retained
+data and subsequent adapter work, not arbitrary callback allocation or time.
+The returned runtime value has no theorem authority.
+
+The experimental target controller now implements the supported `Interface`
+and returns the actual supported `Step`; it stamps a selected supported offer
+into a supported decision before the policy session performs the existing
+engine-owned key/freshness transition checks. The concrete `OfferId`,
+`OfferKey`, instantiation/split encodings, staged/adaptive/feature policies,
+package callbacks, event history, sessions, and branch-search loop remain under
+`HexInterval/Experiment`. In particular no `balancedV1`, score model, storage
+layout, scheduler, or default policy is selected by the supported contract.
+
 ```lean
 structure PolicyKey where
   name    : String
@@ -5037,6 +5065,11 @@ their declared cost inside a scheduler bound.
   dependency watchers, dirty bits, append-only work queues with policy
   tombstones, controller resources, and transactional checked builders. These
   decoded arrays do not select the optimized branch-storage implementation.
+- `HexInterval/Policy.lean`: supported Mathlib-free scope and policy keys,
+  generic bounded offer/view/decision/step/interface contracts, exact retained
+  offer revalidation, and checked count/byte/pair/work/score admission. Concrete
+  semantic offer keys and policies remain experimental; package measurement
+  and nested-key equality callbacks are explicitly non-preemptible.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and
   extension admission. Its engine extends and mutates only through the

--- a/HexInterval/State.lean
+++ b/HexInterval/State.lean
@@ -254,10 +254,15 @@ def generationsCheck (branch : Branch Fact Cause) : Bool := Id.run do
   return true
 
 /-- Validate all immutable array alignments, append-only program structure,
-depths, and exact per-node update chronology. -/
-def check (branch : Branch Fact Cause) : Bool :=
-  let snapshot := branch.snapshot
-  branch.baseProgram.check && branch.program.check &&
+depths, and exact per-node update chronology, returning the reconstructed
+snapshot without repeating that work. -/
+def checkedSnapshot? (branch : Branch Fact Cause) : Option (Snapshot Fact) := do
+  let facts <- branch.restoredFacts?
+  let snapshot : Snapshot Fact :=
+    { facts
+      versions := branch.versions
+      contradictory := branch.contradictory }
+  if branch.baseProgram.check && branch.program.check &&
     programPrefix branch.baseProgram branch.program &&
     branch.initialFacts.size == branch.baseProgram.nodes.size &&
     branch.seeds.size == branch.program.nodes.size - branch.baseProgram.nodes.size &&
@@ -265,7 +270,15 @@ def check (branch : Branch Fact Cause) : Bool :=
     snapshot.versions.size == branch.program.nodes.size &&
     branch.generationsCheck &&
     branch.program.depths? == some branch.depths &&
-    branch.restoredVersions? == some branch.versions
+    branch.restoredVersions? == some branch.versions then
+    some snapshot
+  else
+    none
+
+/-- Validate all immutable array alignments, append-only program structure,
+depths, and exact per-node update chronology. -/
+def check (branch : Branch Fact Cause) : Bool :=
+  branch.checkedSnapshot?.isSome
 
 /-- Install one already-computed update only when it names the exact live
 predecessor and current program version. -/

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -2653,6 +2653,163 @@ def retainedLog? : Option Hex.Interval.Trace.Log :=
       | _ => false
   | _, _ => false
 
+/-! # Supported bounded policy boundary -/
+
+def policyAction : Action :=
+  { action with
+    serial := 0
+    programVersion := 0
+    application := { index := 0 }
+    inputs := [{ node := contractNode 0, version := 0 }]
+    generation := 0 }
+
+def policyOffer : Hex.Interval.Policy.OfferView Nat Action :=
+  { id := 7
+    key := policyAction
+    offerClass := .invoke
+    age := 3
+    score := 2 }
+
+def policyBudget : Hex.Interval.Policy.EngineBudgetView :=
+  { actions := 4
+    matcherVisits := 3
+    acceptedFacts := 2
+    nodes := 2
+    applications := 1
+    equalities := 1
+    retainedSuggestions := 1
+    instances := 1
+    queueEntries := 2
+    generation := 1 }
+
+def policyView : Hex.Interval.Policy.View Nat Nat Action :=
+  { scope := { index := 5 }
+    serial := 11
+    programVersion := 0
+    offers := #[policyOffer]
+    facts := { facts := #[13, 23], versions := #[0, 0], contradictory := false }
+    remaining := policyBudget
+    incomplete := false }
+
+def policyLimits : Hex.Interval.Policy.Limits :=
+  { maxOffers := 1
+    maxBytes := 4
+    maxPairs := 1
+    maxWork := 2
+    maxScore := 2 }
+
+def policyMeasure : Hex.Interval.Policy.Measure Nat Action :=
+  { id := fun _ => { bytes := 1 }
+    key := fun action =>
+      { bytes := 3, pairs := action.inputs.length, work := 2 } }
+
+def policyDecision : Hex.Interval.Policy.Decision Nat Action :=
+  Hex.Interval.Policy.select policyView policyOffer
+
+def policyError (wanted : Hex.Interval.Policy.Error)
+    (result : Except Hex.Interval.Policy.Error α) : Bool :=
+  match result with
+  | .error actual => decide (actual = wanted)
+  | .ok _ => false
+
+#guard match Hex.Interval.Policy.checkViewWithin policyLimits policyMeasure
+    contractProgram policyView with
+  | .ok cost => cost.bytes == 4 && cost.pairs == 1 && cost.work == 2
+  | .error _ => false
+
+#guard match branch? with
+  | some branch =>
+      match Hex.Interval.Policy.checkDecisionWithin policyLimits policyMeasure branch
+          policyView policyDecision with
+      | .ok offer => decide (offer = policyOffer)
+      | .error _ => false
+  | none => false
+
+-- Exact scope, serial, program, budget, fact version, and action identity are
+-- independently load-bearing.
+#guard policyError .wrongScope <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with scope := { index := 6 } }
+#guard policyError .staleSerial <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with serial := 12 }
+#guard policyError .staleProgram <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with programVersion := 1 }
+#guard policyError .staleBudget <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with remaining := { policyBudget with actions := 3 } }
+#guard policyError .mutatedOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with expected :=
+      { policyAction with inputs := [{ node := contractNode 0, version := 1 }] } }
+#guard policyError .mutatedOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with expected :=
+      { policyAction with key := { localKey with schema := 5 } } }
+#guard match branch? with
+  | some branch =>
+      let staleFacts :=
+        { policyView with facts := { policyView.facts with versions := #[1, 0] } }
+      policyError .malformedState <|
+        Hex.Interval.Policy.checkDecisionWithin policyLimits policyMeasure branch
+          staleFacts policyDecision
+  | none => false
+#guard match branch? with
+  | some branch =>
+      let staleFacts :=
+        { policyView with facts := { policyView.facts with facts := #[13, 999] } }
+      policyError .malformedState <|
+        Hex.Interval.Policy.checkDecisionWithin policyLimits policyMeasure branch
+          staleFacts policyDecision
+  | none => false
+
+-- Every exposed offer field is echoed, not just its compact identifier/key.
+#guard policyError .mutatedOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with offerClass := .retry }
+#guard policyError .mutatedOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with age := 4 }
+#guard policyError .mutatedOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with score := 1 }
+#guard policyError .missingOffer <| Hex.Interval.Policy.revalidate policyView
+  { policyDecision with id := 8 }
+
+-- Each retained dimension has a distinct transactional one-under refusal.
+#guard policyError .offerLimit <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxOffers := 0 } policyMeasure contractProgram policyView
+#guard policyError .byteLimit <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxBytes := 3 } policyMeasure contractProgram policyView
+#guard policyError .pairLimit <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxPairs := 0 } policyMeasure contractProgram policyView
+#guard policyError .workLimit <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxWork := 1 } policyMeasure contractProgram policyView
+#guard policyError .scoreLimit <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxScore := 1 } policyMeasure contractProgram policyView
+#guard policyError .duplicateId <| Hex.Interval.Policy.checkViewWithin
+  { policyLimits with maxOffers := 2 } policyMeasure contractProgram
+    { policyView with offers := #[policyOffer, policyOffer] }
+
+def stoppedPolicy : Hex.Interval.Policy.Interface Nat Bool Nat Action :=
+  { choose := fun state _ => .stop state }
+
+def firstPolicy : Hex.Interval.Policy.Interface Nat Bool Nat Action :=
+  { choose := fun state view =>
+      match view.offers[0]? with
+      | some offer => .select offer state
+      | none => .stop state }
+
+#guard match stoppedPolicy.choose false policyView with
+  | .stop false => true
+  | _ => false
+
+#guard match firstPolicy.choose false policyView with
+  | .select offer false => offer == policyOffer
+  | _ => false
+
+/-- Kernel replay is parameterized by neither policy choice nor policy-private
+state.  Substituting an arbitrary policy cannot change this theorem. -/
+theorem replayIgnoresPolicy
+    (_policy : Hex.Interval.Policy.Interface Nat Bool Nat Action) :
+    policyOffer.key = policyAction := rfl
+
+/-- info: 'Hex.Interval.Conformance.Contracts.replayIgnoresPolicy' does not depend on any axioms -/
+#guard_msgs in
+#print axioms replayIgnoresPolicy
+
 end Contracts
 
 end Hex.Interval.Conformance

--- a/conformance/HexInterval/Conformance.lean
+++ b/conformance/HexInterval/Conformance.lean
@@ -2330,6 +2330,18 @@ def stateLimits : Hex.Interval.State.Limits :=
 def branch? : Option (Hex.Interval.State.Branch Nat Nat) :=
   (Hex.Interval.State.Branch.startWithin stateLimits contractProgram #[13, 23]).toOption
 
+-- Checked reconstruction returns the exact authenticated snapshot once, and
+-- malformed retained seed data produces no partially trusted snapshot.
+#guard match branch? with
+  | some branch =>
+      match branch.checkedSnapshot? with
+      | some checked =>
+          checked.facts == #[13, 23] && checked.versions == #[0, 0] &&
+            !checked.contradictory &&
+            ({ branch with seeds := #[999, 23] }).checkedSnapshot?.isNone
+      | none => false
+  | none => false
+
 def firstUpdate : Hex.Interval.State.Update Nat Nat :=
   { programVersion := 0
     node := contractNode 1

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -18,6 +18,13 @@ place of the registry when checking the final facts.
 
 namespace Hex.Interval.DyadicRulesConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment Propagator
 open DyadicRules
 
@@ -629,7 +636,7 @@ inductive ConcreteCommand
   | split (key : RuleKey)
 
 def commandMatches (command : ConcreteCommand)
-    (offer : Propagator.Policy.OfferView) : Bool :=
+    (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match command, offer.key with
   | .invoke key, .invoke source => source.rule == key
   | .instantiate key, .instantiate source _ => source.rule == key
@@ -640,7 +647,7 @@ def commandMatches (command : ConcreteCommand)
   | _, _ => false
 
 def concreteChoose (commands : List ConcreteCommand)
-    (view : Propagator.Policy.View Fact) :
+    (view : (Hex.Interval.Policy.View Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
     Propagator.Policy.Driver.Step (List ConcreteCommand) :=
   match commands with
   | [] => .stop []

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -655,13 +655,7 @@ def concreteChoose (commands : List ConcreteCommand)
       match view.offers.toList.find? (commandMatches command) with
       | none => .stop rest
       | some offer =>
-      .select
-        { scope := view.scope
-          serial := view.serial
-          programVersion := view.programVersion
-          id := offer.id
-          expected := offer.key }
-        rest
+      .select (Hex.Interval.Policy.select view offer) rest
 
 def concreteController :
     Propagator.Policy.Driver.Controller Fact (List ConcreteCommand) where

--- a/conformance/HexInterval/FeaturePolicyConformance.lean
+++ b/conformance/HexInterval/FeaturePolicyConformance.lean
@@ -15,6 +15,13 @@ The policy sees only configured addresses and signed integers.
 
 namespace Hex.Interval.FeaturePolicyConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment Propagator Propagator.Policy PolicyFeature FeaturePolicy
 
 private def node (index : Nat) : NodeId := { index }
@@ -42,7 +49,7 @@ private def splitOffer (index : Nat) : OfferView :=
     offerClass := .split
     age := 0 }
 
-private def view (offers : Array OfferView) : Policy.View Nat :=
+private def view (offers : Array OfferView) : (Hex.Interval.Policy.View Nat _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   { scope := { index := 0 }
     serial := 2
     programVersion := 3

--- a/conformance/HexInterval/MatcherSchedulerConformance.lean
+++ b/conformance/HexInterval/MatcherSchedulerConformance.lean
@@ -20,6 +20,13 @@ contribute to theorem-instantiation generation.
 
 namespace Hex.Interval.MatcherSchedulerConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment.Propagator
 
 abbrev Rank := Nat
@@ -586,16 +593,18 @@ def registryAdmitted? : Option (Registry Rank × Engine Rank) := do
 
 /-! ## The replaceable policy sees and selects the same engine-owned batch -/
 
-def policyLimits : Policy.Limits :=
+def policyLimits : Experiment.Propagator.Policy.Limits :=
   { maxDecisions := 8
     maxTraversal := 32
     maxLiveOffers := 8 }
 
 def retainedTraversal (maxTraversal : Nat) :
-    Option (Except Policy.ViewError (Policy.View Rank × Policy.State Rank)) := do
+    Option (Except Experiment.Propagator.Policy.ViewError
+      (Hex.Interval.Policy.View Rank Experiment.Propagator.Policy.OfferId
+        Experiment.Propagator.Policy.OfferKey × Experiment.Propagator.Policy.State Rank)) := do
   let engine <- retainedOddness?
   let state :=
-    Policy.State.start engine { policyLimits with maxTraversal }
+    Experiment.Propagator.Policy.State.start engine { policyLimits with maxTraversal }
   some state.view
 
 -- The retained oddness offer costs two backing slots, nine proposal items,
@@ -621,9 +630,9 @@ def retryEngine? : Option (Engine Rank) := do
       (request.action.reply (.success [] [.retry 1] {})) | none
   if plan.kept.length == 1 then some state else none
 
-def selectedRetry? : Option (RuleRequest Rank × Policy.State Rank) := do
+def selectedRetry? : Option (RuleRequest Rank × Experiment.Propagator.Policy.State Rank) := do
   let engine <- retryEngine?
-  let state := Policy.State.start engine policyLimits
+  let state := Experiment.Propagator.Policy.State.start engine policyLimits
   let offer <- state.offer? (.suggestion { index := 0 })
   let .request request state :=
     state.select
@@ -664,7 +673,7 @@ def selectedRetry? : Option (RuleRequest Rank × Policy.State Rank) := do
             { engine with
               matcherCursors :=
                 engine.matcherCursors.set! 0 (some { cursor with epoch := cursor.epoch + 1 }) }
-          let state := Policy.State.start engine policyLimits
+          let state := Experiment.Propagator.Policy.State.start engine policyLimits
           match state.offer? (.suggestion { index := 0 }) with
           | some offer =>
               match state.select
@@ -680,9 +689,11 @@ def selectedRetry? : Option (RuleRequest Rank × Policy.State Rank) := do
       | _ => false
   | none => false
 
-def policyView? : Option (Policy.View Rank × Policy.State Rank) := do
+def policyView? : Option
+    (Hex.Interval.Policy.View Rank Experiment.Propagator.Policy.OfferId
+      Experiment.Propagator.Policy.OfferKey × Experiment.Propagator.Policy.State Rank) := do
   let engine <- started?
-  match (Policy.State.start engine policyLimits).view with
+  match (Experiment.Propagator.Policy.State.start engine policyLimits).view with
   | .ok pair => some pair
   | .error _ => none
 
@@ -691,7 +702,7 @@ def policyView? : Option (Policy.View Rank × Policy.State Rank) := do
   | some (view, _) =>
       view.offers.size == 1 && view.remaining.matcherVisits == 16 &&
         match view.offers[0]?.map (fun offer => offer.key) with
-        | some (Policy.OfferKey.invoke invocation) =>
+        | some (Experiment.Propagator.Policy.OfferKey.invoke invocation) =>
             invocation.structuralInputs.map (fun input => input.key) ==
                 [.node (node 0), .node (node 1)] &&
               invocation.matcherEpoch == some 0 && !invocation.matcherBlocked
@@ -699,11 +710,11 @@ def policyView? : Option (Policy.View Rank × Policy.State Rank) := do
   | none => false
 
 def policySelected? :
-    Option (RuleRequest Rank × Policy.State Rank × Policy.InvocationKey) := do
+    Option (RuleRequest Rank × Experiment.Propagator.Policy.State Rank × Experiment.Propagator.Policy.InvocationKey) := do
   let (view, state) <- policyView?
   let offer <- view.offers[0]?
-  let Policy.OfferKey.invoke invocation := offer.key | none
-  let selection : Policy.Selection :=
+  let Experiment.Propagator.Policy.OfferKey.invoke invocation := offer.key | none
+  let selection : Selection :=
     { scope := view.scope
       serial := view.serial
       programVersion := view.programVersion
@@ -731,11 +742,13 @@ def policySelected? :
         | _ => false
   | none => false
 
-def blockedPolicy? : Option (Policy.View Rank × Policy.State Rank) := do
+def blockedPolicy? : Option
+    (Hex.Interval.Policy.View Rank Experiment.Propagator.Policy.OfferId
+      Experiment.Propagator.Policy.OfferKey × Experiment.Propagator.Policy.State Rank) := do
   let .ok engine :=
     Engine.start rankDomain program #[matcherRule, contractRule] #[0, 0, 0]
       { limits with maxMatcherVisits := 0 } | none
-  match (Policy.State.start engine policyLimits).view with
+  match (Experiment.Propagator.Policy.State.start engine policyLimits).view with
   | .ok pair => some pair
   | .error _ => none
 
@@ -747,7 +760,7 @@ def blockedPolicy? : Option (Policy.View Rank × Policy.State Rank) := do
       match view.offers[0]? with
       | some offer =>
           match offer.key with
-          | Policy.OfferKey.invoke invocation =>
+          | Experiment.Propagator.Policy.OfferKey.invoke invocation =>
               invocation.matcherBlocked &&
                 match state.select
                     { scope := view.scope

--- a/conformance/HexInterval/MatcherSchedulerConformance.lean
+++ b/conformance/HexInterval/MatcherSchedulerConformance.lean
@@ -640,7 +640,11 @@ def selectedRetry? : Option (RuleRequest Rank × Experiment.Propagator.Policy.St
         serial := state.serial
         programVersion := state.engine.programVersion
         id := offer.id
-        expected := offer.key } | none
+        expected := offer.key
+        offerClass := offer.offerClass
+        age := offer.age
+        score := offer.score
+        remaining := state.budgetView } | none
   pure (request, state)
 
 -- A retained retry replays its original structural evidence without claiming
@@ -681,7 +685,11 @@ def selectedRetry? : Option (RuleRequest Rank × Experiment.Propagator.Policy.St
                     serial := state.serial
                     programVersion := state.engine.programVersion
                     id := offer.id
-                    expected := offer.key } with
+                    expected := offer.key
+                    offerClass := offer.offerClass
+                    age := offer.age
+                    score := offer.score
+                    remaining := state.budgetView } with
               | .rejected .malformedState after =>
                   after.engine.metrics.matcherVisits == 2
               | _ => false
@@ -714,12 +722,7 @@ def policySelected? :
   let (view, state) <- policyView?
   let offer <- view.offers[0]?
   let Experiment.Propagator.Policy.OfferKey.invoke invocation := offer.key | none
-  let selection : Selection :=
-    { scope := view.scope
-      serial := view.serial
-      programVersion := view.programVersion
-      id := offer.id
-      expected := offer.key }
+  let selection : Selection := Hex.Interval.Policy.select view offer
   let .request request state := state.select selection | none
   pure (request, state, invocation)
 
@@ -767,7 +770,11 @@ def blockedPolicy? : Option
                       serial := view.serial
                       programVersion := view.programVersion
                       id := offer.id
-                      expected := offer.key } with
+                      expected := offer.key
+                      offerClass := offer.offerClass
+                      age := offer.age
+                      score := offer.score
+                      remaining := view.remaining } with
                 | .engineResource .matcherVisits _ => true
                 | _ => false
           | _ => false

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -19,6 +19,13 @@ frontiers differ on live pending work.
 
 namespace Hex.Interval.NestedBranchConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Lean Elab Tactic Meta
 open Hex.Interval
 open Experiment
@@ -43,8 +50,8 @@ private inductive Route where
   | close
   deriving DecidableEq, Repr
 
-private def splitAt (wanted : NodeId) (view : Policy.View Bound) :
-    Option Policy.OfferView :=
+private def splitAt (wanted : NodeId) (view : (Hex.Interval.Policy.View Bound _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) :
+    Option OfferView :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation =>
@@ -52,8 +59,8 @@ private def splitAt (wanted : NodeId) (view : Policy.View Bound) :
     | .split _ seen _ _ => seen.node == wanted
     | _ => false
 
-private def expAt (wanted : NodeId) (view : Policy.View Bound) :
-    Option Policy.OfferView :=
+private def expAt (wanted : NodeId) (view : (Hex.Interval.Policy.View Bound _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) :
+    Option OfferView :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation =>

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -137,7 +137,11 @@ def selectOffer (state : State Rank) (id : OfferId) : SelectResult Rank :=
           serial := state.serial
           programVersion := state.engine.programVersion
           id
-          expected := offer.key }
+          expected := offer.key
+          offerClass := offer.offerClass
+          age := offer.age
+          score := offer.score
+          remaining := state.budgetView }
 
 def dismissOffer (state : State Rank) (id : OfferId) : Option (State Rank) := do
   let offer <- state.offer? id
@@ -146,7 +150,11 @@ def dismissOffer (state : State Rank) (id : OfferId) : Option (State Rank) := do
         serial := state.serial
         programVersion := state.engine.programVersion
         id
-        expected := offer.key } with
+        expected := offer.key
+        offerClass := offer.offerClass
+        age := offer.age
+        score := offer.score
+        remaining := state.budgetView } with
   | .completed .dismissed next => some next
   | _ => none
 
@@ -353,7 +361,11 @@ def instantiateFirst? : Option ScheduleResult := do
         serial := state.serial
         programVersion := state.engine.programVersion
         id := .suggestion (suggestion 0)
-        expected := retryOffer.key } with
+        expected := retryOffer.key
+        offerClass := retryOffer.offerClass
+        age := retryOffer.age
+        score := retryOffer.score
+        remaining := state.budgetView } with
     | .completed .dismissed next => some next
     | _ => none
   let (splitPlan, state) <- split? state (suggestion 2)
@@ -495,13 +507,17 @@ def afterInitialWith? (engineLimit : Hex.Interval.State.Limits) : Option (State 
   | none => false
   | some state =>
       match state.offer? (.suggestion (suggestion 0)) with
-      | some { key := .retry source 1, .. } =>
+      | some offer@{ key := .retry source 1, .. } =>
           let fabricated : Selection :=
             { scope := state.scope
               serial := state.serial
               programVersion := state.engine.programVersion
               id := .suggestion (suggestion 0)
-              expected := .retry source 2 }
+              expected := .retry source 2
+              offerClass := offer.offerClass
+              age := offer.age
+              score := offer.score
+              remaining := state.budgetView }
           match state.select fabricated with
           | .rejected .wrongKey next =>
               next.metrics.decisions == state.metrics.decisions + 1 &&
@@ -512,6 +528,52 @@ def afterInitialWith? (engineLimit : Hex.Interval.State.Limits) : Option (State 
                 | none => false
           | _ => false
       | _ => false
+
+-- The experimental controller authenticates the complete supported decision
+-- echo, including the engine budget and every exposed offer field.
+#guard
+  match initial? with
+  | some state =>
+      match state.offer? (.application (application 0)) with
+      | some offer =>
+          let exact : Selection :=
+            { scope := state.scope
+              serial := state.serial
+              programVersion := state.engine.programVersion
+              id := offer.id
+              expected := offer.key
+              offerClass := offer.offerClass
+              age := offer.age
+              score := offer.score
+              remaining := state.budgetView }
+          match state.select
+              { exact with
+                remaining := { exact.remaining with actions := exact.remaining.actions + 1 } } with
+          | .rejected .staleBudget next => next.metrics.rejected == 1
+          | _ => false
+      | none => false
+  | none => false
+
+#guard
+  match initial? with
+  | some state =>
+      match state.offer? (.application (application 0)) with
+      | some offer =>
+          let exact : Selection :=
+            { scope := state.scope
+              serial := state.serial
+              programVersion := state.engine.programVersion
+              id := offer.id
+              expected := offer.key
+              offerClass := offer.offerClass
+              age := offer.age
+              score := offer.score
+              remaining := state.budgetView }
+          match state.select { exact with age := exact.age + 1 } with
+          | .rejected .mutatedOffer next => next.metrics.rejected == 1
+          | _ => false
+      | none => false
+  | none => false
 
 def staleEqualityResult? : Option (SelectResult Rank) := do
   let state <- afterInitial?
@@ -524,7 +586,11 @@ def staleEqualityResult? : Option (SelectResult Rank) := do
       serial := state.serial
       programVersion := state.engine.programVersion
       id := .equality (equality 0)
-      expected := oldOffer.key }
+      expected := oldOffer.key
+      offerClass := oldOffer.offerClass
+      age := oldOffer.age
+      score := oldOffer.score
+      remaining := state.budgetView }
 
 -- A still-dirty equality is rejected when either endpoint version has moved.
 #guard
@@ -1080,7 +1146,11 @@ def splitChangedTarget (request : RuleRequest Rank) : Outcome Rank :=
                 serial := state.serial
                 programVersion := state.engine.programVersion
                 id := offer.id
-                expected := offer.key } with
+                expected := offer.key
+                offerClass := offer.offerClass
+                age := offer.age
+                score := offer.score
+                remaining := state.budgetView } with
           | .completed .dismissed next =>
               match next.view with
               | .ok (view, _) => view.offers.isEmpty && view.incomplete

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -17,6 +17,13 @@ arithmetic semantics.
 
 namespace Hex.Interval.PolicyConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment.Propagator
 open Experiment.Propagator.Policy
 

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -44,12 +44,7 @@ def findOffer? (view : (Hex.Interval.Policy.View Fact _root_.Hex.Interval.Experi
 
 def selection? (view : (Hex.Interval.Policy.View Fact _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) (id : OfferId) : Option Selection := do
   let offer <- findOffer? view id
-  some
-    { scope := view.scope
-      serial := view.serial
-      programVersion := view.programVersion
-      id
-      expected := offer.key }
+  some (Hex.Interval.Policy.select view offer)
 
 def choose : List Command -> (Hex.Interval.Policy.View Rank _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) -> Step (List Command)
   | [], _ => .stop []
@@ -64,14 +59,8 @@ def choose : List Command -> (Hex.Interval.Policy.View Rank _root_.Hex.Interval.
       | none => .stop rest
   | .wrongRetry id effort :: rest, view =>
       match selection? view (.suggestion id) with
-      | some { expected := .retry source _, .. } =>
-          .select
-            { scope := view.scope
-              serial := view.serial
-              programVersion := view.programVersion
-              id := .suggestion id
-              expected := .retry source effort }
-            rest
+      | some selection@{ expected := .retry source _, .. } =>
+          .select { selection with expected := .retry source effort } rest
       | _ => .stop rest
   | .stale id :: rest, view =>
       match selection? view id with

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -18,6 +18,13 @@ stream records their different causal histories exactly.
 
 namespace Hex.Interval.PolicyDriverConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment.Propagator
 open Experiment.Propagator.Policy
 open Experiment.Propagator.Policy.Driver
@@ -32,10 +39,10 @@ inductive Command
   | stale (id : OfferId)
   | stop
 
-def findOffer? (view : View Fact) (id : OfferId) : Option OfferView :=
+def findOffer? (view : (Hex.Interval.Policy.View Fact _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) (id : OfferId) : Option OfferView :=
   view.offers.toList.find? fun offer => offer.id == id
 
-def selection? (view : View Fact) (id : OfferId) : Option Selection := do
+def selection? (view : (Hex.Interval.Policy.View Fact _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) (id : OfferId) : Option Selection := do
   let offer <- findOffer? view id
   some
     { scope := view.scope
@@ -44,7 +51,7 @@ def selection? (view : View Fact) (id : OfferId) : Option Selection := do
       id
       expected := offer.key }
 
-def choose : List Command -> View Rank -> Step (List Command)
+def choose : List Command -> (Hex.Interval.Policy.View Rank _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) -> Step (List Command)
   | [], _ => .stop []
   | .stop :: rest, _ => .stop rest
   | .select id :: rest, view =>

--- a/conformance/HexInterval/PolicyFeatureConformance.lean
+++ b/conformance/HexInterval/PolicyFeatureConformance.lean
@@ -51,8 +51,9 @@ private def splitOffer : OfferView :=
     age := 1 }
 
 private def sameOffer (left right : OfferView) : Bool :=
-  left.id == right.id && left.key == right.key &&
-    left.offerClass == right.offerClass && left.age == right.age
+  left == right
+
+#guard !sameOffer invokeOffer { invokeOffer with score := 1 }
 
 private def sameOffers : List OfferView -> List OfferView -> Bool
   | [], [] => true

--- a/conformance/HexInterval/PolicyFeatureConformance.lean
+++ b/conformance/HexInterval/PolicyFeatureConformance.lean
@@ -16,6 +16,13 @@ decorator contains neither interpretation.
 
 namespace Hex.Interval.PolicyFeatureConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment Propagator Propagator.Policy PolicyFeature
 
 private def node (index : Nat) : NodeId := { index }
@@ -53,7 +60,7 @@ private def sameOffers : List OfferView -> List OfferView -> Bool
       sameOffer left right && sameOffers lefts rights
   | _, _ => false
 
-private def baseView : Policy.View Nat :=
+private def baseView : (Hex.Interval.Policy.View Nat _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   { scope := { index := 0 }
     serial := 9
     programVersion := 7
@@ -72,7 +79,7 @@ private def baseView : Policy.View Nat :=
         generation := 8 }
     incomplete := false }
 
-private def sameView (left right : Policy.View Nat) : Bool :=
+private def sameView (left right : (Hex.Interval.Policy.View Nat _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   left.scope == right.scope && left.serial == right.serial &&
     left.programVersion == right.programVersion &&
     sameOffers left.offers.toList right.offers.toList &&

--- a/conformance/HexInterval/PolicyFunctionConformance.lean
+++ b/conformance/HexInterval/PolicyFunctionConformance.lean
@@ -283,11 +283,7 @@ def invocation? (session : PolicySession.Session Rank) (key : RuleKey) :
       | some offer =>
           some
             (offer,
-              { scope := view.scope
-                serial := view.serial
-                programVersion := view.programVersion
-                id := offer.id
-                expected := offer.key },
+              Hex.Interval.Policy.select view offer,
               viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
@@ -302,11 +298,7 @@ def instantiation? (session : PolicySession.Session Rank) :
       | some offer =>
           some
             (offer,
-              { scope := view.scope
-                serial := view.serial
-                programVersion := view.programVersion
-                id := offer.id
-                expected := offer.key },
+              Hex.Interval.Policy.select view offer,
               viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 

--- a/conformance/HexInterval/PolicyFunctionConformance.lean
+++ b/conformance/HexInterval/PolicyFunctionConformance.lean
@@ -26,6 +26,13 @@ and matcher cursor together.
 
 namespace Hex.Interval.PolicyFunctionConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment Propagator PayloadArena PolicySession SemanticReplay
 
 abbrev Rank := Nat
@@ -255,19 +262,19 @@ def matcherInputs : List StructuralInput :=
    { key := .node (node 2), generation := 0 },
    { key := .application { index := 0 }, generation := 0 }]
 
-def invokes (key : RuleKey) (offer : Propagator.Policy.OfferView) : Bool :=
+def invokes (key : RuleKey) (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .invoke invocation => invocation.rule == key
   | _ => false
 
-def instantiatesMatcher (offer : Propagator.Policy.OfferView) : Bool :=
+def instantiatesMatcher (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .instantiate source _ => source.rule == matcherKey
   | _ => false
 
 def invocation? (session : PolicySession.Session Rank) (key : RuleKey) :
     Option
-      (Propagator.Policy.OfferView × Propagator.Policy.Selection ×
+      ((Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × (Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) ×
         PolicySession.Session Rank) :=
   match session.view with
   | .ready view viewed =>
@@ -286,7 +293,7 @@ def invocation? (session : PolicySession.Session Rank) (key : RuleKey) :
 
 def instantiation? (session : PolicySession.Session Rank) :
     Option
-      (Propagator.Policy.OfferView × Propagator.Policy.Selection ×
+      ((Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × (Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) ×
         PolicySession.Session Rank) :=
   match session.view with
   | .ready view viewed =>

--- a/conformance/HexInterval/PolicySessionConformance.lean
+++ b/conformance/HexInterval/PolicySessionConformance.lean
@@ -18,6 +18,13 @@ narrowing work, and prepare a split.
 
 namespace Hex.Interval.PolicySessionConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment Propagator
 open DyadicRules
 open PolicySession
@@ -129,7 +136,7 @@ inductive Command
   | dismissRetry (key : RuleKey) (effort : Nat)
   | split (key : RuleKey)
 
-def commandMatches : Command -> Propagator.Policy.OfferView -> Bool
+def commandMatches : Command -> (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) -> Bool
   | .invoke key, { key := .invoke source, .. } => source.rule == key
   | .instantiate key, { key := .instantiate source _, .. } => source.rule == key
   | .retry key effort, { key := .retry source offered, .. } =>
@@ -141,7 +148,7 @@ def commandMatches : Command -> Propagator.Policy.OfferView -> Bool
   | _, _ => false
 
 def selection? (session : PolicySession.Session Fact) (command : Command) :
-    Option (Propagator.Policy.Selection × PolicySession.Session Fact) :=
+    Option ((Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × PolicySession.Session Fact) :=
   match session.view with
   | .ready view viewed =>
       match view.offers.toList.find? (commandMatches command) with
@@ -763,7 +770,7 @@ def matcherStart? : Option (PolicySession.Session Nat) :=
   | .error _ => none
 
 def matcherSelection? (session : PolicySession.Session Nat) :
-    Option (Propagator.Policy.Selection × PolicySession.Session Nat) :=
+    Option ((Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × PolicySession.Session Nat) :=
   match session.view with
   | .ready view viewed =>
       match view.offers.toList.find? fun offer =>

--- a/conformance/HexInterval/PolicySessionConformance.lean
+++ b/conformance/HexInterval/PolicySessionConformance.lean
@@ -155,11 +155,7 @@ def selection? (session : PolicySession.Session Fact) (command : Command) :
       | none => none
       | some offer =>
           some
-            ({ scope := view.scope
-               serial := view.serial
-               programVersion := view.programVersion
-               id := offer.id
-               expected := offer.key },
+            (Hex.Interval.Policy.select view offer,
              viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
@@ -781,11 +777,7 @@ def matcherSelection? (session : PolicySession.Session Nat) :
       | none => none
       | some offer =>
           some
-            ({ scope := view.scope
-               serial := view.serial
-               programVersion := view.programVersion
-               id := offer.id
-               expected := offer.key },
+            (Hex.Interval.Policy.select view offer,
              viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 

--- a/conformance/HexInterval/ScopeConformance.lean
+++ b/conformance/HexInterval/ScopeConformance.lean
@@ -569,7 +569,7 @@ def scopeOnlyAdmitted? (customLimits : Hex.Interval.State.Limits := limits) :
             event.newApplications == [{ index := 3 }])
   | none => false
 
-def scopePolicyLimits : Policy.Limits :=
+def scopePolicyLimits : Experiment.Propagator.Policy.Limits :=
   { maxDecisions := 4
     maxTraversal := 64
     maxLiveOffers := 16 }
@@ -579,7 +579,7 @@ def scopePolicyLimits : Policy.Limits :=
 #guard
   match scopeOnlyAdmitted? with
   | some (engine, _) =>
-      match (Policy.State.start engine scopePolicyLimits).view with
+      match (Experiment.Propagator.Policy.State.start engine scopePolicyLimits).view with
       | .ok (view, _) => view.remaining.generation == 1
       | .error _ => false
   | none => false
@@ -590,7 +590,7 @@ def scopePolicyLimits : Policy.Limits :=
 #guard
   match scopeOnlyAdmitted? with
   | some (engine, _) =>
-      match (Policy.State.start engine
+      match (Experiment.Propagator.Policy.State.start engine
           { scopePolicyLimits with maxTraversal := 5 }).view with
       | .error .traversalLimit => true
       | _ => false
@@ -599,7 +599,7 @@ def scopePolicyLimits : Policy.Limits :=
 #guard
   match scopeOnlyAdmitted? with
   | some (engine, _) =>
-      match (Policy.State.start engine
+      match (Experiment.Propagator.Policy.State.start engine
           { scopePolicyLimits with maxTraversal := 24 }).view with
       | .error .traversalLimit => true
       | _ => false
@@ -608,7 +608,7 @@ def scopePolicyLimits : Policy.Limits :=
 #guard
   match scopeOnlyAdmitted? with
   | some (engine, _) =>
-      match (Policy.State.start engine
+      match (Experiment.Propagator.Policy.State.start engine
           { scopePolicyLimits with maxTraversal := 25 }).view with
       | .ok (_, next) => next.metrics.traversal == 25
       | .error _ => false

--- a/conformance/HexInterval/StagedPolicyConformance.lean
+++ b/conformance/HexInterval/StagedPolicyConformance.lean
@@ -19,6 +19,13 @@ resulting solver split.
 
 namespace Hex.Interval.StagedPolicyConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Experiment
 open Propagator PolicySession SemanticReplay TargetRun
 open ExpSign StagedPolicy
@@ -97,29 +104,29 @@ private def invocation (index : Nat) (kind : ActionKind) : Policy.InvocationKey 
     effort := 0
     inputs := [] }
 
-private def offer (index age : Nat) (key : Policy.OfferKey) : Policy.OfferView :=
+private def offer (index age : Nat) (key : Policy.OfferKey) : OfferView :=
   { id := .suggestion { index }, key, offerClass := key.offerClass, age }
 
-private def forwardOffer : Policy.OfferView :=
+private def forwardOffer : OfferView :=
   offer 0 1 (.invoke (invocation 0 .forward))
 
-private def olderForward : Policy.OfferView :=
+private def olderForward : OfferView :=
   offer 1 5 (.invoke (invocation 1 .forward))
 
-private def instanceProbe : Policy.OfferView :=
+private def instanceProbe : OfferView :=
   offer 2 9 (.invoke (invocation 2 .instantiate))
 
-private def instanceOffer : Policy.OfferView :=
+private def instanceOffer : OfferView :=
   offer 3 9 (.instantiate (invocation 3 .instantiate)
     { family := 0, generation := 0, nodes := [], equalities := [], scopes := [] })
 
-private def retryOffer : Policy.OfferView :=
+private def retryOffer : OfferView :=
   offer 4 9 (.retry (invocation 4 .improve) 2)
 
-private def splitProbe : Policy.OfferView :=
+private def splitProbe : OfferView :=
   offer 5 9 (.invoke (invocation 5 .split))
 
-private def splitOffer : Policy.OfferView :=
+private def splitOffer : OfferView :=
   offer 6 9 (.split (invocation 6 .split)
     { node := node 0, version := 0 } 0 .midpoint)
 
@@ -163,7 +170,7 @@ private def invocation (index effort : Nat) (kind : ActionKind := .forward) :
     effort
     inputs := [] }
 
-private def offer (index age : Nat) (key : Policy.OfferKey) : Policy.OfferView :=
+private def offer (index age : Nat) (key : Policy.OfferKey) : OfferView :=
   { id := .application { index }, key, offerClass := key.offerClass, age }
 
 private def change (index : Nat) : Policy.FactDelta Nat :=
@@ -245,7 +252,7 @@ exact-snapshot fixed-point penalty. -/
 private def rewokenProductiveKey : Policy.InvocationKey :=
   { productiveKey with inputs := [{ node := node 0, version := 1 }] }
 
-private def rewokenProductiveOffer : Policy.OfferView :=
+private def rewokenProductiveOffer : OfferView :=
   offer 0 0 (.invoke rewokenProductiveKey)
 
 #guard
@@ -334,7 +341,7 @@ private def fairQuiet := { quietOffer with age := 20 }
 
 /- Learning never lets a speculative split leapfrog unsaturated cheap
 propagation merely because it is untried. -/
-private def splitOffer : Policy.OfferView :=
+private def splitOffer : OfferView :=
   offer 3 0 (.split (invocation 3 0 .split)
     { node := node 0, version := 0 } 0 .midpoint)
 
@@ -358,7 +365,7 @@ private def equalityLearned : AdaptivePolicy.State :=
         changes := #[change 0]
         narrowCalls := 2 }
 
-private def equalityOffer : Policy.OfferView :=
+private def equalityOffer : OfferView :=
   { id := .equality { index := 0 }
     key := .equality equalityKey
     offerClass := .equality

--- a/conformance/HexIntervalMathlib/ExactBranchConformance.lean
+++ b/conformance/HexIntervalMathlib/ExactBranchConformance.lean
@@ -23,6 +23,13 @@ empty, and closes through package-owned refutation.
 
 namespace Hex.IntervalMathlib.ExactBranchConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Lean Elab Tactic Meta
 open Hex.Interval Hex.Interval.Experiment
 open Propagator PayloadArena PolicySession SemanticReplay ChronologicalReplay
@@ -505,8 +512,8 @@ private inductive Route where
   deriving DecidableEq, Repr
 
 private def offerFor (key : RuleKey)
-    (view : Propagator.Policy.View DyadicInterval.Fact) :
-    Option Propagator.Policy.OfferView :=
+    (view : (Hex.Interval.Policy.View DyadicInterval.Fact Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
+    Option (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation => invocation.rule == key

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -163,13 +163,7 @@ def offer? (session : PolicySession.Session Bound)
       | none => none
       | some offer =>
           some
-            (offer,
-              { scope := view.scope
-                serial := view.serial
-                programVersion := view.programVersion
-                id := offer.id
-                expected := offer.key },
-              viewed)
+            (offer, Hex.Interval.Policy.select view offer, viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
 def invokesExpAt (target : NodeId) (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -25,6 +25,13 @@ ordinary kernel-checked theorem.
 
 namespace Hex.IntervalMathlib.ExpSignConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Lean Elab Tactic Meta
 open Hex.Interval
 open Hex.Interval.Experiment
@@ -146,9 +153,9 @@ private def spareOperation : Operation :=
       baseProgram := { program with operations := operations.push spareOperation } }
 
 def offer? (session : PolicySession.Session Bound)
-    (accepts : Propagator.Policy.OfferView → Bool) :
+    (accepts : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) → Bool) :
     Option
-      (Propagator.Policy.OfferView × Propagator.Policy.Selection ×
+      ((Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × (Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) ×
         PolicySession.Session Bound) :=
   match session.view with
   | .ready view viewed =>
@@ -165,13 +172,13 @@ def offer? (session : PolicySession.Session Bound)
               viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
-def invokesExpAt (target : NodeId) (offer : Propagator.Policy.OfferView) : Bool :=
+def invokesExpAt (target : NodeId) (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .invoke invocation =>
       invocation.rule == expRuleKey && invocation.anchor == target
   | _ => false
 
-def invokesExp (offer : Propagator.Policy.OfferView) : Bool :=
+def invokesExp (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   invokesExpAt (node 1) offer
 
 def contracted? : Option (PolicySession.Session Bound) := do
@@ -233,7 +240,7 @@ structure RunFixture extends Fixture where
 
 def runWith? (runtimePackages : Array (Package Bound))
     (input : CheckerInput Bound) (controller : TargetRun.Controller Bound Unit)
-    (fuel : Nat) (scope : Propagator.Policy.ScopeId := { index := 0 }) :
+    (fuel : Nat) (scope : Hex.Interval.Policy.ScopeId := { index := 0 }) :
     Option (TargetRun.Result Bound Unit) := do
   let .ok session := PolicySession.Session.start factDomain
       input.baseProgram runtimePackages input.initialFacts limits scope
@@ -242,12 +249,12 @@ def runWith? (runtimePackages : Array (Package Bound))
     fuel session ())
 
 def runRaw? (input : CheckerInput Bound) (controller : TargetRun.Controller Bound Unit)
-    (fuel : Nat) (scope : Propagator.Policy.ScopeId := { index := 0 }) :
+    (fuel : Nat) (scope : Hex.Interval.Policy.ScopeId := { index := 0 }) :
     Option (TargetRun.Result Bound Unit) :=
   runWith? packages input controller fuel scope
 
 def runInput? (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId := { index := 0 }) : Option RunFixture := do
+    (scope : Hex.Interval.Policy.ScopeId := { index := 0 }) : Option RunFixture := do
   let result <- runRaw? input firstOffer limits.policy.maxDecisions scope
   let .target reached := result.stop | none
   match ProofRegistry.build result.session.registry proofPackages with
@@ -277,8 +284,8 @@ def trace? : Option (Frontend.Trace Bound) := do
 
 /-! ## Live zero-split child sessions -/
 
-private def splitOffer? (view : Propagator.Policy.View Bound) :
-    Option Propagator.Policy.OfferView :=
+private def splitOffer? (view : (Hex.Interval.Policy.View Bound Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
+    Option (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation => invocation.rule == splitRuleKey
@@ -399,8 +406,8 @@ private def inheritBranch (side : Bound) (observed : NodeId)
 
 private def leftInput : CheckerInput Bound := branchInput .nonnegative
 private def rightInput : CheckerInput Bound := branchInput .negative
-private def leftScope : Propagator.Policy.ScopeId := { index := 1 }
-private def rightScope : Propagator.Policy.ScopeId := { index := 2 }
+private def leftScope : Hex.Interval.Policy.ScopeId := { index := 1 }
+private def rightScope : Hex.Interval.Policy.ScopeId := { index := 2 }
 private def leftFacts : List (NodeFact Bound) := branchFacts .nonnegative
 private def rightFacts : List (NodeFact Bound) := branchFacts .negative
 
@@ -976,7 +983,7 @@ private def splitParent : Evidence
   ProofEmitter.assumed (by simp [baseFacts, branchFact, node])
 
 private meta def emitChild (context : ProofFrontend.Context Bound Name)
-    (input : CheckerInput Bound) (scope : Propagator.Policy.ScopeId)
+    (input : CheckerInput Bound) (scope : Hex.Interval.Policy.ScopeId)
     (seed : Expr) (side : Bound) : MetaM Expr := do
   let some fixture := runInput? input scope
     | throwError "interval_exp_split: child search failed"
@@ -1289,8 +1296,8 @@ private def outputSplitPackage : Package Bound :=
 private def outputSplitPackages : Array (Package Bound) :=
   #[sourcePackage, expPackage, outputSplitPackage]
 
-private def outputSplitOffer? (view : Propagator.Policy.View Bound) :
-    Option Propagator.Policy.OfferView :=
+private def outputSplitOffer? (view : (Hex.Interval.Policy.View Bound Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
+    Option (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation => invocation.rule == outputSplitKey
@@ -1335,8 +1342,8 @@ private def outputLeftInput : CheckerInput Bound := outputInput .nonnegative
 private def outputRightInput : CheckerInput Bound := outputInput .negative
 private def outputLeftFacts : List (NodeFact Bound) := outputFacts .nonnegative
 private def outputRightFacts : List (NodeFact Bound) := outputFacts .negative
-private def outputLeftScope : Propagator.Policy.ScopeId := { index := 1 }
-private def outputRightScope : Propagator.Policy.ScopeId := { index := 2 }
+private def outputLeftScope : Hex.Interval.Policy.ScopeId := { index := 1 }
+private def outputRightScope : Hex.Interval.Policy.ScopeId := { index := 2 }
 
 private def inheritOutput (side : Bound) (observed : NodeId)
     (different : observed ≠ node 1) (fact : Bound)
@@ -1428,7 +1435,7 @@ private def sameChecker (left right : CheckerInput Bound) : Bool :=
       fixture.registry.refute.find? .all == none
 
 private meta def emitOutputTarget (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId) : MetaM Expr := do
+    (scope : Hex.Interval.Policy.ScopeId) : MetaM Expr := do
   let some result := runRaw? input firstOffer limits.policy.maxDecisions scope
     | throwError "interval_exp_refute: target child did not start"
   let .target reached := result.stop
@@ -1443,7 +1450,7 @@ private meta def emitOutputTarget (input : CheckerInput Bound)
     input.target
 
 private meta def emitOutputRefute (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId) : MetaM Expr := do
+    (scope : Hex.Interval.Policy.ScopeId) : MetaM Expr := do
   let some result := runRaw? input firstOffer limits.policy.maxDecisions scope
     | throwError "interval_exp_refute: contradiction child did not start"
   let .contradiction := result.stop

--- a/conformance/HexIntervalMathlib/ReluConformance.lean
+++ b/conformance/HexIntervalMathlib/ReluConformance.lean
@@ -25,6 +25,13 @@ theorem is unconditional and does not mathematically require branching.
 
 namespace Hex.IntervalMathlib.ReluConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Lean Elab Tactic Meta
 open Hex.Interval
 open Hex.Interval.Experiment
@@ -32,8 +39,8 @@ open Propagator PolicySession SemanticReplay ChronologicalReplay ProofEmitter
 open Frontend FrontendEncoder ProofFrontend ProofRegistry GoalFrontend ExpSign
 open GoalClosure BranchStart
 
-private def splitOffer? (view : Propagator.Policy.View Bound) :
-    Option Propagator.Policy.OfferView :=
+private def splitOffer? (view : (Hex.Interval.Policy.View Bound Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
+    Option (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation => invocation.rule == splitRuleKey
@@ -370,8 +377,8 @@ private theorem closeRelu (x : ℝ)
       rcases member with rfl | rfl <;> trivial)
   exact holds
 
-private def reluOffer? (key : RuleKey) (view : Propagator.Policy.View Bound) :
-    Option Propagator.Policy.OfferView :=
+private def reluOffer? (key : RuleKey) (view : (Hex.Interval.Policy.View Bound Propagator.Policy.OfferId Propagator.Policy.OfferKey)) :
+    Option (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) :=
   view.offers.toList.find? fun offer =>
     match offer.key with
     | .invoke invocation => invocation.rule == key
@@ -387,7 +394,7 @@ private def reluRulePolicy (key : RuleKey) :
 
 private def reluRunWith? (runtimePackages : Array (Package Bound))
     (input : CheckerInput Bound) (controller : TargetRun.Controller Bound Unit)
-    (scope : Propagator.Policy.ScopeId := { index := 0 }) :
+    (scope : Hex.Interval.Policy.ScopeId := { index := 0 }) :
     Option (TargetRun.Result Bound Unit) := do
   let .ok session := PolicySession.Session.start factDomain
       input.baseProgram runtimePackages input.initialFacts limits scope
@@ -469,7 +476,7 @@ private structure ReluRun where
   reached : TargetRun.Reached Bound
 
 private def reluRunChild? (side : Bound) (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId) : Option ReluRun := do
+    (scope : Hex.Interval.Policy.ScopeId) : Option ReluRun := do
   let key := if side == .nonnegative then reluNonnegativeKey else reluNegativeKey
   let result ← reluRunWith? reluPackages input (reluRulePolicy key) scope
   let .target reached := result.stop | none
@@ -524,13 +531,13 @@ private def reluTree? (resources : BranchTree.Limits := treeLimits) :
   reluPrepared?.any fun lifted =>
     let children := lifted.down
     children.depth == 1 && BranchProof.sameInput children.parent reluInput &&
-      children.leftScope == ({ index := 1 } : Propagator.Policy.ScopeId) &&
-      children.rightScope == ({ index := 2 } : Propagator.Policy.ScopeId) &&
+      children.leftScope == ({ index := 1 } : Hex.Interval.Policy.ScopeId) &&
+      children.rightScope == ({ index := 2 } : Hex.Interval.Policy.ScopeId) &&
       BranchProof.sameInput children.left reluLeftInput &&
       BranchProof.sameInput children.right reluRightInput
 
 private def reluTraceUses? (side : Bound) (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId) : Bool :=
+    (scope : Hex.Interval.Policy.ScopeId) : Bool :=
   match reluRunChild? side input scope with
   | none => false
   | some run =>
@@ -617,7 +624,7 @@ private def reluParent : Evidence
 
 private meta def emitReluChild (context : ProofFrontend.Context Bound Name)
     (side : Bound) (input : CheckerInput Bound)
-    (scope : Propagator.Policy.ScopeId) (seed : Expr) : MetaM Expr := do
+    (scope : Hex.Interval.Policy.ScopeId) (seed : Expr) : MetaM Expr := do
   let some run := reluRunChild? side input scope
     | throwError "interval_relu_split: child search failed"
   let some trace := Frontend.trace? run.session.state.engine run.session.arena
@@ -791,7 +798,7 @@ example : True := by
   run_tac
     let checkMutation (context : ProofFrontend.Context Bound Name)
         (side wrong : Bound) (input : CheckerInput Bound)
-        (scope : Propagator.Policy.ScopeId) (seed : Expr) : MetaM Unit := do
+        (scope : Hex.Interval.Policy.ScopeId) (seed : Expr) : MetaM Unit := do
       let some run := reluRunChild? side input scope
         | throwError "interval_relu_split mutation: child search failed"
       let some trace := Frontend.trace? run.session.state.engine run.session.arena

--- a/conformance/HexIntervalMathlib/SineSignConformance.lean
+++ b/conformance/HexIntervalMathlib/SineSignConformance.lean
@@ -17,6 +17,13 @@ against the Mathlib theorem schemas.
 
 namespace Hex.IntervalMathlib.SineSignConformance
 
+local notation "OfferView" =>
+  Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "Selection" =>
+  Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey
+local notation "ScopeId" => Hex.Interval.Policy.ScopeId
+local notation "OfferClass" => Hex.Interval.Policy.OfferClass
+
 open Hex.Interval
 open Hex.Interval.Experiment
 open Propagator PolicySession SemanticReplay ChronologicalReplay TraceReplay
@@ -24,9 +31,9 @@ open Propagator PolicySession SemanticReplay ChronologicalReplay TraceReplay
 open SineSign
 
 def offer? (session : PolicySession.Session Range)
-    (accepts : Propagator.Policy.OfferView -> Bool) :
+    (accepts : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) -> Bool) :
     Option
-      (Propagator.Policy.OfferView × Propagator.Policy.Selection ×
+      ((Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) × (Hex.Interval.Policy.Decision _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey) ×
         PolicySession.Session Range) :=
   match session.view with
   | .ready view viewed =>
@@ -44,17 +51,17 @@ def offer? (session : PolicySession.Session Range)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
 def invokes (key : RuleKey) (anchor : NodeId)
-    (offer : Propagator.Policy.OfferView) : Bool :=
+    (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .invoke invocation => invocation.rule == key && invocation.anchor == anchor
   | _ => false
 
-def instantiatesOddness (offer : Propagator.Policy.OfferView) : Bool :=
+def instantiatesOddness (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .instantiate source _ => source.rule == oddnessRuleKey
   | _ => false
 
-def firstEquality (offer : Propagator.Policy.OfferView) : Bool :=
+def firstEquality (offer : (Hex.Interval.Policy.OfferView _root_.Hex.Interval.Experiment.Propagator.Policy.OfferId _root_.Hex.Interval.Experiment.Propagator.Policy.OfferKey)) : Bool :=
   match offer.key with
   | .equality contractor => contractor.equality == ({ index := 0 } : EqualityId)
   | _ => false

--- a/conformance/HexIntervalMathlib/SineSignConformance.lean
+++ b/conformance/HexIntervalMathlib/SineSignConformance.lean
@@ -41,13 +41,7 @@ def offer? (session : PolicySession.Session Range)
       | none => none
       | some offer =>
           some
-            (offer,
-              { scope := view.scope
-                serial := view.serial
-                programVersion := view.programVersion
-                id := offer.id
-                expected := offer.key },
-              viewed)
+            (offer, Hex.Interval.Policy.select view offer, viewed)
   | .resource _ _ | .contradiction _ | .invalidSession _ => none
 
 def invokes (key : RuleKey) (anchor : NodeId)

--- a/progress/20260815T153548Z.md
+++ b/progress/20260815T153548Z.md
@@ -1,0 +1,45 @@
+# Accomplished
+
+- Added supported Mathlib-free `HexInterval.Policy` contracts for stable scope
+  and policy identities, generic complete offer views, exact stamped decisions,
+  remaining engine budgets, replaceable policy steps/interfaces, and
+  package-owned logical measurements.
+- Added transactional supported validation for checked programs/fact snapshots,
+  exact scope/serial/program/budget/offer echoing, duplicate identifiers, and
+  independent offer-count, byte, pair, work, and score limits. Retained-cost
+  addition is preflighted before allocation; arbitrary measurement callbacks
+  and nested-key equality are explicitly non-preemptible.
+- Migrated the experimental policy frontier, target controller, policy session,
+  feature decorators, staged/adaptive policies, branch search, and all affected
+  conformance fixtures to consume the actual supported generic types. The
+  concrete semantic offer-key variants and policy implementations remain
+  experimental rather than aliases or supported defaults.
+- Added conformance for stale scope, serial, program, fact version, action key,
+  and budget; every mutated offer field; count/byte/pair/work/score one-under
+  refusals; duplicate identifiers; conservative stop; exact retained selection;
+  and an axiom-free theorem showing policy substitution has no replay authority.
+- Updated the umbrella and central SPEC with the exact current supported policy
+  boundary, file map, non-preemptibility envelope, and remaining experimental
+  algorithms/search/storage boundary.
+- Built both complete controller experiment umbrellas and the full 9,487-job
+  conformance target; DAG, line-count, copyright, trust, factor-freshness, PNT
+  inventory, and whitespace checks pass.
+
+# Current frontier
+
+The supported layer owns bounded immutable policy data and fail-closed exact
+decision revalidation, while experimental code still owns `OfferId`/`OfferKey`
+semantics, callback outcomes/proposals, feature providers, observations,
+sessions, concrete staged/adaptive/feature policies, branch search, and replay.
+No default scheduler, scoring model, or storage representation is selected.
+
+# Next step
+
+Extract the smallest supported package invocation/controller transition which
+combines `Program`, `State`, `Trace`, and `Policy` without promoting the current
+proposal or session representations. Keep proof reconstruction independent and
+measure callback construction/storage before selecting a production layout.
+
+# Blockers
+
+None.

--- a/progress/20260821T050027Z.md
+++ b/progress/20260821T050027Z.md
@@ -1,0 +1,28 @@
+# Supported policy restack
+
+## Accomplished
+
+- Replayed the audited supported bounded-policy contract directly onto the
+  final supported State/Trace candidate.
+- Preserved the current public interval surface while adding the supported
+  policy boundary to the umbrella documentation.
+- Reconciled policy state authentication with authoritative branch fact
+  reconstruction and added a load-bearing stale-fact rejection guard.
+- Rebuilt supported policy, experimental controller, and conformance
+  consumers and reran structural, trust, freshness, and inventory checks.
+
+## Current frontier
+
+- Supported code owns immutable bounded policy offers, echoed decisions,
+  resource admission, and transactional revalidation. Concrete offer keys,
+  callbacks, policy algorithms, sessions, search, and replay remain
+  experimental.
+
+## Next step
+
+- Restack this local feature commit onto the exact merge commit of PR #9311,
+  then publish it for exact-head review and CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T072029Z.md
+++ b/progress/20260821T072029Z.md
@@ -1,0 +1,31 @@
+# Authenticate complete policy choices
+
+## Accomplished
+
+- Extended the experimental policy validator to authenticate the supported
+  decision's remaining budget, class, age, and score as well as its existing
+  scope, serial, program version, identifier, and semantic key.
+- Added distinct stale-budget and mutated-offer rejection canaries and migrated
+  every live conformance choice to echo the complete observed offer.
+- Added checked branch-snapshot reconstruction and staged supported offer
+  validation so branch-backed decision checking reconstructs facts and checks
+  the program only once.
+- Documented arbitrary reconstructed-fact equality as part of the explicit
+  non-preemptible policy boundary.
+- Passed the 2057-job affected build, DAG, trust-surface, Mathlib-free bench,
+  factor-freshness, PNT inventory, ban, and diff checks.
+
+## Current frontier
+
+PR #9336 now rejects all three review counterexamples while preserving the
+standalone `checkViewWithin` validation contract and returning only the
+controller-owned retained offer.
+
+## Next step
+
+Push the exact repaired head with lease, then monitor its automatic exact-head
+CI for merge readiness.
+
+## Blockers
+
+None.

--- a/progress/20260821T073707Z.md
+++ b/progress/20260821T073707Z.md
@@ -1,0 +1,27 @@
+# Harden supported policy record construction
+
+## Accomplished
+
+- Moved the complete decision-echo contract onto the supported `Decision`
+  record and documented experimental `Rejection` as rejection reasons.
+- Removed defaults from the policy view's remaining budget and every echoed
+  decision field, making incomplete construction a compile-time error.
+- Made the feature-policy conformance helper compare whole offers and added a
+  score-only mutation guard.
+- Updated the implemented-contract SPEC sketch to the current decision and
+  engine-budget records and placed its introduction immediately before the
+  code block.
+
+## Current frontier
+
+The accepted supported-contract hardenings compile across the supported and
+experimental policy modules; final affected builds and static checks remain.
+
+## Next step
+
+Run the full affected validation set, commit, and replace PR #9336's head with
+an exact force-with-lease push.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add a Mathlib-free supported policy boundary for immutable bounded offers, echoed decisions, replaceable choice interfaces, and fail-closed revalidation
- migrate the experimental controller stack to consume the supported policy types while leaving concrete offer keys, callbacks, policy algorithms, sessions, search, and proof replay experimental
- authenticate policy decisions against reconstructed supported branch snapshots and add stale-scope/version/budget/fact/offer/resource mutation guards

## Validation

- focused supported, experimental, and affected Mathlib conformance build (2057 jobs)
- DAG, published trust surface, factor freshness, Mathlib-free bench, PNT inventory/tests, banned-mechanism, and diff checks

No default policy, scoring model, scheduler, storage layout, or proof authority is selected by this PR.