### PR TITLE
fix: pin hex-poly-fp-mathlib into the publish manifest and its consumers

### DIFF
--- a/HexPolyFpMathlib/README.md
+++ b/HexPolyFpMathlib/README.md
@@ -1,0 +1,63 @@
+# hex-poly-fp-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+The Mathlib correspondence layer for
+[`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp). It relates the
+executable prime-field polynomials `Hex.FpPoly p` to Mathlib's
+`Polynomial (ZMod p)` through a ring equivalence, and transports
+coefficients, monicity, arithmetic, derivatives, and divisibility across
+it. It builds on
+[`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib) and
+[`hex-mod-arith-mathlib`](https://github.com/leanprover/hex-mod-arith-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-poly-fp-mathlib"
+git = "https://github.com/leanprover/hex-poly-fp-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexPolyFpMathlib
+```
+
+# Functionality
+
+The package exposes the correspondence between the executable prime-field
+polynomials and Mathlib's:
+
+- `fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p)`, with
+  `toMathlibPolynomial` as the forward map named for use in statements.
+- Coefficient and monicity transport (`coeff_toMathlibPolynomial`,
+  `toMathlibPolynomial_monic`).
+- Transport lemmas for addition, multiplication, subtraction, derivatives,
+  constants, `X`, monomials, and divisibility.
+- A `CommRing (Hex.FpPoly p)` instance derived from the equivalence.
+
+# Verification
+
+The headline result is the ring equivalence:
+
+```lean
+def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p)
+```
+
+Everything is stated under the executable bounds hypothesis
+`Hex.ZMod64.Bounds p`; lemmas that need `p` prime say so in their own
+hypotheses. Runtime-only clients should depend on
+[`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp); this package is
+for theorem statements and interoperability involving Mathlib. See the
+[SPEC](SPEC/hex-poly-fp-mathlib.md) for the correspondence contract and
+ownership boundaries.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexPolyFpMathlib/README.md
+++ b/HexPolyFpMathlib/README.md
@@ -24,6 +24,10 @@ rev = "main"
 
 ```lean
 import HexPolyFpMathlib
+
+noncomputable example {p : Nat} [Hex.ZMod64.Bounds p] :
+    Hex.FpPoly p ≃+* Polynomial (ZMod p) :=
+  HexPolyFpMathlib.fpPolyEquiv
 ```
 
 # Functionality
@@ -37,7 +41,8 @@ polynomials and Mathlib's:
   `toMathlibPolynomial_monic`).
 - Transport lemmas for addition, multiplication, subtraction, derivatives,
   constants, `X`, monomials, and divisibility.
-- A `CommRing (Hex.FpPoly p)` instance derived from the equivalence.
+- A `CommRing (Hex.FpPoly p)` instance whose operations are the executable
+  ones, proved from the ring laws `HexPolyFp` establishes.
 
 # Verification
 
@@ -47,9 +52,11 @@ The headline result is the ring equivalence:
 def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p)
 ```
 
-Everything is stated under the executable bounds hypothesis
-`Hex.ZMod64.Bounds p`; lemmas that need `p` prime say so in their own
-hypotheses. Runtime-only clients should depend on
+The equivalence and transport lemmas are stated under the executable bounds
+hypothesis `Hex.ZMod64.Bounds p`; lemmas that need `p` prime say so in their
+own hypotheses, and `primeModulus_of_fact` derives the executable
+prime-modulus witness from `Fact (Nat.Prime p)`. Runtime-only clients should
+depend on
 [`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp); this package is
 for theorem statements and interoperability involving Mathlib. See the
 [SPEC](SPEC/hex-poly-fp-mathlib.md) for the correspondence contract and

--- a/progress/20260821T110500Z_poly-fp-mathlib-publish-pins.md
+++ b/progress/20260821T110500Z_poly-fp-mathlib-publish-pins.md
@@ -1,0 +1,40 @@
+# hex-poly-fp-mathlib publish manifest entry and consumer pins
+
+## Accomplished
+
+- Added the `leanprover/hex-poly-fp-mathlib` entry to
+  `scripts/release/released.yml`, placed after `hex-mod-arith-mathlib`
+  (its last dependency) with the computed pin closure.
+- Added `hex-poly-fp-mathlib` to the pins of `hex-berlekamp-mathlib` and
+  `hex-berlekamp-zassenhaus-mathlib`, whose monorepo sources import
+  `HexPolyFpMathlib` since the extraction in #9295; without the pin the
+  next real sync would have published repos that cannot build. Also added
+  it to the `leanprover/hex` aggregate pins, which must equal the
+  complete split set.
+- Authored `HexPolyFpMathlib/README.md` per `SPEC/readme.md`, required
+  for the new manifest entry's managed-path check.
+- `python3 scripts/release/check_released_manifest.py` passes: 36 split
+  repositories + 1 aggregate.
+- The GitHub repository `leanprover/hex-poly-fp-mathlib` exists (created
+  this session, empty), along with the other six repos for the
+  finite-field publishing batch.
+
+## Current frontier
+
+- The new repo has no Lake/CI skeleton yet, so a sync dispatched now
+  fails safe at skeleton validation. Do not dispatch `sync-released.yml`
+  until the skeleton lands and the `hex-publishing` token has been
+  widened and approved for the new repositories.
+
+## Next step
+
+- Author the `leanprover/hex-poly-fp-mathlib` skeleton per
+  `scripts/release/BOOTSTRAP.md`, then continue the batch: READMEs and
+  manifest entries for hex-conway, hex-gfq-field, hex-gf2,
+  hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, plus the phase work
+  recorded in progress/2026-08-21T10-46-37Z.md.
+
+## Blockers
+
+- Token widening needs an organization owner's approval before any real
+  sync.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -190,6 +190,17 @@ repos:
     pins: [hex-arith, hex-mod-arith]
     lakefile: toml
 
+  - repo: leanprover/hex-poly-fp-mathlib
+    lib: HexPolyFpMathlib
+    umbrella: true
+    spec: hex-poly-fp-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-arith, hex-poly, hex-mod-arith, hex-poly-fp, hex-poly-mathlib, hex-mod-arith-mathlib]
+    lakefile: toml
+
   - repo: leanprover/hex-gfq-ring
     component: Quotient rings `F_p[x]/(f)`
     lib: HexGFqRing
@@ -400,7 +411,7 @@ repos:
     conformance: false
     fixtures: []
     oracles: []
-    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib, hex-poly-fp-mathlib]
     lakefile: toml
 
   - repo: leanprover/hex-gram-schmidt
@@ -495,7 +506,7 @@ repos:
     conformance: false
     fixtures: []
     oracles: []
-    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-determinant, hex-bareiss, hex-mod-arith, hex-gram-schmidt, hex-poly-z, hex-lll, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-hensel, hex-berlekamp-zassenhaus, hex-poly-mathlib, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-mod-arith-mathlib, hex-gram-schmidt-mathlib, hex-poly-z-mathlib, hex-lll-mathlib, hex-berlekamp-mathlib, hex-hensel-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-determinant, hex-bareiss, hex-mod-arith, hex-gram-schmidt, hex-poly-z, hex-lll, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-hensel, hex-berlekamp-zassenhaus, hex-poly-mathlib, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gram-schmidt-mathlib, hex-poly-z-mathlib, hex-lll-mathlib, hex-berlekamp-mathlib, hex-hensel-mathlib]
     lakefile: lean
 
   # Aggregate: re-pinned only, never regenerated from managed source (its
@@ -507,5 +518,5 @@ repos:
   - repo: leanprover/hex
     pins_only: true
     readme_template: scripts/release/hex-README.md
-    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
     lakefile: toml


### PR DESCRIPTION
This PR add the `leanprover/hex-poly-fp-mathlib` entry to `scripts/release/released.yml` and add the missing `hex-poly-fp-mathlib` pin to the `hex-berlekamp-mathlib`, `hex-berlekamp-zassenhaus-mathlib`, and aggregate `leanprover/hex` entries. The monorepo's `HexBerlekampMathlib` and `HexBerlekampZassenhausMathlib` import `HexPolyFpMathlib` since the extraction in #9295, so without the pin the next real sync would publish repos that cannot build. The new entry requires `HexPolyFpMathlib/README.md` as a managed path, authored here per `SPEC/readme.md`. `check_released_manifest.py` passes with 36 split repositories plus the aggregate.

The GitHub repository `leanprover/hex-poly-fp-mathlib` exists but has no Lake/CI skeleton yet, so a sync dispatched before the skeleton lands fails safe at skeleton validation; the skeleton and the `hex-publishing` token widening are follow-ups.

🤖 Prepared with Claude Code