### PR TITLE
feat(interval): support authenticated search contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
       - run: python3 scripts/check_copyright_headers.py
       - name: Lint Lean file line counts (SPEC/CI.md §Source-file lints)
         run: python3 scripts/check_file_line_counts.py
-      - run: python3 scripts/check_dag.py
+      - name: Check dependency DAG and trusted-internals imports
+        run: |
+          python3 -m unittest scripts/test_check_dag.py
+          python3 scripts/check_dag.py
       - run: python3 scripts/release/check_released_manifest.py
       - name: Check the manual's released/unreleased split matches released.yml
         run: python3 scripts/release/check_manual_split.py

--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -12,6 +12,7 @@ public import HexInterval.Action
 public import HexInterval.State
 public import HexInterval.Trace
 public import HexInterval.Policy
+public import HexInterval.Search
 
 public section
 
@@ -37,7 +38,9 @@ registrations, scoped bindings, actions, immutable package requests, checked
 immutable branch state, dependency/work queues, authoritative chronology, and
 bounded diagnostics. The public policy contract exposes bounded immutable
 offers, exact echoed decisions, and fail-closed revalidation without selecting
-a default policy.
-Concrete callbacks and proposals, policy implementations, search, proof replay,
-and measurement-selected storage remain experimental.
+a default policy. The public search contract authenticates selected actions, transactionally
+checks untrusted callback deltas, and supplies bounded stable branch-frontier
+accounting. Concrete callbacks and proposals, offer generation, policy
+implementations, split semantics, proof replay, and measurement-selected
+storage remain experimental.
 -/

--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -38,11 +38,15 @@ registrations, scoped bindings, actions, immutable package requests, checked
 immutable branch state, dependency/work queues, authoritative chronology, and
 bounded diagnostics. The public policy contract exposes bounded immutable
 offers, exact echoed decisions, and fail-closed revalidation without selecting
-a default policy. The public search contract seals authenticated sessions,
+a default policy. At the ordinary/public import boundary, the search contract
+seals authenticated sessions,
 authenticates selected actions, transactionally checks untrusted callback
 deltas, and supplies bounded stable branch-frontier accounting. Its specialized
 leaf frontier can advance only through the parent/depth/scope/branch-checked
-transition; generic frontier scheduling cannot be installed into it. Concrete
+transition; generic frontier scheduling cannot be installed into it. A
+deliberate `import all HexInterval.Search` is trusted implementation access,
+not decoded-runtime authority, and repository checks reject accidental uses.
+Concrete
 callbacks and proposals, offer generation, policy
 implementations, split semantics, proof replay, and measurement-selected
 storage remain experimental.

--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -38,9 +38,12 @@ registrations, scoped bindings, actions, immutable package requests, checked
 immutable branch state, dependency/work queues, authoritative chronology, and
 bounded diagnostics. The public policy contract exposes bounded immutable
 offers, exact echoed decisions, and fail-closed revalidation without selecting
-a default policy. The public search contract authenticates selected actions, transactionally
-checks untrusted callback deltas, and supplies bounded stable branch-frontier
-accounting. Concrete callbacks and proposals, offer generation, policy
+a default policy. The public search contract seals authenticated sessions,
+authenticates selected actions, transactionally checks untrusted callback
+deltas, and supplies bounded stable branch-frontier accounting. Its specialized
+leaf frontier can advance only through the parent/depth/scope/branch-checked
+transition; generic frontier scheduling cannot be installed into it. Concrete
+callbacks and proposals, offer generation, policy
 implementations, split semantics, proof replay, and measurement-selected
 storage remain experimental.
 -/

--- a/HexInterval/Experiment/BranchProof.lean
+++ b/HexInterval/Experiment/BranchProof.lean
@@ -79,7 +79,7 @@ def sameChild [DecidableEq Fact]
 
 partial def emitAt [DecidableEq Fact]
     (limits : Limits) (emitter : Emitter Fact PolicyState)
-    (tree : BranchTree.State Fact PolicyState) (depth : Nat)
+    (tree : BranchTree.Snapshot Fact PolicyState) (depth : Nat)
     (id : BranchTree.TreeId) : MetaM (Output Fact PolicyState) := do
   if depth > limits.maxDepth then
     throwError "interval branch proof: traversal depth exhausted"
@@ -138,8 +138,8 @@ partial def emitAt [DecidableEq Fact]
 `expected` is normally the current goal type.  The final check is deliberately
 inside the generic frontend, so even a single-leaf tree cannot return an
 unrelated callback term. -/
-def emit [DecidableEq Fact] (limits : Limits) (emitter : Emitter Fact PolicyState)
-    (tree : BranchTree.State Fact PolicyState) (expected : Expr) : MetaM Expr := do
+def emitSnapshot [DecidableEq Fact] (limits : Limits) (emitter : Emitter Fact PolicyState)
+    (tree : BranchTree.Snapshot Fact PolicyState) (expected : Expr) : MetaM Expr := do
   if !tree.frontier.isEmpty then
     throwError "interval branch proof: tree still has pending work"
   if tree.nodes.isEmpty then
@@ -153,5 +153,10 @@ def emit [DecidableEq Fact] (limits : Limits) (emitter : Emitter Fact PolicyStat
   unless ← isDefEq (← inferType proof) expected do
     throwError "interval branch proof: emitted root has the wrong type"
   pure proof
+
+/-- Snapshot a sealed live tree, then replay its untrusted retained data. -/
+def emit [DecidableEq Fact] (limits : Limits) (emitter : Emitter Fact PolicyState)
+    (tree : BranchTree.State Fact PolicyState) (expected : Expr) : MetaM Expr :=
+  emitSnapshot limits emitter tree.snapshot expected
 
 end Hex.Interval.Experiment.BranchProof

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -91,8 +91,9 @@ inductive Node (Fact PolicyState : Type) : Type 1
       (run : TargetRun.Result Fact PolicyState)
       (children : BranchStart.Children Fact) (left right : TreeId)
 
-/-- Monotone retained state for one tree.  `leaves` counts current leaves, so
-an accepted binary split increases it by exactly one. -/
+/-- Ordinary-import-sealed monotone retained state for one tree. `leaves`
+counts current leaves, so an accepted binary split increases it by one. A
+deliberate `import all` is trusted implementation access, not decoded data. -/
 structure State (Fact PolicyState : Type) : Type 1 where
   private mk ::
   nodes : Array (Node Fact PolicyState)

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -194,7 +194,7 @@ private def retainLeaf (limits : Hex.Interval.Search.Limits)
     (state : State Fact PolicyState) (id : TreeId)
     (source : Leaf Fact PolicyState) (ending : LeafEnd Fact PolicyState) :
     Except Error (State Fact PolicyState) := do
-  match state.search.settleWithin limits with
+  match state.search.settleHeadWithin limits with
   | .error _ => throw .malformedAccounting
   | .ok (settled, search) =>
       if settled != id then throw .malformedAccounting
@@ -244,7 +244,7 @@ opaque step [DecidableEq Fact] (config : Config Fact PolicyState)
       let fresh :=
         (if leftPending then [leftId] else []) ++
           (if rightPending then [rightId] else [])
-      match state.search.splitWithin config.limits config.order fresh with
+      match state.search.splitHeadWithin config.limits config.order fresh with
       | .error _ => throw .malformedAccounting
       | .ok (splitId, search) =>
           if splitId != id then throw .malformedAccounting

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexInterval.Experiment.BranchStart
+public import HexInterval.Search
 
 @[expose] public section
 
@@ -34,22 +35,6 @@ inductive Side where
   | right
   deriving DecidableEq, Repr
 
-/-- Replaceable pending-leaf order. -/
-inductive Order where
-  | depthFirst
-  | breadthFirst
-  deriving DecidableEq, Repr
-
-/-- Global tree resources.  Child sessions retain their independent engine,
-policy, and payload limits. -/
-structure Limits where
-  branch : BranchStart.Limits
-  maxSteps : Nat
-  maxSplits : Nat
-  maxLeaves : Nat
-  leafFuel : Nat
-  deriving DecidableEq, Repr
-
 /-- Everything needed to run and split one pending leaf. -/
 structure Config (Fact PolicyState : Type) : Type 1 where
   factDomain : FactDomain Fact
@@ -58,8 +43,8 @@ structure Config (Fact PolicyState : Type) : Type 1 where
   controller : TargetRun.Controller Fact PolicyState
   splitter : BranchStart.Splitter Fact
   forkPolicy : PolicyState -> Side -> PolicyState
-  order : Order
-  limits : Limits
+  order : Hex.Interval.Search.Order
+  limits : Hex.Interval.Search.Limits
 
 /-- Stable index into the append-only node array. -/
 structure TreeId where
@@ -86,6 +71,7 @@ inductive Blocked where
   | splitRejected (error : BranchStart.Error)
   | splitLimit
   | leafLimit
+  | frontierLimit
   deriving DecidableEq, Repr
 
 /-- Terminal runtime data for a leaf.  None of these constructors is proof
@@ -109,15 +95,14 @@ inductive Node (Fact PolicyState : Type) : Type 1
 an accepted binary split increases it by exactly one. -/
 structure State (Fact PolicyState : Type) : Type 1 where
   nodes : Array (Node Fact PolicyState)
-  frontier : List TreeId
+  frontier : Hex.Interval.Search.Frontier TreeId
   branch : BranchStart.State
-  splits : Nat
-  leaves : Nat
-  steps : Nat
+  accounting : Hex.Interval.Search.Accounting
 
 /-- Failure before a coherent root tree exists. -/
 inductive StartError where
   | leafLimit
+  | frontierLimit
   | scopeLimit
   | unknownTarget
   | session (error : PolicySession.StartError)
@@ -127,6 +112,8 @@ inductive StartError where
 inductive Error where
   | missingNode (id : TreeId)
   | settledNode (id : TreeId)
+  | malformedAccounting
+  | wrongScope
   deriving DecidableEq, Repr
 
 def sourceOf (job : Job Fact PolicyState) : Leaf Fact PolicyState :=
@@ -141,15 +128,17 @@ def State.settled (state : State Fact PolicyState) : Bool :=
   state.frontier.isEmpty
 
 /-- The global processing budget may leave a nonempty frontier. -/
-def State.stepLimited (limits : Limits) (state : State Fact PolicyState) : Bool :=
-  state.steps >= limits.maxSteps && !state.frontier.isEmpty
+def State.stepLimited (limits : Hex.Interval.Search.Limits)
+    (state : State Fact PolicyState) : Bool :=
+  state.accounting.steps >= limits.maxSteps && !state.frontier.isEmpty
 
 /-- Build a coherent root session from the exact caller input. -/
 def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeId)
     (input : CheckerInput Fact) (policyState : PolicyState) :
     Except StartError (State Fact PolicyState) := do
   if config.limits.maxLeaves = 0 then throw .leafLimit
-  if config.limits.branch.maxScopes = 0 then throw .scopeLimit
+  if config.limits.maxFrontier = 0 then throw .frontierLimit
+  if config.limits.maxScopes = 0 then throw .scopeLimit
   if (input.baseProgram.node? input.target.node).isNone then
     throw StartError.unknownTarget
   let session <-
@@ -161,16 +150,9 @@ def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeI
     { scope, depth := 0, input, policyState, session }
   pure
     { nodes := #[.pending root]
-      frontier := [{ index := 0 }]
+      frontier := .singleton { index := 0 }
       branch := BranchStart.State.start session
-      splits := 0
-      leaves := 1
-      steps := 0 }
-
-def schedule (order : Order) (rest fresh : List TreeId) : List TreeId :=
-  match order with
-  | .depthFirst => fresh ++ rest
-  | .breadthFirst => rest ++ fresh
+      accounting := { nextScope := scope.index + 1 } }
 
 def childNode (config : Config Fact PolicyState) (side : Side)
     (scope : Hex.Interval.Policy.ScopeId) (depth : Nat) (input : CheckerInput Fact)
@@ -190,19 +172,20 @@ def childNode (config : Config Fact PolicyState) (side : Side)
 
 def retainLeaf (state : State Fact PolicyState) (id : TreeId)
     (source : Leaf Fact PolicyState) (ending : LeafEnd Fact PolicyState)
-    (rest : List TreeId) : State Fact PolicyState :=
+    (rest : Hex.Interval.Search.Frontier TreeId) : State Fact PolicyState :=
   { state with
     nodes := state.nodes.set! id.index (.leaf source ending)
     frontier := rest
-    steps := state.steps + 1 }
+    accounting := { state.accounting with steps := state.accounting.steps + 1 } }
 
 /-- Process one pending leaf.  Split rejection and tree-resource exhaustion
 are terminal leaf data; only a malformed internal frontier returns `Error`. -/
 def step [DecidableEq Fact] (config : Config Fact PolicyState)
     (state : State Fact PolicyState) : Except Error (State Fact PolicyState) := do
-  if state.steps >= config.limits.maxSteps then return state
-  let some id := state.frontier.head? | return state
-  let rest := state.frontier.tail
+  if !state.accounting.check config.limits state.frontier.pending.length then
+    throw .malformedAccounting
+  if state.accounting.steps >= config.limits.maxSteps then return state
+  let some (id, rest) := Hex.Interval.Search.pop state.frontier | return state
   let some node := state.nodes[id.index]? | throw (.missingNode id)
   let .pending job := node | throw (.settledNode id)
   let source := sourceOf job
@@ -211,15 +194,22 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
     job.session job.policyState
   let .split plan := run.stop |
     return retainLeaf state id source (.result run) rest
-  if state.splits >= config.limits.maxSplits then
+  if state.accounting.splits >= config.limits.maxSplits then
     return retainLeaf state id source (.blocked run .splitLimit) rest
-  if state.leaves + 1 > config.limits.maxLeaves then
+  if state.accounting.leaves + 1 > config.limits.maxLeaves then
     return retainLeaf state id source (.blocked run .leafLimit) rest
-  match BranchStart.prepare config.limits.branch state.branch run.session plan
+  if rest.pending.length + 2 > config.limits.maxFrontier then
+    return retainLeaf state id source (.blocked run .frontierLimit) rest
+  let branchLimits : BranchStart.Limits :=
+    { maxDepth := config.limits.maxDepth, maxScopes := config.limits.maxScopes }
+  match BranchStart.prepare branchLimits state.branch run.session plan
       job.input.target config.splitter with
   | .error error =>
       pure (retainLeaf state id source (.blocked run (.splitRejected error)) rest)
   | .ok (branch, children) =>
+      if children.leftScope.index != state.accounting.nextScope ||
+          children.rightScope.index != state.accounting.nextScope + 1 then
+        throw .wrongScope
       let leftId : TreeId := { index := state.nodes.size }
       let rightId : TreeId := { index := state.nodes.size + 1 }
       let (leftNode, leftPending) := childNode config .left children.leftScope
@@ -232,11 +222,14 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
       pure
         { nodes := (state.nodes.set! id.index
               (.split source run children leftId rightId)).push leftNode |>.push rightNode
-          frontier := schedule config.order rest fresh
+          frontier := rest.schedule config.order fresh
           branch
-          splits := state.splits + 1
-          leaves := state.leaves + 1
-          steps := state.steps + 1 }
+          accounting :=
+            { steps := state.accounting.steps + 1
+              splits := state.accounting.splits + 1
+              leaves := state.accounting.leaves + 1
+              scopes := state.accounting.scopes + 2
+              nextScope := state.accounting.nextScope + 2 } }
 
 /-- Run for at most the caller fuel and never beyond the retained global step
 budget.  A nonempty frontier in the result is an honest partial tree. -/
@@ -244,7 +237,7 @@ def runFrom [DecidableEq Fact] (config : Config Fact PolicyState) :
     Nat -> State Fact PolicyState -> Except Error (State Fact PolicyState)
   | 0, state => pure state
   | fuel + 1, state =>
-      if state.settled || state.steps >= config.limits.maxSteps then pure state
+      if state.settled || state.accounting.steps >= config.limits.maxSteps then pure state
       else do
         let state ← step config state
         runFrom config fuel state

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -106,6 +106,7 @@ inductive StartError where
   | scopeLimit
   | unknownTarget
   | session (error : PolicySession.StartError)
+  | accounting (error : Hex.Interval.Search.Error)
   deriving DecidableEq, Repr
 
 /-- An append-only tree should only schedule valid pending nodes. -/
@@ -148,11 +149,15 @@ def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeI
     | .error error => throw (.session error)
   let root : Job Fact PolicyState :=
     { scope, depth := 0, input, policyState, session }
-  pure
-    { nodes := #[.pending root]
-      frontier := .singleton { index := 0 }
-      branch := BranchStart.State.start session
-      accounting := { nextScope := scope.index + 1 } }
+  let frontier : Hex.Interval.Search.Frontier TreeId := .singleton { index := 0 }
+  match Hex.Interval.Search.Accounting.startWithin config.limits scope frontier with
+  | .error error => throw (.accounting error)
+  | .ok accounting =>
+      pure
+        { nodes := #[.pending root]
+          frontier
+          branch := BranchStart.State.start session
+          accounting }
 
 def childNode (config : Config Fact PolicyState) (side : Side)
     (scope : Hex.Interval.Policy.ScopeId) (depth : Nat) (input : CheckerInput Fact)
@@ -170,13 +175,19 @@ def childNode (config : Config Fact PolicyState) (side : Side)
           session }, true)
   | .error error => (.leaf source (.startError error), false)
 
-def retainLeaf (state : State Fact PolicyState) (id : TreeId)
+def retainLeaf (limits : Hex.Interval.Search.Limits)
+    (state : State Fact PolicyState) (id : TreeId)
     (source : Leaf Fact PolicyState) (ending : LeafEnd Fact PolicyState)
-    (rest : Hex.Interval.Search.Frontier TreeId) : State Fact PolicyState :=
-  { state with
-    nodes := state.nodes.set! id.index (.leaf source ending)
-    frontier := rest
-    accounting := { state.accounting with steps := state.accounting.steps + 1 } }
+    (rest : Hex.Interval.Search.Frontier TreeId) : Except Error (State Fact PolicyState) := do
+  match Hex.Interval.Search.Accounting.settleWithin
+      limits state.frontier state.accounting with
+  | .error _ => throw .malformedAccounting
+  | .ok accounting =>
+      pure
+        { state with
+          nodes := state.nodes.set! id.index (.leaf source ending)
+          frontier := rest
+          accounting }
 
 /-- Process one pending leaf.  Split rejection and tree-resource exhaustion
 are terminal leaf data; only a malformed internal frontier returns `Error`. -/
@@ -193,19 +204,19 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
     job.input.target.fact config.controller config.limits.leafFuel
     job.session job.policyState
   let .split plan := run.stop |
-    return retainLeaf state id source (.result run) rest
+    return ← retainLeaf config.limits state id source (.result run) rest
   if state.accounting.splits >= config.limits.maxSplits then
-    return retainLeaf state id source (.blocked run .splitLimit) rest
+    return ← retainLeaf config.limits state id source (.blocked run .splitLimit) rest
   if state.accounting.leaves + 1 > config.limits.maxLeaves then
-    return retainLeaf state id source (.blocked run .leafLimit) rest
+    return ← retainLeaf config.limits state id source (.blocked run .leafLimit) rest
   if rest.pending.length + 2 > config.limits.maxFrontier then
-    return retainLeaf state id source (.blocked run .frontierLimit) rest
+    return ← retainLeaf config.limits state id source (.blocked run .frontierLimit) rest
   let branchLimits : BranchStart.Limits :=
     { maxDepth := config.limits.maxDepth, maxScopes := config.limits.maxScopes }
   match BranchStart.prepare branchLimits state.branch run.session plan
       job.input.target config.splitter with
   | .error error =>
-      pure (retainLeaf state id source (.blocked run (.splitRejected error)) rest)
+      retainLeaf config.limits state id source (.blocked run (.splitRejected error)) rest
   | .ok (branch, children) =>
       if children.leftScope.index != state.accounting.nextScope ||
           children.rightScope.index != state.accounting.nextScope + 1 then
@@ -219,17 +230,16 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
       let fresh :=
         (if leftPending then [leftId] else []) ++
           (if rightPending then [rightId] else [])
-      pure
-        { nodes := (state.nodes.set! id.index
-              (.split source run children leftId rightId)).push leftNode |>.push rightNode
-          frontier := rest.schedule config.order fresh
-          branch
-          accounting :=
-            { steps := state.accounting.steps + 1
-              splits := state.accounting.splits + 1
-              leaves := state.accounting.leaves + 1
-              scopes := state.accounting.scopes + 2
-              nextScope := state.accounting.nextScope + 2 } }
+      match Hex.Interval.Search.Accounting.splitWithin
+          config.limits state.frontier state.accounting with
+      | .error _ => throw .malformedAccounting
+      | .ok accounting =>
+          pure
+            { nodes := (state.nodes.set! id.index
+                  (.split source run children leftId rightId)).push leftNode |>.push rightNode
+              frontier := rest.schedule config.order fresh
+              branch
+              accounting }
 
 /-- Run for at most the caller fuel and never beyond the retained global step
 budget.  A nonempty frontier in the result is an honest partial tree. -/

--- a/HexInterval/Experiment/BranchTree.lean
+++ b/HexInterval/Experiment/BranchTree.lean
@@ -94,10 +94,28 @@ inductive Node (Fact PolicyState : Type) : Type 1
 /-- Monotone retained state for one tree.  `leaves` counts current leaves, so
 an accepted binary split increases it by exactly one. -/
 structure State (Fact PolicyState : Type) : Type 1 where
+  private mk ::
+  nodes : Array (Node Fact PolicyState)
+  search : Hex.Interval.Search.FrontierState TreeId
+  branch : BranchStart.State
+
+def State.frontier (state : State Fact PolicyState) :
+    Hex.Interval.Search.Frontier TreeId :=
+  state.search.frontier
+
+def State.accounting (state : State Fact PolicyState) :
+    Hex.Interval.Search.Accounting :=
+  state.search.accounting
+
+/-- Read-only retained tree data supplied to the proof fold. This snapshot is
+untrusted proof input: callers may edit it, and `BranchProof` must reject every
+malformed coverage relation. It carries no live search accounting authority. -/
+structure Snapshot (Fact PolicyState : Type) : Type 1 where
   nodes : Array (Node Fact PolicyState)
   frontier : Hex.Interval.Search.Frontier TreeId
-  branch : BranchStart.State
-  accounting : Hex.Interval.Search.Accounting
+
+def State.snapshot (state : State Fact PolicyState) : Snapshot Fact PolicyState :=
+  { nodes := state.nodes, frontier := state.frontier }
 
 /-- Failure before a coherent root tree exists. -/
 inductive StartError where
@@ -123,18 +141,20 @@ def sourceOf (job : Job Fact PolicyState) : Leaf Fact PolicyState :=
     input := job.input
     policyState := job.policyState }
 
+namespace State
+
 /-- A tree is settled exactly when it has no runnable leaf.  It may still
 contain blocked, unfinished, or failed leaves. -/
-def State.settled (state : State Fact PolicyState) : Bool :=
+def settled (state : State Fact PolicyState) : Bool :=
   state.frontier.isEmpty
 
 /-- The global processing budget may leave a nonempty frontier. -/
-def State.stepLimited (limits : Hex.Interval.Search.Limits)
+def stepLimited (limits : Hex.Interval.Search.Limits)
     (state : State Fact PolicyState) : Bool :=
   state.accounting.steps >= limits.maxSteps && !state.frontier.isEmpty
 
 /-- Build a coherent root session from the exact caller input. -/
-def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeId)
+opaque start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeId)
     (input : CheckerInput Fact) (policyState : PolicyState) :
     Except StartError (State Fact PolicyState) := do
   if config.limits.maxLeaves = 0 then throw .leafLimit
@@ -149,15 +169,10 @@ def start (config : Config Fact PolicyState) (scope : Hex.Interval.Policy.ScopeI
     | .error error => throw (.session error)
   let root : Job Fact PolicyState :=
     { scope, depth := 0, input, policyState, session }
-  let frontier : Hex.Interval.Search.Frontier TreeId := .singleton { index := 0 }
-  match Hex.Interval.Search.Accounting.startWithin config.limits scope frontier with
+  match Hex.Interval.Search.FrontierState.startWithin config.limits scope ({ index := 0 } : TreeId) with
   | .error error => throw (.accounting error)
-  | .ok accounting =>
-      pure
-        { nodes := #[.pending root]
-          frontier
-          branch := BranchStart.State.start session
-          accounting }
+  | .ok search =>
+      pure { nodes := #[.pending root], search, branch := BranchStart.State.start session }
 
 def childNode (config : Config Fact PolicyState) (side : Side)
     (scope : Hex.Interval.Policy.ScopeId) (depth : Nat) (input : CheckerInput Fact)
@@ -175,28 +190,27 @@ def childNode (config : Config Fact PolicyState) (side : Side)
           session }, true)
   | .error error => (.leaf source (.startError error), false)
 
-def retainLeaf (limits : Hex.Interval.Search.Limits)
+private def retainLeaf (limits : Hex.Interval.Search.Limits)
     (state : State Fact PolicyState) (id : TreeId)
-    (source : Leaf Fact PolicyState) (ending : LeafEnd Fact PolicyState)
-    (rest : Hex.Interval.Search.Frontier TreeId) : Except Error (State Fact PolicyState) := do
-  match Hex.Interval.Search.Accounting.settleWithin
-      limits state.frontier state.accounting with
+    (source : Leaf Fact PolicyState) (ending : LeafEnd Fact PolicyState) :
+    Except Error (State Fact PolicyState) := do
+  match state.search.settleWithin limits with
   | .error _ => throw .malformedAccounting
-  | .ok accounting =>
+  | .ok (settled, search) =>
+      if settled != id then throw .malformedAccounting
       pure
-        { state with
-          nodes := state.nodes.set! id.index (.leaf source ending)
-          frontier := rest
-          accounting }
+        { nodes := state.nodes.set! id.index (.leaf source ending)
+          search := search
+          branch := state.branch }
 
 /-- Process one pending leaf.  Split rejection and tree-resource exhaustion
 are terminal leaf data; only a malformed internal frontier returns `Error`. -/
-def step [DecidableEq Fact] (config : Config Fact PolicyState)
+opaque step [DecidableEq Fact] (config : Config Fact PolicyState)
     (state : State Fact PolicyState) : Except Error (State Fact PolicyState) := do
   if !state.accounting.check config.limits state.frontier.pending.length then
     throw .malformedAccounting
   if state.accounting.steps >= config.limits.maxSteps then return state
-  let some (id, rest) := Hex.Interval.Search.pop state.frontier | return state
+  let some id := state.search.head? | return state
   let some node := state.nodes[id.index]? | throw (.missingNode id)
   let .pending job := node | throw (.settledNode id)
   let source := sourceOf job
@@ -204,19 +218,19 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
     job.input.target.fact config.controller config.limits.leafFuel
     job.session job.policyState
   let .split plan := run.stop |
-    return ← retainLeaf config.limits state id source (.result run) rest
+    return ← retainLeaf config.limits state id source (.result run)
   if state.accounting.splits >= config.limits.maxSplits then
-    return ← retainLeaf config.limits state id source (.blocked run .splitLimit) rest
+    return ← retainLeaf config.limits state id source (.blocked run .splitLimit)
   if state.accounting.leaves + 1 > config.limits.maxLeaves then
-    return ← retainLeaf config.limits state id source (.blocked run .leafLimit) rest
-  if rest.pending.length + 2 > config.limits.maxFrontier then
-    return ← retainLeaf config.limits state id source (.blocked run .frontierLimit) rest
+    return ← retainLeaf config.limits state id source (.blocked run .leafLimit)
+  if state.search.pending.length + 1 > config.limits.maxFrontier then
+    return ← retainLeaf config.limits state id source (.blocked run .frontierLimit)
   let branchLimits : BranchStart.Limits :=
     { maxDepth := config.limits.maxDepth, maxScopes := config.limits.maxScopes }
   match BranchStart.prepare branchLimits state.branch run.session plan
       job.input.target config.splitter with
   | .error error =>
-      retainLeaf config.limits state id source (.blocked run (.splitRejected error)) rest
+      retainLeaf config.limits state id source (.blocked run (.splitRejected error))
   | .ok (branch, children) =>
       if children.leftScope.index != state.accounting.nextScope ||
           children.rightScope.index != state.accounting.nextScope + 1 then
@@ -230,16 +244,15 @@ def step [DecidableEq Fact] (config : Config Fact PolicyState)
       let fresh :=
         (if leftPending then [leftId] else []) ++
           (if rightPending then [rightId] else [])
-      match Hex.Interval.Search.Accounting.splitWithin
-          config.limits state.frontier state.accounting with
+      match state.search.splitWithin config.limits config.order fresh with
       | .error _ => throw .malformedAccounting
-      | .ok accounting =>
+      | .ok (splitId, search) =>
+          if splitId != id then throw .malformedAccounting
           pure
             { nodes := (state.nodes.set! id.index
                   (.split source run children leftId rightId)).push leftNode |>.push rightNode
-              frontier := rest.schedule config.order fresh
-              branch
-              accounting }
+              search
+              branch }
 
 /-- Run for at most the caller fuel and never beyond the retained global step
 budget.  A nonempty frontier in the result is an honest partial tree. -/
@@ -258,5 +271,15 @@ termination_by fuel _ => fuel
 def run [DecidableEq Fact] (config : Config Fact PolicyState)
     (state : State Fact PolicyState) : Except Error (State Fact PolicyState) :=
   runFrom config config.limits.maxSteps state
+
+end State
+
+def start := @State.start
+
+def step := @State.step
+
+def run := @State.run
+
+def runFrom := @State.runFrom
 
 end Hex.Interval.Experiment.BranchTree

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3113,15 +3113,17 @@ without repeating whole-program validation. The returned runtime value has no
 theorem authority.
 
 The supported Mathlib-free `HexInterval/Search.lean` layer owns the next
-generic boundary. Its sealed `Search.Session` binds one exact checked
-`State.Branch`, registration snapshot, scope, serial, complete policy view,
+generic boundary. Under ordinary/public imports, its sealed `Search.Session`
+binds one exact checked `State.Branch`, registration snapshot, scope, serial,
+complete policy view,
 controller-owned offer-to-`Action` bindings, bounded diagnostic log, and
 the cumulative accepted-step count for that run. `Session.startWithin` is the
-only reset point and creates a new run; no decoded record constructor or record
-update can install fresh counters into a live session. Session-only accounting
-does not require frontier capacity, so `maxFrontier = 0` does not reject a
-non-branching session. Before any semantic scan or package measurement, session
-authentication uses `Policy.maxOffers` to cap the retained offer array before
+only reset point and creates a new run; no public-import client can use its
+record constructor or update to install fresh counters into a live session.
+Session-only accounting does not require frontier capacity, so
+`maxFrontier = 0` does not reject a non-branching session. Before any semantic
+scan or package measurement, session authentication uses `Policy.maxOffers` to
+cap the retained offer array before
 mapping or traversing it. It separately caps the base and current program,
 history and aligned branch arrays, registry, binding/application/equality
 arrays, every
@@ -3160,20 +3162,23 @@ update. Callback failure has an exact conservative stop, and diagnostic
 truncation can change only the log, not facts, versions, provenance, scope, or
 contradiction state.
 
-`Search.Frontier` is a public ordering value, but live tree authority is the
-sealed `Search.FrontierState`, which inseparably owns the pending frontier and
-its cumulative step, split, retained-leaf, scope, and next-scope accounting.
+`Search.Frontier` is a public ordering value, but ordinary-import live tree
+authority is the sealed `Search.FrontierState`, which owns the pending frontier
+and its cumulative step, split, retained-leaf, scope, and next-scope accounting.
 The raw `Accounting` constructor and advance operations are private. Checked
 composite start, settle-head, and split-head transitions consume and return the
 whole sealed value, so a fresh counter cannot be transplanted onto an existing
 frontier and a phantom frontier cannot advance live counters. Reusing an old
 pure value may produce an alternative bounded successor; it cannot create a
-successor which bypasses that value's own limits. A separate start creates a
-documented new run rather than resetting an existing one.
+successor which bypasses the limits supplied to that checked transition/run
+handle. Limits are not stored in the value and may be tightened by a later
+transition. A separate start creates a documented new run rather than resetting
+an existing one.
 
-The supported parent/depth/scope/branch contract adds a second sealed type,
-`Search.LeafFrontier Fact Cause Payload`. Its private constructor and private
-inner `FrontierState (Leaf ...)` prevent callers from feeding a generically
+The supported parent/depth/scope/branch contract adds a second
+ordinary-import-sealed type, `Search.LeafFrontier Fact Cause Payload`. Its
+private constructor and private inner `FrontierState (Leaf ...)` prevent callers
+from feeding a generically
 scheduled leaf-shaped frontier back into `Search.splitWithin`. Read-only head,
 pending, raw-frontier, and accounting projections support inspection. Only
 `startFrontierWithin`, `settleWithin`, and the specialized `splitWithin` return
@@ -3181,12 +3186,21 @@ another `LeafFrontier`, and the latter checks exact parent restoration, child
 depth, fresh scopes, branch validity, and retained-scope uniqueness before the
 new wrapper becomes available. Thus the generic composite remains usable by a
 different sealed controller such as `BranchTree`, but it is not authority for
-the stronger leaf protocol.
+the stronger leaf protocol for public-import clients.
 
-The experimental `BranchTree.State` is likewise sealed and contains one
-`FrontierState TreeId`; callers cannot independently replace its nodes,
-frontier, branch manager, or counters. Its checked transitions derive the exact
-head internally. The generic composite split authenticates only cumulative
+This visibility is not a claim against Lean's deliberate `import all
+HexInterval.Search`. That form exposes private implementation names to trusted
+source and is an explicit trusted-internals escape hatch, not decoded runtime
+data or proof authority. Arbitrary trusted Lean source can already use `unsafe`
+or introduce axioms, so it lies outside the fail-closed callback/data threat
+model. The repository DAG check rejects `import all HexInterval.Search` outside
+an exact reviewed owning/internal allowlist (currently empty); downstream code
+which deliberately chooses `import all` accepts that trusted-source boundary.
+
+Under ordinary imports, experimental `BranchTree.State` is likewise sealed and
+contains one `FrontierState TreeId`; callers cannot independently replace its
+nodes, frontier, branch manager, or counters. Its checked transitions derive
+the exact head internally. The generic composite split authenticates only cumulative
 resources and stable scheduling for at most two package-validated children;
 the enclosing sealed `BranchTree` checks child construction and semantics.
 The supported `Search.splitWithin` specialization additionally preflights

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3171,6 +3171,18 @@ pure value may produce an alternative bounded successor; it cannot create a
 successor which bypasses that value's own limits. A separate start creates a
 documented new run rather than resetting an existing one.
 
+The supported parent/depth/scope/branch contract adds a second sealed type,
+`Search.LeafFrontier Fact Cause Payload`. Its private constructor and private
+inner `FrontierState (Leaf ...)` prevent callers from feeding a generically
+scheduled leaf-shaped frontier back into `Search.splitWithin`. Read-only head,
+pending, raw-frontier, and accounting projections support inspection. Only
+`startFrontierWithin`, `settleWithin`, and the specialized `splitWithin` return
+another `LeafFrontier`, and the latter checks exact parent restoration, child
+depth, fresh scopes, branch validity, and retained-scope uniqueness before the
+new wrapper becomes available. Thus the generic composite remains usable by a
+different sealed controller such as `BranchTree`, but it is not authority for
+the stronger leaf protocol.
+
 The experimental `BranchTree.State` is likewise sealed and contains one
 `FrontierState TreeId`; callers cannot independently replace its nodes,
 frontier, branch manager, or counters. Its checked transitions derive the exact
@@ -5193,8 +5205,9 @@ their declared cost inside a scheduler bound.
 - `HexInterval/Search.lean`: supported Mathlib-free sealed authenticated
   policy/action sessions, transactional callback-delta validation, exact
   generic stop/resource classes, stable depth-first/breadth-first frontiers,
-  immutable parent restoration, and sealed cumulative step/split/leaf/frontier/
-  depth/scope accounting. It contains no concrete callback, offer generator, split
+  a separately sealed parent/depth/scope-checked leaf frontier, immutable parent
+  restoration, and sealed cumulative step/split/leaf/frontier/depth/scope
+  accounting. It contains no concrete callback, offer generator, split
   semantics, policy algorithm, storage choice, or proof replay.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3135,6 +3135,10 @@ cap. The same preflight enforces operation/node/rule/arity/depth, matcher-batch,
 effort, generation, application, equality, and accepted-fact limits with the
 exact State resource class.
 
+The checked `Envelope` is supplied to each session transition and is not stored
+inside the session value. A later call may supply different, including tighter,
+limits while the cumulative accepted-step count remains part of the session.
+
 The current supported session retains generation stamps for compact
 `ApplicationId`s but not the concrete application table compiled by the
 experimental controller. Search therefore treats the compact identifier as an

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3117,14 +3117,17 @@ generic boundary. Its decoded `Search.Session` binds one exact checked
 `State.Branch`, registration snapshot, scope, serial, complete policy view,
 controller-owned offer-to-`Action` bindings, bounded diagnostic log, and
 global accounting. Before any semantic scan or package measurement, session
-authentication caps the base and current program, history and aligned branch
-arrays, registry, binding/application/equality arrays, retained actions, every
+authentication uses `Policy.maxOffers` to cap the retained offer array before
+mapping or traversing it. It separately caps the base and current program,
+history and aligned branch arrays, registry, binding/application/equality
+arrays, every
 operation/node/rule/binding port list, and every action input/write/structural
 input list against the corresponding `State.Limits`. Binding count uses
 `maxApplications`; `maxScopeNodes` independently caps each scoped read list and
-write list. The same preflight enforces operation/node/rule/arity/depth,
-matcher-batch, effort, generation, action, application, equality, and accepted-
-fact limits with the exact State resource class.
+write list. `State.maxActions` is cumulative controller work, not an offer-array
+cap. The same preflight enforces operation/node/rule/arity/depth, matcher-batch,
+effort, generation, application, equality, and accepted-fact limits with the
+exact State resource class.
 
 The current supported session retains generation stamps for compact
 `ApplicationId`s but not the concrete application table compiled by the
@@ -3155,7 +3158,11 @@ contradiction state.
 
 `Search.Frontier` and `Search.Accounting` supply stable depth-first and
 breadth-first ordering plus independent step, split, retained-leaf, frontier,
-depth, and scope limits. Child records retain an exact immutable parent branch
+depth, and scope limits. `Accounting` has a private constructor: decoded callers
+cannot reset its counters or `nextScope`, and supported code can create or
+advance it only through checked singleton-start, settle, and split builders.
+The experimental `BranchTree` consumes those builders rather than constructing
+or updating accounting records. Child records retain an exact immutable parent branch
 for restoration. `splitWithin` consumes the complete bounded pre-split
 frontier, rejects duplicate pending leaves, derives the parent and remaining
 frontier by popping the stable head internally, preflights every retained
@@ -5069,8 +5076,11 @@ candidates, and `b` the number of live branch states.
   `invokeWithin` call, that authentication and the package-owned policy
   measurements run once. Accepted callback batches fold already-preflighted
   exact successor updates without re-running `Branch.check` for every event.
-  Split admission traverses at most the bounded retained frontier and validates
-  its popped parent and both children once. Arbitrary callback execution and
+  Split admission preflights every branch in the bounded retained frontier,
+  then validates the popped parent and both children. With `f` pending leaves
+  and branch validation cost `B`, its current transparent-reference cost is
+  `O(f * B)`, plus bounded scope-uniqueness work; it is not one parent/child
+  validation independent of frontier size. Arbitrary callback execution and
   equality on caller-selected facts, causes, identifiers, and keys
   remain non-preemptible.
 - Fact comparison and contradiction checks use exact endpoint comparison. For

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3116,23 +3116,57 @@ The supported Mathlib-free `HexInterval/Search.lean` layer owns the next
 generic boundary. Its decoded `Search.Session` binds one exact checked
 `State.Branch`, registration snapshot, scope, serial, complete policy view,
 controller-owned offer-to-`Action` bindings, bounded diagnostic log, and
-global accounting. `prepareWithin` revalidates the external policy decision
-and returns only the exact controller-owned action. `acceptWithin` checks an
-untrusted callback batch against that action's serial, program version, input
-versions, and write set and applies the whole batch to a local branch before
-returning a replacement session. A stale later update therefore cannot
-partially commit an earlier update. Callback failure has an exact conservative
-stop, and diagnostic truncation can change only the log, not facts, versions,
-provenance, scope, or contradiction state.
+global accounting. Before any semantic scan or package measurement, session
+authentication caps the base and current program, history and aligned branch
+arrays, registry, binding/application/equality arrays, retained actions, every
+operation/node/rule/binding port list, and every action input/write/structural
+input list against the corresponding `State.Limits`. Binding count uses
+`maxApplications`; `maxScopeNodes` independently caps each scoped read list and
+write list. The same preflight enforces operation/node/rule/arity/depth,
+matcher-batch, effort, generation, action, application, equality, and accepted-
+fact limits with the exact State resource class.
+
+The current supported session retains generation stamps for compact
+`ApplicationId`s but not the concrete application table compiled by the
+experimental controller. Search therefore treats the compact identifier as an
+opaque scheduler handle: it authenticates its bounds and generation while
+independently checking the action's rule key and local rule id, anchor,
+operation, kind, reads, writes, and structural inputs. A callback must not use
+the compact application id as authority for a rule or anchor. Retaining and
+checking the exact application table is an obligation for the supported
+controller/package assembly; the present Search contract does not claim that
+correspondence.
+
+`prepareWithin` authenticates the session once, revalidates the external policy
+decision against that already-checked immutable view, and returns only the
+exact controller-owned action. `chooseWithin`, `acceptWithin`, and
+`invokeWithin` use the same private-constructor checked artifact internally:
+each public transition reconstructs branch history and invokes policy
+measurement callbacks once, while callers cannot forge or retain the artifact.
+`invokeWithin` authenticates the decision and checks step exhaustion before
+executing the non-preemptible callback. `acceptWithin` checks an untrusted
+callback batch against that action's serial, program version, input versions,
+and write set, preflights total retained history, and folds exact successor
+updates over the once-authenticated local branch before returning a replacement
+session. A stale later update therefore cannot partially commit an earlier
+update. Callback failure has an exact conservative stop, and diagnostic
+truncation can change only the log, not facts, versions, provenance, scope, or
+contradiction state.
 
 `Search.Frontier` and `Search.Accounting` supply stable depth-first and
 breadth-first ordering plus independent step, split, retained-leaf, frontier,
 depth, and scope limits. Child records retain an exact immutable parent branch
-for restoration; the generic layer validates this binding but deliberately
-does not interpret split semantics. Callback execution, measurements, and
-equality on caller-selected Lean objects remain explicitly non-preemptible:
-packages must bound result construction before returning, after which search
-preflights returned counts, retained bytes, and declared work.
+for restoration. `splitWithin` consumes the complete bounded pre-split
+frontier, rejects duplicate pending leaves, derives the parent and remaining
+frontier by popping the stable head internally, preflights every retained
+parent/child branch against State limits, and then checks exact parent records;
+a caller cannot supply a detached parent/rest pair or keep a second scheduled
+copy of the split head. `settleWithin` likewise consumes the frontier instead
+of trusting a detached count. The generic layer deliberately does not interpret
+split semantics. Callback execution, measurements, and equality on caller-
+selected Lean objects remain explicitly non-preemptible: packages must bound
+result construction before returning, after which search preflights returned
+counts, retained bytes, and declared work.
 
 The experimental target controller now implements the supported `Interface`
 and returns the actual supported `Step`; it stamps a selected supported offer
@@ -5026,6 +5060,19 @@ candidates, and `b` the number of live branch states.
   scans its retained order. Avoiding these whole-state scans is a requirement
   for the selected production store and queue, not a property of the current
   transparent reference builders.
+- One supported `Search` transition first performs bounded prefix checks on
+  every decoded list and O(1) size checks on every retained array, then validates
+  the complete base/current branch chronology, registry, scoped bindings,
+  offers, and actions. The current transparent reference contract therefore
+  still has whole-branch/program/registry work; it does not claim local
+  asymptotics. Within one `prepareWithin`, `chooseWithin`, `acceptWithin`, or
+  `invokeWithin` call, that authentication and the package-owned policy
+  measurements run once. Accepted callback batches fold already-preflighted
+  exact successor updates without re-running `Branch.check` for every event.
+  Split admission traverses at most the bounded retained frontier and validates
+  its popped parent and both children once. Arbitrary callback execution and
+  equality on caller-selected facts, causes, identifiers, and keys
+  remain non-preemptible.
 - Fact comparison and contradiction checks use exact endpoint comparison. For
   the dyadic candidate, integer cost is proportional to effective endpoint
   height and the permitted exponent-alignment shift; a rational candidate must

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -2267,11 +2267,13 @@ The first generic runtime tree manager now retains internal nodes recording
 validated plans and exact child inputs, and leaves recording target,
 contradiction, saturation, resource failure, split refusal, session-start
 failure, or any other precise `TargetRun` result. It stores the append-only
-node array and a separate pending frontier, so a global step limit returns an
-honest partial tree rather than relabelling unexplored leaves as closed.
-Independent limits bound processed leaves, accepted splits, current leaf
-count, split depth, total created scopes, and each leaf run's policy fuel in
-addition to the per-session engine and payload limits. Split- and leaf-limit
+node array and the supported stable pending frontier, so a global step limit
+returns an honest partial tree rather than relabelling unexplored leaves as
+closed.
+Independent supported limits bound processed leaves, accepted splits, current
+leaf count, pending frontier count, split depth, total created scopes, and each
+leaf run's policy fuel in addition to the per-session engine and payload limits.
+Split- and leaf-limit
 exhaustion is retained at the exact parent leaf. A child session which cannot
 start is likewise retained beside its sibling instead of silently deleting
 the branch.
@@ -3110,6 +3112,28 @@ reconstructs and validates the branch snapshot once, then checks bounded offers
 without repeating whole-program validation. The returned runtime value has no
 theorem authority.
 
+The supported Mathlib-free `HexInterval/Search.lean` layer owns the next
+generic boundary. Its decoded `Search.Session` binds one exact checked
+`State.Branch`, registration snapshot, scope, serial, complete policy view,
+controller-owned offer-to-`Action` bindings, bounded diagnostic log, and
+global accounting. `prepareWithin` revalidates the external policy decision
+and returns only the exact controller-owned action. `acceptWithin` checks an
+untrusted callback batch against that action's serial, program version, input
+versions, and write set and applies the whole batch to a local branch before
+returning a replacement session. A stale later update therefore cannot
+partially commit an earlier update. Callback failure has an exact conservative
+stop, and diagnostic truncation can change only the log, not facts, versions,
+provenance, scope, or contradiction state.
+
+`Search.Frontier` and `Search.Accounting` supply stable depth-first and
+breadth-first ordering plus independent step, split, retained-leaf, frontier,
+depth, and scope limits. Child records retain an exact immutable parent branch
+for restoration; the generic layer validates this binding but deliberately
+does not interpret split semantics. Callback execution, measurements, and
+equality on caller-selected Lean objects remain explicitly non-preemptible:
+packages must bound result construction before returning, after which search
+preflights returned counts, retained bytes, and declared work.
+
 The experimental target controller now implements the supported `Interface`
 and returns the actual supported `Step`; it stamps a selected supported offer
 into a supported decision before the policy session authenticates the exact
@@ -3117,9 +3141,16 @@ scope, serial, program version, remaining budget, identifier, semantic key,
 class, age, and score and performs the existing engine-owned freshness checks.
 The concrete `OfferId`,
 `OfferKey`, instantiation/split encodings, staged/adaptive/feature policies,
-package callbacks, event history, sessions, and branch-search loop remain under
-`HexInterval/Experiment`. In particular no `balancedV1`, score model, storage
-layout, scheduler, or default policy is selected by the supported contract.
+package callbacks, semantic outcome interpretation, event history, concrete
+policy sessions, target-specific stop taxonomy, and proof replay remain under
+`HexInterval/Experiment`. The experimental `BranchTree` consumes the supported
+search order, limits, accounting, and frontier container, while its
+package-specific child construction remains behind `BranchStart`. The older
+sealed propagator session is not presented as a supported `Search.Session`:
+its concrete engine/registry/payload ownership must be migrated through the
+new authenticated transition boundary rather than hidden by an alias. No
+`balancedV1`, score model, storage layout, offer generator, scheduler default,
+or proof format is selected by the supported contracts.
 
 The implemented generic records and current concrete experimental keys are
 sketched below:
@@ -5089,6 +5120,12 @@ their declared cost inside a scheduler bound.
   semantic offer keys and policies remain experimental; package measurement
   callbacks and equality on nested identifiers, keys, and reconstructed facts
   are explicitly non-preemptible.
+- `HexInterval/Search.lean`: supported Mathlib-free authenticated
+  policy/action sessions, transactional callback-delta validation, exact
+  generic stop/resource classes, stable depth-first/breadth-first frontiers,
+  immutable parent restoration, and bounded step/split/leaf/frontier/depth/
+  scope accounting. It contains no concrete callback, offer generator, split
+  semantics, policy algorithm, storage choice, or proof replay.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and
   extension admission. Its engine extends and mutates only through the
@@ -5096,11 +5133,13 @@ their declared cost inside a scheduler bound.
   inspectable experimental storage candidate.
 - `HexInterval/Experiment/{PackageRegistry,PolicyDriver,PolicySession,
   StagedPolicy,AdaptivePolicy,FeaturePolicy,BranchTree}.lean`: current
-  provisional package callback, policy, session, and branch-search designs.
-   Optimized storage, policy/search APIs, and a default policy will be selected
+   provisional package callback, policy implementation, semantic session,
+   target driver, and split-construction designs. Optimized storage, concrete
+   offer generation, package protocols, and a default policy will be selected
    from measurements; none is frozen by the decoded supported snapshots.
-- `conformance/HexInterval/{Conformance,MinMaxConformance,EmitFixtures}.lean`:
-  Lean-only checks and oracle fixtures.
+ - `conformance/HexInterval/{Conformance,SearchConformance,MinMaxConformance,
+   EmitFixtures}.lean`:
+   Lean-only checks and oracle fixtures.
 - `HexInterval/Experiment/PntFks2FamilyData*.lean` and
   `HexInterval/Experiment/PntFks2Family.lean`: committed source-pinned family
   data and the Mathlib-free complete-family checker.
@@ -5149,6 +5188,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - diagnostic event count, payload-byte, logical-work, and code refusal,
   malformed cached totals, and a truncation canary showing that diagnostic
   loss cannot change branch facts, versions, provenance, or contradiction;
+- stale or mutated search decisions and callback replies, unauthorized writes,
+  stale later updates with whole-batch rollback, callback failure, and exact
+  step/split/leaf/frontier/depth/scope one-over refusal; stable DFS/BFS order,
+  exact parent scope/version/provenance restoration, and trace truncation with
+  identical retained branch state;
 - equal endpoints in all closure combinations;
 - empty, singleton, one-sided unbounded, and whole intervals;
 - table-driven empty laws: every unary operation and `regularize` preserve

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3113,10 +3113,14 @@ without repeating whole-program validation. The returned runtime value has no
 theorem authority.
 
 The supported Mathlib-free `HexInterval/Search.lean` layer owns the next
-generic boundary. Its decoded `Search.Session` binds one exact checked
+generic boundary. Its sealed `Search.Session` binds one exact checked
 `State.Branch`, registration snapshot, scope, serial, complete policy view,
 controller-owned offer-to-`Action` bindings, bounded diagnostic log, and
-global accounting. Before any semantic scan or package measurement, session
+the cumulative accepted-step count for that run. `Session.startWithin` is the
+only reset point and creates a new run; no decoded record constructor or record
+update can install fresh counters into a live session. Session-only accounting
+does not require frontier capacity, so `maxFrontier = 0` does not reject a
+non-branching session. Before any semantic scan or package measurement, session
 authentication uses `Policy.maxOffers` to cap the retained offer array before
 mapping or traversing it. It separately caps the base and current program,
 history and aligned branch arrays, registry, binding/application/equality
@@ -3156,21 +3160,30 @@ update. Callback failure has an exact conservative stop, and diagnostic
 truncation can change only the log, not facts, versions, provenance, scope, or
 contradiction state.
 
-`Search.Frontier` and `Search.Accounting` supply stable depth-first and
-breadth-first ordering plus independent step, split, retained-leaf, frontier,
-depth, and scope limits. `Accounting` has a private constructor: decoded callers
-cannot reset its counters or `nextScope`, and supported code can create or
-advance it only through checked singleton-start, settle, and split builders.
-The experimental `BranchTree` consumes those builders rather than constructing
-or updating accounting records. Child records retain an exact immutable parent branch
-for restoration. `splitWithin` consumes the complete bounded pre-split
-frontier, rejects duplicate pending leaves, derives the parent and remaining
-frontier by popping the stable head internally, preflights every retained
-parent/child branch against State limits, and then checks exact parent records;
-a caller cannot supply a detached parent/rest pair or keep a second scheduled
-copy of the split head. `settleWithin` likewise consumes the frontier instead
-of trusting a detached count. The generic layer deliberately does not interpret
-split semantics. Callback execution, measurements, and equality on caller-
+`Search.Frontier` is a public ordering value, but live tree authority is the
+sealed `Search.FrontierState`, which inseparably owns the pending frontier and
+its cumulative step, split, retained-leaf, scope, and next-scope accounting.
+The raw `Accounting` constructor and advance operations are private. Checked
+composite start, settle-head, and split-head transitions consume and return the
+whole sealed value, so a fresh counter cannot be transplanted onto an existing
+frontier and a phantom frontier cannot advance live counters. Reusing an old
+pure value may produce an alternative bounded successor; it cannot create a
+successor which bypasses that value's own limits. A separate start creates a
+documented new run rather than resetting an existing one.
+
+The experimental `BranchTree.State` is likewise sealed and contains one
+`FrontierState TreeId`; callers cannot independently replace its nodes,
+frontier, branch manager, or counters. Its checked transitions derive the exact
+head internally. The generic composite split authenticates only cumulative
+resources and stable scheduling for at most two package-validated children;
+the enclosing sealed `BranchTree` checks child construction and semantics.
+The supported `Search.splitWithin` specialization additionally preflights
+every retained parent/child branch, requires exact immutable parent records,
+fresh scopes and depth, and rejects detached parents. `settleWithin` likewise
+returns and charges the exact head rather than trusting a detached count.
+`BranchTree.snapshot` deliberately exports editable retained nodes/frontier as
+untrusted proof-fold input, but that snapshot carries no live accounting or
+mutation authority. Callback execution, measurements, and equality on caller-
 selected Lean objects remain explicitly non-preemptible: packages must bound
 result construction before returning, after which search preflights returned
 counts, retained bytes, and declared work.
@@ -5177,11 +5190,11 @@ their declared cost inside a scheduler bound.
   semantic offer keys and policies remain experimental; package measurement
   callbacks and equality on nested identifiers, keys, and reconstructed facts
   are explicitly non-preemptible.
-- `HexInterval/Search.lean`: supported Mathlib-free authenticated
+- `HexInterval/Search.lean`: supported Mathlib-free sealed authenticated
   policy/action sessions, transactional callback-delta validation, exact
   generic stop/resource classes, stable depth-first/breadth-first frontiers,
-  immutable parent restoration, and bounded step/split/leaf/frontier/depth/
-  scope accounting. It contains no concrete callback, offer generator, split
+  immutable parent restoration, and sealed cumulative step/split/leaf/frontier/
+  depth/scope accounting. It contains no concrete callback, offer generator, split
   semantics, policy algorithm, storage choice, or proof replay.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -20,7 +20,7 @@ callback updates against `State.Branch`. It also supplies bounded tree
 accounting and stable depth-first/breadth-first frontier operations.
 
 The callback invocation and equality on caller-selected facts, causes,
-identifiers, keys, and payloads are explicitly non-preemptible. A callback
+identifiers, and keys are explicitly non-preemptible. A callback
 must bound construction before returning. Search checks the returned action,
 counts, versions, write authority, retained diagnostic bytes, and declared
 work before it commits any branch mutation. Neither an accepted callback
@@ -78,6 +78,7 @@ inductive Resource where
   | frontier
   | depth
   | scopes
+  | state (resource : State.Resource)
   deriving DecidableEq, Repr
 
 /-- Precise generic stop classes. Package-specific errors remain an opaque
@@ -132,12 +133,27 @@ structure Envelope where
   search : Limits
   deriving DecidableEq, Repr
 
+inductive Error where
+  | invalidSession
+  | policy (error : Policy.Error)
+  | staleReply
+  | malformedOutcome
+  | unauthorizedWrite (node : NodeId)
+  | outcomeLimit
+  | state (error : State.BranchError)
+  | trace
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
 /-- A decoded session. Every mutating consumer rechecks this record; its public
 constructor grants no authority. -/
 structure Session (Fact Cause OfferId SemanticKey : Type) where
   branch : State.Branch Fact Cause
   rules : Array Registration
   bindings : Array ScopeBinding
+  /-- Generation stamps for opaque scheduler application handles. This layer
+  does not retain an application table and therefore does not infer a
+  rule/anchor pair from the compact identifier. -/
   applicationGenerations : Array Nat
   equalityGenerations : Array Nat
   matcherEpoch : Nat
@@ -159,39 +175,130 @@ def Session.view (session : Session Fact Cause OfferId SemanticKey) :
     remaining := session.remaining
     incomplete := session.incomplete }
 
-def actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
+/-- Check a decoded list against a cap without traversing beyond the first
+disallowed cell. -/
+def listWithin : Nat -> List α -> Bool
+  | _, [] => true
+  | 0, _ :: _ => false
+  | limit + 1, _ :: rest => listWithin limit rest
+
+private def stateResource (resource : State.Resource) : Error :=
+  .resource (.state resource)
+
+private def preflightProgram (limits : State.Limits) (program : Program) : Except Error Unit := do
+  if limits.maxOperations < program.operations.size then
+    throw (stateResource .operations)
+  if limits.maxNodes < program.nodes.size then throw (stateResource .nodes)
+  if program.operations.any (fun operation => !listWithin limits.maxArity operation.inputs) ||
+      program.nodes.any (fun node => !listWithin limits.maxArity node.args) then
+    throw (stateResource .arity)
+
+private def preflightBranch (limits : State.Limits)
+    (branch : State.Branch Fact Cause) : Except Error Unit := do
+  preflightProgram limits branch.baseProgram
+  preflightProgram limits branch.program
+  if limits.maxAcceptedFacts < branch.history.size then
+    throw (stateResource .acceptedFacts)
+  if limits.maxNodes < branch.initialFacts.size ||
+      limits.maxNodes < branch.seeds.size ||
+      limits.maxNodes < branch.versions.size ||
+      limits.maxNodes < branch.generations.size ||
+      limits.maxNodes < branch.depths.size then
+    throw (stateResource .nodes)
+  if branch.initialFacts.size != branch.baseProgram.nodes.size ||
+      branch.program.nodes.size < branch.baseProgram.nodes.size ||
+      branch.seeds.size != branch.program.nodes.size - branch.baseProgram.nodes.size ||
+      branch.versions.size != branch.program.nodes.size ||
+      branch.generations.size != branch.program.nodes.size ||
+      branch.depths.size != branch.program.nodes.size then
+    throw .invalidSession
+  if branch.depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (stateResource .nodeDepth)
+  if branch.generations.any (fun generation => limits.maxGeneration < generation) then
+    throw (stateResource .generation)
+
+private def preflightAction (limits : State.Limits) (rules : Array Registration)
+    (action : Action) : Except Error Unit := do
+  if limits.maxEffort < action.effort then throw (stateResource .effort)
+  let some registration := rules[action.rule.index]? | throw .invalidSession
+  let portLimit := match registration.binding with
+    | .local => limits.maxArity + 1
+    | .scoped => limits.maxScopeNodes
+    | .global => 0
+  let portResource := match registration.binding with
+    | .local => State.Resource.arity
+    | .scoped => State.Resource.scopes
+    | .global => State.Resource.arity
+  if !listWithin portLimit action.inputs || !listWithin portLimit action.writes then
+    throw (stateResource portResource)
+  if !listWithin limits.matcherBatchSize action.structuralInputs then
+    throw (stateResource .matcherVisits)
+
+private def preflightSession (limits : State.Limits)
+    (session : Session Fact Cause OfferId SemanticKey) : Except Error Unit := do
+  preflightBranch limits session.branch
+  if limits.maxRules < session.rules.size then throw (stateResource .rules)
+  if limits.maxApplications < session.bindings.size ||
+      limits.maxApplications < session.applicationGenerations.size then
+    throw (stateResource .applications)
+  if limits.maxEqualities < session.equalityGenerations.size then
+    throw (stateResource .equalities)
+  if session.rules.any (fun rule => limits.maxEffort < rule.initialEffort) then
+    throw (stateResource .effort)
+  if session.rules.any (fun rule =>
+      !listWithin (limits.maxArity + 1) rule.watches ||
+        !listWithin (limits.maxArity + 1) rule.writes) then
+    throw (stateResource .arity)
+  if session.bindings.any (fun binding =>
+      !listWithin limits.maxScopeNodes binding.watches ||
+        !listWithin limits.maxScopeNodes binding.writes) then
+    throw (stateResource .scopes)
+  if limits.matcherBatchSize == 0 &&
+      session.rules.any (fun rule => rule.matchWatch == .network) then
+    throw (stateResource .matcherVisits)
+  if session.applicationGenerations.any (fun generation => limits.maxGeneration < generation) ||
+      session.equalityGenerations.any (fun generation => limits.maxGeneration < generation) then
+    throw (stateResource .generation)
+  for offer in session.offers do
+    preflightAction limits session.rules offer.action
+
+private def actionCurrentWithin (limits : State.Limits) (branch : State.Branch Fact Cause)
     (rules : Array Registration) (bindings : Array ScopeBinding)
     (applicationGenerations equalityGenerations : Array Nat)
     (matcherEpoch serial : Nat)
-    (action : Action) : Bool := Id.run do
+    (action : Action) : Except Error Unit := do
   if action.serial != serial || action.programVersion != branch.programVersion ||
       limits.maxEffort < action.effort then
-    return false
+    if limits.maxEffort < action.effort then throw (stateResource .effort)
+    else throw .invalidSession
   let some applicationGeneration := applicationGenerations[action.application.index]?
-    | return false
-  if applicationGeneration != action.generation then return false
-  let some registration := rules[action.rule.index]? | return false
-  if registration.key != action.key || registration.kind != action.kind then return false
-  let some instruction := branch.program.node? action.node | return false
-  let some operation := branch.program.operation? instruction.op | return false
+    | throw .invalidSession
+  if applicationGeneration != action.generation then throw .invalidSession
+  let some registration := rules[action.rule.index]? | throw .invalidSession
+  if registration.key != action.key || registration.kind != action.kind then
+    throw .invalidSession
+  preflightAction limits rules action
+  let some instruction := branch.program.node? action.node | throw .invalidSession
+  let some operation := branch.program.operation? instruction.op | throw .invalidSession
   if operation.key != registration.head || !allDistinct action.inputs ||
-      !allDistinct action.writes || !allDistinct action.structuralInputs then return false
+      !allDistinct action.writes || !allDistinct action.structuralInputs then
+    throw .invalidSession
   for seen in action.inputs do
-    let some version := branch.versions[seen.node.index]? | return false
-    if version != seen.version then return false
+    let some version := branch.versions[seen.node.index]? | throw .invalidSession
+    if version != seen.version then throw .invalidSession
   for node in action.writes do
-    if (branch.program.node? node).isNone then return false
+    if (branch.program.node? node).isNone then throw .invalidSession
   for input in action.structuralInputs do
     match input.key with
     | .node node =>
-        let some generation := branch.generations[node.index]? | return false
-        if generation != input.generation then return false
+        let some generation := branch.generations[node.index]? | throw .invalidSession
+        if generation != input.generation then throw .invalidSession
     | .application application =>
-        let some generation := applicationGenerations[application.index]? | return false
-        if generation != input.generation then return false
+        let some generation := applicationGenerations[application.index]? | throw .invalidSession
+        if generation != input.generation then throw .invalidSession
     | .equality equality =>
-        let some generation := equalityGenerations[equality.index]? | return false
-        if generation != input.generation then return false
+        let some generation := equalityGenerations[equality.index]? | throw .invalidSession
+        if generation != input.generation then throw .invalidSession
   let inputNodes := action.inputs.map (·.node)
   let bindingValid := match registration.binding with
     | .local =>
@@ -205,46 +312,56 @@ def actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
   let matcherValid := match registration.matchWatch with
     | .none => action.matcherEpoch.isNone && action.structuralInputs.isEmpty
     | .network => action.matcherEpoch == some matcherEpoch && !action.structuralInputs.isEmpty
-  return bindingValid && matcherValid
+  if !bindingValid || !matcherValid then throw .invalidSession
 
-def Session.check [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+opaque actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
+    (rules : Array Registration) (bindings : Array ScopeBinding)
+    (applicationGenerations equalityGenerations : Array Nat)
+    (matcherEpoch serial : Nat) (action : Action) : Bool :=
+  (actionCurrentWithin limits branch rules bindings applicationGenerations
+    equalityGenerations matcherEpoch serial action).isOk
+
+private structure Checked (Fact OfferId SemanticKey : Type) where
+  view : Policy.View Fact OfferId SemanticKey
+
+private def authenticate [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
-    (session : Session Fact Cause OfferId SemanticKey) : Bool := Id.run do
-  if !session.branch.check ||
-      !Registration.check session.branch.program session.rules ||
+    (session : Session Fact Cause OfferId SemanticKey) :
+    Except Error (Checked Fact OfferId SemanticKey) := do
+  if envelope.policy.maxOffers < session.offers.size then
+    throw (.policy .offerLimit)
+  preflightSession envelope.state session
+  let some snapshot := session.branch.checkedSnapshot? | throw .invalidSession
+  if !Registration.check session.branch.program session.rules ||
       !ScopeBinding.checkAll session.branch.program session.rules session.bindings ||
-      envelope.state.maxRules < session.rules.size ||
-      envelope.state.maxScopeNodes < session.bindings.size ||
-      envelope.state.maxApplications < session.applicationGenerations.size ||
-      envelope.state.maxEqualities < session.equalityGenerations.size ||
       !session.accounting.check envelope.search 0 ||
-      !session.trace.check envelope.trace then return false
-  let view := session.view
-  match Policy.checkViewWithin envelope.policy measure session.branch.program view with
-  | .error _ => return false
+      !session.trace.check envelope.trace then
+    throw .invalidSession
+  let view : Policy.View Fact OfferId SemanticKey :=
+    { scope := session.scope
+      serial := session.serial
+      programVersion := session.branch.programVersion
+      offers := session.offers.map (·.view)
+      facts := snapshot
+      remaining := session.remaining
+      incomplete := session.incomplete }
+  match Policy.checkOffersWithin envelope.policy measure view with
+  | .error error => throw (.policy error)
   | .ok _ => pure ()
   for offer in session.offers do
-    if !actionCurrent envelope.state session.branch session.rules
-        session.bindings session.applicationGenerations session.equalityGenerations
-        session.matcherEpoch session.serial offer.action then
-      return false
-  return true
+    actionCurrentWithin envelope.state session.branch session.rules
+      session.bindings session.applicationGenerations session.equalityGenerations
+      session.matcherEpoch session.serial offer.action
+  pure { view }
 
-inductive Error where
-  | invalidSession
-  | policy (error : Policy.Error)
-  | staleReply
-  | malformedOutcome
-  | unauthorizedWrite (node : NodeId)
-  | outcomeLimit
-  | state (error : State.BranchError)
-  | trace
-  | resource (resource : Resource)
-  deriving DecidableEq, Repr
+opaque Session.check [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey) : Bool :=
+  (authenticate envelope measure session).isOk
 
 /-- Build one exact checked session transactionally. Offer generation remains
 external; this builder only authenticates its complete returned snapshot. -/
-def Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+opaque Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
     (branch : State.Branch Fact Cause) (rules : Array Registration)
     (bindings : Array ScopeBinding) (applicationGenerations equalityGenerations : Array Nat)
@@ -266,23 +383,25 @@ def Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Offe
       incomplete
       trace := {}
       accounting := { nextScope := scope.index + 1 } }
-  if !session.check envelope measure then throw .invalidSession
+  let _ <- authenticate envelope measure session
   pure session
 
 /-- Install a newly generated complete offer snapshot only after validating it
 against the exact current session. Failure preserves the preceding session. -/
-def Session.refreshWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+opaque Session.refreshWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
     (session : Session Fact Cause OfferId SemanticKey)
     (offers : Array (Offer OfferId SemanticKey))
     (remaining : Policy.EngineBudgetView) (incomplete : Bool) :
     Except Error (Session Fact Cause OfferId SemanticKey) := do
-  if !session.check envelope measure then throw .invalidSession
   let next := { session with offers, remaining, incomplete }
-  if !next.check envelope measure then throw .invalidSession
+  let _ <- authenticate envelope measure next
   pure next
 
-/-- Exact authenticated callback request. -/
+/-- Exact authenticated callback request. Rule, anchor, kind, ports, versions,
+and generations have been checked independently. `action.application` remains
+an opaque generation-stamped scheduler handle at this layer, not authority for
+the rule or anchor. -/
 structure Request (Fact OfferId SemanticKey : Type) where
   scope : Policy.ScopeId
   serial : Nat
@@ -323,17 +442,13 @@ inductive Choice (PolicyState OfferId SemanticKey : Type)
 
 variable {Fact Cause OfferId SemanticKey : Type}
 
-/-- Revalidate the policy's complete echoed offer, then return the exact
-controller-owned action request. -/
-def prepareWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
-    [DecidableEq SemanticKey] (envelope : Envelope)
-    (measure : Policy.Measure OfferId SemanticKey)
+private def prepareChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
     (session : Session Fact Cause OfferId SemanticKey)
-    (decision : Policy.Decision OfferId SemanticKey) : Except Error (Request Fact OfferId SemanticKey) := do
-  if !session.check envelope measure then throw .invalidSession
-  let view := session.view
+    (checked : Checked Fact OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) :
+    Except Error (Request Fact OfferId SemanticKey) := do
   let selected <-
-    match Policy.checkDecisionWithin envelope.policy measure session.branch view decision with
+    match Policy.revalidate checked.view decision with
     | .ok selected => pure selected
     | .error error => throw (.policy error)
   let some offer := session.offers.find? fun offer => offer.view == selected
@@ -344,28 +459,37 @@ def prepareWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
       programVersion := session.branch.programVersion
       offer := offer.view
       action := offer.action
-      facts := session.branch.snapshot }
+      facts := checked.view.facts }
+
+/-- Revalidate the policy's complete echoed offer, then return the exact
+controller-owned action request. -/
+opaque prepareWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) : Except Error (Request Fact OfferId SemanticKey) := do
+  let checked <- authenticate envelope measure session
+  prepareChecked session checked decision
 
 /-- Run a replaceable policy over the exact checked view. A selected or
 dismissed offer is revalidated before its exact decision is returned; stopping
 cannot mutate the session. Policy callback execution is non-preemptible. -/
-def chooseWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+opaque chooseWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     [DecidableEq SemanticKey] (envelope : Envelope)
     (measure : Policy.Measure OfferId SemanticKey)
     (policy : Policy.Interface Fact PolicyState OfferId SemanticKey)
     (policyState : PolicyState) (session : Session Fact Cause OfferId SemanticKey) :
     Except Error (Choice PolicyState OfferId SemanticKey) := do
-  if !session.check envelope measure then throw .invalidSession
-  let view := session.view
-  match policy.choose policyState view with
-  | .stop next => pure (.stopped (.policyStop view.offers.size) next)
+  let checked <- authenticate envelope measure session
+  match policy.choose policyState checked.view with
+  | .stop next => pure (.stopped (.policyStop checked.view.offers.size) next)
   | .select offer next =>
-      let decision := Policy.select view offer
-      let _ <- prepareWithin envelope measure session decision
+      let decision := Policy.select checked.view offer
+      let _ <- prepareChecked session checked decision
       pure (.select decision next)
   | .dismiss offer next =>
-      let decision := Policy.select view offer
-      let _ <- prepareWithin envelope measure session decision
+      let decision := Policy.select checked.view offer
+      let _ <- prepareChecked session checked decision
       pure (.dismiss decision next)
 
 def appendDiagnostic (limit : Trace.Limit) (log : Trace.Log)
@@ -384,18 +508,27 @@ def sameReply [DecidableEq OfferId] [DecidableEq SemanticKey]
     outcome.programVersion == request.programVersion && outcome.offer == request.offer &&
     outcome.action == request.action
 
-/-- Validate and commit the whole returned delta transactionally. Every event
-must be an exact successor for a node in the selected action's write set. The
-returned contradiction bit is runtime status only. -/
-def acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
-    [DecidableEq SemanticKey] (envelope : Envelope)
-    (measure : Policy.Measure OfferId SemanticKey)
-    (session : Session Fact Cause OfferId SemanticKey)
-    (decision : Policy.Decision OfferId SemanticKey)
-    (reply : Reply Fact Cause OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
-  if session.accounting.steps >= envelope.search.maxSteps then
-    return .stopped (.resource .steps) session
-  let request <- prepareWithin envelope measure session decision
+private def pushChecked (branch : State.Branch Fact Cause)
+    (event : State.Update Fact Cause) (contradiction : Bool) :
+    Except Error (State.Branch Fact Cause) := do
+  if event.programVersion != branch.programVersion then
+    throw (.state .wrongProgramVersion)
+  let some current := branch.versions[event.node.index]?
+    | throw (.state (.staleVersion event.node))
+  if event.previous.node != event.node || event.previous.version != current ||
+      event.version != current + 1 then
+    throw (.state (.staleVersion event.node))
+  pure
+    { branch with
+      versions := branch.versions.set! event.node.index event.version
+      history := branch.history.push event
+      contradictory := branch.contradictory || contradiction }
+
+private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
+    (envelope : Envelope) (session : Session Fact Cause OfferId SemanticKey)
+    (request : Request Fact OfferId SemanticKey)
+    (reply : Reply Fact Cause OfferId SemanticKey) :
+    Except Error (Step Fact Cause OfferId SemanticKey) := do
   match reply with
   | .failure code diagnostic =>
       if envelope.trace.maxCode < code then throw .malformedOutcome
@@ -405,15 +538,14 @@ def acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
       if !sameReply request outcome then throw .staleReply
       if envelope.state.maxOutcomeCandidates < outcome.updates.size then
         throw .outcomeLimit
+      if envelope.state.maxAcceptedFacts < outcome.updates.size ||
+          envelope.state.maxAcceptedFacts - outcome.updates.size < session.branch.history.size then
+        throw (stateResource .acceptedFacts)
       let mut branch := session.branch
       for event in outcome.updates do
         if !request.action.writes.contains event.node then
           throw (.unauthorizedWrite event.node)
-        let next <-
-          match branch.pushWithin envelope.state event outcome.contradiction with
-          | .ok updated => pure updated
-          | .error error => throw (.state error)
-        branch := next
+        branch <- pushChecked branch event outcome.contradiction
       if outcome.contradiction && outcome.updates.isEmpty then throw .malformedOutcome
       let trace <- appendDiagnostic envelope.trace session.trace outcome.diagnostic
       let next : Session Fact Cause OfferId SemanticKey :=
@@ -426,17 +558,35 @@ def acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
           accounting := { session.accounting with steps := session.accounting.steps + 1 } }
       pure (.applied next)
 
+/-- Validate and commit the whole returned delta transactionally. Every event
+must be an exact successor for a node in the selected action's write set. The
+returned contradiction bit is runtime status only. -/
+opaque acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey)
+    (reply : Reply Fact Cause OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
+  let checked <- authenticate envelope measure session
+  let request <- prepareChecked session checked decision
+  if session.accounting.steps >= envelope.search.maxSteps then
+    return .stopped (.resource .steps) session
+  acceptChecked envelope session request reply
+
 /-- Invoke an arbitrary callback and then pass its decoded result through
 `acceptWithin`. Callback execution itself is deliberately non-preemptible and
 has no mutation authority. -/
-def invokeWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+opaque invokeWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     [DecidableEq SemanticKey] (envelope : Envelope)
     (measure : Policy.Measure OfferId SemanticKey)
     (callback : Request Fact OfferId SemanticKey -> Reply Fact Cause OfferId SemanticKey)
     (session : Session Fact Cause OfferId SemanticKey)
     (decision : Policy.Decision OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
-  let request <- prepareWithin envelope measure session decision
-  acceptWithin envelope measure session decision (callback request)
+  let checked <- authenticate envelope measure session
+  let request <- prepareChecked session checked decision
+  if session.accounting.steps >= envelope.search.maxSteps then
+    return .stopped (.resource .steps) session
+  acceptChecked envelope session request (callback request)
 
 /-- Exact retained parent snapshot for a child. -/
 structure Parent (Fact Cause : Type) where
@@ -453,6 +603,7 @@ structure Leaf (Fact Cause Payload : Type) where
   branch : State.Branch Fact Cause
   parent : Option (Parent Fact Cause) := none
   payload : Payload
+  deriving DecidableEq
 
 def Leaf.asParent (leaf : Leaf Fact Cause Payload) : Parent Fact Cause :=
   { scope := leaf.scope, depth := leaf.depth, branch := leaf.branch }
@@ -462,12 +613,14 @@ and contradiction state. -/
 def Leaf.restoreParent? (leaf : Leaf Fact Cause Payload) : Option (Parent Fact Cause) :=
   leaf.parent
 
-/-- Build a root frontier after all count caps admit it. -/
-def startFrontierWithin (limits : Limits) (root : Leaf Fact Cause Payload) :
+/-- Build a root frontier after all structural and count caps admit it. -/
+opaque startFrontierWithin (stateLimits : State.Limits) (limits : Limits)
+    (root : Leaf Fact Cause Payload) :
     Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
   if limits.maxLeaves < 1 then throw (.resource .leaves)
   if limits.maxScopes < 1 then throw (.resource .scopes)
   if limits.maxFrontier < 1 then throw (.resource .frontier)
+  preflightBranch stateLimits root.branch
   if root.depth != 0 || root.parent.isSome || !root.branch.check then throw .invalidSession
   pure ({ nextScope := root.scope.index + 1 }, .singleton root)
 
@@ -476,32 +629,51 @@ def pop (frontier : Frontier α) : Option (α × Frontier α) := do
   let head <- frontier.head?
   pure (head, frontier.tail)
 
-/-- Retain a terminal leaf and charge exactly one processing step. -/
-def settleWithin (limits : Limits) (frontierCount : Nat) (accounting : Accounting) :
+/-- Retain the authenticated frontier head as a terminal leaf and charge
+exactly one processing step. The caller cannot substitute a detached count. -/
+def settleWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
     Except Error Accounting := do
-  if !accounting.check limits (frontierCount + 1) then throw .invalidSession
+  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
+  if frontier.pending.isEmpty ||
+      !accounting.check limits frontier.pending.length then throw .invalidSession
   if accounting.steps >= limits.maxSteps then throw (.resource .steps)
   pure { accounting with steps := accounting.steps + 1 }
 
 /-- Admit an exact binary split and schedule its children transactionally.
 The package owns child semantics; generic search authenticates the retained
-parent, checked child branches, fresh scopes, depth, and global resources. -/
-def splitWithin [DecidableEq Fact] [DecidableEq Cause]
-    (limits : Limits) (order : Order) (accounting : Accounting)
-    (parent : Leaf Fact Cause Payload) (rest : Frontier (Leaf Fact Cause Payload))
+frontier head as the parent, checked child branches, fresh scopes, depth, and
+global resources. -/
+opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
+    (stateLimits : State.Limits) (limits : Limits) (order : Order)
+    (accounting : Accounting) (frontier : Frontier (Leaf Fact Cause Payload))
     (left right : Leaf Fact Cause Payload) :
     Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
-  if !accounting.check limits (rest.pending.length + 1) then throw .invalidSession
+  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
+  for pending in frontier.pending do
+    preflightBranch stateLimits pending.branch
+    match pending.parent with
+    | none => pure ()
+    | some retained => preflightBranch stateLimits retained.branch
+  if !allDistinct (frontier.pending.map (·.scope)) then throw .invalidSession
+  if !accounting.check limits frontier.pending.length then throw .invalidSession
+  let some (parent, rest) := pop frontier | throw .invalidSession
   if accounting.steps >= limits.maxSteps then throw (.resource .steps)
   if accounting.splits >= limits.maxSplits then throw (.resource .splits)
   if accounting.leaves >= limits.maxLeaves then throw (.resource .leaves)
   if accounting.scopes + 2 > limits.maxScopes then throw (.resource .scopes)
   let depth := parent.depth + 1
   if limits.maxDepth < depth then throw (.resource .depth)
+  preflightBranch stateLimits left.branch
+  preflightBranch stateLimits right.branch
   let expected := parent.asParent
-  if left.depth != depth || right.depth != depth || left.parent != some expected ||
-      right.parent != some expected || left.scope == right.scope ||
-      left.scope == parent.scope || right.scope == parent.scope ||
+  let some leftParent := left.parent | throw .invalidSession
+  let some rightParent := right.parent | throw .invalidSession
+  preflightBranch stateLimits leftParent.branch
+  preflightBranch stateLimits rightParent.branch
+  if !parent.branch.check || left.depth != depth || right.depth != depth ||
+      leftParent != expected || rightParent != expected ||
+      left.scope == right.scope || left.scope == parent.scope || right.scope == parent.scope ||
+      rest.pending.any (fun pending => pending.scope == left.scope || pending.scope == right.scope) ||
       left.scope.index != accounting.nextScope ||
       right.scope.index != accounting.nextScope + 1 ||
       !left.branch.check || !right.branch.check then throw .invalidSession

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -1,0 +1,517 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Policy
+
+@[expose] public section
+
+/-!
+# Authenticated search sessions
+
+This module is the supported, Mathlib-free ownership boundary for generic
+search. It authenticates policy choices against immutable views, binds the
+selected offer to an exact `Action`, and transactionally validates untrusted
+callback updates against `State.Branch`. It also supplies bounded tree
+accounting and stable depth-first/breadth-first frontier operations.
+
+The callback invocation and equality on caller-selected facts, causes,
+identifiers, keys, and payloads are explicitly non-preemptible. A callback
+must bound construction before returning. Search checks the returned action,
+counts, versions, write authority, retained diagnostic bytes, and declared
+work before it commits any branch mutation. Neither an accepted callback
+result nor a runtime contradiction is theorem evidence.
+
+Concrete callbacks, offer generation, package assembly, policy algorithms,
+storage choices, split semantics, and proof replay remain outside this module.
+-/
+
+namespace Hex.Interval.Search
+
+/-- Stable pending-leaf order. Equal-priority entries retain insertion order. -/
+inductive Order where
+  | depthFirst
+  | breadthFirst
+  deriving DecidableEq, Repr
+
+/-- Global run and retained-tree limits. `leafFuel` bounds one package-owned
+leaf driver; this layer only retains the value and does not interpret a
+callback step. -/
+structure Limits where
+  maxSteps : Nat
+  maxSplits : Nat
+  maxLeaves : Nat
+  maxFrontier : Nat
+  maxDepth : Nat
+  maxScopes : Nat
+  leafFuel : Nat
+  deriving DecidableEq, Repr
+
+/-- Exact global accounting. `leaves` counts retained current leaves, including
+settled leaves; a binary split increments it by one. -/
+structure Accounting where
+  steps : Nat := 0
+  splits : Nat := 0
+  leaves : Nat := 1
+  scopes : Nat := 1
+  nextScope : Nat := 1
+  deriving DecidableEq, Repr
+
+def Accounting.check (limits : Limits) (frontierCount : Nat)
+    (accounting : Accounting) : Bool :=
+    accounting.leaves == accounting.splits + 1 &&
+    accounting.scopes == accounting.splits * 2 + 1 &&
+    accounting.scopes ≤ accounting.nextScope &&
+    accounting.splits ≤ accounting.steps && frontierCount ≤ accounting.leaves &&
+    accounting.steps ≤ limits.maxSteps && accounting.splits ≤ limits.maxSplits &&
+    accounting.leaves ≤ limits.maxLeaves && accounting.scopes ≤ limits.maxScopes &&
+    frontierCount ≤ limits.maxFrontier
+
+inductive Resource where
+  | steps
+  | splits
+  | leaves
+  | frontier
+  | depth
+  | scopes
+  deriving DecidableEq, Repr
+
+/-- Precise generic stop classes. Package-specific errors remain an opaque
+callback code and cannot become proof evidence. -/
+inductive Stop (Reached Split : Type) where
+  | target (reached : Reached)
+  | saturated
+  | contradiction
+  | split (plan : Split)
+  | policyStop (liveOffers : Nat)
+  | incomplete
+  | callbackFailure (code : Nat)
+  | resource (resource : Resource)
+  | malformed
+
+/-- A stable front-to-back pending sequence. -/
+structure Frontier (α : Type) where
+  pending : List α
+  deriving DecidableEq, Repr
+
+namespace Frontier
+
+def singleton (item : α) : Frontier α := { pending := [item] }
+
+def isEmpty (frontier : Frontier α) : Bool := frontier.pending.isEmpty
+
+def head? (frontier : Frontier α) : Option α := frontier.pending.head?
+
+def tail (frontier : Frontier α) : Frontier α := { pending := frontier.pending.tail }
+
+/-- Schedule left-to-right fresh children either before or after the stable
+old suffix. -/
+def schedule (order : Order) (rest : Frontier α) (fresh : List α) : Frontier α :=
+  { pending := match order with
+    | .depthFirst => fresh ++ rest.pending
+    | .breadthFirst => rest.pending ++ fresh }
+
+end Frontier
+
+/-- One controller-owned offer and the exact action it authorizes. The policy
+sees only `view`. -/
+structure Offer (OfferId SemanticKey : Type) where
+  view : Policy.OfferView OfferId SemanticKey
+  action : Action
+  deriving DecidableEq
+
+/-- All supported envelopes for one authenticated session. -/
+structure Envelope where
+  state : State.Limits
+  policy : Policy.Limits
+  trace : Trace.Limit
+  search : Limits
+  deriving DecidableEq, Repr
+
+/-- A decoded session. Every mutating consumer rechecks this record; its public
+constructor grants no authority. -/
+structure Session (Fact Cause OfferId SemanticKey : Type) where
+  branch : State.Branch Fact Cause
+  rules : Array Registration
+  bindings : Array ScopeBinding
+  applicationGenerations : Array Nat
+  equalityGenerations : Array Nat
+  matcherEpoch : Nat
+  scope : Policy.ScopeId
+  serial : Nat
+  offers : Array (Offer OfferId SemanticKey)
+  remaining : Policy.EngineBudgetView
+  incomplete : Bool
+  trace : Trace.Log
+  accounting : Accounting
+
+def Session.view (session : Session Fact Cause OfferId SemanticKey) :
+    Policy.View Fact OfferId SemanticKey :=
+  { scope := session.scope
+    serial := session.serial
+    programVersion := session.branch.programVersion
+    offers := session.offers.map (·.view)
+    facts := session.branch.snapshot
+    remaining := session.remaining
+    incomplete := session.incomplete }
+
+def actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
+    (rules : Array Registration) (bindings : Array ScopeBinding)
+    (applicationGenerations equalityGenerations : Array Nat)
+    (matcherEpoch serial : Nat)
+    (action : Action) : Bool := Id.run do
+  if action.serial != serial || action.programVersion != branch.programVersion ||
+      limits.maxEffort < action.effort then
+    return false
+  let some applicationGeneration := applicationGenerations[action.application.index]?
+    | return false
+  if applicationGeneration != action.generation then return false
+  let some registration := rules[action.rule.index]? | return false
+  if registration.key != action.key || registration.kind != action.kind then return false
+  let some instruction := branch.program.node? action.node | return false
+  let some operation := branch.program.operation? instruction.op | return false
+  if operation.key != registration.head || !allDistinct action.inputs ||
+      !allDistinct action.writes || !allDistinct action.structuralInputs then return false
+  for seen in action.inputs do
+    let some version := branch.versions[seen.node.index]? | return false
+    if version != seen.version then return false
+  for node in action.writes do
+    if (branch.program.node? node).isNone then return false
+  for input in action.structuralInputs do
+    match input.key with
+    | .node node =>
+        let some generation := branch.generations[node.index]? | return false
+        if generation != input.generation then return false
+    | .application application =>
+        let some generation := applicationGenerations[application.index]? | return false
+        if generation != input.generation then return false
+    | .equality equality =>
+        let some generation := equalityGenerations[equality.index]? | return false
+        if generation != input.generation then return false
+  let inputNodes := action.inputs.map (·.node)
+  let bindingValid := match registration.binding with
+    | .local =>
+        Slot.resolveAll? action.node instruction registration.watches == some inputNodes &&
+          Slot.resolveAll? action.node instruction registration.writes == some action.writes
+    | .scoped =>
+        bindings.any fun binding =>
+          binding.rule == action.key && binding.anchor == action.node &&
+            binding.watches == inputNodes && binding.writes == action.writes
+    | .global => inputNodes.isEmpty && action.writes.isEmpty
+  let matcherValid := match registration.matchWatch with
+    | .none => action.matcherEpoch.isNone && action.structuralInputs.isEmpty
+    | .network => action.matcherEpoch == some matcherEpoch && !action.structuralInputs.isEmpty
+  return bindingValid && matcherValid
+
+def Session.check [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey) : Bool := Id.run do
+  if !session.branch.check ||
+      !Registration.check session.branch.program session.rules ||
+      !ScopeBinding.checkAll session.branch.program session.rules session.bindings ||
+      envelope.state.maxRules < session.rules.size ||
+      envelope.state.maxScopeNodes < session.bindings.size ||
+      envelope.state.maxApplications < session.applicationGenerations.size ||
+      envelope.state.maxEqualities < session.equalityGenerations.size ||
+      !session.accounting.check envelope.search 0 ||
+      !session.trace.check envelope.trace then return false
+  let view := session.view
+  match Policy.checkViewWithin envelope.policy measure session.branch.program view with
+  | .error _ => return false
+  | .ok _ => pure ()
+  for offer in session.offers do
+    if !actionCurrent envelope.state session.branch session.rules
+        session.bindings session.applicationGenerations session.equalityGenerations
+        session.matcherEpoch session.serial offer.action then
+      return false
+  return true
+
+inductive Error where
+  | invalidSession
+  | policy (error : Policy.Error)
+  | staleReply
+  | malformedOutcome
+  | unauthorizedWrite (node : NodeId)
+  | outcomeLimit
+  | state (error : State.BranchError)
+  | trace
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+/-- Build one exact checked session transactionally. Offer generation remains
+external; this builder only authenticates its complete returned snapshot. -/
+def Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (branch : State.Branch Fact Cause) (rules : Array Registration)
+    (bindings : Array ScopeBinding) (applicationGenerations equalityGenerations : Array Nat)
+    (matcherEpoch : Nat) (scope : Policy.ScopeId)
+    (offers : Array (Offer OfferId SemanticKey))
+    (remaining : Policy.EngineBudgetView := {}) (incomplete : Bool := false) :
+    Except Error (Session Fact Cause OfferId SemanticKey) := do
+  let session : Session Fact Cause OfferId SemanticKey :=
+    { branch
+      rules
+      bindings
+      applicationGenerations
+      equalityGenerations
+      matcherEpoch
+      scope
+      serial := 0
+      offers
+      remaining
+      incomplete
+      trace := {}
+      accounting := { nextScope := scope.index + 1 } }
+  if !session.check envelope measure then throw .invalidSession
+  pure session
+
+/-- Install a newly generated complete offer snapshot only after validating it
+against the exact current session. Failure preserves the preceding session. -/
+def Session.refreshWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    (envelope : Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (offers : Array (Offer OfferId SemanticKey))
+    (remaining : Policy.EngineBudgetView) (incomplete : Bool) :
+    Except Error (Session Fact Cause OfferId SemanticKey) := do
+  if !session.check envelope measure then throw .invalidSession
+  let next := { session with offers, remaining, incomplete }
+  if !next.check envelope measure then throw .invalidSession
+  pure next
+
+/-- Exact authenticated callback request. -/
+structure Request (Fact OfferId SemanticKey : Type) where
+  scope : Policy.ScopeId
+  serial : Nat
+  programVersion : Nat
+  offer : Policy.OfferView OfferId SemanticKey
+  action : Action
+  facts : Snapshot Fact
+
+/-- Untrusted callback delta. All identity fields must echo the exact request. -/
+structure Outcome (Fact Cause OfferId SemanticKey : Type) where
+  scope : Policy.ScopeId
+  serial : Nat
+  programVersion : Nat
+  offer : Policy.OfferView OfferId SemanticKey
+  action : Action
+  updates : Array (State.Update Fact Cause)
+  contradiction : Bool := false
+  diagnostic : Option Trace.Event := none
+
+/-- A callback either returns an untrusted delta or an exact bounded failure
+code. Both forms may carry a diagnostic assembled outside the preemptible
+envelope. -/
+inductive Reply (Fact Cause OfferId SemanticKey : Type)
+  | outcome (outcome : Outcome Fact Cause OfferId SemanticKey)
+  | failure (code : Nat) (diagnostic : Option Trace.Event := none)
+
+/-- A checked callback step either commits a replacement session or stops with
+an unchanged proof state. -/
+inductive Step (Fact Cause OfferId SemanticKey : Type)
+  | applied (session : Session Fact Cause OfferId SemanticKey)
+  | stopped (stop : Stop Unit Unit) (session : Session Fact Cause OfferId SemanticKey)
+
+/-- Checked interpretation of an external policy result. -/
+inductive Choice (PolicyState OfferId SemanticKey : Type)
+  | select (decision : Policy.Decision OfferId SemanticKey) (next : PolicyState)
+  | dismiss (decision : Policy.Decision OfferId SemanticKey) (next : PolicyState)
+  | stopped (stop : Stop Unit Unit) (next : PolicyState)
+
+variable {Fact Cause OfferId SemanticKey : Type}
+
+/-- Revalidate the policy's complete echoed offer, then return the exact
+controller-owned action request. -/
+def prepareWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) : Except Error (Request Fact OfferId SemanticKey) := do
+  if !session.check envelope measure then throw .invalidSession
+  let view := session.view
+  let selected <-
+    match Policy.checkDecisionWithin envelope.policy measure session.branch view decision with
+    | .ok selected => pure selected
+    | .error error => throw (.policy error)
+  let some offer := session.offers.find? fun offer => offer.view == selected
+    | throw .invalidSession
+  pure
+    { scope := session.scope
+      serial := session.serial
+      programVersion := session.branch.programVersion
+      offer := offer.view
+      action := offer.action
+      facts := session.branch.snapshot }
+
+/-- Run a replaceable policy over the exact checked view. A selected or
+dismissed offer is revalidated before its exact decision is returned; stopping
+cannot mutate the session. Policy callback execution is non-preemptible. -/
+def chooseWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (policy : Policy.Interface Fact PolicyState OfferId SemanticKey)
+    (policyState : PolicyState) (session : Session Fact Cause OfferId SemanticKey) :
+    Except Error (Choice PolicyState OfferId SemanticKey) := do
+  if !session.check envelope measure then throw .invalidSession
+  let view := session.view
+  match policy.choose policyState view with
+  | .stop next => pure (.stopped (.policyStop view.offers.size) next)
+  | .select offer next =>
+      let decision := Policy.select view offer
+      let _ <- prepareWithin envelope measure session decision
+      pure (.select decision next)
+  | .dismiss offer next =>
+      let decision := Policy.select view offer
+      let _ <- prepareWithin envelope measure session decision
+      pure (.dismiss decision next)
+
+def appendDiagnostic (limit : Trace.Limit) (log : Trace.Log)
+    (diagnostic : Option Trace.Event) : Except Error Trace.Log :=
+  match diagnostic with
+  | none => pure log
+  | some event =>
+      match log.append limit event with
+      | .retained next | .truncated next => pure next
+      | .malformed => throw .trace
+
+def sameReply [DecidableEq OfferId] [DecidableEq SemanticKey]
+    (request : Request Fact OfferId SemanticKey)
+    (outcome : Outcome Fact Cause OfferId SemanticKey) : Bool :=
+  outcome.scope == request.scope && outcome.serial == request.serial &&
+    outcome.programVersion == request.programVersion && outcome.offer == request.offer &&
+    outcome.action == request.action
+
+/-- Validate and commit the whole returned delta transactionally. Every event
+must be an exact successor for a node in the selected action's write set. The
+returned contradiction bit is runtime status only. -/
+def acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey)
+    (reply : Reply Fact Cause OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
+  if session.accounting.steps >= envelope.search.maxSteps then
+    return .stopped (.resource .steps) session
+  let request <- prepareWithin envelope measure session decision
+  match reply with
+  | .failure code diagnostic =>
+      if envelope.trace.maxCode < code then throw .malformedOutcome
+      let trace <- appendDiagnostic envelope.trace session.trace diagnostic
+      return .stopped (.callbackFailure code) { session with trace }
+  | .outcome outcome =>
+      if !sameReply request outcome then throw .staleReply
+      if envelope.state.maxOutcomeCandidates < outcome.updates.size then
+        throw .outcomeLimit
+      let mut branch := session.branch
+      for event in outcome.updates do
+        if !request.action.writes.contains event.node then
+          throw (.unauthorizedWrite event.node)
+        let next <-
+          match branch.pushWithin envelope.state event outcome.contradiction with
+          | .ok updated => pure updated
+          | .error error => throw (.state error)
+        branch := next
+      if outcome.contradiction && outcome.updates.isEmpty then throw .malformedOutcome
+      let trace <- appendDiagnostic envelope.trace session.trace outcome.diagnostic
+      let next : Session Fact Cause OfferId SemanticKey :=
+        { session with
+          branch
+          serial := session.serial + 1
+          offers := #[]
+          incomplete := true
+          trace
+          accounting := { session.accounting with steps := session.accounting.steps + 1 } }
+      pure (.applied next)
+
+/-- Invoke an arbitrary callback and then pass its decoded result through
+`acceptWithin`. Callback execution itself is deliberately non-preemptible and
+has no mutation authority. -/
+def invokeWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (callback : Request Fact OfferId SemanticKey -> Reply Fact Cause OfferId SemanticKey)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
+  let request <- prepareWithin envelope measure session decision
+  acceptWithin envelope measure session decision (callback request)
+
+/-- Exact retained parent snapshot for a child. -/
+structure Parent (Fact Cause : Type) where
+  scope : Policy.ScopeId
+  depth : Nat
+  branch : State.Branch Fact Cause
+  deriving DecidableEq
+
+/-- One pending leaf. Payload construction is outside the preemptible search
+envelope. -/
+structure Leaf (Fact Cause Payload : Type) where
+  scope : Policy.ScopeId
+  depth : Nat
+  branch : State.Branch Fact Cause
+  parent : Option (Parent Fact Cause) := none
+  payload : Payload
+
+def Leaf.asParent (leaf : Leaf Fact Cause Payload) : Parent Fact Cause :=
+  { scope := leaf.scope, depth := leaf.depth, branch := leaf.branch }
+
+/-- Restore the exact retained parent, including versions, provenance, scope,
+and contradiction state. -/
+def Leaf.restoreParent? (leaf : Leaf Fact Cause Payload) : Option (Parent Fact Cause) :=
+  leaf.parent
+
+/-- Build a root frontier after all count caps admit it. -/
+def startFrontierWithin (limits : Limits) (root : Leaf Fact Cause Payload) :
+    Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
+  if limits.maxLeaves < 1 then throw (.resource .leaves)
+  if limits.maxScopes < 1 then throw (.resource .scopes)
+  if limits.maxFrontier < 1 then throw (.resource .frontier)
+  if root.depth != 0 || root.parent.isSome || !root.branch.check then throw .invalidSession
+  pure ({ nextScope := root.scope.index + 1 }, .singleton root)
+
+/-- Pop the stable next pending leaf. -/
+def pop (frontier : Frontier α) : Option (α × Frontier α) := do
+  let head <- frontier.head?
+  pure (head, frontier.tail)
+
+/-- Retain a terminal leaf and charge exactly one processing step. -/
+def settleWithin (limits : Limits) (frontierCount : Nat) (accounting : Accounting) :
+    Except Error Accounting := do
+  if !accounting.check limits (frontierCount + 1) then throw .invalidSession
+  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
+  pure { accounting with steps := accounting.steps + 1 }
+
+/-- Admit an exact binary split and schedule its children transactionally.
+The package owns child semantics; generic search authenticates the retained
+parent, checked child branches, fresh scopes, depth, and global resources. -/
+def splitWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (order : Order) (accounting : Accounting)
+    (parent : Leaf Fact Cause Payload) (rest : Frontier (Leaf Fact Cause Payload))
+    (left right : Leaf Fact Cause Payload) :
+    Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
+  if !accounting.check limits (rest.pending.length + 1) then throw .invalidSession
+  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
+  if accounting.splits >= limits.maxSplits then throw (.resource .splits)
+  if accounting.leaves >= limits.maxLeaves then throw (.resource .leaves)
+  if accounting.scopes + 2 > limits.maxScopes then throw (.resource .scopes)
+  let depth := parent.depth + 1
+  if limits.maxDepth < depth then throw (.resource .depth)
+  let expected := parent.asParent
+  if left.depth != depth || right.depth != depth || left.parent != some expected ||
+      right.parent != some expected || left.scope == right.scope ||
+      left.scope == parent.scope || right.scope == parent.scope ||
+      left.scope.index != accounting.nextScope ||
+      right.scope.index != accounting.nextScope + 1 ||
+      !left.branch.check || !right.branch.check then throw .invalidSession
+  if limits.maxFrontier < rest.pending.length + 2 then throw (.resource .frontier)
+  let accounting :=
+    { steps := accounting.steps + 1
+      splits := accounting.splits + 1
+      leaves := accounting.leaves + 1
+      scopes := accounting.scopes + 2
+      nextScope := accounting.nextScope + 2 }
+  pure (accounting, rest.schedule order [left, right])
+
+end Hex.Interval.Search

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -28,6 +28,13 @@ result nor a runtime contradiction is theorem evidence.
 
 Concrete callbacks, offer generation, package assembly, policy algorithms,
 storage choices, split semantics, and proof replay remain outside this module.
+
+Here and below, "sealed" means sealed at the ordinary/public import boundary.
+Lean's deliberate `import all HexInterval.Search` escape hatch exposes private
+implementation names to trusted source. Such source is already outside the
+decoded-runtime threat model (and can use `unsafe` or introduce axioms); a
+repository static check rejects accidental uses outside an exact reviewed
+allowlist.
 -/
 
 namespace Hex.Interval.Search
@@ -118,8 +125,8 @@ def schedule (order : Order) (rest : Frontier α) (fresh : List α) : Frontier �
 
 end Frontier
 
-/-- A sealed pending frontier and the cumulative accounting that governs it.
-The private constructor prevents a fresh counter from being transplanted onto
+/-- An ordinary-import-sealed pending frontier and its cumulative accounting.
+The private constructor prevents public-import clients from transplanting a fresh counter onto
 an existing frontier, or an independently edited frontier from being paired
 with live counters. -/
 structure FrontierState (α : Type) where
@@ -208,8 +215,8 @@ private def frontierCountWithin (limits : Limits) (frontier : Frontier α) :
 
 namespace FrontierState
 
-/-- Start a sealed singleton frontier. This is the only reset point; consumers
-must keep the returned composite inside their own sealed live state. -/
+/-- Start an ordinary-import-sealed singleton frontier. This is the only public
+reset point; consumers keep the composite inside their own sealed live state. -/
 opaque startWithin (limits : Limits) (scope : Policy.ScopeId) (root : α) :
     Except Error (FrontierState α) := do
   if limits.maxFrontier < 1 then throw (.resource .frontier)
@@ -240,8 +247,8 @@ opaque splitHeadWithin (limits : Limits) (order : Order) (state : FrontierState 
 
 end FrontierState
 
-/-- A sealed live search session. `startWithin` is the documented reset point
-for a new run; subsequent transitions preserve its cumulative step count. -/
+/-- An ordinary-import-sealed live search session. `startWithin` is the public
+reset point for a new run; later transitions preserve its cumulative steps. -/
 structure Session (Fact Cause OfferId SemanticKey : Type) where
   private mk ::
   branch : State.Branch Fact Cause
@@ -695,8 +702,8 @@ structure Leaf (Fact Cause Payload : Type) where
   payload : Payload
   deriving DecidableEq
 
-/-- A sealed leaf frontier. Its inner generic frontier is readable for
-inspection, but only the specialized checked transitions can construct another
+/-- An ordinary-import-sealed leaf frontier. Read-only projections expose its
+contents, but only specialized checked public transitions construct another
 `LeafFrontier`; generic scheduling therefore cannot bypass leaf invariants. -/
 structure LeafFrontier (Fact Cause Payload : Type) where
   private mk ::

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -248,7 +248,9 @@ opaque splitHeadWithin (limits : Limits) (order : Order) (state : FrontierState 
 end FrontierState
 
 /-- An ordinary-import-sealed live search session. `startWithin` is the public
-reset point for a new run; later transitions preserve its cumulative steps. -/
+reset point for a new run; later transitions preserve its cumulative steps.
+The checked `Envelope` is supplied per call rather than retained in the value,
+so a later transition may use different, including tighter, limits. -/
 structure Session (Fact Cause OfferId SemanticKey : Type) where
   private mk ::
   branch : State.Branch Fact Cause

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -217,7 +217,7 @@ opaque startWithin (limits : Limits) (scope : Policy.ScopeId) (root : α) :
   pure { accounting, frontier := .singleton root }
 
 /-- Pop and charge the exact head of a sealed frontier. -/
-opaque settleWithin (limits : Limits) (state : FrontierState α) :
+opaque settleHeadWithin (limits : Limits) (state : FrontierState α) :
     Except Error (α × FrontierState α) := do
   let count <- frontierCountWithin limits state.frontier
   let some head := state.frontier.head? | throw .invalidSession
@@ -228,7 +228,7 @@ opaque settleWithin (limits : Limits) (state : FrontierState α) :
 caller-validated pending children. This container transition authenticates
 only cumulative resources and ordering; the enclosing sealed controller owns
 child semantics. -/
-opaque splitWithin (limits : Limits) (order : Order) (state : FrontierState α)
+opaque splitHeadWithin (limits : Limits) (order : Order) (state : FrontierState α)
     (fresh : List α) : Except Error (α × FrontierState α) := do
   if !listWithin 2 fresh then throw .invalidSession
   let count <- frontierCountWithin limits state.frontier
@@ -695,6 +695,31 @@ structure Leaf (Fact Cause Payload : Type) where
   payload : Payload
   deriving DecidableEq
 
+/-- A sealed leaf frontier. Its inner generic frontier is readable for
+inspection, but only the specialized checked transitions can construct another
+`LeafFrontier`; generic scheduling therefore cannot bypass leaf invariants. -/
+structure LeafFrontier (Fact Cause Payload : Type) where
+  private mk ::
+  private state : FrontierState (Leaf Fact Cause Payload)
+
+opaque LeafFrontier.accounting (frontier : LeafFrontier Fact Cause Payload) : Accounting :=
+  frontier.state.accounting
+
+opaque LeafFrontier.frontier (state : LeafFrontier Fact Cause Payload) :
+    Frontier (Leaf Fact Cause Payload) :=
+  state.state.frontier
+
+opaque LeafFrontier.pending (state : LeafFrontier Fact Cause Payload) :
+    List (Leaf Fact Cause Payload) :=
+  state.state.pending
+
+opaque LeafFrontier.isEmpty (state : LeafFrontier Fact Cause Payload) : Bool :=
+  state.state.isEmpty
+
+opaque LeafFrontier.head? (state : LeafFrontier Fact Cause Payload) :
+    Option (Leaf Fact Cause Payload) :=
+  state.state.head?
+
 def Leaf.asParent (leaf : Leaf Fact Cause Payload) : Parent Fact Cause :=
   { scope := leaf.scope, depth := leaf.depth, branch := leaf.branch }
 
@@ -704,13 +729,13 @@ def Leaf.restoreParent? (leaf : Leaf Fact Cause Payload) : Option (Parent Fact C
   leaf.parent
 
 /-- Build a root frontier after all structural and count caps admit it. -/
-opaque startFrontierWithin (stateLimits : State.Limits) (limits : Limits)
+opaque LeafFrontier.startWithin (stateLimits : State.Limits) (limits : Limits)
     (root : Leaf Fact Cause Payload) :
-    Except Error (FrontierState (Leaf Fact Cause Payload)) := do
+    Except Error (LeafFrontier Fact Cause Payload) := do
   let state <- FrontierState.startWithin limits root.scope root
   preflightBranch stateLimits root.branch
   if root.depth != 0 || root.parent.isSome || !root.branch.check then throw .invalidSession
-  pure state
+  pure { state }
 
 /-- Pop the stable next pending leaf. -/
 def pop (frontier : Frontier α) : Option (α × Frontier α) := do
@@ -719,20 +744,21 @@ def pop (frontier : Frontier α) : Option (α × Frontier α) := do
 
 /-- Retain and return the authenticated frontier head while charging exactly
 one processing step in the same sealed frontier state. -/
-def settleWithin (limits : Limits) (state : FrontierState α) :
-    Except Error (α × FrontierState α) :=
-  state.settleWithin limits
+opaque LeafFrontier.settleWithin (limits : Limits) (state : LeafFrontier Fact Cause Payload) :
+    Except Error (Leaf Fact Cause Payload × LeafFrontier Fact Cause Payload) := do
+  let (leaf, next) <- state.state.settleHeadWithin limits
+  pure (leaf, { state := next })
 
 /-- Admit an exact binary split and schedule its children transactionally.
 The package owns child semantics; generic search authenticates the retained
 frontier head as the parent, checked child branches, fresh scopes, depth, and
 global resources. -/
-opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
+opaque LeafFrontier.splitWithin [DecidableEq Fact] [DecidableEq Cause]
     (stateLimits : State.Limits) (limits : Limits) (order : Order)
-    (state : FrontierState (Leaf Fact Cause Payload))
+    (state : LeafFrontier Fact Cause Payload)
     (left right : Leaf Fact Cause Payload) :
-    Except Error (FrontierState (Leaf Fact Cause Payload)) := do
-  let (parent, next) <- state.splitWithin limits order [left, right]
+    Except Error (LeafFrontier Fact Cause Payload) := do
+  let (parent, next) <- state.state.splitHeadWithin limits order [left, right]
   let frontier := state.frontier
   for pending in state.pending do
     preflightBranch stateLimits pending.branch
@@ -757,6 +783,12 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
       left.scope.index != state.accounting.nextScope ||
       right.scope.index != state.accounting.nextScope + 1 ||
       !left.branch.check || !right.branch.check then throw .invalidSession
-  pure next
+  pure { state := next }
+
+def startFrontierWithin := @LeafFrontier.startWithin
+
+def settleWithin := @LeafFrontier.settleWithin
+
+def splitWithin := @LeafFrontier.splitWithin
 
 end Hex.Interval.Search

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -54,12 +54,12 @@ structure Limits where
 /-- Exact global accounting. `leaves` counts retained current leaves, including
 settled leaves; a binary split increments it by one. -/
 structure Accounting where
+  private mk ::
   steps : Nat := 0
   splits : Nat := 0
   leaves : Nat := 1
   scopes : Nat := 1
   nextScope : Nat := 1
-  deriving DecidableEq, Repr
 
 def Accounting.check (limits : Limits) (frontierCount : Nat)
     (accounting : Accounting) : Bool :=
@@ -145,6 +145,61 @@ inductive Error where
   | resource (resource : Resource)
   deriving DecidableEq, Repr
 
+/-- Check a decoded list against a cap without traversing beyond the first
+disallowed cell. -/
+def listWithin : Nat -> List α -> Bool
+  | _, [] => true
+  | 0, _ :: _ => false
+  | limit + 1, _ :: rest => listWithin limit rest
+
+namespace Accounting
+
+private def frontierCountWithin (limits : Limits) (frontier : Frontier α) :
+    Except Error Nat := do
+  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
+  pure frontier.pending.length
+
+/-- Create the only initial accounting value for one exact singleton
+frontier. The private constructor prevents decoded callers from choosing
+counters or `nextScope` directly. -/
+opaque startWithin (limits : Limits) (scope : Policy.ScopeId) (frontier : Frontier α) :
+    Except Error Accounting := do
+  let count <- frontierCountWithin limits frontier
+  if count != 1 then throw .invalidSession
+  if limits.maxLeaves < 1 then throw (.resource .leaves)
+  if limits.maxScopes < 1 then throw (.resource .scopes)
+  let accounting : Accounting := { nextScope := scope.index + 1 }
+  if !accounting.check limits count then throw .invalidSession
+  pure accounting
+
+/-- Charge one authenticated non-split step against a nonempty frontier. -/
+opaque settleWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
+    Except Error Accounting := do
+  let count <- frontierCountWithin limits frontier
+  if count == 0 || !accounting.check limits count then throw .invalidSession
+  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
+  pure { accounting with steps := accounting.steps + 1 }
+
+/-- Charge one binary split of the authenticated frontier head. Child meaning,
+depth, and branch checks remain the caller's responsibility. -/
+opaque splitWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
+    Except Error Accounting := do
+  let count <- frontierCountWithin limits frontier
+  if count == 0 || !accounting.check limits count then throw .invalidSession
+  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
+  if accounting.splits >= limits.maxSplits then throw (.resource .splits)
+  if accounting.leaves >= limits.maxLeaves then throw (.resource .leaves)
+  if accounting.scopes + 2 > limits.maxScopes then throw (.resource .scopes)
+  if limits.maxFrontier < count + 1 then throw (.resource .frontier)
+  pure
+    { steps := accounting.steps + 1
+      splits := accounting.splits + 1
+      leaves := accounting.leaves + 1
+      scopes := accounting.scopes + 2
+      nextScope := accounting.nextScope + 2 }
+
+end Accounting
+
 /-- A decoded session. Every mutating consumer rechecks this record; its public
 constructor grants no authority. -/
 structure Session (Fact Cause OfferId SemanticKey : Type) where
@@ -174,13 +229,6 @@ def Session.view (session : Session Fact Cause OfferId SemanticKey) :
     facts := session.branch.snapshot
     remaining := session.remaining
     incomplete := session.incomplete }
-
-/-- Check a decoded list against a cap without traversing beyond the first
-disallowed cell. -/
-def listWithin : Nat -> List α -> Bool
-  | _, [] => true
-  | 0, _ :: _ => false
-  | limit + 1, _ :: rest => listWithin limit rest
 
 private def stateResource (resource : State.Resource) : Error :=
   .resource (.state resource)
@@ -262,7 +310,7 @@ private def preflightSession (limits : State.Limits)
   for offer in session.offers do
     preflightAction limits session.rules offer.action
 
-private def actionCurrentWithin (limits : State.Limits) (branch : State.Branch Fact Cause)
+private def actionCurrentChecked (limits : State.Limits) (branch : State.Branch Fact Cause)
     (rules : Array Registration) (bindings : Array ScopeBinding)
     (applicationGenerations equalityGenerations : Array Nat)
     (matcherEpoch serial : Nat)
@@ -277,7 +325,6 @@ private def actionCurrentWithin (limits : State.Limits) (branch : State.Branch F
   let some registration := rules[action.rule.index]? | throw .invalidSession
   if registration.key != action.key || registration.kind != action.kind then
     throw .invalidSession
-  preflightAction limits rules action
   let some instruction := branch.program.node? action.node | throw .invalidSession
   let some operation := branch.program.operation? instruction.op | throw .invalidSession
   if operation.key != registration.head || !allDistinct action.inputs ||
@@ -318,8 +365,10 @@ opaque actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
     (rules : Array Registration) (bindings : Array ScopeBinding)
     (applicationGenerations equalityGenerations : Array Nat)
     (matcherEpoch serial : Nat) (action : Action) : Bool :=
-  (actionCurrentWithin limits branch rules bindings applicationGenerations
-    equalityGenerations matcherEpoch serial action).isOk
+  (do
+    preflightAction limits rules action
+    actionCurrentChecked limits branch rules bindings applicationGenerations
+      equalityGenerations matcherEpoch serial action).isOk
 
 private structure Checked (Fact OfferId SemanticKey : Type) where
   view : Policy.View Fact OfferId SemanticKey
@@ -349,7 +398,7 @@ private def authenticate [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Off
   | .error error => throw (.policy error)
   | .ok _ => pure ()
   for offer in session.offers do
-    actionCurrentWithin envelope.state session.branch session.rules
+    actionCurrentChecked envelope.state session.branch session.rules
       session.bindings session.applicationGenerations session.equalityGenerations
       session.matcherEpoch session.serial offer.action
   pure { view }
@@ -369,6 +418,7 @@ opaque Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq O
     (offers : Array (Offer OfferId SemanticKey))
     (remaining : Policy.EngineBudgetView := {}) (incomplete : Bool := false) :
     Except Error (Session Fact Cause OfferId SemanticKey) := do
+  let accounting <- Accounting.startWithin envelope.search scope (.singleton ())
   let session : Session Fact Cause OfferId SemanticKey :=
     { branch
       rules
@@ -382,7 +432,7 @@ opaque Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq O
       remaining
       incomplete
       trace := {}
-      accounting := { nextScope := scope.index + 1 } }
+      accounting }
   let _ <- authenticate envelope measure session
   pure session
 
@@ -548,6 +598,7 @@ private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
         branch <- pushChecked branch event outcome.contradiction
       if outcome.contradiction && outcome.updates.isEmpty then throw .malformedOutcome
       let trace <- appendDiagnostic envelope.trace session.trace outcome.diagnostic
+      let accounting <- Accounting.settleWithin envelope.search (.singleton ()) session.accounting
       let next : Session Fact Cause OfferId SemanticKey :=
         { session with
           branch
@@ -555,7 +606,7 @@ private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
           offers := #[]
           incomplete := true
           trace
-          accounting := { session.accounting with steps := session.accounting.steps + 1 } }
+          accounting }
       pure (.applied next)
 
 /-- Validate and commit the whole returned delta transactionally. Every event
@@ -617,12 +668,11 @@ def Leaf.restoreParent? (leaf : Leaf Fact Cause Payload) : Option (Parent Fact C
 opaque startFrontierWithin (stateLimits : State.Limits) (limits : Limits)
     (root : Leaf Fact Cause Payload) :
     Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
-  if limits.maxLeaves < 1 then throw (.resource .leaves)
-  if limits.maxScopes < 1 then throw (.resource .scopes)
-  if limits.maxFrontier < 1 then throw (.resource .frontier)
+  let frontier := .singleton root
+  let accounting <- Accounting.startWithin limits root.scope frontier
   preflightBranch stateLimits root.branch
   if root.depth != 0 || root.parent.isSome || !root.branch.check then throw .invalidSession
-  pure ({ nextScope := root.scope.index + 1 }, .singleton root)
+  pure (accounting, frontier)
 
 /-- Pop the stable next pending leaf. -/
 def pop (frontier : Frontier α) : Option (α × Frontier α) := do
@@ -632,12 +682,8 @@ def pop (frontier : Frontier α) : Option (α × Frontier α) := do
 /-- Retain the authenticated frontier head as a terminal leaf and charge
 exactly one processing step. The caller cannot substitute a detached count. -/
 def settleWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
-    Except Error Accounting := do
-  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
-  if frontier.pending.isEmpty ||
-      !accounting.check limits frontier.pending.length then throw .invalidSession
-  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
-  pure { accounting with steps := accounting.steps + 1 }
+    Except Error Accounting :=
+  Accounting.settleWithin limits frontier accounting
 
 /-- Admit an exact binary split and schedule its children transactionally.
 The package owns child semantics; generic search authenticates the retained
@@ -648,19 +694,14 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
     (accounting : Accounting) (frontier : Frontier (Leaf Fact Cause Payload))
     (left right : Leaf Fact Cause Payload) :
     Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
-  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
+  let nextAccounting <- Accounting.splitWithin limits frontier accounting
   for pending in frontier.pending do
     preflightBranch stateLimits pending.branch
     match pending.parent with
     | none => pure ()
     | some retained => preflightBranch stateLimits retained.branch
   if !allDistinct (frontier.pending.map (·.scope)) then throw .invalidSession
-  if !accounting.check limits frontier.pending.length then throw .invalidSession
   let some (parent, rest) := pop frontier | throw .invalidSession
-  if accounting.steps >= limits.maxSteps then throw (.resource .steps)
-  if accounting.splits >= limits.maxSplits then throw (.resource .splits)
-  if accounting.leaves >= limits.maxLeaves then throw (.resource .leaves)
-  if accounting.scopes + 2 > limits.maxScopes then throw (.resource .scopes)
   let depth := parent.depth + 1
   if limits.maxDepth < depth then throw (.resource .depth)
   preflightBranch stateLimits left.branch
@@ -677,13 +718,6 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
       left.scope.index != accounting.nextScope ||
       right.scope.index != accounting.nextScope + 1 ||
       !left.branch.check || !right.branch.check then throw .invalidSession
-  if limits.maxFrontier < rest.pending.length + 2 then throw (.resource .frontier)
-  let accounting :=
-    { steps := accounting.steps + 1
-      splits := accounting.splits + 1
-      leaves := accounting.leaves + 1
-      scopes := accounting.scopes + 2
-      nextScope := accounting.nextScope + 2 }
-  pure (accounting, rest.schedule order [left, right])
+  pure (nextAccounting, rest.schedule order [left, right])
 
 end Hex.Interval.Search

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -118,6 +118,25 @@ def schedule (order : Order) (rest : Frontier α) (fresh : List α) : Frontier �
 
 end Frontier
 
+/-- A sealed pending frontier and the cumulative accounting that governs it.
+The private constructor prevents a fresh counter from being transplanted onto
+an existing frontier, or an independently edited frontier from being paired
+with live counters. -/
+structure FrontierState (α : Type) where
+  private mk ::
+  accounting : Accounting
+  frontier : Frontier α
+
+namespace FrontierState
+
+def pending (state : FrontierState α) : List α := state.frontier.pending
+
+def isEmpty (state : FrontierState α) : Bool := state.frontier.isEmpty
+
+def head? (state : FrontierState α) : Option α := state.frontier.head?
+
+end FrontierState
+
 /-- One controller-owned offer and the exact action it authorizes. The policy
 sees only `view`. -/
 structure Offer (OfferId SemanticKey : Type) where
@@ -152,45 +171,29 @@ def listWithin : Nat -> List α -> Bool
   | 0, _ :: _ => false
   | limit + 1, _ :: rest => listWithin limit rest
 
-namespace Accounting
-
-private def frontierCountWithin (limits : Limits) (frontier : Frontier α) :
-    Except Error Nat := do
-  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
-  pure frontier.pending.length
-
-/-- Create the only initial accounting value for one exact singleton
-frontier. The private constructor prevents decoded callers from choosing
-counters or `nextScope` directly. -/
-opaque startWithin (limits : Limits) (scope : Policy.ScopeId) (frontier : Frontier α) :
+private def Accounting.startWithin (limits : Limits) (scope : Policy.ScopeId) :
     Except Error Accounting := do
-  let count <- frontierCountWithin limits frontier
-  if count != 1 then throw .invalidSession
   if limits.maxLeaves < 1 then throw (.resource .leaves)
   if limits.maxScopes < 1 then throw (.resource .scopes)
   let accounting : Accounting := { nextScope := scope.index + 1 }
-  if !accounting.check limits count then throw .invalidSession
+  if !accounting.check limits 1 then throw .invalidSession
   pure accounting
 
-/-- Charge one authenticated non-split step against a nonempty frontier. -/
-opaque settleWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
+private def Accounting.settleWithin (limits : Limits) (frontierCount : Nat)
+    (accounting : Accounting) :
     Except Error Accounting := do
-  let count <- frontierCountWithin limits frontier
-  if count == 0 || !accounting.check limits count then throw .invalidSession
+  if frontierCount == 0 || !accounting.check limits frontierCount then throw .invalidSession
   if accounting.steps >= limits.maxSteps then throw (.resource .steps)
   pure { accounting with steps := accounting.steps + 1 }
 
-/-- Charge one binary split of the authenticated frontier head. Child meaning,
-depth, and branch checks remain the caller's responsibility. -/
-opaque splitWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
+private def Accounting.splitWithin (limits : Limits) (frontierCount : Nat)
+    (accounting : Accounting) :
     Except Error Accounting := do
-  let count <- frontierCountWithin limits frontier
-  if count == 0 || !accounting.check limits count then throw .invalidSession
+  if frontierCount == 0 || !accounting.check limits frontierCount then throw .invalidSession
   if accounting.steps >= limits.maxSteps then throw (.resource .steps)
   if accounting.splits >= limits.maxSplits then throw (.resource .splits)
   if accounting.leaves >= limits.maxLeaves then throw (.resource .leaves)
   if accounting.scopes + 2 > limits.maxScopes then throw (.resource .scopes)
-  if limits.maxFrontier < count + 1 then throw (.resource .frontier)
   pure
     { steps := accounting.steps + 1
       splits := accounting.splits + 1
@@ -198,11 +201,49 @@ opaque splitWithin (limits : Limits) (frontier : Frontier α) (accounting : Acco
       scopes := accounting.scopes + 2
       nextScope := accounting.nextScope + 2 }
 
-end Accounting
+private def frontierCountWithin (limits : Limits) (frontier : Frontier α) :
+    Except Error Nat := do
+  if !listWithin limits.maxFrontier frontier.pending then throw (.resource .frontier)
+  pure frontier.pending.length
 
-/-- A decoded session. Every mutating consumer rechecks this record; its public
-constructor grants no authority. -/
+namespace FrontierState
+
+/-- Start a sealed singleton frontier. This is the only reset point; consumers
+must keep the returned composite inside their own sealed live state. -/
+opaque startWithin (limits : Limits) (scope : Policy.ScopeId) (root : α) :
+    Except Error (FrontierState α) := do
+  if limits.maxFrontier < 1 then throw (.resource .frontier)
+  let accounting <- Accounting.startWithin limits scope
+  pure { accounting, frontier := .singleton root }
+
+/-- Pop and charge the exact head of a sealed frontier. -/
+opaque settleWithin (limits : Limits) (state : FrontierState α) :
+    Except Error (α × FrontierState α) := do
+  let count <- frontierCountWithin limits state.frontier
+  let some head := state.frontier.head? | throw .invalidSession
+  let accounting <- Accounting.settleWithin limits count state.accounting
+  pure (head, { accounting, frontier := state.frontier.tail })
+
+/-- Pop and charge the exact head of a sealed frontier, then schedule the
+caller-validated pending children. This container transition authenticates
+only cumulative resources and ordering; the enclosing sealed controller owns
+child semantics. -/
+opaque splitWithin (limits : Limits) (order : Order) (state : FrontierState α)
+    (fresh : List α) : Except Error (α × FrontierState α) := do
+  if !listWithin 2 fresh then throw .invalidSession
+  let count <- frontierCountWithin limits state.frontier
+  let some head := state.frontier.head? | throw .invalidSession
+  let accounting <- Accounting.splitWithin limits count state.accounting
+  let frontier := state.frontier.tail.schedule order fresh
+  let _ <- frontierCountWithin limits frontier
+  pure (head, { accounting, frontier })
+
+end FrontierState
+
+/-- A sealed live search session. `startWithin` is the documented reset point
+for a new run; subsequent transitions preserve its cumulative step count. -/
 structure Session (Fact Cause OfferId SemanticKey : Type) where
+  private mk ::
   branch : State.Branch Fact Cause
   rules : Array Registration
   bindings : Array ScopeBinding
@@ -218,7 +259,7 @@ structure Session (Fact Cause OfferId SemanticKey : Type) where
   remaining : Policy.EngineBudgetView
   incomplete : Bool
   trace : Trace.Log
-  accounting : Accounting
+  steps : Nat
 
 def Session.view (session : Session Fact Cause OfferId SemanticKey) :
     Policy.View Fact OfferId SemanticKey :=
@@ -383,7 +424,7 @@ private def authenticate [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Off
   let some snapshot := session.branch.checkedSnapshot? | throw .invalidSession
   if !Registration.check session.branch.program session.rules ||
       !ScopeBinding.checkAll session.branch.program session.rules session.bindings ||
-      !session.accounting.check envelope.search 0 ||
+      envelope.search.maxSteps < session.steps ||
       !session.trace.check envelope.trace then
     throw .invalidSession
   let view : Policy.View Fact OfferId SemanticKey :=
@@ -418,7 +459,6 @@ opaque Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq O
     (offers : Array (Offer OfferId SemanticKey))
     (remaining : Policy.EngineBudgetView := {}) (incomplete : Bool := false) :
     Except Error (Session Fact Cause OfferId SemanticKey) := do
-  let accounting <- Accounting.startWithin envelope.search scope (.singleton ())
   let session : Session Fact Cause OfferId SemanticKey :=
     { branch
       rules
@@ -432,7 +472,7 @@ opaque Session.startWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq O
       remaining
       incomplete
       trace := {}
-      accounting }
+      steps := 0 }
   let _ <- authenticate envelope measure session
   pure session
 
@@ -598,7 +638,6 @@ private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
         branch <- pushChecked branch event outcome.contradiction
       if outcome.contradiction && outcome.updates.isEmpty then throw .malformedOutcome
       let trace <- appendDiagnostic envelope.trace session.trace outcome.diagnostic
-      let accounting <- Accounting.settleWithin envelope.search (.singleton ()) session.accounting
       let next : Session Fact Cause OfferId SemanticKey :=
         { session with
           branch
@@ -606,7 +645,7 @@ private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
           offers := #[]
           incomplete := true
           trace
-          accounting }
+          steps := session.steps + 1 }
       pure (.applied next)
 
 /-- Validate and commit the whole returned delta transactionally. Every event
@@ -620,7 +659,7 @@ opaque acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (reply : Reply Fact Cause OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
   let checked <- authenticate envelope measure session
   let request <- prepareChecked session checked decision
-  if session.accounting.steps >= envelope.search.maxSteps then
+  if session.steps >= envelope.search.maxSteps then
     return .stopped (.resource .steps) session
   acceptChecked envelope session request reply
 
@@ -635,7 +674,7 @@ opaque invokeWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (decision : Policy.Decision OfferId SemanticKey) : Except Error (Step Fact Cause OfferId SemanticKey) := do
   let checked <- authenticate envelope measure session
   let request <- prepareChecked session checked decision
-  if session.accounting.steps >= envelope.search.maxSteps then
+  if session.steps >= envelope.search.maxSteps then
     return .stopped (.resource .steps) session
   acceptChecked envelope session request (callback request)
 
@@ -667,23 +706,22 @@ def Leaf.restoreParent? (leaf : Leaf Fact Cause Payload) : Option (Parent Fact C
 /-- Build a root frontier after all structural and count caps admit it. -/
 opaque startFrontierWithin (stateLimits : State.Limits) (limits : Limits)
     (root : Leaf Fact Cause Payload) :
-    Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
-  let frontier := .singleton root
-  let accounting <- Accounting.startWithin limits root.scope frontier
+    Except Error (FrontierState (Leaf Fact Cause Payload)) := do
+  let state <- FrontierState.startWithin limits root.scope root
   preflightBranch stateLimits root.branch
   if root.depth != 0 || root.parent.isSome || !root.branch.check then throw .invalidSession
-  pure (accounting, frontier)
+  pure state
 
 /-- Pop the stable next pending leaf. -/
 def pop (frontier : Frontier α) : Option (α × Frontier α) := do
   let head <- frontier.head?
   pure (head, frontier.tail)
 
-/-- Retain the authenticated frontier head as a terminal leaf and charge
-exactly one processing step. The caller cannot substitute a detached count. -/
-def settleWithin (limits : Limits) (frontier : Frontier α) (accounting : Accounting) :
-    Except Error Accounting :=
-  Accounting.settleWithin limits frontier accounting
+/-- Retain and return the authenticated frontier head while charging exactly
+one processing step in the same sealed frontier state. -/
+def settleWithin (limits : Limits) (state : FrontierState α) :
+    Except Error (α × FrontierState α) :=
+  state.settleWithin limits
 
 /-- Admit an exact binary split and schedule its children transactionally.
 The package owns child semantics; generic search authenticates the retained
@@ -691,17 +729,17 @@ frontier head as the parent, checked child branches, fresh scopes, depth, and
 global resources. -/
 opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
     (stateLimits : State.Limits) (limits : Limits) (order : Order)
-    (accounting : Accounting) (frontier : Frontier (Leaf Fact Cause Payload))
+    (state : FrontierState (Leaf Fact Cause Payload))
     (left right : Leaf Fact Cause Payload) :
-    Except Error (Accounting × Frontier (Leaf Fact Cause Payload)) := do
-  let nextAccounting <- Accounting.splitWithin limits frontier accounting
-  for pending in frontier.pending do
+    Except Error (FrontierState (Leaf Fact Cause Payload)) := do
+  let (parent, next) <- state.splitWithin limits order [left, right]
+  let frontier := state.frontier
+  for pending in state.pending do
     preflightBranch stateLimits pending.branch
     match pending.parent with
     | none => pure ()
     | some retained => preflightBranch stateLimits retained.branch
   if !allDistinct (frontier.pending.map (·.scope)) then throw .invalidSession
-  let some (parent, rest) := pop frontier | throw .invalidSession
   let depth := parent.depth + 1
   if limits.maxDepth < depth then throw (.resource .depth)
   preflightBranch stateLimits left.branch
@@ -714,10 +752,11 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
   if !parent.branch.check || left.depth != depth || right.depth != depth ||
       leftParent != expected || rightParent != expected ||
       left.scope == right.scope || left.scope == parent.scope || right.scope == parent.scope ||
-      rest.pending.any (fun pending => pending.scope == left.scope || pending.scope == right.scope) ||
-      left.scope.index != accounting.nextScope ||
-      right.scope.index != accounting.nextScope + 1 ||
+      frontier.tail.pending.any (fun pending =>
+        pending.scope == left.scope || pending.scope == right.scope) ||
+      left.scope.index != state.accounting.nextScope ||
+      right.scope.index != state.accounting.nextScope + 1 ||
       !left.branch.check || !right.branch.check then throw .invalidSession
-  pure (nextAccounting, rest.schedule order [left, right])
+  pure next
 
 end Hex.Interval.Search

--- a/HexInterval/State.lean
+++ b/HexInterval/State.lean
@@ -132,6 +132,7 @@ structure Update (Fact Cause : Type) where
   fact : Fact
   version : Nat
   cause : Cause
+  deriving DecidableEq
 
 /-- Immutable fact state for one search branch. Base facts and appended-node
 seeds are the authoritative version-zero facts; later current facts are
@@ -150,6 +151,7 @@ structure Branch (Fact Cause : Type) where
   depths : Array Nat
   history : Array (Update Fact Cause)
   contradictory : Bool
+  deriving DecidableEq
 
 inductive BranchError where
   | invalidProgram

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -761,6 +761,7 @@ structure Hex.Interval.Config where
   maxSplits      : Nat
   maxDepth       : Nat
   maxLeaves      : Nat
+  maxFrontier    : Nat
   maxLocalPieces : Nat
   maxEndpointHeight : Nat
   maxAlignmentShift : Nat

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -93,14 +93,16 @@ private def splitter : Splitter Bound :=
       else
         none }
 
-private def resources : BranchTree.Limits :=
-  { branch := { maxDepth := 3, maxScopes := 5 }
-    maxSteps := 5
+private def resources : Search.Limits :=
+  { maxSteps := 5
     maxSplits := 2
     maxLeaves := 3
+    maxFrontier := 3
+    maxDepth := 3
+    maxScopes := 5
     leafFuel := limits.policy.maxDecisions }
 
-private def config (order : Order) : Config Bound Route :=
+private def config (order : Search.Order) : Config Bound Route :=
   { factDomain
     packages := splitPackages
     sessionLimits := limits
@@ -110,7 +112,7 @@ private def config (order : Order) : Config Bound Route :=
     order
     limits := resources }
 
-private def run? (order : Order) (fuel : Nat) : Option (State Bound Route) := do
+private def run? (order : Search.Order) (fuel : Nat) : Option (State Bound Route) := do
   let .ok state := BranchTree.start (config order) { index := 0 } input .root
     | none
   let .ok state := BranchTree.runFrom (config order) fuel state | none
@@ -131,18 +133,18 @@ private def leafReached? (entry : BranchTree.Node Bound Route) : Bool :=
 
 #guard
   (run? .depthFirst 2).any fun state =>
-    state.steps == 2 && state.splits == 2 && state.leaves == 3 &&
-      state.frontier == [{ index := 3 }, { index := 4 }, { index := 2 }]
+    state.accounting.steps == 2 && state.accounting.splits == 2 && state.accounting.leaves == 3 &&
+      state.frontier.pending == [{ index := 3 }, { index := 4 }, { index := 2 }]
 
 #guard
   (run? .breadthFirst 2).any fun state =>
-    state.steps == 2 && state.splits == 2 && state.leaves == 3 &&
-      state.frontier == [{ index := 2 }, { index := 3 }, { index := 4 }]
+    state.accounting.steps == 2 && state.accounting.splits == 2 && state.accounting.leaves == 3 &&
+      state.frontier.pending == [{ index := 2 }, { index := 3 }, { index := 4 }]
 
 #guard
   (run? .depthFirst 5).any fun state =>
-    state.settled && state.steps == 5 && state.splits == 2 &&
-      state.leaves == 3 && state.nodes.size == 5 &&
+    state.settled && state.accounting.steps == 5 && state.accounting.splits == 2 &&
+      state.accounting.leaves == 3 && state.nodes.size == 5 &&
       match state.nodes[0]?, state.nodes[1]?, state.nodes[2]?,
           state.nodes[3]?, state.nodes[4]? with
       | some (BranchTree.Node.split root _ rootChildren left right),
@@ -167,8 +169,8 @@ private def leafReached? (entry : BranchTree.Node Bound Route) : Bool :=
 
 #guard
   (run? .breadthFirst 5).any fun state =>
-    state.settled && state.steps == 5 && state.splits == 2 &&
-      state.leaves == 3 && state.nodes.size == 5 &&
+    state.settled && state.accounting.steps == 5 && state.accounting.splits == 2 &&
+      state.accounting.leaves == 3 && state.nodes.size == 5 &&
       state.nodes.toList.countP leafReached? == 3
 
 /-! ## Propagate before splitting -/
@@ -208,11 +210,13 @@ private def postController : Controller Bound PostRoute :=
 
 private def postFork (_ : PostRoute) (_ : Side) : PostRoute := .close
 
-private def postResources : BranchTree.Limits :=
-  { branch := { maxDepth := 1, maxScopes := 3 }
-    maxSteps := 3
+private def postResources : Search.Limits :=
+  { maxSteps := 3
     maxSplits := 1
     maxLeaves := 2
+    maxFrontier := 2
+    maxDepth := 1
+    maxScopes := 3
     leafFuel := limits.policy.maxDecisions }
 
 private def postConfig : Config Bound PostRoute :=

--- a/conformance/HexInterval/NestedBranchConformance.lean
+++ b/conformance/HexInterval/NestedBranchConformance.lean
@@ -271,32 +271,33 @@ example : True := by
   run_tac
     let some tree := postTree?
       | throwError "interval post-run split mutation: runtime tree failed"
-    let some root := tree.nodes[0]?
+    let snapshot := tree.snapshot
+    let some root := snapshot.nodes[0]?
       | throwError "interval post-run split mutation: root missing"
     let BranchTree.Node.split source result children left right := root
       | throwError "interval post-run split mutation: root is not split"
     let staleChildren := { children with parent := source.input }
     let stale :=
-      { tree with
-        nodes := tree.nodes.set! 0 (.split source result staleChildren left right) }
-    if (← observing? <| BranchProof.emit postProofLimits trueEmitter stale
+      { snapshot with
+        nodes := snapshot.nodes.set! 0 (.split source result staleChildren left right) }
+    if (← observing? <| BranchProof.emitSnapshot postProofLimits trueEmitter stale
         (mkConst ``True)).isSome then
       throwError "interval post-run split mutation: stale parent was accepted"
     let wrongPlan := { children.plan with point := 1 }
     let changedChildren := { children with plan := wrongPlan }
     let changed :=
-      { tree with
-        nodes := tree.nodes.set! 0 (.split source result changedChildren left right) }
-    if (← observing? <| BranchProof.emit postProofLimits trueEmitter changed
+      { snapshot with
+        nodes := snapshot.nodes.set! 0 (.split source result changedChildren left right) }
+    if (← observing? <| BranchProof.emitSnapshot postProofLimits trueEmitter changed
         (mkConst ``True)).isSome then
       throwError "interval post-run split mutation: changed plan was accepted"
     let wrongVersion := { children.plan with version := children.plan.version + 1 }
     let changedVersionChildren := { children with plan := wrongVersion }
     let changedVersion :=
-      { tree with
-        nodes := tree.nodes.set! 0
+      { snapshot with
+        nodes := snapshot.nodes.set! 0
           (.split source result changedVersionChildren left right) }
-    if (← observing? <| BranchProof.emit postProofLimits trueEmitter changedVersion
+    if (← observing? <| BranchProof.emitSnapshot postProofLimits trueEmitter changedVersion
         (mkConst ``True)).isSome then
       throwError "interval post-run split mutation: changed plan version was accepted"
   trivial

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -203,9 +203,45 @@ private def startNetworkError (limits : State.Limits) : Option Search.Error := d
       | _ => false
   | _, _ => false
 
+private def settleAccounting : Nat -> Search.Accounting -> Option Search.Accounting
+  | 0, accounting => some accounting
+  | fuel + 1, accounting => do
+      let accounting <-
+        (Search.Accounting.settleWithin searchLimits (.singleton ()) accounting).toOption
+      settleAccounting fuel accounting
+
+private def rootAccounting? : Option Search.Accounting :=
+  (Search.Accounting.startWithin searchLimits { index := 5 }
+    (Search.Frontier.singleton ())).toOption
+
+-- `Accounting` has no public constructor or record-update surface. These
+-- canaries consume only its checked builders and pin their exact counter
+-- progression and fail-closed exhaustion behavior.
+#guard rootAccounting?.any fun accounting =>
+  accounting.steps == 0 && accounting.splits == 0 && accounting.leaves == 1 &&
+    accounting.scopes == 1 && accounting.nextScope == 6
+
+#guard match rootAccounting? with
+  | some accounting =>
+      (settleAccounting searchLimits.maxSteps accounting).any fun charged =>
+        charged.steps == searchLimits.maxSteps && charged.splits == 0 &&
+          charged.leaves == 1 && charged.scopes == 1 && charged.nextScope == 6
+  | none => false
+
+#guard match rootAccounting? >>= settleAccounting searchLimits.maxSteps with
+  | some accounting =>
+      searchError (.resource .steps) <|
+        Search.Accounting.settleWithin searchLimits (.singleton ()) accounting
+  | none => false
+
+#guard searchError .invalidSession <|
+  Search.Accounting.startWithin searchLimits { index := 5 }
+    ({ pending := [] } : Search.Frontier Unit)
+
 private def atStepLimit? : Option (Search.Session Nat Nat Nat Action) := do
   let session <- session?
-  pure { session with accounting := { session.accounting with steps := searchLimits.maxSteps } }
+  let accounting <- settleAccounting searchLimits.maxSteps session.accounting
+  pure { session with accounting }
 
 -- A resource stop cannot launder a malformed decision, while `invokeWithin`
 -- refuses before evaluating a callback once the authenticated step budget is
@@ -398,11 +434,13 @@ private def nested? (order : Search.Order) :
 -- Both stable orders retain left-to-right sibling order and differ only in
 -- where fresh work is placed relative to the old suffix.
 #guard nested? .depthFirst |>.any fun result =>
-  result.1 == { steps := 2, splits := 2, leaves := 3, scopes := 5, nextScope := 5 } &&
+  result.1.steps == 2 && result.1.splits == 2 && result.1.leaves == 3 &&
+    result.1.scopes == 5 && result.1.nextScope == 5 &&
     result.2.pending.map (fun leaf => leaf.scope.index) == [3, 4, 2]
 
 #guard nested? .breadthFirst |>.any fun result =>
-  result.1 == { steps := 2, splits := 2, leaves := 3, scopes := 5, nextScope := 5 } &&
+  result.1.steps == 2 && result.1.splits == 2 && result.1.leaves == 3 &&
+    result.1.scopes == 5 && result.1.nextScope == 5 &&
     result.2.pending.map (fun leaf => leaf.scope.index) == [2, 3, 4]
 
 -- Child restoration returns the exact immutable parent, including scope,

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -65,8 +65,129 @@ private def searchError (wanted : Search.Error)
   | .error actual => decide (actual = wanted)
   | .ok _ => false
 
+private def offerFor (action : Action) : Search.Offer Nat Action :=
+  { view := { policyOffer with key := action }, action }
+
+private def startActionError (action : Action)
+    (limits : State.Limits := stateLimits) : Option Search.Error := do
+  let branch <- branch?
+  match Search.Session.startWithin { envelope with state := limits } policyMeasure branch
+      #[localRule] #[] #[0] #[0] 0 { index := 5 } #[offerFor action]
+      policyBudget false with
+  | .error error => some error
+  | .ok _ => none
+
+private def scopedAction : Action :=
+  { serial := 0
+    programVersion := 0
+    application := { index := 0 }
+    rule := { index := 0 }
+    key := scopedKey
+    node := contractNode 1
+    kind := .improve
+    effort := 0
+    generation := 0
+    inputs := [{ node := contractNode 0, version := 0 }]
+    writes := [contractNode 1] }
+
+private def startScopedError (limits : State.Limits) : Option Search.Error := do
+  let branch <- branch?
+  match Search.Session.startWithin { envelope with state := limits } policyMeasure branch
+      #[scopeRule] #[binding] #[0] #[0] 0 { index := 5 } #[offerFor scopedAction]
+      policyBudget false with
+  | .error error => some error
+  | .ok _ => none
+
+private def networkRule : Registration :=
+  { key := { name := "search.network" }
+    head := unaryKey
+    kind := .instantiate
+    watches := []
+    writes := []
+    binding := .global
+    watchesProgram := true
+    matchWatch := .network }
+
+private def startNetworkError (limits : State.Limits) : Option Search.Error := do
+  let branch <- branch?
+  match Search.Session.startWithin { envelope with state := limits } policyMeasure branch
+      #[networkRule] #[] #[] #[0] 0 { index := 5 } #[] policyBudget false with
+  | .error error => some error
+  | .ok _ => none
+
 #guard match session? with
   | some session => session.check envelope policyMeasure
+  | none => false
+
+#guard startActionError policyAction == none
+#guard startScopedError stateLimits == none
+#guard startNetworkError stateLimits == none
+
+#guard match branch? with
+  | some branch =>
+      searchError (.policy .offerLimit) <|
+        Search.Session.startWithin
+          { envelope with policy := { policyLimits with maxOffers := 0 } }
+          policyMeasure branch #[localRule] #[] #[0] #[0] 0 { index := 5 }
+          #[offer] policyBudget false
+  | none => false
+
+-- Every untrusted list and structural array is capped before semantic scans or
+-- package measurements. The resource class identifies the governing State
+-- limit rather than collapsing all oversized sessions to `invalidSession`.
+#guard startActionError
+  { policyAction with inputs := [
+      { node := contractNode 0, version := 0 },
+      { node := contractNode 1, version := 0 },
+      { node := contractNode 0, version := 1 },
+      { node := contractNode 1, version := 1 }] } ==
+    some (.resource (.state .arity))
+
+#guard startActionError
+  { policyAction with writes := [contractNode 0, contractNode 1,
+      contractNode 0, contractNode 1] } == some (.resource (.state .arity))
+
+#guard startActionError
+  { policyAction with structuralInputs := [
+      { key := .node (contractNode 0), generation := 0 },
+      { key := .node (contractNode 1), generation := 0 }] } ==
+    some (.resource (.state .matcherVisits))
+
+#guard startActionError policyAction { stateLimits with maxOperations := 1 } ==
+  some (.resource (.state .operations))
+#guard startActionError policyAction { stateLimits with maxNodes := 1 } ==
+  some (.resource (.state .nodes))
+#guard startActionError policyAction { stateLimits with maxRules := 0 } ==
+  some (.resource (.state .rules))
+#guard startActionError policyAction { stateLimits with maxArity := 0 } ==
+  some (.resource (.state .arity))
+#guard startActionError policyAction { stateLimits with maxNodeDepth := 0 } ==
+  some (.resource (.state .nodeDepth))
+#guard startActionError policyAction { stateLimits with maxEqualities := 0 } ==
+  some (.resource (.state .equalities))
+#guard startActionError { policyAction with effort := stateLimits.maxEffort + 1 } ==
+  some (.resource (.state .effort))
+
+-- Binding count and per-binding ports use independent limits. In particular,
+-- one binding cannot slip through merely because `maxScopeNodes` is nonzero.
+#guard startScopedError { stateLimits with maxApplications := 0 } ==
+  some (.resource (.state .applications))
+#guard startScopedError { stateLimits with maxScopeNodes := 0 } ==
+  some (.resource (.state .scopes))
+#guard startNetworkError { stateLimits with matcherBatchSize := 0 } ==
+  some (.resource (.state .matcherVisits))
+
+-- Search currently treats the compact application id as an opaque scheduler
+-- handle: it authenticates its generation while independently checking the
+-- rule, anchor, kind, and ports. No application table is claimed here.
+#guard match branch? with
+  | some branch =>
+      match Search.Session.startWithin envelope policyMeasure branch #[localRule] #[]
+          #[0, 0] #[0] 0 { index := 5 }
+          #[offerFor { policyAction with application := { index := 1 } }]
+          policyBudget false with
+      | .ok _ => true
+      | .error _ => false
   | none => false
 
 -- A successful batch is bound to the exact selected action and commits one
@@ -79,6 +200,29 @@ private def searchError (wanted : Search.Error)
           next.branch.snapshot.facts == #[13, 29] && next.branch.versions == #[0, 1] &&
             next.branch.history == #[firstUpdate] && next.serial == 1 &&
             next.offers.isEmpty && next.accounting.steps == 1
+      | _ => false
+  | _, _ => false
+
+private def atStepLimit? : Option (Search.Session Nat Nat Nat Action) := do
+  let session <- session?
+  pure { session with accounting := { session.accounting with steps := searchLimits.maxSteps } }
+
+-- A resource stop cannot launder a malformed decision, while `invokeWithin`
+-- refuses before evaluating a callback once the authenticated step budget is
+-- exhausted.
+#guard match atStepLimit?, decision? with
+  | some session, some decision =>
+      searchError (.policy .wrongScope) <|
+        Search.acceptWithin envelope policyMeasure session
+          { decision with scope := { index := 4 } } (.failure 0)
+  | _, _ => false
+
+#guard match atStepLimit?, decision? with
+  | some session, some decision =>
+      match Search.invokeWithin envelope policyMeasure
+          (fun _ => (.failure 9 : Search.Reply Nat Nat Nat Action))
+          session decision with
+      | .ok (.stopped (.resource .steps) _) => true
       | _ => false
   | _, _ => false
 
@@ -175,6 +319,14 @@ private def searchError (wanted : Search.Error)
           policyMeasure session decision (.outcome (outcome))
   | _, _ => false
 
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError (.resource (.state .acceptedFacts)) <|
+        Search.acceptWithin
+          { envelope with state := { stateLimits with maxAcceptedFacts := 0 } }
+          policyMeasure session decision (.outcome (outcome))
+  | _, _ => false
+
 -- A callback failure has an exact stop and cannot mutate branch facts,
 -- versions, provenance, or contradiction state.
 #guard match session?, decision? with
@@ -227,19 +379,20 @@ private def leaf (scope depth payload : Nat)
 private def nested? (order : Search.Order) :
     Option (Search.Accounting × Search.Frontier (Search.Leaf Nat Nat Nat)) := do
   let root <- leaf 0 0 0
-  let .ok (accounting, frontier) := Search.startFrontierWithin searchLimits root | none
-  let (root, rest) <- Search.pop frontier
+  let .ok (accounting, frontier) :=
+    Search.startFrontierWithin stateLimits searchLimits root | none
+  let root <- frontier.head?
   let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
   let right <- leaf 2 1 2 (some parent)
   let .ok (accounting, frontier) :=
-    Search.splitWithin searchLimits order accounting root rest left right | none
-  let (left, rest) <- Search.pop frontier
+    Search.splitWithin stateLimits searchLimits order accounting frontier left right | none
+  let left <- frontier.head?
   let parent := left.asParent
   let leftLeft <- leaf 3 2 3 (some parent)
   let leftRight <- leaf 4 2 4 (some parent)
   let .ok result :=
-    Search.splitWithin searchLimits order accounting left rest leftLeft leftRight | none
+    Search.splitWithin stateLimits searchLimits order accounting frontier leftLeft leftRight | none
   pure result
 
 -- Both stable orders retain left-to-right sibling order and differ only in
@@ -267,17 +420,18 @@ private def nested? (order : Search.Order) :
 #guard match leaf 0 0 0 with
   | some root =>
       searchError (.resource .frontier) <|
-        Search.startFrontierWithin { searchLimits with maxFrontier := 0 } root
+        Search.startFrontierWithin stateLimits { searchLimits with maxFrontier := 0 } root
   | none => false
 
 private def splitError (limits : Search.Limits) : Option Search.Error := do
   let root <- leaf 0 0 0
-  let .ok (accounting, frontier) := Search.startFrontierWithin searchLimits root | none
-  let (root, rest) <- Search.pop frontier
+  let .ok (accounting, frontier) :=
+    Search.startFrontierWithin stateLimits searchLimits root | none
+  let root <- frontier.head?
   let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
   let right <- leaf 2 1 2 (some parent)
-  match Search.splitWithin limits .depthFirst accounting root rest left right with
+  match Search.splitWithin stateLimits limits .depthFirst accounting frontier left right with
   | .error error => some error
   | .ok _ => none
 
@@ -287,5 +441,35 @@ private def splitError (limits : Search.Limits) : Option Search.Error := do
 #guard splitError { searchLimits with maxScopes := 2 } == some (.resource .scopes)
 #guard splitError { searchLimits with maxDepth := 0 } == some (.resource .depth)
 #guard splitError { searchLimits with maxFrontier := 1 } == some (.resource .frontier)
+
+private def malformedParentError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok (accounting, _) :=
+    Search.startFrontierWithin stateLimits searchLimits root | none
+  let malformed := { root with branch := { root.branch with versions := #[9, 0] } }
+  let frontier : Search.Frontier (Search.Leaf Nat Nat Nat) := { pending := [malformed] }
+  let parent := malformed.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst accounting frontier left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def duplicateParentError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok (accounting, _) :=
+    Search.startFrontierWithin stateLimits searchLimits root | none
+  let frontier : Search.Frontier (Search.Leaf Nat Nat Nat) := { pending := [root, root] }
+  let parent := root.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst accounting frontier left right with
+  | .error error => some error
+  | .ok _ => none
+
+-- The split parent is derived from the authenticated frontier head. A caller
+-- can neither substitute a detached parent nor retain a duplicate occurrence.
+#guard malformedParentError == some .invalidSession
+#guard duplicateParentError == some .invalidSession
 
 end Hex.Interval.SearchConformance

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -397,6 +397,26 @@ private def leaf (scope depth payload : Nat)
   let branch <- branch?
   pure { scope := { index := scope }, depth, branch, parent, payload }
 
+private def settledRoot? : Option (Search.Leaf Nat Nat Nat × Search.LeafFrontier Nat Nat Nat) := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  Search.settleWithin searchLimits state |>.toOption
+
+-- Settle consumes and returns the exact head, empties a singleton frontier,
+-- and charges one step in the same sealed leaf frontier.
+#guard settledRoot?.any fun result =>
+  result.1.payload == 0 && result.2.isEmpty && result.2.accounting.steps == 1 &&
+    result.2.accounting.splits == 0
+
+#guard match leaf 0 0 0 with
+  | some root =>
+      match Search.startFrontierWithin stateLimits searchLimits root with
+      | .ok state =>
+          searchError (.resource .steps) <|
+            Search.settleWithin { searchLimits with maxSteps := 0 } state
+      | .error _ => false
+  | none => false
+
 private def nested? (order : Search.Order) :
     Option (Search.LeafFrontier Nat Nat Nat) := do
   let root <- leaf 0 0 0
@@ -484,8 +504,39 @@ private def wrongChildScopeError : Option Search.Error := do
   let root <- leaf 0 0 0
   let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
   let parent := root.asParent
+  let left <- leaf 3 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def wrongChildDepthError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := root.asParent
+  let left <- leaf 1 2 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def missingChildParentError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := root.asParent
+  let left <- leaf 1 1 1
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def malformedChildBranchError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
-  let right <- leaf 3 1 2 (some parent)
+  let left := { left with branch := { left.branch with versions := #[9, 0] } }
+  let right <- leaf 2 1 2 (some parent)
   match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
   | .error error => some error
   | .ok _ => none
@@ -509,6 +560,9 @@ private def secondSplitError (limits : Search.Limits) : Option Search.Error := d
 #guard malformedParentError == some .invalidSession
 #guard detachedParentError == some .invalidSession
 #guard wrongChildScopeError == some .invalidSession
+#guard wrongChildDepthError == some .invalidSession
+#guard missingChildParentError == some .invalidSession
+#guard malformedChildBranchError == some .invalidSession
 #guard secondSplitError { searchLimits with maxSteps := 1 } == some (.resource .steps)
 #guard secondSplitError { searchLimits with maxSplits := 1 } == some (.resource .splits)
 #guard secondSplitError { searchLimits with maxFrontier := 2 } == some (.resource .frontier)

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -398,7 +398,7 @@ private def leaf (scope depth payload : Nat)
   pure { scope := { index := scope }, depth, branch, parent, payload }
 
 private def nested? (order : Search.Order) :
-    Option (Search.FrontierState (Search.Leaf Nat Nat Nat)) := do
+    Option (Search.LeafFrontier Nat Nat Nat) := do
   let root <- leaf 0 0 0
   let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
   let root <- state.head?
@@ -480,6 +480,16 @@ private def detachedParentError : Option Search.Error := do
   | .error error => some error
   | .ok _ => none
 
+private def wrongChildScopeError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := root.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 3 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
 private def secondSplitError (limits : Search.Limits) : Option Search.Error := do
   let root <- leaf 0 0 0
   let .ok state := Search.startFrontierWithin stateLimits limits root | none
@@ -498,6 +508,7 @@ private def secondSplitError (limits : Search.Limits) : Option Search.Error := d
 -- one live frontier. Detached parents and nested one-over resources fail.
 #guard malformedParentError == some .invalidSession
 #guard detachedParentError == some .invalidSession
+#guard wrongChildScopeError == some .invalidSession
 #guard secondSplitError { searchLimits with maxSteps := 1 } == some (.resource .steps)
 #guard secondSplitError { searchLimits with maxSplits := 1 } == some (.resource .splits)
 #guard secondSplitError { searchLimits with maxFrontier := 2 } == some (.resource .frontier)

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -197,79 +197,65 @@ private def startNetworkError (limits : State.Limits) : Option Search.Error := d
       match Search.acceptWithin envelope policyMeasure session decision
           (.outcome (outcome)) with
       | .ok (.applied next) =>
-          next.branch.snapshot.facts == #[13, 29] && next.branch.versions == #[0, 1] &&
+            next.branch.snapshot.facts == #[13, 29] && next.branch.versions == #[0, 1] &&
             next.branch.history == #[firstUpdate] && next.serial == 1 &&
-            next.offers.isEmpty && next.accounting.steps == 1
+            next.offers.isEmpty && next.steps == 1
       | _ => false
   | _, _ => false
 
-private def settleAccounting : Nat -> Search.Accounting -> Option Search.Accounting
-  | 0, accounting => some accounting
-  | fuel + 1, accounting => do
-      let accounting <-
-        (Search.Accounting.settleWithin searchLimits (.singleton ()) accounting).toOption
-      settleAccounting fuel accounting
-
-private def rootAccounting? : Option Search.Accounting :=
-  (Search.Accounting.startWithin searchLimits { index := 5 }
-    (Search.Frontier.singleton ())).toOption
-
--- `Accounting` has no public constructor or record-update surface. These
--- canaries consume only its checked builders and pin their exact counter
--- progression and fail-closed exhaustion behavior.
-#guard rootAccounting?.any fun accounting =>
-  accounting.steps == 0 && accounting.splits == 0 && accounting.leaves == 1 &&
-    accounting.scopes == 1 && accounting.nextScope == 6
-
-#guard match rootAccounting? with
-  | some accounting =>
-      (settleAccounting searchLimits.maxSteps accounting).any fun charged =>
-        charged.steps == searchLimits.maxSteps && charged.splits == 0 &&
-          charged.leaves == 1 && charged.scopes == 1 && charged.nextScope == 6
-  | none => false
-
-#guard match rootAccounting? >>= settleAccounting searchLimits.maxSteps with
-  | some accounting =>
-      searchError (.resource .steps) <|
-        Search.Accounting.settleWithin searchLimits (.singleton ()) accounting
-  | none => false
-
-#guard searchError .invalidSession <|
-  Search.Accounting.startWithin searchLimits { index := 5 }
-    ({ pending := [] } : Search.Frontier Unit)
+private def stepEnvelope : Search.Envelope :=
+  { envelope with search := { searchLimits with maxSteps := 1, maxFrontier := 0 } }
 
 private def atStepLimit? : Option (Search.Session Nat Nat Nat Action) := do
-  let session <- session?
-  let accounting <- settleAccounting searchLimits.maxSteps session.accounting
-  pure { session with accounting }
+  let branch <- branch?
+  let session <- (Search.Session.startWithin stepEnvelope policyMeasure branch #[localRule] #[]
+    #[0] #[0] 0 { index := 5 } #[offer] policyBudget false).toOption
+  let decision := Policy.select session.view offer.view
+  let .applied session <-
+    (Search.acceptWithin stepEnvelope policyMeasure session decision
+      (.outcome outcome)).toOption | none
+  let nextAction := { policyAction with serial := 1 }
+  let nextOffer := offerFor nextAction
+  Search.Session.refreshWithin stepEnvelope policyMeasure session #[nextOffer]
+    policyBudget false |>.toOption
+
+-- A session-only step budget is independent of branch-tree frontier capacity.
+#guard atStepLimit?.any fun session => session.steps == 1
 
 -- A resource stop cannot launder a malformed decision, while `invokeWithin`
 -- refuses before evaluating a callback once the authenticated step budget is
 -- exhausted.
 #guard match atStepLimit?, decision? with
-  | some session, some decision =>
-      searchError (.policy .wrongScope) <|
-        Search.acceptWithin envelope policyMeasure session
-          { decision with scope := { index := 4 } } (.failure 0)
+  | some session, some _decision =>
+      match session.offers[0]? with
+      | some current =>
+          searchError (.policy .wrongScope) <|
+            Search.acceptWithin stepEnvelope policyMeasure session
+              { (Policy.select session.view current.view) with scope := { index := 4 } }
+              (.failure 0)
+      | none => false
   | _, _ => false
 
 #guard match atStepLimit?, decision? with
-  | some session, some decision =>
-      match Search.invokeWithin envelope policyMeasure
-          (fun _ => (.failure 9 : Search.Reply Nat Nat Nat Action))
-          session decision with
-      | .ok (.stopped (.resource .steps) _) => true
-      | _ => false
+  | some session, some _decision =>
+      match session.offers[0]? with
+      | some current =>
+          match Search.invokeWithin stepEnvelope policyMeasure
+              (fun _ => (.failure 9 : Search.Reply Nat Nat Nat Action))
+              session (Policy.select session.view current.view) with
+          | .ok (.stopped (.resource .steps) _) => true
+          | _ => false
+      | none => false
   | _, _ => false
 
 -- Application generation is authenticated rather than inferred from a compact
--- count. A stale generation makes the entire decoded session invalid.
-#guard match session?, decision? with
-  | some session, some decision =>
+-- count. A stale generation prevents construction of a sealed session.
+#guard match branch? with
+  | some branch =>
       searchError .invalidSession <|
-        Search.prepareWithin envelope policyMeasure
-          { session with applicationGenerations := #[1] } decision
-  | _, _ => false
+        Search.Session.startWithin envelope policyMeasure branch #[localRule] #[]
+          #[1] #[0] 0 { index := 5 } #[offer] policyBudget false
+  | none => false
 
 -- Scope, serial, program, semantic key, and every exposed offer field remain
 -- load-bearing at the supported transition boundary.
@@ -301,14 +287,13 @@ private def atStepLimit? : Option (Search.Session Nat Nat Nat Action) := do
           .outcome { outcome with action := { policyAction with serial := 1 } }
   | _, _ => false
 
-#guard match session?, decision? with
-  | some session, some decision =>
+#guard match session? with
+  | some session =>
       let changed :=
-        { session with offers := #[{ offer with
-            action := { policyAction with key := { localKey with schema := 9 } } }] }
+        #[{ offer with action := { policyAction with key := { localKey with schema := 9 } } }]
       searchError .invalidSession <|
-        Search.prepareWithin envelope policyMeasure changed decision
-  | _, _ => false
+        Search.Session.refreshWithin envelope policyMeasure session changed policyBudget false
+  | none => false
 
 #guard match session?, decision? with
   | some session, some decision =>
@@ -413,40 +398,38 @@ private def leaf (scope depth payload : Nat)
   pure { scope := { index := scope }, depth, branch, parent, payload }
 
 private def nested? (order : Search.Order) :
-    Option (Search.Accounting × Search.Frontier (Search.Leaf Nat Nat Nat)) := do
+    Option (Search.FrontierState (Search.Leaf Nat Nat Nat)) := do
   let root <- leaf 0 0 0
-  let .ok (accounting, frontier) :=
-    Search.startFrontierWithin stateLimits searchLimits root | none
-  let root <- frontier.head?
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let root <- state.head?
   let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
   let right <- leaf 2 1 2 (some parent)
-  let .ok (accounting, frontier) :=
-    Search.splitWithin stateLimits searchLimits order accounting frontier left right | none
-  let left <- frontier.head?
+  let .ok state := Search.splitWithin stateLimits searchLimits order state left right | none
+  let left <- state.head?
   let parent := left.asParent
   let leftLeft <- leaf 3 2 3 (some parent)
   let leftRight <- leaf 4 2 4 (some parent)
-  let .ok result :=
-    Search.splitWithin stateLimits searchLimits order accounting frontier leftLeft leftRight | none
-  pure result
+  Search.splitWithin stateLimits searchLimits order state leftLeft leftRight |>.toOption
 
 -- Both stable orders retain left-to-right sibling order and differ only in
 -- where fresh work is placed relative to the old suffix.
 #guard nested? .depthFirst |>.any fun result =>
-  result.1.steps == 2 && result.1.splits == 2 && result.1.leaves == 3 &&
-    result.1.scopes == 5 && result.1.nextScope == 5 &&
-    result.2.pending.map (fun leaf => leaf.scope.index) == [3, 4, 2]
+  result.accounting.steps == 2 && result.accounting.splits == 2 &&
+    result.accounting.leaves == 3 && result.accounting.scopes == 5 &&
+    result.accounting.nextScope == 5 &&
+    result.pending.map (fun leaf => leaf.scope.index) == [3, 4, 2]
 
 #guard nested? .breadthFirst |>.any fun result =>
-  result.1.steps == 2 && result.1.splits == 2 && result.1.leaves == 3 &&
-    result.1.scopes == 5 && result.1.nextScope == 5 &&
-    result.2.pending.map (fun leaf => leaf.scope.index) == [2, 3, 4]
+  result.accounting.steps == 2 && result.accounting.splits == 2 &&
+    result.accounting.leaves == 3 && result.accounting.scopes == 5 &&
+    result.accounting.nextScope == 5 &&
+    result.pending.map (fun leaf => leaf.scope.index) == [2, 3, 4]
 
 -- Child restoration returns the exact immutable parent, including scope,
 -- fact versions, and provenance history.
 #guard nested? .depthFirst |>.any fun result =>
-  match result.2.pending[0]? with
+  match result.pending[0]? with
   | some child =>
       child.restoreParent?.any fun parent =>
         parent.scope.index == 1 && parent.branch.versions == #[0, 0] &&
@@ -463,13 +446,12 @@ private def nested? (order : Search.Order) :
 
 private def splitError (limits : Search.Limits) : Option Search.Error := do
   let root <- leaf 0 0 0
-  let .ok (accounting, frontier) :=
-    Search.startFrontierWithin stateLimits searchLimits root | none
-  let root <- frontier.head?
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let root <- state.head?
   let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
   let right <- leaf 2 1 2 (some parent)
-  match Search.splitWithin stateLimits limits .depthFirst accounting frontier left right with
+  match Search.splitWithin stateLimits limits .depthFirst state left right with
   | .error error => some error
   | .ok _ => none
 
@@ -482,32 +464,42 @@ private def splitError (limits : Search.Limits) : Option Search.Error := do
 
 private def malformedParentError : Option Search.Error := do
   let root <- leaf 0 0 0
-  let .ok (accounting, _) :=
-    Search.startFrontierWithin stateLimits searchLimits root | none
   let malformed := { root with branch := { root.branch with versions := #[9, 0] } }
-  let frontier : Search.Frontier (Search.Leaf Nat Nat Nat) := { pending := [malformed] }
-  let parent := malformed.asParent
-  let left <- leaf 1 1 1 (some parent)
-  let right <- leaf 2 1 2 (some parent)
-  match Search.splitWithin stateLimits searchLimits .depthFirst accounting frontier left right with
+  match Search.startFrontierWithin stateLimits searchLimits malformed with
   | .error error => some error
   | .ok _ => none
 
-private def duplicateParentError : Option Search.Error := do
+private def detachedParentError : Option Search.Error := do
   let root <- leaf 0 0 0
-  let .ok (accounting, _) :=
-    Search.startFrontierWithin stateLimits searchLimits root | none
-  let frontier : Search.Frontier (Search.Leaf Nat Nat Nat) := { pending := [root, root] }
+  let detached <- leaf 9 0 9
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := detached.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def secondSplitError (limits : Search.Limits) : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits limits root | none
   let parent := root.asParent
   let left <- leaf 1 1 1 (some parent)
   let right <- leaf 2 1 2 (some parent)
-  match Search.splitWithin stateLimits searchLimits .depthFirst accounting frontier left right with
+  let .ok state := Search.splitWithin stateLimits limits .depthFirst state left right | none
+  let parent := left.asParent
+  let leftLeft <- leaf 3 2 3 (some parent)
+  let leftRight <- leaf 4 2 4 (some parent)
+  match Search.splitWithin stateLimits limits .depthFirst state leftLeft leftRight with
   | .error error => some error
   | .ok _ => none
 
--- The split parent is derived from the authenticated frontier head. A caller
--- can neither substitute a detached parent nor retain a duplicate occurrence.
+-- The sealed composite derives the split parent and cumulative counters from
+-- one live frontier. Detached parents and nested one-over resources fail.
 #guard malformedParentError == some .invalidSession
-#guard duplicateParentError == some .invalidSession
+#guard detachedParentError == some .invalidSession
+#guard secondSplitError { searchLimits with maxSteps := 1 } == some (.resource .steps)
+#guard secondSplitError { searchLimits with maxSplits := 1 } == some (.resource .splits)
+#guard secondSplitError { searchLimits with maxFrontier := 2 } == some (.resource .frontier)
 
 end Hex.Interval.SearchConformance

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -417,6 +417,11 @@ private def settledRoot? : Option (Search.Leaf Nat Nat Nat × Search.LeafFrontie
       | .error _ => false
   | none => false
 
+#guard match settledRoot? with
+  | some (_, state) =>
+      searchError .invalidSession <| Search.settleWithin searchLimits state
+  | none => false
+
 private def nested? (order : Search.Order) :
     Option (Search.LeafFrontier Nat Nat Nat) := do
   let root <- leaf 0 0 0
@@ -510,6 +515,29 @@ private def wrongChildScopeError : Option Search.Error := do
   | .error error => some error
   | .ok _ => none
 
+private def wrongRightScopeError : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
+  let parent := root.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 3 1 2 (some parent)
+  match Search.splitWithin stateLimits searchLimits .depthFirst state left right with
+  | .error error => some error
+  | .ok _ => none
+
+private def wrongRootDepthError : Option Search.Error := do
+  let root <- leaf 0 1 0
+  match Search.startFrontierWithin stateLimits searchLimits root with
+  | .error error => some error
+  | .ok _ => none
+
+private def parentedRootError : Option Search.Error := do
+  let parentLeaf <- leaf 9 0 9
+  let root <- leaf 0 0 0 (some parentLeaf.asParent)
+  match Search.startFrontierWithin stateLimits searchLimits root with
+  | .error error => some error
+  | .ok _ => none
+
 private def wrongChildDepthError : Option Search.Error := do
   let root <- leaf 0 0 0
   let .ok state := Search.startFrontierWithin stateLimits searchLimits root | none
@@ -560,6 +588,9 @@ private def secondSplitError (limits : Search.Limits) : Option Search.Error := d
 #guard malformedParentError == some .invalidSession
 #guard detachedParentError == some .invalidSession
 #guard wrongChildScopeError == some .invalidSession
+#guard wrongRightScopeError == some .invalidSession
+#guard wrongRootDepthError == some .invalidSession
+#guard parentedRootError == some .invalidSession
 #guard wrongChildDepthError == some .invalidSession
 #guard missingChildParentError == some .invalidSession
 #guard malformedChildBranchError == some .invalidSession

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Conformance
+
+/-!
+# Supported search-contract conformance
+
+These guards discriminate exact policy/action binding, transactional callback
+updates, independent resource stops, stable frontier order, parent restoration,
+and diagnostic truncation from proof-state mutation.
+-/
+
+namespace Hex.Interval.SearchConformance
+
+open Conformance.Contracts
+open Search
+
+private def searchLimits : Search.Limits :=
+  { maxSteps := 4
+    maxSplits := 2
+    maxLeaves := 3
+    maxFrontier := 3
+    maxDepth := 2
+    maxScopes := 5
+    leafFuel := 4 }
+
+private def traceLimits : Trace.Limit :=
+  { maxEvents := 1, maxBytes := 1, maxWork := 1, maxCode := 8 }
+
+private def envelope : Search.Envelope :=
+  { state := stateLimits
+    policy := policyLimits
+    trace := traceLimits
+    search := searchLimits }
+
+private def offer : Search.Offer Nat Action :=
+  { view := policyOffer, action := policyAction }
+
+private def session? : Option (Search.Session Nat Nat Nat Action) := do
+  let branch <- branch?
+  (Search.Session.startWithin envelope policyMeasure branch #[localRule] #[]
+    #[0] #[0] 0 { index := 5 } #[offer] policyBudget false).toOption
+
+private def decision? : Option (Policy.Decision Nat Action) := do
+  let session <- session?
+  pure (Policy.select session.view offer.view)
+
+private def outcome (updates : Array (State.Update Nat Nat) := #[firstUpdate])
+    (diagnostic : Option Trace.Event := none) : Search.Outcome Nat Nat Nat Action :=
+  { scope := { index := 5 }
+    serial := 0
+    programVersion := 0
+    offer := offer.view
+    action := policyAction
+    updates
+    diagnostic }
+
+private def searchError (wanted : Search.Error)
+    (result : Except Search.Error α) : Bool :=
+  match result with
+  | .error actual => decide (actual = wanted)
+  | .ok _ => false
+
+#guard match session? with
+  | some session => session.check envelope policyMeasure
+  | none => false
+
+-- A successful batch is bound to the exact selected action and commits one
+-- versioned update atomically.
+#guard match session?, decision? with
+  | some session, some decision =>
+      match Search.acceptWithin envelope policyMeasure session decision
+          (.outcome (outcome)) with
+      | .ok (.applied next) =>
+          next.branch.snapshot.facts == #[13, 29] && next.branch.versions == #[0, 1] &&
+            next.branch.history == #[firstUpdate] && next.serial == 1 &&
+            next.offers.isEmpty && next.accounting.steps == 1
+      | _ => false
+  | _, _ => false
+
+-- Application generation is authenticated rather than inferred from a compact
+-- count. A stale generation makes the entire decoded session invalid.
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError .invalidSession <|
+        Search.prepareWithin envelope policyMeasure
+          { session with applicationGenerations := #[1] } decision
+  | _, _ => false
+
+-- Scope, serial, program, semantic key, and every exposed offer field remain
+-- load-bearing at the supported transition boundary.
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError (.policy .wrongScope) <|
+        Search.prepareWithin envelope policyMeasure session
+          { decision with scope := { index := 4 } }
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError (.policy .staleSerial) <|
+        Search.prepareWithin envelope policyMeasure session
+          { decision with serial := 1 }
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError (.policy .staleProgram) <|
+        Search.prepareWithin envelope policyMeasure session
+          { decision with programVersion := 1 }
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError .staleReply <|
+        Search.acceptWithin envelope policyMeasure session decision <|
+          .outcome { outcome with action := { policyAction with serial := 1 } }
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      let changed :=
+        { session with offers := #[{ offer with
+            action := { policyAction with key := { localKey with schema := 9 } } }] }
+      searchError .invalidSession <|
+        Search.prepareWithin envelope policyMeasure changed decision
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError .staleReply <|
+        Search.acceptWithin envelope policyMeasure session decision <|
+          .outcome { outcome with offer := { offer.view with age := 9 } }
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError .malformedOutcome <|
+        Search.acceptWithin envelope policyMeasure session decision <|
+          .outcome { outcome (#[]) with contradiction := true }
+  | _, _ => false
+
+-- Writes outside exact action authority and a stale second update reject the
+-- whole batch. The caller still owns the unchanged original session.
+#guard match session?, decision? with
+  | some session, some decision =>
+      let wrongNode : State.Update Nat Nat :=
+        { firstUpdate with
+          node := contractNode 0
+          previous := { node := contractNode 0, version := 0 } }
+      searchError (.unauthorizedWrite (contractNode 0)) <|
+        Search.acceptWithin envelope policyMeasure session decision
+          (.outcome (outcome #[wrongNode]))
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      let staleSecond :=
+        { secondUpdate with previous := { node := contractNode 1, version := 0 } }
+      searchError (.state (.staleVersion (contractNode 1)))
+          (Search.acceptWithin envelope policyMeasure session decision
+            (.outcome (outcome #[firstUpdate, staleSecond]))) &&
+        session.branch.snapshot.facts == #[13, 23] && session.branch.history.isEmpty
+  | _, _ => false
+
+#guard match session?, decision? with
+  | some session, some decision =>
+      searchError .outcomeLimit <|
+        Search.acceptWithin
+          { envelope with state := { stateLimits with maxOutcomeCandidates := 0 } }
+          policyMeasure session decision (.outcome (outcome))
+  | _, _ => false
+
+-- A callback failure has an exact stop and cannot mutate branch facts,
+-- versions, provenance, or contradiction state.
+#guard match session?, decision? with
+  | some session, some decision =>
+      match Search.acceptWithin envelope policyMeasure session decision (.failure 3) with
+      | .ok (.stopped (.callbackFailure 3) next) => next.branch == session.branch
+      | _ => false
+  | _, _ => false
+
+-- Diagnostic truncation changes only the retained log. The accepted proof
+-- state is byte-for-byte the same as the no-diagnostic run.
+#guard match session?, decision? with
+  | some session, some decision =>
+      let plain := Search.acceptWithin envelope policyMeasure session decision
+        (.outcome (outcome))
+      let noisy := Search.acceptWithin envelope policyMeasure session decision
+        (.outcome (outcome (diagnostic := some { code := 1, payload := #[1, 2] })))
+      match plain, noisy with
+      | .ok (.applied left), .ok (.applied right) =>
+          left.branch == right.branch && !left.trace.truncated && right.trace.truncated
+      | _, _ => false
+  | _, _ => false
+
+-- Stopping is conservative even with a nonempty frontier. A policy which
+-- returns a mutated copy is rejected rather than authorized.
+private def stopped : Policy.Interface Nat Bool Nat Action :=
+  { choose := fun state _ => .stop state }
+
+private def mutated : Policy.Interface Nat Bool Nat Action :=
+  { choose := fun state _ => .select { offer.view with score := 0 } state }
+
+#guard match session? with
+  | some session =>
+      match Search.chooseWithin envelope policyMeasure stopped false session with
+      | .ok (.stopped (.policyStop 1) false) => true
+      | _ => false
+  | none => false
+
+#guard match session? with
+  | some session =>
+      searchError (.policy .mutatedOffer) <|
+        Search.chooseWithin envelope policyMeasure mutated false session
+  | none => false
+
+private def leaf (scope depth payload : Nat)
+    (parent : Option (Search.Parent Nat Nat) := none) : Option (Search.Leaf Nat Nat Nat) := do
+  let branch <- branch?
+  pure { scope := { index := scope }, depth, branch, parent, payload }
+
+private def nested? (order : Search.Order) :
+    Option (Search.Accounting × Search.Frontier (Search.Leaf Nat Nat Nat)) := do
+  let root <- leaf 0 0 0
+  let .ok (accounting, frontier) := Search.startFrontierWithin searchLimits root | none
+  let (root, rest) <- Search.pop frontier
+  let parent := root.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  let .ok (accounting, frontier) :=
+    Search.splitWithin searchLimits order accounting root rest left right | none
+  let (left, rest) <- Search.pop frontier
+  let parent := left.asParent
+  let leftLeft <- leaf 3 2 3 (some parent)
+  let leftRight <- leaf 4 2 4 (some parent)
+  let .ok result :=
+    Search.splitWithin searchLimits order accounting left rest leftLeft leftRight | none
+  pure result
+
+-- Both stable orders retain left-to-right sibling order and differ only in
+-- where fresh work is placed relative to the old suffix.
+#guard nested? .depthFirst |>.any fun result =>
+  result.1 == { steps := 2, splits := 2, leaves := 3, scopes := 5, nextScope := 5 } &&
+    result.2.pending.map (fun leaf => leaf.scope.index) == [3, 4, 2]
+
+#guard nested? .breadthFirst |>.any fun result =>
+  result.1 == { steps := 2, splits := 2, leaves := 3, scopes := 5, nextScope := 5 } &&
+    result.2.pending.map (fun leaf => leaf.scope.index) == [2, 3, 4]
+
+-- Child restoration returns the exact immutable parent, including scope,
+-- fact versions, and provenance history.
+#guard nested? .depthFirst |>.any fun result =>
+  match result.2.pending[0]? with
+  | some child =>
+      child.restoreParent?.any fun parent =>
+        parent.scope.index == 1 && parent.branch.versions == #[0, 0] &&
+          parent.branch.history.isEmpty
+  | none => false
+
+-- Independent one-over resources fail before a replacement frontier or
+-- accounting value is returned.
+#guard match leaf 0 0 0 with
+  | some root =>
+      searchError (.resource .frontier) <|
+        Search.startFrontierWithin { searchLimits with maxFrontier := 0 } root
+  | none => false
+
+private def splitError (limits : Search.Limits) : Option Search.Error := do
+  let root <- leaf 0 0 0
+  let .ok (accounting, frontier) := Search.startFrontierWithin searchLimits root | none
+  let (root, rest) <- Search.pop frontier
+  let parent := root.asParent
+  let left <- leaf 1 1 1 (some parent)
+  let right <- leaf 2 1 2 (some parent)
+  match Search.splitWithin limits .depthFirst accounting root rest left right with
+  | .error error => some error
+  | .ok _ => none
+
+#guard splitError { searchLimits with maxSteps := 0 } == some (.resource .steps)
+#guard splitError { searchLimits with maxSplits := 0 } == some (.resource .splits)
+#guard splitError { searchLimits with maxLeaves := 1 } == some (.resource .leaves)
+#guard splitError { searchLimits with maxScopes := 2 } == some (.resource .scopes)
+#guard splitError { searchLimits with maxDepth := 0 } == some (.resource .depth)
+#guard splitError { searchLimits with maxFrontier := 1 } == some (.resource .frontier)
+
+end Hex.Interval.SearchConformance

--- a/conformance/HexIntervalMathlib/ExactBranchConformance.lean
+++ b/conformance/HexIntervalMathlib/ExactBranchConformance.lean
@@ -545,9 +545,9 @@ private def splitter : BranchStart.Splitter DyadicInterval.Fact :=
         | .error _ => none
       else none }
 
-private def treeLimits : BranchTree.Limits :=
-  { branch := { maxDepth := 1, maxScopes := 3 }
-    maxSteps := 3, maxSplits := 1, maxLeaves := 2
+private def treeLimits : Search.Limits :=
+  { maxSteps := 3, maxSplits := 1, maxLeaves := 2, maxFrontier := 2
+    maxDepth := 1, maxScopes := 3
     leafFuel := sessionLimits.policy.maxDecisions }
 
 private def config : BranchTree.Config DyadicInterval.Fact Route :=
@@ -572,7 +572,7 @@ private def rightInput : CheckerInput DyadicInterval.Fact :=
 
 #guard
   tree?.any fun tree =>
-    tree.settled && tree.nodes.size == 3 && tree.steps == 3 &&
+    tree.settled && tree.nodes.size == 3 && tree.accounting.steps == 3 &&
       match tree.nodes[0]?, tree.nodes[1]?, tree.nodes[2]? with
       | some (BranchTree.Node.split source run children _ _),
           some (BranchTree.Node.leaf left (.result leftRun)),

--- a/conformance/HexIntervalMathlib/ExpSignConformance.lean
+++ b/conformance/HexIntervalMathlib/ExpSignConformance.lean
@@ -609,14 +609,16 @@ private def treePolicy : TargetRun.Controller Bound Unit :=
       | none => .stop state }
 
 private def treeLimits (maxSteps := 3) (maxSplits := 1)
-    (maxLeaves := 2) : BranchTree.Limits :=
-  { branch := branchLimits
-    maxSteps
+    (maxLeaves := 2) : Search.Limits :=
+  { maxSteps
     maxSplits
     maxLeaves
+    maxFrontier := maxLeaves
+    maxDepth := branchLimits.maxDepth
+    maxScopes := branchLimits.maxScopes
     leafFuel := limits.policy.maxDecisions }
 
-private def treeConfig (resources : BranchTree.Limits) :
+private def treeConfig (resources : Search.Limits) :
     BranchTree.Config Bound Unit :=
   { factDomain
     packages := splitPackages
@@ -627,7 +629,7 @@ private def treeConfig (resources : BranchTree.Limits) :
     order := .depthFirst
     limits := resources }
 
-private def runTree? (resources : BranchTree.Limits) :
+private def runTree? (resources : Search.Limits) :
     Option (BranchTree.State Bound Unit) := do
   let .ok state := BranchTree.start (treeConfig resources) { index := 0 }
       checkerInput () | none
@@ -651,7 +653,7 @@ private def targetLeaf (expectedScope : Nat) (expectedSource : Bound)
 #guard
   runTree? (treeLimits) |>.any fun state =>
     state.nodes.size == 3 && state.frontier.isEmpty && state.settled &&
-      state.steps == 3 && state.splits == 1 && state.leaves == 2 &&
+      state.accounting.steps == 3 && state.accounting.splits == 1 && state.accounting.leaves == 2 &&
       match state.nodes[0]?, state.nodes[1]?, state.nodes[2]? with
       | some (BranchTree.Node.split source _ children left right),
           some leftNode, some rightNode =>
@@ -668,8 +670,8 @@ private def targetLeaf (expectedScope : Nat) (expectedSource : Bound)
 not claim that either child or the tree is complete. -/
 #guard
   runTree? (treeLimits (maxSteps := 1)) |>.any fun state =>
-    state.nodes.size == 3 && state.steps == 1 && state.splits == 1 &&
-      state.leaves == 2 && state.frontier == [{ index := 1 }, { index := 2 }] &&
+    state.nodes.size == 3 && state.accounting.steps == 1 && state.accounting.splits == 1 &&
+      state.accounting.leaves == 2 && state.frontier.pending == [{ index := 1 }, { index := 2 }] &&
       state.stepLimited (treeLimits (maxSteps := 1)) &&
       match state.nodes[1]?, state.nodes[2]? with
       | some (BranchTree.Node.pending _), some (BranchTree.Node.pending _) => true
@@ -677,8 +679,8 @@ not claim that either child or the tree is complete. -/
 
 #guard
   runTree? (treeLimits (maxSplits := 0)) |>.any fun state =>
-    state.nodes.size == 1 && state.frontier.isEmpty && state.splits == 0 &&
-      state.leaves == 1 &&
+    state.nodes.size == 1 && state.frontier.isEmpty && state.accounting.splits == 0 &&
+      state.accounting.leaves == 1 &&
       match state.nodes[0]? with
       | some (BranchTree.Node.leaf _
           (BranchTree.LeafEnd.blocked _ BranchTree.Blocked.splitLimit)) => true
@@ -686,21 +688,23 @@ not claim that either child or the tree is complete. -/
 
 #guard
   runTree? (treeLimits (maxLeaves := 1)) |>.any fun state =>
-    state.nodes.size == 1 && state.frontier.isEmpty && state.splits == 0 &&
-      state.leaves == 1 &&
+    state.nodes.size == 1 && state.frontier.isEmpty && state.accounting.splits == 0 &&
+      state.accounting.leaves == 1 &&
       match state.nodes[0]? with
       | some (BranchTree.Node.leaf _
           (BranchTree.LeafEnd.blocked _ BranchTree.Blocked.leafLimit)) => true
       | _ => false
 
 #guard
-  BranchTree.schedule .depthFirst [{ index := 9 }]
-      [{ index := 1 }, { index := 2 }] ==
+  (Search.Frontier.schedule .depthFirst
+      ({ pending := [{ index := 9 }] } : Search.Frontier BranchTree.TreeId)
+      [{ index := 1 }, { index := 2 }]).pending ==
     [{ index := 1 }, { index := 2 }, { index := 9 }]
 
 #guard
-  BranchTree.schedule .breadthFirst [{ index := 9 }]
-      [{ index := 1 }, { index := 2 }] ==
+  (Search.Frontier.schedule .breadthFirst
+      ({ pending := [{ index := 9 }] } : Search.Frontier BranchTree.TreeId)
+      [{ index := 1 }, { index := 2 }]).pending ==
     [{ index := 9 }, { index := 1 }, { index := 2 }]
 
 /-! ## Operation-composed semantics at an arbitrary graph node -/

--- a/conformance/HexIntervalMathlib/ReluConformance.lean
+++ b/conformance/HexIntervalMathlib/ReluConformance.lean
@@ -66,11 +66,13 @@ private def branchLimits : BranchStart.Limits :=
   { maxDepth := 4, maxScopes := 8 }
 
 private def treeLimits (maxSteps := 3) (maxSplits := 1)
-    (maxLeaves := 2) : BranchTree.Limits :=
-  { branch := branchLimits
-    maxSteps
+    (maxLeaves := 2) : Search.Limits :=
+  { maxSteps
     maxSplits
     maxLeaves
+    maxFrontier := maxLeaves
+    maxDepth := branchLimits.maxDepth
+    maxScopes := branchLimits.maxScopes
     leafFuel := limits.policy.maxDecisions }
 
 private def boundExpr : Bound → Expr
@@ -496,7 +498,7 @@ private def reluTreePolicy : TargetRun.Controller Bound Unit :=
       | some offer => .select offer state
       | none => .stop state }
 
-private def reluTreeConfig (resources : BranchTree.Limits) :
+private def reluTreeConfig (resources : Search.Limits) :
     BranchTree.Config Bound Unit :=
   { factDomain
     packages := reluSplitPackages
@@ -507,7 +509,7 @@ private def reluTreeConfig (resources : BranchTree.Limits) :
     order := .depthFirst
     limits := resources }
 
-private def reluTree? (resources : BranchTree.Limits := treeLimits) :
+private def reluTree? (resources : Search.Limits := treeLimits) :
     Option (BranchTree.State Bound Unit) := do
   let .ok state := BranchTree.start (reluTreeConfig resources) { index := 0 }
       reluInput () | none
@@ -516,8 +518,8 @@ private def reluTree? (resources : BranchTree.Limits := treeLimits) :
 
 #guard
   reluTree?.any fun state =>
-    state.settled && state.nodes.size == 3 && state.steps == 3 &&
-      state.splits == 1 && state.leaves == 2 &&
+    state.settled && state.nodes.size == 3 && state.accounting.steps == 3 &&
+      state.accounting.splits == 1 && state.accounting.leaves == 2 &&
       match state.nodes[1]?, state.nodes[2]? with
       | some (BranchTree.Node.leaf left (BranchTree.LeafEnd.result leftRun)),
           some (BranchTree.Node.leaf right (BranchTree.LeafEnd.result rightRun)) =>

--- a/conformance/HexIntervalMathlib/ReluConformance.lean
+++ b/conformance/HexIntervalMathlib/ReluConformance.lean
@@ -776,21 +776,22 @@ example : True := by
       throwError "interval_relu_tree test: pending children produced a proof"
     let some tree := reluTree?
       | throwError "interval_relu_tree test: complete tree failed"
-    let some root := tree.nodes[0]?
+    let snapshot := tree.snapshot
+    let some root := snapshot.nodes[0]?
       | throwError "interval_relu_tree test: root is missing"
     let BranchTree.Node.split source run children left _ := root
       | throwError "interval_relu_tree test: root is not a split"
     let shared :=
-      { tree with
-        nodes := tree.nodes.set! 0
+      { snapshot with
+        nodes := snapshot.nodes.set! 0
           (BranchTree.Node.split source run children left left) }
-    if (← observing? <| BranchProof.emit reluProofLimits reluTreeEmitter shared
+    if (← observing? <| BranchProof.emitSnapshot reluProofLimits reluTreeEmitter shared
         expected).isSome then
       throwError "interval_relu_tree test: a shared sibling produced a proof"
-    let some extra := tree.nodes[1]?
+    let some extra := snapshot.nodes[1]?
       | throwError "interval_relu_tree test: child is missing"
-    let unreachable := { tree with nodes := tree.nodes.push extra }
-    if (← observing? <| BranchProof.emit reluProofLimits reluTreeEmitter unreachable
+    let unreachable := { snapshot with nodes := snapshot.nodes.push extra }
+    if (← observing? <| BranchProof.emitSnapshot reluProofLimits reluTreeEmitter unreachable
         expected).isSome then
       throwError "interval_relu_tree test: an unreachable node produced a proof"
   trivial

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -514,6 +514,7 @@ lean_lib HexConformance where
 
     ++ #[`HexInterval.PolicyFeatureConformance,
       `HexInterval.FeaturePolicyConformance,
+      `HexInterval.SearchConformance,
       `HexIntervalMathlib.MixedFunctionsConformance,
       `HexIntervalMathlib.MixedInstantiationConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one

--- a/progress/20260815T155541Z.md
+++ b/progress/20260815T155541Z.md
@@ -1,0 +1,43 @@
+# Supported authenticated search contract
+
+## Accomplished
+
+- Added Mathlib-free `HexInterval/Search.lean` with checked policy/action
+  sessions, exact action requests, non-authoritative callback replies,
+  transactional update-batch admission, conservative callback/policy stops,
+  bounded diagnostics, and stable bounded DFS/BFS frontiers.
+- Bound application, equality, matcher, scope, program, fact-version, write,
+  and opaque provenance data before state mutation. Failed later updates leave
+  the caller's entire preceding session unchanged.
+- Moved the experimental `BranchTree` order, limits, accounting, and frontier
+  representation onto the supported contracts while leaving package sessions,
+  split interpretation, target stops, and proof replay experimental.
+- Added conformance for stale and mutated decisions/replies, malformed deltas,
+  rollback, callback failure, diagnostic truncation, exact resource one-over
+  stops, stable nested DFS/BFS order, and parent restoration.
+- Updated the supported umbrella, file map, current-state SPEC, and tactic
+  configuration surface. The complete 9492-job experiment/conformance build
+  and focused search/branch builds pass; DAG, trust, factor-freshness, banned-
+  mechanism, and whitespace checks pass.
+
+## Current frontier
+
+- The supported layer authenticates decoded offers, actions, and structural
+  state but deliberately does not generate offers or interpret a callback's
+  mathematical claim. Accepted runtime contradictions remain data only.
+- `Experiment.PolicySession` still owns the concrete registry, payload arena,
+  and propagator engine. `TargetRun` retains its package-specific event and stop
+  taxonomy. They are not aliases for `Search.Session`.
+
+## Next step
+
+- Adapt one concrete experimental package/session vertical to construct and
+  refresh `Search.Session`, invoke its callback through `Search.invokeWithin`,
+  and translate only the structurally accepted result into the existing
+  package-specific outcome path. Keep semantic replay separate while measuring
+  whether the generic session needs a smaller authenticated offer payload.
+
+## Blockers
+
+- None. Callback allocation, measurement, and equality on caller-selected Lean
+  objects remain an explicit non-preemptible envelope by design.

--- a/progress/20260821T084908Z.md
+++ b/progress/20260821T084908Z.md
@@ -1,0 +1,29 @@
+# Supported authenticated search publication
+
+## Accomplished
+
+- Replayed the previously audited supported `HexInterval.Search` contract onto exact
+  main `84152c67d7d6de0f0ece1d40095fa78f2234887e`, preserving the merged supported
+  State and Policy contracts and all current registrations.
+- Reconciled the conformance suite with State's authoritative reconstructed branch
+  snapshot, rather than the removed experimental facts cache.
+- Built the supported Search conformance and every affected experimental/Mathlib
+  split consumer through a clean 1,999-job focused build.
+- Passed DAG, trust-surface, Mathlib-free bench, factor-freshness, PNT inventory,
+  diff, and banned-proof-mechanism checks.
+
+## Current frontier
+
+- The supported layer now owns a Mathlib-free authenticated search session,
+  transition validation, stable frontier order, bounded accounting, and retained
+  parent/leaf records. Existing concrete callback packages, offer discovery,
+  scheduler policy, split semantics, and proof replay remain experimental.
+
+## Next step
+
+- Publish the exact reconciled head as a non-draft upstream PR to `main` and let
+  the ordinary pull-request workflow validate the same commit.
+
+## Blockers
+
+- None.

--- a/progress/20260821T091932Z.md
+++ b/progress/20260821T091932Z.md
@@ -1,0 +1,36 @@
+# Harden supported Search authentication
+
+## Accomplished
+
+- Added resource-first preflight for decoded branch programs and arrays,
+  registries, bindings, application/equality generations, offers, and every
+  variable-length action port before semantic scans or policy measurements.
+- Corrected binding accounting: `maxApplications` bounds binding count while
+  `maxScopeNodes` independently bounds each scoped read and write list.
+- Introduced a private checked-session artifact so each public search
+  transition authenticates branch chronology and measures the policy view once;
+  accepted callback batches now fold exact successors over that checked branch.
+- Changed split admission to consume and pop the complete bounded frontier,
+  validate exact parent/child branches, and reject duplicate scheduled scopes.
+- Added discriminating one-over, malformed-session, exhausted-step,
+  detached-parent, and duplicate-parent conformance guards and updated the
+  current-state and complexity contracts.
+- Made the remaining compact-application boundary explicit: Search checks the
+  opaque handle's bound and generation plus every independent action field, but
+  does not claim application-id-to-rule/anchor correspondence without the exact
+  compiled application table.
+
+## Current frontier
+
+- The repaired supported Search contract and all directly affected retained-tree
+  and Mathlib conformance consumers build locally. Runtime callback results and
+  contradictions remain untrusted data; proof replay remains outside Search.
+
+## Next step
+
+- Run the full affected build and static/trust/freshness gates, then supersede
+  PR #9339 with the exact repaired head and monitor its automatic CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T095032Z.md
+++ b/progress/20260821T095032Z.md
@@ -1,0 +1,32 @@
+# Seal supported search accounting
+
+## Accomplished
+
+- Made the supported `Search.Accounting` constructor private and added checked
+  singleton-start, terminal-settle, and binary-split builders that enforce the
+  exact retained-frontier and independent resource invariants.
+- Migrated supported sessions, supported frontier transitions, and the
+  experimental `BranchTree` consumer away from direct accounting literals and
+  record updates.
+- Added conformance guards for exact builder-only counter progression, exhausted
+  steps, malformed starts, and both stable nested split schedules.
+- Removed the duplicate variable-length action preflight from authenticated
+  offer validation while retaining the standalone public action check.
+- Corrected the current Search resource and complexity contract: offers use
+  `Policy.maxOffers`, `State.maxActions` remains cumulative work, and split
+  admission validates every bounded retained frontier branch.
+
+## Current frontier
+
+- The accounting API and directly affected supported/experimental modules build
+  locally. The full conformance graph and static gates are running before the
+  exact PR head is superseded.
+
+## Next step
+
+- Finish full affected and static validation, commit, force-with-lease update
+  PR #9339, and monitor its automatic exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T102902Z.md
+++ b/progress/20260821T102902Z.md
@@ -1,0 +1,36 @@
+# Seal live search ownership
+
+## Accomplished
+
+- Replaced detached public accounting transitions with a sealed
+  `FrontierState` that owns the pending frontier and its cumulative tree
+  counters together; raw counter start/settle/split operations are private.
+- Sealed supported `Search.Session`, retained its accepted-step count inside
+  the session, and made a new-session start the only reset point while keeping
+  non-branching sessions independent of `maxFrontier`.
+- Sealed experimental `BranchTree.State` around the supported composite and
+  migrated every settle/split transition to consume and return that exact
+  state. Editable proof-fold corruption tests now use an explicitly untrusted
+  snapshot with no live resource authority.
+- Added load-bearing conformance for a session at `maxFrontier = 0`, exact
+  cumulative step/split/frontier exhaustion across nested splits, and detached
+  parent rejection. Updated the current-state SPEC to distinguish pure
+  alternative successors from counter reset or transplantation.
+- Passed the 9,560-job conformance build plus DAG, trust-surface, Mathlib-free
+  bench, factor-freshness, PNT inventory, copyright, diff, and banned-proof
+  checks.
+
+## Current frontier
+
+- The supported Search and experimental retained-tree consumers now expose no
+  public constructor or record-update path that can install fresh accounting
+  into an existing live run.
+
+## Next step
+
+- Commit and force-with-lease update PR #9339, then monitor its automatic
+  exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T104946Z.md
+++ b/progress/20260821T104946Z.md
@@ -1,0 +1,32 @@
+# Seal the supported leaf frontier
+
+## Accomplished
+
+- Added a private-constructor `Search.LeafFrontier` whose inner generic
+  `FrontierState (Leaf ...)` is private, so generic scheduling cannot be fed
+  back into the supported parent/depth/scope/branch transition.
+- Renamed the generic composite advances to explicit head-settle/head-split
+  primitives and kept them available to the separately sealed experimental
+  `BranchTree.State`.
+- Migrated supported leaf start, settle, split, accessors, conformance, and the
+  umbrella/current-state SPEC to the two-layer sealed contract.
+- Kept malformed branch, detached parent, depth, and exact fresh-scope checks
+  load-bearing, including a distinct wrong-child-scope guard.
+- Passed the 9,560-job conformance build and the DAG, trust-surface,
+  Mathlib-free bench, factor-freshness, PNT inventory, copyright, diff, and
+  banned-proof checks.
+
+## Current frontier
+
+- A leaf-shaped generic frontier can consume only generic resource/order
+  operations; it cannot be constructed or installed as a supported
+  `LeafFrontier` without passing the specialized checks.
+
+## Next step
+
+- Commit and force-with-lease supersede PR #9339, then monitor the automatic
+  exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T110735Z.md
+++ b/progress/20260821T110735Z.md
@@ -1,0 +1,33 @@
+# State the trusted import-all boundary
+
+## Accomplished
+
+- Corrected the supported Search contract to state that private constructors
+  seal ordinary/public imports, while Lean's deliberate `import all` is trusted
+  implementation access outside the decoded-runtime threat model.
+- Extended the existing DAG checker with an exact-path allowlist guard for
+  `import all HexInterval.Search`; the allowlist is currently empty, so an
+  accidental use anywhere in the repository fails the existing CI job.
+- Corrected resource wording: limits are supplied to each checked transition or
+  run handle and are not retained inside a frontier value.
+- Added conformance for exact leaf-head settlement, empty successor and step
+  charging/refusal, plus missing parent, wrong depth, malformed child branch,
+  and left-child scope rejection.
+- Passed the 9,560-job conformance build and DAG, trust-surface, Mathlib-free
+  bench, factor-freshness, PNT inventory, copyright, diff, and banned-proof
+  checks.
+
+## Current frontier
+
+- Ordinary downstream imports cannot construct or transplant sealed Search
+  internals; trusted source must opt into `import all` explicitly, and the
+  monorepo rejects that opt-in unless an exact owning path is reviewed.
+
+## Next step
+
+- Commit and force-with-lease supersede PR #9339, then monitor automatic
+  exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T112528Z.md
+++ b/progress/20260821T112528Z.md
@@ -1,0 +1,28 @@
+# Cover ownerless Lean roots in the trusted-import guard
+
+## Accomplished
+
+- Moved the sealed `import all HexInterval.Search` scan ahead of library-owner
+  filtering so every project Lean file, including `conformance/` and `bench/`,
+  is checked.
+- Added a unit regression with forbidden imports in both ownerless roots and
+  extended the existing single CI job's DAG step to execute it.
+- Added leaf-frontier guards for settling an empty frontier, malformed root
+  depth/parent, symmetric child-scope rejection, and documented that session
+  envelopes are supplied per call rather than stored.
+- Passed the focused 1,971-job build, full 9,560-job conformance build, DAG unit
+  test and checker, trust, Mathlib-free bench, freshness, PNT, copyright, diff,
+  and banned-proof checks.
+
+## Current frontier
+
+- The ordinary-import Search seal is now guarded across all repository Lean
+  roots, while the library DAG ownership checks remain scoped to owned modules.
+
+## Next step
+
+- Supersede PR #9339 with this exact repair and monitor automatic CI.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -604,5 +604,11 @@
     "baseline_blob": null,
     "current_blob": "d21532df570af19a454bcf6c2fcd1e350ecf3ee1",
     "reason": "Relocates the exact-division contract from HexResultant/ExactDiv.lean into a new HexBasic module: the ExactDivLaws class, its cancellation theorems, the total exactDiv wrapper, and the Int and field instances, all verbatim. The factorization path reaches it through the HexBasic umbrella, but no executable factorization definition calls exactDiv or mentions ExactDivLaws, and the two instances were already global via hex-resultant, so the compiled call graph is unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "a860987f71b25a081e9a8575048cf7a0484bed2b",
+    "reason": "Additionally registers the Mathlib-free supported HexInterval search-contract conformance module on top of the current public interval and PNT registrations; it does not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -181,6 +181,31 @@ def project_lean_files(root: Path) -> list[Path]:
     return sorted(files)
 
 
+def check_sealed_import_all(root: Path, files: list[Path]) -> list[str]:
+    """Reject trusted-internals imports outside exact reviewed owning paths.
+
+    This scan deliberately covers every project Lean file, including roots such
+    as ``conformance/`` and ``bench/`` which have no library DAG owner.
+    """
+    errors = []
+    for rel_path in files:
+        path = root / rel_path
+        for line_no, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            import_all = IMPORT_ALL_RE.match(line.split("--", 1)[0].rstrip())
+            if not import_all:
+                continue
+            module = import_all.group(1)
+            allowed = SEALED_IMPORT_ALL_ALLOWLIST.get(module)
+            if allowed is not None and rel_path not in allowed:
+                errors.append(
+                    f"{rel_path}:{line_no} uses `import all {module}` outside its "
+                    "exact trusted-internals allowlist"
+                )
+    return errors
+
+
 def import_roots(line: str) -> list[str]:
     match = IMPORT_RE.match(line.split("--", 1)[0].rstrip())
     if not match:
@@ -236,21 +261,15 @@ def main() -> int:
     )
     errors.extend(check_umbrella_completeness(root, libraries, build_roots))
 
-    for rel_path in project_lean_files(root):
+    lean_files = project_lean_files(root)
+    errors.extend(check_sealed_import_all(root, lean_files))
+
+    for rel_path in lean_files:
         owner = library_owner_for_path(rel_path, libraries)
         if owner is None:
             continue
         path = root / rel_path
         for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-            import_all = IMPORT_ALL_RE.match(line.split("--", 1)[0].rstrip())
-            if import_all:
-                module = import_all.group(1)
-                allowed = SEALED_IMPORT_ALL_ALLOWLIST.get(module)
-                if allowed is not None and rel_path not in allowed:
-                    errors.append(
-                        f"{rel_path}:{line_no} uses `import all {module}` outside its "
-                        "exact trusted-internals allowlist"
-                    )
             for imported_root in import_roots(line):
                 if imported_root == owner:
                     continue

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -23,6 +23,17 @@ LEAN_EXE_ROOT_RE = re.compile(r"^\s*root\s*:=\s*`([A-Za-z0-9_.]+)\s*$")
 LEAN_GLOB_MODULE_RE = re.compile(r"`([A-Z][A-Za-z0-9_.]+)")
 LEAN_LIB_RE = re.compile(r"^lean_lib\s+([A-Za-z0-9_]+)\b")
 QUALIFIED_IMPORT_RE = re.compile(r"^\s*(?:public\s+|private\s+)?import\s+([A-Za-z0-9_.]+)\s*$")
+IMPORT_ALL_RE = re.compile(
+    r"^\s*(?:(?:public|private|meta)\s+)*import\s+all\s+([A-Za-z0-9_.]+)\s*$"
+)
+
+# Private constructors in these modules are an ordinary/public-import API
+# boundary. `import all` is a deliberate trusted-internals escape hatch, so
+# every owning exception must be an exact reviewed path rather than a suffix or
+# directory convention. There are currently no required exceptions.
+SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
+    "HexInterval.Search": frozenset(),
+}
 
 UMBRELLA_BUILD_TARGETS = {
     "HexLLLBenchSupport",
@@ -231,6 +242,15 @@ def main() -> int:
             continue
         path = root / rel_path
         for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            import_all = IMPORT_ALL_RE.match(line.split("--", 1)[0].rstrip())
+            if import_all:
+                module = import_all.group(1)
+                allowed = SEALED_IMPORT_ALL_ALLOWLIST.get(module)
+                if allowed is not None and rel_path not in allowed:
+                    errors.append(
+                        f"{rel_path}:{line_no} uses `import all {module}` outside its "
+                        "exact trusted-internals allowlist"
+                    )
             for imported_root in import_roots(line):
                 if imported_root == owner:
                     continue

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_dag import check_sealed_import_all
+
+
+class SealedImportAllTest(unittest.TestCase):
+    def test_ownerless_roots_are_checked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            files = [
+                Path("conformance/HexInterval/Bypass.lean"),
+                Path("bench/HexInterval/Bypass.lean"),
+            ]
+            for path in files:
+                full_path = root / path
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text("import all HexInterval.Search\n", encoding="utf-8")
+
+            self.assertEqual(
+                check_sealed_import_all(root, files),
+                [
+                    "conformance/HexInterval/Bypass.lean:1 uses `import all "
+                    "HexInterval.Search` outside its exact trusted-internals allowlist",
+                    "bench/HexInterval/Bypass.lean:1 uses `import all "
+                    "HexInterval.Search` outside its exact trusted-internals allowlist",
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add supported Mathlib-free authenticated Search session, frontier, leaf, transition, and accounting contracts over Program/State/Policy
- validate decoded callbacks, decisions, actions, branches, dependencies, resources, and exact parent/depth/scope relationships transactionally
- seal cumulative session/frontier authority at the ordinary/public import boundary and reject accidental `import all HexInterval.Search` through the existing DAG checker
- migrate the experimental controller skeleton to the supported contracts and add discriminating conformance/resource/mutation canaries

## Trust and scope

Runtime callbacks, offers, decisions, payloads, traces, and decoded state remain untrusted data and never become proof evidence. Private constructors enforce the supported boundary under ordinary/public imports. Lean's deliberate `import all` is trusted-internals source access, outside the decoded-runtime threat model; the repository allowlist for `HexInterval.Search` is currently empty.

Concrete package callbacks, package assembly, offer generation, staged/adaptive policy algorithms, default scheduling policy, storage optimizations, branch proof replay, and tactic syntax remain experimental or future work.

## Validation

- `lake build HexConformance` (9,560 jobs)
- focused Search/NestedBranch/ReLU conformance build
- DAG, trust-surface, Mathlib-free bench, factor-freshness, PNT inventory, copyright, diff, and banned-proof checks
