### PR TITLE
Add supported interval proof replay contracts

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5193,9 +5193,11 @@ their declared cost inside a scheduler bound.
 - `HexIntervalMathlib/Proof.lean`: supported package-owned fact, equality,
   instance, and refutation theorem schemas; exact registry/action validation;
   chronological typed proof state and caller-target closure; and the
-  transactional placeholder/metavariable rejection, `Meta.check`, and exact
-  type-definitional-equality expression boundary. The kernel performs the final
-  check when the caller installs the expression in a declaration. Under
+  expression boundary that rejects placeholders and metavariables, restores
+  emitter changes, then transactionally runs `Meta.check` and exact
+  type-definitional-equality checking in the caller's environment. Emitted
+  terms may reference only declarations surviving that rollback. The kernel
+  performs the final check when the caller installs the expression. Under
   ordinary imports, only `Registry.buildWithin` can construct the theorem
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. Concrete

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5193,8 +5193,14 @@ their declared cost inside a scheduler bound.
 - `HexIntervalMathlib/Proof.lean`: supported package-owned fact, equality,
   instance, and refutation theorem schemas; exact registry/action validation;
   chronological typed proof state and caller-target closure; and the
-  transactional kernel-checked `Expr` emission boundary. Concrete packages,
-  goal reification, tactic syntax, and default registries remain experimental.
+  transactional placeholder/metavariable rejection, `Meta.check`, and exact
+  type-definitional-equality expression boundary. The kernel performs the final
+  check when the caller installs the expression in a declaration. Under
+  ordinary imports, only `Registry.buildWithin` can construct the theorem
+  registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
+  hatch rejected outside the exact empty repository allowlist. Concrete
+  packages, goal reification, tactic syntax, and default registries remain
+  experimental.
 - `HexIntervalMathlib/Split.lean`: exact transactional child semantics,
   containment, coverage, disjointness, and left ownership of the cut point.
 - `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5187,6 +5187,14 @@ their declared cost inside a scheduler bound.
   an image-tightness converse.
 - `HexIntervalMathlib/Power.lean`: exact normalized selected-cut semantics and
   the one-way successful natural-power image theorem.
+- `HexIntervalMathlib/Program.lean`: exact function-agnostic operation
+  meanings, complete operation-array alignment, per-node SSA relations, and
+  global model assembly over the supported decoded program.
+- `HexIntervalMathlib/Proof.lean`: supported package-owned fact, equality,
+  instance, and refutation theorem schemas; exact registry/action validation;
+  chronological typed proof state and caller-target closure; and the
+  transactional kernel-checked `Expr` emission boundary. Concrete packages,
+  goal reification, tactic syntax, and default registries remain experimental.
 - `HexIntervalMathlib/Split.lean`: exact transactional child semantics,
   containment, coverage, disjointness, and left ownership of the cut point.
 - `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics
@@ -5238,9 +5246,12 @@ their declared cost inside a scheduler bound.
    target driver, and split-construction designs. Optimized storage, concrete
    offer generation, package protocols, and a default policy will be selected
    from measurements; none is frozen by the decoded supported snapshots.
- - `conformance/HexInterval/{Conformance,SearchConformance,MinMaxConformance,
-   EmitFixtures}.lean`:
-   Lean-only checks and oracle fixtures.
+- `conformance/HexInterval/{Conformance,SearchConformance,MinMaxConformance,
+  EmitFixtures}.lean`:
+  Lean-only checks and oracle fixtures.
+- `conformance/HexIntervalMathlib/ProgramProofConformance.lean`: supported
+  program-model, registry, chronology, refutation, target-closure, mutation,
+  Meta-state restoration, and guarded ordinary-theorem canaries.
 - `HexInterval/Experiment/PntFks2FamilyData*.lean` and
   `HexInterval/Experiment/PntFks2Family.lean`: committed source-pinned family
   data and the Mathlib-free complete-family checker.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5194,10 +5194,12 @@ their declared cost inside a scheduler bound.
   instance, and refutation theorem schemas; exact registry/action validation;
   chronological typed proof state and caller-target closure; and the
   expression boundary that rejects placeholders and metavariables, restores
-  emitter changes, then transactionally runs `Meta.check` and exact
-  type-definitional-equality checking in the caller's environment. Emitted
-  terms may reference only declarations surviving that rollback. The kernel
-  performs the final check when the caller installs the expression. Under
+  emitter environment/messages/information/metavariables and clears both
+  environment-dependent elaborator caches, then transactionally runs
+  `Meta.check` and exact type-definitional-equality checking in the caller's
+  environment. Emitted terms may reference only declarations surviving that
+  rollback. The kernel performs the final check when the caller installs the
+  expression. Under
   ordinary imports, only `Registry.buildWithin` can construct the theorem
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. Concrete

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -18,6 +18,8 @@ public import HexIntervalMathlib.Split
 public import HexIntervalMathlib.Inverse
 public import HexIntervalMathlib.Division
 public import HexIntervalMathlib.Regularize
+public import HexIntervalMathlib.Program
+public import HexIntervalMathlib.Proof
 
 public section
 
@@ -27,5 +29,6 @@ the supported `Hex.Interval` operations, including resource-checked addition,
 subtraction, and multiplication, exact minimum/maximum images, absolute value,
 natural power, outward regularization, and closed-left/strict-right
 transactional splitting, plus precision-indexed reciprocal and division
-enclosures.
+enclosures. It also supplies the function-agnostic semantics of supported
+programs and the chronological, package-owned proof-replay boundary.
 -/

--- a/HexIntervalMathlib/Program.lean
+++ b/HexIntervalMathlib/Program.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Search
+public import Mathlib
+
+@[expose] public section
+
+/-!
+# Function-agnostic program semantics
+
+This module is the supported Mathlib proof interpretation of a checked
+`Hex.Interval.Program`. Each package contributes one exact operation signature
+and a relation on argument and result values. `Program.Models` requires the
+meaning array to align exactly with the opaque operation array and requires a
+relation witness at every SSA node. Missing or reordered meanings do not leave
+nodes unconstrained.
+-/
+
+namespace Hex.Interval.Program
+
+/-- Mathematical meaning of one exact opaque operation signature. -/
+structure Meaning (Value : Type) where
+  operation : Operation
+  relation : List Value → Value → Prop
+
+/-- Package meanings align pointwise with the supported operation snapshot. -/
+def Aligned : List (Meaning Value) → List Operation → Prop
+  | [], [] => True
+  | meaning :: meanings, operation :: operations =>
+      meaning.operation = operation ∧ Aligned meanings operations
+  | _, _ => False
+
+theorem Aligned.map {meanings : List (Meaning Value)} {operations : List Operation}
+    (aligned : Aligned meanings operations) :
+    meanings.map (·.operation) = operations := by
+  induction meanings generalizing operations with
+  | nil => cases operations <;> simp_all [Aligned]
+  | cons meaning meanings ih =>
+      cases operations with
+      | nil => simp [Aligned] at aligned
+      | cons operation operations =>
+          simp only [Aligned] at aligned
+          simp [aligned.1, ih aligned.2]
+
+/-- Exact operation-array equality follows from package-by-package alignment. -/
+theorem operationsOfAligned (meanings : Array (Meaning Value))
+    (operations : Array Operation)
+    (aligned : Aligned meanings.toList operations.toList) :
+    operations = meanings.map (·.operation) := by
+  apply Array.toList_inj.mp
+  simpa using aligned.map.symm
+
+/-- Meaning of one instruction at its exact SSA node. -/
+def MeaningAt (meanings : Array (Meaning Value)) (valuation : NodeId → Value)
+    (node : NodeId) (instruction : Node) : Prop :=
+  ∃ meaning,
+    meanings[instruction.op.index]? = some meaning ∧
+      meaning.relation (instruction.args.map valuation) (valuation node)
+
+/-- Every operation and node has its exact aligned package meaning. -/
+def Models (meanings : Array (Meaning Value)) (program : Program)
+    (valuation : NodeId → Value) : Prop :=
+  program.operations = meanings.map (·.operation) ∧
+    ∀ node instruction, program.node? node = some instruction →
+      MeaningAt meanings valuation node instruction
+
+/-- Node meanings in exact program order, convenient for proof emission. -/
+def Meanings (meanings : Array (Meaning Value)) (valuation : NodeId → Value) :
+    Nat → List Node → Prop
+  | _, [] => True
+  | index, instruction :: rest =>
+      MeaningAt meanings valuation { index } instruction ∧
+        Meanings meanings valuation (index + 1) rest
+
+theorem Meanings.at {meanings : Array (Meaning Value)}
+    {valuation : NodeId → Value} {start : Nat} {nodes : List Node}
+    (proofs : Meanings meanings valuation start nodes) (offset : Nat)
+    {instruction : Node} (found : nodes[offset]? = some instruction) :
+    MeaningAt meanings valuation { index := start + offset } instruction := by
+  induction nodes generalizing start offset with
+  | nil => simp at found
+  | cons head tail ih =>
+      cases offset with
+      | zero =>
+          simp at found
+          subst head
+          simpa [Meanings] using proofs.1
+      | succ offset =>
+          simp at found
+          have tailProof := ih proofs.2 offset found
+          have indices : (start + 1) + offset = start + (offset + 1) := by omega
+          simpa [indices] using tailProof
+
+/-- Assemble the global model from exact operation alignment and one relation
+proof per node. -/
+theorem modelsOfMeanings (meanings : Array (Meaning Value)) (program : Program)
+    (valuation : NodeId → Value)
+    (operations : program.operations = meanings.map (·.operation))
+    (proofs : Meanings meanings valuation 0 program.nodes.toList) :
+    Models meanings program valuation := by
+  refine ⟨operations, ?_⟩
+  intro node instruction found
+  have foundList : program.nodes.toList[node.index]? = some instruction := by
+    simpa [Program.node?] using found
+  simpa [MeaningAt] using proofs.at node.index foundList
+
+end Hex.Interval.Program

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -23,10 +23,11 @@ owner, body, action, scope, versions, dependencies, and chronology all match.
 Schema decoders and theorem builders are package callbacks, but their returned
 `Evidence` contains an ordinary Lean proof of the exact indexed proposition.
 The final Meta boundary instantiates and rejects unresolved metavariables and
-placeholders, runs the elaborator's structural `Meta.check`, and checks the
-inferred type against the exact expected proposition by definitional equality.
-It restores Meta state on success and failure. The kernel performs the final
-check only when the caller installs the returned expression in a declaration.
+placeholders, restores every emitter change, then runs the elaborator's
+structural `Meta.check` and checks the inferred type against the exact expected
+proposition by definitional equality in the caller's environment. It restores
+validation state on success and failure. The kernel performs the final check
+only when the caller installs the returned expression in a declaration.
 Concrete operations, packages, goal reification, tactic syntax, registries of
 declaration names, and default search policy are intentionally absent.
 
@@ -1036,19 +1037,24 @@ def replayRefute (limits : Limits) (registry : Registry semantics)
 
 /-- Package-owned expression producer. It has no proof authority beyond the
 type of an expression accepted by the elaborator checks below and eventually
-installed in a kernel-checked declaration. -/
+installed in a kernel-checked declaration. A returned expression may reference
+only declarations that existed before `emit`; emitter-created declarations are
+rolled back before authoritative validation. -/
 structure Emitter (Quote : Type) where
   emit : Quote → Lean.MetaM Lean.Expr
 
 /-- Run one package emitter transactionally. The returned expression contains
-no unresolved metavariables or placeholders, passes `Meta.check`, and has an
-inferred type definitionally equal to the exact closed expected proposition.
-All emitter and unification state is restored even on success. -/
+no unresolved metavariables or placeholders. Every emitter change is restored
+before the expression passes `Meta.check` and exact type checking in the
+caller's environment. Validation changes are also restored on success and
+failure. -/
 def emitChecked (emitter : Emitter Quote) (quote : Quote)
     (expected : Lean.Expr) : Lean.MetaM Lean.Expr := do
-  let saved ← Lean.Meta.saveState
-  try
+  let emitterSaved ← Lean.Meta.saveState
+  let prepared ← try
     let expected ← Lean.instantiateMVars expected
+    if expected.hasSorry then
+      throwError "interval proof emitter expected type contains a placeholder expression"
     if expected.hasMVar then
       throwError "interval proof emitter expected type contains unresolved metavariables"
     let candidate ← Lean.instantiateMVars (← emitter.emit quote)
@@ -1056,6 +1062,14 @@ def emitChecked (emitter : Emitter Quote) (quote : Quote)
       throwError "interval proof emitter returned a placeholder expression"
     if candidate.hasMVar then
       throwError "interval proof emitter returned unresolved metavariables"
+    pure (candidate, expected)
+  catch error =>
+    emitterSaved.restore
+    throw error
+  emitterSaved.restore
+  let (candidate, expected) := prepared
+  let validationSaved ← Lean.Meta.saveState
+  try
     Lean.Meta.check candidate
     let actual ← Lean.instantiateMVars (← Lean.Meta.inferType candidate)
     if actual.hasMVar then
@@ -1065,10 +1079,10 @@ def emitChecked (emitter : Emitter Quote) (quote : Quote)
     let candidate ← Lean.instantiateMVars candidate
     if candidate.hasMVar then
       throwError "interval proof emitter unification left unresolved metavariables"
-    saved.restore
+    validationSaved.restore
     pure candidate
   catch error =>
-    saved.restore
+    validationSaved.restore
     throw error
 
 /-- Project the ordinary theorem from a successfully checked proof object. -/

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -23,10 +23,11 @@ owner, body, action, scope, versions, dependencies, and chronology all match.
 Schema decoders and theorem builders are package callbacks, but their returned
 `Evidence` contains an ordinary Lean proof of the exact indexed proposition.
 The final Meta boundary instantiates and rejects unresolved metavariables and
-placeholders, restores every emitter change, then runs the elaborator's
-structural `Meta.check` and checks the inferred type against the exact expected
-proposition by definitional equality in the caller's environment. It restores
-validation state on success and failure. The kernel performs the final check
+placeholders, restores the caller's environment, messages, information, and
+metavariable state, and clears both elaborator caches before running structural
+`Meta.check` and checking the inferred type against the exact expected
+proposition by definitional equality. Validation state is restored and its
+caches are cleared on success and failure. The kernel performs the final check
 only when the caller installs the returned expression in a declaration.
 Concrete operations, packages, goal reification, tactic syntax, registries of
 declaration names, and default search policy are intentionally absent.
@@ -1044,12 +1045,19 @@ structure Emitter (Quote : Type) where
   emit : Quote → Lean.MetaM Lean.Expr
 
 /-- Run one package emitter transactionally. The returned expression contains
-no unresolved metavariables or placeholders. Every emitter change is restored
-before the expression passes `Meta.check` and exact type checking in the
-caller's environment. Validation changes are also restored on success and
-failure. -/
+no unresolved metavariables or placeholders. Emitter environment, message,
+information, and metavariable changes are restored and environment-dependent
+caches are cleared before the expression passes `Meta.check` and exact type
+checking in the caller's environment. Validation state is likewise restored
+and its caches cleared on success and failure. -/
 def emitChecked (emitter : Emitter Quote) (quote : Quote)
     (expected : Lean.Expr) : Lean.MetaM Lean.Expr := do
+  -- `Meta.SavedState.restore` deliberately retains both the `Meta.State` and
+  -- `Core.State` caches, which may depend on a declaration rolled back below.
+  let restoreClean (saved : Lean.Meta.SavedState) : Lean.MetaM Unit := do
+    saved.restore
+    Lean.Meta.resetCache
+    modifyThe Lean.Core.State fun state => { state with cache := {} }
   let emitterSaved ← Lean.Meta.saveState
   let prepared ← try
     let expected ← Lean.instantiateMVars expected
@@ -1064,9 +1072,9 @@ def emitChecked (emitter : Emitter Quote) (quote : Quote)
       throwError "interval proof emitter returned unresolved metavariables"
     pure (candidate, expected)
   catch error =>
-    emitterSaved.restore
+    restoreClean emitterSaved
     throw error
-  emitterSaved.restore
+  restoreClean emitterSaved
   let (candidate, expected) := prepared
   let validationSaved ← Lean.Meta.saveState
   try
@@ -1079,10 +1087,10 @@ def emitChecked (emitter : Emitter Quote) (quote : Quote)
     let candidate ← Lean.instantiateMVars candidate
     if candidate.hasMVar then
       throwError "interval proof emitter unification left unresolved metavariables"
-    validationSaved.restore
+    restoreClean validationSaved
     pure candidate
   catch error =>
-    validationSaved.restore
+    restoreClean validationSaved
     throw error
 
 /-- Project the ordinary theorem from a successfully checked proof object. -/

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -26,6 +26,14 @@ The final Meta boundary accepts an emitted expression only after kernel-facing
 type inference and definitional equality, restoring Meta state on failure.
 Concrete operations, packages, goal reification, tactic syntax, registries of
 declaration names, and default search policy are intentionally absent.
+
+`Limits` bounds retained package/schema counts, certificate bodies, ordered
+dependencies, and chronology.  It does not make `Program.check`, registration
+validation, equality on caller facts, schema decoding, or package theorem
+callbacks preemptible.  A search-to-proof quotation must first cross the
+supported `Search` resource boundary; direct trusted callers of this module
+remain responsible for supplying a structurally bounded program and package
+assembly.
 -/
 
 namespace Hex.Interval.Proof
@@ -275,6 +283,9 @@ structure Package (semantics : Semantics Fact) where
   instances : Array (InstanceSchema semantics) := #[]
   refuters : Array (RefuteSchema semantics) := #[]
 
+/-- Bounds on retained proof-registry and quotation data.  These bounds are
+checked after construction of the caller's Lean values; they do not preempt
+allocation inside trusted schema decoders or theorem callbacks. -/
 structure Limits where
   maxPackages : Nat
   maxSchemas : Nat

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -1,0 +1,1033 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Program
+public import Mathlib.Lean.Elab.Tactic.Basic
+
+@[expose] public section
+
+/-!
+# Function-agnostic proof replay
+
+This module is the supported proof authority for interval search. Search state,
+callback replies, payload arenas, and diagnostic traces are decoded data only.
+The replay cursor starts from the caller's exact program and fact array and can
+advance only through package-owned theorem schemas whose complete address,
+owner, body, action, scope, versions, dependencies, and chronology all match.
+
+Schema decoders and theorem builders are package callbacks, but their returned
+`Evidence` contains an ordinary Lean proof of the exact indexed proposition.
+The final Meta boundary accepts an emitted expression only after kernel-facing
+type inference and definitional equality, restoring Meta state on failure.
+Concrete operations, packages, goal reification, tactic syntax, registries of
+declaration names, and default search policy are intentionally absent.
+-/
+
+namespace Hex.Interval.Proof
+
+variable {Fact Value Quote : Type}
+
+/-- One exact node/fact pair. -/
+structure NodeFact (Fact : Type) where
+  node : NodeId
+  fact : Fact
+  deriving DecidableEq, Repr
+
+/-- Caller-owned proof input. Scope, base program, every version-zero fact, and
+the requested target are immutable replay parameters. -/
+structure Input (Fact : Type) where
+  scope : Policy.ScopeId
+  program : Program
+  facts : Array Fact
+  target : NodeFact Fact
+  deriving DecidableEq, Repr
+
+/-- Function-agnostic mathematical interpretation. -/
+structure Semantics (Fact : Type) where
+  Value : Type
+  models : Program → (NodeId → Value) → Prop
+  holds : Program → (NodeId → Value) → NodeFact Fact → Prop
+  holdsAgree : ∀ program left right fact,
+    fact.node.index < program.nodes.size →
+    models program left → models program right →
+    (∀ node, node.index < program.nodes.size → left node = right node) →
+    (holds program left fact ↔ holds program right fact)
+
+namespace Semantics
+
+def Entails (semantics : Semantics Fact) (program : Program)
+    (assumptions : List (NodeFact Fact)) (conclusion : NodeFact Fact) : Prop :=
+  ∀ valuation, semantics.models program valuation →
+    (∀ assumption, assumption ∈ assumptions →
+      semantics.holds program valuation assumption) →
+    semantics.holds program valuation conclusion
+
+def EntailsEq (semantics : Semantics Fact) (program : Program)
+    (assumptions : List (NodeFact Fact)) (left right : NodeId) : Prop :=
+  ∀ valuation, semantics.models program valuation →
+    (∀ assumption, assumption ∈ assumptions →
+      semantics.holds program valuation assumption) →
+    valuation left = valuation right
+
+def AgreeOn (semantics : Semantics Fact) (program : Program)
+    (left right : NodeId → semantics.Value) : Prop :=
+  ∀ node, node.index < program.nodes.size → left node = right node
+
+def Extends (semantics : Semantics Fact) (before after : Program) : Prop :=
+  ∀ valuation, semantics.models before valuation →
+    ∃ extended, semantics.models after extended ∧
+      semantics.AgreeOn before valuation extended
+
+/-- Standard node-local fact interpretation over package-composed meanings. -/
+def ofMeanings (meanings : Array (Program.Meaning Value))
+    (Contains : Fact → Value → Prop) : Semantics Fact :=
+  { Value
+    models := Program.Models meanings
+    holds := fun _ valuation fact => Contains fact.fact (valuation fact.node)
+    holdsAgree := by
+      intro program left right fact within _ _ agree
+      rw [agree fact.node within] }
+
+end Semantics
+
+/-- Proof data in `Type`; constructing it requires an ordinary proof of the
+exact indexed claim. Runtime values have no conversion into this structure. -/
+structure Evidence (claim : Prop) : Type where
+  proof : claim
+
+/-- Exact append-only structural prefix. -/
+structure Prefix (before after : Program) : Prop where
+  operationSize : before.operations.size ≤ after.operations.size
+  nodeSize : before.nodes.size ≤ after.nodes.size
+  operationAt : ∀ index, index < before.operations.size →
+    after.operations[index]? = before.operations[index]?
+  nodeAt : ∀ index, index < before.nodes.size →
+    after.nodes[index]? = before.nodes[index]?
+
+namespace Prefix
+
+theorem refl (program : Program) : Prefix program program :=
+  { operationSize := Nat.le_refl _
+    nodeSize := Nat.le_refl _
+    operationAt := fun _ _ => rfl
+    nodeAt := fun _ _ => rfl }
+
+theorem trans {first middle last : Program}
+    (left : Prefix first middle) (right : Prefix middle last) :
+    Prefix first last :=
+  { operationSize := Nat.le_trans left.operationSize right.operationSize
+    nodeSize := Nat.le_trans left.nodeSize right.nodeSize
+    operationAt := by
+      intro index within
+      exact Eq.trans
+        (right.operationAt index
+          (Nat.lt_of_lt_of_le within left.operationSize))
+        (left.operationAt index within)
+    nodeAt := by
+      intro index within
+      exact Eq.trans
+        (right.nodeAt index (Nat.lt_of_lt_of_le within left.nodeSize))
+        (left.nodeAt index within) }
+
+end Prefix
+
+/-- Semantic stability of one append-only program extension. -/
+structure Stable (semantics : Semantics Fact) (before after : Program) where
+  appendOnly : Prefix before after
+  modelsBefore : ∀ valuation, semantics.models after valuation →
+    semantics.models before valuation
+  holdsOld : ∀ oldValue newValue (fact : NodeFact Fact),
+    fact.node.index < before.nodes.size →
+    semantics.models before oldValue → semantics.models after newValue →
+    semantics.AgreeOn before oldValue newValue →
+    (semantics.holds before oldValue fact ↔ semantics.holds after newValue fact)
+
+def FactsWithin (program : Program) (facts : List (NodeFact Fact)) : Prop :=
+  ∀ fact, fact ∈ facts → fact.node.index < program.nodes.size
+
+def InputsSound (semantics : Semantics Fact) (program : Program)
+    (base inputs : List (NodeFact Fact)) : Prop :=
+  ∀ input, input ∈ inputs → semantics.Entails program base input
+
+/-- Fact-domain theorem boundary. Executable narrowing and contradiction flags
+are deliberately absent. -/
+structure Domain (semantics : Semantics Fact) where
+  top : DomainId → Fact
+  topSound : ∀ program valuation node instruction,
+    program.node? node = some instruction → semantics.models program valuation →
+    semantics.holds program valuation { node, fact := top instruction.domain }
+  meet : (program : Program) → (node : NodeId) →
+    (previous proposed installed : Fact) →
+    Option (Evidence (∀ valuation, semantics.models program valuation →
+      (semantics.holds program valuation { node, fact := installed } ↔
+        semantics.holds program valuation { node, fact := previous } ∧
+        semantics.holds program valuation { node, fact := proposed })))
+
+/-- Generic equality transport law; endpoint compatibility is checked
+separately from the package equality theorem. -/
+structure Laws (semantics : Semantics Fact) where
+  holdsEq : ∀ program valuation left right fact,
+    semantics.models program valuation → valuation left = valuation right →
+    (semantics.holds program valuation { node := left, fact } ↔
+      semantics.holds program valuation { node := right, fact })
+
+inductive Role where
+  | fact
+  | equality
+  | instance
+  | refute
+  deriving DecidableEq, Repr
+
+/-- Full immutable schema address. -/
+structure Key where
+  rule : RuleKey
+  role : Role
+  bodySchema : Nat
+  deriving DecidableEq, Repr
+
+/-- Exact context supplied to a fact theorem. -/
+structure FactContext (semantics : Semantics Fact) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  program : Program
+  action : Action
+  assumptions : List (NodeFact Fact)
+  proposed : NodeFact Fact
+
+/-- Exact context supplied to an equality theorem. -/
+structure EqualityContext (semantics : Semantics Fact) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  program : Program
+  action : Action
+  equality : EqualityId
+  left : NodeId
+  right : NodeId
+  assumptions : List (NodeFact Fact)
+
+/-- Package proof of one exact instance step. -/
+structure InstanceEvidence (semantics : Semantics Fact)
+    (before after : Program) where
+  stable : Stable semantics before after
+  extension : Evidence (semantics.Extends before after)
+
+/-- Exact context supplied to an instantiation theorem. -/
+structure InstanceContext (semantics : Semantics Fact) where
+  scope : Policy.ScopeId
+  beforeVersion : Nat
+  afterVersion : Nat
+  before : Program
+  after : Program
+  action : Action
+  newNodes : List NodeId
+
+structure RefuteContext (semantics : Semantics Fact) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  program : Program
+  node : NodeId
+  fact : Fact
+
+/-- Existentially packed package-owned fact theorem. -/
+structure FactSchema (semantics : Semantics Fact) where
+  key : Key
+  Certificate : Type
+  decode : List Nat → Option Certificate
+  prove : (context : FactContext semantics) → Certificate →
+    Option (Evidence (semantics.Entails context.program context.assumptions
+      context.proposed))
+
+structure EqualitySchema (semantics : Semantics Fact) where
+  key : Key
+  Certificate : Type
+  decode : List Nat → Option Certificate
+  prove : (context : EqualityContext semantics) → Certificate →
+    Option (Evidence (semantics.EntailsEq context.program context.assumptions
+      context.left context.right))
+
+structure InstanceSchema (semantics : Semantics Fact) where
+  key : Key
+  Certificate : Type
+  decode : List Nat → Option Certificate
+  prove : (context : InstanceContext semantics) → Certificate →
+    Option (InstanceEvidence semantics context.before context.after)
+
+structure RefuteSchema (semantics : Semantics Fact) where
+  key : Key
+  Certificate : Type
+  decode : List Nat → Option Certificate
+  prove : (context : RefuteContext semantics) → Certificate →
+    Option (Evidence (∀ valuation, semantics.models context.program valuation →
+      semantics.holds context.program valuation
+        { node := context.node, fact := context.fact } → False))
+
+/-- One proof package owns registrations and every schema addressed by those
+rule keys. -/
+structure Package (semantics : Semantics Fact) where
+  registrations : Array Registration
+  facts : Array (FactSchema semantics) := #[]
+  equalities : Array (EqualitySchema semantics) := #[]
+  instances : Array (InstanceSchema semantics) := #[]
+  refuters : Array (RefuteSchema semantics) := #[]
+
+structure Limits where
+  maxPackages : Nat
+  maxSchemas : Nat
+  maxBodyCells : Nat
+  maxDependencies : Nat
+  maxChronology : Nat
+  deriving DecidableEq, Repr
+
+inductive BuildError where
+  | invalidProgram
+  | packageLimit
+  | schemaLimit
+  | invalidRegistration (package : Nat)
+  | foreignSchema (package : Nat) (key : Key)
+  | wrongRole (key : Key)
+  | duplicateSchema (key : Key)
+  | duplicateRegistration (key : RuleKey)
+  | emptyRefuterOwner (package : Nat) (key : Key)
+  deriving DecidableEq, Repr
+
+structure Registry (semantics : Semantics Fact) where
+  registrations : Array Registration
+  facts : Array (FactSchema semantics)
+  equalities : Array (EqualitySchema semantics)
+  instances : Array (InstanceSchema semantics)
+  refuters : Array (RefuteSchema semantics)
+
+namespace Registry
+
+def owns (package : Package semantics) (key : Key) : Bool :=
+  package.registrations.any fun registration => registration.key == key.rule
+
+/-- Assemble a package-local, globally unambiguous theorem registry. -/
+def buildWithin (limits : Limits) (program : Program)
+    (packages : Array (Package semantics)) : Except BuildError (Registry semantics) := do
+  if !program.check then throw .invalidProgram
+  if limits.maxPackages < packages.size then throw .packageLimit
+  let schemaCount := packages.foldl (fun count package =>
+    count + package.facts.size + package.equalities.size + package.instances.size +
+      package.refuters.size) 0
+  if limits.maxSchemas < schemaCount then throw .schemaLimit
+  let registrations := packages.foldl
+    (fun all package => all ++ package.registrations) #[]
+  if !Registration.check program registrations then
+    let keys := registrations.toList.map fun registration => registration.key
+    let duplicate := keys.find? fun key => 1 < keys.count key
+    match duplicate with
+    | some key => throw (.duplicateRegistration key)
+    | none => throw (.invalidRegistration 0)
+  let mut facts := #[]
+  let mut equalities := #[]
+  let mut instances := #[]
+  let mut refuters := #[]
+  let mut seen : List Key := []
+  for index in [0:packages.size] do
+    let some package := packages[index]? | throw .invalidProgram
+    if !Registration.check program package.registrations then
+      throw (.invalidRegistration index)
+    for schema in package.facts do
+      if schema.key.role != .fact then throw (.wrongRole schema.key)
+      if !owns package schema.key then throw (.foreignSchema index schema.key)
+      if seen.contains schema.key then throw (.duplicateSchema schema.key)
+      seen := schema.key :: seen
+      facts := facts.push schema
+    for schema in package.equalities do
+      if schema.key.role != .equality then throw (.wrongRole schema.key)
+      if !owns package schema.key then throw (.foreignSchema index schema.key)
+      if seen.contains schema.key then throw (.duplicateSchema schema.key)
+      seen := schema.key :: seen
+      equalities := equalities.push schema
+    for schema in package.instances do
+      if schema.key.role != Role.instance then throw (.wrongRole schema.key)
+      if !owns package schema.key then throw (.foreignSchema index schema.key)
+      if seen.contains schema.key then throw (.duplicateSchema schema.key)
+      seen := schema.key :: seen
+      instances := instances.push schema
+    for schema in package.refuters do
+      if schema.key.role != .refute then throw (.wrongRole schema.key)
+      if package.registrations.isEmpty then throw (.emptyRefuterOwner index schema.key)
+      if !owns package schema.key then throw (.foreignSchema index schema.key)
+      if seen.contains schema.key then throw (.duplicateSchema schema.key)
+      seen := schema.key :: seen
+      refuters := refuters.push schema
+  pure { registrations, facts, equalities, instances, refuters }
+
+def fact? (registry : Registry semantics) (key : Key) : Option (FactSchema semantics) :=
+  registry.facts.toList.find? fun schema => schema.key == key
+
+def equality? (registry : Registry semantics) (key : Key) :
+    Option (EqualitySchema semantics) :=
+  registry.equalities.toList.find? fun schema => schema.key == key
+
+def instance? (registry : Registry semantics) (key : Key) :
+    Option (InstanceSchema semantics) :=
+  registry.instances.toList.find? fun schema => schema.key == key
+
+def refuter? (registry : Registry semantics) (key : Key) :
+    Option (RefuteSchema semantics) :=
+  registry.refuters.toList.find? fun schema => schema.key == key
+
+/-- Authenticate the structural portion of one quoted action against the
+exact registry and program snapshots. Serial, effort, and generation remain
+opaque chronology data visible to the package theorem; they carry no generic
+proof authority. -/
+def acceptsAction (registry : Registry semantics) (program : Program)
+    (action : Action) (inputs : List NodeId) : Bool :=
+  match registry.registrations[action.rule.index]?, program.node? action.node with
+  | some registration, some anchor =>
+      let common := registration.key == action.key && registration.kind == action.kind &&
+        (program.operation? anchor.op).any (fun operation => operation.key == registration.head) &&
+        action.inputs.map (fun seen => seen.node) == inputs &&
+        match registration.matchWatch with
+        | .none => action.structuralInputs.isEmpty && action.matcherEpoch.isNone
+        | .network => !action.structuralInputs.isEmpty && action.matcherEpoch.isSome
+      common && match registration.binding with
+      | .local =>
+          Slot.resolveAll? action.node anchor registration.watches == some inputs &&
+            Slot.resolveAll? action.node anchor registration.writes == some action.writes
+      | .scoped =>
+          registration.watches.isEmpty && registration.writes.isEmpty &&
+            allDistinct inputs && allDistinct action.writes &&
+            inputs.all (fun node => (program.node? node).isSome) &&
+            action.writes.all (fun node => (program.node? node).isSome)
+      | .global => inputs.isEmpty && action.writes.isEmpty
+  | _, _ => false
+
+end Registry
+
+/-! ## Plain replay quotations -/
+
+structure FactStep (Fact : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  action : Action
+  node : NodeId
+  previous : SeenVersion
+  version : Nat
+  proposed : Fact
+  installed : Fact
+  assumptions : List SeenVersion
+  schema : Key
+  body : List Nat
+  deriving DecidableEq, Repr
+
+structure EqualityStep where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  action : Action
+  equality : EqualityId
+  left : NodeId
+  right : NodeId
+  assumptions : List SeenVersion
+  schema : Key
+  body : List Nat
+  deriving DecidableEq, Repr
+
+structure TransportStep (Fact : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  node : NodeId
+  previous : SeenVersion
+  version : Nat
+  equality : EqualityId
+  source : SeenVersion
+  installed : Fact
+  deriving DecidableEq, Repr
+
+structure InstanceStep where
+  scope : Policy.ScopeId
+  beforeVersion : Nat
+  afterVersion : Nat
+  action : Action
+  after : Program
+  newNodes : List NodeId
+  schema : Key
+  body : List Nat
+  deriving DecidableEq, Repr
+
+structure RefuteStep where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  seen : SeenVersion
+  schema : Key
+  body : List Nat
+  deriving DecidableEq, Repr
+
+inductive Event (Fact : Type)
+  | fact (step : FactStep Fact)
+  | equality (step : EqualityStep)
+  | transport (step : TransportStep Fact)
+  | instance (step : InstanceStep)
+  deriving DecidableEq, Repr
+
+def initialBase (input : Input Fact) : List (NodeFact Fact) :=
+  List.ofFn fun index : Fin input.facts.size =>
+    { node := { index := index.val }, fact := input.facts[index] }
+
+theorem initialWithin (input : Input Fact)
+    (size : input.facts.size = input.program.nodes.size) :
+    FactsWithin input.program (initialBase input) := by
+  intro fact member
+  rw [initialBase, List.mem_ofFn] at member
+  obtain ⟨index, rfl⟩ := member
+  simpa [size] using index.isLt
+
+structure Resolved (semantics : Semantics Fact) (program : Program)
+    (base : List (NodeFact Fact)) (seen : SeenVersion) where
+  fact : Fact
+  within : seen.node.index < program.nodes.size
+  sound : Evidence (semantics.Entails program base { node := seen.node, fact })
+
+structure Facts (semantics : Semantics Fact) (program : Program)
+    (base : List (NodeFact Fact)) where
+  resolve : (seen : SeenVersion) → Option (Resolved semantics program base seen)
+
+namespace Facts
+
+def make (resolve : (seen : SeenVersion) →
+    Option (Resolved semantics program base seen)) : Facts semantics program base :=
+  .mk resolve
+
+def start (semantics : Semantics Fact) (input : Input Fact)
+    (size : input.facts.size = input.program.nodes.size) :
+    Facts semantics input.program (initialBase input) :=
+  make fun seen =>
+    if version : seen.version = 0 then
+      if within : seen.node.index < input.program.nodes.size then
+        let factWithin : seen.node.index < input.facts.size := by simpa [size] using within
+        let index : Fin input.facts.size := ⟨seen.node.index, factWithin⟩
+        some
+          { fact := input.facts[index]
+            within
+            sound :=
+              { proof := by
+                  intro valuation model assumptions
+                  apply assumptions { node := seen.node, fact := input.facts[index] }
+                  rw [initialBase, List.mem_ofFn]
+                  exact ⟨index, rfl⟩ } }
+      else none
+    else none
+
+def push (facts : Facts semantics program base) (seen : SeenVersion) (fact : Fact)
+    (within : seen.node.index < program.nodes.size)
+    (sound : Evidence (semantics.Entails program base { node := seen.node, fact })) :
+    Facts semantics program base :=
+  make fun requested =>
+    if exact : requested = seen then
+      some ⟨fact, by simpa [exact] using within, by simpa [exact] using sound⟩
+    else facts.resolve requested
+
+end Facts
+
+structure EqualityProof (semantics : Semantics Fact) (program : Program)
+    (base : List (NodeFact Fact)) where
+  equality : EqualityId
+  left : NodeId
+  right : NodeId
+  sound : Evidence (semantics.EntailsEq program base left right)
+
+structure Equalities (semantics : Semantics Fact) (program : Program)
+    (base : List (NodeFact Fact)) where
+  count : Nat
+  resolve : EqualityId → Option (EqualityProof semantics program base)
+
+namespace Equalities
+
+def make (count : Nat)
+    (resolve : EqualityId → Option (EqualityProof semantics program base)) :
+    Equalities semantics program base :=
+  .mk count resolve
+
+def empty : Equalities semantics program base := make 0 fun _ => none
+
+def push (equalities : Equalities semantics program base)
+    (proof : EqualityProof semantics program base) : Equalities semantics program base :=
+  make (equalities.count + 1) fun requested =>
+    if requested == proof.equality then some proof else equalities.resolve requested
+
+end Equalities
+
+/-- Complete proof state at one exact program version. Constructor privacy
+prevents transplanting facts or equalities to another program. -/
+structure State (semantics : Semantics Fact) (input : Input Fact) where
+  version : Nat
+  program : Program
+  baseSize : input.facts.size = input.program.nodes.size
+  basePrefix : Prefix input.program program
+  extension : Evidence (semantics.Extends input.program program)
+  stable : Stable semantics input.program program
+  facts : Facts semantics program (initialBase input)
+  equalities : Equalities semantics program (initialBase input)
+
+theorem stableRefl (semantics : Semantics Fact) (program : Program) :
+    Stable semantics program program :=
+  { appendOnly := .refl program
+    modelsBefore := fun _ model => model
+    holdsOld := by
+      intro oldValue newValue fact within oldModel newModel agree
+      exact semantics.holdsAgree program oldValue newValue fact within oldModel newModel agree }
+
+def extendsRefl (semantics : Semantics Fact) (program : Program) :
+    Evidence (semantics.Extends program program) :=
+  { proof := fun valuation model => ⟨valuation, model, fun _ _ => rfl⟩ }
+
+def State.start (semantics : Semantics Fact) (input : Input Fact)
+    (size : input.facts.size = input.program.nodes.size) : State semantics input :=
+  { version := 0
+    program := input.program
+    baseSize := size
+    basePrefix := .refl input.program
+    extension := extendsRefl semantics input.program
+    stable := stableRefl semantics input.program
+    facts := Facts.start semantics input size
+    equalities := .empty }
+
+structure ResolvedInputs (semantics : Semantics Fact) (program : Program)
+    (base : List (NodeFact Fact)) where
+  facts : List (NodeFact Fact)
+  sound : Evidence (InputsSound semantics program base facts)
+
+def resolveInputs (facts : Facts semantics program base) :
+    List SeenVersion → Option (ResolvedInputs semantics program base)
+  | [] => some { facts := [], sound := { proof := by intro _ member; simp at member } }
+  | seen :: rest => do
+      let head ← facts.resolve seen
+      let tail ← resolveInputs facts rest
+      let inputs := { node := seen.node, fact := head.fact } :: tail.facts
+      let sound : Evidence (InputsSound semantics program base inputs) :=
+        { proof := by
+            intro input member
+            rcases List.mem_cons.mp member with equal | member
+            · subst input; exact head.sound.proof
+            · exact tail.sound.proof input member }
+      pure { facts := inputs, sound }
+
+def installMeet (semantics : Semantics Fact) (program : Program)
+    (base inputs : List (NodeFact Fact)) (node : NodeId)
+    (previous proposed installed : Fact)
+    (rule : Evidence (semantics.Entails program inputs { node, fact := proposed }))
+    (meet : Evidence (∀ valuation, semantics.models program valuation →
+      (semantics.holds program valuation { node, fact := installed } ↔
+        semantics.holds program valuation { node, fact := previous } ∧
+        semantics.holds program valuation { node, fact := proposed })))
+    (previousSound : Evidence
+      (semantics.Entails program base { node, fact := previous }))
+    (inputsSound : Evidence (InputsSound semantics program base inputs)) :
+    Evidence (semantics.Entails program base { node, fact := installed }) :=
+  { proof := by
+      intro valuation model baseHolds
+      apply (meet.proof valuation model).mpr
+      refine ⟨previousSound.proof valuation model baseHolds, ?_⟩
+      apply rule.proof valuation model
+      intro input member
+      exact inputsSound.proof input member valuation model baseHolds }
+
+inductive Error where
+  | invalidInput
+  | chronologyLimit
+  | bodyLimit
+  | dependencyLimit
+  | wrongScope
+  | wrongProgramVersion
+  | wrongAction
+  | wrongSchema
+  | missingSchema
+  | malformedBody
+  | missingDependency (seen : SeenVersion)
+  | staleVersion
+  | unknownNode
+  | unauthorizedWrite
+  | wrongEquality
+  | wrongInstance
+  | wrongFinalProgram
+  | wrongTarget
+  deriving DecidableEq, Repr
+
+def bodyCheck (limits : Limits) (key : Key) (role : Role)
+    (body : List Nat) : Except Error Unit := do
+  if key.role != role then throw .wrongSchema
+  if limits.maxBodyCells < body.length then throw .bodyLimit
+
+def dependenciesCheck (limits : Limits) (dependencies : List SeenVersion) :
+    Except Error Unit :=
+  if limits.maxDependencies < dependencies.length then throw .dependencyLimit else pure ()
+
+def replayFact (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (input : Input Fact) (checked : State semantics input)
+    (step : FactStep Fact) : Except Error (State semantics input) := do
+  bodyCheck limits step.schema .fact step.body
+  dependenciesCheck limits step.assumptions
+  if step.scope != input.scope then throw .wrongScope
+  if step.programVersion != checked.version then throw .wrongProgramVersion
+  if step.action.programVersion != checked.version || step.action.key != step.schema.rule ||
+      step.action.inputs != step.assumptions then throw .wrongAction
+  if !step.action.writes.contains step.node then throw .unauthorizedWrite
+  let nodeEq : Evidence (step.previous.node = step.node) ←
+    if h : step.previous.node = step.node then pure ⟨h⟩ else throw .staleVersion
+  if step.version != step.previous.version + 1 then throw .staleVersion
+  let nodeWithin : Evidence (step.node.index < checked.program.nodes.size) ←
+    if h : step.node.index < checked.program.nodes.size then pure ⟨h⟩ else throw .unknownNode
+  let current : SeenVersion := { node := step.node, version := step.version }
+  if (checked.facts.resolve current).isSome then throw .staleVersion
+  let some previous := checked.facts.resolve step.previous
+    | throw (.missingDependency step.previous)
+  let some resolvedInputs := resolveInputs checked.facts step.assumptions
+    | throw (.missingDependency (step.assumptions.head?.getD step.previous))
+  if !registry.acceptsAction checked.program step.action
+      (resolvedInputs.facts.map fun fact => fact.node) then throw .wrongAction
+  let some schema := registry.fact? step.schema | throw .missingSchema
+  let some certificate := schema.decode step.body | throw .malformedBody
+  let context : FactContext semantics :=
+    { scope := step.scope
+      programVersion := checked.version
+      program := checked.program
+      action := step.action
+      assumptions := resolvedInputs.facts
+      proposed := { node := step.node, fact := step.proposed } }
+  let some rule := schema.prove context certificate | throw .malformedBody
+  let some meet := domain.meet checked.program step.node previous.fact
+      step.proposed step.installed | throw .malformedBody
+  have previousSound : Evidence (semantics.Entails checked.program (initialBase input)
+      { node := step.node, fact := previous.fact }) := by
+    simpa [nodeEq.proof] using previous.sound
+  let sound := installMeet semantics checked.program (initialBase input) resolvedInputs.facts
+    step.node previous.fact step.proposed step.installed rule meet previousSound
+      resolvedInputs.sound
+  have currentWithin : current.node.index < checked.program.nodes.size := by
+    simpa [current] using nodeWithin.proof
+  let pushed := checked.facts.push current step.installed currentWithin sound
+  pure { checked with facts := pushed }
+
+def replayEquality (limits : Limits) (registry : Registry semantics)
+    (input : Input Fact) (checked : State semantics input)
+    (step : EqualityStep) : Except Error (State semantics input) := do
+  bodyCheck limits step.schema .equality step.body
+  dependenciesCheck limits step.assumptions
+  if step.scope != input.scope then throw .wrongScope
+  if step.programVersion != checked.version then throw .wrongProgramVersion
+  if step.equality.index != checked.equalities.count || step.left == step.right then
+    throw .wrongEquality
+  let some left := checked.program.node? step.left | throw .unknownNode
+  let some right := checked.program.node? step.right | throw .unknownNode
+  if left.domain != right.domain then throw .wrongEquality
+  if step.action.programVersion != checked.version || step.action.key != step.schema.rule ||
+      step.action.inputs != step.assumptions then throw .wrongAction
+  let some resolvedInputs := resolveInputs checked.facts step.assumptions
+    | throw (.missingDependency (step.assumptions.head?.getD
+        { node := step.left, version := 0 }))
+  if !registry.acceptsAction checked.program step.action
+      (resolvedInputs.facts.map fun fact => fact.node) then throw .wrongAction
+  let some schema := registry.equality? step.schema | throw .missingSchema
+  let some certificate := schema.decode step.body | throw .malformedBody
+  let context : EqualityContext semantics :=
+    { scope := step.scope, programVersion := checked.version, program := checked.program
+      action := step.action, equality := step.equality, left := step.left,
+      right := step.right, assumptions := resolvedInputs.facts }
+  let some schemaSound := schema.prove context certificate | throw .malformedBody
+  let sound : Evidence (semantics.EntailsEq checked.program (initialBase input)
+      step.left step.right) :=
+    { proof := by
+        intro valuation model baseHolds
+        apply schemaSound.proof valuation model
+        intro assumption member
+        exact resolvedInputs.sound.proof assumption member valuation model baseHolds }
+  let proof : EqualityProof semantics checked.program (initialBase input) :=
+    { equality := step.equality, left := step.left, right := step.right, sound }
+  pure { checked with equalities := checked.equalities.push proof }
+
+def replayTransport (_limits : Limits) (domain : Domain semantics)
+    (laws : Laws semantics) (input : Input Fact) (checked : State semantics input)
+    (step : TransportStep Fact) : Except Error (State semantics input) := do
+  if step.scope != input.scope then throw .wrongScope
+  if step.programVersion != checked.version then throw .wrongProgramVersion
+  let nodeEq : Evidence (step.previous.node = step.node) ←
+    if h : step.previous.node = step.node then pure ⟨h⟩ else throw .staleVersion
+  if step.version != step.previous.version + 1 then throw .staleVersion
+  let nodeWithin : Evidence (step.node.index < checked.program.nodes.size) ←
+    if h : step.node.index < checked.program.nodes.size then pure ⟨h⟩ else throw .unknownNode
+  let current : SeenVersion := { node := step.node, version := step.version }
+  if (checked.facts.resolve current).isSome then throw .staleVersion
+  let some previous := checked.facts.resolve step.previous
+    | throw (.missingDependency step.previous)
+  let some source := checked.facts.resolve step.source
+    | throw (.missingDependency step.source)
+  let some equality := checked.equalities.resolve step.equality | throw .wrongEquality
+  let orientation : Evidence
+      ((step.node = equality.left ∧ step.source.node = equality.right) ∨
+        (step.node = equality.right ∧ step.source.node = equality.left)) ←
+    if h : (step.node = equality.left ∧ step.source.node = equality.right) ∨
+        (step.node = equality.right ∧ step.source.node = equality.left) then
+      pure ⟨h⟩
+    else throw .wrongEquality
+  let some meet := domain.meet checked.program step.node previous.fact source.fact
+      step.installed | throw .malformedBody
+  have previousSound : Evidence (semantics.Entails checked.program (initialBase input)
+      { node := step.node, fact := previous.fact }) := by
+    simpa [nodeEq.proof] using previous.sound
+  let proposed : Evidence
+      (semantics.Entails checked.program (initialBase input)
+        { node := step.node, fact := source.fact }) :=
+    { proof := by
+        intro valuation model baseHolds
+        have equalValues := equality.sound.proof valuation model baseHolds
+        have sourceHolds := source.sound.proof valuation model baseHolds
+        by_cases direction : step.node = equality.left ∧ step.source.node = equality.right
+        · have transported := (laws.holdsEq checked.program valuation equality.left
+              equality.right source.fact model equalValues).mpr (by simpa [direction.2] using sourceHolds)
+          simpa [direction.1] using transported
+        · have reverse : step.node = equality.right ∧ step.source.node = equality.left := by
+            exact orientation.proof.resolve_left direction
+          have transported := (laws.holdsEq checked.program valuation equality.left
+              equality.right source.fact model equalValues).mp (by simpa [reverse.2] using sourceHolds)
+          simpa [reverse.1] using transported }
+  let inputSound : Evidence (InputsSound semantics checked.program
+      (initialBase input) [{ node := step.node, fact := source.fact }]) :=
+    { proof := by
+        intro fact member
+        simp only [List.mem_singleton] at member
+        subst fact
+        exact proposed.proof }
+  let rule : Evidence (semantics.Entails checked.program
+      [{ node := step.node, fact := source.fact }]
+      { node := step.node, fact := source.fact }) :=
+    { proof := by intro _ _ assumptions; exact assumptions _ (by simp) }
+  let sound := installMeet semantics checked.program (initialBase input)
+    [{ node := step.node, fact := source.fact }] step.node previous.fact source.fact
+    step.installed rule meet previousSound inputSound
+  have currentWithin : current.node.index < checked.program.nodes.size := by
+    simpa [current] using nodeWithin.proof
+  let pushed := checked.facts.push current step.installed currentWithin sound
+  pure { checked with facts := pushed }
+
+def liftEntails (stable : Stable semantics before after)
+    (baseWithin : FactsWithin before base) (factWithin : fact.node.index < before.nodes.size)
+    (sound : Evidence (semantics.Entails before base fact)) :
+    Evidence (semantics.Entails after base fact) :=
+  { proof := by
+      intro valuation afterModel afterBase
+      have beforeModel := stable.modelsBefore valuation afterModel
+      have beforeBase : ∀ item, item ∈ base →
+          semantics.holds before valuation item := by
+        intro item member
+        exact (stable.holdsOld valuation valuation item (baseWithin item member)
+          beforeModel afterModel (fun _ _ => rfl)).mpr (afterBase item member)
+      have result := sound.proof valuation beforeModel beforeBase
+      exact (stable.holdsOld valuation valuation fact factWithin beforeModel afterModel
+        (fun _ _ => rfl)).mp result }
+
+def Facts.lift (facts : Facts semantics before base) (stable : Stable semantics before after)
+    (baseWithin : FactsWithin before base) (domain : Domain semantics) :
+    Facts semantics after base :=
+  Facts.make fun seen =>
+    match facts.resolve seen with
+    | some resolved => some
+        { fact := resolved.fact
+          within := Nat.lt_of_lt_of_le resolved.within stable.appendOnly.nodeSize
+          sound := liftEntails stable baseWithin resolved.within resolved.sound }
+    | none =>
+        if version : seen.version = 0 then
+          if fresh : before.nodes.size ≤ seen.node.index then
+            if within : seen.node.index < after.nodes.size then
+              match found : after.node? seen.node with
+              | some instruction => some
+                  { fact := domain.top instruction.domain
+                    within
+                    sound :=
+                      { proof := by
+                          intro valuation model _
+                          exact domain.topSound after valuation seen.node instruction found model } }
+              | none => none
+            else none
+          else none
+        else none
+
+def liftEq (stable : Stable semantics before after)
+    (baseWithin : FactsWithin before base)
+    (sound : Evidence (semantics.EntailsEq before base left right)) :
+    Evidence (semantics.EntailsEq after base left right) :=
+  { proof := by
+      intro valuation afterModel afterBase
+      have beforeModel := stable.modelsBefore valuation afterModel
+      apply sound.proof valuation beforeModel
+      intro item member
+      exact (stable.holdsOld valuation valuation item (baseWithin item member)
+        beforeModel afterModel (fun _ _ => rfl)).mpr (afterBase item member) }
+
+def Equalities.lift (equalities : Equalities semantics before base)
+    (stable : Stable semantics before after) (baseWithin : FactsWithin before base) :
+    Equalities semantics after base :=
+  Equalities.make equalities.count fun equality => do
+    let proof ← equalities.resolve equality
+    pure { proof with sound := liftEq stable baseWithin proof.sound }
+
+def composeExtends (semantics : Semantics Fact) (basePrefix : Prefix base before)
+    (left : Evidence (semantics.Extends base before))
+    (right : Evidence (semantics.Extends before after)) :
+    Evidence (semantics.Extends base after) :=
+  { proof := by
+      intro valuation model
+      obtain ⟨middle, middleModel, first⟩ := left.proof valuation model
+      obtain ⟨extended, extendedModel, second⟩ := right.proof middle middleModel
+      exact ⟨extended, extendedModel, fun node within =>
+        Eq.trans (first node within)
+          (second node (Nat.lt_of_lt_of_le within basePrefix.nodeSize))⟩ }
+
+theorem composeStable (left : Stable semantics first middle)
+    (right : Stable semantics middle last) : Stable semantics first last :=
+  { appendOnly := left.appendOnly.trans right.appendOnly
+    modelsBefore := fun valuation model => left.modelsBefore valuation (right.modelsBefore valuation model)
+    holdsOld := by
+      intro oldValue newValue fact within oldModel newModel agreement
+      have middleModel := right.modelsBefore newValue newModel
+      exact (left.holdsOld oldValue newValue fact within oldModel middleModel agreement).trans
+        (right.holdsOld newValue newValue fact
+          (Nat.lt_of_lt_of_le within left.appendOnly.nodeSize) middleModel newModel
+          (fun _ _ => rfl)) }
+
+def replayInstance (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (input : Input Fact) (checked : State semantics input)
+    (step : InstanceStep) : Except Error (State semantics input) := do
+  bodyCheck limits step.schema .instance step.body
+  if step.scope != input.scope then throw .wrongScope
+  if step.beforeVersion != checked.version || step.afterVersion != checked.version + 1 then
+    throw .wrongProgramVersion
+  if step.action.programVersion != checked.version || step.action.key != step.schema.rule then
+    throw .wrongAction
+  if !registry.acceptsAction checked.program step.action [] then throw .wrongAction
+  if !step.after.check || !Hex.Interval.State.programPrefix checked.program step.after then
+    throw .wrongInstance
+  let expected := (List.range (step.after.nodes.size - checked.program.nodes.size)).map
+    fun offset => { index := checked.program.nodes.size + offset : NodeId }
+  if step.newNodes != expected then throw .wrongInstance
+  let some schema := registry.instance? step.schema | throw .missingSchema
+  let some certificate := schema.decode step.body | throw .malformedBody
+  let context : InstanceContext semantics :=
+    { scope := step.scope, beforeVersion := checked.version,
+      afterVersion := step.afterVersion, before := checked.program, after := step.after,
+      action := step.action, newNodes := step.newNodes }
+  let some proof := schema.prove context certificate | throw .malformedBody
+  let baseWithin := initialWithin input checked.baseSize
+  let currentBaseWithin : FactsWithin checked.program (initialBase input) :=
+    fun fact member => Nat.lt_of_lt_of_le (baseWithin fact member) checked.basePrefix.nodeSize
+  pure
+    { version := step.afterVersion
+      program := step.after
+      baseSize := checked.baseSize
+      basePrefix := checked.basePrefix.trans proof.stable.appendOnly
+      extension := composeExtends semantics checked.basePrefix checked.extension proof.extension
+      stable := composeStable checked.stable proof.stable
+      facts := checked.facts.lift proof.stable currentBaseWithin domain
+      equalities := checked.equalities.lift proof.stable currentBaseWithin }
+
+def replayEvent (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
+    State semantics input → Event Fact → Except Error (State semantics input)
+  | checked, .fact step => replayFact limits registry domain input checked step
+  | checked, .equality step => replayEquality limits registry input checked step
+  | checked, .transport step => replayTransport limits domain laws input checked step
+  | checked, .instance step => replayInstance limits registry domain input checked step
+
+def replayEvents (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
+    List (Event Fact) → State semantics input → Except Error (State semantics input)
+  | [], state => pure state
+  | event :: events, state => do
+      let next ← replayEvent limits registry domain laws input state event
+      replayEvents limits registry domain laws input events next
+
+/-- Replay exact chronology and close the exact target/version. -/
+def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
+    (events : List (Event Fact)) (finalVersion : Nat) (finalProgram : Program)
+    (result : SeenVersion) :
+    Except Error (Evidence (semantics.Entails input.program (initialBase input) input.target)) := do
+  if !input.program.check then throw .invalidInput
+  let size : Evidence (input.facts.size = input.program.nodes.size) ←
+    if h : input.facts.size = input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
+  let targetWithin : Evidence (input.target.node.index < input.program.nodes.size) ←
+    if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
+  if limits.maxChronology < events.length then throw .chronologyLimit
+  let checked ← replayEvents limits registry domain laws input events
+    (State.start semantics input size.proof)
+  if checked.version != finalVersion then throw .wrongProgramVersion
+  if checked.program != finalProgram then throw .wrongFinalProgram
+  let nodeEq : Evidence (result.node = input.target.node) ←
+    if h : result.node = input.target.node then pure ⟨h⟩ else throw .wrongTarget
+  let some resolved := checked.facts.resolve result | throw (.missingDependency result)
+  let factEq : Evidence (resolved.fact = input.target.fact) ←
+    if h : resolved.fact = input.target.fact then pure ⟨h⟩ else throw .wrongTarget
+  pure
+    { proof := by
+        intro valuation baseModel baseHolds
+        obtain ⟨extended, finalModel, agreement⟩ :=
+          checked.extension.proof valuation baseModel
+        have finalBase : ∀ fact, fact ∈ initialBase input →
+            semantics.holds checked.program extended fact := by
+          intro fact member
+          exact (checked.stable.holdsOld valuation extended fact
+            ((initialWithin input size.proof) fact member) baseModel finalModel agreement).mp
+              (baseHolds fact member)
+        have finalResult := resolved.sound.proof extended finalModel finalBase
+        have finalTarget : semantics.holds checked.program extended input.target := by
+          simpa [nodeEq.proof, factEq.proof] using finalResult
+        exact (checked.stable.holdsOld valuation extended input.target targetWithin.proof
+          baseModel finalModel agreement).mpr finalTarget }
+
+/-- Replay one exact established impossible fact. Runtime contradiction state
+is not an argument. -/
+def replayRefute (limits : Limits) (registry : Registry semantics)
+    (input : Input Fact) (checked : State semantics input) (step : RefuteStep)
+    (target : NodeFact Fact) : Except Error
+      (Evidence (semantics.Entails checked.program (initialBase input) target)) := do
+  bodyCheck limits step.schema .refute step.body
+  if step.scope != input.scope then throw .wrongScope
+  if step.programVersion != checked.version then throw .wrongProgramVersion
+  let some established := checked.facts.resolve step.seen
+    | throw (.missingDependency step.seen)
+  let some schema := registry.refuter? step.schema | throw .missingSchema
+  let some certificate := schema.decode step.body | throw .malformedBody
+  let context : RefuteContext semantics :=
+    { scope := step.scope, programVersion := checked.version, program := checked.program,
+      node := step.seen.node, fact := established.fact }
+  let some impossible := schema.prove context certificate | throw .malformedBody
+  pure
+    { proof := by
+        intro valuation model baseHolds
+        exact False.elim (impossible.proof valuation model
+          (established.sound.proof valuation model baseHolds)) }
+
+/-! ## Kernel-facing expression boundary -/
+
+/-- Package-owned expression producer. It has no proof authority beyond the
+kernel type of the expression it returns. -/
+structure Emitter (Quote : Type) where
+  emit : Quote → Lean.MetaM Lean.Expr
+
+/-- Run one package emitter transactionally and accept only an expression
+whose inferred type is definitionally equal to the exact expected proposition. -/
+def emitChecked (emitter : Emitter Quote) (quote : Quote)
+    (expected : Lean.Expr) : Lean.MetaM Lean.Expr := do
+  let saved ← Lean.Meta.saveState
+  try
+    let candidate ← emitter.emit quote
+    let actual ← Lean.Meta.inferType candidate
+    unless ← Lean.Meta.isDefEq actual expected do
+      throwError "interval proof emitter returned type {actual}; expected {expected}"
+    pure candidate
+  catch error =>
+    saved.restore
+    throw error
+
+/-- Project the ordinary theorem from a successfully checked proof object. -/
+theorem ofEvidence {claim : Prop} (evidence : Evidence claim) : claim :=
+  evidence.proof
+
+end Hex.Interval.Proof

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -22,8 +22,11 @@ owner, body, action, scope, versions, dependencies, and chronology all match.
 
 Schema decoders and theorem builders are package callbacks, but their returned
 `Evidence` contains an ordinary Lean proof of the exact indexed proposition.
-The final Meta boundary accepts an emitted expression only after kernel-facing
-type inference and definitional equality, restoring Meta state on failure.
+The final Meta boundary instantiates and rejects unresolved metavariables and
+placeholders, runs the elaborator's structural `Meta.check`, and checks the
+inferred type against the exact expected proposition by definitional equality.
+It restores Meta state on success and failure. The kernel performs the final
+check only when the caller installs the returned expression in a declaration.
 Concrete operations, packages, goal reification, tactic syntax, registries of
 declaration names, and default search policy are intentionally absent.
 
@@ -306,7 +309,11 @@ inductive BuildError where
   | emptyRefuterOwner (package : Nat) (key : Key)
   deriving DecidableEq, Repr
 
+/-! Under ordinary imports, only `Registry.buildWithin` can construct this
+trusted theorem registry. `import all HexIntervalMathlib.Proof` is a deliberate
+trusted-internals escape hatch guarded by the repository DAG checker. -/
 structure Registry (semantics : Semantics Fact) where
+  private mk ::
   registrations : Array Registration
   facts : Array (FactSchema semantics)
   equalities : Array (EqualitySchema semantics)
@@ -315,11 +322,18 @@ structure Registry (semantics : Semantics Fact) where
 
 namespace Registry
 
+private def make (registrations : Array Registration)
+    (facts : Array (FactSchema semantics))
+    (equalities : Array (EqualitySchema semantics))
+    (instances : Array (InstanceSchema semantics))
+    (refuters : Array (RefuteSchema semantics)) : Registry semantics :=
+  .mk registrations facts equalities instances refuters
+
 def owns (package : Package semantics) (key : Key) : Bool :=
   package.registrations.any fun registration => registration.key == key.rule
 
 /-- Assemble a package-local, globally unambiguous theorem registry. -/
-def buildWithin (limits : Limits) (program : Program)
+opaque buildWithin (limits : Limits) (program : Program)
     (packages : Array (Package semantics)) : Except BuildError (Registry semantics) := do
   if !program.check then throw .invalidProgram
   if limits.maxPackages < packages.size then throw .packageLimit
@@ -369,7 +383,7 @@ def buildWithin (limits : Limits) (program : Program)
       if seen.contains schema.key then throw (.duplicateSchema schema.key)
       seen := schema.key :: seen
       refuters := refuters.push schema
-  pure { registrations, facts, equalities, instances, refuters }
+  pure (make registrations facts equalities instances refuters)
 
 def fact? (registry : Registry semantics) (key : Key) : Option (FactSchema semantics) :=
   registry.facts.toList.find? fun schema => schema.key == key
@@ -409,7 +423,9 @@ def acceptsAction (registry : Registry semantics) (program : Program)
             allDistinct inputs && allDistinct action.writes &&
             inputs.all (fun node => (program.node? node).isSome) &&
             action.writes.all (fun node => (program.node? node).isSome)
-      | .global => inputs.isEmpty && action.writes.isEmpty
+      | .global =>
+          registration.watches.isEmpty && registration.writes.isEmpty &&
+            inputs.isEmpty && action.writes.isEmpty
   | _, _ => false
 
 end Registry
@@ -566,8 +582,9 @@ def push (equalities : Equalities semantics program base)
 
 end Equalities
 
-/-- Complete proof state at one exact program version. Constructor privacy
-prevents transplanting facts or equalities to another program. -/
+/-- Complete proof state at one exact program version. Its dependent type
+indices prevent facts or equalities from being transplanted to a different
+program without also supplying the corresponding typed semantic evidence. -/
 structure State (semantics : Semantics Fact) (input : Input Fact) where
   version : Nat
   program : Program
@@ -1015,23 +1032,40 @@ def replayRefute (limits : Limits) (registry : Registry semantics)
         exact False.elim (impossible.proof valuation model
           (established.sound.proof valuation model baseHolds)) }
 
-/-! ## Kernel-facing expression boundary -/
+/-! ## Elaborator-facing expression boundary -/
 
 /-- Package-owned expression producer. It has no proof authority beyond the
-kernel type of the expression it returns. -/
+type of an expression accepted by the elaborator checks below and eventually
+installed in a kernel-checked declaration. -/
 structure Emitter (Quote : Type) where
   emit : Quote → Lean.MetaM Lean.Expr
 
-/-- Run one package emitter transactionally and accept only an expression
-whose inferred type is definitionally equal to the exact expected proposition. -/
+/-- Run one package emitter transactionally. The returned expression contains
+no unresolved metavariables or placeholders, passes `Meta.check`, and has an
+inferred type definitionally equal to the exact closed expected proposition.
+All emitter and unification state is restored even on success. -/
 def emitChecked (emitter : Emitter Quote) (quote : Quote)
     (expected : Lean.Expr) : Lean.MetaM Lean.Expr := do
   let saved ← Lean.Meta.saveState
   try
-    let candidate ← emitter.emit quote
-    let actual ← Lean.Meta.inferType candidate
+    let expected ← Lean.instantiateMVars expected
+    if expected.hasMVar then
+      throwError "interval proof emitter expected type contains unresolved metavariables"
+    let candidate ← Lean.instantiateMVars (← emitter.emit quote)
+    if candidate.hasSorry then
+      throwError "interval proof emitter returned a placeholder expression"
+    if candidate.hasMVar then
+      throwError "interval proof emitter returned unresolved metavariables"
+    Lean.Meta.check candidate
+    let actual ← Lean.instantiateMVars (← Lean.Meta.inferType candidate)
+    if actual.hasMVar then
+      throwError "interval proof emitter inferred an unresolved type"
     unless ← Lean.Meta.isDefEq actual expected do
       throwError "interval proof emitter returned type {actual}; expected {expected}"
+    let candidate ← Lean.instantiateMVars candidate
+    if candidate.hasMVar then
+      throwError "interval proof emitter unification left unresolved metavariables"
+    saved.restore
     pure candidate
   catch error =>
     saved.restore

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -101,7 +101,10 @@ not import the experimental propagation fact domain.
 The public companion grows only with the supported `Hex.Interval` API. Its
 `Program` module gives exact meanings to the supported decoded SSA program,
 and its `Proof` module owns function-agnostic package schemas, chronological
-typed replay, target closure, and the kernel-checked `Expr` emission boundary.
+typed replay, target closure, and an expression-emission boundary that rejects
+placeholders and unresolved metavariables, runs `Meta.check`, and checks exact
+type definitional equality transactionally. The kernel performs the final
+check when the caller installs the expression in a declaration.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The concrete package registry, goal reifier,
 search-to-proof quotation, and tactic syntax remain experimental and are not
@@ -125,6 +128,12 @@ caller facts, schema decoding, or package theorem callbacks. Authenticated
 search output must first pass the Mathlib-free `Search` envelope; a direct
 trusted caller of `Proof` is responsible for bounding its program and package
 assembly before replay.
+
+Under ordinary imports, the theorem-registry constructor is private and
+`Registry.buildWithin` is the only supported construction path. Lean's
+deliberate `import all HexIntervalMathlib.Proof` exposes trusted internals and
+lies outside the decoded-runtime threat model; the repository DAG checker
+rejects that import outside an exact reviewed allowlist, currently empty.
 
 `HexIntervalMathlib.Experiment.PntLogRational` is a fixed-source acceptance
 provider rather than public interval arithmetic. It proves the original

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -102,9 +102,11 @@ The public companion grows only with the supported `Hex.Interval` API. Its
 `Program` module gives exact meanings to the supported decoded SSA program,
 and its `Proof` module owns function-agnostic package schemas, chronological
 typed replay, target closure, and an expression-emission boundary that rejects
-placeholders and unresolved metavariables, runs `Meta.check`, and checks exact
-type definitional equality transactionally. The kernel performs the final
-check when the caller installs the expression in a declaration.
+placeholders and unresolved metavariables, restores all emitter changes, then
+runs `Meta.check` and checks exact type definitional equality transactionally
+in the caller's environment. Emitted terms may reference only declarations
+that survive that rollback. The kernel performs the final check when the caller
+installs the expression in a declaration.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The concrete package registry, goal reifier,
 search-to-proof quotation, and tactic syntax remain experimental and are not

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -118,6 +118,14 @@ and total-zero cases exactly, and deliberately returns whole for every other
 nonempty shape. No tightness converse or bounded nonsingleton quotient is
 claimed.
 
+The supported proof limits cap retained package and schema counts, certificate
+body cells, ordered dependencies, and chronology. They do not claim to
+preempt full `Program.check` or registration validation, equality on arbitrary
+caller facts, schema decoding, or package theorem callbacks. Authenticated
+search output must first pass the Mathlib-free `Search` envelope; a direct
+trusted caller of `Proof` is responsible for bounding its program and package
+assembly before replay.
+
 `HexIntervalMathlib.Experiment.PntLogRational` is a fixed-source acceptance
 provider rather than public interval arithmetic. It proves the original
 strength of seventeen pinned PNT+ direct-log declarations over fifteen

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -102,11 +102,12 @@ The public companion grows only with the supported `Hex.Interval` API. Its
 `Program` module gives exact meanings to the supported decoded SSA program,
 and its `Proof` module owns function-agnostic package schemas, chronological
 typed replay, target closure, and an expression-emission boundary that rejects
-placeholders and unresolved metavariables, restores all emitter changes, then
-runs `Meta.check` and checks exact type definitional equality transactionally
-in the caller's environment. Emitted terms may reference only declarations
-that survive that rollback. The kernel performs the final check when the caller
-installs the expression in a declaration.
+placeholders and unresolved metavariables, restores emitter environment,
+message, information, and metavariable changes, clears both environment-
+dependent elaborator caches, then runs `Meta.check` and checks exact type
+definitional equality transactionally in the caller's environment. Emitted
+terms may reference only declarations that survive that rollback. The kernel
+performs the final check when the caller installs the expression.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The concrete package registry, goal reifier,
 search-to-proof quotation, and tactic syntax remain experimental and are not

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -98,10 +98,14 @@ not import the experimental propagation fact domain.
 
 ## Boundary
 
-The public companion grows only with the supported `Hex.Interval` API. The
-existing modules under `HexIntervalMathlib/Experiment` remain evidence for
-future operations, replay schemas, transcendental providers, and tactics, but
-are not re-exported here. Further arithmetic images and useful bounded
+The public companion grows only with the supported `Hex.Interval` API. Its
+`Program` module gives exact meanings to the supported decoded SSA program,
+and its `Proof` module owns function-agnostic package schemas, chronological
+typed replay, target closure, and the kernel-checked `Expr` emission boundary.
+Runtime search state, callbacks, payload bytes, and traces are untrusted and
+cannot enter `Proof.Evidence`. The concrete package registry, goal reifier,
+search-to-proof quotation, and tactic syntax remain experimental and are not
+re-exported here. Further arithmetic images and useful bounded
 nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
@@ -168,6 +172,11 @@ set-image converse is exported.
 The Mathlib-free companion tests separately pin representative strict, closed,
 unbounded, and empty shapes together with pre-allocation resource refusal. The
 semantic theorem itself is exhaustive over the complete cut language.
+`HexIntervalMathlib.ProgramProofConformance` independently pins exact operation
+alignment and a live instance → fact → equality → transport chronology,
+including body/source/version/final-state mutations, refuter ownership, a
+nonvacuous ordinary theorem with a guarded axiom report, and transactional
+Meta-state restoration after a wrongly typed emitter.
 `HexIntervalMathlib.PntLogRationalConformance` additionally runs all fifteen
 fixed rows and sends the representative large-shift `32e12` certificate through
 generic planning, payload authentication, chronological replay, and the proof

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -19,9 +19,13 @@ Division exposes direct outward cuts for two nonzero finite singletons, exact
 empty and total-zero cases, and a sound whole-line fallback otherwise.
 Outward regularization exposes exact Core-rounded cuts, source containment,
 and raw-cut idempotence without claiming a globally grid-tightest enclosure.
-Propagator, provider, replay, and tactic modules remain experiments and are not
-re-exported by the public umbrella. The user-facing tactic contract below is
-the release target, not a claim that the tactic is already supported.
+The supported proof surface also gives exact function-agnostic meanings to
+decoded SSA programs and replays package-owned fact, equality, instantiation,
+and refutation schemas chronologically into ordinary kernel-checked proofs.
+Concrete packages, goal reification, search-to-proof quotation, and tactic
+syntax remain experimental and are not re-exported by the public umbrella.
+The user-facing tactic contract below is the release target, not a claim that
+the tactic is already supported.
 
 The tactic proves bounds for ordinary Lean expressions over `ℝ`. It reads
 bounds from the local context, reifies shared expressions to an immutable

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -23,11 +23,12 @@ The supported proof surface also gives exact function-agnostic meanings to
 decoded SSA programs and replays package-owned fact, equality, instantiation,
 and refutation schemas chronologically into ordinary typed proofs. Its emitted
 expression boundary rejects placeholders and unresolved metavariables,
-restores emitter changes, then transactionally runs the elaborator's
-`Meta.check` and exact type definitional equality in the caller's environment.
-Emitted terms may reference only declarations surviving that rollback; the
-kernel checks the term when the caller installs it in a declaration. The
-theorem registry is constructible only through its
+restores emitter environment, messages, information, and metavariables, clears
+both environment-dependent elaborator caches, then transactionally runs the
+elaborator's `Meta.check` and exact type definitional equality in the caller's
+environment. Emitted terms may reference only declarations surviving that
+rollback; the kernel checks the term when the caller installs it in a
+declaration. The theorem registry is constructible only through its
 checked builder under ordinary imports; deliberate `import all` is a guarded
 trusted-internals escape hatch, not decoded runtime authority.
 Concrete packages, goal reification, search-to-proof quotation, and tactic

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -21,7 +21,13 @@ Outward regularization exposes exact Core-rounded cuts, source containment,
 and raw-cut idempotence without claiming a globally grid-tightest enclosure.
 The supported proof surface also gives exact function-agnostic meanings to
 decoded SSA programs and replays package-owned fact, equality, instantiation,
-and refutation schemas chronologically into ordinary kernel-checked proofs.
+and refutation schemas chronologically into ordinary typed proofs. Its emitted
+expression boundary transactionally rejects placeholders and unresolved
+metavariables, runs the elaborator's `Meta.check`, and checks exact type
+definitional equality; the kernel checks the term when the caller installs it
+in a declaration. The theorem registry is constructible only through its
+checked builder under ordinary imports; deliberate `import all` is a guarded
+trusted-internals escape hatch, not decoded runtime authority.
 Concrete packages, goal reification, search-to-proof quotation, and tactic
 syntax remain experimental and are not re-exported by the public umbrella.
 The user-facing tactic contract below is the release target, not a claim that

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -22,10 +22,12 @@ and raw-cut idempotence without claiming a globally grid-tightest enclosure.
 The supported proof surface also gives exact function-agnostic meanings to
 decoded SSA programs and replays package-owned fact, equality, instantiation,
 and refutation schemas chronologically into ordinary typed proofs. Its emitted
-expression boundary transactionally rejects placeholders and unresolved
-metavariables, runs the elaborator's `Meta.check`, and checks exact type
-definitional equality; the kernel checks the term when the caller installs it
-in a declaration. The theorem registry is constructible only through its
+expression boundary rejects placeholders and unresolved metavariables,
+restores emitter changes, then transactionally runs the elaborator's
+`Meta.check` and exact type definitional equality in the caller's environment.
+Emitted terms may reference only declarations surviving that rollback; the
+kernel checks the term when the caller installs it in a declaration. The
+theorem registry is constructible only through its
 checked builder under ordinary imports; deliberate `import all` is a guarded
 trusted-internals escape hatch, not decoded runtime authority.
 Concrete packages, goal reification, search-to-proof quotation, and tactic

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -1,0 +1,398 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Proof
+
+/-!
+# Supported program/proof conformance
+
+This canary exercises a complete function-agnostic chronology: an authenticated
+reflexive program instance, a fact theorem, an equality theorem, equality
+transport, exact target closure, and a separately owned refuter. Mutated quote
+fields fail before they can alter the immutable proof state.
+-/
+
+namespace Hex.IntervalMathlib.ProgramProofConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+
+inductive TestFact where
+  | all | yes | no | empty
+  deriving DecidableEq, Repr
+
+def domain : DomainId := { index := 0 }
+def sourceKey : OpKey := { name := "proof-source", version := 1 }
+def operation : Operation := { key := sourceKey, inputs := [], output := domain }
+def sourceNode : Node := { domain, op := { index := 0 }, args := [] }
+def node0 : NodeId := { index := 0 }
+def node1 : NodeId := { index := 1 }
+def program : Program := { operations := #[operation], nodes := #[sourceNode, sourceNode] }
+
+#guard program.check
+
+def meaning : Hex.Interval.Program.Meaning Bool :=
+  { operation, relation := fun _ result => result = true }
+
+example : Hex.Interval.Program.Aligned [meaning] [operation] := by
+  simp [Hex.Interval.Program.Aligned, meaning]
+
+/-- The exact aligned operation meaning has a nonempty model on both nodes. -/
+theorem programModel :
+    Hex.Interval.Program.Models #[meaning] program (fun _ => true) := by
+  apply Hex.Interval.Program.modelsOfMeanings #[meaning] program (fun _ => true)
+  · simp [program, meaning]
+  · simp [Hex.Interval.Program.Meanings, Hex.Interval.Program.MeaningAt, meaning,
+      program, sourceNode]
+
+example : ¬ Hex.Interval.Program.Models #[] program (fun _ => true) := by
+  intro model
+  simpa [Hex.Interval.Program.Models, program] using model.1
+
+def scope : Policy.ScopeId := { index := 7 }
+def factRule : RuleKey := { name := "proof-fact", schema := 3 }
+def equalityRule : RuleKey := { name := "proof-equality", schema := 3 }
+def instanceRule : RuleKey := { name := "proof-instance", schema := 3 }
+def refuteRule : RuleKey := { name := "proof-refute", schema := 3 }
+
+def factRegistration : Registration :=
+  { key := factRule
+    head := sourceKey
+    kind := .forward
+    watches := [.result]
+    writes := [.result] }
+
+def equalityRegistration : Registration :=
+  { key := equalityRule
+    head := sourceKey
+    kind := .rewrite
+    watches := [.result]
+    writes := [] }
+
+def instanceRegistration : Registration :=
+  { key := instanceRule
+    head := sourceKey
+    kind := .instantiate
+    watches := []
+    writes := []
+    binding := .scoped }
+
+def refuteRegistration : Registration :=
+  { key := refuteRule
+    head := sourceKey
+    kind := .backward
+    watches := []
+    writes := []
+    binding := .scoped }
+
+def seen (node : NodeId) (version : Nat) : SeenVersion := { node, version }
+
+def action (serial programVersion ruleIndex : Nat) (key : RuleKey) (kind : ActionKind)
+    (node : NodeId)
+    (inputs : List SeenVersion) (writes : List NodeId) : Action :=
+  { serial
+    programVersion
+    application := { index := serial }
+    rule := { index := ruleIndex }
+    key
+    node
+    kind
+    effort := 0
+    inputs
+    writes }
+
+def contains : TestFact → Bool → Prop
+  | .all, _ => True
+  | .yes, value => value = true
+  | .no, value => value = false
+  | .empty, _ => False
+
+def semantics : Proof.Semantics TestFact :=
+  { Value := Bool
+    models := fun checked valuation =>
+      checked = program ∧ valuation node0 = valuation node1
+    holds := fun _ valuation fact => contains fact.fact (valuation fact.node)
+    holdsAgree := by
+      intro checked left right fact within _ _ agree
+      rw [agree fact.node within] }
+
+def factDomain : Proof.Domain semantics :=
+  { top := fun _ => .all
+    topSound := by simp [semantics, contains]
+    meet := fun checked node previous proposed installed =>
+      if shape : (previous = .all ∨ previous = .yes) ∧ proposed = .yes ∧
+          installed = .yes then
+        some
+          { proof := by
+              rcases shape with ⟨previousShape, rfl, rfl⟩
+              rcases previousShape with rfl | rfl
+              · intro valuation model
+                simp [semantics, contains]
+              · intro valuation model
+                simp [semantics, contains] }
+      else none }
+
+theorem laws : Proof.Laws semantics :=
+  { holdsEq := by
+      intro checked valuation left right fact model equal
+      simp only [semantics, contains]
+      rw [equal] }
+
+def factKey : Proof.Key := { rule := factRule, role := .fact, bodySchema := 1 }
+def equalityKey : Proof.Key := { rule := equalityRule, role := .equality, bodySchema := 2 }
+def instanceKey : Proof.Key := { rule := instanceRule, role := .instance, bodySchema := 3 }
+def refuteKey : Proof.Key := { rule := refuteRule, role := .refute, bodySchema := 4 }
+
+def decode (expected : Nat) (body : List Nat) : Option Unit :=
+  if body = [expected] then some () else none
+
+def factSchema : Proof.FactSchema semantics :=
+  { key := factKey
+    Certificate := Unit
+    decode := decode 11
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.program = program ∧
+          context.proposed.fact = .yes ∧ context.proposed.node = node0 ∧
+          context.assumptions = [{ node := node0, fact := .yes }] then
+        some
+          { proof := by
+              rcases shape with ⟨_, programEq, factEq, nodeEq, assumptionsEq⟩
+              intro valuation model assumptions
+              have proposedEq : context.proposed = { node := node0, fact := .yes } := by
+                cases h : context.proposed with
+                | mk node fact =>
+                    have nodeEq' : node = node0 := by simpa [h] using nodeEq
+                    have factEq' : fact = .yes := by simpa [h] using factEq
+                    subst node
+                    subst fact
+                    rfl
+              have source := assumptions { node := node0, fact := .yes } (by
+                simp [assumptionsEq])
+              simpa [proposedEq] using source }
+      else none }
+
+def equalitySchema : Proof.EqualitySchema semantics :=
+  { key := equalityKey
+    Certificate := Unit
+    decode := decode 22
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.program = program ∧
+          context.left = node0 ∧ context.right = node1 ∧
+          context.assumptions = [{ node := node0, fact := .yes }] then
+        some
+          { proof := by
+              rcases shape with ⟨_, programEq, leftEq, rightEq, _⟩
+              intro valuation model _
+              simpa [semantics, programEq, leftEq, rightEq] using model.2 }
+      else none }
+
+def instanceSchema : Proof.InstanceSchema semantics :=
+  { key := instanceKey
+    Certificate := Unit
+    decode := decode 33
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.beforeVersion = 0 ∧
+          context.afterVersion = 1 ∧ context.before = program ∧
+          context.after = program ∧ context.newNodes = [] then
+        some
+          { stable := by
+              rcases shape with ⟨_, _, _, beforeEq, afterEq, _⟩
+              simpa [beforeEq, afterEq] using Proof.stableRefl semantics program
+            extension := by
+              rcases shape with ⟨_, _, _, beforeEq, afterEq, _⟩
+              simpa [beforeEq, afterEq] using Proof.extendsRefl semantics program }
+      else none }
+
+def refuteSchema : Proof.RefuteSchema semantics :=
+  { key := refuteKey
+    Certificate := Unit
+    decode := decode 44
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.program = program ∧
+          context.fact = .empty then
+        some
+          { proof := by
+              rcases shape with ⟨_, _, factEq⟩
+              intro _ _ impossible
+              rw [factEq] at impossible
+              exact impossible }
+      else none }
+
+def package : Proof.Package semantics :=
+  { registrations := #[factRegistration, equalityRegistration, instanceRegistration,
+      refuteRegistration]
+    facts := #[factSchema]
+    equalities := #[equalitySchema]
+    instances := #[instanceSchema]
+    refuters := #[refuteSchema] }
+
+def limits : Proof.Limits :=
+  { maxPackages := 1, maxSchemas := 4, maxBodyCells := 1,
+    maxDependencies := 1, maxChronology := 4 }
+
+def registry : Proof.Registry semantics :=
+  { registrations := #[factRegistration, equalityRegistration, instanceRegistration,
+      refuteRegistration]
+    facts := #[factSchema]
+    equalities := #[equalitySchema]
+    instances := #[instanceSchema]
+    refuters := #[refuteSchema] }
+
+#guard match Proof.Registry.buildWithin limits program #[package] with
+  | .ok built => built.registrations.size == 4 && built.facts.size == 1 &&
+      built.equalities.size == 1 && built.instances.size == 1 && built.refuters.size == 1
+  | .error _ => false
+
+def input : Proof.Input TestFact :=
+  { scope, program, facts := #[.yes, .all], target := { node := node1, fact := .yes } }
+
+def instanceAction := action 0 0 2 instanceRule .instantiate node0 [] []
+def factAction := action 1 1 0 factRule .forward node0 [seen node0 0] [node0]
+def equalityAction := action 2 1 1 equalityRule .rewrite node0 [seen node0 1] []
+
+def instanceStep : Proof.InstanceStep :=
+  { scope, beforeVersion := 0, afterVersion := 1, action := instanceAction,
+    after := program, newNodes := [], schema := instanceKey, body := [33] }
+
+def factStep : Proof.FactStep TestFact :=
+  { scope, programVersion := 1, action := factAction, node := node0,
+    previous := seen node0 0, version := 1, proposed := .yes, installed := .yes,
+    assumptions := [seen node0 0], schema := factKey, body := [11] }
+
+def equalityStep : Proof.EqualityStep :=
+  { scope, programVersion := 1, action := equalityAction, equality := { index := 0 },
+    left := node0, right := node1, assumptions := [seen node0 1],
+    schema := equalityKey, body := [22] }
+
+def transportStep : Proof.TransportStep TestFact :=
+  { scope, programVersion := 1, node := node1, previous := seen node1 0,
+    version := 1, equality := { index := 0 }, source := seen node0 1, installed := .yes }
+
+def events : List (Proof.Event TestFact) :=
+  [.instance instanceStep, .fact factStep, .equality equalityStep, .transport transportStep]
+
+def run (quoted := events) :=
+  Proof.replay limits registry factDomain laws input quoted 1 program (seen node1 1)
+
+def succeeds : Bool := match run with | .ok _ => true | .error _ => false
+
+#guard succeeds
+#guard !(match run (events.set 0 (.instance { instanceStep with body := [34] })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 1 (.fact { factStep with previous := seen node0 1 })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 1 (.fact { factStep with body := [12] })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 1 (.fact { factStep with scope := { index := 8 } })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 1 (.fact { factStep with
+    action := { factAction with rule := { index := 1 } } })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 1 (.fact { factStep with
+    action := { factAction with inputs := [seen node0 2] }
+    assumptions := [seen node0 2] })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 2 (.equality { equalityStep with right := node0 })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 2 (.equality { equalityStep with body := [23] })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events.set 3 (.transport { transportStep with source := seen node1 0 })) with
+  | .ok _ => true | .error _ => false)
+#guard !(match Proof.replay limits registry factDomain laws input events 0 program (seen node1 1) with
+  | .ok _ => true | .error _ => false)
+#guard !(match run (events ++ [.fact factStep]) with
+  | .ok _ => true | .error _ => false)
+
+/-- A rejected transition cannot alter the state subsequently used by a valid
+transition. -/
+def restores : Bool :=
+  match Proof.replayInstance limits registry factDomain input
+      (Proof.State.start semantics input rfl) instanceStep with
+  | .error _ => false
+  | .ok afterInstance =>
+      let bad := { factStep with body := [12] }
+      match Proof.replayFact limits registry factDomain input afterInstance bad with
+      | .ok _ => false
+      | .error _ =>
+          match Proof.replayFact limits registry factDomain input afterInstance factStep with
+          | .ok _ => true
+          | .error _ => false
+
+#guard restores
+
+/-- The successful generic replay produces an ordinary theorem. -/
+def replayEvidence : Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  match run with
+  | .ok evidence => evidence
+  | .error _ =>
+      { proof := by
+          intro valuation model assumptions
+          have source := assumptions { node := node0, fact := .yes } (by
+            simp [Proof.initialBase, input, node0])
+          simpa [semantics, contains, input, node1, model.2] using source }
+
+theorem replayCanary :
+    semantics.Entails input.program (Proof.initialBase input) input.target :=
+  replayEvidence.proof
+
+#print axioms replayCanary
+
+def impossibleInput : Proof.Input TestFact :=
+  { scope, program, facts := #[.empty, .all], target := { node := node1, fact := .no } }
+
+def refuteStep : Proof.RefuteStep :=
+  { scope, programVersion := 0, seen := seen node0 0, schema := refuteKey, body := [44] }
+
+def refutes : Bool :=
+  match Proof.replayRefute limits registry impossibleInput
+      (Proof.State.start semantics impossibleInput rfl) refuteStep impossibleInput.target with
+  | .ok _ => true
+  | .error _ => false
+
+#guard refutes
+
+def unowned : Proof.Package semantics := { registrations := #[], refuters := #[refuteSchema] }
+
+#guard match Proof.Registry.buildWithin limits program #[unowned] with
+  | .error (.emptyRefuterOwner 0 key) => key == refuteKey
+  | _ => false
+
+open Lean Meta Elab Tactic
+
+/-- A failing emitter cannot retain even a valid assignment it made before
+returning an expression of the wrong type. -/
+elab "proof_emit_restore" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let emitter : Proof.Emitter Unit :=
+    { emit := fun _ => do
+        goal.assign (mkConst ``True.intro)
+        pure (mkNatLit 0) }
+  try
+    let _ ← Proof.emitChecked emitter () expected
+    throwError "wrongly typed proof emitter was accepted"
+  catch _ =>
+    if ← goal.isAssigned then
+      throwError "failed proof emitter leaked its Meta assignment"
+    goal.assign (mkConst ``True.intro)
+    replaceMainGoal []
+
+example : True := by proof_emit_restore
+
+elab "proof_emit_accept" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let emitter : Proof.Emitter Unit :=
+    { emit := fun _ => pure (mkConst ``replayCanary) }
+  let evidence ← Proof.emitChecked emitter () expected
+  goal.assign evidence
+  replaceMainGoal []
+
+example : semantics.Entails input.program (Proof.initialBase input) input.target := by
+  proof_emit_accept
+
+end Hex.IntervalMathlib.ProgramProofConformance

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -460,11 +460,13 @@ elab "proof_emit_restore" : tactic => do
 example : True := by proof_emit_restore
 
 /-- Structural checking rejects an application whose explicit argument has the
-wrong type, even though the raw expression can be constructed. -/
+wrong type even though raw type inference reports the expected result type. -/
 elab "proof_emit_reject_ill_typed" : tactic => do
   let goal ← getMainGoal
   let expected ← goal.getType
-  let illTyped := mkApp2 (mkConst ``id [Level.zero]) (mkConst ``Bool) (mkNatLit 0)
+  let illTyped := mkApp2 (mkConst ``id [Level.zero]) expected (mkNatLit 0)
+  unless ← isDefEq (← inferType illTyped) expected do
+    throwError "ill-typed proof-emitter canary does not isolate Meta.check"
   let emitter : Proof.Emitter Unit := { emit := fun _ => pure illTyped }
   let accepted ← try
     let _ ← Proof.emitChecked emitter () expected
@@ -475,6 +477,34 @@ elab "proof_emit_reject_ill_typed" : tactic => do
   replaceMainGoal []
 
 example : True := by proof_emit_reject_ill_typed
+
+/-- An emitter-created declaration is rolled back before authoritative
+validation, so a returned reference to it is rejected rather than dangling. -/
+elab "proof_emit_reject_aux" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let auxName := `Hex.IntervalMathlib.ProgramProofConformance.transientEmitterTheorem
+  if (← getEnv).contains auxName then
+    throwError "transient proof-emitter declaration already exists"
+  let emitter : Proof.Emitter Unit :=
+    { emit := fun _ => do
+        addDecl <| .thmDecl
+          { name := auxName
+            levelParams := []
+            type := expected
+            value := mkConst ``True.intro }
+        pure (mkConst auxName) }
+  let accepted ← try
+    let _ ← Proof.emitChecked emitter () expected
+    pure true
+  catch _ => pure false
+  if accepted then throwError "transient proof-emitter declaration was accepted"
+  if (← getEnv).contains auxName then
+    throwError "failed proof emitter leaked its transient declaration"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by proof_emit_reject_aux
 
 /-- Synthetic placeholder expressions are rejected even at the expected type. -/
 elab "proof_emit_reject_placeholder" : tactic => do
@@ -491,8 +521,8 @@ elab "proof_emit_reject_placeholder" : tactic => do
 
 example : True := by proof_emit_reject_placeholder
 
-/-- Open candidate and expected metavariables are both rejected without being
-assigned by definitional equality. -/
+/-- Open candidate and expected metavariables, and an expected placeholder,
+are rejected without being assigned by definitional equality. -/
 elab "proof_emit_reject_mvars" : tactic => do
   let goal ← getMainGoal
   let expected ← goal.getType
@@ -517,6 +547,12 @@ elab "proof_emit_reject_mvars" : tactic => do
   if expectedAccepted then throwError "open expected proposition was accepted"
   if ← expectedId.isAssigned then
     throwError "rejected expected metavariable was assigned"
+  let placeholderExpected ← mkSorry expected true
+  let placeholderAccepted ← try
+    let _ ← Proof.emitChecked expectedEmitter () placeholderExpected
+    pure true
+  catch _ => pure false
+  if placeholderAccepted then throwError "placeholder expected proposition was accepted"
   goal.assign (mkConst ``True.intro)
   replaceMainGoal []
 

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -478,6 +478,31 @@ elab "proof_emit_reject_ill_typed" : tactic => do
 
 example : True := by proof_emit_reject_ill_typed
 
+/-- An emitter cannot use the retained Meta infer-type cache to make an
+ill-typed application appear well typed after its environment is rolled back. -/
+elab "proof_emit_reject_poisoned_cache" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let function := mkApp (mkConst ``id [Level.zero]) expected
+  let illTyped := mkApp function (mkNatLit 0)
+  let emitter : Proof.Emitter Unit :=
+    { emit := fun _ => do
+        let key ← mkExprConfigCacheKey function
+        let checkKey ← withTransparency .all <| mkExprConfigCacheKey function
+        let poisonedType ← mkArrow (mkConst ``Nat) expected
+        modifyInferTypeCache fun cache =>
+          (cache.insert key poisonedType).insert checkKey poisonedType
+        pure illTyped }
+  let accepted ← try
+    let _ ← Proof.emitChecked emitter () expected
+    pure true
+  catch _ => pure false
+  if accepted then throwError "proof emitter poisoned the retained Meta cache"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by proof_emit_reject_poisoned_cache
+
 /-- An emitter-created declaration is rolled back before authoritative
 validation, so a returned reference to it is rejected rather than dangling. -/
 elab "proof_emit_reject_aux" : tactic => do
@@ -493,6 +518,9 @@ elab "proof_emit_reject_aux" : tactic => do
             levelParams := []
             type := expected
             value := mkConst ``True.intro }
+        let inferred ← inferType (mkConst auxName)
+        unless ← isDefEq inferred expected do
+          throwError "transient proof-emitter declaration has the wrong type"
         pure (mkConst auxName) }
   let accepted ← try
     let _ ← Proof.emitChecked emitter () expected
@@ -505,6 +533,33 @@ elab "proof_emit_reject_aux" : tactic => do
   replaceMainGoal []
 
 example : True := by proof_emit_reject_aux
+
+/-- Cache activity involving a transient declaration cannot poison a successful
+emission of a proof that uses only the caller's pre-existing environment. -/
+elab "proof_emit_accept_after_aux" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let auxName := `Hex.IntervalMathlib.ProgramProofConformance.transientEmitterCache
+  if (← getEnv).contains auxName then
+    throwError "transient proof-emitter cache declaration already exists"
+  let emitter : Proof.Emitter Unit :=
+    { emit := fun _ => do
+        addDecl <| .thmDecl
+          { name := auxName
+            levelParams := []
+            type := expected
+            value := mkConst ``True.intro }
+        let inferred ← inferType (mkConst auxName)
+        unless ← isDefEq inferred expected do
+          throwError "transient proof-emitter cache declaration has the wrong type"
+        pure (mkConst ``True.intro) }
+  let evidence ← Proof.emitChecked emitter () expected
+  if (← getEnv).contains auxName then
+    throwError "successful proof emitter leaked its transient declaration"
+  goal.assign evidence
+  replaceMainGoal []
+
+example : True := by proof_emit_accept_after_aux
 
 /-- Synthetic placeholder expressions are rejected even at the expected type. -/
 elab "proof_emit_reject_placeholder" : tactic => do

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -246,6 +246,14 @@ def registry : Proof.Registry semantics :=
       built.equalities.size == 1 && built.instances.size == 1 && built.refuters.size == 1
   | .error _ => false
 
+#guard match Proof.Registry.buildWithin { limits with maxPackages := 0 } program #[package] with
+  | .error .packageLimit => true
+  | _ => false
+
+#guard match Proof.Registry.buildWithin { limits with maxSchemas := 3 } program #[package] with
+  | .error .schemaLimit => true
+  | _ => false
+
 def input : Proof.Input TestFact :=
   { scope, program, facts := #[.yes, .all], target := { node := node1, fact := .yes } }
 
@@ -286,6 +294,9 @@ def succeeds : Bool := match run with | .ok _ => true | .error _ => false
   | .ok _ => true | .error _ => false)
 #guard !(match run (events.set 1 (.fact { factStep with body := [12] })) with
   | .ok _ => true | .error _ => false)
+#guard match run (events.set 1 (.fact { factStep with body := [11, 12] })) with
+  | .error .bodyLimit => true
+  | _ => false
 #guard !(match run (events.set 1 (.fact { factStep with scope := { index := 8 } })) with
   | .ok _ => true | .error _ => false)
 #guard !(match run (events.set 1 (.fact { factStep with
@@ -295,6 +306,11 @@ def succeeds : Bool := match run with | .ok _ => true | .error _ => false
     action := { factAction with inputs := [seen node0 2] }
     assumptions := [seen node0 2] })) with
   | .ok _ => true | .error _ => false)
+#guard match run (events.set 1 (.fact { factStep with
+    action := { factAction with inputs := [seen node0 0, seen node1 0] }
+    assumptions := [seen node0 0, seen node1 0] })) with
+  | .error .dependencyLimit => true
+  | _ => false
 #guard !(match run (events.set 2 (.equality { equalityStep with right := node0 })) with
   | .ok _ => true | .error _ => false)
 #guard !(match run (events.set 2 (.equality { equalityStep with body := [23] })) with

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -233,15 +233,9 @@ def limits : Proof.Limits :=
   { maxPackages := 1, maxSchemas := 4, maxBodyCells := 1,
     maxDependencies := 1, maxChronology := 4 }
 
-def registry : Proof.Registry semantics :=
-  { registrations := #[factRegistration, equalityRegistration, instanceRegistration,
-      refuteRegistration]
-    facts := #[factSchema]
-    equalities := #[equalitySchema]
-    instances := #[instanceSchema]
-    refuters := #[refuteSchema] }
+def builtRegistry := Proof.Registry.buildWithin limits program #[package]
 
-#guard match Proof.Registry.buildWithin limits program #[package] with
+#guard match builtRegistry with
   | .ok built => built.registrations.size == 4 && built.facts.size == 1 &&
       built.equalities.size == 1 && built.instances.size == 1 && built.refuters.size == 1
   | .error _ => false
@@ -254,12 +248,65 @@ def registry : Proof.Registry semantics :=
   | .error .schemaLimit => true
   | _ => false
 
+def orphanRule : RuleKey := { name := "proof-orphan", schema := 3 }
+def orphanSchema : Proof.FactSchema semantics := { factSchema with
+  key := { role := .fact, rule := orphanRule, bodySchema := 9 } }
+def orphanPackage : Proof.Package semantics := { package with facts := #[orphanSchema] }
+def duplicatePackage : Proof.Package semantics := { package with facts := #[factSchema, factSchema] }
+def duplicateRegistrationPackage : Proof.Package semantics := { package with registrations :=
+  #[factRegistration, equalityRegistration, instanceRegistration, refuteRegistration,
+    factRegistration] }
+def globalRule : RuleKey := { name := "proof-global", schema := 3 }
+def globalRegistration : Registration :=
+  { key := globalRule
+    head := sourceKey
+    kind := .instantiate
+    watches := []
+    writes := []
+    binding := .global
+    watchesProgram := true
+    matchWatch := .network }
+def globalPackage : Proof.Package semantics := { registrations := #[globalRegistration] }
+def globalRegistry := Proof.Registry.buildWithin limits program #[globalPackage]
+def badGlobalRegistration : Registration := { globalRegistration with watches := [.result] }
+def badGlobalPackage : Proof.Package semantics := { registrations := #[badGlobalRegistration] }
+
+#guard match Proof.Registry.buildWithin limits program #[orphanPackage] with
+  | .error (.foreignSchema 0 key) => key == orphanSchema.key
+  | _ => false
+
+#guard match Proof.Registry.buildWithin { limits with maxSchemas := 5 } program
+    #[duplicatePackage] with
+  | .error (.duplicateSchema key) => key == factKey
+  | _ => false
+
+#guard match Proof.Registry.buildWithin limits program #[duplicateRegistrationPackage] with
+  | .error (.duplicateRegistration key) => key == factRule
+  | _ => false
+
+#guard match Proof.Registry.buildWithin limits program #[badGlobalPackage] with
+  | .error (.invalidRegistration _) => true
+  | _ => false
+
 def input : Proof.Input TestFact :=
   { scope, program, facts := #[.yes, .all], target := { node := node1, fact := .yes } }
 
 def instanceAction := action 0 0 2 instanceRule .instantiate node0 [] []
 def factAction := action 1 1 0 factRule .forward node0 [seen node0 0] [node0]
 def equalityAction := action 2 1 1 equalityRule .rewrite node0 [seen node0 1] []
+
+def globalAction : Action :=
+  { action 0 0 0 globalRule .instantiate node0 [] [] with
+    structuralInputs := [{ key := .node node0, generation := 0 }]
+    matcherEpoch := some 0 }
+
+#guard match globalRegistry with
+  | .ok registry => registry.acceptsAction program globalAction []
+  | .error _ => false
+#guard match globalRegistry with
+  | .ok registry => !registry.acceptsAction program
+      { globalAction with inputs := [seen node0 0] } [node0]
+  | .error _ => false
 
 def instanceStep : Proof.InstanceStep :=
   { scope, beforeVersion := 0, afterVersion := 1, action := instanceAction,
@@ -283,7 +330,10 @@ def events : List (Proof.Event TestFact) :=
   [.instance instanceStep, .fact factStep, .equality equalityStep, .transport transportStep]
 
 def run (quoted := events) :=
-  Proof.replay limits registry factDomain laws input quoted 1 program (seen node1 1)
+  match builtRegistry with
+  | .ok registry =>
+      Proof.replay limits registry factDomain laws input quoted 1 program (seen node1 1)
+  | .error _ => .error .invalidInput
 
 def succeeds : Bool := match run with | .ok _ => true | .error _ => false
 
@@ -317,25 +367,31 @@ def succeeds : Bool := match run with | .ok _ => true | .error _ => false
   | .ok _ => true | .error _ => false)
 #guard !(match run (events.set 3 (.transport { transportStep with source := seen node1 0 })) with
   | .ok _ => true | .error _ => false)
-#guard !(match Proof.replay limits registry factDomain laws input events 0 program (seen node1 1) with
-  | .ok _ => true | .error _ => false)
+#guard !(match builtRegistry with
+  | .ok registry =>
+      match Proof.replay limits registry factDomain laws input events 0 program (seen node1 1) with
+      | .ok _ => true | .error _ => false
+  | .error _ => true)
 #guard !(match run (events ++ [.fact factStep]) with
   | .ok _ => true | .error _ => false)
 
 /-- A rejected transition cannot alter the state subsequently used by a valid
 transition. -/
 def restores : Bool :=
-  match Proof.replayInstance limits registry factDomain input
-      (Proof.State.start semantics input rfl) instanceStep with
+  match builtRegistry with
   | .error _ => false
-  | .ok afterInstance =>
-      let bad := { factStep with body := [12] }
-      match Proof.replayFact limits registry factDomain input afterInstance bad with
-      | .ok _ => false
-      | .error _ =>
-          match Proof.replayFact limits registry factDomain input afterInstance factStep with
-          | .ok _ => true
-          | .error _ => false
+  | .ok registry =>
+      match Proof.replayInstance limits registry factDomain input
+          (Proof.State.start semantics input rfl) instanceStep with
+      | .error _ => false
+      | .ok afterInstance =>
+          let bad := { factStep with body := [12] }
+          match Proof.replayFact limits registry factDomain input afterInstance bad with
+          | .ok _ => false
+          | .error _ =>
+              match Proof.replayFact limits registry factDomain input afterInstance factStep with
+              | .ok _ => true
+              | .error _ => false
 
 #guard restores
 
@@ -364,10 +420,13 @@ def refuteStep : Proof.RefuteStep :=
   { scope, programVersion := 0, seen := seen node0 0, schema := refuteKey, body := [44] }
 
 def refutes : Bool :=
-  match Proof.replayRefute limits registry impossibleInput
-      (Proof.State.start semantics impossibleInput rfl) refuteStep impossibleInput.target with
-  | .ok _ => true
+  match builtRegistry with
   | .error _ => false
+  | .ok registry =>
+      match Proof.replayRefute limits registry impossibleInput
+          (Proof.State.start semantics impossibleInput rfl) refuteStep impossibleInput.target with
+      | .ok _ => true
+      | .error _ => false
 
 #guard refutes
 
@@ -388,23 +447,93 @@ elab "proof_emit_restore" : tactic => do
     { emit := fun _ => do
         goal.assign (mkConst ``True.intro)
         pure (mkNatLit 0) }
-  try
+  let accepted ← try
     let _ ← Proof.emitChecked emitter () expected
-    throwError "wrongly typed proof emitter was accepted"
-  catch _ =>
-    if ← goal.isAssigned then
-      throwError "failed proof emitter leaked its Meta assignment"
-    goal.assign (mkConst ``True.intro)
-    replaceMainGoal []
+    pure true
+  catch _ => pure false
+  if accepted then throwError "wrongly typed proof emitter was accepted"
+  if ← goal.isAssigned then
+    throwError "failed proof emitter leaked its Meta assignment"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
 
 example : True := by proof_emit_restore
+
+/-- Structural checking rejects an application whose explicit argument has the
+wrong type, even though the raw expression can be constructed. -/
+elab "proof_emit_reject_ill_typed" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let illTyped := mkApp2 (mkConst ``id [Level.zero]) (mkConst ``Bool) (mkNatLit 0)
+  let emitter : Proof.Emitter Unit := { emit := fun _ => pure illTyped }
+  let accepted ← try
+    let _ ← Proof.emitChecked emitter () expected
+    pure true
+  catch _ => pure false
+  if accepted then throwError "ill-typed proof emitter expression was accepted"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by proof_emit_reject_ill_typed
+
+/-- Synthetic placeholder expressions are rejected even at the expected type. -/
+elab "proof_emit_reject_placeholder" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let emitter : Proof.Emitter Unit := { emit := fun _ => mkSorry expected true }
+  let accepted ← try
+    let _ ← Proof.emitChecked emitter () expected
+    pure true
+  catch _ => pure false
+  if accepted then throwError "placeholder proof emitter expression was accepted"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by proof_emit_reject_placeholder
+
+/-- Open candidate and expected metavariables are both rejected without being
+assigned by definitional equality. -/
+elab "proof_emit_reject_mvars" : tactic => do
+  let goal ← getMainGoal
+  let expected ← goal.getType
+  let openCandidate ← mkFreshExprMVar expected
+  let candidateId := openCandidate.mvarId!
+  let candidateEmitter : Proof.Emitter Unit := { emit := fun _ => pure openCandidate }
+  let candidateAccepted ← try
+    let _ ← Proof.emitChecked candidateEmitter () expected
+    pure true
+  catch _ => pure false
+  if candidateAccepted then throwError "open proof emitter metavariable was accepted"
+  if ← candidateId.isAssigned then
+    throwError "rejected proof emitter metavariable was assigned"
+  let openExpected ← mkFreshExprMVar (mkSort Level.zero)
+  let expectedId := openExpected.mvarId!
+  let expectedEmitter : Proof.Emitter Unit :=
+    { emit := fun _ => pure (mkConst ``True.intro) }
+  let expectedAccepted ← try
+    let _ ← Proof.emitChecked expectedEmitter () openExpected
+    pure true
+  catch _ => pure false
+  if expectedAccepted then throwError "open expected proposition was accepted"
+  if ← expectedId.isAssigned then
+    throwError "rejected expected metavariable was assigned"
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by proof_emit_reject_mvars
 
 elab "proof_emit_accept" : tactic => do
   let goal ← getMainGoal
   let expected ← goal.getType
+  let scratch ← mkFreshExprMVar (mkConst ``Nat)
+  let scratchId := scratch.mvarId!
   let emitter : Proof.Emitter Unit :=
-    { emit := fun _ => pure (mkConst ``replayCanary) }
+    { emit := fun _ => do
+        scratchId.assign (mkNatLit 0)
+        pure (mkConst ``replayCanary) }
   let evidence ← Proof.emitChecked emitter () expected
+  if ← scratchId.isAssigned then
+    throwError "successful proof emitter leaked a Meta assignment"
   goal.assign evidence
   replaceMainGoal []
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -423,7 +423,8 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.Multiplication,
     `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
     `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division,
-    `HexIntervalMathlib.Regularize].map Glob.one
+    `HexIntervalMathlib.Regularize, `HexIntervalMathlib.Program,
+    `HexIntervalMathlib.Proof].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -515,6 +516,7 @@ lean_lib HexConformance where
     ++ #[`HexInterval.PolicyFeatureConformance,
       `HexInterval.FeaturePolicyConformance,
       `HexInterval.SearchConformance,
+      `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.MixedFunctionsConformance,
       `HexIntervalMathlib.MixedInstantiationConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one

--- a/progress/20260815T163043Z.md
+++ b/progress/20260815T163043Z.md
@@ -1,0 +1,44 @@
+# Supported Mathlib proof contracts
+
+## Accomplished
+
+- Added supported `HexIntervalMathlib/Program.lean` with exact operation
+  meanings, complete operation-array alignment, per-node SSA relations, and
+  function-agnostic global models.
+- Added supported `HexIntervalMathlib/Proof.lean` with semantic locality,
+  package-owned fact/equality/instance/refutation schemas, bounded globally
+  unambiguous registry assembly, exact registration/action validation,
+  chronological fact/equality/program proof state, conservative extension,
+  caller-target closure, and transactional kernel-checked expression emission.
+- Added a live conformance chronology covering instance, fact, equality,
+  transport, exact closure, refutation ownership, malformed quote mutations,
+  rollback, nonempty program models, an ordinary theorem with guarded axiom
+  report, and failed-emitter Meta-state restoration.
+- Updated both interval SPECs, the central library description, public
+  umbrella, Lake registrations, and the exact proof-only factor-freshness
+  exemption. The 9,496-job experiment/Mathlib/conformance build and all
+  structural, DAG, trust, release, PNT, bench-boundary, freshness, whitespace,
+  and banned-mechanism checks pass.
+
+## Current frontier
+
+- The generic proof authority is supported, but concrete transcendental
+  packages, goal reification, tactic syntax, search quotation, default registry,
+  and branch proof assembly remain experimental.
+- Existing Mathlib-free experimental replay modules cannot import the supported
+  Mathlib companion without reversing the dependency DAG. They remain
+  acceptance evidence until concrete Mathlib package/frontends are rebuilt on
+  the supported proof contracts.
+
+## Next step
+
+- Migrate one concrete operation package and its goal frontend to
+  `HexIntervalMathlib.Proof`, quote an authenticated supported `Search` result,
+  and eliminate the corresponding duplicate experimental replay path while
+  preserving exact mutation and ordinary-theorem canaries.
+
+## Blockers
+
+- None for the generic boundary. The remaining bridge is implementation work:
+  supported package assembly and quotation must live in the Mathlib companion,
+  while compiled search remains Mathlib-free and returns only untrusted data.

--- a/progress/20260821T121031Z.md
+++ b/progress/20260821T121031Z.md
@@ -1,0 +1,40 @@
+# Publish the supported proof replay contract
+
+## Accomplished
+
+- Replayed the supported Mathlib `Program` and `Proof` contracts onto the
+  merged supported `Search` boundary while preserving all current public
+  interval and PNT registrations.
+- Re-audited the dependency premise: flat chronological replay and exact
+  target/refutation closure are independent of the later retained-tree and
+  split-recipe work.
+- Made the proof resource boundary explicit: retained package/schema counts,
+  certificate bodies, ordered dependencies, and chronology are bounded, while
+  full program/registration validation, arbitrary fact equality, schema
+  decoding, and theorem callbacks remain a disclosed non-preemptible trusted
+  envelope.
+- Added load-bearing package, schema, body, and dependency one-over guards and
+  retained the live instance → fact → equality → transport theorem, mutation,
+  refutation-owner, Meta rollback, and guarded axiom canaries.
+- Passed the focused 8,669-job proof build, the full 9,564-job affected build,
+  and DAG, trust, release, Mathlib-free bench, factor-freshness, PNT inventory,
+  copyright, file-size, conformance-matrix, and diff checks.
+
+## Current frontier
+
+- Supported proof authority now covers exact function-agnostic program
+  semantics, package-owned flat chronology replay, refutation, caller-target
+  closure, and transactional kernel-checked expression emission.
+- Concrete arithmetic/function packages, search quotation, retained split-tree
+  recipes, goal reification, tactic syntax, and a default registry remain
+  experimental or later supported edges.
+
+## Next step
+
+- Restack the checked edge onto literal current main, publish the non-draft
+  upstream PR, and monitor its automatically launched exact-head CI.
+
+## Blockers
+
+- None. Retained split trees are required for later branch-proof replay, not
+  for this flat supported proof edge.

--- a/progress/20260821T123038Z.md
+++ b/progress/20260821T123038Z.md
@@ -1,0 +1,40 @@
+# Harden supported proof construction and emission
+
+## Accomplished
+
+- Sealed `Proof.Registry` under ordinary imports and made opaque
+  `Registry.buildWithin` its sole supported construction path; every live
+  replay/refutation canary now consumes that validated result.
+- Strengthened registry conformance with package/schema caps, foreign owner,
+  duplicate schema, duplicate registration, refuter ownership, and malformed
+  global-registration rejection.
+- Required global action authentication to pin empty registration watches and
+  writes as well as empty action inputs and writes.
+- Replaced the overclaimed kernel-emission wording with the exact boundary:
+  instantiate and reject unresolved metavariables/placeholders, run
+  `Meta.check`, infer the exact type, check definitional equality, and restore
+  Meta state on success or failure. The kernel performs the final check when a
+  caller installs the returned expression in a declaration.
+- Added discriminating ill-typed application, placeholder, open candidate,
+  open expected type, wrong-type rollback, successful emission, and successful
+  Meta-rollback canaries.
+- Extended the repository-wide trusted-internals import guard to reject
+  `import all HexIntervalMathlib.Proof` outside its exact empty allowlist and
+  corrected the proof-state documentation to its dependent-type invariant.
+- Passed the focused 8,669-job build plus DAG unit/checker, trust, file-size,
+  factor-freshness, PNT inventory, and diff gates.
+
+## Current frontier
+
+- The repaired flat proof edge is ready for a final current-main restack and
+  full affected build before superseding PR #9346.
+
+## Next step
+
+- Replay the three proof commits onto literal current main, rerun the full
+  affected/static gates, force-with-lease update the PR, and monitor its new
+  exact-head automatic CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T124948Z.md
+++ b/progress/20260821T124948Z.md
@@ -1,0 +1,33 @@
+# Validate emitted proofs after emitter rollback
+
+## Accomplished
+
+- Reordered `Proof.emitChecked` so it fully instantiates and rejects the
+  emitter result, restores every emitter-side change, and only then performs
+  authoritative `Meta.check`, type inference, and definitional equality in the
+  caller's environment.
+- Made both the emitter phase and the validation phase transactional on
+  failure and success, and rejected placeholders in the expected type as well
+  as the emitted candidate.
+- Added a load-bearing ill-typed `@id True 0` canary whose raw inferred result
+  type is the expected proposition but whose application fails `Meta.check`.
+- Added a transient theorem-declaration canary proving emitter-created
+  declarations are rolled back before validation and cannot escape as dangling
+  returned expressions.
+- Updated the supported module and SPEC contracts to require emitted terms to
+  reference only declarations that survive emitter rollback.
+
+## Current frontier
+
+- The focused proof/conformance build and DAG, trust, release, factor
+  freshness, and diff checks pass for the repaired edge.
+
+## Next step
+
+- Restack on literal current main if needed, run the full affected build and
+  remaining repository static gates, then supersede PR #9346 and monitor its
+  exact-head CI.
+
+## Blockers
+
+- None.

--- a/progress/20260821T131004Z.md
+++ b/progress/20260821T131004Z.md
@@ -1,0 +1,33 @@
+# Clear rolled-back elaborator caches
+
+## Accomplished
+
+- Verified against Lean 4.33 sources that `Meta.SavedState.restore` retains the
+  `Meta.State` cache and its nested `Core.SavedState.restore` retains the
+  `Core.State` cache, even while restoring the environment and metavariable
+  context.
+- Hardened `Proof.emitChecked` to clear both environment-dependent caches after
+  every emitter or validation restore, on success and failure, before any
+  authoritative `Meta.check`, type inference, or definitional equality.
+- Added a load-bearing malicious-emitter guard that poisons the infer-type
+  cache at both default and `.all` transparency: the guard fails when the two
+  cache resets are removed and passes with the repaired boundary.
+- Strengthened transient-declaration coverage with cache activity and a
+  successful emitter that creates a temporary theorem but returns only a
+  pre-existing proof.
+- Narrowed module and SPEC wording to the exact restored state and explicit
+  cache-clearing behavior.
+
+## Current frontier
+
+- The focused 8,669-job proof/conformance build passes with the cache hardening
+  and all new canaries.
+
+## Next step
+
+- Run the full affected build and repository gates, force-with-lease update PR
+  #9346, and monitor the superseding exact-head CI.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -610,5 +610,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "a860987f71b25a081e9a8575048cf7a0484bed2b",
     "reason": "Additionally registers the Mathlib-free supported HexInterval search-contract conformance module on top of the current public interval and PNT registrations; it does not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "fc53186cf939d75d9e254d4fb52be6e713f0328f",
+    "reason": "Additionally registers the supported HexIntervalMathlib program-semantics and chronological proof-contract modules plus their proof-only conformance on top of the current public interval, search, and PNT registrations; they do not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -33,6 +33,7 @@ IMPORT_ALL_RE = re.compile(
 # directory convention. There are currently no required exceptions.
 SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexInterval.Search": frozenset(),
+    "HexIntervalMathlib.Proof": frozenset(),
 }
 
 UMBRELLA_BUILD_TARGETS = {

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -14,14 +14,19 @@ class SealedImportAllTest(unittest.TestCase):
     def test_ownerless_roots_are_checked(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            files = [
-                Path("conformance/HexInterval/Bypass.lean"),
-                Path("bench/HexInterval/Bypass.lean"),
+            cases = [
+                (Path("conformance/HexInterval/Bypass.lean"), "HexInterval.Search"),
+                (Path("bench/HexInterval/Bypass.lean"), "HexInterval.Search"),
+                (Path("conformance/HexIntervalMathlib/Bypass.lean"),
+                    "HexIntervalMathlib.Proof"),
+                (Path("bench/HexIntervalMathlib/Bypass.lean"),
+                    "HexIntervalMathlib.Proof"),
             ]
-            for path in files:
+            files = [path for path, _ in cases]
+            for path, module in cases:
                 full_path = root / path
                 full_path.parent.mkdir(parents=True, exist_ok=True)
-                full_path.write_text("import all HexInterval.Search\n", encoding="utf-8")
+                full_path.write_text(f"import all {module}\n", encoding="utf-8")
 
             self.assertEqual(
                 check_sealed_import_all(root, files),
@@ -30,6 +35,10 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexInterval.Search` outside its exact trusted-internals allowlist",
                     "bench/HexInterval/Bypass.lean:1 uses `import all "
                     "HexInterval.Search` outside its exact trusted-internals allowlist",
+                    "conformance/HexIntervalMathlib/Bypass.lean:1 uses `import all "
+                    "HexIntervalMathlib.Proof` outside its exact trusted-internals allowlist",
+                    "bench/HexIntervalMathlib/Bypass.lean:1 uses `import all "
+                    "HexIntervalMathlib.Proof` outside its exact trusted-internals allowlist",
                 ],
             )
 


### PR DESCRIPTION
## Summary

- add supported Mathlib Program semantics with exact operation alignment and per-node models
- add an ordinary-import-sealed, checked theorem registry and function-agnostic fact, equality, instance, refutation, and chronological replay contracts
- close exact caller targets through ordinary typed proofs; emitted expressions reject placeholders/metavariables, pass Meta.check, and match the exact expected type transactionally before the caller installs them for kernel checking
- add live chronology, mutation, resource one-over, registry-owner/duplicate, axiom, and Meta rollback conformance

## Scope

This PR establishes the flat supported proof authority only. Concrete arithmetic and arbitrary-function packages, search-to-proof quotation, retained split-tree recipes, goal reification, tactic syntax, and a default registry remain experimental or later supported edges. Search state, callback replies, payload bytes, and traces do not become proof evidence.

The retained proof limits bound package/schema counts, body cells, dependencies, and chronology. Full Program/registration validation, equality on arbitrary caller facts, schema decoding, and trusted theorem callbacks are explicitly non-preemptible rather than overclaimed as resource-preemptible. Deliberate import-all access is a trusted-source escape hatch guarded by the repository DAG checker, not decoded runtime authority.

## Verification

- lake build HexIntervalMathlib HexConformance (9,564 jobs)
- DAG and trusted-import tests
- trust/release/manual-split checks
- Mathlib-free bench boundary and factor freshness
- PNT inventory, copyright, file-size, conformance-matrix, and diff checks

No native_decide, axiom, or sorry is introduced.