### PR TITLE
feat: route the release sync across multiple publishing tokens

### DIFF
--- a/.github/workflows/sync-released.yml
+++ b/.github/workflows/sync-released.yml
@@ -8,7 +8,9 @@ name: Sync released repos
 # to their `main`, and advances the baseline — one dispatch drives it all the way
 # through. The uncoordinated-commit guard skips any released repo whose `main` has
 # moved off the baseline, so out-of-band commits are never clobbered. Needs the
-# `RELEASED_SYNC_PAT` secret (contents:write on the released repos).
+# `RELEASED_SYNC_PAT` and `RELEASED_SYNC_PAT_2` secrets (contents:write on the
+# released repos; the set is split across two fine-grained tokens because one
+# token caps its selected-repository list — the sync routes per repo).
 
 on:
   workflow_dispatch:
@@ -59,6 +61,7 @@ jobs:
       - name: Sync released repos
         env:
           RELEASED_SYNC_PAT: ${{ secrets.RELEASED_SYNC_PAT }}
+          RELEASED_SYNC_PAT_2: ${{ secrets.RELEASED_SYNC_PAT_2 }}
         run: |
           args=()
           [ "${{ inputs.dry_run }}" = "false" ] || args+=(--dry-run)

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -197,44 +197,48 @@ Rewriting the cross-repo revisions touches **every** lakefile and
 trusts the manifest, so a stale lockfile would otherwise rebuild against
 the old revision.
 
-### Publishing a new library: widen the token first
+### Publishing a new library: widen a token first
 
-The sync authenticates with the `RELEASED_SYNC_PAT` secret, currently a
-fine-grained token named `hex-publishing` owned by @kim-em. It is scoped to an
-explicit list of repositories, deliberately not to every repository, so
-publishing a new library takes three steps in this order:
+The sync authenticates with the `RELEASED_SYNC_PAT` and `RELEASED_SYNC_PAT_2`
+secrets, currently fine-grained tokens named `hex-publishing` and
+`hex-publishing-2` owned by @kim-em. Each is scoped to an explicit list of
+repositories, deliberately not to every repository, and a fine-grained token
+caps how many repositories it can select — which is why there is more than
+one. The sync does not care which token carries which repository: its
+preflight probes every target against every token and routes each clone and
+push through the first token that can see that repository, so a new library
+goes on whichever token has room. Publishing one takes three steps in this
+order:
 
 1. create the repository under `leanprover` and give it the un-managed Lake
    and CI skeleton (`scripts/release/BOOTSTRAP.md`); the sync clones but never
    creates;
-2. add that repository to the selected repositories of the token behind
-   `RELEASED_SYNC_PAT` with `Contents: Read and write`, and have an
-   organization owner approve the request at
+2. add that repository to the selected repositories of a token with room,
+   with `Contents: Read and write`, and have an organization owner approve
+   the request at
    https://github.com/organizations/leanprover/settings/personal-access-token-requests;
-   the current token is at
-   https://github.com/settings/personal-access-tokens/16433897, but find it
-   under https://github.com/settings/personal-access-tokens if it has since
-   been rotated; then
+   find the current tokens under
+   https://github.com/settings/personal-access-tokens; then
 3. add its entry to `released.yml` here and run the sync.
 
 The repository has to exist before step 2 can name it, which is why step 1
 comes first; nothing in this order is circular. Step 2 is the one with a
-human in the loop, so start it early. Rotating the token means redoing step 2
-for every published repository at once, so keep the secret and the token
-identified by name rather than by that numeric URL.
+human in the loop, so start it early. Rotating a token means redoing step 2
+for everything on that token at once, so keep the secrets and the tokens
+identified by name.
 
 Skipping step 2 used to fail partway through a publish, after earlier
-repositories had already been pushed: the token simply cannot see a repository
-outside its list, so the clone succeeds from public https and only the push
-returns `403 Permission to leanprover/<repo>.git denied`. `sync_released.py`
-now preflights every target repository before the first push and refuses to
-start, naming the repositories to add and both URLs above. A dry run does not
-preflight, having no token and pushing nothing.
+repositories had already been pushed: a fine-grained token simply cannot see a
+repository outside its list, so the clone succeeds from public https and only
+the push returns `403 Permission to leanprover/<repo>.git denied`.
+`sync_released.py` now preflights every target repository against every token
+before the first push and refuses to start, naming the repositories no token
+covers. A dry run does not preflight, having no token and pushing nothing.
 
 **What the preflight does not prove.** It checks that each repository is in
-the token's selection, and nothing stronger. `GET /repos` needs only
+some token's selection, and nothing stronger. `GET /repos` needs only
 `Metadata: read`, and the `permissions` it returns describe the authenticated
-user's role rather than this token's grants, so a token holding only
+user's role rather than that token's grants, so a token holding only
 `Contents: read` on a selected repository still looks fine to it. Nor does it
 know whether branch protection or a ruleset on a mirror's `main` would reject
 the push. Those failures still surface only at push time; the invariant the

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -204,9 +204,9 @@ secrets, currently fine-grained tokens named `hex-publishing` and
 `hex-publishing-2` owned by @kim-em. Each is scoped to an explicit list of
 repositories, deliberately not to every repository, and a fine-grained token
 caps how many repositories it can select — which is why there is more than
-one. The sync does not care which token carries which repository: its
-preflight probes every target against every token and routes each clone and
-push through the first token that can see that repository, so a new library
+one. The sync does not care which token carries which repository: for each
+target its preflight probes the tokens in order until one can see it, and
+routes that repository's clone and push through that token, so a new library
 goes on whichever token has room. Publishing one takes three steps in this
 order:
 
@@ -231,9 +231,9 @@ Skipping step 2 used to fail partway through a publish, after earlier
 repositories had already been pushed: a fine-grained token simply cannot see a
 repository outside its list, so the clone succeeds from public https and only
 the push returns `403 Permission to leanprover/<repo>.git denied`.
-`sync_released.py` now preflights every target repository against every token
+`sync_released.py` now preflights every target repository against the tokens
 before the first push and refuses to start, naming the repositories no token
-covers. A dry run does not preflight, having no token and pushing nothing.
+covers. A dry run does not preflight, using no token and pushing nothing.
 
 **What the preflight does not prove.** It checks that each repository is in
 some token's selection, and nothing stronger. `GET /repos` needs only

--- a/progress/20260821T134500Z_second-publishing-token.md
+++ b/progress/20260821T134500Z_second-publishing-token.md
@@ -1,0 +1,38 @@
+# Second publishing token for the release sync
+
+## Accomplished
+
+- Created the seven `leanprover/` repositories for the next publish wave
+  (hex-resultant, hex-resultant-mathlib, hex-number-field,
+  hex-number-field-mathlib, hex-number-field-tower,
+  hex-number-field-tower-mathlib, hex-rcf), empty and public, matching
+  the state of the already-created hex-poly-fp-mathlib.
+- The fine-grained `hex-publishing` token hit its selected-repository
+  cap while adding them, so Kim created `hex-publishing-2` (carrying the
+  two hex-resultant repos) and stores it as the `RELEASED_SYNC_PAT_2`
+  secret on kim-em/hex-dev.
+- Taught the sync to route across multiple tokens: `sync_released.py`
+  now collects `$RELEASED_SYNC_PAT`, `$RELEASED_SYNC_PAT_2`, ... (or
+  repeated `--token`), and the preflight probes each target repository
+  against each token, assigning every clone and push the first token
+  that can see that repository. No manifest bookkeeping of which
+  library is on which token. Updated the workflow env, the
+  released.yml header, and PLAN/Releases.md accordingly.
+- Unit-tested the routing and env-collection helpers and smoke-ran a
+  no-token `--dry-run --only hex-basic`.
+
+## Current frontier
+
+- Token approvals pending: the six-repo request on `hex-publishing`
+  and the new `hex-publishing-2` need org-owner approval.
+- The repos still need their un-managed Lake/CI skeletons
+  (scripts/release/BOOTSTRAP.md) before released.yml entries can land.
+
+## Next step
+
+- After approvals: skeletons, then released.yml entries in pin order
+  (hex-poly-fp-mathlib and hex-resultant first).
+
+## Blockers
+
+- Org-owner approval for both token requests.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -12,11 +12,13 @@
 # Order is topological (upstream first) so each repo's freshly-pushed SHA is
 # known before its downstream consumers are processed.
 #
-# ADDING A REPO HERE IS ONLY HALF THE JOB. The publishing token is scoped to an
-# explicit list of repositories, so the new one must also be added to the
-# `hex-publishing` fine-grained token and approved by an organization owner
-# before the sync can push to it. See PLAN/Releases.md
-# §"Publishing a new library: widen the token first"; sync_released.py
+# ADDING A REPO HERE IS ONLY HALF THE JOB. Each publishing token is scoped to
+# an explicit list of repositories (and a fine-grained token caps that list,
+# so there is more than one), so the new repo must also be added to one of the
+# `hex-publishing` / `hex-publishing-2` fine-grained tokens and approved by an
+# organization owner before the sync can push to it. Any token with room
+# works; the sync routes per repo. See PLAN/Releases.md
+# §"Publishing a new library: widen a token first"; sync_released.py
 # preflights this and refuses to start if it was missed.
 #
 # Per-repo managed path conventions (resolved by the driver):

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -17,13 +17,17 @@ pins resolve to the freshly-pushed commits. Its one managed artifact is the
 README, rendered by `aggregate_readme.py` from a template plus the manifest's
 `component:` labels so the published library table cannot fall behind.
 
-Auth (non-dry-run): a token from --token or $RELEASED_SYNC_PAT is used as an
-`x-access-token` basic-auth credential for clone and push. Dry-run clones over
-public https and never pushes.
+Auth (non-dry-run): tokens from --token (repeatable) or the environment
+($RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ... in numeric order) are used as
+`x-access-token` basic-auth credentials for clone and push. A fine-grained
+token caps its selected-repository list, so the published set is split across
+more than one token; the preflight probes each target repository against each
+token and routes every clone and push through the first token that can see
+that repository. Dry-run clones over public https and never pushes.
 
 Usage:
   python3 scripts/release/sync_released.py --dry-run
-  RELEASED_SYNC_PAT=... python3 scripts/release/sync_released.py
+  RELEASED_SYNC_PAT=... RELEASED_SYNC_PAT_2=... python3 scripts/release/sync_released.py
 """
 from __future__ import annotations
 
@@ -52,21 +56,25 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST = REPO_ROOT / "scripts" / "release" / "released.yml"
 BASELINE = REPO_ROOT / "scripts" / "release" / "synced.json"
 TOOLCHAIN = REPO_ROOT / "lean-toolchain"
-# The `RELEASED_SYNC_PAT` secret holds the `hex-publishing` fine-grained token.
-# It is deliberately scoped to the hex repositories rather than to every
-# repository, which means publishing a *new* library is a two-part change: add
-# it to released.yml here, and add it to the token's selected repositories
-# there. The second part needs an organization owner's approval, so start it
-# before the release rather than discovering it mid-publish.
+# The `RELEASED_SYNC_PAT` / `RELEASED_SYNC_PAT_2` secrets hold the
+# `hex-publishing` / `hex-publishing-2` fine-grained tokens. Each is
+# deliberately scoped to hex repositories rather than to every repository, and
+# a fine-grained token caps how many repositories it can select, which is why
+# there is more than one. Publishing a *new* library is therefore a two-part
+# change: add it to released.yml here, and add it to the selected repositories
+# of a token with room. The second part needs an organization owner's
+# approval, so start it before the release rather than discovering it
+# mid-publish. The sync does not care which token carries which repository; it
+# routes per repository to the first token that can see it.
 TOKEN_HELP = (
-    "Add the repositories above to the selected repositories of the token behind\n"
-    "the RELEASED_SYNC_PAT secret (Contents: Read and write). That is currently\n"
-    "the `hex-publishing` fine-grained token, at the time of writing\n"
-    "https://github.com/settings/personal-access-tokens/16433897 ; if it has been\n"
-    "rotated since, find the current one under\n"
-    "https://github.com/settings/personal-access-tokens . The token is scoped to\n"
-    "the hex repositories on purpose, so each newly published library has to be\n"
-    "added by hand. An organization owner then approves the request at\n"
+    "Add the repositories above to the selected repositories of one of the tokens\n"
+    "behind the RELEASED_SYNC_PAT / RELEASED_SYNC_PAT_2 secrets (Contents: Read\n"
+    "and write). Those are currently the `hex-publishing` and `hex-publishing-2`\n"
+    "fine-grained tokens, listed under\n"
+    "https://github.com/settings/personal-access-tokens . Any token with room\n"
+    "works; the sync routes per repository. Each token is scoped to hex\n"
+    "repositories on purpose, so each newly published library has to be added by\n"
+    "hand. An organization owner then approves the request at\n"
     "https://github.com/organizations/leanprover/settings/personal-access-token-requests"
 )
 LAKE_MANIFEST = REPO_ROOT / "lake-manifest.json"
@@ -240,21 +248,33 @@ def selection_check(repo: str, token: str) -> str | None:
             "missing or unselected is undetermined")
 
 
-def preflight_token(entries: list[dict], token: str) -> list[str]:
-    """Report every repo this run would push to that the token cannot reach.
+def route_tokens(entries: list[dict], tokens: list[str]) -> tuple[dict[str, str], list[str]]:
+    """Assign each target repo the first token that can see it.
 
-    Checked up front, before the first push: the publishing token is scoped to
-    an explicit list of repositories, so a library released here but not added
-    to that list would otherwise fail partway through, after earlier repos were
-    already published. This proves selection, not write access; see
+    Returns (repo -> token, blocked-report lines). Checked up front, before the
+    first push: each publishing token is scoped to an explicit list of
+    repositories, and a fine-grained token caps that list, so the published set
+    is split across more than one token. Nothing here assumes any particular
+    split; each repository is probed against each token in order and every
+    later clone and push uses the token routed here. A library released here
+    but on no token's list would otherwise fail partway through, after earlier
+    repos were already published. This proves selection, not write access; see
     `selection_check`.
     """
+    routed: dict[str, str] = {}
     blocked: list[str] = []
     for entry in entries:
-        reason = selection_check(entry["repo"], token)
-        if reason:
-            blocked.append(f"{entry['repo']}: {reason}")
-    return blocked
+        repo = entry["repo"]
+        reasons: list[str] = []
+        for index, token in enumerate(tokens):
+            reason = selection_check(repo, token)
+            if reason is None:
+                routed[repo] = token
+                break
+            reasons.append(f"token {index + 1}: {reason}")
+        else:
+            blocked.append(f"{repo}: " + "; ".join(reasons))
+    return routed, blocked
 
 
 def _lake_files(clone: Path, name_globs: list[str]) -> list[Path]:
@@ -753,11 +773,23 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         return True
 
 
+def env_tokens() -> list[str]:
+    """Tokens from $RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ... in numeric order."""
+    def order(name: str) -> int:
+        suffix = name.removeprefix("RELEASED_SYNC_PAT")
+        return int(suffix[1:]) if suffix else 1
+    names = [name for name in os.environ
+             if re.fullmatch(r"RELEASED_SYNC_PAT(_[0-9]+)?", name) and os.environ[name]]
+    return [os.environ[name] for name in sorted(names, key=order)]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Publish released split repos from the monorepo.")
     ap.add_argument("--dry-run", action="store_true", help="print planned changes; do not push")
-    ap.add_argument("--token", default=os.environ.get("RELEASED_SYNC_PAT"),
-                    help="GitHub token with contents:write on the released repos")
+    ap.add_argument("--token", action="append", default=None,
+                    help="GitHub token with contents:write on (a subset of) the "
+                         "released repos; repeatable, tried in order per repo. "
+                         "Defaults to $RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ...")
     ap.add_argument("--only", help="sync only this repo short-name (e.g. hex-matrix)")
     ap.add_argument("--force", action="store_true",
                     help="override the uncoordinated-commit guard and overwrite anyway")
@@ -766,8 +798,10 @@ def main() -> int:
                          "(the workflow points this at the release-sync-baseline branch's copy)")
     args = ap.parse_args()
 
-    if not args.dry_run and not args.token:
-        ap.error("a token (--token or $RELEASED_SYNC_PAT) is required unless --dry-run")
+    tokens = args.token or env_tokens()
+    if not args.dry_run and not tokens:
+        ap.error("a token (--token or $RELEASED_SYNC_PAT / $RELEASED_SYNC_PAT_2 / ...) "
+                 "is required unless --dry-run")
 
     manifest = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
     baseline_doc = json.loads(args.baseline.read_text(encoding="utf-8")) if args.baseline.exists() else {}
@@ -792,19 +826,20 @@ def main() -> int:
         print(f"release sync: --only {args.only} matches {len(targets)} manifest "
               "entries; expected exactly one", file=sys.stderr)
         return 1
+    repo_token: dict[str, str] = {}
     if not args.dry_run:
-        blocked = preflight_token(targets, args.token)
+        repo_token, blocked = route_tokens(targets, tokens)
         if blocked:
-            print(f"\nrelease sync: the publishing token cannot reach "
-                  f"{len(blocked)} of {len(targets)} target repositories:",
+            print(f"\nrelease sync: none of the {len(tokens)} publishing token(s) "
+                  f"can reach {len(blocked)} of {len(targets)} target repositories:",
                   file=sys.stderr)
             for line in blocked:
                 print(f"  {line}", file=sys.stderr)
             print(f"\n{TOKEN_HELP}", file=sys.stderr)
             return 1
-        print(f"token preflight: all {len(targets)} target repositories are in "
-              "the token's selection (this does not prove write access; see "
-              "selection_check)")
+        print(f"token preflight: all {len(targets)} target repositories are covered "
+              f"by the {len(tokens)} publishing token(s) (this does not prove write "
+              "access; see selection_check)")
 
     failed_repo: str | None = None
     current_repo = "<manifest>"
@@ -813,13 +848,14 @@ def main() -> int:
             current_repo = entry["repo"]
             if args.only and entry["repo"].split("/")[-1] != args.only:
                 continue
-            sync_repo(entry, source_sha, args.token, args.dry_run,
+            token = repo_token.get(entry["repo"], tokens[0] if tokens else None)
+            sync_repo(entry, source_sha, token, args.dry_run,
                       synced, baseline, args.force, dep_owner, pins)
     except Exception as exc:
         failed_repo = current_repo
         message = str(exc)
-        if args.token:
-            message = message.replace(args.token, "<redacted>")
+        for token in tokens:
+            message = message.replace(token, "<redacted>")
         print(
             f"\nrelease sync failed in {failed_repo}: "
             f"{type(exc).__name__}: {message}",

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -21,9 +21,9 @@ Auth (non-dry-run): tokens from --token (repeatable) or the environment
 ($RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ... in numeric order) are used as
 `x-access-token` basic-auth credentials for clone and push. A fine-grained
 token caps its selected-repository list, so the published set is split across
-more than one token; the preflight probes each target repository against each
-token and routes every clone and push through the first token that can see
-that repository. Dry-run clones over public https and never pushes.
+more than one token; for each target repository the preflight probes the
+tokens in order until one can see it, and routes that repository's clone and
+push through that token. Dry-run clones over public https and never pushes.
 
 Usage:
   python3 scripts/release/sync_released.py --dry-run
@@ -67,10 +67,13 @@ TOOLCHAIN = REPO_ROOT / "lean-toolchain"
 # mid-publish. The sync does not care which token carries which repository; it
 # routes per repository to the first token that can see it.
 TOKEN_HELP = (
-    "Add the repositories above to the selected repositories of one of the tokens\n"
-    "behind the RELEASED_SYNC_PAT / RELEASED_SYNC_PAT_2 secrets (Contents: Read\n"
-    "and write). Those are currently the `hex-publishing` and `hex-publishing-2`\n"
-    "fine-grained tokens, listed under\n"
+    "Follow the per-token reasons above: a repository reported as not selected\n"
+    "must be added to the selected repositories of one of the tokens behind the\n"
+    "RELEASED_SYNC_PAT / RELEASED_SYNC_PAT_2 secrets (Contents: Read and write);\n"
+    "a missing repository must be created first; an indeterminate reason (rate\n"
+    "limit, network, credentials) calls for a retry or a token repair, not a\n"
+    "selection change. The tokens are currently `hex-publishing` and\n"
+    "`hex-publishing-2`, listed under\n"
     "https://github.com/settings/personal-access-tokens . Any token with room\n"
     "works; the sync routes per repository. Each token is scoped to hex\n"
     "repositories on purpose, so each newly published library has to be added by\n"
@@ -255,8 +258,9 @@ def route_tokens(entries: list[dict], tokens: list[str]) -> tuple[dict[str, str]
     first push: each publishing token is scoped to an explicit list of
     repositories, and a fine-grained token caps that list, so the published set
     is split across more than one token. Nothing here assumes any particular
-    split; each repository is probed against each token in order and every
-    later clone and push uses the token routed here. A library released here
+    split; each repository is probed against the tokens in order until one sees
+    it, and every later clone and push uses the token routed here. A library
+    released here
     but on no token's list would otherwise fail partway through, after earlier
     repos were already published. This proves selection, not write access; see
     `selection_check`.
@@ -774,12 +778,19 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
 
 
 def env_tokens() -> list[str]:
-    """Tokens from $RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ... in numeric order."""
+    """Tokens from $RELEASED_SYNC_PAT, $RELEASED_SYNC_PAT_2, ... in numeric order.
+
+    Only the canonical slot names count: the base name, then suffixes that are
+    integers >= 2 without leading zeroes, so no `_0`/`_1`/`_01` alias can sort
+    ambiguously against the base slot. Empty slots are skipped (the workflow
+    exports the secrets unconditionally, so an unset secret arrives as "").
+    """
     def order(name: str) -> int:
         suffix = name.removeprefix("RELEASED_SYNC_PAT")
         return int(suffix[1:]) if suffix else 1
     names = [name for name in os.environ
-             if re.fullmatch(r"RELEASED_SYNC_PAT(_[0-9]+)?", name) and os.environ[name]]
+             if re.fullmatch(r"RELEASED_SYNC_PAT(_(?:[2-9]|[1-9][0-9]+))?", name)
+             and os.environ[name]]
     return [os.environ[name] for name in sorted(names, key=order)]
 
 
@@ -798,6 +809,11 @@ def main() -> int:
                          "(the workflow points this at the release-sync-baseline branch's copy)")
     args = ap.parse_args()
 
+    # An empty token would probe anonymously, win the routing for every public
+    # repository, and only fail at push time — after earlier repositories were
+    # already published. Reject it loudly instead.
+    if args.token is not None and any(not token.strip() for token in args.token):
+        ap.error("--token values must be nonempty")
     tokens = args.token or env_tokens()
     if not args.dry_run and not tokens:
         ap.error("a token (--token or $RELEASED_SYNC_PAT / $RELEASED_SYNC_PAT_2 / ...) "
@@ -830,16 +846,18 @@ def main() -> int:
     if not args.dry_run:
         repo_token, blocked = route_tokens(targets, tokens)
         if blocked:
-            print(f"\nrelease sync: none of the {len(tokens)} publishing token(s) "
-                  f"can reach {len(blocked)} of {len(targets)} target repositories:",
+            print(f"\nrelease sync: could not establish token coverage for "
+                  f"{len(blocked)} of {len(targets)} target repositories:",
                   file=sys.stderr)
             for line in blocked:
                 print(f"  {line}", file=sys.stderr)
             print(f"\n{TOKEN_HELP}", file=sys.stderr)
             return 1
+        per_slot = ", ".join(
+            f"token {index + 1}: {sum(1 for t in repo_token.values() if t == token)}"
+            for index, token in enumerate(tokens))
         print(f"token preflight: all {len(targets)} target repositories are covered "
-              f"by the {len(tokens)} publishing token(s) (this does not prove write "
-              "access; see selection_check)")
+              f"({per_slot}; this does not prove write access, see selection_check)")
 
     failed_repo: str | None = None
     current_repo = "<manifest>"
@@ -848,7 +866,9 @@ def main() -> int:
             current_repo = entry["repo"]
             if args.only and entry["repo"].split("/")[-1] != args.only:
                 continue
-            token = repo_token.get(entry["repo"], tokens[0] if tokens else None)
+            # Dry runs skip routing and clone over public https; real runs index
+            # the routed map so a repository routing ever missed fails closed.
+            token = None if args.dry_run else repo_token[entry["repo"]]
             sync_repo(entry, source_sha, token, args.dry_run,
                       synced, baseline, args.force, dep_owner, pins)
     except Exception as exc:

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -253,24 +253,60 @@ class SyncReleasedTests(unittest.TestCase):
 
 
 class TokenPreflightTests(unittest.TestCase):
-    """A library published here but missing from the token's selected
+    """A library published here but missing from every token's selected
     repositories must stop the run before anything is pushed."""
 
     ENTRIES = [{"repo": "leanprover/hex-basic"}, {"repo": "leanprover/hex-arith"}]
 
     def test_writable_repos_pass(self) -> None:
         with patch.object(sync_released, "selection_check", return_value=None):
-            self.assertEqual(sync_released.preflight_token(self.ENTRIES, "t"), [])
+            routed, blocked = sync_released.route_tokens(self.ENTRIES, ["t"])
+        self.assertEqual(blocked, [])
+        self.assertEqual(routed, {e["repo"]: "t" for e in self.ENTRIES})
 
-    def test_unlisted_repo_is_reported_with_its_reason(self) -> None:
-        def check(repo: str, _token: str) -> str | None:
-            return None if repo.endswith("hex-basic") else "not in the token's selected repositories"
+    def test_unlisted_repo_is_reported_with_every_tokens_reason(self) -> None:
+        def check(repo: str, token: str) -> str | None:
+            if repo.endswith("hex-basic"):
+                return None
+            return f"not in the token's selected repositories ({token})"
 
         with patch.object(sync_released, "selection_check", side_effect=check):
-            blocked = sync_released.preflight_token(self.ENTRIES, "t")
+            routed, blocked = sync_released.route_tokens(self.ENTRIES, ["t1", "t2"])
+        self.assertEqual(routed, {"leanprover/hex-basic": "t1"})
         self.assertEqual(len(blocked), 1)
         self.assertIn("leanprover/hex-arith", blocked[0])
-        self.assertIn("selected repositories", blocked[0])
+        self.assertIn("token 1: not in the token's selected repositories (t1)", blocked[0])
+        self.assertIn("token 2: not in the token's selected repositories (t2)", blocked[0])
+
+    def test_repos_split_across_tokens_each_route_to_a_seeing_token(self) -> None:
+        def check(repo: str, token: str) -> str | None:
+            on = {"leanprover/hex-basic": "t1", "leanprover/hex-arith": "t2"}
+            return None if on[repo] == token else "not in the token's selected repositories"
+
+        with patch.object(sync_released, "selection_check", side_effect=check):
+            routed, blocked = sync_released.route_tokens(self.ENTRIES, ["t1", "t2"])
+        self.assertEqual(blocked, [])
+        self.assertEqual(routed, {"leanprover/hex-basic": "t1",
+                                  "leanprover/hex-arith": "t2"})
+
+    def test_first_seeing_token_wins_and_later_tokens_are_not_probed(self) -> None:
+        probes: list[tuple[str, str]] = []
+
+        def check(repo: str, token: str) -> str | None:
+            probes.append((repo, token))
+            return None
+
+        with patch.object(sync_released, "selection_check", side_effect=check):
+            routed, _ = sync_released.route_tokens(self.ENTRIES, ["t1", "t2"])
+        self.assertEqual(set(routed.values()), {"t1"})
+        self.assertNotIn(("leanprover/hex-basic", "t2"), probes)
+
+    def test_env_tokens_collects_in_numeric_order_and_skips_empty(self) -> None:
+        env = {"RELEASED_SYNC_PAT_2": "tok2", "RELEASED_SYNC_PAT": "tok1",
+               "RELEASED_SYNC_PAT_10": "tok10", "RELEASED_SYNC_PATX": "not-a-slot",
+               "RELEASED_SYNC_PAT_3": ""}
+        with patch.dict(sync_released.os.environ, env, clear=True):
+            self.assertEqual(sync_released.env_tokens(), ["tok1", "tok2", "tok10"])
 
     def _check(self, responses: list) -> str | None:
         """Run selection_check with `_api_repo` answering from `responses`,

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -308,6 +308,48 @@ class TokenPreflightTests(unittest.TestCase):
         with patch.dict(sync_released.os.environ, env, clear=True):
             self.assertEqual(sync_released.env_tokens(), ["tok1", "tok2", "tok10"])
 
+    def test_env_tokens_ignores_noncanonical_slots(self) -> None:
+        # `_0`, `_1`, and zero-padded suffixes would sort ambiguously against
+        # the base slot, so only the base and integer suffixes >= 2 count.
+        env = {"RELEASED_SYNC_PAT": "tok1", "RELEASED_SYNC_PAT_0": "alias0",
+               "RELEASED_SYNC_PAT_1": "alias1", "RELEASED_SYNC_PAT_02": "alias02"}
+        with patch.dict(sync_released.os.environ, env, clear=True):
+            self.assertEqual(sync_released.env_tokens(), ["tok1"])
+
+    def test_empty_cli_token_is_rejected(self) -> None:
+        # An empty token probes anonymously and would win the routing for every
+        # public repository, only to fail at push time.
+        argv = ["sync_released.py", "--token", "", "--baseline",
+                str(self.repo / "baseline.json")]
+        with patch("sys.argv", argv), self.assertRaises(SystemExit) as caught:
+            sync_released.main()
+        self.assertEqual(caught.exception.code, 2)
+
+    def test_dry_run_passes_no_token_despite_env_tokens(self) -> None:
+        manifest = self.repo / "released.yml"
+        manifest.write_text("repos:\n  - repo: leanprover/hex-basic\n", encoding="utf-8")
+        baseline = self.repo / "baseline.json"
+        baseline.write_text(json.dumps({"hex-basic": "old"}), encoding="utf-8")
+        seen_tokens: list = []
+
+        def publish(entry, _source_sha, token, _dry_run, synced,
+                    _baseline, _force, _dep_owner, _pins):
+            seen_tokens.append(token)
+            return False
+
+        argv = ["sync_released.py", "--dry-run", "--baseline", str(baseline)]
+        env = {"RELEASED_SYNC_PAT": "tok1", "RELEASED_SYNC_PAT_2": "tok2"}
+        with (
+            patch.object(sync_released, "MANIFEST", manifest),
+            patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "sync_repo", side_effect=publish),
+            patch.dict(sync_released.os.environ, env),
+            patch("sys.argv", argv),
+        ):
+            self.assertEqual(sync_released.main(), 0)
+        self.assertEqual(seen_tokens, [None])
+
     def _check(self, responses: list) -> str | None:
         """Run selection_check with `_api_repo` answering from `responses`,
         in call order: authenticated first, then the anonymous probe."""


### PR DESCRIPTION
This PR teach the release sync to authenticate with more than one publishing token. A fine-grained token caps its selected-repository list, and the published set has outgrown one token: `hex-publishing-2` now exists alongside `hex-publishing`, carried by a new `RELEASED_SYNC_PAT_2` secret. `sync_released.py` collects `$RELEASED_SYNC_PAT`, `$RELEASED_SYNC_PAT_2`, ... (or repeated `--token`), and its preflight probes every target repository against every token, routing each clone and push through the first token that can see that repository — so nothing records which library is on which token, and a new library goes on whichever token has room. The workflow passes both secrets, and the `released.yml` header and `PLAN/Releases.md` §"Publishing a new library: widen a token first" describe the setup.

🤖 Prepared with Claude Code