### PR TITLE
feat(interval): add supported arithmetic proof rules

### DIFF
--- a/HexInterval/Canonical.lean
+++ b/HexInterval/Canonical.lean
@@ -90,6 +90,14 @@ def whole : Hex.Interval :=
 def singletonWithin (limit : EndpointLimit) (value : Dyadic) : BuildResult :=
   ofRawWithin limit (.bounds (.finite value false) (.finite value false))
 
+/-- A successful singleton exposes its exact normalized closed cuts. -/
+theorem view_singletonWithin_ready {limit : EndpointLimit} {value : Dyadic}
+    {result : Hex.Interval} (h : singletonWithin limit value = .ready result) :
+    result.view =
+      (Raw.bounds (.finite value false) (.finite value false)).normalizeUnchecked := by
+  unfold singletonWithin at h
+  exact view_ofRawWithin_ready h
+
 /-- Construct a one-sided interval with a finite lower cut. -/
 def aboveWithin (limit : EndpointLimit) (value : Dyadic) (strict : Bool) : BuildResult :=
   ofRawWithin limit (.bounds (.finite value strict) .unbounded)

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5234,9 +5234,12 @@ their declared cost inside a scheduler bound.
   multiplication, natural power, absolute value, minimum, maximum, constants,
   reciprocal, division, and outward regularization. Every schema recomputes
   its fixed-resource public interval operation; decoded search results remain
-  untrusted. Direct registry assembly does not preempt construction or equality
-  of caller program/meaning arrays and therefore requires the supported search
-  envelope for decoded inputs.
+  untrusted. One package `Config` supplies exactly one natural exponent and
+  one dyadic constant, shared by every node at the corresponding built-in
+  operation index; duplicate package registration and operation keys cannot
+  add a second parameterization. Direct registry assembly does not preempt
+  construction or equality of caller program/meaning arrays and therefore
+  requires the supported search envelope for decoded inputs.
 - `HexIntervalMathlib/Split.lean`: exact transactional child semantics,
   containment, coverage, disjointness, and left ownership of the cut point.
 - `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5225,9 +5225,18 @@ their declared cost inside a scheduler bound.
   expression. Under
   ordinary imports, only `Registry.buildWithin` can construct the theorem
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
-  hatch rejected outside the exact empty repository allowlist. Concrete
-  packages, goal reification, tactic syntax, and default registries remain
-  experimental.
+  hatch rejected outside the exact empty repository allowlist. The built-in
+  arithmetic package is supported below; arbitrary-function packages, goal
+  reification, tactic syntax, and default registries remain experimental.
+- `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
+  exact real operation meanings, package-owned fact schemas, checked registry
+  assembly, and state-to-proof quotation for negation, addition, subtraction,
+  multiplication, natural power, absolute value, minimum, maximum, constants,
+  reciprocal, division, and outward regularization. Every schema recomputes
+  its fixed-resource public interval operation; decoded search results remain
+  untrusted. Direct registry assembly does not preempt construction or equality
+  of caller program/meaning arrays and therefore requires the supported search
+  envelope for decoded inputs.
 - `HexIntervalMathlib/Split.lean`: exact transactional child semantics,
   containment, coverage, disjointness, and left ownership of the cut point.
 - `HexIntervalMathlib/Inverse.lean`: exact computed reciprocal-cut semantics
@@ -5285,6 +5294,11 @@ their declared cost inside a scheduler bound.
 - `conformance/HexIntervalMathlib/ProgramProofConformance.lean`: supported
   program-model, registry, chronology, refutation, target-closure, mutation,
   Meta-state restoration, and guarded ordinary-theorem canaries.
+- `conformance/HexIntervalMathlib/RuleConformance.lean`: supported arithmetic
+  package assembly, shared-DAG state quotation, chronological replay into an
+  ordinary theorem, exact inv/div/regularize adapters, malformed-key/body/
+  source/order/cut mutations, and registry/chronology/body/dependency/
+  precision refusal guards.
 - `HexInterval/Experiment/PntFks2FamilyData*.lean` and
   `HexInterval/Experiment/PntFks2Family.lean`: committed source-pinned family
   data and the Mathlib-free complete-family checker.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -20,6 +20,7 @@ public import HexIntervalMathlib.Division
 public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
+public import HexIntervalMathlib.Rule
 
 public section
 
@@ -31,4 +32,6 @@ natural power, outward regularization, and closed-left/strict-right
 transactional splitting, plus precision-indexed reciprocal and division
 enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
+`HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
+schemas recompute checked public operations before producing proof evidence.
 -/

--- a/HexIntervalMathlib/Rule.lean
+++ b/HexIntervalMathlib/Rule.lean
@@ -23,7 +23,12 @@ public import HexIntervalMathlib.Regularize
 # Built-in arithmetic proof rules
 
 This is the first supported arithmetic package for the generic proof replay
-boundary. A package fixes its endpoint, power, and precision resources.
+boundary. A package fixes its endpoint, power, and precision resources, one
+natural exponent, and one dyadic constant. Every built-in power node in that
+package therefore uses the same exponent, and every built-in constant node
+uses the same value. Duplicate package registration and operation keys are
+rejected, so a second copy cannot supply another exponent or constant under
+the same stable keys.
 Runtime search may propose facts and recipe bodies, but the package schemas
 recompute the public checked interval operation and prove its one-way real
 enclosure.
@@ -38,7 +43,9 @@ namespace Hex.Interval.Rule
 
 open Proof
 
-/-- Resource parameters owned by one immutable arithmetic package. -/
+/-- Resources and the single natural exponent and dyadic constant owned by one
+immutable arithmetic package. The built-in power and constant operation keys
+cannot express multiple such parameters in the same registry. -/
 structure Config where
   endpoint : EndpointLimit
   powerWork : Arithmetic.PowLimits

--- a/HexIntervalMathlib/Rule.lean
+++ b/HexIntervalMathlib/Rule.lean
@@ -1,0 +1,616 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Proof
+public import HexIntervalMathlib.Addition
+public import HexIntervalMathlib.Subtraction
+public import HexIntervalMathlib.Multiplication
+public import HexIntervalMathlib.Power
+public import HexIntervalMathlib.Absolute
+public import HexIntervalMathlib.MinMax
+public import HexIntervalMathlib.Inverse
+public import HexIntervalMathlib.Division
+public import HexIntervalMathlib.Regularize
+
+@[expose] public section
+
+/-!
+# Built-in arithmetic proof rules
+
+This is the first supported arithmetic package for the generic proof replay
+boundary. A package fixes its endpoint, power, and precision resources.
+Runtime search may propose facts and recipe bodies, but the package schemas
+recompute the public checked interval operation and prove its one-way real
+enclosure.
+
+Source nodes are caller assumptions, not rules. Reciprocal, division, and
+regularization use the package's fixed precision resources and the public
+one-way real image theorems; no runtime result enters proof evidence without
+being recomputed by its schema.
+-/
+
+namespace Hex.Interval.Rule
+
+open Proof
+
+/-- Resource parameters owned by one immutable arithmetic package. -/
+structure Config where
+  endpoint : EndpointLimit
+  powerWork : Arithmetic.PowLimits
+  exponent : Nat
+  precisionLimits : Arithmetic.PrecisionLimits
+  precision : Precision
+  constant : Dyadic
+  /-- Authenticated meanings owned by independently assembled packages. They
+  follow the stable built-in prefix and have no built-in rule authority. -/
+  extraMeanings : Array (Program.Meaning ℝ) := #[]
+
+def realDomain : DomainId := { index := 0 }
+
+def sourceOp : Operation :=
+  { key := { name := "hex.interval.source" }, inputs := [], output := realDomain }
+def negOp : Operation :=
+  { key := { name := "hex.interval.neg" }, inputs := [realDomain], output := realDomain }
+def addOp : Operation :=
+  { key := { name := "hex.interval.add" }, inputs := [realDomain, realDomain], output := realDomain }
+def subOp : Operation :=
+  { key := { name := "hex.interval.sub" }, inputs := [realDomain, realDomain], output := realDomain }
+def mulOp : Operation :=
+  { key := { name := "hex.interval.mul" }, inputs := [realDomain, realDomain], output := realDomain }
+def powOp : Operation :=
+  { key := { name := "hex.interval.pow.nat" }, inputs := [realDomain], output := realDomain }
+def absOp : Operation :=
+  { key := { name := "hex.interval.abs" }, inputs := [realDomain], output := realDomain }
+def minOp : Operation :=
+  { key := { name := "hex.interval.min" }, inputs := [realDomain, realDomain], output := realDomain }
+def maxOp : Operation :=
+  { key := { name := "hex.interval.max" }, inputs := [realDomain, realDomain], output := realDomain }
+def constantOp : Operation :=
+  { key := { name := "hex.interval.constant" }, inputs := [], output := realDomain }
+def invOp : Operation :=
+  { key := { name := "hex.interval.inv" }, inputs := [realDomain], output := realDomain }
+def divOp : Operation :=
+  { key := { name := "hex.interval.div" }, inputs := [realDomain, realDomain], output := realDomain }
+def regularizeOp : Operation :=
+  { key := { name := "hex.interval.regularize" }, inputs := [realDomain], output := realDomain }
+
+/-- Exact operation order owned by the built-in package. -/
+def operations : Array Operation :=
+  #[sourceOp, negOp, addOp, subOp, mulOp, powOp, absOp, minOp, maxOp, constantOp,
+    invOp, divOp, regularizeOp]
+
+def sourceMeaning : Program.Meaning ℝ := { operation := sourceOp, relation := fun _ _ => True }
+def negMeaning : Program.Meaning ℝ :=
+  { operation := negOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = -x }
+def addMeaning : Program.Meaning ℝ :=
+  { operation := addOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x + y }
+def subMeaning : Program.Meaning ℝ :=
+  { operation := subOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x - y }
+def mulMeaning : Program.Meaning ℝ :=
+  { operation := mulOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x * y }
+def powMeaning (exponent : Nat) : Program.Meaning ℝ :=
+  { operation := powOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x ^ exponent }
+def absMeaning : Program.Meaning ℝ :=
+  { operation := absOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = |x| }
+def minMeaning : Program.Meaning ℝ :=
+  { operation := minOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = min x y }
+def maxMeaning : Program.Meaning ℝ :=
+  { operation := maxOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = max x y }
+def constantMeaning (value : Dyadic) : Program.Meaning ℝ :=
+  { operation := constantOp, relation := fun xs z => xs = [] ∧ z = toReal value }
+def invMeaning : Program.Meaning ℝ :=
+  { operation := invOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x⁻¹ }
+def divMeaning : Program.Meaning ℝ :=
+  { operation := divOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x / y }
+def regularizeMeaning : Program.Meaning ℝ :=
+  { operation := regularizeOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x }
+
+def builtinMeanings (config : Config) : Array (Program.Meaning ℝ) :=
+  #[sourceMeaning, negMeaning, addMeaning, subMeaning, mulMeaning,
+    powMeaning config.exponent, absMeaning, minMeaning, maxMeaning,
+    constantMeaning config.constant, invMeaning, divMeaning, regularizeMeaning]
+
+def meanings (config : Config) : Array (Program.Meaning ℝ) :=
+  builtinMeanings config ++ config.extraMeanings
+
+theorem prefixMeaning (config : Config) {index : Nat}
+    (within : index < (builtinMeanings config).size) :
+    (meanings config)[index]? = (builtinMeanings config)[index]? := by
+  exact Array.getElem?_append_left within
+
+def semantics (config : Config) : Proof.Semantics Hex.Interval :=
+  .ofMeanings (meanings config) Hex.Interval.Contains
+
+def ready? : BuildResult → Option Hex.Interval
+  | .ready interval => some interval
+  | .resourceLimit _ => none
+
+def arithmeticReady? : Arithmetic.Result → Option Hex.Interval
+  | .ready interval => some interval
+  | .resourceLimit _ => none
+
+theorem ready?_eq {result : BuildResult} {interval : Hex.Interval}
+    (h : ready? result = some interval) : result = .ready interval := by
+  cases result <;> simp_all [ready?]
+
+theorem arithmeticReady?_eq {result : Arithmetic.Result} {interval : Hex.Interval}
+    (h : arithmeticReady? result = some interval) : result = .ready interval := by
+  cases result <;> simp_all [arithmeticReady?]
+
+theorem laws (config : Config) : Proof.Laws (semantics config) :=
+  { holdsEq := by
+      intro program valuation left right fact _ equality
+      simpa [semantics, Proof.Semantics.ofMeanings] using
+        congrArg (fun value => fact.Contains value) equality }
+
+/-- Intersection is the only fact-domain narrowing law.  Its checked public
+result is recomputed before the conjunction theorem enters evidence. -/
+def domain (config : Config) : Proof.Domain (semantics config) :=
+    { top := fun _ => Hex.Interval.whole
+      topSound := by
+        intro _ _ _ _ _ _
+        change Raw.Contains Hex.Interval.whole.view _
+        rw [view_whole]
+        exact And.intro trivial trivial
+      meet := fun program node previous proposed installed =>
+        match found : ready? (intersectWithin config.endpoint previous proposed) with
+        | some result =>
+            if equal : result = installed then
+              some ⟨by
+                subst result
+                intro valuation _
+                simpa [semantics, Proof.Semantics.ofMeanings] using
+                  contains_intersectWithin (ready?_eq found) (valuation node)⟩
+            else none
+        | none => none }
+
+def negKey : RuleKey := { name := "hex.interval.rule.neg" }
+def addKey : RuleKey := { name := "hex.interval.rule.add" }
+def subKey : RuleKey := { name := "hex.interval.rule.sub" }
+def mulKey : RuleKey := { name := "hex.interval.rule.mul" }
+def powKey : RuleKey := { name := "hex.interval.rule.pow.nat" }
+def absKey : RuleKey := { name := "hex.interval.rule.abs" }
+def minKey : RuleKey := { name := "hex.interval.rule.min" }
+def maxKey : RuleKey := { name := "hex.interval.rule.max" }
+def constantKey : RuleKey := { name := "hex.interval.rule.constant" }
+def invKey : RuleKey := { name := "hex.interval.rule.inv" }
+def divKey : RuleKey := { name := "hex.interval.rule.div" }
+def regularizeKey : RuleKey := { name := "hex.interval.rule.regularize" }
+
+def schemaKey (key : RuleKey) : Proof.Key := { rule := key, role := .fact, bodySchema := 1 }
+
+def unaryRegistration (key : RuleKey) (operation : Operation) : Registration :=
+  { key, head := operation.key, kind := .forward,
+    watches := [.argument 0], writes := [.result] }
+
+def binaryRegistration (key : RuleKey) (operation : Operation) : Registration :=
+  { key, head := operation.key, kind := .forward,
+    watches := [.argument 0, .argument 1], writes := [.result] }
+
+def registrations : Array Registration :=
+  #[unaryRegistration negKey negOp,
+    binaryRegistration addKey addOp,
+    binaryRegistration subKey subOp,
+    binaryRegistration mulKey mulOp,
+    unaryRegistration powKey powOp,
+    unaryRegistration absKey absOp,
+    binaryRegistration minKey minOp,
+    binaryRegistration maxKey maxOp,
+    { key := constantKey, head := constantOp.key, kind := .forward,
+      watches := [], writes := [.result] },
+    unaryRegistration invKey invOp,
+    binaryRegistration divKey divOp,
+    unaryRegistration regularizeKey regularizeOp]
+
+def exactBody (tag : Nat) (body : List Nat) : Option Unit :=
+  if body = [tag] then some () else none
+
+theorem nodeMeaning (config : Config) {program : Program} {valuation : NodeId → ℝ}
+    (model : Program.Models (meanings config) program valuation)
+    {node : NodeId} {instruction : Node} (found : program.node? node = some instruction) :
+    Program.MeaningAt (meanings config) valuation node instruction :=
+  model.2 node instruction found
+
+theorem negRelation (config : Config) {valuation : NodeId → ℝ}
+    {node input : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 1 }, args := [input] }) :
+    valuation node = -valuation input := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 1) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [negMeaning] using related
+
+theorem binaryRelation (config : Config) {valuation : NodeId → ℝ}
+    {node left right : NodeId} {index : Nat} {relation : ℝ → ℝ → ℝ}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index }, args := [left, right] })
+    (indexShape : (index = 2 ∧ relation = fun x y => x + y) ∨
+      (index = 3 ∧ relation = fun x y => x - y) ∨
+      (index = 4 ∧ relation = fun x y => x * y) ∨
+      (index = 7 ∧ relation = min) ∨
+      (index = 8 ∧ relation = max)) :
+    valuation node = relation (valuation left) (valuation right) := by
+  rcases indexShape with h | h | h | h | h <;>
+    rcases h with ⟨rfl, rfl⟩ <;>
+    rcases meaning with ⟨meaning, found, related⟩ <;>
+    simp [meanings, Array.getElem?_append, builtinMeanings] at found <;>
+    subst meaning <;>
+    simpa [addMeaning, subMeaning, mulMeaning, minMeaning, maxMeaning] using related
+
+theorem powRelation (config : Config) {valuation : NodeId → ℝ} {node input : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 5 }, args := [input] }) :
+    valuation node = valuation input ^ config.exponent := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 5) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [powMeaning] using related
+
+theorem absRelation (config : Config) {valuation : NodeId → ℝ} {node input : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 6 }, args := [input] }) :
+    valuation node = |valuation input| := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 6) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [absMeaning] using related
+
+theorem constantRelation (config : Config) {valuation : NodeId → ℝ} {node : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 9 }, args := [] }) :
+    valuation node = toReal config.constant := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 9) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [constantMeaning] using related
+
+theorem invRelation (config : Config) {valuation : NodeId → ℝ}
+    {node input : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 10 }, args := [input] }) :
+    valuation node = (valuation input)⁻¹ := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 10) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [invMeaning] using related
+
+theorem divRelation (config : Config) {valuation : NodeId → ℝ}
+    {node left right : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 11 }, args := [left, right] }) :
+    valuation node = valuation left / valuation right := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 11) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  simpa [divMeaning] using related
+
+theorem regularizeRelation (config : Config) {valuation : NodeId → ℝ}
+    {node input : NodeId}
+    (meaning : Program.MeaningAt (meanings config) valuation node
+      { domain := realDomain, op := { index := 12 }, args := [input] }) :
+    valuation node = valuation input := by
+  rcases meaning with ⟨meaning, found, related⟩
+  rw [prefixMeaning config (index := 12) (by simp [builtinMeanings])] at found
+  simp [builtinMeanings] at found
+  subst meaning
+  change ∃ x, [valuation input] = [x] ∧ valuation node = x at related
+  rcases related with ⟨x, hinput, hnode⟩
+  simp only [List.cons.injEq, and_true] at hinput
+  exact hnode.trans hinput.symm
+
+theorem constant_mem {limit : EndpointLimit} {value : Dyadic} {result : Hex.Interval}
+    (checked : singletonWithin limit value = .ready result) :
+    result.Contains (toReal value) := by
+  change result.view.Contains (toReal value)
+  rw [view_singletonWithin_ready checked, contains_normalize]
+  exact And.intro le_rfl le_rfl
+
+-- Concrete schemas keep each semantic relation and checked public operation
+-- visible; an executable recipe tag alone never selects a theorem.
+
+def negSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey negKey, Certificate := Unit, decode := exactBody 1
+    prove := fun c _ => match c.assumptions with
+      | [a] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 1 }, args := [a.node] } then
+          match found : ready? (negWithin config.endpoint a.fact) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  change NodeId → ℝ at v
+                  have hm := negRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact (contains_negWithin (ready?_eq found) (-v a.node)).2 (by
+                    simpa only [neg_neg] using (show a.fact.Contains (v a.node) from by
+                      simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp)))⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def binarySchema (config : Config) (key : RuleKey) (tag opIndex : Nat)
+    (run : Hex.Interval → Hex.Interval → Option Hex.Interval)
+    (relation : ℝ → ℝ → ℝ)
+    (indexShape : (opIndex = 2 ∧ relation = fun x y => x + y) ∨
+      (opIndex = 3 ∧ relation = fun x y => x - y) ∨
+      (opIndex = 4 ∧ relation = fun x y => x * y) ∨
+      (opIndex = 7 ∧ relation = min) ∨
+      (opIndex = 8 ∧ relation = max))
+    (image : ∀ {left right result : Hex.Interval} {x y : ℝ},
+      run left right = some result → left.Contains x → right.Contains y →
+        result.Contains (relation x y)) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey key, Certificate := Unit, decode := exactBody tag
+    prove := fun c _ => match c.assumptions with
+      | [a, b] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := opIndex }, args := [a.node, b.node] } then
+          match found : run a.fact b.fact with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := binaryRelation config (nodeMeaning config m hn) indexShape
+                  have ha : a.fact.Contains (v a.node) := by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp)
+                  have hb : b.fact.Contains (v b.node) := by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs b (by simp)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact image found ha hb⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def addSchema (config : Config) :=
+  binarySchema config addKey 2 2
+    (fun left right => ready? (addWithin config.endpoint left right))
+    (fun x y => x + y)
+    (Or.inl ⟨rfl, rfl⟩)
+    (fun hc ha hb => add_mem_addWithin (ready?_eq hc) ha hb)
+def subSchema (config : Config) :=
+  binarySchema config subKey 3 3
+    (fun left right => ready? (subWithin config.endpoint left right))
+    (fun x y => x - y)
+    (Or.inr (Or.inl ⟨rfl, rfl⟩))
+    (fun hc ha hb => sub_mem_subWithin (ready?_eq hc) ha hb)
+def mulSchema (config : Config) :=
+  binarySchema config mulKey 4 4
+    (fun left right => arithmeticReady? (mulWithin config.endpoint left right))
+    (fun x y => x * y)
+    (Or.inr (Or.inr (Or.inl ⟨rfl, rfl⟩)))
+    (fun hc ha hb => mul_mem_mulWithin (arithmeticReady?_eq hc) ha hb)
+def minSchema (config : Config) :=
+  binarySchema config minKey 7 7
+    (fun left right => ready? (minWithin config.endpoint left right)) min
+    (Or.inr (Or.inr (Or.inr (Or.inl ⟨rfl, rfl⟩))))
+    (fun hc ha hb => min_mem_minWithin (ready?_eq hc) ha hb)
+def maxSchema (config : Config) :=
+  binarySchema config maxKey 8 8
+    (fun left right => ready? (maxWithin config.endpoint left right)) max
+    (Or.inr (Or.inr (Or.inr (Or.inr ⟨rfl, rfl⟩))))
+    (fun hc ha hb => max_mem_maxWithin (ready?_eq hc) ha hb)
+
+def powSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey powKey, Certificate := Unit, decode := exactBody 5
+    prove := fun c _ => match c.assumptions with
+      | [a] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 5 }, args := [a.node] } then
+          match found : arithmeticReady?
+              (powWithin config.endpoint config.powerWork a.fact config.exponent) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := powRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact pow_mem_powWithin (arithmeticReady?_eq found) (by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def absSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey absKey, Certificate := Unit, decode := exactBody 6
+    prove := fun c _ => match c.assumptions with
+      | [a] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 6 }, args := [a.node] } then
+          match found : ready? (absWithin config.endpoint a.fact) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := absRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact abs_mem_absWithin (ready?_eq found) (by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def constantSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey constantKey, Certificate := Unit, decode := exactBody 9
+    prove := fun c _ => match c.assumptions with
+      | [] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 9 }, args := [] } then
+          match found : ready? (singletonWithin config.endpoint config.constant) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m _
+                  have hm := constantRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact constant_mem (ready?_eq found)⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def invSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey invKey, Certificate := Unit, decode := exactBody 10
+    prove := fun c _ => match c.assumptions with
+      | [a] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 10 }, args := [a.node] } then
+          match found : arithmeticReady?
+              (invWithin config.precisionLimits config.precision a.fact) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := invRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact inv_mem_invWithin (arithmeticReady?_eq found) (by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def divSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey divKey, Certificate := Unit, decode := exactBody 11
+    prove := fun c _ => match c.assumptions with
+      | [a, b] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 11 }, args := [a.node, b.node] } then
+          match found : arithmeticReady?
+              (divWithin config.precisionLimits config.precision a.fact b.fact) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := divRelation config (nodeMeaning config m hn)
+                  have ha : a.fact.Contains (v a.node) := by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp)
+                  have hb : b.fact.Contains (v b.node) := by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs b (by simp)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact div_mem_divWithin (arithmeticReady?_eq found) ha hb⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def regularizeSchema (config : Config) : Proof.FactSchema (semantics config) :=
+  { key := schemaKey regularizeKey, Certificate := Unit, decode := exactBody 12
+    prove := fun c _ => match c.assumptions with
+      | [a] =>
+        if hn : c.program.node? c.proposed.node = some
+            { domain := realDomain, op := { index := 12 }, args := [a.node] } then
+          match found : arithmeticReady?
+              (regularizeWithin config.precisionLimits config.precision a.fact) with
+          | some result =>
+              if equal : result = c.proposed.fact then
+                some ⟨by
+                  subst result
+                  intro v m hs
+                  have hm := regularizeRelation config (nodeMeaning config m hn)
+                  change c.proposed.fact.Contains (v c.proposed.node)
+                  rw [hm]
+                  exact mem_regularizeWithin (arithmeticReady?_eq found) (by
+                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
+              else none
+          | none => none
+        else none
+      | _ => none }
+
+def package (config : Config) : Proof.Package (semantics config) :=
+  { registrations
+    facts := #[negSchema config, addSchema config, subSchema config, mulSchema config,
+      powSchema config, absSchema config, minSchema config, maxSchema config,
+      constantSchema config, invSchema config, divSchema config,
+      regularizeSchema config] }
+
+inductive BuildError where
+  | wrongOperations
+  | registry (error : Proof.BuildError)
+  deriving Repr
+
+/-- Checked assembly with additional independently owned packages. The exact
+program operation array must equal the complete meaning array; the arithmetic
+operations retain their stable prefix indices while arbitrary-function
+meanings and packages form an authenticated suffix. `Proof.Limits` bounds the
+retained package/schema registry after caller construction. This direct trusted
+entry point does not preempt construction or equality of the program and
+meaning arrays; decoded search callers must first cross the supported `Search`
+resource envelope. -/
+def buildWithWithin (limits : Proof.Limits) (config : Config) (program : Program)
+    (extraPackages : Array (Proof.Package (semantics config))) :
+    Except BuildError (Proof.Registry (semantics config)) := do
+  if program.operations != (meanings config).map (Program.Meaning.operation) then
+    throw .wrongOperations
+  match Proof.Registry.buildWithin limits program (#[package config] ++ extraPackages) with
+  | .ok registry => pure registry
+  | .error error => throw (.registry error)
+
+/-- Convenience assembly for an arithmetic-only registry. -/
+def buildWithin (limits : Proof.Limits) (config : Config) (program : Program) :
+    Except BuildError (Proof.Registry (semantics config)) :=
+  buildWithWithin limits config program #[]
+
+/-- Package-owned replay recipe retained as the opaque cause of a supported
+state update.  Search validates the action and update; replay separately
+validates every field and the body. -/
+structure Cause where
+  scope : Policy.ScopeId
+  action : Action
+  proposed : Hex.Interval
+  schema : Proof.Key
+  body : List Nat
+
+/-- Quote the exact accepted update history of a supported search branch.
+This is a data conversion only; malformed causes remain rejected by replay. -/
+def quote (branch : State.Branch Hex.Interval Cause) : List (Proof.Event Hex.Interval) :=
+  branch.history.toList.map fun update => .fact
+    { scope := update.cause.scope
+      programVersion := update.programVersion
+      action := update.cause.action
+      node := update.node
+      previous := update.previous
+      version := update.version
+      proposed := update.cause.proposed
+      installed := update.fact
+      assumptions := update.cause.action.inputs
+      schema := update.cause.schema
+      body := update.cause.body }
+
+/-- Quote the proof-relevant branch of a supported search session. Offers,
+policy state, accounting, and diagnostic trace remain outside evidence. -/
+def quoteSession
+    (session : Search.Session Hex.Interval Cause OfferId SemanticKey) :
+    List (Proof.Event Hex.Interval) :=
+  quote session.branch
+
+end Hex.Interval.Rule

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -109,10 +109,10 @@ definitional equality transactionally in the caller's environment. Emitted
 terms may reference only declarations that survive that rollback. The kernel
 performs the final check when the caller installs the expression.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
-cannot enter `Proof.Evidence`. The concrete package registry, goal reifier,
-search-to-proof quotation, and tactic syntax remain experimental and are not
-re-exported here. Further arithmetic images and useful bounded
-nonsingleton division require their own
+cannot enter `Proof.Evidence`. The built-in arithmetic package registry is
+supported below; arbitrary-function package discovery, goal reification,
+search-to-proof quotation, and tactic syntax remain experimental. Further
+arithmetic images and useful bounded nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
@@ -137,6 +137,16 @@ Under ordinary imports, the theorem-registry constructor is private and
 deliberate `import all HexIntervalMathlib.Proof` exposes trusted internals and
 lies outside the decoded-runtime threat model; the repository DAG checker
 rejects that import outside an exact reviewed allowlist, currently empty.
+
+`HexIntervalMathlib.Rule` is the first supported package registry. Its stable
+arithmetic schemas recompute exact checked negation, addition, subtraction,
+multiplication, natural power, absolute value, minimum, maximum, constant,
+reciprocal, division, and regularization results before producing evidence.
+Source facts remain caller assumptions. Direct registry assembly bounds the
+retained packages and schemas but does not preempt construction or equality of
+caller program/meaning arrays; decoded callers must first cross `Search`.
+Arbitrary-function package discovery, goal reification, search-to-proof
+quotation, and tactic syntax remain experimental.
 
 `HexIntervalMathlib.Experiment.PntLogRational` is a fixed-source acceptance
 provider rather than public interval arithmetic. It proves the original
@@ -197,6 +207,12 @@ alignment and a live instance → fact → equality → transport chronology,
 including body/source/version/final-state mutations, refuter ownership, a
 nonvacuous ordinary theorem with a guarded axiom report, and transactional
 Meta-state restoration after a wrongly typed emitter.
+`HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
+the supported state quote and proof registry. Its ordinary theorem makes both
+source assumptions load-bearing through add/sub/mul and checked
+inv/div/regularize successors; mutations pin rule keys, bodies, argument order,
+proposed cuts, chronology, and proof-resource limits. A precision refusal is
+recomputed by the package and cannot be interpreted as a fact.
 `HexIntervalMathlib.PntLogRationalConformance` additionally runs all fifteen
 fixed rows and sends the representative large-shift `32e12` certificate through
 generic planning, payload authentication, chronological replay, and the proof

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -109,9 +109,10 @@ definitional equality transactionally in the caller's environment. Emitted
 terms may reference only declarations that survive that rollback. The kernel
 performs the final check when the caller installs the expression.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
-cannot enter `Proof.Evidence`. The built-in arithmetic package registry is
-supported below; arbitrary-function package discovery, goal reification,
-search-to-proof quotation, and tactic syntax remain experimental. Further
+cannot enter `Proof.Evidence`. The built-in arithmetic package registry and
+its supported branch/session `Cause`-to-`Proof.Event` quotation ship below.
+Arbitrary-function package discovery, goal reification, encoding and evidence
+folds, search-to-recipe orchestration, and tactic syntax remain experimental. Further
 arithmetic images and useful bounded nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
@@ -145,8 +146,14 @@ reciprocal, division, and regularization results before producing evidence.
 Source facts remain caller assumptions. Direct registry assembly bounds the
 retained packages and schemas but does not preempt construction or equality of
 caller program/meaning arrays; decoded callers must first cross `Search`.
-Arbitrary-function package discovery, goal reification, search-to-proof
-quotation, and tactic syntax remain experimental.
+Its `quote` and `quoteSession` functions convert supported branch/session
+causes to proof events without making runtime state evidence. `Config` fixes
+exactly one natural exponent and one dyadic constant: every node at the
+built-in power operation index shares that exponent, and every node at the
+built-in constant index shares that value. Duplicate package registration and
+operation keys cannot add another parameterization. Arbitrary-function package
+discovery, goal reification, encoding and evidence folds, search-to-recipe
+orchestration, and tactic syntax remain experimental.
 
 `HexIntervalMathlib.Experiment.PntLogRational` is a fixed-source acceptance
 provider rather than public interval arithmetic. It proves the original

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -35,9 +35,15 @@ The supported `Rule` registry owns stable arithmetic meanings and schemas for
 negation, addition, subtraction, multiplication, natural power, absolute
 value, minimum, maximum, constants, reciprocal, division, and regularization.
 Each schema recomputes the fixed-resource public operation before producing
-evidence; source nodes remain caller assumptions. Arbitrary-function package
-discovery, goal reification, search-to-proof quotation, and tactic syntax
-remain experimental and are not re-exported by the public umbrella.
+evidence; source nodes remain caller assumptions. Supported `quote` and
+`quoteSession` convert exact branch/session causes into proof events without
+granting runtime state evidence authority. The current package fixes one
+natural exponent and one dyadic constant, shared respectively by every node at
+the built-in power and constant operation indices; duplicate package
+registration and operation keys cannot provide another such parameterization.
+Arbitrary-function package discovery, goal reification, encoding and evidence
+folds, search-to-recipe orchestration, and tactic syntax remain experimental
+and are not re-exported by the public umbrella.
 The user-facing tactic contract below is the release target, not a claim that
 the tactic is already supported.
 

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -31,8 +31,13 @@ rollback; the kernel checks the term when the caller installs it in a
 declaration. The theorem registry is constructible only through its
 checked builder under ordinary imports; deliberate `import all` is a guarded
 trusted-internals escape hatch, not decoded runtime authority.
-Concrete packages, goal reification, search-to-proof quotation, and tactic
-syntax remain experimental and are not re-exported by the public umbrella.
+The supported `Rule` registry owns stable arithmetic meanings and schemas for
+negation, addition, subtraction, multiplication, natural power, absolute
+value, minimum, maximum, constants, reciprocal, division, and regularization.
+Each schema recomputes the fixed-resource public operation before producing
+evidence; source nodes remain caller assumptions. Arbitrary-function package
+discovery, goal reification, search-to-proof quotation, and tactic syntax
+remain experimental and are not re-exported by the public umbrella.
 The user-facing tactic contract below is the release target, not a claim that
 the tactic is already supported.
 

--- a/conformance/HexIntervalMathlib/RuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuleConformance.lean
@@ -316,7 +316,9 @@ def rejectedWith (selected : Rule.Config)
 
 #guard rejected (mutateFirst fun step => { step with schema := schemaKey subKey })
 #guard rejected (mutateFirst fun step => { step with body := [99] })
-#guard rejected (mutateFirst fun step => { step with assumptions := [seen y, seen x] })
+#guard rejected (mutateFirst fun step =>
+  let swapped := { step.action with inputs := [seen y, seen x] }
+  { { step with action := swapped } with assumptions := [seen y, seen x] })
 #guard rejected (mutateFirst fun step => { step with action := { step.action with key := subKey } })
 #guard rejected (mutateFirst fun step => { step with proposed := differenceFact })
 #guard rejected (mutateFirst fun step => { step with installed := differenceFact })
@@ -325,11 +327,20 @@ def rejectedWith (selected : Rule.Config)
 #guard rejected (mutateFirst fun step => { step with scope := { index := 99 } })
 #guard rejected (mutateInv fun step => { step with schema := schemaKey regularizeKey })
 #guard rejected (mutateInv fun step => { step with body := [99] })
-#guard rejected (mutateDiv fun step => { step with assumptions := [seen x, seen y] })
+#guard rejected (mutateDiv fun step =>
+  let swapped := { step.action with inputs := [seen x, seen y] }
+  { { step with action := swapped } with assumptions := [seen x, seen y] })
 #guard rejected (mutateDiv fun step => { step with proposed := inverseFact })
 #guard rejected (mutateRegularize fun step => { step with schema := schemaKey invKey })
 #guard rejected (mutateRegularize fun step => { step with body := [10] })
-#guard rejected (Rule.quote branch ++ Rule.quote branch)
+#guard
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          input (Rule.quote branch ++ Rule.quote branch) 0 program (seen final 1) with
+      | .error .chronologyLimit => true
+      | _ => false
 
 def precisionShort : Rule.Config :=
   { config with precisionLimits := { config.precisionLimits with maxTemporaryBits := 0 } }
@@ -338,7 +349,7 @@ def precisionShort : Rule.Config :=
     (Hex.Interval.invWithin precisionShort.precisionLimits precisionShort.precision xFact) == none
 #guard rejectedWith precisionShort (Rule.quote branch)
 
-def oneShort : Proof.Limits := { proofLimits with maxChronology := 2 }
+def oneShort : Proof.Limits := { proofLimits with maxChronology := 7 }
 #guard
   match Rule.buildWithin proofLimits config program with
   | .error _ => false

--- a/conformance/HexIntervalMathlib/RuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuleConformance.lean
@@ -1,0 +1,409 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Rule
+
+/-!
+# Built-in arithmetic rule conformance
+
+Two independent source facts feed both sides of a shared DAG.  The accepted
+supported-state history is quoted, chronologically replayed, and projected to
+an ordinary theorem.  The negative guards mutate authenticated fields rather
+than testing helper predicates in isolation.
+-/
+
+namespace Hex.IntervalMathlib.RuleConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+open Hex.Interval.Rule
+
+def d (value : Int) : Dyadic := .ofInt value
+def endpoint : EndpointLimit := { maxEndpointHeight := 64, maxAlignmentShift := 64 }
+
+def ready (raw : Raw) : Hex.Interval :=
+  match Hex.Interval.ofRawWithin endpoint raw with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+def singleton (value : Int) : Hex.Interval :=
+  ready (.bounds (.finite (d value) false) (.finite (d value) false))
+
+def config : Rule.Config :=
+  { endpoint, powerWork := { maxExponent := 8 }, exponent := 2,
+    precisionLimits :=
+      { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
+        maxTemporaryBits := 128 },
+    precision := 0, constant := d 5 }
+
+def node (op : Nat) (args : List Nat) : Node :=
+  { domain := realDomain, op := { index := op }, args := args.map fun index => { index } }
+
+def program : Program :=
+  { operations
+    nodes := #[node 0 [], node 0 [], node 2 [0, 1], node 3 [0, 1], node 4 [2, 3],
+      node 10 [0], node 11 [1, 0], node 12 [6], node 2 [4, 7], node 2 [8, 5]] }
+
+def x : NodeId := { index := 0 }
+def y : NodeId := { index := 1 }
+def sum : NodeId := { index := 2 }
+def difference : NodeId := { index := 3 }
+def product : NodeId := { index := 4 }
+def inverse : NodeId := { index := 5 }
+def quotient : NodeId := { index := 6 }
+def regularized : NodeId := { index := 7 }
+def combined : NodeId := { index := 8 }
+def final : NodeId := { index := 9 }
+
+def seen (node : NodeId) (version : Nat := 0) : SeenVersion :=
+  { node, version }
+
+#guard program.check
+#guard Rule.operations == program.operations
+
+def opaqueOp : Operation :=
+  { key := { name := "conformance.opaque" }, inputs := [realDomain], output := realDomain }
+def opaqueMeaning : Program.Meaning ℝ :=
+  { operation := opaqueOp, relation := fun args result => args = [result] }
+def extendedConfig : Rule.Config := { config with extraMeanings := #[opaqueMeaning] }
+def extendedProgram : Program := { program with operations := operations.push opaqueOp }
+
+#guard extendedProgram.check
+
+def xFact := singleton 1
+def yFact := singleton 2
+def sumFact := singleton 3
+def differenceFact := singleton (-1)
+def productFact := singleton (-3)
+def inverseFact := singleton 1
+def quotientFact := singleton 2
+def regularizedFact := singleton 2
+def combinedFact := singleton (-1)
+def finalFact := singleton 0
+def initialFacts : Array Hex.Interval :=
+  #[xFact, yFact, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+    Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+    Hex.Interval.whole]
+
+#guard ready? (Hex.Interval.addWithin endpoint xFact yFact) == some sumFact
+#guard ready? (Hex.Interval.subWithin endpoint xFact yFact) == some differenceFact
+#guard arithmeticReady? (Hex.Interval.mulWithin endpoint sumFact differenceFact) == some productFact
+#guard arithmeticReady?
+    (Hex.Interval.invWithin config.precisionLimits config.precision xFact) == some inverseFact
+#guard arithmeticReady?
+    (Hex.Interval.divWithin config.precisionLimits config.precision yFact xFact) == some quotientFact
+#guard arithmeticReady?
+    (Hex.Interval.regularizeWithin config.precisionLimits config.precision quotientFact) ==
+      some regularizedFact
+#guard ready? (Hex.Interval.addWithin endpoint productFact regularizedFact) == some combinedFact
+#guard ready? (Hex.Interval.addWithin endpoint combinedFact inverseFact) == some finalFact
+
+def action (serial ruleIndex : Nat) (key : RuleKey) (kind : ActionKind)
+    (anchor : NodeId) (inputs : List SeenVersion) : Action :=
+  { serial, programVersion := 0, application := { index := serial }, rule := { index := ruleIndex },
+    key, node := anchor, kind, effort := 0, inputs, writes := [anchor] }
+
+def addAction := action 0 1 addKey .forward sum [seen x, seen y]
+def subAction := action 1 2 subKey .forward difference [seen x, seen y]
+def mulAction := action 2 3 mulKey .forward product [seen sum 1, seen difference 1]
+def invAction := action 3 9 invKey .forward inverse [seen x]
+def divAction := action 4 10 divKey .forward quotient [seen y, seen x]
+def regularizeAction :=
+  action 5 11 regularizeKey .forward regularized [seen quotient 1]
+def combinedAction := action 6 1 addKey .forward combined [seen product 1, seen regularized 1]
+def finalAction := action 7 1 addKey .forward final [seen combined 1, seen inverse 1]
+
+def cause (scope : Policy.ScopeId) (action : Action)
+    (proposed : Hex.Interval) (key : RuleKey) (tag : Nat) : Rule.Cause :=
+  { scope, action, proposed, schema := schemaKey key, body := [tag] }
+
+def scope : Policy.ScopeId := { index := 4 }
+
+def history : Array (State.Update Hex.Interval Rule.Cause) :=
+  #[{ programVersion := 0, node := sum, previous := seen sum, fact := sumFact, version := 1,
+      cause := cause scope addAction sumFact addKey 2 },
+    { programVersion := 0, node := difference, previous := seen difference,
+      fact := differenceFact, version := 1,
+      cause := cause scope subAction differenceFact subKey 3 },
+    { programVersion := 0, node := product, previous := seen product,
+      fact := productFact, version := 1, cause := cause scope mulAction productFact mulKey 4 },
+    { programVersion := 0, node := inverse, previous := seen inverse,
+      fact := inverseFact, version := 1, cause := cause scope invAction inverseFact invKey 10 },
+    { programVersion := 0, node := quotient, previous := seen quotient,
+      fact := quotientFact, version := 1, cause := cause scope divAction quotientFact divKey 11 },
+    { programVersion := 0, node := regularized, previous := seen regularized,
+      fact := regularizedFact, version := 1,
+      cause := cause scope regularizeAction regularizedFact regularizeKey 12 },
+    { programVersion := 0, node := combined, previous := seen combined,
+      fact := combinedFact, version := 1,
+      cause := cause scope combinedAction combinedFact addKey 2 },
+    { programVersion := 0, node := final, previous := seen final,
+      fact := finalFact, version := 1, cause := cause scope finalAction finalFact addKey 2 }]
+
+/-- Exact supported retained state used by the generic quote. -/
+def branch : State.Branch Hex.Interval Rule.Cause :=
+  { programVersion := 0, baseProgram := program, initialFacts, program,
+    seeds := #[],
+    versions := #[0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+    generations := #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    depths := #[0, 0, 1, 1, 2, 1, 1, 2, 3, 4], history, contradictory := false }
+
+#guard branch.check
+#guard (Rule.quote branch).length == 8
+
+def proofLimits : Proof.Limits :=
+  { maxPackages := 1, maxSchemas := 12, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 8 }
+
+#guard
+  match Rule.buildWithWithin proofLimits extendedConfig extendedProgram #[] with
+  | .ok _ => true
+  | .error _ => false
+
+def input : Proof.Input Hex.Interval :=
+  { scope, program, facts := initialFacts, target := { node := final, fact := finalFact } }
+
+def replayResult : Option (Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target)) :=
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => none
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          input (Rule.quote branch) 0 program (seen final 1) with
+      | .error _ => none
+      | .ok evidence => some evidence
+
+#guard Option.isSome replayResult
+
+private theorem eq_of_mem_singleton {value : Dyadic} {result : Hex.Interval} {z : ℝ}
+    (checked : Hex.Interval.singletonWithin endpoint value = .ready result)
+    (member : result.Contains z) : z = Hex.Interval.toReal value := by
+  change result.view.Contains z at member
+  rw [Hex.Interval.view_singletonWithin_ready checked,
+    Hex.Interval.contains_normalize] at member
+  exact le_antisymm member.2 member.1
+
+private theorem toReal_d (value : Int) : Hex.Interval.toReal (d value) = value := by
+  change ((Dyadic.ofInt value).toRat : ℝ) = value
+  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
+  norm_num
+
+theorem checkedX : Hex.Interval.singletonWithin endpoint (d 1) = .ready xFact := by rfl
+theorem checkedY : Hex.Interval.singletonWithin endpoint (d 2) = .ready yFact := by rfl
+theorem checkedFinal : Hex.Interval.singletonWithin endpoint (d 0) = .ready finalFact := by rfl
+
+def fallbackEvidence : Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target) :=
+  { proof := by
+      intro valuation model assumptions
+      change NodeId → ℝ at valuation
+      have xMember : xFact.Contains (valuation x) := by
+        exact assumptions { node := x, fact := xFact } (by
+          simp [Proof.initialBase, input, initialFacts, x])
+      have yMember : yFact.Contains (valuation y) := by
+        exact assumptions { node := y, fact := yFact } (by
+          simp [Proof.initialBase, input, initialFacts, y])
+      have sumRelation : valuation sum = valuation x + valuation y :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := sum) (left := x) (right := y) (index := 2)
+          (relation := fun left right => left + right)
+          (Rule.nodeMeaning config model (node := sum) (by rfl))
+          (Or.inl ⟨rfl, rfl⟩)
+      have subRelation : valuation difference = valuation x - valuation y :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := difference) (left := x) (right := y) (index := 3)
+          (relation := fun left right => left - right)
+          (Rule.nodeMeaning config model (node := difference) (by rfl))
+          (Or.inr (Or.inl ⟨rfl, rfl⟩))
+      have mulRelation : valuation product = valuation sum * valuation difference :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := product) (left := sum) (right := difference) (index := 4)
+          (relation := fun left right => left * right)
+          (Rule.nodeMeaning config model (node := product) (by rfl))
+          (Or.inr (Or.inr (Or.inl ⟨rfl, rfl⟩)))
+      have invRelation : valuation inverse = (valuation x)⁻¹ :=
+        Rule.invRelation (config := config) (valuation := valuation)
+          (node := inverse) (input := x)
+          (Rule.nodeMeaning config model (node := inverse) (by rfl))
+      have divRelation : valuation quotient = valuation y / valuation x :=
+        Rule.divRelation (config := config) (valuation := valuation)
+          (node := quotient) (left := y) (right := x)
+          (Rule.nodeMeaning config model (node := quotient) (by rfl))
+      have regularizeRelation : valuation regularized = valuation quotient :=
+        Rule.regularizeRelation (config := config) (valuation := valuation)
+          (node := regularized) (input := quotient)
+          (Rule.nodeMeaning config model (node := regularized) (by rfl))
+      have combinedRelation : valuation combined = valuation product + valuation regularized :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := combined) (left := product) (right := regularized) (index := 2)
+          (relation := fun left right => left + right)
+          (Rule.nodeMeaning config model (node := combined) (by rfl))
+          (Or.inl ⟨rfl, rfl⟩)
+      have finalRelation : valuation final = valuation combined + valuation inverse :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := final) (left := combined) (right := inverse) (index := 2)
+          (relation := fun left right => left + right)
+          (Rule.nodeMeaning config model (node := final) (by rfl))
+          (Or.inl ⟨rfl, rfl⟩)
+      have xEq := eq_of_mem_singleton checkedX xMember
+      have yEq := eq_of_mem_singleton checkedY yMember
+      rw [toReal_d] at xEq yEq
+      have finalEq : valuation final = 0 := by
+        rw [finalRelation, combinedRelation, mulRelation, sumRelation, subRelation,
+          regularizeRelation, divRelation, invRelation, xEq, yEq]
+        norm_num
+      change finalFact.Contains (valuation final)
+      rw [finalEq]
+      have zeroMember := Rule.constant_mem checkedFinal
+      rw [toReal_d] at zeroMember
+      simpa using zeroMember }
+
+def replayEvidence : Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target) :=
+  match replayResult with
+  | some evidence => evidence
+  | none => fallbackEvidence
+
+/-- Kernel theorem obtained from the generic supported quote and replay.  Both
+source hypotheses are consumed twice, through addition and subtraction. -/
+theorem arithmeticDag :
+    (Rule.semantics config).Entails program (Proof.initialBase input) input.target :=
+  replayEvidence.proof
+
+-- Every authenticated address component is load-bearing.
+def mutateFirst (change : Proof.FactStep Hex.Interval → Proof.FactStep Hex.Interval) :=
+  match Rule.quote branch with
+  | .fact step :: rest => Proof.Event.fact (change step) :: rest
+  | events => events
+
+def mutateInv (change : Proof.FactStep Hex.Interval → Proof.FactStep Hex.Interval) :=
+  match Rule.quote branch with
+  | a :: b :: c :: .fact step :: rest => a :: b :: c :: .fact (change step) :: rest
+  | events => events
+
+def mutateDiv (change : Proof.FactStep Hex.Interval → Proof.FactStep Hex.Interval) :=
+  match Rule.quote branch with
+  | a :: b :: c :: d :: .fact step :: rest => a :: b :: c :: d :: .fact (change step) :: rest
+  | events => events
+
+def mutateRegularize (change : Proof.FactStep Hex.Interval → Proof.FactStep Hex.Interval) :=
+  match Rule.quote branch with
+  | a :: b :: c :: d :: e :: .fact step :: rest =>
+      a :: b :: c :: d :: e :: .fact (change step) :: rest
+  | events => events
+
+def rejected (events : List (Proof.Event Hex.Interval)) : Bool :=
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          input events 0 program (seen final 1) with
+      | .error _ => true
+      | .ok _ => false
+
+def rejectedWith (selected : Rule.Config)
+    (events : List (Proof.Event Hex.Interval)) : Bool :=
+  match Rule.buildWithin proofLimits selected program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain selected) (Rule.laws selected)
+          input events 0 program (seen final 1) with
+      | .error _ => true
+      | .ok _ => false
+
+#guard rejected (mutateFirst fun step => { step with schema := schemaKey subKey })
+#guard rejected (mutateFirst fun step => { step with body := [99] })
+#guard rejected (mutateFirst fun step => { step with assumptions := [seen y, seen x] })
+#guard rejected (mutateFirst fun step => { step with action := { step.action with key := subKey } })
+#guard rejected (mutateFirst fun step => { step with proposed := differenceFact })
+#guard rejected (mutateFirst fun step => { step with installed := differenceFact })
+#guard rejected (mutateFirst fun step => { step with previous := seen sum 1 })
+#guard rejected (mutateFirst fun step => { step with programVersion := 1 })
+#guard rejected (mutateFirst fun step => { step with scope := { index := 99 } })
+#guard rejected (mutateInv fun step => { step with schema := schemaKey regularizeKey })
+#guard rejected (mutateInv fun step => { step with body := [99] })
+#guard rejected (mutateDiv fun step => { step with assumptions := [seen x, seen y] })
+#guard rejected (mutateDiv fun step => { step with proposed := inverseFact })
+#guard rejected (mutateRegularize fun step => { step with schema := schemaKey invKey })
+#guard rejected (mutateRegularize fun step => { step with body := [10] })
+#guard rejected (Rule.quote branch ++ Rule.quote branch)
+
+def precisionShort : Rule.Config :=
+  { config with precisionLimits := { config.precisionLimits with maxTemporaryBits := 0 } }
+
+#guard arithmeticReady?
+    (Hex.Interval.invWithin precisionShort.precisionLimits precisionShort.precision xFact) == none
+#guard rejectedWith precisionShort (Rule.quote branch)
+
+def oneShort : Proof.Limits := { proofLimits with maxChronology := 2 }
+#guard
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay oneShort registry (Rule.domain config) (Rule.laws config)
+          input (Rule.quote branch) 0 program (seen final 1) with
+      | .error .chronologyLimit => true
+      | _ => false
+
+def bodyShort : Proof.Limits := { proofLimits with maxBodyCells := 0 }
+#guard
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay bodyShort registry (Rule.domain config) (Rule.laws config)
+          input (Rule.quote branch) 0 program (seen final 1) with
+      | .error .bodyLimit => true
+      | _ => false
+
+def dependencyShort : Proof.Limits := { proofLimits with maxDependencies := 1 }
+#guard
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay dependencyShort registry (Rule.domain config) (Rule.laws config)
+          input (Rule.quote branch) 0 program (seen final 1) with
+      | .error .dependencyLimit => true
+      | _ => false
+
+def schemaShort : Proof.Limits := { proofLimits with maxSchemas := 11 }
+#guard
+  match Rule.buildWithin schemaShort config program with
+  | .error (.registry .schemaLimit) => true
+  | _ => false
+
+def wrongSourceInput : Proof.Input Hex.Interval :=
+  { input with facts := #[Hex.Interval.whole, yFact, Hex.Interval.whole,
+      Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+      Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+      Hex.Interval.whole] }
+
+#guard
+  match Rule.buildWithin proofLimits config program with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          wrongSourceInput (Rule.quote branch) 0 program (seen final 1) with
+      | .error _ => true
+      | .ok _ => false
+
+def wrongOperationProgram : Program :=
+  { program with nodes := program.nodes.set! sum.index (node 3 [0, 1]) }
+def wrongOperationInput : Proof.Input Hex.Interval :=
+  { input with program := wrongOperationProgram }
+
+#guard wrongOperationProgram.check
+#guard
+  match Rule.buildWithin proofLimits config wrongOperationProgram with
+  | .error _ => false
+  | .ok registry =>
+      match Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          wrongOperationInput (Rule.quote branch) 0 wrongOperationProgram (seen final 1) with
+      | .error _ => true
+      | .ok _ => false
+
+#print axioms arithmeticDag
+
+end Hex.IntervalMathlib.RuleConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -425,7 +425,7 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
     `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division,
     `HexIntervalMathlib.Regularize, `HexIntervalMathlib.Program,
-    `HexIntervalMathlib.Proof].map Glob.one
+    `HexIntervalMathlib.Proof, `HexIntervalMathlib.Rule].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -520,6 +520,7 @@ lean_lib HexConformance where
       `HexInterval.FeaturePolicyConformance,
       `HexInterval.SearchConformance,
       `HexIntervalMathlib.ProgramProofConformance,
+      `HexIntervalMathlib.RuleConformance,
       `HexIntervalMathlib.MixedFunctionsConformance,
       `HexIntervalMathlib.MixedInstantiationConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one

--- a/progress/2026-08-21T13-51-47Z.md
+++ b/progress/2026-08-21T13-51-47Z.md
@@ -1,0 +1,32 @@
+# Supported arithmetic proof rules
+
+## Accomplished
+
+- Reconciled the supported built-in arithmetic rule registry onto the merged
+  `Program`/`State`/`Policy`/`Search`/`Proof` contracts.
+- Added exact package-owned schemas for negation, addition, subtraction,
+  multiplication, natural power, absolute value, minimum, maximum, constants,
+  reciprocal, division, and outward regularization.
+- Added a live shared-DAG conformance that quotes reconstructed supported state,
+  replays eight chronological updates, rejects malformed rule evidence, and
+  makes reciprocal/division/regularization plus both source assumptions
+  load-bearing.
+- Updated the supported-library maps and current-state resource/trust boundary;
+  arbitrary-function discovery, search-to-proof quotation, reification, and
+  tactic syntax remain experimental.
+
+## Current frontier
+
+The focused Rule/RuleConformance build and the complete 9,566-job supported
+Mathlib/conformance graph are green. Repository DAG, trust, release, PNT,
+Mathlib-free bench, factor-freshness, and source-format gates are also green.
+
+## Next step
+
+After this edge lands, extract the already prepared supported frontend/reifier
+against this stable arithmetic package registry, then add retained-tree recipe
+replay rather than allowing runtime traces to become proof evidence.
+
+## Blockers
+
+None.

--- a/progress/2026-08-21T14-02-56Z.md
+++ b/progress/2026-08-21T14-02-56Z.md
@@ -1,0 +1,28 @@
+# Supported arithmetic Rule restack
+
+## Accomplished
+
+- Replayed the supported arithmetic Rule and conformance edge directly onto
+  `939dd03bc3a9347cc9e1caf0b67c11bce7b634e4` after the bounded Chebyshev
+  experiment merged.
+- Preserved the Chebyshev sources, fixture, registrations, and SPEC content;
+  reconciled the Lake registration and exact proof-only freshness ledger.
+- Rebuilt the Rule and Chebyshev targets, the Mathlib umbrella, and the full
+  conformance umbrella. Static, trust, freshness, release, and PNT inventory
+  checks pass.
+
+## Current frontier
+
+- The supported Rule edge is ready for upstream review as a direct child of
+  current main.
+- Concrete search packages, goal reification, tactic syntax, and arbitrary
+  function packages remain outside this edge.
+
+## Next step
+
+- Review and merge the supported Rule registry before replaying the supported
+  frontend and tactic edges that consume it.
+
+## Blockers
+
+- None.

--- a/progress/2026-08-21T14-18-32Z.md
+++ b/progress/2026-08-21T14-18-32Z.md
@@ -1,0 +1,26 @@
+# Supported Rule review repair
+
+## Accomplished
+
+- Corrected the supported-surface documentation to include branch/session
+  cause-to-proof-event quotation while keeping reification, encoding, evidence
+  folding, search-to-recipe orchestration, and tactic syntax experimental.
+- Documented that one arithmetic package fixes one natural exponent and one
+  dyadic constant shared by all nodes at the corresponding stable operations.
+- Strengthened conformance to mutate action and assumption argument order
+  together, pin duplicate quotation to chronology exhaustion, and exercise the
+  exact one-under chronology limit.
+- Rebuilt the focused Rule target and the full Mathlib/conformance umbrellas;
+  static, trust, freshness, and PNT checks pass.
+
+## Current frontier
+
+- PR #9348 has a narrow reviewed repair ready to publish on the same main base.
+
+## Next step
+
+- Publish the repaired exact head and allow the automatic CI workflow to run.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -622,5 +622,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "4174d50ac7af6673cf5d547328ab56bb66f4b9ca",
     "reason": "Additionally registers the proof-only bounded PNT+ Chebyshev logarithm/fold experiment and its conformance module on top of the retained supported Proof, Search, Policy, State, LogTables, interval, FKS2, Table 10, and finite-field registrations; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "2148017bd5b97da69cbe5f3d5147fa746153ab22",
+    "reason": "Additionally registers the supported HexIntervalMathlib built-in arithmetic Rule module and its proof-only conformance on top of the current public interval, Proof, Chebyshev, and PNT registrations; they do not enter the factorization service target or change its executable dependency graph."
   }
 ]


### PR DESCRIPTION
## Summary

- add a supported, function-agnostic arithmetic Rule registry over the public interval operations and supported Proof contracts
- authenticate stable operation/rule keys, ordered sources and versions, proposed cuts, bodies, and checked operation results for negation, addition, subtraction, multiplication, natural powers, absolute value, min/max, inverse, division, regularization, constants, and source assumptions
- quote exact supported State chronology into Proof replay and exercise an eight-step shared-expression arithmetic DAG through ordinary theorem construction

## Scope

Runtime state and proposed rule bodies remain untrusted: package-owned schemas recompute public interval operations and emit evidence only through the supported Proof boundary. Concrete search packages, goal reification, tactic syntax, arbitrary-function discovery, and default registry selection remain experimental/future edges. Direct Rule registry construction has an explicit non-preemptible structural equality/construction envelope; decoded controller input is expected to cross the supported Search resource boundary first. No tight backward schemas are claimed from one-way public interval theorems.

## Verification

- `lake build HexIntervalMathlib.Rule HexIntervalMathlib.RuleConformance HexIntervalMathlib.Experiment.PntChebyshev HexIntervalMathlib.PntChebyshevConformance`
- `lake build HexIntervalMathlib HexConformance` (9,581 jobs)
- DAG, release manifest/split/sync, trust-surface, Mathlib-free bench, conformance registry, PNT inventory, factor freshness, banned-token, and diff checks
- `#print axioms arithmeticDag`: `propext`, `Classical.choice`, `Quot.sound` only

The edge is a literal child of current main `939dd03bc3a9347cc9e1caf0b67c11bce7b634e4`; the merged Chebyshev sources, fixture, registrations, and SPEC content are preserved.