### PR TITLE
feat(interval): replay authenticated split trees

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -49,8 +49,9 @@ checked current parent snapshot and one exact seed delta, retains explicit
 target/refutation/unknown terminals, and carries no theorem authority. A
 deliberate `import all HexInterval.Search` is trusted implementation access,
 not decoded-runtime authority, and repository checks reject accidental uses.
-Concrete
-callbacks and proposals, offer generation, policy
-implementations, split semantics, proof replay, and measurement-selected
-storage remain experimental.
+Concrete callbacks and proposals, offer generation, policy implementations,
+the branch-search controller and callback-to-proof-recipe bridge, and
+measurement-selected storage remain experimental. Exact public interval
+splitting is already supported; the Mathlib companion separately owns flat
+forward replay and checked retained-tree proof folding.
 -/

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -96,15 +96,24 @@ uses the dyadic grid `2⁻¹⁶`; programmatic clients may choose another precis
 within the explicit envelope. Because each computed arithmetic layer is
 followed by an internal regularization layer, its term-depth cap `32` admits
 about 16 nested arithmetic operations along one expression spine. Generic
-search-selected recipes, broader local-context parsing, and
-split replay remain experimental. The first
+search-selected recipes and broader local-context parsing remain experimental.
+The supported proof companion can separately consume a checked retained
+`Search.Result.Tree` plus caller-supplied proof chronology: its registry
+authenticates package-owned binary cover and refutation schemas, its checked
+state rebases inherited child facts without promoting them to assumptions, and
+its bounded recursive fold closes target/refutation leaves, rejects unknown
+leaves, and joins siblings only through the exact cover. Producing that proof
+recipe from generic search callbacks and invoking the fold from the public
+tactic remain later controller work. The first
 concrete supported registry is the Mathlib arithmetic package for one
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. Arbitrary-function package assembly,
-callback outcomes and proposals, concrete policy algorithms, sessions, branch
-search, search-to-recipe orchestration, payload storage, tactic syntax, and the
-optimized backing store remain experimental.
+callback outcomes and proposals, concrete policy algorithms and default
+scheduling, the branch-search controller, callback-to-recipe orchestration,
+payload storage, and the optimized backing store remain experimental.
+Supported authenticated sessions and the narrow direct-forward tactic do not
+yet supply that missing controller bridge.
 In particular, the current instantiation proposal's package-supplied numeric
 policy family is not part of the supported action contract.
 
@@ -3293,8 +3302,10 @@ class, age, and score and performs the existing engine-owned freshness checks.
 The concrete `OfferId`,
 `OfferKey`, instantiation/split encodings, staged/adaptive/feature policies,
 package callbacks, semantic outcome interpretation, event history, concrete
-policy sessions, target-specific stop taxonomy, and proof replay remain under
-`HexInterval/Experiment`. The experimental `BranchTree` consumes the supported
+policy sessions, target-specific stop taxonomy, and callback-to-proof-recipe
+driver remain under `HexInterval/Experiment`. The Mathlib companion's generic
+tree replay does not make the older concrete `BranchProof` controller a
+supported API. The experimental `BranchTree` consumes the supported
 search order, limits, accounting, and frontier container, while its
 package-specific child construction remains behind `BranchStart`. The older
 sealed propagator session is not presented as a supported `Search.Session`:
@@ -3992,7 +4003,7 @@ arguments.
 
 ### Budgets and termination
 
-Every search is finite because the configuration bounds:
+Every target search is required to be finite because its configuration bounds:
 
 - reified base nodes, dynamically generated nodes and equality edges,
   instantiation actions and generation depth, and alternate forms per original
@@ -4006,6 +4017,16 @@ Every search is finite because the configuration bounds:
 - retained trace nodes, frozen payload entries and bytes, kernel-checker work,
   and estimated proof nodes;
 - optional wall-clock time.
+
+The current supported proof layer has two distinct decoded-data envelopes.
+`Proof.Limits` bounds packages, schemas, body cells, ordered dependencies, and
+flat chronology. `Proof.TreeLimits` additionally bounds retained proof nodes,
+depth, aggregate tree/body cells, and structural proof work. It does not expose
+a separate checker-execution counter. The Mathlib-free `Search.Result.Limits`
+and exact caller-supplied `Measure` authenticate and bound the retained runtime
+tree first; changing that measure can make the same pure tree fail validation.
+These limits are checked independently because runtime tree records and proof
+recipes are both untrusted data.
 
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
@@ -4069,14 +4090,16 @@ Reaching a budget returns `unknown` with the best state and diagnostics. It
 does not silently lower a target, discard a branch, or turn a failed strict
 bound into a weak one.
 
-After any solver split, a reported bound is global. For each requested node,
-the result takes the hull of its proved interval over every live, completed,
-and pending leaf. An unexplored child contributes at least its inherited
-ancestor facts, never the tighter state of its sibling. The result retains a
-partial `BranchTree` whose leaves close membership in this hull, even if they
-do not close the original goal. `interval_bound` can therefore replay a real
-theorem from an `unknown` search; diagnostics never present a branch-local cut
-as a context-wide fact.
+The target branch-search API must report only global bounds after a split. For
+each requested node, it will take the hull of the proved interval over every
+live, completed, and pending leaf; an unexplored child must contribute at least
+its inherited ancestor facts, never the tighter state of its sibling. That
+partial-tree hull and its proof are not implemented by the current public
+`interval_bound`: today that command runs only the supported direct-forward
+derivation and prints its selected cuts as diagnostics. The retained-tree
+proof fold implemented below closes a target only when every leaf is a checked
+target or refutation; it rejects unknown leaves rather than manufacturing a
+global bound from them.
 
 ## Derivation trace
 
@@ -5219,10 +5242,12 @@ candidates, and `b` the number of live branch states.
 - The current `Search.Result.Tree` reference builders validate the complete
   retained prefix before and after every split or settlement. If `N` nodes are
   retained incrementally and `B` is the bounded per-node branch/state
-  validation cost, this construction/revalidation term is `Θ(N² * B)`;
-  it is not an incremental tree-store bound. `maxNodes` therefore stays small
-  and measurement-gated until a production representation avoids repeated
-  full-prefix validation.
+  validation cost, the repeated branch-validation term is `Θ(N² * B)`.
+  The current pairwise retained-scope uniqueness scan adds `Θ(N³)` across
+  the same incremental construction, for a combined `Θ(N² * B + N³)`
+  reference cost. This is not an incremental tree-store bound. `maxNodes`
+  therefore stays small and measurement-gated until a production
+  representation avoids repeated full-prefix validation.
 - Fact comparison and contradiction checks use exact endpoint comparison. For
   the dyadic candidate, integer cost is proportional to effective endpoint
   height and the permitted exponent-alignment shift; a rational candidate must
@@ -5288,8 +5313,11 @@ their declared cost inside a scheduler bound.
   meanings, complete operation-array alignment, per-node SSA relations, and
   global model assembly over the supported decoded program.
 - `HexIntervalMathlib/Proof.lean`: supported package-owned fact, equality,
-  instance, and refutation theorem schemas; exact registry/action validation;
-  chronological typed proof state and caller-target closure; and the
+  instance, refutation, and binary-cover theorem schemas; exact
+  registry/action validation; chronological typed proof state and caller-target
+  closure; separately authenticated retained-tree recipes; exact child seeding
+  with one new branch assumption and derived inherited evidence; bounded
+  target/refutation replay with unknown-leaf rejection and cover joins; and the
   expression boundary that rejects placeholders and metavariables, restores
   emitter environment/messages/information/metavariables and clears both
   environment-dependent elaborator caches, then transactionally runs
@@ -5300,8 +5328,9 @@ their declared cost inside a scheduler bound.
   ordinary imports, only `Registry.buildWithin` can construct the theorem
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. The built-in
-  arithmetic package is supported below; arbitrary-function packages, goal
-  reification, tactic syntax, and default registries remain experimental.
+  arithmetic package and direct-forward reifier/tactic are supported below;
+  arbitrary-function packages, callback-to-tree-recipe orchestration,
+  split-search tactic integration, and default registries remain experimental.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry
   assembly, and state-to-proof quotation for negation, addition, subtraction,
@@ -5388,8 +5417,9 @@ their declared cost inside a scheduler bound.
   EmitFixtures}.lean`:
   Lean-only checks and oracle fixtures.
 - `conformance/HexIntervalMathlib/ProgramProofConformance.lean`: supported
-  program-model, registry, chronology, refutation, target-closure, mutation,
-  Meta-state restoration, and guarded ordinary-theorem canaries.
+  program-model, registry, chronology, refutation, binary-cover/tree replay,
+  target-closure, mutation, Meta-state restoration, and guarded
+  ordinary-theorem canaries.
 - `conformance/HexIntervalMathlib/RuleConformance.lean`: supported arithmetic
   package assembly, shared-DAG state quotation, chronological replay into an
   ordinary theorem, exact inv/div/regularize adapters, malformed-key/body/

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -4028,6 +4028,15 @@ tree first; changing that measure can make the same pure tree fail validation.
 These limits are checked independently because runtime tree records and proof
 recipes are both untrusted data.
 
+The current retained tree freezes each node's `Source.branch` when that node is
+created. A split child restarts its program version and fact generations at
+zero and the retained-tree API does not yet advance that child snapshot.
+Consequently a non-root proof chronology must be empty or proof-state-only,
+and a target/refutation terminal can cite only facts current at node creation.
+This edge proves exact split/refutation folding, not recursive propagation in
+children; authenticated callback-to-recipe quotation plus branch advancement
+is the next controller edge.
+
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
 exponent. This deliberately charges dynamic range linearly: a fact near

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -1567,7 +1567,11 @@ decreasing_by
 
 /-- Check an exact retained search tree, authenticate its root against the
 caller input, and replay all leaves transactionally. Unknown or pending leaves
-cannot produce a proof. -/
+cannot produce a proof. The current retained `Source.branch` is frozen when
+its node is created: non-root sources restart at program version zero, so their
+chronology can only be empty or proof-state-only and their terminals can cite
+only facts already current in that creation snapshot. Recursive branch
+advancement belongs to the later search-to-recipe controller. -/
 def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
     (searchLimits : Search.Result.Limits)
     (measure : Search.Result.Measure Fact Cause Plan Key)
@@ -1577,6 +1581,7 @@ def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
     (recipe : TreeRecipe Fact) : Except Error
       (Evidence (semantics.Entails input.program (initialBase input) input.target)) := do
   if !tree.check searchLimits measure then throw .wrongTree
+  if !tree.pending.isEmpty then throw .unknownLeaf
   checkTreeLimits treeLimits tree recipe
   let some root := tree.nodes[0]? | throw .wrongTree
   let source := root.source

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -19,6 +19,11 @@ callback replies, payload arenas, and diagnostic traces are decoded data only.
 The replay cursor starts from the caller's exact program and fact array and can
 advance only through package-owned theorem schemas whose complete address,
 owner, body, action, scope, versions, dependencies, and chronology all match.
+Binary splits additionally require a package-owned cover theorem. Each child
+adds exactly one assumption; inherited facts are rebased as derived evidence.
+A bounded fold checks an exact retained `Search.Result.Tree`, rejects unknown
+leaves, closes target or checked-refutation leaves, and joins children only
+under that cover.
 
 Schema decoders and theorem builders are package callbacks, but their returned
 `Evidence` contains an ordinary Lean proof of the exact indexed proposition.
@@ -86,6 +91,15 @@ def EntailsEq (semantics : Semantics Fact) (program : Program)
     (∀ assumption, assumption ∈ assumptions →
       semantics.holds program valuation assumption) →
     valuation left = valuation right
+
+/-- A package-owned binary cover. Under the exact established inputs, every
+model satisfies at least one ordered branch fact. -/
+def Covers (semantics : Semantics Fact) (program : Program)
+    (assumptions : List (NodeFact Fact)) (left right : NodeFact Fact) : Prop :=
+  ∀ valuation, semantics.models program valuation →
+    (∀ assumption, assumption ∈ assumptions →
+      semantics.holds program valuation assumption) →
+    semantics.holds program valuation left ∨ semantics.holds program valuation right
 
 def AgreeOn (semantics : Semantics Fact) (program : Program)
     (left right : NodeId → semantics.Value) : Prop :=
@@ -194,6 +208,7 @@ inductive Role where
   | equality
   | instance
   | refute
+  | split
   deriving DecidableEq, Repr
 
 /-- Full immutable schema address. -/
@@ -246,6 +261,17 @@ structure RefuteContext (semantics : Semantics Fact) where
   node : NodeId
   fact : Fact
 
+structure SplitContext (semantics : Semantics Fact) (Plan : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  program : Program
+  action : Action
+  assumptions : List (NodeFact Fact)
+  parent : NodeFact Fact
+  left : NodeFact Fact
+  right : NodeFact Fact
+  plan : Plan
+
 /-- Existentially packed package-owned fact theorem. -/
 structure FactSchema (semantics : Semantics Fact) where
   key : Key
@@ -279,14 +305,23 @@ structure RefuteSchema (semantics : Semantics Fact) where
       semantics.holds context.program valuation
         { node := context.node, fact := context.fact } → False))
 
+structure SplitSchema (semantics : Semantics Fact) (Plan : Type) where
+  key : Key
+  Certificate : Type
+  decode : List Nat → Option Certificate
+  prove : (context : SplitContext semantics Plan) → Certificate →
+    Option (Evidence (semantics.Covers context.program context.assumptions
+      context.left context.right))
+
 /-- One proof package owns registrations and every schema addressed by those
 rule keys. -/
-structure Package (semantics : Semantics Fact) where
+structure Package (semantics : Semantics Fact) (Plan : Type := List Nat) where
   registrations : Array Registration
   facts : Array (FactSchema semantics) := #[]
   equalities : Array (EqualitySchema semantics) := #[]
   instances : Array (InstanceSchema semantics) := #[]
   refuters : Array (RefuteSchema semantics) := #[]
+  splits : Array (SplitSchema semantics Plan) := #[]
 
 /-- Bounds on retained proof-registry and quotation data.  These bounds are
 checked after construction of the caller's Lean values; they do not preempt
@@ -314,13 +349,14 @@ inductive BuildError where
 /-! Under ordinary imports, only `Registry.buildWithin` can construct this
 trusted theorem registry. `import all HexIntervalMathlib.Proof` is a deliberate
 trusted-internals escape hatch guarded by the repository DAG checker. -/
-structure Registry (semantics : Semantics Fact) where
+structure Registry (semantics : Semantics Fact) (Plan : Type := List Nat) where
   private mk ::
   registrations : Array Registration
   facts : Array (FactSchema semantics)
   equalities : Array (EqualitySchema semantics)
   instances : Array (InstanceSchema semantics)
   refuters : Array (RefuteSchema semantics)
+  splits : Array (SplitSchema semantics Plan)
 
 namespace Registry
 
@@ -328,20 +364,22 @@ private def make (registrations : Array Registration)
     (facts : Array (FactSchema semantics))
     (equalities : Array (EqualitySchema semantics))
     (instances : Array (InstanceSchema semantics))
-    (refuters : Array (RefuteSchema semantics)) : Registry semantics :=
-  .mk registrations facts equalities instances refuters
+    (refuters : Array (RefuteSchema semantics))
+    (splits : Array (SplitSchema semantics Plan)) : Registry semantics Plan :=
+  .mk registrations facts equalities instances refuters splits
 
-def owns (package : Package semantics) (key : Key) : Bool :=
+def owns (package : Package semantics Plan) (key : Key) : Bool :=
   package.registrations.any fun registration => registration.key == key.rule
 
 /-- Assemble a package-local, globally unambiguous theorem registry. -/
 opaque buildWithin (limits : Limits) (program : Program)
-    (packages : Array (Package semantics)) : Except BuildError (Registry semantics) := do
+    (packages : Array (Package semantics Plan)) :
+    Except BuildError (Registry semantics Plan) := do
   if !program.check then throw .invalidProgram
   if limits.maxPackages < packages.size then throw .packageLimit
   let schemaCount := packages.foldl (fun count package =>
     count + package.facts.size + package.equalities.size + package.instances.size +
-      package.refuters.size) 0
+      package.refuters.size + package.splits.size) 0
   if limits.maxSchemas < schemaCount then throw .schemaLimit
   let registrations := packages.foldl
     (fun all package => all ++ package.registrations) #[]
@@ -355,6 +393,7 @@ opaque buildWithin (limits : Limits) (program : Program)
   let mut equalities := #[]
   let mut instances := #[]
   let mut refuters := #[]
+  let mut splits := #[]
   let mut seen : List Key := []
   for index in [0:packages.size] do
     let some package := packages[index]? | throw .invalidProgram
@@ -385,28 +424,38 @@ opaque buildWithin (limits : Limits) (program : Program)
       if seen.contains schema.key then throw (.duplicateSchema schema.key)
       seen := schema.key :: seen
       refuters := refuters.push schema
-  pure (make registrations facts equalities instances refuters)
+    for schema in package.splits do
+      if schema.key.role != .split then throw (.wrongRole schema.key)
+      if !owns package schema.key then throw (.foreignSchema index schema.key)
+      if seen.contains schema.key then throw (.duplicateSchema schema.key)
+      seen := schema.key :: seen
+      splits := splits.push schema
+  pure (make registrations facts equalities instances refuters splits)
 
-def fact? (registry : Registry semantics) (key : Key) : Option (FactSchema semantics) :=
+def fact? (registry : Registry semantics Plan) (key : Key) : Option (FactSchema semantics) :=
   registry.facts.toList.find? fun schema => schema.key == key
 
-def equality? (registry : Registry semantics) (key : Key) :
+def equality? (registry : Registry semantics Plan) (key : Key) :
     Option (EqualitySchema semantics) :=
   registry.equalities.toList.find? fun schema => schema.key == key
 
-def instance? (registry : Registry semantics) (key : Key) :
+def instance? (registry : Registry semantics Plan) (key : Key) :
     Option (InstanceSchema semantics) :=
   registry.instances.toList.find? fun schema => schema.key == key
 
-def refuter? (registry : Registry semantics) (key : Key) :
+def refuter? (registry : Registry semantics Plan) (key : Key) :
     Option (RefuteSchema semantics) :=
   registry.refuters.toList.find? fun schema => schema.key == key
+
+def split? (registry : Registry semantics Plan) (key : Key) :
+    Option (SplitSchema semantics Plan) :=
+  registry.splits.toList.find? fun schema => schema.key == key
 
 /-- Authenticate the structural portion of one quoted action against the
 exact registry and program snapshots. Serial, effort, and generation remain
 opaque chronology data visible to the package theorem; they carry no generic
 proof authority. -/
-def acceptsAction (registry : Registry semantics) (program : Program)
+def acceptsAction (registry : Registry semantics Plan) (program : Program)
     (action : Action) (inputs : List NodeId) : Bool :=
   match registry.registrations[action.rule.index]?, program.node? action.node with
   | some registration, some anchor =>
@@ -490,6 +539,20 @@ structure RefuteStep where
   body : List Nat
   deriving DecidableEq, Repr
 
+/-- Exact theorem-bearing portion of one retained split. The ordered child
+seeds are deltas, not complete child fact snapshots. -/
+structure SplitStep (Fact Plan : Type) where
+  scope : Policy.ScopeId
+  programVersion : Nat
+  action : Action
+  parent : SeenVersion
+  plan : Plan
+  left : Search.Result.Seed Fact
+  right : Search.Result.Seed Fact
+  schema : Key
+  body : List Nat
+  deriving DecidableEq, Repr
+
 inductive Event (Fact : Type)
   | fact (step : FactStep Fact)
   | equality (step : EqualityStep)
@@ -501,6 +564,12 @@ def initialBase (input : Input Fact) : List (NodeFact Fact) :=
   List.ofFn fun index : Fin input.facts.size =>
     { node := { index := index.val }, fact := input.facts[index] }
 
+/-- Exact logical assumptions visible at one replay node. Branch assumptions
+are appended one at a time and are never reconstructed from runtime facts. -/
+def replayBase (input : Input Fact) (assumptions : List (NodeFact Fact)) :
+    List (NodeFact Fact) :=
+  initialBase input ++ assumptions
+
 theorem initialWithin (input : Input Fact)
     (size : input.facts.size = input.program.nodes.size) :
     FactsWithin input.program (initialBase input) := by
@@ -508,6 +577,14 @@ theorem initialWithin (input : Input Fact)
   rw [initialBase, List.mem_ofFn] at member
   obtain ⟨index, rfl⟩ := member
   simpa [size] using index.isLt
+
+theorem replayBaseWithin (input : Input Fact) (size : input.facts.size = input.program.nodes.size)
+    (assumptions : List (NodeFact Fact))
+    (assumptionsWithin : FactsWithin input.program assumptions) :
+    FactsWithin input.program (replayBase input assumptions) := by
+  intro fact member
+  rw [replayBase, List.mem_append] at member
+  exact member.elim (initialWithin input size fact) (assumptionsWithin fact)
 
 structure Resolved (semantics : Semantics Fact) (program : Program)
     (base : List (NodeFact Fact)) (seen : SeenVersion) where
@@ -556,6 +633,16 @@ def push (facts : Facts semantics program base) (seen : SeenVersion) (fact : Fac
 
 end Facts
 
+def weakenEntails (semantics : Semantics Fact)
+    (sound : Evidence (semantics.Entails program oldBase fact))
+    (extra : NodeFact Fact) :
+    Evidence (semantics.Entails program (oldBase ++ [extra]) fact) :=
+  { proof := by
+      intro valuation model extended
+      apply sound.proof valuation model
+      intro assumption member
+      exact extended assumption (List.mem_append_left [extra] member) }
+
 structure EqualityProof (semantics : Semantics Fact) (program : Program)
     (base : List (NodeFact Fact)) where
   equality : EqualityId
@@ -585,17 +672,44 @@ def push (equalities : Equalities semantics program base)
 end Equalities
 
 /-- Complete proof state at one exact program version. Its dependent type
-indices prevent facts or equalities from being transplanted to a different
-program without also supplying the corresponding typed semantic evidence. -/
-structure State (semantics : Semantics Fact) (input : Input Fact) where
+indices and assumptions prevent facts or equalities from being transplanted to
+a different program or branch base without supplying the corresponding typed
+semantic evidence. -/
+def weakenEq (semantics : Semantics Fact)
+    (sound : Evidence (semantics.EntailsEq program oldBase left right))
+    (extra : NodeFact Fact) :
+    Evidence (semantics.EntailsEq program (oldBase ++ [extra]) left right) :=
+  { proof := by
+      intro valuation model extended
+      apply sound.proof valuation model
+      intro assumption member
+      exact extended assumption (List.mem_append_left [extra] member) }
+
+def Equalities.weaken (equalities : Equalities semantics program oldBase)
+    (extra : NodeFact Fact) : Equalities semantics program (oldBase ++ [extra]) :=
+  Equalities.make equalities.count fun equality => do
+    let proof ← equalities.resolve equality
+    pure { proof with sound := weakenEq semantics proof.sound extra }
+
+structure State (semantics : Semantics Fact) (input : Input Fact)
+    (assumptions : List (NodeFact Fact) := []) where
+  scope : Policy.ScopeId
   version : Nat
   program : Program
   baseSize : input.facts.size = input.program.nodes.size
   basePrefix : Prefix input.program program
   extension : Evidence (semantics.Extends input.program program)
   stable : Stable semantics input.program program
-  facts : Facts semantics program (initialBase input)
-  equalities : Equalities semantics program (initialBase input)
+  /-- Program at entry to this tree node. Child proofs close back to this
+  snapshot before a split join; independent child extensions cannot leak. -/
+  origin : Program
+  originFromInput : Prefix input.program origin
+  baseWithinOrigin : FactsWithin origin (replayBase input assumptions)
+  originPrefix : Prefix origin program
+  originExtension : Evidence (semantics.Extends origin program)
+  originStable : Stable semantics origin program
+  facts : Facts semantics program (replayBase input assumptions)
+  equalities : Equalities semantics program (replayBase input assumptions)
 
 theorem stableRefl (semantics : Semantics Fact) (program : Program) :
     Stable semantics program program :=
@@ -611,14 +725,150 @@ def extendsRefl (semantics : Semantics Fact) (program : Program) :
 
 def State.start (semantics : Semantics Fact) (input : Input Fact)
     (size : input.facts.size = input.program.nodes.size) : State semantics input :=
-  { version := 0
+  { scope := input.scope
+    version := 0
     program := input.program
     baseSize := size
     basePrefix := .refl input.program
     extension := extendsRefl semantics input.program
     stable := stableRefl semantics input.program
-    facts := Facts.start semantics input size
+    origin := input.program
+    originFromInput := .refl input.program
+    baseWithinOrigin := by simpa [replayBase] using initialWithin input size
+    originPrefix := .refl input.program
+    originExtension := extendsRefl semantics input.program
+    originStable := stableRefl semantics input.program
+    facts := by simpa [replayBase] using Facts.start semantics input size
     equalities := .empty }
+
+inductive Error where
+  | invalidInput
+  | chronologyLimit
+  | bodyLimit
+  | dependencyLimit
+  | wrongScope
+  | wrongProgramVersion
+  | wrongAction
+  | wrongSchema
+  | missingSchema
+  | malformedBody
+  | missingDependency (seen : SeenVersion)
+  | staleVersion
+  | unknownNode
+  | unauthorizedWrite
+  | wrongEquality
+  | wrongInstance
+  | wrongFinalProgram
+  | wrongTarget
+  | wrongSplit
+  | wrongTree
+  | unknownLeaf
+  | proofNodeLimit
+  | proofDepthLimit
+  | proofBodyLimit
+  | proofWorkLimit
+  deriving DecidableEq, Repr
+
+/-- Data-level alignment between one retained runtime snapshot and its checked
+proof state. This check never creates evidence; it only prevents a retained
+snapshot from selecting proofs for a different fact or version. -/
+def State.matchesBranch [DecidableEq Fact] [DecidableEq Cause]
+    (semantics : Semantics Fact) (checked : State semantics input assumptions)
+    (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) : Bool := Id.run do
+  if checked.scope != scope || checked.version != branch.programVersion ||
+      checked.program != branch.program || !branch.check then return false
+  let some snapshot := branch.checkedSnapshot? | return false
+  for index in [0:snapshot.facts.size] do
+    let some version := branch.versions[index]? | return false
+    let seen : SeenVersion := { node := { index }, version }
+    let some resolved := checked.facts.resolve seen | return false
+    let some fact := snapshot.facts[index]? | return false
+    if resolved.fact != fact then return false
+  return true
+
+/-- Rebase every current inherited runtime fact to child-local version zero,
+while installing exactly one appended branch assumption at its node. The
+remaining child facts stay derived evidence and do not become assumptions. -/
+structure Seeded (semantics : Semantics Fact) (input : Input Fact)
+    (assumptions : List (NodeFact Fact)) (origin : Program) where
+  state : State semantics input assumptions
+  originEq : state.origin = origin
+
+def seedChild [DecidableEq Fact] [DecidableEq Cause]
+    (semantics : Semantics Fact) (input : Input Fact)
+    (parent : State semantics input assumptions)
+    (parentScope childScope : Policy.ScopeId) (runtime : State.Branch Fact Cause)
+    (seed : Search.Result.Seed Fact) : Except Error
+      (Seeded semantics input
+        (assumptions ++ [{ node := seed.node, fact := seed.fact }]) parent.program) := do
+  if !parent.matchesBranch semantics parentScope runtime then throw .wrongSplit
+  if seed.previous.node != seed.node then throw .wrongSplit
+  let some old := parent.facts.resolve seed.previous
+    | throw (.missingDependency seed.previous)
+  let some runtimeOld := runtime.factAt? seed.previous | throw .wrongSplit
+  if old.fact != runtimeOld || old.fact == seed.fact then throw .wrongSplit
+  let within : Evidence (seed.node.index < parent.program.nodes.size) ←
+    if h : seed.node.index < parent.program.nodes.size then pure ⟨h⟩ else throw .unknownNode
+  let branchFact : NodeFact Fact := { node := seed.node, fact := seed.fact }
+  let inheritedWithin : FactsWithin parent.program (replayBase input assumptions) :=
+    fun fact member => Nat.lt_of_lt_of_le (parent.baseWithinOrigin fact member)
+      parent.originPrefix.nodeSize
+  let childBaseWithin : FactsWithin parent.program
+      (replayBase input (assumptions ++ [branchFact])) := by
+    simpa [replayBase, List.append_assoc] using
+      (show FactsWithin parent.program (replayBase input assumptions ++ [branchFact]) from by
+        intro fact member
+        rw [List.mem_append, List.mem_singleton] at member
+        exact member.elim (inheritedWithin fact) (fun equal => by
+          subst fact
+          exact within.proof))
+  let childFacts : Facts semantics parent.program
+      (replayBase input (assumptions ++ [branchFact])) :=
+    Facts.make fun requested =>
+      if isLocal : requested.version = 0 then
+        if seeded : requested.node = seed.node then
+          some
+            { fact := seed.fact
+              within := by simpa [seeded] using within.proof
+              sound :=
+                { proof := by
+                    intro valuation model assumptionsHold
+                    simpa [seeded, branchFact] using
+                      assumptionsHold branchFact (by simp [replayBase, branchFact]) } }
+        else
+          match runtime.versions[requested.node.index]? with
+          | none => none
+          | some version =>
+              match parent.facts.resolve { node := requested.node, version } with
+              | none => none
+              | some resolved => some
+                  { fact := resolved.fact
+                    within := resolved.within
+                    sound := by
+                      simpa [replayBase, List.append_assoc] using
+                        weakenEntails semantics resolved.sound branchFact }
+      else none
+  let childEqualities : Equalities semantics parent.program
+      (replayBase input (assumptions ++ [branchFact])) := by
+    simpa [replayBase, List.append_assoc] using parent.equalities.weaken branchFact
+  pure
+    { state :=
+        { scope := childScope
+          version := 0
+          program := parent.program
+          baseSize := parent.baseSize
+          basePrefix := parent.basePrefix
+          extension := parent.extension
+          stable := parent.stable
+          origin := parent.program
+          originFromInput := parent.basePrefix
+          baseWithinOrigin := childBaseWithin
+          originPrefix := .refl parent.program
+          originExtension := extendsRefl semantics parent.program
+          originStable := stableRefl semantics parent.program
+          facts := childFacts
+          equalities := childEqualities }
+      originEq := rfl }
 
 structure ResolvedInputs (semantics : Semantics Fact) (program : Program)
     (base : List (NodeFact Fact)) where
@@ -660,27 +910,6 @@ def installMeet (semantics : Semantics Fact) (program : Program)
       intro input member
       exact inputsSound.proof input member valuation model baseHolds }
 
-inductive Error where
-  | invalidInput
-  | chronologyLimit
-  | bodyLimit
-  | dependencyLimit
-  | wrongScope
-  | wrongProgramVersion
-  | wrongAction
-  | wrongSchema
-  | missingSchema
-  | malformedBody
-  | missingDependency (seen : SeenVersion)
-  | staleVersion
-  | unknownNode
-  | unauthorizedWrite
-  | wrongEquality
-  | wrongInstance
-  | wrongFinalProgram
-  | wrongTarget
-  deriving DecidableEq, Repr
-
 def bodyCheck (limits : Limits) (key : Key) (role : Role)
     (body : List Nat) : Except Error Unit := do
   if key.role != role then throw .wrongSchema
@@ -690,12 +919,13 @@ def dependenciesCheck (limits : Limits) (dependencies : List SeenVersion) :
     Except Error Unit :=
   if limits.maxDependencies < dependencies.length then throw .dependencyLimit else pure ()
 
-def replayFact (limits : Limits) (registry : Registry semantics)
-    (domain : Domain semantics) (input : Input Fact) (checked : State semantics input)
-    (step : FactStep Fact) : Except Error (State semantics input) := do
+def replayFact (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (input : Input Fact)
+    (checked : State semantics input assumptions)
+    (step : FactStep Fact) : Except Error (State semantics input assumptions) := do
   bodyCheck limits step.schema .fact step.body
   dependenciesCheck limits step.assumptions
-  if step.scope != input.scope then throw .wrongScope
+  if step.scope != checked.scope then throw .wrongScope
   if step.programVersion != checked.version then throw .wrongProgramVersion
   if step.action.programVersion != checked.version || step.action.key != step.schema.rule ||
       step.action.inputs != step.assumptions then throw .wrongAction
@@ -725,10 +955,10 @@ def replayFact (limits : Limits) (registry : Registry semantics)
   let some rule := schema.prove context certificate | throw .malformedBody
   let some meet := domain.meet checked.program step.node previous.fact
       step.proposed step.installed | throw .malformedBody
-  have previousSound : Evidence (semantics.Entails checked.program (initialBase input)
+  have previousSound : Evidence (semantics.Entails checked.program (replayBase input assumptions)
       { node := step.node, fact := previous.fact }) := by
     simpa [nodeEq.proof] using previous.sound
-  let sound := installMeet semantics checked.program (initialBase input) resolvedInputs.facts
+  let sound := installMeet semantics checked.program (replayBase input assumptions) resolvedInputs.facts
     step.node previous.fact step.proposed step.installed rule meet previousSound
       resolvedInputs.sound
   have currentWithin : current.node.index < checked.program.nodes.size := by
@@ -736,12 +966,12 @@ def replayFact (limits : Limits) (registry : Registry semantics)
   let pushed := checked.facts.push current step.installed currentWithin sound
   pure { checked with facts := pushed }
 
-def replayEquality (limits : Limits) (registry : Registry semantics)
-    (input : Input Fact) (checked : State semantics input)
-    (step : EqualityStep) : Except Error (State semantics input) := do
+def replayEquality (limits : Limits) (registry : Registry semantics Plan)
+    (input : Input Fact) (checked : State semantics input assumptions)
+    (step : EqualityStep) : Except Error (State semantics input assumptions) := do
   bodyCheck limits step.schema .equality step.body
   dependenciesCheck limits step.assumptions
-  if step.scope != input.scope then throw .wrongScope
+  if step.scope != checked.scope then throw .wrongScope
   if step.programVersion != checked.version then throw .wrongProgramVersion
   if step.equality.index != checked.equalities.count || step.left == step.right then
     throw .wrongEquality
@@ -762,21 +992,22 @@ def replayEquality (limits : Limits) (registry : Registry semantics)
       action := step.action, equality := step.equality, left := step.left,
       right := step.right, assumptions := resolvedInputs.facts }
   let some schemaSound := schema.prove context certificate | throw .malformedBody
-  let sound : Evidence (semantics.EntailsEq checked.program (initialBase input)
+  let sound : Evidence (semantics.EntailsEq checked.program (replayBase input assumptions)
       step.left step.right) :=
     { proof := by
         intro valuation model baseHolds
         apply schemaSound.proof valuation model
         intro assumption member
         exact resolvedInputs.sound.proof assumption member valuation model baseHolds }
-  let proof : EqualityProof semantics checked.program (initialBase input) :=
+  let proof : EqualityProof semantics checked.program (replayBase input assumptions) :=
     { equality := step.equality, left := step.left, right := step.right, sound }
   pure { checked with equalities := checked.equalities.push proof }
 
 def replayTransport (_limits : Limits) (domain : Domain semantics)
-    (laws : Laws semantics) (input : Input Fact) (checked : State semantics input)
-    (step : TransportStep Fact) : Except Error (State semantics input) := do
-  if step.scope != input.scope then throw .wrongScope
+    (laws : Laws semantics) (input : Input Fact)
+    (checked : State semantics input assumptions)
+    (step : TransportStep Fact) : Except Error (State semantics input assumptions) := do
+  if step.scope != checked.scope then throw .wrongScope
   if step.programVersion != checked.version then throw .wrongProgramVersion
   let nodeEq : Evidence (step.previous.node = step.node) ←
     if h : step.previous.node = step.node then pure ⟨h⟩ else throw .staleVersion
@@ -799,11 +1030,11 @@ def replayTransport (_limits : Limits) (domain : Domain semantics)
     else throw .wrongEquality
   let some meet := domain.meet checked.program step.node previous.fact source.fact
       step.installed | throw .malformedBody
-  have previousSound : Evidence (semantics.Entails checked.program (initialBase input)
+  have previousSound : Evidence (semantics.Entails checked.program (replayBase input assumptions)
       { node := step.node, fact := previous.fact }) := by
     simpa [nodeEq.proof] using previous.sound
   let proposed : Evidence
-      (semantics.Entails checked.program (initialBase input)
+      (semantics.Entails checked.program (replayBase input assumptions)
         { node := step.node, fact := source.fact }) :=
     { proof := by
         intro valuation model baseHolds
@@ -819,7 +1050,7 @@ def replayTransport (_limits : Limits) (domain : Domain semantics)
               equality.right source.fact model equalValues).mp (by simpa [reverse.2] using sourceHolds)
           simpa [reverse.1] using transported }
   let inputSound : Evidence (InputsSound semantics checked.program
-      (initialBase input) [{ node := step.node, fact := source.fact }]) :=
+      (replayBase input assumptions) [{ node := step.node, fact := source.fact }]) :=
     { proof := by
         intro fact member
         simp only [List.mem_singleton] at member
@@ -829,7 +1060,7 @@ def replayTransport (_limits : Limits) (domain : Domain semantics)
       [{ node := step.node, fact := source.fact }]
       { node := step.node, fact := source.fact }) :=
     { proof := by intro _ _ assumptions; exact assumptions _ (by simp) }
-  let sound := installMeet semantics checked.program (initialBase input)
+  let sound := installMeet semantics checked.program (replayBase input assumptions)
     [{ node := step.node, fact := source.fact }] step.node previous.fact source.fact
     step.installed rule meet previousSound inputSound
   have currentWithin : current.node.index < checked.program.nodes.size := by
@@ -922,11 +1153,12 @@ theorem composeStable (left : Stable semantics first middle)
           (Nat.lt_of_lt_of_le within left.appendOnly.nodeSize) middleModel newModel
           (fun _ _ => rfl)) }
 
-def replayInstance (limits : Limits) (registry : Registry semantics)
-    (domain : Domain semantics) (input : Input Fact) (checked : State semantics input)
-    (step : InstanceStep) : Except Error (State semantics input) := do
+def replayInstance (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (input : Input Fact)
+    (checked : State semantics input assumptions)
+    (step : InstanceStep) : Except Error (State semantics input assumptions) := do
   bodyCheck limits step.schema .instance step.body
-  if step.scope != input.scope then throw .wrongScope
+  if step.scope != checked.scope then throw .wrongScope
   if step.beforeVersion != checked.version || step.afterVersion != checked.version + 1 then
     throw .wrongProgramVersion
   if step.action.programVersion != checked.version || step.action.key != step.schema.rule then
@@ -944,34 +1176,89 @@ def replayInstance (limits : Limits) (registry : Registry semantics)
       afterVersion := step.afterVersion, before := checked.program, after := step.after,
       action := step.action, newNodes := step.newNodes }
   let some proof := schema.prove context certificate | throw .malformedBody
-  let baseWithin := initialWithin input checked.baseSize
-  let currentBaseWithin : FactsWithin checked.program (initialBase input) :=
-    fun fact member => Nat.lt_of_lt_of_le (baseWithin fact member) checked.basePrefix.nodeSize
+  let currentBaseWithin : FactsWithin checked.program (replayBase input assumptions) :=
+    fun fact member => Nat.lt_of_lt_of_le (checked.baseWithinOrigin fact member)
+      checked.originPrefix.nodeSize
   pure
-    { version := step.afterVersion
+    { scope := checked.scope
+      version := step.afterVersion
       program := step.after
       baseSize := checked.baseSize
       basePrefix := checked.basePrefix.trans proof.stable.appendOnly
       extension := composeExtends semantics checked.basePrefix checked.extension proof.extension
       stable := composeStable checked.stable proof.stable
+      origin := checked.origin
+      originFromInput := checked.originFromInput
+      baseWithinOrigin := checked.baseWithinOrigin
+      originPrefix := checked.originPrefix.trans proof.stable.appendOnly
+      originExtension := composeExtends semantics checked.originPrefix checked.originExtension
+        proof.extension
+      originStable := composeStable checked.originStable proof.stable
       facts := checked.facts.lift proof.stable currentBaseWithin domain
       equalities := checked.equalities.lift proof.stable currentBaseWithin }
 
-def replayEvent (limits : Limits) (registry : Registry semantics)
+def replayEvent (limits : Limits) (registry : Registry semantics Plan)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
-    State semantics input → Event Fact → Except Error (State semantics input)
+    State semantics input assumptions → Event Fact →
+      Except Error (State semantics input assumptions)
   | checked, .fact step => replayFact limits registry domain input checked step
   | checked, .equality step => replayEquality limits registry input checked step
   | checked, .transport step => replayTransport limits domain laws input checked step
   | checked, .instance step => replayInstance limits registry domain input checked step
 
-def replayEvents (limits : Limits) (registry : Registry semantics)
+def replayEvents (limits : Limits) (registry : Registry semantics Plan)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
-    List (Event Fact) → State semantics input → Except Error (State semantics input)
+    List (Event Fact) → State semantics input assumptions →
+      Except Error (State semantics input assumptions)
   | [], state => pure state
   | event :: events, state => do
       let next ← replayEvent limits registry domain laws input state event
       replayEvents limits registry domain laws input events next
+
+/-- A successfully replayed chronology retains its checked proof state. It is
+the only input accepted by later target, refutation, split, and child-seed
+operations; decoded runtime state never constructs this value. -/
+structure Replay (semantics : Semantics Fact) (input : Input Fact)
+    (assumptions : List (NodeFact Fact)) (start : State semantics input assumptions) where
+  state : State semantics input assumptions
+  originEq : state.origin = start.origin := by rfl
+
+/-- Replay from an already authenticated proof state and require the exact
+final program version and structural program. Failure returns no partial
+state. -/
+def replayFrom (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
+    (start : State semantics input assumptions) (events : List (Event Fact))
+    (finalVersion : Nat) (finalProgram : Program) :
+    Except Error (Replay semantics input assumptions start) := do
+  if limits.maxChronology < events.length then throw .chronologyLimit
+  let checked ← replayEvents limits registry domain laws input events start
+  if checked.version != finalVersion then throw .wrongProgramVersion
+  if checked.program != finalProgram then throw .wrongFinalProgram
+  let originEq : Evidence (checked.origin = start.origin) ←
+    if h : checked.origin = start.origin then pure ⟨h⟩ else throw .wrongFinalProgram
+  pure { state := checked, originEq := originEq.proof }
+
+/-- Close a proof in the node's possibly extended program back to the exact
+program at entry to that node. Independent child extensions therefore meet at
+one common parent program before a split join. -/
+def closeOrigin (checked : State semantics input assumptions) (target : NodeFact Fact)
+    (targetWithin : target.node.index < checked.origin.nodes.size)
+    (sound : Evidence (semantics.Entails checked.program (replayBase input assumptions) target)) :
+    Evidence (semantics.Entails checked.origin (replayBase input assumptions) target) :=
+  { proof := by
+      intro valuation originModel originBase
+      obtain ⟨extended, finalModel, agreement⟩ :=
+        checked.originExtension.proof valuation originModel
+      have finalBase : ∀ fact, fact ∈ replayBase input assumptions →
+          semantics.holds checked.program extended fact := by
+        intro fact member
+        exact (checked.originStable.holdsOld valuation extended fact
+          (checked.baseWithinOrigin fact member) originModel finalModel agreement).mp
+            (originBase fact member)
+      have finalTarget := sound.proof extended finalModel finalBase
+      exact (checked.originStable.holdsOld valuation extended target targetWithin
+        originModel finalModel agreement).mpr finalTarget }
 
 /-- Replay exact chronology and close the exact target/version. -/
 def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
@@ -984,11 +1271,9 @@ def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
     if h : input.facts.size = input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
   let targetWithin : Evidence (input.target.node.index < input.program.nodes.size) ←
     if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
-  if limits.maxChronology < events.length then throw .chronologyLimit
-  let checked ← replayEvents limits registry domain laws input events
-    (State.start semantics input size.proof)
-  if checked.version != finalVersion then throw .wrongProgramVersion
-  if checked.program != finalProgram then throw .wrongFinalProgram
+  let replayed ← replayFrom limits registry domain laws input
+    (State.start semantics input size.proof) events finalVersion finalProgram
+  let checked := replayed.state
   let nodeEq : Evidence (result.node = input.target.node) ←
     if h : result.node = input.target.node then pure ⟨h⟩ else throw .wrongTarget
   let some resolved := checked.facts.resolve result | throw (.missingDependency result)
@@ -1005,7 +1290,8 @@ def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
           exact (checked.stable.holdsOld valuation extended fact
             ((initialWithin input size.proof) fact member) baseModel finalModel agreement).mp
               (baseHolds fact member)
-        have finalResult := resolved.sound.proof extended finalModel finalBase
+        have finalResult := resolved.sound.proof extended finalModel (by
+          simpa [replayBase] using finalBase)
         have finalTarget : semantics.holds checked.program extended input.target := by
           simpa [nodeEq.proof, factEq.proof] using finalResult
         exact (checked.stable.holdsOld valuation extended input.target targetWithin.proof
@@ -1013,12 +1299,12 @@ def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
 
 /-- Replay one exact established impossible fact. Runtime contradiction state
 is not an argument. -/
-def replayRefute (limits : Limits) (registry : Registry semantics)
-    (input : Input Fact) (checked : State semantics input) (step : RefuteStep)
+def replayRefute (limits : Limits) (registry : Registry semantics Plan)
+    (input : Input Fact) (checked : State semantics input assumptions) (step : RefuteStep)
     (target : NodeFact Fact) : Except Error
-      (Evidence (semantics.Entails checked.program (initialBase input) target)) := do
+      (Evidence (semantics.Entails checked.program (replayBase input assumptions) target)) := do
   bodyCheck limits step.schema .refute step.body
-  if step.scope != input.scope then throw .wrongScope
+  if step.scope != checked.scope then throw .wrongScope
   if step.programVersion != checked.version then throw .wrongProgramVersion
   let some established := checked.facts.resolve step.seen
     | throw (.missingDependency step.seen)
@@ -1033,6 +1319,274 @@ def replayRefute (limits : Limits) (registry : Registry semantics)
         intro valuation model baseHolds
         exact False.elim (impossible.proof valuation model
           (established.sound.proof valuation model baseHolds)) }
+
+/-- Authenticate one package-owned binary cover against the exact checked
+parent proof state. The runtime split plan and child facts remain inert data
+until this theorem schema succeeds. -/
+def replaySplit [DecidableEq Fact] [DecidableEq Plan]
+    (limits : Limits) (registry : Registry semantics Plan)
+    (input : Input Fact) (checked : State semantics input assumptions)
+    (step : SplitStep Fact Plan) : Except Error
+      (Evidence (semantics.Covers checked.program (replayBase input assumptions)
+        { node := step.left.node, fact := step.left.fact }
+        { node := step.right.node, fact := step.right.fact })) := do
+  bodyCheck limits step.schema .split step.body
+  dependenciesCheck limits step.action.inputs
+  if step.scope != checked.scope then throw .wrongScope
+  if step.programVersion != checked.version ||
+      step.action.programVersion != checked.version then throw .wrongProgramVersion
+  if step.action.kind != .split || step.action.key != step.schema.rule ||
+      step.action.node != step.parent.node || !step.action.inputs.contains step.parent then
+    throw .wrongAction
+  if step.left.previous != step.parent || step.right.previous != step.parent ||
+      step.left.node != step.parent.node || step.right.node != step.parent.node ||
+      step.left.fact == step.right.fact then throw .wrongSplit
+  let some parent := checked.facts.resolve step.parent
+    | throw (.missingDependency step.parent)
+  let some resolvedInputs := resolveInputs checked.facts step.action.inputs
+    | throw (.missingDependency (step.action.inputs.head?.getD step.parent))
+  if !registry.acceptsAction checked.program step.action
+      (resolvedInputs.facts.map fun fact => fact.node) then throw .wrongAction
+  let some schema := registry.split? step.schema | throw .missingSchema
+  let some certificate := schema.decode step.body | throw .malformedBody
+  let context : SplitContext semantics Plan :=
+    { scope := checked.scope
+      programVersion := checked.version
+      program := checked.program
+      action := step.action
+      assumptions := resolvedInputs.facts
+      parent := { node := step.parent.node, fact := parent.fact }
+      left := { node := step.left.node, fact := step.left.fact }
+      right := { node := step.right.node, fact := step.right.fact }
+      plan := step.plan }
+  let some cover := schema.prove context certificate | throw .malformedBody
+  pure
+    { proof := by
+        intro valuation model baseHolds
+        apply cover.proof valuation model
+        intro assumption member
+        exact resolvedInputs.sound.proof assumption member valuation model baseHolds }
+
+def joinCover (semantics : Semantics Fact)
+    (cover : Evidence (semantics.Covers program baseFacts leftFact rightFact))
+    (left : Evidence (semantics.Entails program (baseFacts ++ [leftFact]) target))
+    (right : Evidence (semantics.Entails program (baseFacts ++ [rightFact]) target)) :
+    Evidence (semantics.Entails program baseFacts target) :=
+  { proof := by
+      intro valuation model baseHolds
+      rcases cover.proof valuation model baseHolds with leftHolds | rightHolds
+      · apply left.proof valuation model
+        intro assumption member
+        rw [List.mem_append, List.mem_singleton] at member
+        exact member.elim (baseHolds assumption) (fun equal => by simpa [equal] using leftHolds)
+      · apply right.proof valuation model
+        intro assumption member
+        rw [List.mem_append, List.mem_singleton] at member
+        exact member.elim (baseHolds assumption) (fun equal => by simpa [equal] using rightHolds) }
+
+/-! ## Retained-tree proof fold -/
+
+/-- Exact retained parent edge echoed by an untrusted proof recipe. Replaying
+the recipe requires this value to match the already-checked runtime tree; it is
+neither evidence nor authority to alter that tree. -/
+structure TreeEdge (Fact : Type) where
+  parent : Option Search.Result.Id := none
+  side : Option Search.Result.Side := none
+  seed : Option (Search.Result.Seed Fact) := none
+  deriving DecidableEq, Repr
+
+/-- Proof chronology aligned by retained tree node. It is decoded untrusted
+data; exact replay, parent-edge, and node-state alignment are checked before
+use. Constructing this value does not quote or trust a search callback. -/
+structure TreeRecipe (Fact : Type) where
+  events : Array (List (Event Fact))
+  edges : Array (TreeEdge Fact)
+  deriving DecidableEq, Repr
+
+/-- Independent proof-fold limits. Search has already bounded retained state;
+these limits bound theorem chronology and recursive proof construction. Work
+is the structural sum of nodes, event cells, and split/refuter body cells. -/
+structure TreeLimits where
+  maxNodes : Nat
+  maxDepth : Nat
+  maxBodyCells : Nat
+  maxWork : Nat
+  deriving DecidableEq, Repr
+
+def Event.bodyCells : Event Fact → Nat
+  | .fact step => step.body.length
+  | .equality step => step.body.length
+  | .transport _ => 0
+  | .instance step => step.body.length
+
+def nodeBodyCells : Search.Result.Node Fact Cause Plan Key → Nat
+  | .pending _ => 0
+  | .terminal _ (.target _) | .terminal _ (.unknown _) => 0
+  | .terminal _ (.refute step) => step.body.length
+  | .split _ step _ _ => step.body.length
+
+def TreeRecipe.bodyCells (recipe : TreeRecipe Fact) : Nat :=
+  recipe.events.toList.foldl (fun total events =>
+    total + events.foldl (fun subtotal event => subtotal + event.bodyCells) 0) 0
+
+def proofWork (tree : Search.Result.Tree Fact Cause Plan Key)
+    (recipe : TreeRecipe Fact) : Nat :=
+  tree.nodes.size + recipe.edges.size + recipe.events.toList.foldl
+    (fun total events => total + events.length) 0 +
+    recipe.bodyCells + tree.nodes.toList.foldl
+      (fun total node => total + nodeBodyCells node) 0
+
+def checkTreeLimits (limits : TreeLimits)
+    (tree : Search.Result.Tree Fact Cause Plan Key) (recipe : TreeRecipe Fact) :
+    Except Error Unit := do
+  if tree.nodes.size != recipe.events.size || tree.nodes.size != recipe.edges.size then
+    throw .wrongTree
+  if limits.maxNodes < tree.nodes.size then throw .proofNodeLimit
+  if tree.nodes.any (fun node => limits.maxDepth < node.source.depth) then
+    throw .proofDepthLimit
+  let bodies := recipe.bodyCells + tree.nodes.toList.foldl
+    (fun total node => total + nodeBodyCells node) 0
+  if limits.maxBodyCells < bodies then throw .proofBodyLimit
+  if limits.maxWork < proofWork tree recipe then throw .proofWorkLimit
+
+def terminalTarget [DecidableEq Fact]
+    (input : Input Fact) (checked : State semantics input assumptions)
+    (entry : Search.Result.Target) : Except Error
+      (Evidence (semantics.Entails checked.origin (replayBase input assumptions) input.target)) := do
+  if entry.scope != checked.scope then throw .wrongScope
+  if entry.programVersion != checked.version then throw .wrongProgramVersion
+  let some resolved := checked.facts.resolve entry.seen
+    | throw (.missingDependency entry.seen)
+  let nodeEq : Evidence (entry.seen.node = input.target.node) ←
+    if h : entry.seen.node = input.target.node then pure ⟨h⟩ else throw .wrongTarget
+  let factEq : Evidence (resolved.fact = input.target.fact) ←
+    if h : resolved.fact = input.target.fact then pure ⟨h⟩ else throw .wrongTarget
+  let rootWithin : Evidence (input.target.node.index < input.program.nodes.size) ←
+    if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩
+    else throw .invalidInput
+  let originWithin : input.target.node.index < checked.origin.nodes.size :=
+    Nat.lt_of_lt_of_le rootWithin.proof checked.originFromInput.nodeSize
+  let sound : Evidence
+      (semantics.Entails checked.program (replayBase input assumptions) input.target) := by
+    simpa [nodeEq.proof, factEq.proof] using resolved.sound
+  pure (closeOrigin checked input.target originWithin sound)
+
+def foldNode [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (limits : Limits) (treeLimits : TreeLimits)
+    (registry : Registry semantics Plan) (domain : Domain semantics) (laws : Laws semantics)
+    (input : Input Fact) (tree : Search.Result.Tree Fact Cause Plan Key)
+    (recipe : TreeRecipe Fact) (id : Search.Result.Id)
+    (assumptions : List (NodeFact Fact)) (start : State semantics input assumptions)
+    (fuel : Nat) : Except Error
+      (Evidence (semantics.Entails start.origin (replayBase input assumptions) input.target)) := do
+  let fuelPos : Evidence (0 < fuel) ←
+    if h : 0 < fuel then pure ⟨h⟩ else throw .wrongTree
+  let some node := tree.nodes[id.index]? | throw .wrongTree
+  let source := node.source
+  let some events := recipe.events[id.index]? | throw .wrongTree
+  let some edge := recipe.edges[id.index]? | throw .wrongTree
+  if edge.parent != source.parent || edge.side != source.side || edge.seed != source.seed then
+    throw .wrongTree
+  let replayed ← replayFrom limits registry domain laws input start events
+    source.branch.programVersion source.branch.program
+  let checked := replayed.state
+  have originEq : checked.origin = start.origin := replayed.originEq
+  if !checked.matchesBranch semantics source.scope source.branch then throw .wrongTree
+  match node with
+  | .pending _ => throw .unknownLeaf
+  | .terminal _ (.unknown _) => throw .unknownLeaf
+  | .terminal _ (.target entry) =>
+      let closed ← terminalTarget input checked entry
+      pure (by rw [originEq] at closed; exact closed)
+  | .terminal _ (.refute entry) =>
+      let targetWithinRoot : Evidence
+          (input.target.node.index < input.program.nodes.size) ←
+        if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩
+        else throw .invalidInput
+      let originWithin := Nat.lt_of_lt_of_le targetWithinRoot.proof
+        checked.originFromInput.nodeSize
+      let refuted ← replayRefute limits registry input checked
+        { scope := entry.scope, programVersion := entry.programVersion,
+          seen := entry.seen, schema := entry.schema, body := entry.body }
+        input.target
+      let closed := closeOrigin checked input.target originWithin refuted
+      pure (by rw [originEq] at closed; exact closed)
+  | .split _ split leftId rightId =>
+      let some leftNode := tree.nodes[leftId.index]? | throw .wrongTree
+      let some rightNode := tree.nodes[rightId.index]? | throw .wrongTree
+      let leftSource := leftNode.source
+      let rightSource := rightNode.source
+      let some leftSeed := leftSource.seed | throw .wrongTree
+      let some rightSeed := rightSource.seed | throw .wrongTree
+      if leftSource.parent != some id || leftSource.side != some .left ||
+          rightSource.parent != some id || rightSource.side != some .right then throw .wrongTree
+      let cover ← replaySplit limits registry input checked
+        { scope := split.scope
+          programVersion := split.programVersion
+          action := split.action
+          parent := split.parent
+          plan := split.plan
+          left := leftSeed
+          right := rightSeed
+          schema := split.schema
+          body := split.body }
+      let leftChild ← seedChild semantics input checked source.scope leftSource.scope
+        source.branch leftSeed
+      let rightChild ← seedChild semantics input checked source.scope rightSource.scope
+        source.branch rightSeed
+      let leftStart := leftChild.state
+      let rightStart := rightChild.state
+      let nextFuel := fuel - 1
+      let nextLt : Evidence (nextFuel < fuel) :=
+        { proof := Nat.sub_lt fuelPos.proof (by decide) }
+      let leftProof ← foldNode limits treeLimits registry domain laws input tree recipe
+        leftId (assumptions ++ [{ node := leftSeed.node, fact := leftSeed.fact }])
+        leftStart nextFuel
+      let rightProof ← foldNode limits treeLimits registry domain laws input tree recipe
+        rightId (assumptions ++ [{ node := rightSeed.node, fact := rightSeed.fact }])
+        rightStart nextFuel
+      have leftOrigin : leftStart.origin = checked.program := leftChild.originEq
+      have rightOrigin : rightStart.origin = checked.program := rightChild.originEq
+      let joined : Evidence
+          (semantics.Entails checked.program (replayBase input assumptions) input.target) := by
+        apply joinCover semantics cover
+        · rw [leftOrigin] at leftProof
+          simpa [replayBase, List.append_assoc] using leftProof
+        · rw [rightOrigin] at rightProof
+          simpa [replayBase, List.append_assoc] using rightProof
+      let rootWithin : Evidence (input.target.node.index < input.program.nodes.size) ←
+        if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩
+        else throw .invalidInput
+      let originWithin := Nat.lt_of_lt_of_le rootWithin.proof checked.originFromInput.nodeSize
+      let closed := closeOrigin checked input.target originWithin joined
+      pure (by rw [originEq] at closed; exact closed)
+termination_by fuel
+decreasing_by
+  all_goals
+    simpa [nextFuel] using nextLt.proof
+
+/-- Check an exact retained search tree, authenticate its root against the
+caller input, and replay all leaves transactionally. Unknown or pending leaves
+cannot produce a proof. -/
+def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (searchLimits : Search.Result.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Key)
+    (limits : Limits) (treeLimits : TreeLimits)
+    (registry : Registry semantics Plan) (domain : Domain semantics) (laws : Laws semantics)
+    (input : Input Fact) (tree : Search.Result.Tree Fact Cause Plan Key)
+    (recipe : TreeRecipe Fact) : Except Error
+      (Evidence (semantics.Entails input.program (initialBase input) input.target)) := do
+  if !tree.check searchLimits measure then throw .wrongTree
+  checkTreeLimits treeLimits tree recipe
+  let some root := tree.nodes[0]? | throw .wrongTree
+  let source := root.source
+  if source.scope != input.scope || source.branch.baseProgram != input.program ||
+      source.branch.initialFacts != input.facts then throw .wrongTree
+  let size : Evidence (input.facts.size = input.program.nodes.size) ←
+    if h : input.facts.size = input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
+  let folded ← foldNode limits treeLimits registry domain laws input tree recipe
+    { index := 0 } [] (State.start semantics input size.proof) (tree.nodes.size + 1)
+  pure (by simpa [State.start, replayBase] using folded)
 
 /-! ## Elaborator-facing expression boundary -/
 

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -253,8 +253,27 @@ exactly one natural exponent and one dyadic constant: every node at the
 built-in power operation index shares that exponent, and every node at the
 built-in constant index shares that value. Duplicate package registration and
 operation keys cannot add another parameterization. Arbitrary-function package
-discovery, goal reification, encoding and evidence folds, search-to-recipe
-orchestration, and tactic syntax remain experimental.
+discovery, generic search-to-recipe orchestration, split-search tactic
+integration, and default package discovery remain experimental. The supported
+direct-forward reifier and tactic syntax are a narrow client of this registry,
+not the missing generic search bridge.
+
+The supported proof fold also accepts a `Search.Result.Tree` only after the
+tree passes `Tree.check` under the exact caller-supplied search limits and
+measure. A separate untrusted `TreeRecipe` must echo every parent, side, and
+seed edge and supply the ordered proof events. On a split, the child proof
+state restarts at program version zero: the one branch seed becomes a new
+assumption, while every inherited parent fact remains derived evidence rebased
+to the child-local version. Package-owned keyed split and refutation schemas
+authenticate the cover and contradiction; runtime terminal tags, bodies, and
+contradiction state never become evidence. `Proof.TreeLimits` separately bound
+proof nodes, depth, body cells, and structural work. Pending and unknown leaves
+reject transactionally. Search callback quotation into this recipe and tactic
+integration remain later work. The current retained-tree builder repeatedly
+validates retained branches and pairwise scope uniqueness; incremental
+construction therefore has the documented `Θ(N² * B + N³)` reference cost,
+where `B` is branch validation work, rather than a production-local-update
+claim.
 
 `HexIntervalMathlib.Experiment.PntLogRational` is a fixed-source acceptance
 provider rather than public interval arithmetic. It proves the original

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -269,7 +269,11 @@ authenticate the cover and contradiction; runtime terminal tags, bodies, and
 contradiction state never become evidence. `Proof.TreeLimits` separately bound
 proof nodes, depth, body cells, and structural work. Pending and unknown leaves
 reject transactionally. Search callback quotation into this recipe and tactic
-integration remain later work. The current retained-tree builder repeatedly
+integration remain later work. Each retained node currently freezes its
+`Source.branch` at creation; non-root snapshots restart at version zero, so a
+non-root chronology must be empty or proof-state-only and its terminal can cite
+only creation-snapshot facts. Recursive child propagation is not yet supported.
+The current retained-tree builder repeatedly
 validates retained branches and pairwise scope uniqueness; incremental
 construction therefore has the documented `Θ(N² * B + N³)` reference cost,
 where `B` is branch validation work, rather than a production-local-update

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -41,9 +41,25 @@ granting runtime state evidence authority. The current package fixes one
 natural exponent and one dyadic constant, shared respectively by every node at
 the built-in power and constant operation indices; duplicate package
 registration and operation keys cannot provide another such parameterization.
-Arbitrary-function package discovery, goal reification, encoding and evidence
-folds, search-to-recipe orchestration, and tactic syntax remain experimental
-and are not re-exported by the public umbrella.
+Arbitrary-function package discovery, generic search-to-recipe orchestration,
+split-search tactic integration, and default package discovery remain
+experimental. The supported direct-forward reifier and tactic are a narrow
+client rather than that missing generic bridge. The supported proof layer can
+replay a separately supplied, bounded chronology over a checked
+retained search tree: package-owned binary-cover and refutation schemas are
+resolved by exact key, each child adds exactly one branch assumption while
+inherited parent consequences retain derived evidence, target/refutation
+leaves close, unknown leaves reject, and sibling proofs join only through the
+checked cover. The tree must pass its exact caller-supplied search limits and
+measure, and the untrusted recipe separately echoes every parent, side, and
+seed edge. Child proof states restart at program version zero; inherited facts
+are rebased as derived evidence rather than promoted to assumptions.
+`Proof.TreeLimits` independently cap proof nodes, depth, body cells, and
+structural work. Generic callback-to-recipe quotation and tactic-driven split
+search remain later integration edges. Current retained-tree construction
+inherits the Mathlib-free reference cost `Θ(N² * B + N³)` from repeated branch
+validation and pairwise scope-uniqueness checking; this is not a production
+storage-complexity claim.
 The supported `Frontend` is instead a tactic-independent, flat programmatic
 client. It recursively reifies bounded `Term` values by stable operation key,
 rechecks the transparent result's exact node/term/ordered-edge correspondence,
@@ -66,8 +82,8 @@ construction or structural equality. The caller's opaque source-value
 function is also outside this preemptible envelope. It does not
 parse Lean expressions or hypotheses, extract recipes from generic Search
 trees, or expose tactic syntax.
-The user-facing tactic contract below is the release target, not a claim that
-the tactic is already supported.
+The user-facing tactic contract below remains the broader release target; the
+direct forward subset described above is the currently supported tactic.
 
 The tactic proves bounds for ordinary Lean expressions over `ℝ`. It reads
 bounds from the local context, reifies shared expressions to an immutable
@@ -3104,8 +3120,9 @@ the fixed soundness and trust contracts.
   evaluator soundness.
 - `HexIntervalMathlib/Rule.lean`: registration environment and theorem-schema
   validation.
-- `HexIntervalMathlib/Proof.lean`: derivation slicing, certificate checks, and
-  proof construction.
+- `HexIntervalMathlib/Proof.lean`: chronological and retained-tree replay,
+  package-owned fact/equality/instance/refutation/split schemas, exact child
+  seeding and cover joins, certificate checks, and proof construction.
 - `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
 - `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
   enclosures.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -56,7 +56,11 @@ seed edge. Child proof states restart at program version zero; inherited facts
 are rebased as derived evidence rather than promoted to assumptions.
 `Proof.TreeLimits` independently cap proof nodes, depth, body cells, and
 structural work. Generic callback-to-recipe quotation and tactic-driven split
-search remain later integration edges. Current retained-tree construction
+search remain later integration edges. Each retained node currently freezes
+its `Source.branch` at creation; non-root snapshots restart at version zero,
+so their chronology must be empty or proof-state-only and terminals can cite
+only facts current in that creation snapshot. Recursive child propagation
+remains part of the later controller edge. Current retained-tree construction
 inherits the Mathlib-free reference cost `Θ(N² * B + N³)` from repeated branch
 validation and pairwise scope-uniqueness checking; this is not a production
 storage-complexity claim.

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -11,8 +11,10 @@ import HexIntervalMathlib.Proof
 
 This canary exercises a complete function-agnostic chronology: an authenticated
 reflexive program instance, a fact theorem, an equality theorem, equality
-transport, exact target closure, and a separately owned refuter. Mutated quote
-fields fail before they can alter the immutable proof state.
+transport, exact target closure, a separately owned refuter, and an
+authenticated retained split whose children distinguish one new branch
+assumption from inherited derived facts. Mutated quote and tree fields fail
+before they can alter the immutable proof state.
 -/
 
 namespace Hex.IntervalMathlib.ProgramProofConformance
@@ -21,7 +23,7 @@ open Hex.Interval
 open Hex.Interval.Proof
 
 inductive TestFact where
-  | all | yes | no | empty
+  | all | yes | no | decided | empty
   deriving DecidableEq, Repr
 
 def domain : DomainId := { index := 0 }
@@ -53,6 +55,8 @@ example : ¬ Hex.Interval.Program.Models #[] program (fun _ => true) := by
   simpa [Hex.Interval.Program.Models, program] using model.1
 
 def scope : Policy.ScopeId := { index := 7 }
+def leftScope : Policy.ScopeId := { index := 8 }
+def rightScope : Policy.ScopeId := { index := 9 }
 def factRule : RuleKey := { name := "proof-fact", schema := 3 }
 def equalityRule : RuleKey := { name := "proof-equality", schema := 3 }
 def instanceRule : RuleKey := { name := "proof-instance", schema := 3 }
@@ -108,6 +112,7 @@ def contains : TestFact → Bool → Prop
   | .all, _ => True
   | .yes, value => value = true
   | .no, value => value = false
+  | .decided, value => value = true ∨ value = false
   | .empty, _ => False
 
 def semantics : Proof.Semantics TestFact :=
@@ -211,7 +216,7 @@ def refuteSchema : Proof.RefuteSchema semantics :=
     Certificate := Unit
     decode := decode 44
     prove := fun context _ =>
-      if shape : context.scope = scope ∧ context.program = program ∧
+      if shape : (context.scope = scope ∨ context.scope = rightScope) ∧ context.program = program ∧
           context.fact = .empty then
         some
           { proof := by
@@ -227,7 +232,8 @@ def package : Proof.Package semantics :=
     facts := #[factSchema]
     equalities := #[equalitySchema]
     instances := #[instanceSchema]
-    refuters := #[refuteSchema] }
+    refuters := #[refuteSchema]
+    splits := #[] }
 
 def limits : Proof.Limits :=
   { maxPackages := 1, maxSchemas := 4, maxBodyCells := 1,
@@ -435,6 +441,286 @@ def unowned : Proof.Package semantics := { registrations := #[], refuters := #[r
 #guard match Proof.Registry.buildWithin limits program #[unowned] with
   | .error (.emptyRefuterOwner 0 key) => key == refuteKey
   | _ => false
+
+/-! ## Authenticated retained split fold -/
+
+def splitRule : RuleKey := { name := "proof-split", schema := 3 }
+
+def splitRegistration : Registration :=
+  { key := splitRule
+    head := sourceKey
+    kind := .split
+    watches := [.result]
+    writes := [] }
+
+def splitKey : Proof.Key := { rule := splitRule, role := .split, bodySchema := 5 }
+
+def splitSchema : Proof.SplitSchema semantics (List Nat) :=
+  { key := splitKey
+    Certificate := Unit
+    decode := decode 55
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.programVersion = 1 ∧
+          context.program = program ∧
+          context.assumptions = [{ node := node0, fact := .yes }] ∧
+          context.parent = { node := node0, fact := .yes } ∧
+          context.left = { node := node0, fact := .all } ∧
+          context.right = { node := node0, fact := .empty } ∧
+          context.plan = [55] then
+        some
+          { proof := by
+              rcases shape with ⟨_, _, _, _, _, leftEq, _, _⟩
+              intro valuation model inputs
+              left
+              simp [leftEq, semantics, contains] }
+      else none }
+
+def splitPackage : Proof.Package semantics (List Nat) :=
+  { registrations := #[factRegistration, equalityRegistration, instanceRegistration,
+      refuteRegistration, splitRegistration]
+    facts := #[factSchema]
+    equalities := #[equalitySchema]
+    instances := #[instanceSchema]
+    refuters := #[refuteSchema]
+    splits := #[splitSchema] }
+
+def splitLimits : Proof.Limits :=
+  { limits with maxSchemas := 5 }
+
+def splitRegistry? : Option (Proof.Registry semantics (List Nat)) :=
+  (Proof.Registry.buildWithin splitLimits program #[splitPackage]).toOption
+
+#guard match Proof.Registry.buildWithin splitLimits program #[splitPackage] with
+  | .ok built => built.splits.size == 1 && built.registrations.size == 5
+  | .error _ => false
+
+def stateLimits : State.Limits :=
+  { maxOperations := 2
+    maxNodes := 2
+    maxRules := 5
+    maxRegistryEntries := 5
+    maxReplayFormats := 5
+    maxArity := 1
+    maxApplications := 5
+    maxQueueEntries := 5
+    maxActions := 5
+    maxAcceptedFacts := 2
+    maxRetainedSuggestions := 2
+    maxEffort := 4
+    maxObservationValue := 8
+    maxDiagnosticValue := 8
+    maxOutcomeCandidates := 2
+    maxOutcomeSuggestions := 2
+    maxProposalItems := 4
+    maxInstances := 2
+    maxGeneration := 2
+    maxNodeDepth := 1
+    maxEqualities := 1
+    splitEndpointLimit := { maxEndpointHeight := 32, maxAlignmentShift := 32 } }
+
+def rootBranch? : Option (State.Branch TestFact Nat) := do
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
+  let branch ← (State.Branch.extendWithin stateLimits branch program #[] 0).toOption
+  let branch ← (State.Branch.pushWithin stateLimits branch
+    { programVersion := 1, node := node0, previous := seen node0 0,
+      fact := .yes, version := 1, cause := 1 }).toOption
+  (State.Branch.pushWithin stateLimits branch
+    { programVersion := 1, node := node1, previous := seen node1 0,
+      fact := .yes, version := 1, cause := 2 }).toOption
+
+def searchLimits : Search.Result.Limits :=
+  { search :=
+      { maxSteps := 3, maxSplits := 1, maxLeaves := 2, maxFrontier := 2,
+        maxDepth := 1, maxScopes := 3, leafFuel := 4 }
+    state := stateLimits
+    maxNodes := 3
+    maxBodyCells := 1
+    maxBytes := 64
+    maxWork := 64
+    maxCode := 8 }
+
+def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
+
+def treeMeasure : Search.Result.Measure TestFact Nat (List Nat) Proof.Key :=
+  { node := unitCost
+    branch := fun branch =>
+      { bytes := branch.snapshot.facts.size + branch.history.size,
+        work := branch.versions.size + branch.history.size }
+    fact := fun _ => unitCost
+    action := fun _ => unitCost
+    plan := fun _ => unitCost
+    schema := fun _ => unitCost
+    body := fun _ => unitCost
+    code := fun _ => unitCost }
+
+def splitAction : Action :=
+  action 3 1 4 splitRule .split node0 [seen node0 1] []
+
+def splitRecipe : Search.Result.Split (List Nat) Proof.Key :=
+  { scope
+    programVersion := 1
+    action := splitAction
+    parent := seen node0 1
+    plan := [55]
+    schema := splitKey
+    body := [55] }
+
+def leftSeed : Search.Result.Seed TestFact :=
+  { node := node0, previous := splitRecipe.parent, fact := .all }
+
+def rightSeed : Search.Result.Seed TestFact :=
+  { node := node0, previous := splitRecipe.parent, fact := .empty }
+
+def leftEnd : Search.Result.End Proof.Key :=
+  .target { scope := leftScope, programVersion := 0, seen := seen node1 0 }
+
+def rightEnd : Search.Result.End Proof.Key :=
+  .refute
+    { scope := rightScope, programVersion := 0, seen := seen node0 0,
+      schema := refuteKey, body := [44] }
+
+def treeWith? (split := splitRecipe) (left := leftSeed) (right := rightSeed)
+    (leftTerminal := leftEnd) (rightTerminal := rightEnd) :
+    Option (Search.Result.Tree TestFact Nat (List Nat) Proof.Key) := do
+  let branch ← rootBranch?
+  let tree ← (Search.Result.startWithin searchLimits treeMeasure scope branch).toOption
+  let tree ← (Search.Result.splitWithin searchLimits treeMeasure .depthFirst tree
+    split left right).toOption
+  let tree ← (Search.Result.settleWithin searchLimits treeMeasure tree leftTerminal).toOption
+  (Search.Result.settleWithin searchLimits treeMeasure tree rightTerminal).toOption
+
+def splitTree? : Option (Search.Result.Tree TestFact Nat (List Nat) Proof.Key) :=
+  treeWith?
+
+def treeRecipe : Proof.TreeRecipe TestFact :=
+  { events := #[events, [], []]
+    edges :=
+      #[{},
+        { parent := some { index := 0 }, side := some .left, seed := some leftSeed },
+        { parent := some { index := 0 }, side := some .right, seed := some rightSeed }] }
+
+def treeLimits : Proof.TreeLimits :=
+  { maxNodes := 3, maxDepth := 1, maxBodyCells := 5, maxWork := 16 }
+
+def treeRun : Except Proof.Error
+    (Proof.Evidence (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
+  match splitTree? with
+  | none => .error .wrongTree
+  | some tree => match splitRegistry? with
+    | none => .error .invalidInput
+    | some registry => Proof.replayTree searchLimits treeMeasure splitLimits treeLimits
+        registry factDomain laws input tree treeRecipe
+
+#guard treeRun.isOk
+
+def decisionInput : Proof.Input TestFact :=
+  { scope, program, facts := #[.all, .all], target := { node := node0, fact := .decided } }
+
+def leftFact : Proof.NodeFact TestFact := { node := node0, fact := .yes }
+def rightFact : Proof.NodeFact TestFact := { node := node0, fact := .no }
+
+def coverEvidence : Proof.Evidence
+    (semantics.Covers program (Proof.initialBase decisionInput) leftFact rightFact) :=
+  { proof := by
+      intro valuation model assumptions
+      cases value : valuation node0 <;>
+        simp [semantics, contains, leftFact, rightFact, value] }
+
+def leftEvidence : Proof.Evidence
+    (semantics.Entails program (Proof.initialBase decisionInput ++ [leftFact])
+      decisionInput.target) :=
+  { proof := by
+      intro valuation model assumptions
+      have branch := assumptions leftFact (by simp)
+      left
+      simpa [semantics, contains, leftFact, decisionInput] using branch }
+
+def rightEvidence : Proof.Evidence
+    (semantics.Entails program (Proof.initialBase decisionInput ++ [rightFact])
+      decisionInput.target) :=
+  { proof := by
+      intro valuation model assumptions
+      have branch := assumptions rightFact (by simp)
+      right
+      simpa [semantics, contains, rightFact, decisionInput] using branch }
+
+def splitEvidence : Proof.Evidence
+    (semantics.Entails decisionInput.program (Proof.initialBase decisionInput)
+      decisionInput.target) :=
+  Proof.joinCover semantics coverEvidence leftEvidence rightEvidence
+
+/-- The preceding executable guard runs the authenticated retained-tree fold.
+This ordinary theorem separately exercises a genuine Boolean cover whose two
+child proofs consume distinct `yes` and `no` assumptions, so the axiom report
+does not rely on compiled evaluation of the `Except` result. -/
+theorem splitCanary :
+    semantics.Entails decisionInput.program (Proof.initialBase decisionInput)
+      decisionInput.target :=
+  splitEvidence.proof
+
+/--
+info: 'Hex.IntervalMathlib.ProgramProofConformance.splitCanary' depends on axioms: [propext, Quot.sound]
+-/
+#guard_msgs in
+#print axioms splitCanary
+
+def treeError
+    (candidate : Option (Search.Result.Tree TestFact Nat (List Nat) Proof.Key) := splitTree?)
+    (quote : Proof.TreeRecipe TestFact := treeRecipe)
+    (measured : Search.Result.Measure TestFact Nat (List Nat) Proof.Key := treeMeasure)
+    (proofLimits : Proof.TreeLimits := treeLimits) : Option Proof.Error :=
+  match splitRegistry?, candidate with
+  | some registry, some tree =>
+      match Proof.replayTree searchLimits measured splitLimits proofLimits registry
+          factDomain laws input tree quote with
+      | .ok _ => none
+      | .error error => some error
+  | _, _ => some .wrongTree
+
+#guard treeError (candidate := treeWith? (split := { splitRecipe with schema := factKey })) ==
+  some .wrongSchema
+#guard treeError (candidate := treeWith? (split := { splitRecipe with body := [56] })) ==
+  some .malformedBody
+#guard treeError (candidate := treeWith? (split := { splitRecipe with plan := [56] })) ==
+  some .malformedBody
+#guard treeError (candidate := treeWith? (rightTerminal := .refute
+  { scope := rightScope, programVersion := 0, seen := seen node0 0,
+    schema := refuteKey, body := [45] })) == some .malformedBody
+#guard treeError (candidate := treeWith? (rightTerminal := .refute
+  { scope := rightScope, programVersion := 0, seen := seen node0 0,
+    schema := factKey, body := [44] })) == some .wrongSchema
+#guard treeError (candidate := treeWith? (leftTerminal := .target
+  { scope := leftScope, programVersion := 0, seen := seen node0 0 })) == some .wrongTarget
+
+def mapEdge (quote : Proof.TreeRecipe TestFact) (index : Nat)
+    (change : Proof.TreeEdge TestFact → Proof.TreeEdge TestFact) :
+    Proof.TreeRecipe TestFact :=
+  match quote.edges[index]? with
+  | some edge => { quote with edges := quote.edges.set! index (change edge) }
+  | none => quote
+
+#guard treeError (quote := mapEdge treeRecipe 1 fun edge =>
+  { edge with parent := some { index := 2 } }) == some .wrongTree
+#guard treeError (quote := mapEdge treeRecipe 1 fun edge =>
+  { edge with side := some .right }) == some .wrongTree
+#guard treeError (quote := mapEdge treeRecipe 1 fun edge =>
+  { edge with seed := edge.seed.map fun seed => { seed with fact := .no } }) ==
+  some .wrongTree
+#guard treeError (candidate := treeWith? (left := rightSeed) (right := leftSeed)) ==
+  some .malformedBody
+#guard treeError (candidate := treeWith? (leftTerminal := .unknown
+  { scope := leftScope, programVersion := 0, code := 1 })) == some .unknownLeaf
+#guard treeError (quote := { treeRecipe with events := #[events, []] }) == some .wrongTree
+#guard treeError (measured := { treeMeasure with node := { bytes := 2, work := 1 } }) ==
+  some .wrongTree
+#guard treeError (proofLimits := { treeLimits with maxNodes := 2 }) ==
+  some .proofNodeLimit
+#guard treeError (proofLimits := { treeLimits with maxDepth := 0 }) ==
+  some .proofDepthLimit
+#guard treeError (proofLimits := { treeLimits with maxBodyCells := 4 }) ==
+  some .proofBodyLimit
+#guard treeError (proofLimits := { treeLimits with maxWork := 14 }) ==
+  some .proofWorkLimit
 
 open Lean Meta Elab Tactic
 

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -417,6 +417,10 @@ theorem replayCanary :
     semantics.Entails input.program (Proof.initialBase input) input.target :=
   replayEvidence.proof
 
+/--
+info: 'Hex.IntervalMathlib.ProgramProofConformance.replayCanary' depends on axioms: [propext, Quot.sound]
+-/
+#guard_msgs in
 #print axioms replayCanary
 
 def impossibleInput : Proof.Input TestFact :=
@@ -613,6 +617,30 @@ def treeRun : Except Proof.Error
 
 #guard treeRun.isOk
 
+/-- The ordinary theorem below consumes the evidence returned by the actual
+checked retained-tree fold. The explicit error arm keeps this definition total
+without turning an executable `Except` guard into proof authority. -/
+def treeEvidence : Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  match treeRun with
+  | .ok evidence => evidence
+  | .error _ =>
+      { proof := by
+          intro valuation model assumptions
+          have source := assumptions { node := node0, fact := .yes } (by
+            simp [Proof.initialBase, input, node0])
+          simpa [semantics, contains, input, node1, model.2] using source }
+
+theorem treeCanary :
+    semantics.Entails input.program (Proof.initialBase input) input.target :=
+  treeEvidence.proof
+
+/--
+info: 'Hex.IntervalMathlib.ProgramProofConformance.treeCanary' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms treeCanary
+
 def decisionInput : Proof.Input TestFact :=
   { scope, program, facts := #[.all, .all], target := { node := node0, fact := .decided } }
 
@@ -676,6 +704,15 @@ def treeError
       | .ok _ => none
       | .error error => some error
   | _, _ => some .wrongTree
+
+def pendingTree? : Option (Search.Result.Tree TestFact Nat (List Nat) Proof.Key) := do
+  let branch ← rootBranch?
+  (Search.Result.startWithin searchLimits treeMeasure scope branch).toOption
+
+def pendingRecipe : Proof.TreeRecipe TestFact :=
+  { events := #[events], edges := #[{}] }
+
+#guard treeError (candidate := pendingTree?) (quote := pendingRecipe) == some .unknownLeaf
 
 #guard treeError (candidate := treeWith? (split := { splitRecipe with schema := factKey })) ==
   some .wrongSchema

--- a/progress/20260821T191839Z.md
+++ b/progress/20260821T191839Z.md
@@ -1,0 +1,35 @@
+# Supported retained-tree proof replay
+
+## Accomplished
+
+- Extended the supported proof registry with keyed binary-cover schemas and
+  retained refutation ownership.
+- Added checked child proof-state seeding, exact parent/side/seed recipe
+  authentication, bounded recursive retained-tree replay, target/refutation
+  closure, unknown-leaf rejection, and exact cover joins.
+- Added load-bearing conformance mutations for schemas, bodies, plans,
+  refuters, terminals, tree edges, child order, measures, and proof limits,
+  together with an ordinary split theorem whose two branches consume distinct
+  assumptions.
+- Corrected current-state documentation for the supported direct-forward
+  tactic, retained-tree limits and complexity, and the still-missing generic
+  search-to-recipe controller.
+- Built the full `HexConformance` target and passed the dependency, trust,
+  phase, bench-boundary, freshness, copyright, and line-count checks.
+
+## Current frontier
+
+The supported proof layer can consume a checked `Search.Result.Tree` plus a
+separately supplied untrusted proof recipe and replay every closed leaf into an
+ordinary theorem. Runtime callbacks still do not construct this recipe.
+
+## Next step
+
+Add the authenticated callback-to-`TreeRecipe` driver: package-owned recipe
+keys and bodies must be retained alongside search results, validated against
+the exact tree, and passed to this replay fold without becoming evidence.
+
+## Blockers
+
+None for the retained-tree replay edge. Generic search/tactic integration is a
+separate dependency and remains intentionally out of scope here.

--- a/progress/20260821T194647Z.md
+++ b/progress/20260821T194647Z.md
@@ -1,0 +1,25 @@
+# Retained-tree replay hardening
+
+## Accomplished
+
+- Made a nonempty retained pending frontier reject immediately at the public
+  tree-replay boundary and added a discriminating pending-tree guard.
+- Added an ordinary theorem that consumes the evidence returned by the actual
+  checked tree replay, with a separately proved error fallback and exact axiom
+  guard; the existing flat replay axiom report is now guarded as well.
+- Documented the current frozen-node limitation: non-root child snapshots
+  restart at version zero and cannot yet retain recursive child propagation.
+
+## Current frontier
+
+The split/refutation fold is authenticated and bounded, but each retained node
+still contains only its branch snapshot at creation.
+
+## Next step
+
+Add the authenticated callback-to-tree-recipe driver together with checked
+branch advancement before exposing recursive split search through the tactic.
+
+## Blockers
+
+None for this hardening.


### PR DESCRIPTION
## Summary

- extend the supported proof registry with package-owned keyed binary-cover and refutation schemas
- replay a checked sealed `Search.Result.Tree` against a separately supplied untrusted `TreeRecipe`, authenticating exact parent/side/seed edges and ordered chronology
- seed each child with exactly one new branch assumption while retaining inherited parent facts only as derived evidence rebased to child-local version zero
- close target/refutation leaves, reject pending/unknown leaves transactionally, and join siblings only through the authenticated cover
- bound proof nodes, depth, body cells, structural work, flat chronology, dependencies, packages, and schemas

## Trust boundary

The retained tree is checked under the exact caller-supplied search limits and measure. Neither the runtime tree, terminal/refutation records, callback data, nor the proof recipe is evidence. Package-owned schemas reconstruct the cover or contradiction and produce ordinary typed evidence; the final canary has load-bearing distinct branch assumptions and a guarded ordinary axiom report.

## Scope deferred

This PR does not add the authenticated callback-to-`TreeRecipe` driver, generic search-selected recipe quotation, or public tactic split-search integration. The existing direct-forward tactic remains unchanged.

## Validation

- `lake build HexConformance` (9584 jobs)
- focused affected build (8720 jobs)
- DAG/unit, phase 4/7, trust-surface, freshness, copyright, line-count, Mathlib-free bench boundary, and diff checks
- no `native_decide`, project axiom, or `sorry` on the published trust surface