### PR TITLE
feat(interval): add supported arithmetic frontend

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -76,10 +76,24 @@ includes generic bounded policy offers/views, exact echoed decisions, a
 replaceable choice interface, package-measured byte/pair/work caps, and
 transactional revalidation against exact program, fact snapshot, scope,
 serial, program version, remaining budget, and complete offer fields. It does
-not choose a semantic offer-key encoding or a default policy. Package assembly,
+not choose a semantic offer-key encoding or a default policy. The supported
+Mathlib companion now also owns the function-agnostic program interpretation,
+package theorem registry, chronological proof fold, exact caller closure, and
+checked expression boundary. Its first programmatic frontend recursively
+reifies a bounded arithmetic term language by stable operation key, rechecks
+the transparent result's exact node/term correspondence, binds the exact
+selected source facts, replays a caller-supplied authenticated flat
+chronology, and projects
+the result to lower, upper, conjunction, or closed-singleton equality theorems.
+Lean-expression parsing, local-hypothesis proof synthesis, tactic syntax, and
+Meta quotation of the supported records remain experimental. The first
+concrete supported registry is the Mathlib arithmetic package for one
+configured constant and natural exponent plus public negation, addition,
+subtraction, multiplication, power, absolute-value, min/max, reciprocal,
+division, and regularization operations. Arbitrary-function package assembly,
 callback outcomes and proposals, concrete policy algorithms, sessions, branch
-search, payload storage, proof replay, and that optimized backing store remain
-experimental.
+search, search-to-recipe orchestration, payload storage, tactic syntax, and the
+optimized backing store remain experimental.
 In particular, the current instantiation proposal's package-supplied numeric
 policy family is not part of the supported action contract.
 
@@ -5248,6 +5262,12 @@ their declared cost inside a scheduler bound.
   semantics and the one-way total-real-division enclosure theorem.
 - `HexIntervalMathlib/Regularize.lean`: exact normalized rounded-cut semantics,
   outward containment, and raw-cut idempotence without a grid-tightest claim.
+- `HexIntervalMathlib/Frontend.lean`: bounded recursive arithmetic-term
+  reification with structural sharing and stable-key resolution, checked
+  node/term correspondence and exact source binding, supported
+  registry/flat-replay invocation, and programmatic lower,
+  upper, conjunction, and closed-singleton equality closure. Search-to-recipe
+  integration, Lean syntax, and Meta quotation remain outside this module.
 - `HexInterval/Program.lean`: supported stable operation/domain/node
   identifiers, decoded typed SSA programs, fail-closed validation, and
   structural depths.
@@ -5328,6 +5348,10 @@ their declared cost inside a scheduler bound.
   operation package authenticating the exact `315 / 100` π cut.
 - `scripts/conformance/run_pnt_fks2_family.sh`: fail-closed entry point for the
   non-default complete-family proof and conformance profile.
+- `conformance/HexIntervalMathlib/FrontendConformance.lean`: supported
+  recursive shared-DAG reification, exact source binding, malformed-entry,
+  stable-key, and resource rejection, flat chronological replay, and ordinary
+  inequality, conjunction, and equality theorem/axiom canaries.
 - `bench/HexInterval/Bench.lean`: Mathlib-free interval and scheduler
   benchmarks.
 

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -21,6 +21,7 @@ public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
 public import HexIntervalMathlib.Rule
+public import HexIntervalMathlib.Frontend
 
 public section
 
@@ -34,4 +35,6 @@ enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
+`HexIntervalMathlib.Frontend` supplies bounded recursive arithmetic reification,
+exact source binding, and flat programmatic replay/closure combinators.
 -/

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -1,0 +1,338 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Rule
+
+@[expose] public section
+
+/-!
+# Programmatic arithmetic frontend
+
+This module is the supported, tactic-independent frontend boundary. It
+recursively reifies a small arithmetic term language into the exact supported
+SSA `Program`, resolves operations by stable key, constructs version-zero
+source facts, invokes the supported Rule/Proof replay, and closes interval
+membership to ordinary bounds, conjunctions, or singleton equality.
+
+It intentionally contains no syntax elaborator. Turning arbitrary Lean
+expressions and local hypotheses into this programmatic input additionally
+requires a supported quotation bridge for `Program`, `Interval`, replay events,
+and caller proof terms. The existing bridge is experimental and uses different
+certificate types, so importing or aliasing it here would reverse the intended
+production boundary. This module accepts one flat event chronology; it does not
+derive proof recipes from retained search or split trees.
+-/
+
+namespace Hex.Interval.Frontend
+
+open Proof
+
+/-- Function-generic arithmetic syntax. One package-configured constant,
+natural exponent, and precision keep semantic identity in `Rule.Config`, not
+in an untrusted term payload. -/
+inductive Term where
+  | source (index : Nat)
+  | constant
+  | neg (input : Term)
+  | add (left right : Term)
+  | sub (left right : Term)
+  | mul (left right : Term)
+  | pow (input : Term)
+  | abs (input : Term)
+  | min (left right : Term)
+  | max (left right : Term)
+  | inv (input : Term)
+  | div (left right : Term)
+  | regularize (input : Term)
+  deriving DecidableEq, Repr
+
+/-- Reification caps are independent of interval arithmetic and proof replay
+caps. `maxSources` also bounds caller fact-array traversal. `maxOperations`
+admits the already-constructed configured meaning array before stable-key
+lookup; it does not preempt construction of `Rule.Config` or structural
+equality on caller `Term` values. -/
+structure Limits where
+  maxSources : Nat
+  maxOperations : Nat
+  maxNodes : Nat
+  maxDepth : Nat
+  deriving DecidableEq, Repr
+
+/-- Every resource envelope needed by this frontend is explicit. -/
+structure Config where
+  rule : Rule.Config
+  reify : Limits
+  proof : Proof.Limits
+
+structure Entry where
+  term : Term
+  node : NodeId
+  deriving DecidableEq, Repr
+
+structure State where
+  nodes : Array Node := #[]
+  entries : Array Entry := #[]
+  deriving DecidableEq, Repr
+
+structure Result where
+  program : Program
+  target : NodeId
+  entries : Array Entry
+  sourceCount : Nat
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | sourceLimit
+  | operationLimit
+  | sourceIndex (index : Nat)
+  | depthLimit
+  | nodeLimit
+  | missingOperation (key : OpKey)
+  | malformedProgram
+  | malformedResult
+  | wrongSourceCount
+  | missingSource (index : Nat)
+  | rule (error : Rule.BuildError)
+  | replay (error : Proof.Error)
+  deriving Repr
+
+def State.find? (state : State) (term : Term) : Option NodeId :=
+  (state.entries.toList.find? fun entry => entry.term == term).map (·.node)
+
+def operationKey : Term → OpKey
+  | .source _ => Rule.sourceOp.key
+  | .constant => Rule.constantOp.key
+  | .neg _ => Rule.negOp.key
+  | .add _ _ => Rule.addOp.key
+  | .sub _ _ => Rule.subOp.key
+  | .mul _ _ => Rule.mulOp.key
+  | .pow _ => Rule.powOp.key
+  | .abs _ => Rule.absOp.key
+  | .min _ _ => Rule.minOp.key
+  | .max _ _ => Rule.maxOp.key
+  | .inv _ => Rule.invOp.key
+  | .div _ _ => Rule.divOp.key
+  | .regularize _ => Rule.regularizeOp.key
+
+def install (config : Config) (term : Term) (reified : List NodeId)
+    (state : State) : Except Error (NodeId × State) := do
+  if config.reify.maxNodes ≤ state.nodes.size then throw .nodeLimit
+  let key := operationKey term
+  let emptyProgram : Program :=
+    { operations := (Rule.meanings config.rule).map (Program.Meaning.operation)
+      nodes := #[] }
+  let some (operation, signature) :=
+      emptyProgram.operationEntry? key
+    | throw (.missingOperation key)
+  if signature.inputs.length != reified.length then throw .malformedProgram
+  let node : NodeId := { index := state.nodes.size }
+  let instruction : Node :=
+    { domain := Rule.realDomain, op := operation, args := reified }
+  pure (node,
+    { nodes := state.nodes.push instruction
+      entries := state.entries.push { term, node } })
+
+def reifyTerm (config : Config) (sourceCount depth : Nat)
+    (term : Term) (state : State) : Except Error (NodeId × State) := do
+  if config.reify.maxDepth < depth then throw .depthLimit
+  if let some node := state.find? term then return (node, state)
+  match term with
+  | .source index =>
+      if sourceCount ≤ index then throw (.sourceIndex index)
+      install config term [] state
+  | .constant => install config term [] state
+  | .neg input | .pow input | .abs input | .inv input | .regularize input =>
+      let (node, state) ← reifyTerm config sourceCount (depth + 1) input state
+      install config term [node] state
+  | .add left right | .sub left right | .mul left right | .div left right |
+      .min left right | .max left right =>
+      let (leftNode, state) ← reifyTerm config sourceCount (depth + 1) left state
+      let (rightNode, state) ← reifyTerm config sourceCount (depth + 1) right state
+      install config term [leftNode, rightNode] state
+
+/-- Recursively construct a checked SSA program. Failure returns no partial
+result. Exact-expression CSE is structural equality on `Term`. -/
+def reifyWithin (config : Config) (sourceCount : Nat) (target : Term) :
+    Except Error Result := do
+  if config.reify.maxSources < sourceCount then throw .sourceLimit
+  if config.reify.maxOperations < (Rule.meanings config.rule).size then
+    throw .operationLimit
+  let (targetNode, state) ← reifyTerm config sourceCount 0 target {}
+  let program : Program :=
+    { operations := (Rule.meanings config.rule).map (Program.Meaning.operation)
+      nodes := state.nodes }
+  if !program.check then throw .malformedProgram
+  pure { program, target := targetNode, entries := state.entries, sourceCount }
+
+def Result.sourceNode? (result : Result) (index : Nat) : Option NodeId :=
+  (result.entries.toList.find? fun entry => entry.term == .source index).map (·.node)
+
+protected def Term.inputs : Term → List Term
+  | .source _ | .constant => []
+  | .neg input | .pow input | .abs input | .inv input | .regularize input => [input]
+  | .add left right | .sub left right | .mul left right | .div left right |
+      .min left right | .max left right => [left, right]
+
+protected def Result.inputsMatch (entries : Array Entry) : List Term → List NodeId → Bool
+  | [], [] => true
+  | term :: terms, node :: nodes =>
+      (entries[node.index]?).any (fun entry => entry.term == term) &&
+        Result.inputsMatch entries terms nodes
+  | _, _ => false
+
+protected def Result.uniqueTerms : List Entry → Bool
+  | [] => true
+  | entry :: entries =>
+      !(entries.any fun other => other.term == entry.term) && Result.uniqueTerms entries
+
+/-- Authenticate the transparent reification record against its exact program.
+This pins one entry to every SSA node, structural CSE, operation keys and
+ordered child edges. The caller-facing resource checks run before this bounded
+scan; structural equality of the already-constructed `Term` values remains a
+programmatic-caller cost. -/
+def Result.check (result : Result) : Bool :=
+  result.entries.size == result.program.nodes.size &&
+    Result.uniqueTerms result.entries.toList &&
+    (List.range result.entries.size).all fun index =>
+      match result.entries[index]?, result.program.nodes[index]? with
+      | some entry, some node =>
+          entry.node.index == index &&
+            (result.program.operation? node.op).any
+              (fun operation => operation.key == operationKey entry.term) &&
+            (match entry.term with
+              | .source source => source < result.sourceCount
+              | _ => true) &&
+            Result.inputsMatch result.entries entry.term.inputs node.args
+      | _, _ => false
+
+/-- Revalidate the bounded reification result, including its exact node/term
+correspondence, bind every selected source exactly once, and seed all computed
+nodes with domain top. Constants are proved by the constant rule rather than
+trusted as assumptions. -/
+def inputWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
+    (sources : Array Hex.Interval) (target : Hex.Interval) :
+    Except Error (Proof.Input Hex.Interval) := do
+  if config.reify.maxSources < result.sourceCount then throw .sourceLimit
+  let meanings := Rule.meanings config.rule
+  if config.reify.maxOperations < meanings.size ||
+      config.reify.maxOperations < result.program.operations.size then
+    throw .operationLimit
+  if config.reify.maxNodes < result.program.nodes.size ||
+      config.reify.maxNodes < result.entries.size then throw .nodeLimit
+  if result.target.index ≥ result.program.nodes.size || !result.program.check then
+    throw .malformedProgram
+  if result.program.operations != meanings.map (Program.Meaning.operation) then
+    throw .malformedProgram
+  if !result.check then throw .malformedResult
+  if sources.size != result.sourceCount then throw .wrongSourceCount
+  let mut facts := Array.replicate result.program.nodes.size Hex.Interval.whole
+  for index in [0:result.sourceCount] do
+    let some node := result.sourceNode? index | throw (.missingSource index)
+    let some fact := sources[index]? | throw .wrongSourceCount
+    facts := facts.set! node.index fact
+  let input : Proof.Input Hex.Interval :=
+    { scope
+      program := result.program
+      facts
+      target := { node := result.target, fact := target } }
+  pure input
+
+/-- Bounded supported registry assembly followed by exact chronological replay.
+Neither the reifier nor the caller-supplied event list has proof authority. The
+proof layer reauthenticates every event; retained search-tree recipe extraction
+is a separate boundary. -/
+def replay (config : Config) (input : Proof.Input Hex.Interval)
+    (events : List (Proof.Event Hex.Interval)) (finalVersion : Nat)
+    (finalProgram : Program) (result : SeenVersion) :
+    Except Error (Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target)) := do
+  match Rule.buildWithin config.proof config.rule input.program with
+  | .error error => throw (.rule error)
+  | .ok registry =>
+      match Proof.replay config.proof registry (Rule.domain config.rule)
+          (Rule.laws config.rule) input events finalVersion finalProgram result with
+      | .ok evidence => pure evidence
+      | .error error => throw (.replay error)
+
+/-- Eliminate replay evidence at one exact valuation and caller context. -/
+theorem close (config : Config) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node)) :
+    input.target.fact.Contains (valuation input.target.node) := by
+  exact evidence.proof valuation model (by
+    intro fact member
+    simpa [Rule.semantics, Proof.Semantics.ofMeanings] using assumptions fact member)
+
+/-- Close both endpoint predicates. This is the conjunction frontend used for
+two-sided inequality goals. -/
+theorem closeBounds (config : Config) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node))
+    (lower : Lower) (upper : Upper)
+    (shape : input.target.fact.view = .bounds lower upper) :
+    lower.Contains (valuation input.target.node) ∧
+      upper.Contains (valuation input.target.node) := by
+  have member := close config input evidence valuation model assumptions
+  change input.target.fact.view.Contains (valuation input.target.node) at member
+  simpa [shape, Raw.Contains] using member
+
+theorem closeLower (config : Config) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node))
+    (value : Dyadic) (strict : Bool) (upper : Upper)
+    (shape : input.target.fact.view = .bounds (.finite value strict) upper) :
+    (Lower.finite value strict).Contains (valuation input.target.node) :=
+  (closeBounds config input evidence valuation model assumptions _ _ shape).1
+
+theorem closeUpper (config : Config) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node))
+    (lower : Lower) (value : Dyadic) (strict : Bool)
+    (shape : input.target.fact.view = .bounds lower (.finite value strict)) :
+    (Upper.finite value strict).Contains (valuation input.target.node) :=
+  (closeBounds config input evidence valuation model assumptions _ _ shape).2
+
+/-- A closed singleton interval closes an equality goal. -/
+theorem closeSingleton (config : Config) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node))
+    (value : Dyadic)
+    (shape : input.target.fact.view =
+      .bounds (.finite value false) (.finite value false)) :
+    valuation input.target.node = toReal value := by
+  rcases closeBounds config input evidence valuation model assumptions _ _ shape with
+    ⟨lower, upper⟩
+  exact le_antisymm upper lower
+
+end Hex.Interval.Frontend

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -23,6 +23,64 @@ connected-cut characterization and sound total-real-inverse enclosure, while
 `HexIntervalMathlib.Division` proves the computed first-slice quotient cuts and
 sound total-real-division enclosure. `HexIntervalMathlib.Regularize` proves
 exact rounded-cut semantics, outward containment, and raw-cut idempotence.
+`HexIntervalMathlib.Program` is the supported function-agnostic interpretation
+of the Mathlib-free expression DAG. A package contributes an exact opaque
+operation signature and relation; `Program.Models` requires pointwise
+alignment with the complete operation array and one relation witness for every
+SSA node. `HexIntervalMathlib.Proof` is the supported chronological proof
+contract over `Program`, `Fact`, `Action`, `State`, `Policy`, and `Search`.
+It owns semantic consequence, locality and conservative-extension laws,
+package theorem schemas, globally unambiguous registry assembly, plain quoted
+fact/equality/transport/instance/refutation steps, immutable typed proof state,
+and exact caller-target closure.
+
+`HexIntervalMathlib.Rule` is the first supported concrete registry. Its
+immutable configuration fixes endpoint limits, natural-power work and one
+exponent, precision resources, and one dyadic constant. It owns stable
+operation and rule keys, exact real meanings, local registrations, and forward
+schemas for that constant, negation, addition, subtraction, multiplication,
+natural power, absolute value, minimum, maximum, reciprocal, division, and
+regularization. Source nodes obtain their version-zero facts from
+caller hypotheses rather than a rule. Every schema authenticates the exact
+node operation and argument order, source fact versions through the quoted
+action, proposed interval, one-cell body, and the result of rerunning the
+public checked operation. Its fact-domain meet independently reruns checked
+intersection. `Rule.quote` converts the exact accepted `State.Branch` history
+to plain proof chronology; that conversion grants no evidence. Additional
+operation schemas extend the registry only when their public checked operation
+and one-way image theorem are available in the same library revision.
+
+`HexIntervalMathlib.Frontend` is a supported programmatic client of
+those contracts. Its recursive arithmetic `Term` reifier resolves every
+operation from the configured meaning array by stable key, preserves exact
+structural sharing, checks the completed SSA program, and enforces explicit
+source, operation, node, and depth caps separately from registry and replay
+caps. Before seeding facts it rechecks the transparent result's one-entry-per-
+node correspondence, structural sharing, stable operation key, ordered child
+edges, and source-index range. It then binds every caller-selected source
+interval exactly once, leaves computed nodes at domain top, and requires
+constants and every improvement to enter through package-owned chronology.
+Successful replay can be eliminated to a target membership theorem, either
+endpoint inequality, their conjunction, or equality for a closed singleton.
+These are ordinary theorem combinators over a flat caller-supplied event
+chronology: the module does not turn a generic search tree into proof recipes,
+parse Lean expressions or hypotheses, or contain tactic syntax. The caps run
+before array scans; construction and structural equality of caller `Term`
+values remain an explicit programmatic-caller, non-preemptible envelope.
+
+The proof contract treats runtime states, callback replies, payload bytes,
+search decisions, contradiction flags, and diagnostic traces as untrusted
+decoded data. Every accepted fact or equality is an ordinary theorem returned
+by the exact package schema; every instance carries an append-only stability
+theorem and a model-extension theorem. Replay authenticates the complete
+schema address, registry rule index/key/kind, anchor operation, ordered
+read/write projection, scope, action/program versions, node/fact versions,
+dependencies, body, equality orientation, instance suffix, final program, and
+target. A refuter consumes one already-proved exact fact; runtime
+`contradictory` state is not an argument. The final Meta emitter runs
+transactionally and accepts a package-produced `Expr` only after rollback,
+placeholder rejection, `Meta.check`, inference, and definitional equality with
+the exact expected proposition in the caller environment.
 
 For every successful resource-checked public operation it proves:
 
@@ -112,8 +170,8 @@ Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The built-in arithmetic package registry and
 its supported branch/session `Cause`-to-`Proof.Event` quotation ship below.
 Arbitrary-function package discovery, goal reification, encoding and evidence
-folds, search-to-recipe orchestration, and tactic syntax remain experimental. Further
-arithmetic images and useful bounded nonsingleton division require their own
+folds, search-to-recipe orchestration, and tactic syntax remain experimental.
+Further arithmetic images and useful bounded nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
 it claims a tightness converse only when that converse is separately proved.
@@ -236,3 +294,9 @@ proof-frontend closure of the stronger two-sided theorem.
 `HexIntervalMathlib.PntPiPointConformance` pins the exact constant certificate,
 wrong-source and false-endpoint rejection, the ordinary π-bound axiom surface,
 and generic proof-frontend closure.
+`HexIntervalMathlib.FrontendConformance` reconstructs that shared arithmetic
+DAG recursively, pins exact source and configured-constant node binding,
+rejects malformed result entries, duplicate stable keys, and one-over
+source/operation/node/depth limits, replays a flat supported chronology, and
+closes lower inequality, two-sided conjunction, and equality theorems with
+guarded ordinary-theorem axiom reports.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -44,6 +44,17 @@ registration and operation keys cannot provide another such parameterization.
 Arbitrary-function package discovery, goal reification, encoding and evidence
 folds, search-to-recipe orchestration, and tactic syntax remain experimental
 and are not re-exported by the public umbrella.
+The supported `Frontend` is instead a tactic-independent, flat programmatic
+client. It recursively reifies bounded `Term` values by stable operation key,
+rechecks the transparent result's exact node/term/ordered-edge correspondence,
+binds the exact selected source intervals, invokes Rule/Proof replay on an
+explicit caller-supplied event list, and eliminates the resulting evidence to
+lower, upper, conjunction, or closed-singleton equality theorems. It covers
+the current Rule operations but inherits the package's one shared exponent,
+constant, and precision. Array caps precede the revalidation scans, while
+construction and structural equality of programmatic caller `Term` values are
+not preemptible. It does not parse Lean expressions or hypotheses, extract
+recipes from generic Search trees, or expose tactic syntax.
 The user-facing tactic contract below is the release target, not a claim that
 the tactic is already supported.
 

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Frontend
+import HexIntervalMathlib.RuleConformance
+
+/-!
+# Supported arithmetic frontend conformance
+
+The supported recursive frontend reconstructs the shared add/sub/mul prefix of
+the independent rule canary, binds its exact source facts, replays the
+quoted chronology, and closes conjunction, one-sided inequality, and equality
+goals through ordinary kernel theorems.
+-/
+
+namespace Hex.IntervalMathlib.FrontendConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+
+def limits : Frontend.Limits :=
+  { maxSources := 2, maxOperations := 13, maxNodes := 5, maxDepth := 3 }
+def config : Frontend.Config :=
+  { rule := RuleConformance.config, reify := limits, proof := RuleConformance.proofLimits }
+
+def term : Frontend.Term :=
+  .mul (.add (.source 0) (.source 1)) (.sub (.source 0) (.source 1))
+
+def result? := Frontend.reifyWithin config 2 term
+
+def expectedProgram : Program :=
+  { operations := RuleConformance.program.operations
+    nodes := #[RuleConformance.node 0 [], RuleConformance.node 0 [],
+      RuleConformance.node 2 [0, 1], RuleConformance.node 3 [0, 1],
+      RuleConformance.node 4 [2, 3]] }
+
+#guard
+  match result? with
+  | .ok result =>
+      result.program == expectedProgram && result.target == RuleConformance.product &&
+        result.entries.size == 5
+  | .error _ => false
+
+def result : Frontend.Result :=
+  match result? with
+  | .ok result => result
+  | .error _ =>
+      { program := expectedProgram
+        target := RuleConformance.product
+        entries := #[]
+        sourceCount := 2 }
+
+def input? := Frontend.inputWithin config RuleConformance.scope result
+  #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact
+
+def input : Proof.Input Hex.Interval :=
+  { scope := RuleConformance.scope
+    program := expectedProgram
+    facts := #[RuleConformance.xFact, RuleConformance.yFact, Hex.Interval.whole,
+      Hex.Interval.whole, Hex.Interval.whole]
+    target := { node := RuleConformance.product, fact := RuleConformance.productFact } }
+
+#guard
+  match input? with
+  | .ok found => found == input
+  | .error _ => false
+
+def events : List (Proof.Event Hex.Interval) :=
+  (Rule.quote RuleConformance.branch).take 3
+
+#guard events.length == 3
+
+def evidence? :=
+  Frontend.replay config input events 0 expectedProgram
+    (RuleConformance.seen RuleConformance.product 1)
+
+#guard match evidence? with | .ok _ => true | .error _ => false
+
+def shallow : Frontend.Config := { config with reify := { limits with maxDepth := 1 } }
+def fewNodes : Frontend.Config := { config with reify := { limits with maxNodes := 4 } }
+def fewSources : Frontend.Config := { config with reify := { limits with maxSources := 1 } }
+def fewOperations : Frontend.Config :=
+  { config with reify := { limits with maxOperations := 12 } }
+
+#guard match Frontend.reifyWithin shallow 2 term with | .error .depthLimit => true | _ => false
+#guard match Frontend.reifyWithin fewNodes 2 term with | .error .nodeLimit => true | _ => false
+#guard match Frontend.reifyWithin fewSources 2 term with | .error .sourceLimit => true | _ => false
+#guard
+  match Frontend.reifyWithin fewOperations 2 term with
+  | .error .operationLimit => true
+  | _ => false
+#guard
+  match Frontend.reifyWithin config 2 (.source 2) with
+  | .error (.sourceIndex 2) => true
+  | _ => false
+#guard
+  match Frontend.inputWithin config RuleConformance.scope result #[RuleConformance.xFact]
+      RuleConformance.productFact with
+  | .error .wrongSourceCount => true
+  | _ => false
+
+def wrongEntryNode : Frontend.Result :=
+  let bad : Frontend.Entry := { term := .source 0, node := { index := 1 } }
+  { result with entries := result.entries.set! 0 bad }
+
+def wrongEntryTerm : Frontend.Result :=
+  let bad : Frontend.Entry :=
+    { term := .mul (.source 0) (.source 1), node := { index := 2 } }
+  { result with entries := result.entries.set! 2 bad }
+
+def duplicateEntry : Frontend.Result :=
+  let bad : Frontend.Entry := { term := .source 0, node := { index := 1 } }
+  { result with entries := result.entries.set! 1 bad }
+
+#guard
+  match Frontend.inputWithin config RuleConformance.scope wrongEntryNode
+      #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputWithin config RuleConformance.scope wrongEntryTerm
+      #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputWithin config RuleConformance.scope duplicateEntry
+      #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+
+#guard
+  match Frontend.reifyWithin config 1 (.add .constant (.source 0)) with
+  | .ok result => result.program.nodes ==
+      #[RuleConformance.node 9 [], RuleConformance.node 0 [], RuleConformance.node 2 [0, 1]]
+  | .error _ => false
+
+#guard
+  match Frontend.reifyWithin config 2
+      (.regularize (.div (.inv (.source 0)) (.source 1))) with
+  | .ok result => result.program.nodes ==
+      #[RuleConformance.node 0 [], RuleConformance.node 10 [0],
+        RuleConformance.node 0 [], RuleConformance.node 11 [1, 2],
+        RuleConformance.node 12 [3]]
+  | .error _ => false
+
+def duplicateKey : Frontend.Config :=
+  { rule := { config.rule with extraMeanings := #[Rule.sourceMeaning] }
+    reify := { limits with maxOperations := 14 }
+    proof := config.proof }
+
+#guard
+  match Frontend.reifyWithin duplicateKey 1 (.source 0) with
+  | .error .malformedProgram => true
+  | _ => false
+
+theorem productReady :
+    singletonWithin RuleConformance.endpoint (RuleConformance.d (-3)) =
+      .ready RuleConformance.productFact :=
+  Rule.ready?_eq (by rfl)
+
+theorem productShape : RuleConformance.productFact.view =
+    .bounds (.finite (RuleConformance.d (-3)) false)
+      (.finite (RuleConformance.d (-3)) false) := by
+  simpa [Raw.normalizeUnchecked, Raw.consistent] using
+    view_singletonWithin_ready productReady
+
+private theorem eq_of_mem_singleton {value : Dyadic} {result : Hex.Interval} {z : ℝ}
+    (checked : Hex.Interval.singletonWithin RuleConformance.endpoint value = .ready result)
+    (member : result.Contains z) : z = Hex.Interval.toReal value := by
+  change result.view.Contains z at member
+  rw [Hex.Interval.view_singletonWithin_ready checked,
+    Hex.Interval.contains_normalize] at member
+  exact le_antisymm member.2 member.1
+
+private theorem toReal_d (value : Int) :
+    Hex.Interval.toReal (RuleConformance.d value) = value := by
+  change ((Dyadic.ofInt value).toRat : ℝ) = value
+  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
+  norm_num
+
+def fallbackEvidence : Proof.Evidence
+    ((Rule.semantics config.rule).Entails input.program
+      (Proof.initialBase input) input.target) :=
+  { proof := by
+      intro valuation model assumptions
+      change NodeId → ℝ at valuation
+      have xMember : RuleConformance.xFact.Contains (valuation RuleConformance.x) := by
+        exact assumptions { node := RuleConformance.x, fact := RuleConformance.xFact } (by
+          simp [Proof.initialBase, input, RuleConformance.x])
+      have yMember : RuleConformance.yFact.Contains (valuation RuleConformance.y) := by
+        exact assumptions { node := RuleConformance.y, fact := RuleConformance.yFact } (by
+          simp [Proof.initialBase, input, RuleConformance.y])
+      have sumRelation : valuation RuleConformance.sum =
+          valuation RuleConformance.x + valuation RuleConformance.y :=
+        Rule.binaryRelation (config := config.rule) (valuation := valuation)
+          (node := RuleConformance.sum) (left := RuleConformance.x)
+          (right := RuleConformance.y) (index := 2)
+          (relation := fun left right => left + right)
+          (Rule.nodeMeaning config.rule model (node := RuleConformance.sum) (by rfl))
+          (Or.inl ⟨rfl, rfl⟩)
+      have subRelation : valuation RuleConformance.difference =
+          valuation RuleConformance.x - valuation RuleConformance.y :=
+        Rule.binaryRelation (config := config.rule) (valuation := valuation)
+          (node := RuleConformance.difference) (left := RuleConformance.x)
+          (right := RuleConformance.y) (index := 3)
+          (relation := fun left right => left - right)
+          (Rule.nodeMeaning config.rule model (node := RuleConformance.difference) (by rfl))
+          (Or.inr (Or.inl ⟨rfl, rfl⟩))
+      have mulRelation : valuation RuleConformance.product =
+          valuation RuleConformance.sum * valuation RuleConformance.difference :=
+        Rule.binaryRelation (config := config.rule) (valuation := valuation)
+          (node := RuleConformance.product) (left := RuleConformance.sum)
+          (right := RuleConformance.difference) (index := 4)
+          (relation := fun left right => left * right)
+          (Rule.nodeMeaning config.rule model (node := RuleConformance.product) (by rfl))
+          (Or.inr (Or.inr (Or.inl ⟨rfl, rfl⟩)))
+      have xEq := eq_of_mem_singleton RuleConformance.checkedX xMember
+      have yEq := eq_of_mem_singleton RuleConformance.checkedY yMember
+      rw [toReal_d] at xEq yEq
+      have productEq : valuation RuleConformance.product = -3 := by
+        rw [mulRelation, sumRelation, subRelation, xEq, yEq]
+        norm_num
+      change RuleConformance.productFact.Contains (valuation RuleConformance.product)
+      rw [productEq]
+      have member := Rule.constant_mem productReady
+      rw [toReal_d] at member
+      simpa using member }
+
+def evidence : Proof.Evidence
+    ((Rule.semantics config.rule).Entails input.program
+      (Proof.initialBase input) input.target) :=
+  match evidence? with
+  | .ok found => found
+  | .error _ => fallbackEvidence
+
+theorem closesConjunction (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node)) :
+    (Lower.finite (RuleConformance.d (-3)) false).Contains
+        (valuation RuleConformance.product) ∧
+      (Upper.finite (RuleConformance.d (-3)) false).Contains
+        (valuation RuleConformance.product) := by
+  exact Frontend.closeBounds config input evidence valuation model assumptions
+    (.finite (RuleConformance.d (-3)) false)
+    (.finite (RuleConformance.d (-3)) false) productShape
+
+theorem closesLower (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node)) :
+    toReal (RuleConformance.d (-3)) ≤ valuation RuleConformance.product := by
+  exact Frontend.closeLower config input evidence valuation model assumptions
+    (RuleConformance.d (-3)) false (.finite (RuleConformance.d (-3)) false) productShape
+
+theorem closesEquality (valuation : NodeId → ℝ)
+    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (valuation fact.node)) :
+    valuation RuleConformance.product = toReal (RuleConformance.d (-3)) := by
+  exact Frontend.closeSingleton config input evidence valuation model assumptions
+    (RuleConformance.d (-3)) productShape
+
+#print axioms closesConjunction
+#print axioms closesLower
+#print axioms closesEquality
+
+end Hex.IntervalMathlib.FrontendConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -425,7 +425,8 @@ lean_lib HexIntervalMathlib where
     `HexIntervalMathlib.Power, `HexIntervalMathlib.Split,
     `HexIntervalMathlib.Inverse, `HexIntervalMathlib.Division,
     `HexIntervalMathlib.Regularize, `HexIntervalMathlib.Program,
-    `HexIntervalMathlib.Proof, `HexIntervalMathlib.Rule].map Glob.one
+    `HexIntervalMathlib.Proof, `HexIntervalMathlib.Rule,
+    `HexIntervalMathlib.Frontend].map Glob.one
 
 lean_lib HexIntervalReplayProbe where
   srcDir := "bench"
@@ -521,6 +522,7 @@ lean_lib HexConformance where
       `HexInterval.SearchConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.RuleConformance,
+      `HexIntervalMathlib.FrontendConformance,
       `HexIntervalMathlib.MixedFunctionsConformance,
       `HexIntervalMathlib.MixedInstantiationConformance,
       `HexIntervalMathlib.ExactBranchConformance].map Glob.one

--- a/progress/20260815T171554Z.md
+++ b/progress/20260815T171554Z.md
@@ -1,0 +1,42 @@
+# Supported programmatic arithmetic frontend
+
+## Accomplished
+
+- Added `HexIntervalMathlib/Frontend.lean`, a supported programmatic frontend
+  over the supported Program/Rule/Proof contracts. It recursively reifies a
+  bounded arithmetic term language with structural sharing and stable-key
+  resolution, binds exact selected sources, assembles the bounded arithmetic
+  registry, and invokes chronological replay without granting runtime state
+  proof authority.
+- Added ordinary theorem combinators for exact target membership, lower and
+  upper inequalities, two-sided conjunctions, and closed-singleton equality.
+- Added `FrontendConformance` with live shared-DAG reconstruction and replay,
+  configured-constant placement, duplicate-key and source/node/depth rejection,
+  exact source binding, and guarded ordinary-theorem axiom reports.
+- Updated the supported umbrella, Lake targets, central file map/current-state
+  wording, and Mathlib companion boundary/conformance specification.
+- The full 9,496-job conformance build, focused supported/experiment build, and
+  trust, release-manifest, manual-split, factor-freshness, whitespace, and
+  banned-mechanism checks pass.
+
+## Current frontier
+
+- This exact parent predates supported inverse, division, and regularization;
+  their Rule and frontend term cases belong in the current-main restack rather
+  than a durable unsupported claim here.
+- The frontend accepts a typed programmatic term, exact source intervals, and
+  already-quoted chronology. Lean-expression parsing, local-hypothesis proof
+  synthesis, quotation of supported records into `Expr`, tactic syntax, search
+  orchestration, and arbitrary-function package discovery remain experimental.
+
+## Next step
+
+- Restack the supported Rule/frontend edges onto current main, register the
+  newly supported inverse/division/regularization schemas, then implement the
+  supported Meta quotation and elaboration bridge before exposing tactic syntax.
+
+## Blockers
+
+- No blocker for the programmatic frontend. A public tactic would currently
+  require importing experimental encoders and replay types, so tactic syntax is
+  intentionally deferred until a supported quotation/elaboration bridge exists.

--- a/progress/20260821T145124Z.md
+++ b/progress/20260821T145124Z.md
@@ -1,0 +1,41 @@
+# Supported arithmetic frontend extraction
+
+## Accomplished
+
+- Reconciled the supported programmatic arithmetic frontend onto the merged
+  Rule, Proof, Search, Policy, and State contracts.
+- Extended recursive terms through reciprocal, division, and regularization
+  while preserving the package's single configured constant, exponent, and
+  precision.
+- Added explicit operation-array admission and exact transparent-result
+  validation for node ownership, structural sharing, operation keys, ordered
+  child edges, and source indices before fact seeding.
+- Added malformed-result and resource mutation guards and retained ordinary
+  lower, upper, conjunction, and singleton-equality closure canaries.
+- Updated the supported module maps and current-state specifications without
+  claiming Lean-expression parsing, tactic syntax, or search-tree recipe
+  extraction.
+- Built the frontend, Rule, and Chebyshev conformance targets and passed the
+  DAG, trust-surface, Mathlib-free bench, conformance-target, PNT inventory,
+  source hygiene, and factor-freshness checks.
+
+## Current frontier
+
+The supported surface now owns bounded recursive arithmetic reification,
+validated context seeding, flat caller-supplied chronology replay, and
+programmatic theorem closure. Runtime chronology remains untrusted and is
+authenticated again by Rule and Proof.
+
+## Next step
+
+After this edge lands, extract the supported Lean quotation and goal-reifier
+bridge only for expressions and hypotheses that can be translated to this
+frontend without importing experimental certificate types. Search-driven
+closure should wait for the retained tree/recipe bridge rather than fabricating
+a flat chronology.
+
+## Blockers
+
+None for the scoped programmatic frontend. Construction and structural
+equality of already-built caller `Term` values remain explicitly outside the
+preemptible resource envelope.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -628,5 +628,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "2148017bd5b97da69cbe5f3d5147fa746153ab22",
     "reason": "Additionally registers the supported HexIntervalMathlib built-in arithmetic Rule module and its proof-only conformance on top of the current public interval, Proof, Chebyshev, and PNT registrations; they do not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "a50c9bf48b55e2dc948f33b033e459404dde259a",
+    "reason": "Additionally registers the supported HexIntervalMathlib flat programmatic arithmetic frontend and its proof-only replay/closure conformance on top of the current Rule, Chebyshev, public interval, and PNT registrations; they do not enter the factorization service target or change its executable dependency graph."
   }
 ]


### PR DESCRIPTION
## Summary

- add a supported, tactic-independent arithmetic Term reifier over the current Rule operation registry
- validate transparent reification results, exact source bindings, stable operation keys, ordered child edges, and explicit source/operation/node/depth limits
- replay an explicit flat caller-supplied chronology through supported Rule/Proof and expose programmatic lower, upper, conjunction, and singleton-equality closure
- cover current reciprocal, division, regularization, power, and elementary arithmetic operations while preserving the package-owned constant/exponent/precision model

## Scope

This PR does not add Lean-expression or local-hypothesis parsing, tactic syntax, retained-search-tree recipes, or search-to-proof orchestration. Runtime chronology remains untrusted and is reauthenticated by the supported Rule/Proof layer. Construction and structural equality of already-built caller Term values remain an explicit non-preemptible programmatic-caller cost.

## Verification

- lake build HexIntervalMathlib
- lake build HexIntervalMathlib.Frontend HexIntervalMathlib.FrontendConformance HexIntervalMathlib.RuleConformance HexIntervalMathlib.PntChebyshevConformance
- DAG and DAG unit checks
- published trust-surface and banned-mechanism checks
- Mathlib-free bench boundary and conformance-target checks
- PNT inventory and inventory unit checks
- factor-sweep freshness, source hygiene, and diff checks
