### PR TITLE
feat(interval): derive frontend semantic models

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5264,10 +5264,12 @@ their declared cost inside a scheduler bound.
   outward containment, and raw-cut idempotence without a grid-tightest claim.
 - `HexIntervalMathlib/Frontend.lean`: bounded recursive arithmetic-term
   reification with structural sharing and stable-key resolution, checked
-  node/term correspondence and exact source binding, supported
-  registry/flat-replay invocation, and programmatic lower,
-  upper, conjunction, and closed-singleton equality closure. Search-to-recipe
-  integration, Lean syntax, and Meta quotation remain outside this module.
+  node/term/root correspondence and exact source binding, derivation of the
+  complete real `Program.Models` witness from caller source values, supported
+  registry/flat-replay invocation, and programmatic lower, upper, conjunction,
+  and closed-singleton equality closure about the evaluated target term.
+  Search-to-recipe integration, Lean syntax, and Meta quotation remain outside
+  this module.
 - `HexInterval/Program.lean`: supported stable operation/domain/node
   identifiers, decoded typed SSA programs, fail-closed validation, and
   structural depths.
@@ -5350,8 +5352,9 @@ their declared cost inside a scheduler bound.
   non-default complete-family proof and conformance profile.
 - `conformance/HexIntervalMathlib/FrontendConformance.lean`: supported
   recursive shared-DAG reification, exact source binding, malformed-entry,
-  stable-key, and resource rejection, flat chronological replay, and ordinary
-  inequality, conjunction, and equality theorem/axiom canaries.
+  root/operation-table, stable-key, and resource rejection, derived semantic
+  model, flat chronological replay, and ordinary inequality, conjunction, and
+  equality theorem/axiom canaries without a caller-supplied `Program.Models`.
 - `bench/HexInterval/Bench.lean`: Mathlib-free interval and scheduler
   benchmarks.
 

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -17,7 +17,10 @@ This module is the supported, tactic-independent frontend boundary. It
 recursively reifies a small arithmetic term language into the exact supported
 SSA `Program`, resolves operations by stable key, constructs version-zero
 source facts, invokes the supported Rule/Proof replay, and closes interval
-membership to ordinary bounds, conjunctions, or singleton equality.
+membership to ordinary bounds, conjunctions, or singleton equality. A checked
+result also derives its exact `Program.Models` witness from caller source values
+and authenticates that the retained root denotes the original target term, so
+the caller does not assemble one semantic relation proof per SSA node.
 
 It intentionally contains no syntax elaborator. Turning arbitrary Lean
 expressions and local hypotheses into this programmatic input additionally
@@ -82,6 +85,7 @@ structure State where
 structure Result where
   program : Program
   target : NodeId
+  term : Term
   entries : Array Entry
   sourceCount : Nat
   deriving DecidableEq, Repr
@@ -118,6 +122,94 @@ def operationKey : Term → OpKey
   | .inv _ => Rule.invOp.key
   | .div _ _ => Rule.divOp.key
   | .regularize _ => Rule.regularizeOp.key
+
+/-- Exact built-in operation-table slot for one frontend term. Arbitrary
+package meanings remain an authenticated suffix and are not reified by this
+arithmetic frontend. -/
+protected def Term.opIndex : Term → Nat
+  | .source _ => 0
+  | .neg _ => 1
+  | .add _ _ => 2
+  | .sub _ _ => 3
+  | .mul _ _ => 4
+  | .pow _ => 5
+  | .abs _ => 6
+  | .min _ _ => 7
+  | .max _ _ => 8
+  | .constant => 9
+  | .inv _ => 10
+  | .div _ _ => 11
+  | .regularize _ => 12
+
+protected def Term.inputs : Term → List Term
+  | .source _ | .constant => []
+  | .neg input | .pow input | .abs input | .inv input | .regularize input => [input]
+  | .add left right | .sub left right | .mul left right | .div left right |
+      .min left right | .max left right => [left, right]
+
+/-- Short-circuit before descending beyond the caller's admitted term depth.
+This authenticates decoded `Result` terms; `reifyWithin` enforces the same
+root-at-depth-zero convention while constructing them. -/
+protected def Term.depthWithin : Nat → Term → Bool
+  | _, .source _ | _, .constant => true
+  | 0, _ => false
+  | depth + 1, .neg input | depth + 1, .pow input | depth + 1, .abs input |
+      depth + 1, .inv input | depth + 1, .regularize input =>
+      input.depthWithin depth
+  | depth + 1, .add left right | depth + 1, .sub left right |
+      depth + 1, .mul left right | depth + 1, .div left right |
+      depth + 1, .min left right | depth + 1, .max left right =>
+      left.depthWithin depth && right.depthWithin depth
+
+/-- Real evaluation of a frontend term under exact caller source values and
+the package-owned constant and natural exponent. -/
+noncomputable def Term.eval (config : Rule.Config) (sources : Nat → ℝ) : Term → ℝ
+  | .source index => sources index
+  | .constant => toReal config.constant
+  | .neg input => -(input.eval config sources)
+  | .add left right => left.eval config sources + right.eval config sources
+  | .sub left right => left.eval config sources - right.eval config sources
+  | .mul left right => left.eval config sources * right.eval config sources
+  | .pow input => input.eval config sources ^ config.exponent
+  | .abs input => |input.eval config sources|
+  | .min left right => if left.eval config sources ≤ right.eval config sources then
+      left.eval config sources else right.eval config sources
+  | .max left right => if left.eval config sources ≤ right.eval config sources then
+      right.eval config sources else left.eval config sources
+  | .inv input => (input.eval config sources)⁻¹
+  | .div left right => left.eval config sources / right.eval config sources
+  | .regularize input => input.eval config sources
+
+/-- Exact built-in semantic meaning selected by a frontend term. -/
+protected def Term.meaning (config : Rule.Config) : Term → Program.Meaning ℝ
+  | .source _ => Rule.sourceMeaning
+  | .constant => Rule.constantMeaning config.constant
+  | .neg _ => Rule.negMeaning
+  | .add _ _ => Rule.addMeaning
+  | .sub _ _ => Rule.subMeaning
+  | .mul _ _ => Rule.mulMeaning
+  | .pow _ => Rule.powMeaning config.exponent
+  | .abs _ => Rule.absMeaning
+  | .min _ _ => Rule.minMeaning
+  | .max _ _ => Rule.maxMeaning
+  | .inv _ => Rule.invMeaning
+  | .div _ _ => Rule.divMeaning
+  | .regularize _ => Rule.regularizeMeaning
+
+theorem Term.meaningAt (config : Rule.Config) (term : Term) :
+    (Rule.meanings config)[term.opIndex]? = some (term.meaning config) := by
+  cases term <;>
+    simp [Term.opIndex, Term.meaning, Rule.meanings, Rule.builtinMeanings,
+      Array.getElem?_append]
+
+theorem Term.related (config : Rule.Config) (sources : Nat → ℝ) (term : Term) :
+    (term.meaning config).relation (term.inputs.map (Term.eval config sources))
+      (term.eval config sources) := by
+  cases term <;>
+    simp [Term.inputs, Term.eval, Term.meaning, Rule.sourceMeaning, Rule.negMeaning,
+      Rule.addMeaning, Rule.subMeaning, Rule.mulMeaning, Rule.powMeaning, Rule.absMeaning,
+      Rule.minMeaning, Rule.maxMeaning, Rule.constantMeaning, Rule.invMeaning,
+      Rule.divMeaning, Rule.regularizeMeaning, min_def, max_def]
 
 def install (config : Config) (term : Term) (reified : List NodeId)
     (state : State) : Except Error (NodeId × State) := do
@@ -167,16 +259,10 @@ def reifyWithin (config : Config) (sourceCount : Nat) (target : Term) :
     { operations := (Rule.meanings config.rule).map (Program.Meaning.operation)
       nodes := state.nodes }
   if !program.check then throw .malformedProgram
-  pure { program, target := targetNode, entries := state.entries, sourceCount }
+  pure { program, target := targetNode, term := target, entries := state.entries, sourceCount }
 
 def Result.sourceNode? (result : Result) (index : Nat) : Option NodeId :=
   (result.entries.toList.find? fun entry => entry.term == .source index).map (·.node)
-
-protected def Term.inputs : Term → List Term
-  | .source _ | .constant => []
-  | .neg input | .pow input | .abs input | .inv input | .regularize input => [input]
-  | .add left right | .sub left right | .mul left right | .div left right |
-      .min left right | .max left right => [left, right]
 
 protected def Result.inputsMatch (entries : Array Entry) : List Term → List NodeId → Bool
   | [], [] => true
@@ -195,20 +281,161 @@ This pins one entry to every SSA node, structural CSE, operation keys and
 ordered child edges. The caller-facing resource checks run before this bounded
 scan; structural equality of the already-constructed `Term` values remains a
 programmatic-caller cost. -/
-def Result.check (result : Result) : Bool :=
+protected def Result.slotCheck (result : Result) (index : Nat) : Bool :=
+  match result.entries[index]?, result.program.nodes[index]? with
+  | some entry, some node =>
+      entry.node.index == index &&
+        node.op.index == entry.term.opIndex &&
+        (result.program.operation? node.op).any
+          (fun operation => operation.key == operationKey entry.term) &&
+        (match entry.term with
+          | .source source => source < result.sourceCount
+          | _ => true) &&
+        Result.inputsMatch result.entries entry.term.inputs node.args
+  | _, _ => false
+
+protected def Result.headerCheck (result : Result) : Bool :=
   result.entries.size == result.program.nodes.size &&
     Result.uniqueTerms result.entries.toList &&
-    (List.range result.entries.size).all fun index =>
-      match result.entries[index]?, result.program.nodes[index]? with
-      | some entry, some node =>
-          entry.node.index == index &&
-            (result.program.operation? node.op).any
-              (fun operation => operation.key == operationKey entry.term) &&
-            (match entry.term with
-              | .source source => source < result.sourceCount
-              | _ => true) &&
-            Result.inputsMatch result.entries entry.term.inputs node.args
-      | _, _ => false
+    (result.entries[result.target.index]?).any (fun entry => entry.term == result.term)
+
+def Result.check (result : Result) : Bool :=
+  result.headerCheck && (List.range result.entries.size).all result.slotCheck
+
+/-- Every retained recursive term respects the same depth cap used by the
+constructor. The array-size preflight must run before this traversal. -/
+def Result.depthCheck (result : Result) (maxDepth : Nat) : Bool :=
+  result.entries.toList.all (fun entry => entry.term.depthWithin maxDepth)
+
+protected noncomputable def Result.valueAt (config : Rule.Config) (sources : Nat → ℝ)
+    (entries : Array Entry) (node : NodeId) : ℝ :=
+  (entries[node.index]?).map (fun entry => entry.term.eval config sources) |>.getD 0
+
+/-- Evaluate the exact term retained at one checked SSA node. Out-of-range
+values are irrelevant because `Program.Models` quantifies only program nodes. -/
+noncomputable def Result.valuation (config : Rule.Config) (sources : Nat → ℝ)
+    (result : Result) (node : NodeId) : ℝ :=
+  Result.valueAt config sources result.entries node
+
+private theorem Result.slot_of_check (result : Result) (checked : result.check)
+    {index : Nat} (within : index < result.entries.size) : result.slotCheck index := by
+  have split : result.headerCheck = true ∧
+      (List.range result.entries.size).all result.slotCheck = true := by
+    simpa [Result.check, Bool.and_eq_true] using checked
+  have all := split.2
+  simp only [List.all_eq_true] at all
+  exact all index (List.mem_range.mpr within)
+
+private theorem Result.inputs_eval (config : Rule.Config) (sources : Nat → ℝ)
+    (entries : Array Entry) {terms : List Term} {nodes : List NodeId}
+    (matched : Result.inputsMatch entries terms nodes) :
+    nodes.map (Result.valueAt config sources entries) = terms.map (Term.eval config sources) := by
+  induction terms generalizing nodes with
+  | nil => cases nodes <;> simp [Result.inputsMatch] at matched ⊢
+  | cons term terms ih =>
+      cases nodes with
+      | nil => simp [Result.inputsMatch] at matched
+      | cons node nodes =>
+          simp only [Result.inputsMatch, Bool.and_eq_true] at matched
+          generalize found : entries[node.index]? = entry? at matched
+          cases entry? with
+          | none => simp at matched
+          | some entry =>
+              have termEq : entry.term = term := by simpa using matched.1
+              simp [Result.valueAt, found, termEq, ih matched.2]
+
+/-- The checked reification record determines a mathematical model from source
+values; callers do not reconstruct one semantic relation per SSA node. -/
+theorem Result.models (config : Rule.Config) (sources : Nat → ℝ)
+    (result : Result) (checked : result.check)
+    (operations : result.program.operations =
+      (Rule.meanings config).map (Program.Meaning.operation)) :
+    Program.Models (Rule.meanings config) result.program
+      (result.valuation config sources) := by
+  refine ⟨operations, ?_⟩
+  intro node instruction found
+  have split : result.headerCheck = true ∧
+      (List.range result.entries.size).all result.slotCheck = true := by
+    simpa [Result.check, Bool.and_eq_true] using checked
+  have header := split.1
+  simp only [Result.headerCheck, Bool.and_eq_true, beq_iff_eq] at header
+  have nodeFound : result.program.nodes[node.index]? = some instruction := by
+    simpa [Program.node?] using found
+  have nodeWithin : node.index < result.program.nodes.size := by
+    by_contra outside
+    have none : result.program.nodes[node.index]? = none := by simp [outside]
+    rw [none] at nodeFound
+    contradiction
+  have entryWithin : node.index < result.entries.size := by
+    simpa [header.1] using nodeWithin
+  let entry := result.entries[node.index]'entryWithin
+  have entryFound : result.entries[node.index]? = some entry := by simp [entry]
+  have slot := result.slot_of_check checked entryWithin
+  simp only [Result.slotCheck, entryFound, nodeFound,
+    Bool.and_eq_true, beq_iff_eq] at slot
+  have opIndex := slot.1.1.1.2
+  have inputs := slot.2
+  refine ⟨entry.term.meaning config, ?_, ?_⟩
+  · rw [opIndex]
+    exact entry.term.meaningAt config
+  · have values := Result.inputs_eval config sources result.entries inputs
+    have values' : instruction.args.map (result.valuation config sources) =
+        entry.term.inputs.map (Term.eval config sources) := by
+      change instruction.args.map (Result.valueAt config sources result.entries) =
+        entry.term.inputs.map (Term.eval config sources)
+      exact values
+    have atNode : result.valuation config sources node = entry.term.eval config sources := by
+      simp [Result.valuation, Result.valueAt, entryFound]
+    rw [values', atNode]
+    exact entry.term.related config sources
+
+theorem Result.target_eval (config : Rule.Config) (sources : Nat → ℝ)
+    (result : Result) (checked : result.check) :
+    result.valuation config sources result.target = result.term.eval config sources := by
+  have split : result.headerCheck = true ∧
+      (List.range result.entries.size).all result.slotCheck = true := by
+    simpa [Result.check, Bool.and_eq_true] using checked
+  have header := split.1
+  simp only [Result.headerCheck, Bool.and_eq_true, beq_iff_eq] at header
+  generalize found : result.entries[result.target.index]? = entry? at header
+  cases entry? with
+  | none => simp at header
+  | some entry =>
+      have root := header.2
+      simp only [Option.any_some, beq_iff_eq] at root
+      have termEq : entry.term = result.term := root
+      simp [Result.valuation, Result.valueAt, found, termEq]
+
+/-- Proof-carrying semantic interpretation derived from one checked reifier
+result. Its valuation is fixed by the retained term at every node, and the
+authenticated root evaluates to the caller's original target term. -/
+structure Model (config : Rule.Config) (sources : Nat → ℝ) (result : Result) : Type where
+  sound : Program.Models (Rule.meanings config) result.program
+    (result.valuation config sources)
+  target : result.valuation config sources result.target = result.term.eval config sources
+
+/-- Recheck all caps and structural bindings before deriving the semantic
+model. Failure returns no partially authenticated model. Caller source values
+are an opaque function and are not traversed by this operation. -/
+def modelWithin (config : Config) (sources : Nat → ℝ) (result : Result) :
+    Except Error (Model config.rule sources result) := do
+  if config.reify.maxSources < result.sourceCount then throw .sourceLimit
+  let meanings := Rule.meanings config.rule
+  if config.reify.maxOperations < meanings.size ||
+      config.reify.maxOperations < result.program.operations.size then
+    throw .operationLimit
+  if config.reify.maxNodes < result.program.nodes.size ||
+      config.reify.maxNodes < result.entries.size then throw .nodeLimit
+  if !result.depthCheck config.reify.maxDepth then throw .depthLimit
+  if result.target.index ≥ result.program.nodes.size || !result.program.check then
+    throw .malformedProgram
+  if operations : result.program.operations = meanings.map (Program.Meaning.operation) then
+    if checked : result.check then
+      pure {
+        sound := result.models config.rule sources checked operations
+        target := result.target_eval config.rule sources checked }
+    else throw .malformedResult
+  else throw .malformedProgram
 
 /-- Revalidate the bounded reification result, including its exact node/term
 correspondence, bind every selected source exactly once, and seed all computed
@@ -224,6 +451,7 @@ def inputWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
     throw .operationLimit
   if config.reify.maxNodes < result.program.nodes.size ||
       config.reify.maxNodes < result.entries.size then throw .nodeLimit
+  if !result.depthCheck config.reify.maxDepth then throw .depthLimit
   if result.target.index ≥ result.program.nodes.size || !result.program.check then
     throw .malformedProgram
   if result.program.operations != meanings.map (Program.Meaning.operation) then
@@ -273,6 +501,95 @@ theorem close (config : Config) (input : Proof.Input Hex.Interval)
   exact evidence.proof valuation model (by
     intro fact member
     simpa [Rule.semantics, Proof.Semantics.ofMeanings] using assumptions fact member)
+
+/-- Eliminate replay evidence at the exact model and target root derived from
+the checked reification result. The caller supplies source values and proves
+only that its version-zero interval facts contain those values. -/
+theorem closeTerm (config : Config) (result : Result) (sources : Nat → ℝ)
+    (model : Model config.rule sources result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config.rule sources fact.node)) :
+    input.target.fact.Contains (result.term.eval config.rule sources) := by
+  have programModel : Program.Models (Rule.meanings config.rule) input.program
+      (result.valuation config.rule sources) := by
+    simpa [program] using model.sound
+  have member := close config input evidence (result.valuation config.rule sources)
+    programModel assumptions
+  rw [target, model.target] at member
+  exact member
+
+/-- Close both endpoint predicates at the checked reifier target. -/
+theorem closeTermBounds (config : Config) (result : Result) (sources : Nat → ℝ)
+    (model : Model config.rule sources result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config.rule sources fact.node))
+    (lower : Lower) (upper : Upper)
+    (shape : input.target.fact.view = .bounds lower upper) :
+    lower.Contains (result.term.eval config.rule sources) ∧
+      upper.Contains (result.term.eval config.rule sources) := by
+  have member := closeTerm config result sources model input evidence program target assumptions
+  change input.target.fact.view.Contains (result.term.eval config.rule sources) at member
+  simpa [shape, Raw.Contains] using member
+
+/-- Close a lower endpoint predicate at the checked reifier target. -/
+theorem closeTermLower (config : Config) (result : Result) (sources : Nat → ℝ)
+    (model : Model config.rule sources result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config.rule sources fact.node))
+    (value : Dyadic) (strict : Bool) (upper : Upper)
+    (shape : input.target.fact.view = .bounds (.finite value strict) upper) :
+    (Lower.finite value strict).Contains (result.term.eval config.rule sources) :=
+  (closeTermBounds config result sources model input evidence program target assumptions
+    _ _ shape).1
+
+/-- Close an upper endpoint predicate at the checked reifier target. -/
+theorem closeTermUpper (config : Config) (result : Result) (sources : Nat → ℝ)
+    (model : Model config.rule sources result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config.rule sources fact.node))
+    (lower : Lower) (value : Dyadic) (strict : Bool)
+    (shape : input.target.fact.view = .bounds lower (.finite value strict)) :
+    (Upper.finite value strict).Contains (result.term.eval config.rule sources) :=
+  (closeTermBounds config result sources model input evidence program target assumptions
+    _ _ shape).2
+
+/-- Close a singleton equality at the checked reifier target. -/
+theorem closeTermSingleton (config : Config) (result : Result) (sources : Nat → ℝ)
+    (model : Model config.rule sources result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config.rule sources fact.node))
+    (value : Dyadic)
+    (shape : input.target.fact.view =
+      .bounds (.finite value false) (.finite value false)) :
+    result.term.eval config.rule sources = toReal value := by
+  rcases closeTermBounds config result sources model input evidence program target assumptions
+    _ _ shape with ⟨lower, upper⟩
+  exact le_antisymm upper lower
 
 /-- Close both endpoint predicates. This is the conjunction frontend used for
 two-sided inequality goals. -/

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -47,14 +47,21 @@ and are not re-exported by the public umbrella.
 The supported `Frontend` is instead a tactic-independent, flat programmatic
 client. It recursively reifies bounded `Term` values by stable operation key,
 rechecks the transparent result's exact node/term/ordered-edge correspondence,
-binds the exact selected source intervals, invokes Rule/Proof replay on an
-explicit caller-supplied event list, and eliminates the resulting evidence to
-lower, upper, conjunction, or closed-singleton equality theorems. It covers
+and authenticates that the retained root is the original target term. From a
+caller mapping of source indices to real values it derives the complete exact
+`Program.Models` witness; callers prove only that their version-zero source
+intervals contain those values, rather than reconstructing one semantic
+relation per SSA node. The frontend binds the exact selected source intervals,
+invokes Rule/Proof replay on an explicit caller-supplied event list, and
+eliminates the resulting evidence to lower, upper, conjunction, or
+closed-singleton equality theorems about the evaluated target `Term`. It covers
 the current Rule operations but inherits the package's one shared exponent,
-constant, and precision. Array caps precede the revalidation scans, while
-construction and structural equality of programmatic caller `Term` values are
-not preemptible. It does not parse Lean expressions or hypotheses, extract
-recipes from generic Search trees, or expose tactic syntax.
+constant, and precision. Array caps and a short-circuit recursive-depth check
+precede the revalidation scans, while construction and structural equality of
+programmatic caller `Term` values and the caller's opaque source-value function
+are not preemptible. It does not
+parse Lean expressions or hypotheses, extract recipes from generic Search
+trees, or expose tactic syntax.
 The user-facing tactic contract below is the release target, not a claim that
 the tactic is already supported.
 

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -45,13 +45,48 @@ def expectedProgram : Program :=
   | .error _ => false
 
 def result : Frontend.Result :=
+  { program := expectedProgram
+    target := RuleConformance.product
+    term := term
+    entries :=
+      #[{ term := .source 0, node := RuleConformance.x },
+        { term := .source 1, node := RuleConformance.y },
+        { term := .add (.source 0) (.source 1), node := RuleConformance.sum },
+        { term := .sub (.source 0) (.source 1), node := RuleConformance.difference },
+        { term, node := RuleConformance.product }]
+    sourceCount := 2 }
+
+def sourceValues : Nat → ℝ
+  | 0 => 1
+  | 1 => 2
+  | _ => 0
+
+def model? := Frontend.modelWithin config sourceValues result
+
+#guard match model? with | .ok _ => true | .error _ => false
+#guard
   match result? with
-  | .ok result => result
-  | .error _ =>
-      { program := expectedProgram
-        target := RuleConformance.product
-        entries := #[]
-        sourceCount := 2 }
+  | .ok found => found.program == result.program && found.target == result.target &&
+      found.term == result.term && found.entries == result.entries &&
+      found.sourceCount == result.sourceCount
+  | .error _ => false
+
+theorem resultChecked : result.check := by decide
+
+theorem resultOperations : result.program.operations =
+    (Rule.meanings config.rule).map (Program.Meaning.operation) := by
+  simp [result, expectedProgram, RuleConformance.program, config, RuleConformance.config,
+    Rule.meanings, Rule.builtinMeanings, Rule.operations, Rule.sourceMeaning,
+    Rule.negMeaning, Rule.addMeaning, Rule.subMeaning, Rule.mulMeaning, Rule.powMeaning,
+    Rule.absMeaning, Rule.minMeaning, Rule.maxMeaning, Rule.constantMeaning, Rule.invMeaning,
+    Rule.divMeaning, Rule.regularizeMeaning]
+
+noncomputable def semanticModel : Frontend.Model config.rule sourceValues result :=
+  { sound := result.models config.rule sourceValues resultChecked resultOperations
+    target := result.target_eval config.rule sourceValues resultChecked }
+
+theorem targetValue : term.eval config.rule sourceValues = -3 := by
+  norm_num [term, Frontend.Term.eval, sourceValues]
 
 def input? := Frontend.inputWithin config RuleConformance.scope result
   #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact
@@ -115,6 +150,15 @@ def duplicateEntry : Frontend.Result :=
   let bad : Frontend.Entry := { term := .source 0, node := { index := 1 } }
   { result with entries := result.entries.set! 1 bad }
 
+def wrongRoot : Frontend.Result := { result with term := .source 0 }
+
+def wrongOperations : Frontend.Result :=
+  { result with program :=
+      { result.program with operations := result.program.operations.push RuleConformance.opaqueOp } }
+
+def roomy : Frontend.Config :=
+  { config with reify := { limits with maxOperations := 14 } }
+
 #guard
   match Frontend.inputWithin config RuleConformance.scope wrongEntryNode
       #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
@@ -129,6 +173,35 @@ def duplicateEntry : Frontend.Result :=
   match Frontend.inputWithin config RuleConformance.scope duplicateEntry
       #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
   | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputWithin config RuleConformance.scope wrongRoot
+      #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.modelWithin config sourceValues wrongRoot with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.modelWithin roomy sourceValues wrongOperations with
+  | .error .malformedProgram => true
+  | _ => false
+#guard
+  match Frontend.modelWithin fewNodes sourceValues result with
+  | .error .nodeLimit => true
+  | _ => false
+#guard
+  match Frontend.modelWithin shallow sourceValues result with
+  | .error .depthLimit => true
+  | _ => false
+#guard
+  match Frontend.modelWithin fewSources sourceValues result with
+  | .error .sourceLimit => true
+  | _ => false
+#guard
+  match Frontend.modelWithin fewOperations sourceValues result with
+  | .error .operationLimit => true
   | _ => false
 
 #guard
@@ -236,36 +309,37 @@ def evidence : Proof.Evidence
   | .ok found => found
   | .error _ => fallbackEvidence
 
-theorem closesConjunction (valuation : NodeId → ℝ)
-    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+theorem closesConjunction
     (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
-      fact.fact.Contains (valuation fact.node)) :
+      fact.fact.Contains (result.valuation config.rule sourceValues fact.node)) :
     (Lower.finite (RuleConformance.d (-3)) false).Contains
-        (valuation RuleConformance.product) ∧
+        (term.eval config.rule sourceValues) ∧
       (Upper.finite (RuleConformance.d (-3)) false).Contains
-        (valuation RuleConformance.product) := by
-  exact Frontend.closeBounds config input evidence valuation model assumptions
+        (term.eval config.rule sourceValues) := by
+  exact Frontend.closeTermBounds config result sourceValues semanticModel input evidence
+    (by decide) (by decide) assumptions
     (.finite (RuleConformance.d (-3)) false)
     (.finite (RuleConformance.d (-3)) false) productShape
 
-theorem closesLower (valuation : NodeId → ℝ)
-    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+theorem closesLower
     (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
-      fact.fact.Contains (valuation fact.node)) :
-    toReal (RuleConformance.d (-3)) ≤ valuation RuleConformance.product := by
-  exact Frontend.closeLower config input evidence valuation model assumptions
+      fact.fact.Contains (result.valuation config.rule sourceValues fact.node)) :
+    toReal (RuleConformance.d (-3)) ≤ term.eval config.rule sourceValues := by
+  exact Frontend.closeTermLower config result sourceValues semanticModel input evidence
+    (by decide) (by decide) assumptions
     (RuleConformance.d (-3)) false (.finite (RuleConformance.d (-3)) false) productShape
 
-theorem closesEquality (valuation : NodeId → ℝ)
-    (model : Program.Models (Rule.meanings config.rule) input.program valuation)
+theorem closesEquality
     (assumptions : ∀ fact, fact ∈ Proof.initialBase input →
-      fact.fact.Contains (valuation fact.node)) :
-    valuation RuleConformance.product = toReal (RuleConformance.d (-3)) := by
-  exact Frontend.closeSingleton config input evidence valuation model assumptions
+      fact.fact.Contains (result.valuation config.rule sourceValues fact.node)) :
+    term.eval config.rule sourceValues = toReal (RuleConformance.d (-3)) := by
+  exact Frontend.closeTermSingleton config result sourceValues semanticModel input evidence
+    (by decide) (by decide) assumptions
     (RuleConformance.d (-3)) productShape
 
 #print axioms closesConjunction
 #print axioms closesLower
 #print axioms closesEquality
+#print axioms targetValue
 
 end Hex.IntervalMathlib.FrontendConformance

--- a/progress/2026-08-21T15-27-39Z.md
+++ b/progress/2026-08-21T15-27-39Z.md
@@ -1,0 +1,31 @@
+# Supported frontend semantic model
+
+## Accomplished
+
+- Made the recursive frontend retain and authenticate its exact target term and
+  every term/node/operation/ordered-input correspondence.
+- Derived the complete real `Program.Models` interpretation from caller source
+  values, with a bounded fail-closed builder and exact root-evaluation proof.
+- Added decoded-result depth preflight before recursive term validation.
+- Added model-derived lower, upper, conjunction, and singleton-equality closure
+  APIs plus discriminating conformance for malformed roots, operation tables,
+  and resource limits.
+- Updated the current-state specifications to distinguish this supported
+  programmatic bridge from the still-missing Lean-expression and search-recipe
+  frontends.
+
+## Current frontier
+
+- The supported flat frontend can reify a `Term`, derive its semantics, replay
+  a caller chronology, and close an ordinary theorem without a caller-provided
+  `Program.Models` proof.
+
+## Next step
+
+- Add the supported Lean Meta quotation/parser layer, then connect retained
+  search recipes once that separate bridge is available.
+
+## Blockers
+
+- None for the programmatic semantic model. Tactic syntax still depends on the
+  separately planned Meta and search-to-recipe bridges.


### PR DESCRIPTION
## Summary

- authenticate the exact retained target term, SSA operation slot, ordered dependencies, and decoded term depth before semantic replay
- derive the complete `Program.Models` valuation and exact root evaluation from caller source values through resource-first `modelWithin`
- add `closeTerm`, `closeTermBounds`, `closeTermLower`, `closeTermUpper`, and `closeTermSingleton`, so callers supply source containment rather than one semantic proof per SSA node
- keep Lean-expression parsing, tactic syntax, and search-to-recipe integration outside this flat programmatic edge

## Validation

- `lake build HexIntervalMathlib HexConformance` (9583 jobs)
- DAG, copyright-header, line-count, trust-surface, Mathlib-free bench, conformance-target, PNT inventory, and factor-freshness checks
- guarded theorem axiom reports contain only standard foundations; no `native_decide`, `sorry`, or project axioms