### PR TITLE
feat(interval): retain sealed search result trees

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -44,6 +44,9 @@ authenticates selected actions, transactionally checks untrusted callback
 deltas, and supplies bounded stable branch-frontier accounting. Its specialized
 leaf frontier can advance only through the parent/depth/scope/branch-checked
 transition; generic frontier scheduling cannot be installed into it. A
+separate sealed retained-result tree reconstructs split children from the
+checked current parent snapshot and one exact seed delta, retains explicit
+target/refutation/unknown terminals, and carries no theorem authority. A
 deliberate `import all HexInterval.Search` is trusted implementation access,
 not decoded-runtime authority, and repository checks reject accidental uses.
 Concrete

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3226,11 +3226,17 @@ child snapshot. `Result.startWithin` admits one checked root.
 predecessor, structurally checks and retains the complete runtime split action,
 allocates the two fresh scopes through the sealed frontier, and reconstructs
 each restarted child from the checked current parent fact array with exactly
-one version-zero seed delta. It does not independently resolve the action's
-rule key against a package registry. All other child facts therefore come from
-the retained parent consequence snapshot rather than being reclassified as
-new assumptions. `Result.settleWithin` consumes the exact pending head and
-retains an exact target, refutation, or unknown record.
+one version-zero seed delta. The restarted `State.Branch` represents every
+inherited fact at version zero, resets every generation stamp to zero, has no
+history, and has `contradictory = false`. Its inherited facts are not thereby
+reclassified as assumptions or given intrinsic derived provenance by the child
+branch. Instead, the retained tree's exact parent/side/seed edge authenticates
+that they came from the current parent consequence snapshot. A downstream
+controller or proof quotation must consume that edge and must not carry
+pre-split generation stamps into the restarted child. `Result.splitWithin`
+does not independently resolve the action's rule key against a package
+registry. `Result.settleWithin` consumes the exact pending head and retains an
+exact target, refutation, or unknown record.
 Whole-tree validation reconstructs every parent/side/seed edge, restored
 parent, pending set, step/split/leaf/scope equation, branch state, and logical
 cost.
@@ -3242,6 +3248,13 @@ measurement, equality, and construction of arbitrary facts, causes, plans,
 schemas, and bodies remain explicitly non-preemptible; packages must bound
 those values before return. The split plan, schema, refutation record, target
 record, and runtime contradiction state are untrusted data, never evidence.
+As for the sealed frontier, `Result.Tree` is a reusable pure value rather than
+a linear capability. Reusing an old tree may form alternative successors, but
+the checked transition keeps scopes unique within each resulting lineage and
+cannot reset that lineage's retained counters. Limits are supplied per call,
+not stored in the tree: a later call may relax them, while a tightened call
+rejects an already-retained value which exceeds the new caps rather than
+grandfathering it.
 Semantic split coverage, package-owned refutation theorems, recursive proof
 replay, search-to-recipe quotation, and unknown-leaf rejection by a proof fold
 remain later supported edges.
@@ -5203,6 +5216,13 @@ candidates, and `b` the number of live branch states.
   validation independent of frontier size. Arbitrary callback execution and
   equality on caller-selected facts, causes, identifiers, and keys
   remain non-preemptible.
+- The current `Search.Result.Tree` reference builders validate the complete
+  retained prefix before and after every split or settlement. If `N` nodes are
+  retained incrementally and `B` is the bounded per-node branch/state
+  validation cost, this construction/revalidation term is `Θ(N² * B)`;
+  it is not an incremental tree-store bound. `maxNodes` therefore stays small
+  and measurement-gated until a production representation avoids repeated
+  full-prefix validation.
 - Fact comparison and contradiction checks use exact endpoint comparison. For
   the dyadic candidate, integer cost is proportional to effective endpoint
   height and the permitted exponent-alignment shift; a rational candidate must

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3217,6 +3217,35 @@ new wrapper becomes available. Thus the generic composite remains usable by a
 different sealed controller such as `BranchTree`, but it is not authority for
 the stronger leaf protocol for public-import clients.
 
+`Search.Result.Tree` is the supported retained-result prerequisite for a later
+proof-tree fold. Its private constructor keeps the exact node array, sealed
+`FrontierState Result.Id`, cumulative accounting, and logical cost together;
+callers cannot transplant a raw frontier, reset counters, or supply a complete
+child snapshot. `Result.startWithin` admits one checked root.
+`Result.splitWithin` authenticates the exact pending parent and current
+predecessor, structurally checks and retains the complete runtime split action,
+allocates the two fresh scopes through the sealed frontier, and reconstructs
+each restarted child from the checked current parent fact array with exactly
+one version-zero seed delta. It does not independently resolve the action's
+rule key against a package registry. All other child facts therefore come from
+the retained parent consequence snapshot rather than being reclassified as
+new assumptions. `Result.settleWithin` consumes the exact pending head and
+retains an exact target, refutation, or unknown record.
+Whole-tree validation reconstructs every parent/side/seed edge, restored
+parent, pending set, step/split/leaf/scope equation, branch state, and logical
+cost.
+
+Result limits independently bound retained nodes, each package body, declared
+logical bytes and work, plus the existing search and state resources. Count
+caps are checked before retained arrays and body lists are traversed. Adapter
+measurement, equality, and construction of arbitrary facts, causes, plans,
+schemas, and bodies remain explicitly non-preemptible; packages must bound
+those values before return. The split plan, schema, refutation record, target
+record, and runtime contradiction state are untrusted data, never evidence.
+Semantic split coverage, package-owned refutation theorems, recursive proof
+replay, search-to-recipe quotation, and unknown-leaf rejection by a proof fold
+remain later supported edges.
+
 This visibility is not a claim against Lean's deliberate `import all
 HexInterval.Search`. That form exposes private implementation names to trusted
 source and is an explicit trusted-internals escape hatch, not decoded runtime
@@ -5319,9 +5348,11 @@ their declared cost inside a scheduler bound.
   policy/action sessions, transactional callback-delta validation, exact
   generic stop/resource classes, stable depth-first/breadth-first frontiers,
   a separately sealed parent/depth/scope-checked leaf frontier, immutable parent
-  restoration, and sealed cumulative step/split/leaf/frontier/depth/scope
-  accounting. It contains no concrete callback, offer generator, split
-  semantics, policy algorithm, storage choice, or proof replay.
+  restoration, sealed cumulative step/split/leaf/frontier/depth/scope
+  accounting, and a sealed bounded retained result tree with exact single-delta
+  child reconstruction and target/refute/unknown terminals. It contains no
+  concrete callback, offer generator, semantic split/refutation theorem,
+  policy algorithm, storage choice, proof recipe, or proof replay.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and
   extension admission. Its engine extends and mutates only through the

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -17,7 +17,8 @@ This module is the supported, Mathlib-free ownership boundary for generic
 search. It authenticates policy choices against immutable views, binds the
 selected offer to an exact `Action`, and transactionally validates untrusted
 callback updates against `State.Branch`. It also supplies bounded tree
-accounting and stable depth-first/breadth-first frontier operations.
+accounting, stable depth-first/breadth-first frontier operations, and a sealed
+retained result tree whose children are reconstructed from one seed delta.
 
 The callback invocation and equality on caller-selected facts, causes,
 identifiers, and keys are explicitly non-preemptible. A callback
@@ -26,8 +27,13 @@ counts, versions, write authority, retained diagnostic bytes, and declared
 work before it commits any branch mutation. Neither an accepted callback
 result nor a runtime contradiction is theorem evidence.
 
-Concrete callbacks, offer generation, package assembly, policy algorithms,
-storage choices, split semantics, and proof replay remain outside this module.
+The retained tree binds structurally checked runtime actions, opaque plans,
+ordered sides, parent snapshots, and target/refutation/unknown terminal
+records. It does not authenticate an action against a package registry,
+interpret semantic split coverage or refutation schemas, or grant proof
+authority. Concrete callbacks, offer generation, package assembly, policy
+algorithms, storage choices, semantic split validation, and proof replay remain
+outside this module.
 
 Here and below, "sealed" means sealed at the ordinary/public import boundary.
 Lean's deliberate `import all HexInterval.Search` escape hatch exposes private
@@ -799,5 +805,441 @@ def startFrontierWithin := @LeafFrontier.startWithin
 def settleWithin := @LeafFrontier.settleWithin
 
 def splitWithin := @LeafFrontier.splitWithin
+
+/-! ## Retained authenticated search results -/
+
+namespace Result
+
+/-- Stable append-only address in one retained result tree. -/
+structure Id where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Ordered child identity retained for later package-owned coverage replay. -/
+inductive Side where
+  | left
+  | right
+  deriving DecidableEq, Repr
+
+/-- Adapter-declared logical storage and work. These are not physical heap
+bytes or a preemptible bound around arbitrary caller values. -/
+structure Cost where
+  bytes : Nat := 0
+  work : Nat := 0
+  deriving DecidableEq, Repr
+
+namespace Cost
+
+def add (left right : Cost) : Cost :=
+  { bytes := left.bytes + right.bytes, work := left.work + right.work }
+
+instance : Add Cost := ⟨add⟩
+
+end Cost
+
+/-- Caller-owned logical accounting for retained opaque values. Each callback
+must charge the complete encoding of its argument. Callback execution and the
+construction/equality of arbitrary Lean values are non-preemptible. -/
+structure Measure (Fact Cause Plan Schema : Type) where
+  node : Cost
+  branch : State.Branch Fact Cause → Cost
+  fact : Fact → Cost
+  action : Action → Cost
+  plan : Plan → Cost
+  schema : Schema → Cost
+  body : Nat → Cost
+  code : Nat → Cost
+
+/-- Retained-result limits layered over branch and search limits. `maxNodes`
+bounds the complete retained tree, while `maxBodyCells` bounds each opaque
+package body before its logical cost is measured. -/
+structure Limits where
+  search : Search.Limits
+  state : State.Limits
+  maxNodes : Nat
+  maxBodyCells : Nat
+  maxBytes : Nat
+  maxWork : Nat
+  maxCode : Nat
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | nodes
+  | body
+  | bytes
+  | work
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | malformed
+  | terminal
+  | split
+  | search (resource : Search.Resource)
+  | state (error : State.BranchError)
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+/-- The single version-zero delta used to construct a split child. All other
+child facts come from the exact checked current parent snapshot. -/
+structure Seed (Fact : Type) where
+  node : NodeId
+  previous : SeenVersion
+  fact : Fact
+  deriving DecidableEq, Repr
+
+/-- Exact untrusted split record. A later proof layer must resolve `schema`
+through a package registry and establish semantic coverage; none of these
+runtime fields is theorem evidence. -/
+structure Split (Plan Schema : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  action : Action
+  parent : SeenVersion
+  plan : Plan
+  schema : Schema
+  body : List Nat
+  deriving DecidableEq, Repr
+
+structure Target where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  seen : SeenVersion
+  deriving DecidableEq, Repr
+
+structure Refute (Schema : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  seen : SeenVersion
+  schema : Schema
+  body : List Nat
+  deriving DecidableEq, Repr
+
+structure Unknown where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  code : Nat
+  deriving DecidableEq, Repr
+
+/-- Explicit terminal status. Unknown leaves remain honest incomplete results
+and cannot be consumed by a future total proof-tree fold. -/
+inductive End (Schema : Type)
+  | target (target : Target)
+  | refute (refute : Refute Schema)
+  | unknown (unknown : Unknown)
+  deriving DecidableEq, Repr
+
+/-- Exact runtime source for one retained node. Every non-root source binds its
+parent address, ordered side, and sole child seed delta. -/
+structure Source (Fact Cause : Type) where
+  scope : Policy.ScopeId
+  depth : Nat
+  branch : State.Branch Fact Cause
+  parent : Option Id := none
+  side : Option Side := none
+  seed : Option (Seed Fact) := none
+  deriving DecidableEq
+
+inductive Node (Fact Cause Plan Schema : Type)
+  | pending (source : Source Fact Cause)
+  | terminal (source : Source Fact Cause) (ending : End Schema)
+  | split (source : Source Fact Cause) (recipe : Split Plan Schema)
+      (left right : Id)
+  deriving DecidableEq
+
+def Node.source : Node Fact Cause Plan Schema → Source Fact Cause
+  | .pending source | .terminal source _ | .split source _ _ _ => source
+
+/-- Ordinary-import-sealed live retained tree. Its frontier and cumulative
+accounting cannot be reset, advanced, or transplanted independently. Public
+construction and transitions recheck exact tree shape and resources. -/
+structure Tree (Fact Cause Plan Schema : Type) where
+  private mk ::
+  nodes : Array (Node Fact Cause Plan Schema)
+  private live : FrontierState Id
+  cost : Cost
+
+opaque Tree.frontier (tree : Tree Fact Cause Plan Schema) : Frontier Id :=
+  tree.live.frontier
+
+opaque Tree.accounting (tree : Tree Fact Cause Plan Schema) : Accounting :=
+  tree.live.accounting
+
+opaque Tree.pending (tree : Tree Fact Cause Plan Schema) : List Id :=
+  tree.live.pending
+
+opaque Tree.isEmpty (tree : Tree Fact Cause Plan Schema) : Bool :=
+  tree.live.isEmpty
+
+def sumCost (items : List Cost) : Cost :=
+  items.foldl (init := {}) (fun total item => total + item)
+
+def bodyCost (measure : Measure Fact Cause Plan Schema) (body : List Nat) : Cost :=
+  sumCost (body.map measure.body)
+
+def sourceCost (measure : Measure Fact Cause Plan Schema)
+    (source : Source Fact Cause) : Cost :=
+  measure.node + measure.branch source.branch +
+    match source.seed with
+    | none => {}
+    | some seed => measure.fact seed.fact
+
+def nodeCost (measure : Measure Fact Cause Plan Schema) :
+    Node Fact Cause Plan Schema → Cost
+  | .pending source => sourceCost measure source
+  | .terminal source (.target _) => sourceCost measure source
+  | .terminal source (.unknown unknown) =>
+      sourceCost measure source + measure.code unknown.code
+  | .terminal source (.refute refute) =>
+      sourceCost measure source + measure.schema refute.schema + bodyCost measure refute.body
+  | .split source recipe _ _ =>
+      sourceCost measure source + measure.action recipe.action + measure.plan recipe.plan +
+        measure.schema recipe.schema + bodyCost measure recipe.body
+
+def Tree.recomputeCost (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) : Cost :=
+  sumCost (tree.nodes.toList.map (nodeCost measure))
+
+def withinCost (limits : Limits) (cost : Cost) : Bool :=
+  cost.bytes ≤ limits.maxBytes && cost.work ≤ limits.maxWork
+
+private def throwCost (limits : Limits) (cost : Cost) : Except Error Unit := do
+  if limits.maxBytes < cost.bytes then throw (.resource .bytes)
+  if limits.maxWork < cost.work then throw (.resource .work)
+
+def seenCurrent (branch : State.Branch Fact Cause) (seen : SeenVersion) : Bool :=
+  branch.versions[seen.node.index]? == some seen.version && (branch.factAt? seen).isSome
+
+def inputsCurrent (branch : State.Branch Fact Cause) (inputs : List SeenVersion) : Bool :=
+  inputs.all (seenCurrent branch)
+
+private def bodyWithin (limits : Limits) (body : List Nat) : Bool :=
+  listWithin limits.maxBodyCells body
+
+private def actionWithin (limits : State.Limits) (action : Action) : Bool :=
+  let portLimit := Nat.max (limits.maxArity + 1) limits.maxScopeNodes
+  listWithin portLimit action.inputs && listWithin portLimit action.writes &&
+    listWithin limits.matcherBatchSize action.structuralInputs &&
+    action.effort ≤ limits.maxEffort
+
+opaque Split.check (limits : Limits) (source : Source Fact Cause)
+    (recipe : Split Plan Schema) : Bool :=
+  bodyWithin limits recipe.body && actionWithin limits.state recipe.action &&
+    recipe.scope == source.scope &&
+    recipe.programVersion == source.branch.programVersion &&
+    recipe.action.programVersion == source.branch.programVersion &&
+    recipe.action.kind == .split && recipe.action.node == recipe.parent.node &&
+    recipe.action.inputs.contains recipe.parent &&
+    inputsCurrent source.branch recipe.action.inputs && seenCurrent source.branch recipe.parent
+
+opaque End.check (limits : Limits) (source : Source Fact Cause) : End Schema → Bool := fun
+  | .target entry =>
+      entry.scope == source.scope &&
+        entry.programVersion == source.branch.programVersion &&
+        seenCurrent source.branch entry.seen
+  | .refute entry =>
+      entry.scope == source.scope &&
+        entry.programVersion == source.branch.programVersion &&
+        bodyWithin limits entry.body && seenCurrent source.branch entry.seen
+  | .unknown entry =>
+      entry.scope == source.scope &&
+        entry.programVersion == source.branch.programVersion && entry.code ≤ limits.maxCode
+
+private def fromSearch : Search.Error → Error
+  | .resource resource => .search resource
+  | _ => .malformed
+
+private def childBranchWithin [DecidableEq Fact] (limits : Limits)
+    (parent : Source Fact Cause) (seed : Seed Fact) :
+    Except Error (State.Branch Fact Cause) := do
+  if seed.previous.node != seed.node || !seenCurrent parent.branch seed.previous then
+    throw .split
+  let _ ← (preflightBranch limits.state parent.branch).mapError fromSearch
+  let some snapshot := parent.branch.checkedSnapshot? | throw .split
+  let some old := snapshot.facts[seed.node.index]? | throw .split
+  if old == seed.fact then throw .split
+  let facts := snapshot.facts.set! seed.node.index seed.fact
+  match State.Branch.startWithin limits.state parent.branch.program facts with
+  | .ok branch => pure branch
+  | .error error => throw (.state error)
+
+opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (parentId : Id) (parent : Source Fact Cause)
+    (side : Side) (child : Source Fact Cause) : Bool :=
+  child.parent == some parentId && child.side == some side &&
+    child.depth == parent.depth + 1 &&
+    match child.seed with
+    | none => false
+    | some seed => (childBranchWithin limits parent seed).toOption == some child.branch
+
+def pendingIds (tree : Tree Fact Cause Plan Schema) : List Id :=
+  (List.range tree.nodes.size).filterMap fun index =>
+    match tree.nodes[index]? with
+    | some (Node.pending _) => some { index }
+    | _ => none
+
+def terminalCount (tree : Tree Fact Cause Plan Schema) : Nat :=
+  tree.nodes.toList.countP fun node => match node with
+    | .terminal _ _ => true
+    | _ => false
+
+def splitCount (tree : Tree Fact Cause Plan Schema) : Nat :=
+  tree.nodes.toList.countP fun node => match node with
+    | .split _ _ _ _ => true
+    | _ => false
+
+private def nodePreflight (limits : Limits) (node : Node Fact Cause Plan Schema) : Bool :=
+  (preflightBranch limits.state node.source.branch).isOk &&
+    match node with
+    | .pending _ | .terminal _ (.target _) => true
+    | .terminal _ (.unknown _) => true
+    | .terminal _ (.refute refute) => bodyWithin limits refute.body
+    | .split _ split _ _ =>
+        bodyWithin limits split.body && actionWithin limits.state split.action
+
+/-- Validate the complete retained shape, exact parent/child seed relation,
+terminal records, cumulative search accounting, and adapter-declared cost. -/
+opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) : Bool := Id.run do
+  if tree.nodes.isEmpty || limits.maxNodes < tree.nodes.size then return false
+  let some frontierCount := (frontierCountWithin limits.search tree.live.frontier).toOption
+    | return false
+  if !tree.accounting.check limits.search frontierCount ||
+      tree.nodes.any (fun node => !nodePreflight limits node) then return false
+  let some root := tree.nodes[0]? | return false
+  let rootSource := root.source
+  if rootSource.depth != 0 || rootSource.parent.isSome || rootSource.side.isSome ||
+      rootSource.seed.isSome || !rootSource.branch.check then return false
+  let mut incoming := Array.replicate tree.nodes.size 0
+  let mut scopes : List Policy.ScopeId := []
+  for index in [0:tree.nodes.size] do
+    let some node := tree.nodes[index]? | return false
+    let source := node.source
+    if !source.branch.check || limits.search.maxDepth < source.depth ||
+        source.scope.index != rootSource.scope.index + index then return false
+    scopes := source.scope :: scopes
+    match node with
+    | .pending _ => pure ()
+    | .terminal _ ending => if !ending.check limits source then return false
+    | .split _ recipe left right =>
+        if !recipe.check limits source || left == right || left.index ≤ index ||
+            right.index ≤ index then return false
+        let some leftNode := tree.nodes[left.index]? | return false
+        let some rightNode := tree.nodes[right.index]? | return false
+        if !childMatches limits { index } source .left leftNode.source ||
+            !childMatches limits { index } source .right rightNode.source then return false
+        incoming := incoming.set! left.index (incoming[left.index]! + 1)
+        incoming := incoming.set! right.index (incoming[right.index]! + 1)
+  if !allDistinct scopes || incoming[0]? != some 0 then return false
+  for index in [1:incoming.size] do
+    if incoming[index]? != some 1 then return false
+  let pending := pendingIds tree
+  if !allDistinct tree.pending || tree.pending.length != pending.length ||
+      !tree.pending.all pending.contains then return false
+  let splits := splitCount tree
+  let terminals := terminalCount tree
+  if tree.nodes.size != splits * 2 + 1 || tree.accounting.splits != splits ||
+      tree.accounting.steps != splits + terminals || tree.accounting.leaves != splits + 1 ||
+      tree.accounting.scopes != tree.nodes.size ||
+      tree.accounting.nextScope != rootSource.scope.index + tree.nodes.size then return false
+  let cost := tree.recomputeCost measure
+  return tree.cost == cost && withinCost limits cost
+
+private def checked [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) : Except Error (Tree Fact Cause Plan Schema) :=
+  if tree.check limits measure then .ok tree else .error .malformed
+
+/-- Start a sealed singleton retained tree from an exact checked root branch. -/
+opaque startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) :
+    Except Error (Tree Fact Cause Plan Schema) := do
+  if limits.maxNodes < 1 then throw (.resource .nodes)
+  let _ ← (preflightBranch limits.state branch).mapError fromSearch
+  if !branch.check then throw .malformed
+  let source : Source Fact Cause := { scope, depth := 0, branch }
+  let nodes : Array (Node Fact Cause Plan Schema) := #[.pending source]
+  let live <- (FrontierState.startWithin limits.search scope ({ index := 0 } : Id)).mapError fromSearch
+  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  throwCost limits cost
+  checked limits measure { nodes, live, cost }
+
+opaque current? (tree : Tree Fact Cause Plan Schema) : Option (Id × Source Fact Cause) := do
+  let id ← tree.live.head?
+  let node ← tree.nodes[id.index]?
+  match node with
+  | .pending source => some (id, source)
+  | _ => none
+
+/-- Restore the exact retained parent source by append-only node identity. -/
+def restoreParent? (tree : Tree Fact Cause Plan Schema) (child : Id) :
+    Option (Source Fact Cause) := do
+  let node ← tree.nodes[child.index]?
+  let parent ← node.source.parent
+  let parentNode ← tree.nodes[parent.index]?
+  pure parentNode.source
+
+private def makeChild [DecidableEq Fact] (limits : Limits) (parentId : Id)
+    (parent : Source Fact Cause) (side : Side) (scope : Policy.ScopeId)
+    (seed : Seed Fact) : Except Error (Source Fact Cause) := do
+  let branch ← childBranchWithin limits parent seed
+  pure
+    { scope, depth := parent.depth + 1, branch,
+      parent := some parentId, side := some side, seed := some seed }
+
+/-- Retain one exact binary split transactionally. Child branches are rebuilt
+from the checked parent snapshot plus one seed delta each; callers cannot
+supply or transplant a complete child snapshot. -/
+opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (order : Order) (tree : Tree Fact Cause Plan Schema)
+    (recipe : Split Plan Schema) (leftSeed rightSeed : Seed Fact) :
+    Except Error (Tree Fact Cause Plan Schema) := do
+  let tree ← checked limits measure tree
+  let some (parentId, parent) := current? tree | throw .split
+  if !bodyWithin limits recipe.body then throw (.resource .body)
+  if !recipe.check limits parent then throw .split
+  if tree.nodes.size + 2 > limits.maxNodes then throw (.resource .nodes)
+  if limits.search.maxDepth < parent.depth + 1 then throw (.search .depth)
+  if leftSeed.node != recipe.parent.node || rightSeed.node != recipe.parent.node ||
+      leftSeed.previous != recipe.parent || rightSeed.previous != recipe.parent ||
+      leftSeed.fact == rightSeed.fact then throw .split
+  let leftId : Id := { index := tree.nodes.size }
+  let rightId : Id := { index := tree.nodes.size + 1 }
+  let (head, live) ← tree.live.splitHeadWithin limits.search order [leftId, rightId]
+      |>.mapError fromSearch
+  if head != parentId then throw .split
+  let left ← makeChild limits parentId parent .left
+    { index := tree.accounting.nextScope } leftSeed
+  let right ← makeChild limits parentId parent .right
+    { index := tree.accounting.nextScope + 1 } rightSeed
+  let nodes := (tree.nodes.set! parentId.index (.split parent recipe leftId rightId))
+    |>.push (.pending left) |>.push (.pending right)
+  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  throwCost limits cost
+  checked limits measure { nodes, live, cost }
+
+/-- Retain one exact terminal and remove the stable frontier head
+transactionally. Target and refutation records are authenticated runtime data,
+not proof evidence; unknown leaves remain explicit. -/
+opaque settleWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) (ending : End Schema) :
+    Except Error (Tree Fact Cause Plan Schema) := do
+  let tree ← checked limits measure tree
+  let some (id, source) := current? tree | throw .terminal
+  match ending with
+  | .refute entry => if !bodyWithin limits entry.body then throw (.resource .body)
+  | _ => pure ()
+  if !ending.check limits source then throw .terminal
+  let (head, live) ← tree.live.settleHeadWithin limits.search |>.mapError fromSearch
+  if head != id then throw .terminal
+  let nodes := tree.nodes.set! id.index (.terminal source ending)
+  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  throwCost limits cost
+  checked limits measure { nodes, live, cost }
+
+end Result
 
 end Hex.Interval.Search

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -951,7 +951,12 @@ def Node.source : Node Fact Cause Plan Schema → Source Fact Cause
 
 /-- Ordinary-import-sealed live retained tree. Its frontier and cumulative
 accounting cannot be reset, advanced, or transplanted independently. Public
-construction and transitions recheck exact tree shape and resources. -/
+construction and transitions recheck exact tree shape and resources. Limits
+are supplied per transition rather than retained in this pure value: a later
+call may tighten or relax them, and reusing an old tree may create alternative
+bounded lineages but cannot duplicate a scope within either lineage. The
+reference builders revalidate the complete retained prefix before and after
+each transition; `maxNodes` therefore remains small and measurement-gated. -/
 structure Tree (Fact Cause Plan Schema : Type) where
   private mk ::
   nodes : Array (Node Fact Cause Plan Schema)
@@ -1006,10 +1011,10 @@ private def throwCost (limits : Limits) (cost : Cost) : Except Error Unit := do
   if limits.maxBytes < cost.bytes then throw (.resource .bytes)
   if limits.maxWork < cost.work then throw (.resource .work)
 
-def seenCurrent (branch : State.Branch Fact Cause) (seen : SeenVersion) : Bool :=
+private def seenCurrent (branch : State.Branch Fact Cause) (seen : SeenVersion) : Bool :=
   branch.versions[seen.node.index]? == some seen.version && (branch.factAt? seen).isSome
 
-def inputsCurrent (branch : State.Branch Fact Cause) (inputs : List SeenVersion) : Bool :=
+private def inputsCurrent (branch : State.Branch Fact Cause) (inputs : List SeenVersion) : Bool :=
   inputs.all (seenCurrent branch)
 
 private def bodyWithin (limits : Limits) (body : List Nat) : Bool :=
@@ -1021,7 +1026,7 @@ private def actionWithin (limits : State.Limits) (action : Action) : Bool :=
     listWithin limits.matcherBatchSize action.structuralInputs &&
     action.effort ≤ limits.maxEffort
 
-opaque Split.check (limits : Limits) (source : Source Fact Cause)
+private opaque Split.check (limits : Limits) (source : Source Fact Cause)
     (recipe : Split Plan Schema) : Bool :=
   bodyWithin limits recipe.body && actionWithin limits.state recipe.action &&
     recipe.scope == source.scope &&
@@ -1031,7 +1036,7 @@ opaque Split.check (limits : Limits) (source : Source Fact Cause)
     recipe.action.inputs.contains recipe.parent &&
     inputsCurrent source.branch recipe.action.inputs && seenCurrent source.branch recipe.parent
 
-opaque End.check (limits : Limits) (source : Source Fact Cause) : End Schema → Bool := fun
+private opaque End.check (limits : Limits) (source : Source Fact Cause) : End Schema → Bool := fun
   | .target entry =>
       entry.scope == source.scope &&
         entry.programVersion == source.branch.programVersion &&
@@ -1062,7 +1067,7 @@ private def childBranchWithin [DecidableEq Fact] (limits : Limits)
   | .ok branch => pure branch
   | .error error => throw (.state error)
 
-opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
+private opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (parentId : Id) (parent : Source Fact Cause)
     (side : Side) (child : Source Fact Cause) : Bool :=
   child.parent == some parentId && child.side == some side &&
@@ -1126,7 +1131,12 @@ opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
             right.index ≤ index then return false
         let some leftNode := tree.nodes[left.index]? | return false
         let some rightNode := tree.nodes[right.index]? | return false
-        if !childMatches limits { index } source .left leftNode.source ||
+        let some leftSeed := leftNode.source.seed | return false
+        let some rightSeed := rightNode.source.seed | return false
+        if leftSeed.node != recipe.parent.node || rightSeed.node != recipe.parent.node ||
+            leftSeed.previous != recipe.parent || rightSeed.previous != recipe.parent ||
+            leftSeed.fact == rightSeed.fact ||
+            !childMatches limits { index } source .left leftNode.source ||
             !childMatches limits { index } source .right rightNode.source then return false
         incoming := incoming.set! left.index (incoming[left.index]! + 1)
         incoming := incoming.set! right.index (incoming[right.index]! + 1)

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -69,6 +69,12 @@ before array scans. A successful depth check may still traverse the complete
 already-constructed branching `Term`; construction and structural equality of
 caller terms remain an explicit non-preemptible envelope.
 
+The Mathlib-free layer now retains an authenticated `Search.Result.Tree` with
+exact parent/child seed relations and target/refute/unknown terminal data.
+That runtime tree is not evidence. This companion still does not quote it into
+package-owned split/refutation recipes or recursively replay and join it; those
+remain separate later proof edges.
+
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
 selects strongest integer lower and upper hypotheses, constructs the exact

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -71,9 +71,11 @@ caller terms remain an explicit non-preemptible envelope.
 
 The Mathlib-free layer now retains an authenticated `Search.Result.Tree` with
 exact parent/child seed relations and target/refute/unknown terminal data.
-That runtime tree is not evidence. This companion still does not quote it into
-package-owned split/refutation recipes or recursively replay and join it; those
-remain separate later proof edges.
+Restarted child branches themselves reset versions and generations and carry
+no inherited derivation proof; the exact tree edge is what retains that
+provenance. That runtime tree is not evidence. This companion still does not
+quote it into package-owned split/refutation recipes or recursively replay and
+join it; those remain separate later proof edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -598,4 +598,274 @@ private def secondSplitError (limits : Search.Limits) : Option Search.Error := d
 #guard secondSplitError { searchLimits with maxSplits := 1 } == some (.resource .splits)
 #guard secondSplitError { searchLimits with maxFrontier := 2 } == some (.resource .frontier)
 
+/-! ## Sealed retained result trees -/
+
+namespace Retained
+
+open Search.Result
+
+/-- error: Unknown constant `Hex.Interval.Search.Result.Tree.mk` -/
+#guard_msgs in
+#check Search.Result.Tree.mk
+
+private def limits : Search.Result.Limits :=
+  { search := { searchLimits with maxSteps := 6 }
+    state := stateLimits
+    maxNodes := 3
+    maxBodyCells := 2
+    maxBytes := 96
+    maxWork := 96
+    maxCode := 8 }
+
+private def unitCost : Cost := { bytes := 1, work := 1 }
+
+private def measure : Measure Nat Nat Nat Nat :=
+  { node := unitCost
+    branch := fun branch =>
+      { bytes := branch.initialFacts.size + branch.seeds.size + branch.history.size
+        work := branch.versions.size + branch.history.size }
+    fact := fun _ => unitCost
+    action := fun _ => unitCost
+    plan := fun _ => unitCost
+    schema := fun _ => unitCost
+    body := fun _ => unitCost
+    code := fun _ => unitCost }
+
+private def refinedBranch? : Option (State.Branch Nat Nat) := do
+  let branch <- branch?
+  (branch.pushWithin stateLimits firstUpdate).toOption
+
+private def splitAction : Action :=
+  { policyAction with
+    kind := .split
+    node := contractNode 1
+    inputs := [{ node := contractNode 1, version := 1 }]
+    writes := [] }
+
+private def recipe : Split Nat Nat :=
+  { scope := { index := 5 }
+    programVersion := 0
+    action := splitAction
+    parent := { node := contractNode 1, version := 1 }
+    plan := 37
+    schema := 41
+    body := [43] }
+
+private def leftSeed : Seed Nat :=
+  { node := contractNode 1, previous := recipe.parent, fact := 19 }
+
+private def rightSeed : Seed Nat :=
+  { node := contractNode 1, previous := recipe.parent, fact := 31 }
+
+private def root? : Option (Tree Nat Nat Nat Nat) := do
+  let branch <- refinedBranch?
+  (Search.Result.startWithin limits measure { index := 5 } branch).toOption
+
+private def split? : Option (Tree Nat Nat Nat Nat) := do
+  let root <- root?
+  (Search.Result.splitWithin limits measure .depthFirst root recipe leftSeed rightSeed).toOption
+
+#guard root?.any fun tree =>
+  tree.check limits measure && tree.nodes.size == 1 &&
+    tree.pending == [{ index := 0 }] && tree.accounting.nextScope == 6
+
+#guard split?.any fun tree =>
+  tree.check limits measure && tree.nodes.size == 3 &&
+    tree.pending == [{ index := 1 }, { index := 2 }] &&
+    tree.accounting.steps == 1 && tree.accounting.splits == 1 &&
+    tree.accounting.leaves == 2 && tree.accounting.nextScope == 8
+
+-- Child state is rebuilt from the exact current parent snapshot and one
+-- version-one seed delta. The inherited node is not replaced, and no parent
+-- history or current version is silently installed in the restarted child.
+#guard split?.any fun tree =>
+  match tree.nodes[1]?, tree.nodes[2]? with
+  | some (Node.pending left), some (Node.pending right) =>
+      left.branch.snapshot.facts == #[13, 19] &&
+        right.branch.snapshot.facts == #[13, 31] &&
+        left.branch.versions == #[0, 0] && right.branch.versions == #[0, 0] &&
+        left.branch.history.isEmpty && right.branch.history.isEmpty &&
+        left.seed == some leftSeed && right.seed == some rightSeed
+  | _, _ => false
+
+-- Restoration follows the sealed tree address rather than a caller-supplied
+-- copy and recovers the exact refined parent chronology.
+#guard split?.any fun tree =>
+  match Search.Result.restoreParent? tree { index := 1 }, tree.nodes[0]? with
+  | some parent, some root =>
+      parent == root.source && parent.branch.history == #[firstUpdate] &&
+        parent.branch.snapshot.facts == #[13, 29]
+  | _, _ => false
+
+private def leftTarget : End Nat := .target
+  { scope := { index := 6 }
+    programVersion := 0
+    seen := { node := contractNode 1, version := 0 } }
+
+private def rightRefute : End Nat := .refute
+  { scope := { index := 7 }
+    programVersion := 0
+    seen := { node := contractNode 1, version := 0 }
+    schema := 47
+    body := [53] }
+
+private def settled? : Option (Tree Nat Nat Nat Nat) := do
+  let tree <- split?
+  let .ok tree := Search.Result.settleWithin limits measure tree leftTarget | none
+  (Search.Result.settleWithin limits measure tree rightRefute).toOption
+
+#guard settled?.any fun tree =>
+  tree.check limits measure && tree.isEmpty && tree.accounting.steps == 3 &&
+    terminalCount tree == 2 && splitCount tree == 1
+
+private def unknown? : Option (Tree Nat Nat Nat Nat) := do
+  let tree <- root?
+  (Search.Result.settleWithin limits measure tree (.unknown
+    { scope := { index := 5 }, programVersion := 0, code := 8 })).toOption
+
+#guard unknown?.any fun tree =>
+  tree.check limits measure && tree.isEmpty && terminalCount tree == 1
+
+private def resultError (wanted : Search.Result.Error)
+    (result : Except Search.Result.Error α) : Bool :=
+  match result with
+  | .error actual => actual == wanted
+  | .ok _ => false
+
+-- Action kind, current dependency, exact predecessor, sibling distinction,
+-- and nontrivial child deltas are independently load-bearing.
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    { recipe with action := { splitAction with kind := .forward } } leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    { recipe with action := { splitAction with inputs :=
+      [{ node := contractNode 1, version := 0 }] } } leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe { leftSeed with previous := { node := contractNode 1, version := 0 } } rightSeed
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe leftSeed { rightSeed with fact := leftSeed.fact }
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe { leftSeed with fact := 29 } rightSeed
+
+-- Terminal scope, program version, retained version, and unknown code are
+-- checked before the sealed frontier advances.
+#guard split?.any fun tree =>
+  resultError .terminal <| Search.Result.settleWithin limits measure tree (.target
+    { scope := { index := 7 }
+      programVersion := 0
+      seen := { node := contractNode 1, version := 0 } })
+
+#guard split?.any fun tree =>
+  resultError .terminal <| Search.Result.settleWithin limits measure tree (.target
+    { scope := { index := 6 }
+      programVersion := 1
+      seen := { node := contractNode 1, version := 0 } })
+
+#guard split?.any fun tree =>
+  resultError .terminal <| Search.Result.settleWithin limits measure tree (.refute
+    { scope := { index := 6 }
+      programVersion := 0
+      seen := { node := contractNode 1, version := 1 }
+      schema := 47
+      body := [53] })
+
+#guard split?.any fun tree =>
+  resultError .terminal <| Search.Result.settleWithin limits measure tree (.unknown
+    { scope := { index := 6 }, programVersion := 0, code := 9 })
+
+-- Independent one-over tree, body, search, state, logical-byte, and work
+-- resources reject the whole transition without advancing the original tree.
+#guard match refinedBranch? with
+  | some branch =>
+      resultError (.resource .nodes) <|
+        Search.Result.startWithin { limits with maxNodes := 0 }
+          measure { index := 5 } branch
+  | none => false
+
+#guard match refinedBranch? with
+  | some branch =>
+      resultError (.search (.state .nodes)) <|
+        Search.Result.startWithin { limits with state := { stateLimits with maxNodes := 1 } }
+          measure { index := 5 } branch
+  | none => false
+
+#guard root?.any fun tree =>
+  (resultError (.resource .nodes) <|
+      Search.Result.splitWithin { limits with maxNodes := 2 }
+        measure .depthFirst tree recipe leftSeed rightSeed) &&
+    tree.check limits measure && tree.pending == [{ index := 0 }]
+
+#guard root?.any fun tree =>
+  resultError (.resource .body) <|
+    Search.Result.splitWithin { limits with maxBodyCells := 0 }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .leaves) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxLeaves := 1 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .steps) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxSteps := 0 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .splits) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxSplits := 0 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .scopes) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxScopes := 2 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .depth) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxDepth := 0 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard root?.any fun tree =>
+  resultError (.search .frontier) <|
+    Search.Result.splitWithin
+      { limits with search := { limits.search with maxFrontier := 1 } }
+      measure .depthFirst tree recipe leftSeed rightSeed
+
+#guard split?.any fun tree =>
+  let exact := tree.recomputeCost measure
+  resultError (.resource .bytes) <|
+    Search.Result.settleWithin { limits with maxBytes := exact.bytes }
+      measure tree (.refute
+        { scope := { index := 6 }
+          programVersion := 0
+          seen := { node := contractNode 1, version := 0 }
+          schema := 47
+          body := [53] })
+
+#guard split?.any fun tree =>
+  let exact := tree.recomputeCost measure
+  resultError (.resource .work) <|
+    Search.Result.settleWithin { limits with maxWork := exact.work }
+      measure tree (.refute
+        { scope := { index := 6 }
+          programVersion := 0
+          seen := { node := contractNode 1, version := 0 }
+          schema := 47
+          body := [53] })
+
+end Retained
+
 end Hex.Interval.SearchConformance

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -684,7 +684,9 @@ private def split? : Option (Tree Nat Nat Nat Nat) := do
       left.branch.snapshot.facts == #[13, 19] &&
         right.branch.snapshot.facts == #[13, 31] &&
         left.branch.versions == #[0, 0] && right.branch.versions == #[0, 0] &&
+        left.branch.generations == #[0, 0] && right.branch.generations == #[0, 0] &&
         left.branch.history.isEmpty && right.branch.history.isEmpty &&
+        !left.branch.contradictory && !right.branch.contradictory &&
         left.seed == some leftSeed && right.seed == some rightSeed
   | _, _ => false
 
@@ -746,6 +748,18 @@ private def resultError (wanted : Search.Result.Error)
 #guard root?.any fun tree =>
   resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
     recipe { leftSeed with previous := { node := contractNode 1, version := 0 } } rightSeed
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe { leftSeed with node := contractNode 0 } rightSeed
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe leftSeed { rightSeed with previous := { node := contractNode 1, version := 0 } }
+
+#guard root?.any fun tree =>
+  resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree
+    recipe leftSeed { rightSeed with node := contractNode 0 }
 
 #guard root?.any fun tree =>
   resultError .split <| Search.Result.splitWithin limits measure .depthFirst tree

--- a/progress/20260821T180001Z.md
+++ b/progress/20260821T180001Z.md
@@ -1,0 +1,43 @@
+# Supported retained search results
+
+## Accomplished
+
+- Added a sealed Mathlib-free `Search.Result.Tree` which keeps retained nodes,
+  stable frontier order, cumulative accounting, and logical cost inseparable.
+- Reconstructed every split child from the exact checked current parent facts
+  plus one versioned seed delta; callers cannot install a full child snapshot
+  or transplant detached live counters.
+- Added exact target, refutation, and unknown terminal records, complete
+  parent/side/seed restoration checks, and transactional split/settle
+  transitions over the sealed frontier.
+- Enforced independent node, body, logical-byte, logical-work, state, step,
+  split, leaf, frontier, depth, and scope limits with resource-first guards.
+- Added conformance for current-parent inheritance, restarted child versions,
+  parent restoration, terminal mutations, stale/transplanted seeds, the sealed
+  constructor boundary, resource one-over cases, and unchanged failed input.
+- Updated the supported module maps and trust boundary without presenting
+  runtime split/refutation records as evidence.
+- Built the supported Search, Search conformance, public tactic, nested/exact
+  branch, and complete 9,584-job conformance graph; passed the DAG, phase,
+  trust-surface, Mathlib-free bench, PNT inventory, factor-freshness,
+  copyright, line-count, diff, and banned-proof checks.
+
+## Current frontier
+
+The supported runtime can now retain a complete bounded binary result tree.
+Opaque plan/schema/body values are structurally bound runtime data; no package
+registry theorem or proof authority enters this layer.
+
+## Next step
+
+Add the separate Mathlib proof edge: package-owned split coverage and
+refutation schemas, child proof seeds that distinguish the sole new branch
+assumption from inherited consequences, and a bounded recursive fold which
+rejects unknown leaves transactionally.
+
+## Blockers
+
+None. Package measurement callbacks, equality, and construction of arbitrary
+facts, causes, plans, and schemas remain the documented non-preemptible
+envelope. Search-to-recipe quotation and proof replay are intentionally later
+edges.

--- a/progress/20260821T183219Z.md
+++ b/progress/20260821T183219Z.md
@@ -1,0 +1,34 @@
+# Retained-tree proof-replay hardening
+
+## Accomplished
+
+- Re-pinned both retained child seeds to the split recipe's exact node and
+  predecessor during whole-tree validation and required distinct sibling
+  facts there as well as at transition admission.
+- Added independent left/right node, predecessor, and sibling-fact mutations,
+  and pinned restarted child versions, generations, empty history, and false
+  contradiction state.
+- Made the raw current-version, input, split, terminal, and child-reconstruction
+  validators private after confirming they have no supported external caller.
+- Corrected the SPEC's child provenance, pure-value/per-call-limit, scope
+  lineage, and full-prefix reference-cost contracts ahead of proof replay.
+- Rebuilt the complete 9,584-job conformance graph and passed the DAG, phase,
+  trust-surface, Mathlib-free bench, PNT inventory, factor-freshness,
+  copyright, line-count, diff, and banned-proof checks.
+
+## Current frontier
+
+The sealed retained runtime tree now revalidates the exact seed-to-recipe
+relation needed by a future proof fold. Restarted child branches deliberately
+contain version-zero data; their inherited derivation is authenticated by the
+retained parent edge rather than by child-local history.
+
+## Next step
+
+Add package-owned split coverage and refutation proof schemas, then quote and
+replay a bounded tree recipe which consumes these exact retained edges.
+
+## Blockers
+
+None. Runtime terminals remain untrusted, and the reference tree's repeated
+full-prefix validation remains intentionally small and measurement-gated.


### PR DESCRIPTION
## Summary

- add a sealed supported `Search.Result.Tree` whose private ownership keeps its retained `FrontierState` and cumulative accounting inseparable from the validated tree
- reconstruct every child from the exact authenticated parent snapshot plus exactly one versioned branch seed, rejecting parent, sibling, scope, side, version, and seed transplants
- retain target, refute, and unknown terminals strictly as untrusted runtime records while validating the complete tree, parent restoration, pending frontier, and cumulative node/leaf/depth/body/logical-byte/work/state limits
- add discriminating conformance mutations and update the supported/current-state SPEC boundaries

## Trust boundary

The retained terminals and callback data do not establish theorem evidence. This edge deliberately defers package-owned split/refute proof schemas, `TreeRecipe`, proof replay and child join, and controller/tactic integration to later changes.

## Validation

- `lake build HexInterval.SearchConformance HexIntervalMathlib.TacticConformance HexIntervalMathlib.ExactBranchConformance HexInterval.NestedBranchConformance`
- file-line, copyright, DAG, Phase 4, Phase 7, trust-surface, Mathlib-free bench, PNT inventory, factor-freshness, and diff checks
- trust scan: 426 published Lean files contain no axioms, sorries, or `native_decide`