### PR TITLE
feat(interval): authenticate callback recipe steps

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -49,9 +49,10 @@ checked current parent snapshot and one exact seed delta, retains explicit
 target/refutation/unknown terminals, and carries no theorem authority. A
 deliberate `import all HexInterval.Search` is trusted implementation access,
 not decoded-runtime authority, and repository checks reject accidental uses.
-Concrete callbacks and proposals, offer generation, policy implementations,
-the branch-search controller and callback-to-proof-recipe bridge, and
-measurement-selected storage remain experimental. Exact public interval
+Concrete callbacks and offer generation, policy implementations, a complete
+branch-search loop, and measurement-selected storage remain experimental. The
+Mathlib companion supplies a bounded authenticated callback-to-tree-recipe
+step driver; package callbacks and their recipe data remain untrusted. Exact public interval
 splitting is already supported; the Mathlib companion separately owns flat
 forward replay and checked retained-tree proof folding.
 -/

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3255,13 +3255,16 @@ one version-zero seed delta. At creation, the restarted `State.Branch`
 represents every inherited fact at version zero, resets every generation stamp
 to zero, has no history, and has `contradictory = false`. Later accepted
 same-session `Result.advanceWithin` transitions may advance that live child's
-versions, history, generations, facts, and contradiction status through the
-ordinary checked `State.Branch` rules. The inherited creation facts are not
-thereby reclassified as assumptions or given intrinsic derived provenance by
-the child branch. Instead, the retained tree's exact parent/side/seed edge
-authenticates that they came from the current parent consequence snapshot. A
-downstream controller or proof quotation must consume that edge and must not
-carry pre-split generation stamps into the restarted child. `Result.splitWithin`
+versions, history, facts, and contradiction status through the ordinary
+checked `State.Branch` rules. Its `baseProgram`, `initialFacts`, checked
+`program`, `seeds`, `generations`, node `depths`, and `programVersion` remain
+pinned to the creation branch for the lifetime of that retained child. The
+inherited creation facts are not thereby reclassified as assumptions or given
+intrinsic derived provenance by the child branch. Instead, the retained tree's
+exact parent/side/seed edge authenticates that they came from the current
+parent consequence snapshot. A downstream controller or proof quotation must
+consume that edge and must not carry pre-split generation stamps into the
+restarted child. `Result.splitWithin`
 does not independently resolve the action's rule key against a package
 registry. `Result.settleWithin` consumes the exact pending head and retains an
 exact target, refutation, or unknown record.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3203,6 +3203,14 @@ update. Callback failure has an exact conservative stop, and diagnostic
 truncation can change only the log, not facts, versions, provenance, scope, or
 contradiction state.
 
+`invokeWithWithin` is the supported same-invocation payload bridge. Its sealed
+`Applied` value binds the exact before session, selected request, echoed
+outcome, and accepted after session; `AppliedStep` and `Invocation` distinguish
+accepted updates, conservative stops, and the opaque payload produced by that
+same single callback. These values remain runtime data rather than proof
+authority, but a checked consumer such as `Result.advanceWithin` can use the
+sealed before/after relation without reconstructing it from causes or flags.
+
 `Search.Frontier` is a public ordering value, but ordinary-import live tree
 authority is the sealed `Search.FrontierState`, which owns the pending frontier
 and its cumulative step, split, retained-leaf, scope, and next-scope accounting.
@@ -3231,27 +3239,38 @@ the stronger leaf protocol for public-import clients.
 
 `Search.Result.Tree` is the supported retained-result prerequisite for a later
 proof-tree fold. Its private constructor keeps the exact node array, sealed
-`FrontierState Result.Id`, cumulative accounting, and logical cost together;
-callers cannot transplant a raw frontier, reset counters, or supply a complete
-child snapshot. `Result.startWithin` admits one checked root.
+`FrontierState Result.Id`, cumulative advance count, accounting, and logical
+cost together; callers cannot transplant a raw frontier, reset counters, or
+supply a complete child snapshot. `Result.startWithin` admits one checked root.
+`Result.advanceWithin` consumes a sealed `Applied` transition whose before
+branch is the exact pending head, requires a nonempty accepted update, retains
+the same seeded origin/program dimensions, replaces only that head's live
+branch with the authenticated after branch, and increments both the frontier
+step count and private advance count transactionally.
 `Result.splitWithin` authenticates the exact pending parent and current
 predecessor, structurally checks and retains the complete runtime split action,
 allocates the two fresh scopes through the sealed frontier, and reconstructs
 each restarted child from the checked current parent fact array with exactly
-one version-zero seed delta. The restarted `State.Branch` represents every
-inherited fact at version zero, resets every generation stamp to zero, has no
-history, and has `contradictory = false`. Its inherited facts are not thereby
-reclassified as assumptions or given intrinsic derived provenance by the child
-branch. Instead, the retained tree's exact parent/side/seed edge authenticates
-that they came from the current parent consequence snapshot. A downstream
-controller or proof quotation must consume that edge and must not carry
-pre-split generation stamps into the restarted child. `Result.splitWithin`
+one version-zero seed delta. At creation, the restarted `State.Branch`
+represents every inherited fact at version zero, resets every generation stamp
+to zero, has no history, and has `contradictory = false`. Later accepted
+same-session `Result.advanceWithin` transitions may advance that live child's
+versions, history, generations, facts, and contradiction status through the
+ordinary checked `State.Branch` rules. The inherited creation facts are not
+thereby reclassified as assumptions or given intrinsic derived provenance by
+the child branch. Instead, the retained tree's exact parent/side/seed edge
+authenticates that they came from the current parent consequence snapshot. A
+downstream controller or proof quotation must consume that edge and must not
+carry pre-split generation stamps into the restarted child. `Result.splitWithin`
 does not independently resolve the action's rule key against a package
 registry. `Result.settleWithin` consumes the exact pending head and retains an
 exact target, refutation, or unknown record.
 Whole-tree validation reconstructs every parent/side/seed edge, restored
-parent, pending set, step/split/leaf/scope equation, branch state, and logical
-cost.
+parent, pending set, branch consistency, and logical cost; it pins the seeded
+origin and program dimensions while accepting only live branch states that
+pass `Branch.check`. Its cumulative equation is exactly
+`steps = advances + splits + terminals`, rather than equality between a live
+advanced child and its creation-time versions or history.
 
 Result limits independently bound retained nodes, each package body, declared
 logical bytes and work, plus the existing search and state resources. Count
@@ -3266,7 +3285,9 @@ the checked transition keeps scopes unique within each resulting lineage and
 cannot reset that lineage's retained counters. Limits are supplied per call,
 not stored in the tree: a later call may relax them, while a tightened call
 rejects an already-retained value which exceeds the new caps rather than
-grandfathering it.
+grandfathering it. The `Envelope` which authenticated an `Applied` session and
+the `Result.Limits` supplied to the retained-tree transition are independent
+per-call envelopes; neither substitutes for the other's checks.
 Semantic split coverage, package-owned refutation theorems, recursive proof
 replay, and unknown-leaf rejection are supported by the Mathlib proof fold.
 The supported one-step driver retains one already-selected authenticated
@@ -3309,9 +3330,10 @@ class, age, and score and performs the existing engine-owned freshness checks.
 The concrete `OfferId`,
 `OfferKey`, instantiation/split encodings, staged/adaptive/feature policies,
 package callbacks, semantic outcome interpretation, event history, concrete
-policy sessions, target-specific stop taxonomy, and callback-to-proof-recipe
-driver remain under `HexInterval/Experiment`. The Mathlib companion's generic
-tree replay does not make the older concrete `BranchProof` controller a
+policy sessions, target-specific stop taxonomy, and the older concrete
+controller/branch-proof driver remain under `HexInterval/Experiment`. The
+supported Mathlib companion now owns the generic callback-to-recipe driver;
+its existence does not make the older concrete `BranchProof` controller a
 supported API. The experimental `BranchTree` consumes the supported
 search order, limits, accounting, and frontier container, while its
 package-specific child construction remains behind `BranchStart`. The older

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -102,15 +102,18 @@ The supported proof companion can separately consume a checked retained
 authenticates package-owned binary cover and refutation schemas, its checked
 state rebases inherited child facts without promoting them to assumptions, and
 its bounded recursive fold closes target/refutation leaves, rejects unknown
-leaves, and joins siblings only through the exact cover. Producing that proof
-recipe from generic search callbacks and invoking the fold from the public
-tactic remain later controller work. The first
+leaves, and joins siblings only through the exact cover. The supported
+one-step driver now invokes an already-selected authenticated package callback
+and transactionally retains its exact runtime command and separately checked
+recipe data together. It can advance root and child-local fact histories before
+splitting or settling. Offer generation, autonomous search iteration, and
+invoking this path from the public tactic remain later controller work. The first
 concrete supported registry is the Mathlib arithmetic package for one
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. Arbitrary-function package assembly,
-callback outcomes and proposals, concrete policy algorithms and default
-scheduling, the branch-search controller, callback-to-recipe orchestration,
+concrete callback implementations and offer generation, concrete policy
+algorithms and default scheduling, the complete branch-search loop,
 payload storage, and the optimized backing store remain experimental.
 Supported authenticated sessions and the narrow direct-forward tactic do not
 yet supply that missing controller bridge.
@@ -3265,8 +3268,12 @@ not stored in the tree: a later call may relax them, while a tightened call
 rejects an already-retained value which exceeds the new caps rather than
 grandfathering it.
 Semantic split coverage, package-owned refutation theorems, recursive proof
-replay, search-to-recipe quotation, and unknown-leaf rejection by a proof fold
-remain later supported edges.
+replay, and unknown-leaf rejection are supported by the Mathlib proof fold.
+The supported one-step driver retains one already-selected authenticated
+callback command together with its exact separately checked recipe data and
+can advance the current root or child source before a split or terminal.
+Offer generation, repeated autonomous scheduling, and public-tactic
+split-search integration remain later controller edges.
 
 This visibility is not a claim against Lean's deliberate `import all
 HexInterval.Search`. That form exposes private implementation names to trusted
@@ -4028,14 +4035,15 @@ tree first; changing that measure can make the same pure tree fail validation.
 These limits are checked independently because runtime tree records and proof
 recipes are both untrusted data.
 
-The current retained tree freezes each node's `Source.branch` when that node is
-created. A split child restarts its program version and fact generations at
-zero and the retained-tree API does not yet advance that child snapshot.
-Consequently a non-root proof chronology must be empty or proof-state-only,
-and a target/refutation terminal can cite only facts current at node creation.
-This edge proves exact split/refutation folding, not recursive propagation in
-children; authenticated callback-to-recipe quotation plus branch advancement
-is the next controller edge.
+Every split child begins at program version zero with zero fact generations
+and the exact parent snapshot plus one seed. The sealed retained-tree
+transition can then replace the current node's source only with the after-state
+of an accepted callback tied to that exact source branch. The supported
+one-step driver appends the same callback's fact events to that node's recipe
+in the same transaction. Non-root target/refutation leaves and later splits
+may therefore consume child-local fact history after exact replay. This is not
+yet an autonomous controller: offer generation, repeated policy-driven
+iteration, and public-tactic split search remain separate work.
 
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
@@ -5338,8 +5346,13 @@ their declared cost inside a scheduler bound.
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. The built-in
   arithmetic package and direct-forward reifier/tactic are supported below;
-  arbitrary-function packages, callback-to-tree-recipe orchestration,
-  split-search tactic integration, and default registries remain experimental.
+  arbitrary-function packages, autonomous search orchestration, split-search
+  tactic integration, and default registries remain experimental.
+- `HexIntervalMathlib/Driver.lean`: supported one-step execution of an exact
+  already-selected package action, atomic retained-source advancement/split/
+  terminal updates, and bounded alignment of the sealed result tree with its
+  separately untrusted node recipe. It does not generate offers, choose a
+  policy, or run an autonomous search loop.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry
   assembly, and state-to-proof quotation for negation, addition, subtraction,
@@ -5408,8 +5421,9 @@ their declared cost inside a scheduler bound.
   a separately sealed parent/depth/scope-checked leaf frontier, immutable parent
   restoration, sealed cumulative step/split/leaf/frontier/depth/scope
   accounting, and a sealed bounded retained result tree with exact single-delta
-  child reconstruction and target/refute/unknown terminals. It contains no
-  concrete callback, offer generator, semantic split/refutation theorem,
+  child reconstruction, authenticated fact-history advancement, and
+  target/refute/unknown terminals. It contains no concrete callback, offer
+  generator, semantic split/refutation theorem,
   policy algorithm, storage choice, proof recipe, or proof replay.
 - `HexInterval/Experiment/Propagator.lean`: current experimental concrete
   applications, callbacks, outcomes, untrusted proposals and replies, and

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -4032,8 +4032,13 @@ depth, aggregate tree/body cells, and structural proof work. It does not expose
 a separate checker-execution counter. The Mathlib-free `Search.Result.Limits`
 and exact caller-supplied `Measure` authenticate and bound the retained runtime
 tree first; changing that measure can make the same pure tree fail validation.
-These limits are checked independently because runtime tree records and proof
-recipes are both untrusted data.
+The callback driver additionally applies a caller-owned `Driver.Measure` to
+the complete logical encoding of every retained proof event and edge,
+including nested facts, actions, schema keys, dependency versions, body
+naturals, and seed data, then enforces independent recipe byte/work caps over
+the complete bundle on every transition. These callbacks and arbitrary-value
+equality remain non-preemptible. The limits are checked independently because
+runtime tree records and proof recipes are both untrusted data.
 
 Every split child begins at program version zero with zero fact generations
 and the exact parent snapshot plus one seed. The sealed retained-tree
@@ -5351,8 +5356,10 @@ their declared cost inside a scheduler bound.
 - `HexIntervalMathlib/Driver.lean`: supported one-step execution of an exact
   already-selected package action, atomic retained-source advancement/split/
   terminal updates, and bounded alignment of the sealed result tree with its
-  separately untrusted node recipe. It does not generate offers, choose a
-  policy, or run an autonomous search loop.
+  separately untrusted node recipe. A required logical recipe measure and
+  independent byte/work caps charge all retained event and edge payloads over
+  the complete bundle. It does not generate offers, choose a policy, or run an
+  autonomous search loop.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry
   assembly, and state-to-proof quotation for negation, addition, subtraction,

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -1154,12 +1154,15 @@ private opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
         | some initial =>
             /- `child.branch` may have advanced through sealed accepted-update
             transitions since creation. Its checked history reconstructs the
-            live snapshot; this edge pins the immutable seeded origin and the
-            still-unchanged program dimensions. -/
+            live snapshot; this edge pins the immutable base program, initial
+            facts, checked program, seeds, generations, depths, and program
+            version from the seeded creation branch. -/
             initial.baseProgram == child.branch.baseProgram &&
               initial.initialFacts == child.branch.initialFacts &&
               initial.program == child.branch.program && initial.seeds == child.branch.seeds &&
-              initial.generations == child.branch.generations && initial.depths == child.branch.depths
+              initial.generations == child.branch.generations &&
+              initial.depths == child.branch.depths &&
+              initial.programVersion == child.branch.programVersion
 
 def pendingIds (tree : Tree Fact Cause Plan Schema) : List Id :=
   (List.range tree.nodes.size).filterMap fun index =>

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -199,6 +199,13 @@ private def Accounting.settleWithin (limits : Limits) (frontierCount : Nat)
   if accounting.steps >= limits.maxSteps then throw (.resource .steps)
   pure { accounting with steps := accounting.steps + 1 }
 
+/-- Charge one accepted callback update while retaining the current frontier
+head. This primitive is private: only a sealed retained-tree transition may
+bind the charged step to the exact updated head branch. -/
+private def Accounting.advanceWithin (limits : Limits) (frontierCount : Nat)
+    (accounting : Accounting) : Except Error Accounting :=
+  accounting.settleWithin limits frontierCount
+
 private def Accounting.splitWithin (limits : Limits) (frontierCount : Nat)
     (accounting : Accounting) :
     Except Error Accounting := do
@@ -236,6 +243,15 @@ opaque settleHeadWithin (limits : Limits) (state : FrontierState α) :
   let some head := state.frontier.head? | throw .invalidSession
   let accounting <- Accounting.settleWithin limits count state.accounting
   pure (head, { accounting, frontier := state.frontier.tail })
+
+/-- Charge and retain the exact stable head. Kept private so generic frontier
+users cannot detach accounting from the enclosing authenticated transition. -/
+private opaque advanceHeadWithin (limits : Limits) (state : FrontierState α) :
+    Except Error (α × FrontierState α) := do
+  let count <- frontierCountWithin limits state.frontier
+  let some head := state.frontier.head? | throw .invalidSession
+  let accounting <- Accounting.advanceWithin limits count state.accounting
+  pure (head, { accounting, frontier := state.frontier })
 
 /-- Pop and charge the exact head of a sealed frontier, then schedule the
 caller-validated pending children. This container transition authenticates
@@ -533,6 +549,29 @@ inductive Reply (Fact Cause OfferId SemanticKey : Type)
   | outcome (outcome : Outcome Fact Cause OfferId SemanticKey)
   | failure (code : Nat) (diagnostic : Option Trace.Event := none)
 
+/-- Ordinary-import-sealed witness of one exact accepted callback invocation.
+It binds the authenticated pre-state, request, echoed outcome, and committed
+replacement session. The value is data, not theorem evidence; its only runtime
+authority is through supported checked consumers. -/
+structure Applied (Fact Cause OfferId SemanticKey : Type) where
+  private mk ::
+  before : Session Fact Cause OfferId SemanticKey
+  request : Request Fact OfferId SemanticKey
+  outcome : Outcome Fact Cause OfferId SemanticKey
+  after : Session Fact Cause OfferId SemanticKey
+
+/-- Result of a callback invocation that additionally retains an opaque
+caller payload produced by that same single callback execution. -/
+inductive AppliedStep (Fact Cause OfferId SemanticKey : Type)
+  | applied (transition : Applied Fact Cause OfferId SemanticKey)
+  | stopped (stop : Stop Unit Unit) (session : Session Fact Cause OfferId SemanticKey)
+
+/-- A payload callback is not executed when the authenticated session has
+already exhausted its step budget. -/
+inductive Invocation (Fact Cause OfferId SemanticKey Payload : Type)
+  | produced (step : AppliedStep Fact Cause OfferId SemanticKey) (payload : Payload)
+  | stopped (stop : Stop Unit Unit) (session : Session Fact Cause OfferId SemanticKey)
+
 /-- A checked callback step either commits a replacement session or stops with
 an unchanged proof state. -/
 inductive Step (Fact Cause OfferId SemanticKey : Type)
@@ -629,11 +668,11 @@ private def pushChecked (branch : State.Branch Fact Cause)
       history := branch.history.push event
       contradictory := branch.contradictory || contradiction }
 
-private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
+private def acceptAppliedChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
     (envelope : Envelope) (session : Session Fact Cause OfferId SemanticKey)
     (request : Request Fact OfferId SemanticKey)
     (reply : Reply Fact Cause OfferId SemanticKey) :
-    Except Error (Step Fact Cause OfferId SemanticKey) := do
+    Except Error (AppliedStep Fact Cause OfferId SemanticKey) := do
   match reply with
   | .failure code diagnostic =>
       if envelope.trace.maxCode < code then throw .malformedOutcome
@@ -661,7 +700,16 @@ private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
           incomplete := true
           trace
           steps := session.steps + 1 }
-      pure (.applied next)
+      pure (.applied { before := session, request, outcome, after := next })
+
+private def acceptChecked [DecidableEq OfferId] [DecidableEq SemanticKey]
+    (envelope : Envelope) (session : Session Fact Cause OfferId SemanticKey)
+    (request : Request Fact OfferId SemanticKey)
+    (reply : Reply Fact Cause OfferId SemanticKey) :
+    Except Error (Step Fact Cause OfferId SemanticKey) := do
+  match ← acceptAppliedChecked envelope session request reply with
+  | .applied transition => pure (.applied transition.after)
+  | .stopped stop next => pure (.stopped stop next)
 
 /-- Validate and commit the whole returned delta transactionally. Every event
 must be an exact successor for a node in the selected action's write set. The
@@ -677,6 +725,29 @@ opaque acceptWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
   if session.steps >= envelope.search.maxSteps then
     return .stopped (.resource .steps) session
   acceptChecked envelope session request reply
+
+/-- Execute one arbitrary callback exactly once after authenticating the
+selected request, then validate its reply while retaining the caller payload
+returned by that same invocation. Callback and payload construction remain
+non-preemptible; no returned value has mutation or proof authority before the
+checks complete. -/
+opaque invokeWithWithin [DecidableEq Fact] [DecidableEq Cause]
+    [DecidableEq OfferId] [DecidableEq SemanticKey] (envelope : Envelope)
+    (measure : Policy.Measure OfferId SemanticKey)
+    (owner : RuleKey)
+    (callback : Request Fact OfferId SemanticKey →
+      Reply Fact Cause OfferId SemanticKey × Payload)
+    (session : Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) :
+    Except Error (Invocation Fact Cause OfferId SemanticKey Payload) := do
+  let checked <- authenticate envelope measure session
+  let request <- prepareChecked session checked decision
+  if request.action.key != owner then throw .invalidSession
+  if session.steps >= envelope.search.maxSteps then
+    return .stopped (.resource .steps) session
+  let (reply, payload) := callback request
+  let step <- acceptAppliedChecked envelope session request reply
+  pure (.produced step payload)
 
 /-- Invoke an arbitrary callback and then pass its decoded result through
 `acceptWithin`. Callback execution itself is deliberately non-preemptible and
@@ -961,6 +1032,9 @@ structure Tree (Fact Cause Plan Schema : Type) where
   private mk ::
   nodes : Array (Node Fact Cause Plan Schema)
   private live : FrontierState Id
+  /-- Accepted callback-update transitions retained independently of binary
+  splits and terminal settlement. -/
+  private advances : Nat
   cost : Cost
 
 opaque Tree.frontier (tree : Tree Fact Cause Plan Schema) : Frontier Id :=
@@ -1074,7 +1148,18 @@ private opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
     child.depth == parent.depth + 1 &&
     match child.seed with
     | none => false
-    | some seed => (childBranchWithin limits parent seed).toOption == some child.branch
+    | some seed =>
+        match (childBranchWithin limits parent seed).toOption with
+        | none => false
+        | some initial =>
+            /- `child.branch` may have advanced through sealed accepted-update
+            transitions since creation. Its checked history reconstructs the
+            live snapshot; this edge pins the immutable seeded origin and the
+            still-unchanged program dimensions. -/
+            initial.baseProgram == child.branch.baseProgram &&
+              initial.initialFacts == child.branch.initialFacts &&
+              initial.program == child.branch.program && initial.seeds == child.branch.seeds &&
+              initial.generations == child.branch.generations && initial.depths == child.branch.depths
 
 def pendingIds (tree : Tree Fact Cause Plan Schema) : List Id :=
   (List.range tree.nodes.size).filterMap fun index =>
@@ -1149,7 +1234,8 @@ opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
   let splits := splitCount tree
   let terminals := terminalCount tree
   if tree.nodes.size != splits * 2 + 1 || tree.accounting.splits != splits ||
-      tree.accounting.steps != splits + terminals || tree.accounting.leaves != splits + 1 ||
+      tree.accounting.steps != tree.advances + splits + terminals ||
+      tree.accounting.leaves != splits + 1 ||
       tree.accounting.scopes != tree.nodes.size ||
       tree.accounting.nextScope != rootSource.scope.index + tree.nodes.size then return false
   let cost := tree.recomputeCost measure
@@ -1173,7 +1259,7 @@ opaque startWithin [DecidableEq Fact] [DecidableEq Cause]
   let live <- (FrontierState.startWithin limits.search scope ({ index := 0 } : Id)).mapError fromSearch
   let cost := sumCost (nodes.toList.map (nodeCost measure))
   throwCost limits cost
-  checked limits measure { nodes, live, cost }
+  checked limits measure { nodes, live, advances := 0, cost }
 
 opaque current? (tree : Tree Fact Cause Plan Schema) : Option (Id × Source Fact Cause) := do
   let id ← tree.live.head?
@@ -1181,6 +1267,31 @@ opaque current? (tree : Tree Fact Cause Plan Schema) : Option (Id × Source Fact
   match node with
   | .pending source => some (id, source)
   | _ => none
+
+/-- Atomically bind one sealed accepted callback update to the exact retained
+head source. The frontier head is retained and charged once; callers cannot
+replace a source branch from an unattached session or a fabricated delta. -/
+opaque advanceWithin [DecidableEq Fact] [DecidableEq Cause]
+    [DecidableEq OfferId] [DecidableEq SemanticKey]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema)
+    (transition : Applied Fact Cause OfferId SemanticKey) :
+    Except Error (Tree Fact Cause Plan Schema) := do
+  let tree ← checked limits measure tree
+  let some (id, source) := current? tree | throw .terminal
+  if transition.outcome.updates.isEmpty || transition.before.scope != source.scope ||
+      transition.request.scope != source.scope || transition.after.scope != source.scope ||
+      transition.before.branch != source.branch ||
+      transition.after.branch.baseProgram != source.branch.baseProgram ||
+      transition.after.branch.initialFacts != source.branch.initialFacts then
+    throw .malformed
+  let (head, live) ← tree.live.advanceHeadWithin limits.search |>.mapError fromSearch
+  if head != id then throw .malformed
+  let nextSource := { source with branch := transition.after.branch }
+  let nodes := tree.nodes.set! id.index (.pending nextSource)
+  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  throwCost limits cost
+  checked limits measure { nodes, live, advances := tree.advances + 1, cost }
 
 /-- Restore the exact retained parent source by append-only node identity. -/
 def restoreParent? (tree : Tree Fact Cause Plan Schema) (child : Id) :
@@ -1228,7 +1339,7 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
     |>.push (.pending left) |>.push (.pending right)
   let cost := sumCost (nodes.toList.map (nodeCost measure))
   throwCost limits cost
-  checked limits measure { nodes, live, cost }
+  checked limits measure { nodes, live, advances := tree.advances, cost }
 
 /-- Retain one exact terminal and remove the stable frontier head
 transactionally. Target and refutation records are authenticated runtime data,
@@ -1248,7 +1359,7 @@ opaque settleWithin [DecidableEq Fact] [DecidableEq Cause]
   let nodes := tree.nodes.set! id.index (.terminal source ending)
   let cost := sumCost (nodes.toList.map (nodeCost measure))
   throwCost limits cost
-  checked limits measure { nodes, live, cost }
+  checked limits measure { nodes, live, advances := tree.advances, cost }
 
 end Result
 

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -17,6 +17,7 @@ public import HexIntervalMathlib.Power
 public import HexIntervalMathlib.Split
 public import HexIntervalMathlib.Inverse
 public import HexIntervalMathlib.Division
+public import HexIntervalMathlib.Driver
 public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof

--- a/HexIntervalMathlib/Driver.lean
+++ b/HexIntervalMathlib/Driver.lean
@@ -22,22 +22,42 @@ causes, contradiction flags, or diagnostics.
 Callback execution and construction of arbitrary facts, causes, identifiers,
 plans, and bodies remain non-preemptible. Search first authenticates the exact
 selected action and package rule, then validates the echoed outcome. The
-driver bounds and aligns every retained event before atomically returning the
-replacement tree/recipe bundle. Neither the bundle nor callback data is proof
-evidence; `Proof.replayTree` still resolves every schema and constructs the
-ordinary theorem.
+driver structurally bounds and aligns every retained event, then applies a
+caller-owned logical recipe measure to every proposed/installed fact, action,
+schema, body value, and seed before atomically returning the replacement
+tree/recipe bundle. Measurement callbacks and arbitrary-value equality are
+non-preemptible and must charge complete encodings. Neither the bundle nor
+callback data is proof evidence; `Proof.replayTree` still resolves every
+schema and constructs the ordinary theorem.
 -/
 
 namespace Hex.Interval.Driver
 
 open Proof
 
+/-- Independent logical caps for the separately retained proof recipe. -/
+structure RecipeLimits where
+  maxBytes : Nat
+  maxWork : Nat
+  deriving DecidableEq, Repr
+
 /-- Combined retained runtime and proof-recipe limits. -/
 structure Limits where
   result : Search.Result.Limits
   proof : Proof.Limits
   tree : Proof.TreeLimits
+  recipe : RecipeLimits
   deriving DecidableEq, Repr
+
+/-- Caller-owned logical encoding costs for recipe values. `cell` charges each
+retained list/array cell; `event` and `edge` must charge the complete logical
+encoding of their values, including nested facts, identifiers, actions,
+schemas, dependency versions, body naturals, and seed data. Callback execution
+and construction of the measured values remain non-preemptible. -/
+structure Measure (Fact : Type) where
+  cell : Search.Result.Cost
+  event : Proof.Event Fact → Search.Result.Cost
+  edge : Proof.TreeEdge Fact → Search.Result.Cost
 
 /-- Exact callback outcome plus the proof events emitted by that same
 invocation. The events are decoded data and are checked independently. -/
@@ -83,11 +103,19 @@ structure Bundle (Fact Cause Plan : Type) where
   private mk ::
   tree : Search.Result.Tree Fact Cause Plan Proof.Key
   recipe : Proof.TreeRecipe Fact
+  /-- Cached complete logical recipe cost, rechecked on every transition. -/
+  recipeCost : Search.Result.Cost
+
+inductive Resource where
+  | bytes
+  | work
+  deriving DecidableEq, Repr
 
 inductive Error where
   | search (error : Search.Error)
   | result (error : Search.Result.Error)
   | proof (error : Proof.Error)
+  | resource (resource : Resource)
   | mismatch
   deriving DecidableEq, Repr
 
@@ -113,6 +141,31 @@ private def eventWithin (limits : Proof.Limits) : Proof.Event Fact → Except Er
   | .instance step =>
       Proof.bodyCheck limits step.schema .instance step.body |>.mapError Error.proof
 
+/-- The supported callback driver retains only fact events: one event is
+zipped with each accepted fact update. The general proof layer may replay
+other event kinds when supplied through its separate programmatic APIs. -/
+private def eventCost (measure : Measure Fact) : Proof.Event Fact → Except Error Search.Result.Cost
+  | event@(.fact _) => pure (measure.cell + measure.event event)
+  | _ => throw .mismatch
+
+private def edgeCost (measure : Measure Fact) (edge : Proof.TreeEdge Fact) :
+    Search.Result.Cost :=
+  measure.cell + measure.edge edge
+
+private def recipeCost (measure : Measure Fact) (recipe : Proof.TreeRecipe Fact) :
+    Except Error Search.Result.Cost := do
+  let mut total := measure.cell + measure.cell
+  for events in recipe.events do
+    total := total + measure.cell
+    for event in events do total := total + (← eventCost measure event)
+  for edge in recipe.edges do total := total + edgeCost measure edge
+  pure total
+
+private def recipeWithin (limits : RecipeLimits) (cost : Search.Result.Cost) :
+    Except Error Unit := do
+  if limits.maxBytes < cost.bytes then throw (.resource .bytes)
+  if limits.maxWork < cost.work then throw (.resource .work)
+
 private def edgesMatch [DecidableEq Fact]
     (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
     (recipe : Proof.TreeRecipe Fact) : Bool := Id.run do
@@ -134,22 +187,45 @@ private def checkRecipe [DecidableEq Fact]
     if limits.proof.maxChronology < events.length then throw (.proof .chronologyLimit)
     for event in events do eventWithin limits.proof event
 
+private def validate [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits)
+    (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (recipe : Proof.TreeRecipe Fact) : Except Error Search.Result.Cost := do
+  if !tree.check limits.result resultMeasure then throw (.result .malformed)
+  checkRecipe limits tree recipe
+  let cost ← recipeCost recipeMeasure recipe
+  recipeWithin limits.recipe cost
+  pure cost
+
+private def bundleWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits)
+    (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (recipe : Proof.TreeRecipe Fact) : Except Error (Bundle Fact Cause Plan) := do
+  let recipeCost ← validate limits resultMeasure recipeMeasure tree recipe
+  pure { tree, recipe, recipeCost }
+
 private def checked [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits)
-    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
     (bundle : Bundle Fact Cause Plan) : Except Error (Bundle Fact Cause Plan) := do
-  if !bundle.tree.check limits.result measure then throw (.result .malformed)
-  checkRecipe limits bundle.tree bundle.recipe
+  let cost ← validate limits resultMeasure recipeMeasure bundle.tree bundle.recipe
+  if cost != bundle.recipeCost then throw .mismatch
   pure bundle
 
 /-- Start an exact singleton bundle. The root chronology is initially empty. -/
 opaque Bundle.startWithin [DecidableEq Fact] [DecidableEq Cause]
-    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (limits : Limits) (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
     (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) :
     Except Error (Bundle Fact Cause Plan) := do
-  let tree ← Search.Result.startWithin limits.result measure scope branch
+  let tree ← Search.Result.startWithin limits.result resultMeasure scope branch
     |>.mapError Error.result
-  checked limits measure { tree, recipe := { events := #[[]], edges := #[{}] } }
+  bundleWithin limits resultMeasure recipeMeasure tree { events := #[[]], edges := #[{}] }
 
 private def factEventMatches [DecidableEq Fact]
     (request : Search.Request Fact OfferId SemanticKey)
@@ -211,13 +287,14 @@ directly; no later cause-to-recipe reconstruction occurs. -/
 opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     [DecidableEq SemanticKey] [DecidableEq Plan]
     (envelope : Search.Envelope) (policyMeasure : Policy.Measure OfferId SemanticKey)
-    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (limits : Limits) (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
     (order : Search.Order) (package : Package Fact Cause OfferId SemanticKey Plan)
     (bundle : Bundle Fact Cause Plan)
     (session : Search.Session Fact Cause OfferId SemanticKey)
     (decision : Policy.Decision OfferId SemanticKey) :
     Except Error (Step Fact Cause OfferId SemanticKey Plan) := do
-  let bundle ← checked limits measure bundle
+  let bundle ← checked limits resultMeasure recipeMeasure bundle
   let some (id, source) := Search.Result.current? bundle.tree | throw Error.mismatch
   if source.scope != session.scope || source.branch != session.branch then throw .mismatch
   let invocation ← Search.invokeWithWithin envelope policyMeasure package.rule
@@ -237,40 +314,40 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
           echoMatches limits transition echo
           if echo.outcome.updates.isEmpty then throw .mismatch
           let some recipe := appendEvents bundle.recipe id.index echo.events | throw .mismatch
-          let tree ← Search.Result.advanceWithin limits.result measure bundle.tree transition
+          let tree ← Search.Result.advanceWithin limits.result resultMeasure bundle.tree transition
             |>.mapError Error.result
-          let next ← checked limits measure { tree, recipe }
+          let next ← bundleWithin limits resultMeasure recipeMeasure tree recipe
           pure (.continued next transition.after)
       | Command.split proposal =>
           echoMatches limits transition proposal.echo
           if !emptyEcho proposal.echo || !exactSplit transition.request proposal.runtime then
             throw .mismatch
-          let tree ← Search.Result.splitWithin limits.result measure order bundle.tree
+          let tree ← Search.Result.splitWithin limits.result resultMeasure order bundle.tree
             proposal.runtime proposal.left proposal.right |>.mapError Error.result
           let recipe := appendChildren bundle.recipe id proposal.left proposal.right
-          let next ← checked limits measure { tree, recipe }
+          let next ← bundleWithin limits resultMeasure recipeMeasure tree recipe
           pure (.split next)
       | .target echo target =>
           echoMatches limits transition echo
           if !emptyEcho echo || !exactTarget transition.request target then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.target target)
+          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.target target)
             |>.mapError Error.result
-          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
           pure (.terminal next)
       | .refute echo refute =>
           echoMatches limits transition echo
           if !emptyEcho echo || !exactRefute transition.request refute then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.refute refute)
+          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.refute refute)
             |>.mapError Error.result
-          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
           pure (.terminal next)
       | .unknown echo unknown =>
           echoMatches limits transition echo
           if !emptyEcho echo || unknown.scope != transition.request.scope ||
               unknown.programVersion != transition.request.programVersion then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.unknown unknown)
+          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.unknown unknown)
             |>.mapError Error.result
-          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
           pure (.unknown next)
 
 end Hex.Interval.Driver

--- a/HexIntervalMathlib/Driver.lean
+++ b/HexIntervalMathlib/Driver.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Proof
+
+@[expose] public section
+
+/-!
+# Authenticated search-to-proof recipe driver
+
+This module owns the first supported bridge from one exact authenticated
+`Search.Session` invocation to a sealed retained result tree and its separate
+untrusted proof recipe. A package callback returns the runtime command and the
+proof event data together; the driver never reconstructs a recipe later from
+causes, contradiction flags, or diagnostics.
+
+Callback execution and construction of arbitrary facts, causes, identifiers,
+plans, and bodies remain non-preemptible. Search first authenticates the exact
+selected action and package rule, then validates the echoed outcome. The
+driver bounds and aligns every retained event before atomically returning the
+replacement tree/recipe bundle. Neither the bundle nor callback data is proof
+evidence; `Proof.replayTree` still resolves every schema and constructs the
+ordinary theorem.
+-/
+
+namespace Hex.Interval.Driver
+
+open Proof
+
+/-- Combined retained runtime and proof-recipe limits. -/
+structure Limits where
+  result : Search.Result.Limits
+  proof : Proof.Limits
+  tree : Proof.TreeLimits
+  deriving DecidableEq, Repr
+
+/-- Exact callback outcome plus the proof events emitted by that same
+invocation. The events are decoded data and are checked independently. -/
+structure Echo (Fact Cause OfferId SemanticKey : Type) where
+  outcome : Search.Outcome Fact Cause OfferId SemanticKey
+  events : List (Proof.Event Fact)
+
+/-- One package-owned binary split command. -/
+structure Split (Fact Cause OfferId SemanticKey Plan : Type) where
+  echo : Echo Fact Cause OfferId SemanticKey
+  runtime : Search.Result.Split Plan Proof.Key
+  left : Search.Result.Seed Fact
+  right : Search.Result.Seed Fact
+
+/-- One package invocation has exactly one controller interpretation. -/
+inductive Command (Fact Cause OfferId SemanticKey Plan : Type)
+  | continue (echo : Echo Fact Cause OfferId SemanticKey)
+  | split (split : Split Fact Cause OfferId SemanticKey Plan)
+  | target (echo : Echo Fact Cause OfferId SemanticKey) (target : Search.Result.Target)
+  | refute (echo : Echo Fact Cause OfferId SemanticKey) (refute : Search.Result.Refute Proof.Key)
+  | unknown (echo : Echo Fact Cause OfferId SemanticKey) (unknown : Search.Result.Unknown)
+  | stop (code : Nat) (diagnostic : Option Trace.Event := none)
+
+variable {Fact Cause OfferId SemanticKey Plan : Type}
+
+def Command.reply : Command Fact Cause OfferId SemanticKey Plan →
+    Search.Reply Fact Cause OfferId SemanticKey
+  | .continue echo | .target echo _ | .refute echo _ | .unknown echo _ =>
+      .outcome echo.outcome
+  | Command.split proposal => .outcome proposal.echo.outcome
+  | .stop code diagnostic => .failure code diagnostic
+
+/-- One stable rule owner and its replaceable callback. The callback is
+executed only after Search authenticates a selected action with this key. -/
+structure Package (Fact Cause OfferId SemanticKey Plan : Type) where
+  rule : RuleKey
+  invoke : Search.Request Fact OfferId SemanticKey →
+    Command Fact Cause OfferId SemanticKey Plan
+
+/-- Ordinary-import-sealed exact alignment of a retained runtime tree and its
+separate untrusted theorem recipe. -/
+structure Bundle (Fact Cause Plan : Type) where
+  private mk ::
+  tree : Search.Result.Tree Fact Cause Plan Proof.Key
+  recipe : Proof.TreeRecipe Fact
+
+inductive Error where
+  | search (error : Search.Error)
+  | result (error : Search.Result.Error)
+  | proof (error : Proof.Error)
+  | mismatch
+  deriving DecidableEq, Repr
+
+/-- A checked invocation either advances the current node, retains a split or
+terminal, records honest unknown state, or stops without changing the bundle. -/
+inductive Step (Fact Cause OfferId SemanticKey Plan : Type)
+  | continued (bundle : Bundle Fact Cause Plan)
+      (session : Search.Session Fact Cause OfferId SemanticKey)
+  | split (bundle : Bundle Fact Cause Plan)
+  | terminal (bundle : Bundle Fact Cause Plan)
+  | unknown (bundle : Bundle Fact Cause Plan)
+  | stopped (stop : Search.Stop Unit Unit) (bundle : Bundle Fact Cause Plan)
+      (session : Search.Session Fact Cause OfferId SemanticKey)
+
+private def eventWithin (limits : Proof.Limits) : Proof.Event Fact → Except Error Unit
+  | .fact step => do
+      Proof.bodyCheck limits step.schema .fact step.body |>.mapError Error.proof
+      Proof.dependenciesCheck limits step.assumptions |>.mapError Error.proof
+  | .equality step => do
+      Proof.bodyCheck limits step.schema .equality step.body |>.mapError Error.proof
+      Proof.dependenciesCheck limits step.assumptions |>.mapError Error.proof
+  | .transport _ => pure ()
+  | .instance step =>
+      Proof.bodyCheck limits step.schema .instance step.body |>.mapError Error.proof
+
+private def edgesMatch [DecidableEq Fact]
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (recipe : Proof.TreeRecipe Fact) : Bool := Id.run do
+  if tree.nodes.size != recipe.edges.size then return false
+  for index in [0:tree.nodes.size] do
+    let some node := tree.nodes[index]? | return false
+    let some edge := recipe.edges[index]? | return false
+    let source := node.source
+    if edge.parent != source.parent || edge.side != source.side || edge.seed != source.seed then
+      return false
+  return true
+
+private def checkRecipe [DecidableEq Fact]
+    (limits : Limits) (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (recipe : Proof.TreeRecipe Fact) : Except Error Unit := do
+  Proof.checkTreeLimits limits.tree tree recipe |>.mapError Error.proof
+  if !edgesMatch tree recipe then throw .mismatch
+  for events in recipe.events do
+    if limits.proof.maxChronology < events.length then throw (.proof .chronologyLimit)
+    for event in events do eventWithin limits.proof event
+
+private def checked [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (bundle : Bundle Fact Cause Plan) : Except Error (Bundle Fact Cause Plan) := do
+  if !bundle.tree.check limits.result measure then throw (.result .malformed)
+  checkRecipe limits bundle.tree bundle.recipe
+  pure bundle
+
+/-- Start an exact singleton bundle. The root chronology is initially empty. -/
+opaque Bundle.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) :
+    Except Error (Bundle Fact Cause Plan) := do
+  let tree ← Search.Result.startWithin limits.result measure scope branch
+    |>.mapError Error.result
+  checked limits measure { tree, recipe := { events := #[[]], edges := #[{}] } }
+
+private def factEventMatches [DecidableEq Fact]
+    (request : Search.Request Fact OfferId SemanticKey)
+    (update : State.Update Fact Cause) : Proof.Event Fact → Bool
+  | .fact step =>
+      step.scope == request.scope && step.programVersion == request.programVersion &&
+      step.action == request.action && step.node == update.node &&
+      step.previous == update.previous && step.version == update.version &&
+      step.installed == update.fact && step.assumptions == request.action.inputs &&
+      step.schema.rule == request.action.key && step.schema.role == .fact
+  | _ => false
+
+private def echoMatches [DecidableEq Fact]
+    (limits : Limits) (transition : Search.Applied Fact Cause OfferId SemanticKey)
+    (echo : Echo Fact Cause OfferId SemanticKey) : Except Error Unit := do
+  if echo.events.length != echo.outcome.updates.size then
+    throw .mismatch
+  if limits.proof.maxChronology < echo.events.length then throw (.proof .chronologyLimit)
+  for pair in echo.outcome.updates.toList.zip echo.events do
+    if !factEventMatches transition.request pair.1 pair.2 then throw .mismatch
+    eventWithin limits.proof pair.2
+
+private def appendEvents (recipe : Proof.TreeRecipe Fact) (index : Nat)
+    (events : List (Proof.Event Fact)) : Option (Proof.TreeRecipe Fact) := do
+  let old ← recipe.events[index]?
+  pure { recipe with events := recipe.events.set! index (old ++ events) }
+
+private def appendChildren (recipe : Proof.TreeRecipe Fact)
+    (parent : Search.Result.Id) (left right : Search.Result.Seed Fact) : Proof.TreeRecipe Fact :=
+  { recipe with
+    events := recipe.events.push [] |>.push []
+    edges := recipe.edges
+      |>.push { parent := some parent, side := some .left, seed := some left }
+      |>.push { parent := some parent, side := some .right, seed := some right } }
+
+private def emptyEcho (echo : Echo Fact Cause OfferId SemanticKey) : Bool :=
+  echo.outcome.updates.isEmpty && echo.events.isEmpty
+
+private def exactSplit (request : Search.Request Fact OfferId SemanticKey)
+    (split : Search.Result.Split Plan Proof.Key) : Bool :=
+  split.scope == request.scope && split.programVersion == request.programVersion &&
+    split.action == request.action && split.action.kind == .split &&
+    split.schema.rule == request.action.key && split.schema.role == .split
+
+private def exactRefute (request : Search.Request Fact OfferId SemanticKey)
+    (entry : Search.Result.Refute Proof.Key) : Bool :=
+  entry.scope == request.scope && entry.programVersion == request.programVersion &&
+    entry.seen.node == request.action.node && request.action.inputs.contains entry.seen &&
+    entry.schema.rule == request.action.key && entry.schema.role == .refute
+
+private def exactTarget (request : Search.Request Fact OfferId SemanticKey)
+    (entry : Search.Result.Target) : Bool :=
+  entry.scope == request.scope && entry.programVersion == request.programVersion &&
+    entry.seen.node == request.action.node && request.action.inputs.contains entry.seen
+
+/-- Execute exactly one selected package callback and atomically return its
+checked retained-tree/recipe replacement. The callback result is retained
+directly; no later cause-to-recipe reconstruction occurs. -/
+opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] [DecidableEq Plan]
+    (envelope : Search.Envelope) (policyMeasure : Policy.Measure OfferId SemanticKey)
+    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (order : Search.Order) (package : Package Fact Cause OfferId SemanticKey Plan)
+    (bundle : Bundle Fact Cause Plan)
+    (session : Search.Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) :
+    Except Error (Step Fact Cause OfferId SemanticKey Plan) := do
+  let bundle ← checked limits measure bundle
+  let some (id, source) := Search.Result.current? bundle.tree | throw Error.mismatch
+  if source.scope != session.scope || source.branch != session.branch then throw .mismatch
+  let invocation ← Search.invokeWithWithin envelope policyMeasure package.rule
+      (fun request =>
+        let command := package.invoke request
+        (command.reply, command)) session decision |>.mapError Error.search
+  match invocation with
+  | .stopped stop next => pure (.stopped stop bundle next)
+  | .produced (.stopped stop next) command =>
+      match command with
+      | .stop _ _ => pure (.stopped stop bundle next)
+      | _ => throw .mismatch
+  | .produced (.applied transition) command =>
+      match command with
+      | .stop _ _ => throw .mismatch
+      | .continue echo =>
+          echoMatches limits transition echo
+          if echo.outcome.updates.isEmpty then throw .mismatch
+          let some recipe := appendEvents bundle.recipe id.index echo.events | throw .mismatch
+          let tree ← Search.Result.advanceWithin limits.result measure bundle.tree transition
+            |>.mapError Error.result
+          let next ← checked limits measure { tree, recipe }
+          pure (.continued next transition.after)
+      | Command.split proposal =>
+          echoMatches limits transition proposal.echo
+          if !emptyEcho proposal.echo || !exactSplit transition.request proposal.runtime then
+            throw .mismatch
+          let tree ← Search.Result.splitWithin limits.result measure order bundle.tree
+            proposal.runtime proposal.left proposal.right |>.mapError Error.result
+          let recipe := appendChildren bundle.recipe id proposal.left proposal.right
+          let next ← checked limits measure { tree, recipe }
+          pure (.split next)
+      | .target echo target =>
+          echoMatches limits transition echo
+          if !emptyEcho echo || !exactTarget transition.request target then throw .mismatch
+          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.target target)
+            |>.mapError Error.result
+          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          pure (.terminal next)
+      | .refute echo refute =>
+          echoMatches limits transition echo
+          if !emptyEcho echo || !exactRefute transition.request refute then throw .mismatch
+          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.refute refute)
+            |>.mapError Error.result
+          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          pure (.terminal next)
+      | .unknown echo unknown =>
+          echoMatches limits transition echo
+          if !emptyEcho echo || unknown.scope != transition.request.scope ||
+              unknown.programVersion != transition.request.programVersion then throw .mismatch
+          let tree ← Search.Result.settleWithin limits.result measure bundle.tree (.unknown unknown)
+            |>.mapError Error.result
+          let next ← checked limits measure { tree, recipe := bundle.recipe }
+          pure (.unknown next)
+
+end Hex.Interval.Driver

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -1567,11 +1567,10 @@ decreasing_by
 
 /-- Check an exact retained search tree, authenticate its root against the
 caller input, and replay all leaves transactionally. Unknown or pending leaves
-cannot produce a proof. The current retained `Source.branch` is frozen when
-its node is created: non-root sources restart at program version zero, so their
-chronology can only be empty or proof-state-only and their terminals can cite
-only facts already current in that creation snapshot. Recursive branch
-advancement belongs to the later search-to-recipe controller. -/
+cannot produce a proof. A non-root source starts at program version zero from
+its exact parent-plus-seed origin. Sealed driver transitions may subsequently
+advance its fact history; the node-local recipe must replay that exact history
+before a terminal or another split can be consumed. -/
 def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
     (searchLimits : Search.Result.Limits)
     (measure : Search.Result.Measure Fact Cause Plan Key)

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -73,9 +73,12 @@ The Mathlib-free layer now retains an authenticated `Search.Result.Tree` with
 exact parent/child seed relations and target/refute/unknown terminal data.
 Restarted child branches themselves reset versions and generations and carry
 no inherited derivation proof; the exact tree edge is what retains that
-provenance. That runtime tree is not evidence. This companion still does not
-quote it into package-owned split/refutation recipes or recursively replay and
-join it; those remain separate later proof edges.
+provenance. That runtime tree is not evidence. This companion now separately
+checks package-owned split/refutation recipes, recursively replays and joins a
+checked tree, and provides a one-selected-callback driver which advances the
+retained source and appends the callback's exact fact events in one
+transaction. Autonomous offer generation, repeated policy iteration, and
+public-tactic split search remain later edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -253,10 +256,10 @@ exactly one natural exponent and one dyadic constant: every node at the
 built-in power operation index shares that exponent, and every node at the
 built-in constant index shares that value. Duplicate package registration and
 operation keys cannot add another parameterization. Arbitrary-function package
-discovery, generic search-to-recipe orchestration, split-search tactic
-integration, and default package discovery remain experimental. The supported
-direct-forward reifier and tactic syntax are a narrow client of this registry,
-not the missing generic search bridge.
+discovery, autonomous offer generation and policy iteration, split-search
+tactic integration, and default package discovery remain experimental. The
+supported direct-forward reifier and tactic syntax are a narrow client of this
+registry, not the missing autonomous controller.
 
 The supported proof fold also accepts a `Search.Result.Tree` only after the
 tree passes `Tree.check` under the exact caller-supplied search limits and
@@ -268,12 +271,18 @@ to the child-local version. Package-owned keyed split and refutation schemas
 authenticate the cover and contradiction; runtime terminal tags, bodies, and
 contradiction state never become evidence. `Proof.TreeLimits` separately bound
 proof nodes, depth, body cells, and structural work. Pending and unknown leaves
-reject transactionally. Search callback quotation into this recipe and tactic
-integration remain later work. Each retained node currently freezes its
-`Source.branch` at creation; non-root snapshots restart at version zero, so a
-non-root chronology must be empty or proof-state-only and its terminal can cite
-only creation-snapshot facts. Recursive child propagation is not yet supported.
-The current retained-tree builder repeatedly
+reject transactionally. `HexIntervalMathlib.Driver` executes one
+already-selected, authenticated package callback and returns the updated
+sealed tree plus separately untrusted recipe atomically. The current head
+source may advance through that callback before splitting or settling, so
+child-local propagation and its chronology replay are supported. Its
+caller-owned `Driver.Measure` must charge complete logical encodings of every
+retained event and edge, including nested facts, actions, schemas, dependency
+versions, body naturals, and seed data; independent recipe byte/work caps are
+rechecked across the complete bundle on every transition. Measurement and
+callback execution remain explicitly non-preemptible. Autonomous offer
+generation, policy iteration, and tactic integration remain later work. The
+current retained-tree builder repeatedly
 validates retained branches and pairwise scope uniqueness; incremental
 construction therefore has the documented `Θ(N² * B + N³)` reference cost,
 where `B` is branch validation work, rather than a production-local-update

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -41,9 +41,12 @@ granting runtime state evidence authority. The current package fixes one
 natural exponent and one dyadic constant, shared respectively by every node at
 the built-in power and constant operation indices; duplicate package
 registration and operation keys cannot provide another such parameterization.
-Arbitrary-function package discovery, generic search-to-recipe orchestration,
+Arbitrary-function package discovery, a complete autonomous search loop,
 split-search tactic integration, and default package discovery remain
-experimental. The supported direct-forward reifier and tactic are a narrow
+experimental. The supported callback driver executes one already-selected
+authenticated package action and atomically advances a sealed result tree and
+its separately checked proof recipe; it does not choose or enumerate offers.
+The supported direct-forward reifier and tactic are a narrow
 client rather than that missing generic bridge. The supported proof layer can
 replay a separately supplied, bounded chronology over a checked
 retained search tree: package-owned binary-cover and refutation schemas are
@@ -55,12 +58,12 @@ measure, and the untrusted recipe separately echoes every parent, side, and
 seed edge. Child proof states restart at program version zero; inherited facts
 are rebased as derived evidence rather than promoted to assumptions.
 `Proof.TreeLimits` independently cap proof nodes, depth, body cells, and
-structural work. Generic callback-to-recipe quotation and tactic-driven split
-search remain later integration edges. Each retained node currently freezes
-its `Source.branch` at creation; non-root snapshots restart at version zero,
-so their chronology must be empty or proof-state-only and terminals can cite
-only facts current in that creation snapshot. Recursive child propagation
-remains part of the later controller edge. Current retained-tree construction
+structural work. Tactic-driven split search remains a later integration edge.
+Each non-root snapshot starts at version zero from the exact parent-plus-seed
+origin. The supported driver may advance that retained source only with an
+accepted update from the same authenticated session; its node-local recipe is
+retained in the same transaction, so recursive child propagation is replayed
+exactly by the existing proof fold. Current retained-tree construction
 inherits the Mathlib-free reference cost `Θ(N² * B + N³)` from repeated branch
 validation and pairwise scope-uniqueness checking; this is not a production
 storage-complexity claim.
@@ -3167,6 +3170,11 @@ the fixed soundness and trust contracts.
 - `HexIntervalMathlib/Proof.lean`: chronological and retained-tree replay,
   package-owned fact/equality/instance/refutation/split schemas, exact child
   seeding and cover joins, certificate checks, and proof construction.
+- `HexIntervalMathlib/Driver.lean`: one-step authenticated package invocation,
+  atomic retained-node advancement/split/terminal updates, and bounded exact
+  alignment of the sealed runtime tree with a separately untrusted proof
+  recipe. Offer generation, policy selection, and the autonomous search loop
+  remain outside this module.
 - `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
 - `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
   enclosures.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -45,7 +45,12 @@ Arbitrary-function package discovery, a complete autonomous search loop,
 split-search tactic integration, and default package discovery remain
 experimental. The supported callback driver executes one already-selected
 authenticated package action and atomically advances a sealed result tree and
-its separately checked proof recipe; it does not choose or enumerate offers.
+its separately checked proof recipe. A caller-owned logical measure charges
+the complete encoding of every retained event and edge—including nested facts,
+actions, schema keys, dependency versions, body naturals, and seed data—and
+independent recipe byte/work caps are rechecked over the complete bundle on
+every transition. Measurement and callback execution remain non-preemptible.
+The driver does not choose or enumerate offers.
 The supported direct-forward reifier and tactic are a narrow
 client rather than that missing generic bridge. The supported proof layer can
 replay a separately supplied, bounded chronology over a checked
@@ -3173,8 +3178,9 @@ the fixed soundness and trust contracts.
 - `HexIntervalMathlib/Driver.lean`: one-step authenticated package invocation,
   atomic retained-node advancement/split/terminal updates, and bounded exact
   alignment of the sealed runtime tree with a separately untrusted proof
-  recipe. Offer generation, policy selection, and the autonomous search loop
-  remain outside this module.
+  recipe. Its explicit logical event/edge measure and independent byte/work
+  caps cover the complete retained recipe bundle. Offer generation, policy
+  selection, and the autonomous search loop remain outside this module.
 - `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
 - `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
   enclosures.

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -608,6 +608,10 @@ open Search.Result
 #guard_msgs in
 #check Search.Result.Tree.mk
 
+/-- error: Unknown constant `Hex.Interval.Search.Applied.mk` -/
+#guard_msgs in
+#check Search.Applied.mk
+
 private def limits : Search.Result.Limits :=
   { search := { searchLimits with maxSteps := 6 }
     state := stateLimits
@@ -630,6 +634,12 @@ private def measure : Measure Nat Nat Nat Nat :=
     schema := fun _ => unitCost
     body := fun _ => unitCost
     code := fun _ => unitCost }
+
+private def resultError (wanted : Search.Result.Error)
+    (result : Except Search.Result.Error α) : Bool :=
+  match result with
+  | .error actual => actual == wanted
+  | .ok _ => false
 
 private def refinedBranch? : Option (State.Branch Nat Nat) := do
   let branch <- branch?
@@ -661,6 +671,24 @@ private def root? : Option (Tree Nat Nat Nat Nat) := do
   let branch <- refinedBranch?
   (Search.Result.startWithin limits measure { index := 5 } branch).toOption
 
+private def unrefinedRoot? : Option (Tree Nat Nat Nat Nat) := do
+  let branch <- branch?
+  (Search.Result.startWithin limits measure { index := 5 } branch).toOption
+
+private def applied? (updates : Array (State.Update Nat Nat) := #[firstUpdate]) :
+    Option (Search.Applied Nat Nat Nat Action) := do
+  let session <- session?
+  let decision <- decision?
+  match Search.invokeWithWithin envelope policyMeasure localRule.key
+      (fun _ => (.outcome (outcome updates), ())) session decision with
+  | .ok (.produced (.applied transition) ()) => some transition
+  | _ => none
+
+private def advanced? : Option (Tree Nat Nat Nat Nat) := do
+  let tree <- unrefinedRoot?
+  let transition <- applied?
+  (Search.Result.advanceWithin limits measure tree transition).toOption
+
 private def split? : Option (Tree Nat Nat Nat Nat) := do
   let root <- root?
   (Search.Result.splitWithin limits measure .depthFirst root recipe leftSeed rightSeed).toOption
@@ -668,6 +696,36 @@ private def split? : Option (Tree Nat Nat Nat Nat) := do
 #guard root?.any fun tree =>
   tree.check limits measure && tree.nodes.size == 1 &&
     tree.pending == [{ index := 0 }] && tree.accounting.nextScope == 6
+
+#guard advanced?.any fun tree =>
+  tree.check limits measure && tree.accounting.steps == 1 &&
+    tree.pending == [{ index := 0 }] &&
+    match Search.Result.current? tree with
+    | some (_, source) =>
+        source.branch.versions == #[0, 1] && source.branch.history == #[firstUpdate]
+    | none => false
+
+-- An accepted callback is tied to its exact before branch, must contain an
+-- update, and cannot advance a head which has already settled.
+#guard match root?, applied? with
+  | some tree, some transition =>
+      resultError .malformed <| Search.Result.advanceWithin limits measure tree transition
+  | _, _ => false
+
+#guard match unrefinedRoot?, applied? #[] with
+  | some tree, some transition =>
+      resultError .malformed <| Search.Result.advanceWithin limits measure tree transition
+  | _, _ => false
+
+#guard match unrefinedRoot?, applied? with
+  | some tree, some transition =>
+      match Search.Result.settleWithin limits measure tree (.target
+          { scope := { index := 5 }, programVersion := 0,
+            seen := { node := contractNode 1, version := 0 } }) with
+      | .ok terminal =>
+          resultError .terminal <| Search.Result.advanceWithin limits measure terminal transition
+      | .error _ => false
+  | _, _ => false
 
 #guard split?.any fun tree =>
   tree.check limits measure && tree.nodes.size == 3 &&
@@ -727,12 +785,6 @@ private def unknown? : Option (Tree Nat Nat Nat Nat) := do
 
 #guard unknown?.any fun tree =>
   tree.check limits measure && tree.isEmpty && terminalCount tree == 1
-
-private def resultError (wanted : Search.Result.Error)
-    (result : Except Search.Result.Error α) : Bool :=
-  match result with
-  | .error actual => actual == wanted
-  | .ok _ => false
 
 -- Action kind, current dependency, exact predecessor, sibling distinction,
 -- and nontrivial child deltas are independently load-bearing.

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -697,13 +697,18 @@ private def split? : Option (Tree Nat Nat Nat Nat) := do
   tree.check limits measure && tree.nodes.size == 1 &&
     tree.pending == [{ index := 0 }] && tree.accounting.nextScope == 6
 
-#guard advanced?.any fun tree =>
-  tree.check limits measure && tree.accounting.steps == 1 &&
-    tree.pending == [{ index := 0 }] &&
-    match Search.Result.current? tree with
-    | some (_, source) =>
-        source.branch.versions == #[0, 1] && source.branch.history == #[firstUpdate]
-    | none => false
+#guard match advanced?, branch? with
+  | some tree, some initial =>
+      tree.check limits measure && tree.accounting.steps == 1 &&
+        tree.pending == [{ index := 0 }] &&
+        match Search.Result.current? tree with
+        | some (_, source) =>
+            source.branch.versions == #[0, 1] && source.branch.history == #[firstUpdate] &&
+              source.branch.generations == initial.generations &&
+              source.branch.depths == initial.depths &&
+              source.branch.programVersion == initial.programVersion
+        | none => false
+  | _, _ => false
 
 -- An accepted callback is tied to its exact before branch, must contain an
 -- update, and cannot advance a head which has already settled.

--- a/conformance/HexIntervalMathlib/DriverConformance.lean
+++ b/conformance/HexIntervalMathlib/DriverConformance.lean
@@ -218,6 +218,30 @@ def resultMeasure : Search.Result.Measure Fact Nat (List Nat) Proof.Key :=
     fact := fun _ => unitCost, action := fun _ => unitCost, plan := fun _ => unitCost,
     schema := fun _ => unitCost, body := fun _ => unitCost, code := fun _ => unitCost }
 
+private def factBytes : Fact → Nat
+  | .all => 1025
+  | .yes | .empty => 1
+
+private def bodyBytes (body : List Nat) : Nat :=
+  body.foldl (init := 0) fun total value => total + value + 1
+
+def recipeMeasure : Driver.Measure Fact :=
+  { cell := unitCost
+    event := fun
+      | .fact step =>
+          { bytes := 16 + factBytes step.proposed + factBytes step.installed +
+              step.assumptions.length + bodyBytes step.body
+            work := 1 + step.assumptions.length + step.body.length }
+      | .equality step =>
+          { bytes := 14 + step.assumptions.length + bodyBytes step.body,
+            work := 1 + step.assumptions.length + step.body.length }
+      | .transport _ => unitCost
+      | .instance step =>
+          { bytes := 12 + bodyBytes step.body, work := 1 + step.body.length }
+    edge := fun edge =>
+      { bytes := 4 + match edge.seed with | none => 0 | some seed => factBytes seed.fact,
+        work := 1 } }
+
 def resultLimits : Search.Result.Limits :=
   { search := searchLimits, state := stateLimits, maxNodes := 3, maxBodyCells := 1,
     maxBytes := 128, maxWork := 128, maxCode := 8 }
@@ -225,7 +249,9 @@ def resultLimits : Search.Result.Limits :=
 def treeLimits : Proof.TreeLimits :=
   { maxNodes := 3, maxDepth := 1, maxBodyCells := 6, maxWork := 32 }
 
-def limits : Driver.Limits := { result := resultLimits, proof := proofLimits, tree := treeLimits }
+def limits : Driver.Limits :=
+  { result := resultLimits, proof := proofLimits, tree := treeLimits,
+    recipe := { maxBytes := 1024, maxWork := 128 } }
 
 def binding (rule : RuleKey) (anchor : NodeId) (watches writes : List NodeId) :
     ScopeBinding := { rule, anchor, watches, writes }
@@ -328,8 +354,41 @@ def badEchoPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
       let echo := { outcome request (Array.singleton item) with serial := request.serial + 1 }
       .continue (Driver.Echo.mk echo [factEvent request item]) }
 
+def badProgramEchoPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let echo := { outcome request (Array.singleton item) with
+        programVersion := request.programVersion + 1 }
+      .continue (Driver.Echo.mk echo [factEvent request item]) }
+
+def shortEchoPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item)) []) }
+
+def bulkyProposedPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let event := factEvent request item
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [match event with | .fact step => .fact { step with proposed := .all } | other => other]) }
+
+def bulkyBodyPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let event := factEvent request item
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [match event with | .fact step => .fact { step with body := [1024] } | other => other]) }
+
 def stoppingPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
   { rule := forwardRule, invoke := fun _ => .stop 7 }
+
+def oversizedStopPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule, invoke := fun _ => .stop 9 }
 
 def unknownPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
   { rule := forwardRule
@@ -371,27 +430,74 @@ def makeSession (branch : State.Branch Fact Nat) (scope : Policy.ScopeId)
   Search.Session.startWithin envelope policyMeasure branch registrations bindings #[0, 0, 0, 0]
     #[] 0 scope #[selected]
 
+def firstResult (package : Driver.Package Fact Nat Nat Nat (List Nat))
+    (candidateLimits : Driver.Limits := limits) :
+    Except Driver.Error (Driver.Step Fact Nat Nat Nat (List Nat)) := do
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).mapError fun _ => .mismatch
+  let bundle ← Driver.Bundle.startWithin candidateLimits resultMeasure recipeMeasure scope branch
+  let session ← (makeSession branch scope rootBindings
+    (offer 0 .forward rootAction)).mapError Driver.Error.search
+  let some decision := choose? session | throw .mismatch
+  Driver.runWithin envelope policyMeasure candidateLimits resultMeasure recipeMeasure
+    .depthFirst package bundle session decision
+
 def firstWith (package : Driver.Package Fact Nat Nat Nat (List Nat))
-    (candidateLimits : Driver.Limits := limits) : Option (Driver.Step Fact Nat Nat Nat (List Nat)) := do
-  let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
-  let bundle ← (Driver.Bundle.startWithin candidateLimits resultMeasure scope branch).toOption
-  let session ← (makeSession branch scope rootBindings (offer 0 .forward rootAction)).toOption
-  let decision ← choose? session
-  (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure .depthFirst package
-    bundle session decision).toOption
+    (candidateLimits : Driver.Limits := limits) : Option (Driver.Step Fact Nat Nat Nat (List Nat)) :=
+  (firstResult package candidateLimits).toOption
+
+def generousRecipeLimits : Driver.Limits :=
+  { limits with recipe := { maxBytes := 4096, maxWork := 4096 } }
+
+def recipeCostWith (package : Driver.Package Fact Nat Nat Nat (List Nat)) :
+    Option Search.Result.Cost := do
+  let .continued bundle _ ← firstWith package generousRecipeLimits | none
+  pure bundle.recipeCost
+
+def refusesRecipeByteOneOver
+    (package : Driver.Package Fact Nat Nat Nat (List Nat)) : Bool := Id.run do
+  let some cost := recipeCostWith package | return false
+  if cost.bytes == 0 then return false
+  let candidate :=
+    { generousRecipeLimits with
+      recipe := { generousRecipeLimits.recipe with maxBytes := cost.bytes - 1 } }
+  return match firstResult package candidate with
+    | .error (.resource .bytes) => true
+    | _ => false
+
+def refusesRecipeWorkOneOver
+    (package : Driver.Package Fact Nat Nat Nat (List Nat)) : Bool := Id.run do
+  let some cost := recipeCostWith package | return false
+  if cost.work == 0 then return false
+  let candidate :=
+    { generousRecipeLimits with
+      recipe := { generousRecipeLimits.recipe with maxWork := cost.work - 1 } }
+  return match firstResult package candidate with
+    | .error (.resource .work) => true
+    | _ => false
 
 #guard match firstWith rootPackage with | some (.continued _ _) => true | _ => false
 #guard (firstWith badOwnerPackage).isNone
 #guard (firstWith badDependencyPackage).isNone
 #guard (firstWith badSchemaPackage).isNone
 #guard (firstWith badEchoPackage).isNone
+#guard (firstWith badProgramEchoPackage).isNone
+#guard (firstWith shortEchoPackage).isNone
+#guard match firstResult bulkyProposedPackage with
+  | .error (.resource .bytes) => true
+  | _ => false
+#guard match firstResult bulkyBodyPackage with
+  | .error (.resource .bytes) => true
+  | _ => false
+#guard refusesRecipeByteOneOver bulkyProposedPackage
+#guard refusesRecipeByteOneOver bulkyBodyPackage
+#guard refusesRecipeWorkOneOver rootPackage
 #guard match firstWith stoppingPackage with
   | some (.stopped (.callbackFailure 7) bundle session) =>
       session.serial == 0 && bundle.tree.pending.length == 1
   | _ => false
 #guard match firstWith unknownPackage with | some (.unknown _) => true | _ => false
+#guard (firstWith oversizedStopPackage).isNone
 #guard (firstWith rootPackage { limits with proof := { proofLimits with maxChronology := 0 } }).isNone
-#guard (firstWith rootPackage { limits with result := { resultLimits with maxNodes := 0 } }).isNone
 
 def staleAction := { rootAction with generation := 1 }
 #guard match State.Branch.startWithin stateLimits program input.facts with
@@ -401,23 +507,45 @@ def staleAction := { rootAction with generation := 1 }
     | .ok _ => false
   | .error _ => false
 
-def splitWith (package : Driver.Package Fact Nat Nat Nat (List Nat)) :
+def splitWith (package : Driver.Package Fact Nat Nat Nat (List Nat))
+    (candidateLimits : Driver.Limits := limits) :
     Option (Driver.Step Fact Nat Nat Nat (List Nat)) := do
   let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
-  let bundle ← (Driver.Bundle.startWithin limits resultMeasure scope branch).toOption
+  let bundle ← (Driver.Bundle.startWithin candidateLimits resultMeasure recipeMeasure
+    scope branch).toOption
   let session ← (makeSession branch scope rootBindings (offer 0 .forward rootAction)).toOption
   let decision ← choose? session
-  let .continued bundle session ← (Driver.runWithin envelope policyMeasure limits resultMeasure
-    .depthFirst rootPackage bundle session decision).toOption | none
+  let .continued bundle session ← (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure
+    recipeMeasure .depthFirst rootPackage bundle session decision).toOption | none
   let session ← (Search.Session.refreshWithin envelope policyMeasure session
     #[offer 1 .split splitAction] {} false).toOption
   let decision ← choose? session
-  (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst package
+  (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure recipeMeasure
+    .depthFirst package
     bundle session decision).toOption
 
 #guard match splitWith splitPackage with | some (.split _) => true | _ => false
 #guard (splitWith badSplitSchemaPackage).isNone
 #guard (splitWith staleSplitSeedPackage).isNone
+#guard (splitWith splitPackage
+  { limits with result := { resultLimits with maxNodes := 2 } }).isNone
+
+def wrongHeadSession : Bool := Id.run do
+  let some branch := (State.Branch.startWithin stateLimits program input.facts).toOption
+    | return false
+  let some bundle := (Driver.Bundle.startWithin limits resultMeasure recipeMeasure
+    scope branch).toOption | return false
+  let some session := (makeSession branch scope rootBindings
+    (offer 0 .forward rootAction)).toOption | return false
+  let some decision := choose? session | return false
+  let some (.continued bundle _) := (Driver.runWithin envelope policyMeasure limits resultMeasure
+    recipeMeasure .depthFirst rootPackage bundle session decision).toOption | return false
+  return match Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure
+      .depthFirst rootPackage bundle session decision with
+    | .error .mismatch => true
+    | _ => false
+
+#guard wrongHeadSession
 
 private def orCode (code : Nat) (result : Except ε α) : Except Nat α :=
   result.mapError fun _ => code
@@ -426,45 +554,46 @@ private def driverCode (base : Nat) : Driver.Error → Nat
   | .search _ => base + 1
   | .result _ => base + 2
   | .proof _ => base + 3
-  | .mismatch => base + 4
+  | .resource _ => base + 4
+  | .mismatch => base + 5
 
 private def runWith
     (selectedSplit : Driver.Package Fact Nat Nat Nat (List Nat)) :
     Except Nat (Driver.Bundle Fact Nat (List Nat) ×
     Search.Result.Tree Fact Nat (List Nat) Proof.Key × Proof.TreeRecipe Fact) := do
   let branch ← orCode 1 (State.Branch.startWithin stateLimits program input.facts)
-  let bundle ← orCode 2 (Driver.Bundle.startWithin limits resultMeasure scope branch)
+  let bundle ← orCode 2 (Driver.Bundle.startWithin limits resultMeasure recipeMeasure scope branch)
   let session ← orCode 3 (makeSession branch scope rootBindings
     (offer 0 .forward rootAction))
   let some decision := choose? session | throw 4
-  let step ← orCode 5 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
-    rootPackage bundle session decision)
+  let step ← orCode 5 (Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure
+    .depthFirst rootPackage bundle session decision)
   let .continued bundle session := step | throw 6
   let session ← orCode 7 (Search.Session.refreshWithin envelope policyMeasure session
     #[offer 1 .split splitAction] {} false)
   let some decision := choose? session | throw 8
-  let step ← orCode 9 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
-    selectedSplit bundle session decision)
+  let step ← orCode 9 (Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure
+    .depthFirst selectedSplit bundle session decision)
   let .split bundle := step | throw 10
   let some (_, left) := Search.Result.current? bundle.tree | throw 11
   let session ← orCode 12 (makeSession left.branch left.scope leftBindings
     (offer 2 .forward childAction))
   let some decision := choose? session | throw 13
-  let step ← (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+  let step ← (Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure .depthFirst
     childPackage bundle session decision).mapError (driverCode 140)
   let .continued bundle session := step | throw 15
   let session ← orCode 16 (Search.Session.refreshWithin envelope policyMeasure session
     #[offer 3 .forward targetAction] {} false)
   let some decision := choose? session | throw 17
-  let step ← orCode 18 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
-    targetPackage bundle session decision)
+  let step ← orCode 18 (Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure
+    .depthFirst targetPackage bundle session decision)
   let .terminal bundle := step | throw 19
   let some (_, right) := Search.Result.current? bundle.tree | throw 20
   let session ← orCode 21 (makeSession right.branch right.scope rightBindings
     (offer 4 .backward refuteAction))
   let some decision := choose? session | throw 22
-  let step ← orCode 23 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
-    refutePackage bundle session decision)
+  let step ← orCode 23 (Driver.runWithin envelope policyMeasure limits resultMeasure recipeMeasure
+    .depthFirst refutePackage bundle session decision)
   let .terminal bundle := step | throw 24
   pure (bundle, bundle.tree, bundle.recipe)
 
@@ -512,6 +641,9 @@ private def replayMutated
 
 def evidence : Proof.Evidence
     (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  /- `replayRun.isOk` above makes this branch the live executable canary. The
+  fallback is separately proved only because this total definition must inhabit
+  its type even if a future malformed fixture makes executable replay reject. -/
   match replayRun with
   | .ok evidence => evidence
   | .error _ =>

--- a/conformance/HexIntervalMathlib/DriverConformance.lean
+++ b/conformance/HexIntervalMathlib/DriverConformance.lean
@@ -20,6 +20,10 @@ namespace Hex.IntervalMathlib.DriverConformance
 open Hex.Interval
 open Hex.Interval.Proof
 
+/-- error: Unknown constant `Hex.Interval.Driver.Bundle.mk` -/
+#guard_msgs in
+#check Driver.Bundle.mk
+
 inductive Fact where
   | all | yes | empty
   deriving DecidableEq, Repr

--- a/conformance/HexIntervalMathlib/DriverConformance.lean
+++ b/conformance/HexIntervalMathlib/DriverConformance.lean
@@ -503,6 +503,24 @@ def refusesRecipeWorkOneOver
 #guard (firstWith oversizedStopPackage).isNone
 #guard (firstWith rootPackage { limits with proof := { proofLimits with maxChronology := 0 } }).isNone
 
+def changedRecipeMeasure : Driver.Measure Fact :=
+  { recipeMeasure with cell := { bytes := 2, work := 1 } }
+
+def changedMeasureRejected : Bool := Id.run do
+  let some branch := (State.Branch.startWithin stateLimits program input.facts).toOption
+    | return false
+  let some bundle := (Driver.Bundle.startWithin limits resultMeasure recipeMeasure
+    scope branch).toOption | return false
+  let some session := (makeSession branch scope rootBindings
+    (offer 0 .forward rootAction)).toOption | return false
+  let some decision := choose? session | return false
+  return match Driver.runWithin envelope policyMeasure limits resultMeasure changedRecipeMeasure
+      .depthFirst rootPackage bundle session decision with
+    | .error .mismatch => true
+    | _ => false
+
+#guard changedMeasureRejected
+
 def staleAction := { rootAction with generation := 1 }
 #guard match State.Branch.startWithin stateLimits program input.facts with
   | .ok branch => match makeSession branch scope rootBindings
@@ -511,28 +529,48 @@ def staleAction := { rootAction with generation := 1 }
     | .ok _ => false
   | .error _ => false
 
+def splitResult (package : Driver.Package Fact Nat Nat Nat (List Nat))
+    (candidateLimits : Driver.Limits := limits) :
+    Except Driver.Error (Driver.Step Fact Nat Nat Nat (List Nat)) := do
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).mapError fun _ => .mismatch
+  let bundle ← Driver.Bundle.startWithin candidateLimits resultMeasure recipeMeasure scope branch
+  let session ← (makeSession branch scope rootBindings
+    (offer 0 .forward rootAction)).mapError Driver.Error.search
+  let some decision := choose? session | throw .mismatch
+  let .continued bundle session ← Driver.runWithin envelope policyMeasure candidateLimits
+    resultMeasure recipeMeasure .depthFirst rootPackage bundle session decision | throw .mismatch
+  let session ← (Search.Session.refreshWithin envelope policyMeasure session
+    #[offer 1 .split splitAction] {} false).mapError Driver.Error.search
+  let some decision := choose? session | throw .mismatch
+  Driver.runWithin envelope policyMeasure candidateLimits resultMeasure recipeMeasure
+    .depthFirst package bundle session decision
+
 def splitWith (package : Driver.Package Fact Nat Nat Nat (List Nat))
     (candidateLimits : Driver.Limits := limits) :
-    Option (Driver.Step Fact Nat Nat Nat (List Nat)) := do
-  let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
-  let bundle ← (Driver.Bundle.startWithin candidateLimits resultMeasure recipeMeasure
-    scope branch).toOption
-  let session ← (makeSession branch scope rootBindings (offer 0 .forward rootAction)).toOption
-  let decision ← choose? session
-  let .continued bundle session ← (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure
-    recipeMeasure .depthFirst rootPackage bundle session decision).toOption | none
-  let session ← (Search.Session.refreshWithin envelope policyMeasure session
-    #[offer 1 .split splitAction] {} false).toOption
-  let decision ← choose? session
-  (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure recipeMeasure
-    .depthFirst package
-    bundle session decision).toOption
+    Option (Driver.Step Fact Nat Nat Nat (List Nat)) :=
+  (splitResult package candidateLimits).toOption
 
 #guard match splitWith splitPackage with | some (.split _) => true | _ => false
 #guard (splitWith badSplitSchemaPackage).isNone
 #guard (splitWith staleSplitSeedPackage).isNone
 #guard (splitWith splitPackage
   { limits with result := { resultLimits with maxNodes := 2 } }).isNone
+
+def splitRecipeCost? : Option Search.Result.Cost := do
+  let .split bundle ← splitWith splitPackage generousRecipeLimits | none
+  pure bundle.recipeCost
+
+def seededEdgeByteOneOver : Bool := Id.run do
+  let some cost := splitRecipeCost? | return false
+  if cost.bytes == 0 then return false
+  let candidate :=
+    { generousRecipeLimits with
+      recipe := { generousRecipeLimits.recipe with maxBytes := cost.bytes - 1 } }
+  return match splitResult splitPackage candidate with
+    | .error (.resource .bytes) => true
+    | _ => false
+
+#guard seededEdgeByteOneOver
 
 def wrongHeadSession : Bool := Id.run do
   let some branch := (State.Branch.startWithin stateLimits program input.facts).toOption

--- a/conformance/HexIntervalMathlib/DriverConformance.lean
+++ b/conformance/HexIntervalMathlib/DriverConformance.lean
@@ -1,0 +1,534 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Driver
+
+/-!
+# Authenticated search-to-proof driver conformance
+
+The live canary accepts one root improvement, splits that updated root, accepts
+one child-local improvement, closes the left target, and refutes the right
+child.  Every retained proof event is returned by the same package invocation
+as its runtime command; the driver never reconstructs recipes from causes.
+-/
+
+namespace Hex.IntervalMathlib.DriverConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+
+inductive Fact where
+  | all | yes | empty
+  deriving DecidableEq, Repr
+
+def domain : DomainId := { index := 0 }
+def sourceKey : OpKey := { name := "driver-source", version := 1 }
+def operation : Operation := { key := sourceKey, inputs := [], output := domain }
+def sourceNode : Node := { domain, op := { index := 0 }, args := [] }
+def n0 : NodeId := { index := 0 }
+def n1 : NodeId := { index := 1 }
+def n2 : NodeId := { index := 2 }
+def n3 : NodeId := { index := 3 }
+def program : Program :=
+  { operations := #[operation], nodes := #[sourceNode, sourceNode, sourceNode, sourceNode] }
+
+#guard program.check
+
+def scope : Policy.ScopeId := { index := 20 }
+def leftScope : Policy.ScopeId := { index := 21 }
+def rightScope : Policy.ScopeId := { index := 22 }
+def seen (node : NodeId) (version : Nat) : SeenVersion := { node, version }
+
+def contains : Fact → Bool → Prop
+  | .all, _ => True
+  | .yes, value => value = true
+  | .empty, _ => False
+
+def semantics : Proof.Semantics Fact :=
+  { Value := Bool
+    models := fun checked valuation =>
+      checked = program ∧ valuation n0 = valuation n1 ∧ valuation n1 = valuation n2 ∧
+        valuation n2 = valuation n3
+    holds := fun _ valuation fact => contains fact.fact (valuation fact.node)
+    holdsAgree := by
+      intro checked left right fact within _ _ agree
+      rw [agree fact.node within] }
+
+def factDomain : Proof.Domain semantics :=
+  { top := fun _ => .all
+    topSound := by simp [semantics, contains]
+    meet := fun checked node previous proposed installed =>
+      if shape : (previous = .all ∨ previous = .yes) ∧ proposed = .yes ∧
+          installed = .yes then
+        some
+          { proof := by
+              rcases shape with ⟨previousShape, rfl, rfl⟩
+              rcases previousShape with rfl | rfl
+              · intro valuation model
+                simp [semantics, contains]
+              · intro valuation model
+                simp [semantics, contains] }
+      else none }
+
+theorem laws : Proof.Laws semantics :=
+  { holdsEq := by
+      intro checked valuation left right fact model equal
+      simp only [semantics, contains]
+      rw [equal] }
+
+def forwardRule : RuleKey := { name := "driver-forward", schema := 1 }
+def splitRule : RuleKey := { name := "driver-split", schema := 1 }
+def refuteRule : RuleKey := { name := "driver-refute", schema := 1 }
+
+def forwardRegistration : Registration :=
+  { key := forwardRule, head := sourceKey, kind := .forward,
+    watches := [], writes := [], binding := .scoped }
+def splitRegistration : Registration :=
+  { key := splitRule, head := sourceKey, kind := .split,
+    watches := [], writes := [], binding := .scoped }
+def refuteRegistration : Registration :=
+  { key := refuteRule, head := sourceKey, kind := .backward,
+    watches := [], writes := [], binding := .scoped }
+def registrations : Array Registration :=
+  #[forwardRegistration, splitRegistration, refuteRegistration]
+
+def factKey : Proof.Key := { rule := forwardRule, role := .fact, bodySchema := 1 }
+def splitKey : Proof.Key := { rule := splitRule, role := .split, bodySchema := 2 }
+def refuteKey : Proof.Key := { rule := refuteRule, role := .refute, bodySchema := 3 }
+
+def decode (expected : Nat) (body : List Nat) : Option Unit :=
+  if body = [expected] then some () else none
+
+def factSchema : Proof.FactSchema semantics :=
+  { key := factKey
+    Certificate := Unit
+    decode := decode 11
+    prove := fun context _ =>
+      if rootShape : context.scope = scope ∧ context.program = program ∧
+          context.proposed = { node := n2, fact := .yes } ∧
+          context.assumptions = [{ node := n1, fact := .yes }] then
+        some
+          { proof := by
+              rcases rootShape with ⟨_, programEq, proposedEq, assumptionsEq⟩
+              intro valuation model assumptions
+              have source := assumptions { node := n1, fact := .yes } (by
+                simp [assumptionsEq])
+              rw [proposedEq]
+              simpa [semantics, contains, programEq, model.2.2.1] using source }
+      else if childShape : context.scope = leftScope ∧ context.program = program ∧
+          context.proposed = { node := n3, fact := .yes } ∧
+          context.assumptions = [{ node := n0, fact := .yes }] then
+        some
+          { proof := by
+              rcases childShape with ⟨_, programEq, proposedEq, assumptionsEq⟩
+              intro valuation model assumptions
+              have source := assumptions { node := n0, fact := .yes } (by
+                simp [assumptionsEq])
+              rw [proposedEq]
+              simpa [semantics, contains, programEq, model.2.1, model.2.2.1,
+                model.2.2.2] using source }
+      else none }
+
+def splitSchema : Proof.SplitSchema semantics (List Nat) :=
+  { key := splitKey
+    Certificate := Unit
+    decode := decode 22
+    prove := fun context _ =>
+      if shape : context.scope = scope ∧ context.programVersion = 0 ∧
+          context.program = program ∧
+          { node := n1, fact := .yes } ∈ context.assumptions ∧
+          context.parent = { node := n0, fact := .all } ∧
+          context.left = { node := n0, fact := .yes } ∧
+          context.right = { node := n0, fact := .empty } ∧ context.plan = [22] then
+        some
+          { proof := by
+              rcases shape with ⟨_, _, _, sourceMember, _, leftEq, _, _⟩
+              intro valuation model assumptions
+              left
+              have source := assumptions { node := n1, fact := .yes } sourceMember
+              simpa [leftEq, semantics, contains, model.2.1] using source }
+      else none }
+
+def refuteSchema : Proof.RefuteSchema semantics :=
+  { key := refuteKey
+    Certificate := Unit
+    decode := decode 33
+    prove := fun context _ =>
+      if shape : context.scope = rightScope ∧ context.program = program ∧
+          context.fact = .empty then
+        some
+          { proof := by
+              rcases shape with ⟨_, _, factEq⟩
+              intro valuation model impossible
+              rw [factEq] at impossible
+              exact impossible }
+      else none }
+
+def package : Proof.Package semantics (List Nat) :=
+  { registrations, facts := #[factSchema], splits := #[splitSchema],
+    refuters := #[refuteSchema] }
+
+def proofLimits : Proof.Limits :=
+  { maxPackages := 1, maxSchemas := 3, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 2 }
+
+def registry? : Option (Proof.Registry semantics (List Nat)) :=
+  (Proof.Registry.buildWithin proofLimits program #[package]).toOption
+
+def input : Proof.Input Fact :=
+  { scope, program, facts := #[.all, .yes, .all, .all],
+    target := { node := n3, fact := .yes } }
+
+def stateLimits : State.Limits :=
+  { maxOperations := 1, maxNodes := 4, maxRules := 3,
+    maxRegistryEntries := 3, maxReplayFormats := 3, maxArity := 2,
+    maxScopeNodes := 2, maxApplications := 4, maxQueueEntries := 4,
+    maxActions := 8, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 2, maxRetainedSuggestions := 4, maxEffort := 1,
+    maxObservationValue := 4, maxDiagnosticValue := 8,
+    maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0, maxProposalItems := 2,
+    maxInstances := 0, maxGeneration := 1, maxNodeDepth := 0, maxEqualities := 0,
+    splitEndpointLimit := { maxEndpointHeight := 8, maxAlignmentShift := 8 } }
+
+def searchLimits : Search.Limits :=
+  { maxSteps := 5, maxSplits := 1, maxLeaves := 2, maxFrontier := 2,
+    maxDepth := 1, maxScopes := 3, leafFuel := 4 }
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 1, maxBytes := 32, maxPairs := 16, maxWork := 32, maxScore := 4 }
+
+def envelope : Search.Envelope :=
+  { state := stateLimits, policy := policyLimits,
+    trace := { maxEvents := 4, maxBytes := 32, maxWork := 32, maxCode := 8 },
+    search := searchLimits }
+
+def policyMeasure : Policy.Measure Nat Nat :=
+  { id := fun _ => { bytes := 1, pairs := 0, work := 1 },
+    key := fun _ => { bytes := 1, pairs := 0, work := 1 } }
+
+def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
+def resultMeasure : Search.Result.Measure Fact Nat (List Nat) Proof.Key :=
+  { node := unitCost
+    branch := fun branch =>
+      { bytes := branch.snapshot.facts.size + branch.history.size,
+        work := branch.versions.size + branch.history.size }
+    fact := fun _ => unitCost, action := fun _ => unitCost, plan := fun _ => unitCost,
+    schema := fun _ => unitCost, body := fun _ => unitCost, code := fun _ => unitCost }
+
+def resultLimits : Search.Result.Limits :=
+  { search := searchLimits, state := stateLimits, maxNodes := 3, maxBodyCells := 1,
+    maxBytes := 128, maxWork := 128, maxCode := 8 }
+
+def treeLimits : Proof.TreeLimits :=
+  { maxNodes := 3, maxDepth := 1, maxBodyCells := 6, maxWork := 32 }
+
+def limits : Driver.Limits := { result := resultLimits, proof := proofLimits, tree := treeLimits }
+
+def binding (rule : RuleKey) (anchor : NodeId) (watches writes : List NodeId) :
+    ScopeBinding := { rule, anchor, watches, writes }
+
+def action (serial application rule : Nat) (key : RuleKey) (kind : ActionKind)
+    (node : NodeId) (inputs : List SeenVersion) (writes : List NodeId) : Action :=
+  { serial, programVersion := 0, application := { index := application }, rule := { index := rule },
+    key, node, kind, effort := 0, generation := 0, inputs, writes }
+
+def offer (id : Nat) (kind : ActionKind) (action : Action) :
+    Search.Offer Nat Nat :=
+  { view := { id, key := id, offerClass :=
+      match kind with | .split => .split | _ => .invoke, age := 0, score := 0 }, action }
+
+def choose? (session : Search.Session Fact Nat Nat Nat) : Option (Policy.Decision Nat Nat) := do
+  let selected ← session.view.offers[0]?
+  pure (Policy.select session.view selected)
+
+def update (request : Search.Request Fact Nat Nat) (node : NodeId)
+    (previous : SeenVersion) (fact : Fact) (version cause : Nat) : State.Update Fact Nat :=
+  { programVersion := request.programVersion, node, previous, fact, version, cause }
+
+def factEvent (request : Search.Request Fact Nat Nat) (update : State.Update Fact Nat) :
+    Proof.Event Fact :=
+  .fact
+    { scope := request.scope, programVersion := request.programVersion, action := request.action,
+      node := update.node, previous := update.previous, version := update.version,
+      proposed := update.fact, installed := update.fact, assumptions := request.action.inputs,
+      schema := factKey, body := [11] }
+
+def outcome (request : Search.Request Fact Nat Nat) (items : Array (State.Update Fact Nat)) :
+    Search.Outcome Fact Nat Nat Nat :=
+  { scope := request.scope
+    serial := request.serial
+    programVersion := request.programVersion
+    offer := request.offer
+    action := request.action
+    updates := items }
+
+def rootPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [factEvent request item]) }
+
+def splitPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := splitRule
+    invoke := fun request =>
+      .split
+        { echo := Driver.Echo.mk (outcome request #[]) []
+          runtime :=
+            { scope := request.scope, programVersion := request.programVersion,
+              action := request.action, parent := seen n0 0, plan := [22],
+              schema := splitKey, body := [22] }
+          left := { node := n0, previous := seen n0 0, fact := .yes }
+          right := { node := n0, previous := seen n0 0, fact := .empty } } }
+
+def childPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n3 (seen n3 0) .yes 1 2
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [factEvent request item]) }
+
+def targetPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request => .target (Driver.Echo.mk (outcome request #[]) [])
+      { scope := request.scope, programVersion := request.programVersion, seen := seen n3 1 } }
+
+def refutePackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := refuteRule
+    invoke := fun request => .refute (Driver.Echo.mk (outcome request #[]) [])
+      { scope := request.scope, programVersion := request.programVersion, seen := seen n0 0,
+        schema := refuteKey, body := [33] } }
+
+def badOwnerPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rootPackage with rule := splitRule }
+
+def badDependencyPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let event := factEvent request item
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [match event with | .fact step => .fact { step with assumptions := [] } | other => other]) }
+
+def badSchemaPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let event := factEvent request item
+      .continue (Driver.Echo.mk (outcome request (Array.singleton item))
+        [match event with | .fact step => .fact { step with schema := splitKey } | other => other]) }
+
+def badEchoPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      let item := update request n2 (seen n2 0) .yes 1 1
+      let echo := { outcome request (Array.singleton item) with serial := request.serial + 1 }
+      .continue (Driver.Echo.mk echo [factEvent request item]) }
+
+def stoppingPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule, invoke := fun _ => .stop 7 }
+
+def unknownPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request => .unknown (Driver.Echo.mk (outcome request #[]) [])
+      { scope := request.scope, programVersion := request.programVersion, code := 1 } }
+
+def badSplitSchemaPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { splitPackage with invoke := fun request =>
+      match splitPackage.invoke request with
+      | .split split => .split { split with runtime := { split.runtime with schema := factKey } }
+      | command => command }
+
+def staleSplitSeedPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { splitPackage with invoke := fun request =>
+      match splitPackage.invoke request with
+      | .split split => .split { split with left := { split.left with previous := seen n0 1 } }
+      | command => command }
+
+def badSplitPlanPackage : Driver.Package Fact Nat Nat Nat (List Nat) :=
+  { splitPackage with invoke := fun request =>
+      match splitPackage.invoke request with
+      | .split split => .split { split with runtime := { split.runtime with plan := [23] } }
+      | command => command }
+
+def rootAction := action 0 0 0 forwardRule .forward n2 [seen n1 0] [n2]
+def splitAction := action 1 1 1 splitRule .split n0 [seen n1 0, seen n0 0] []
+def childAction := action 0 2 0 forwardRule .forward n3 [seen n0 0] [n3]
+def targetAction := action 1 3 0 forwardRule .forward n3 [seen n3 1] [n3]
+def refuteAction := action 0 2 2 refuteRule .backward n0 [seen n0 0] []
+
+def rootBindings : Array ScopeBinding :=
+  #[binding forwardRule n2 [n1] [n2], binding splitRule n0 [n1, n0] []]
+def leftBindings : Array ScopeBinding :=
+  #[binding forwardRule n3 [n0] [n3], binding forwardRule n3 [n3] [n3]]
+def rightBindings : Array ScopeBinding := #[binding refuteRule n0 [n0] []]
+
+def makeSession (branch : State.Branch Fact Nat) (scope : Policy.ScopeId)
+    (bindings : Array ScopeBinding) (selected : Search.Offer Nat Nat) :=
+  Search.Session.startWithin envelope policyMeasure branch registrations bindings #[0, 0, 0, 0]
+    #[] 0 scope #[selected]
+
+def firstWith (package : Driver.Package Fact Nat Nat Nat (List Nat))
+    (candidateLimits : Driver.Limits := limits) : Option (Driver.Step Fact Nat Nat Nat (List Nat)) := do
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
+  let bundle ← (Driver.Bundle.startWithin candidateLimits resultMeasure scope branch).toOption
+  let session ← (makeSession branch scope rootBindings (offer 0 .forward rootAction)).toOption
+  let decision ← choose? session
+  (Driver.runWithin envelope policyMeasure candidateLimits resultMeasure .depthFirst package
+    bundle session decision).toOption
+
+#guard match firstWith rootPackage with | some (.continued _ _) => true | _ => false
+#guard (firstWith badOwnerPackage).isNone
+#guard (firstWith badDependencyPackage).isNone
+#guard (firstWith badSchemaPackage).isNone
+#guard (firstWith badEchoPackage).isNone
+#guard match firstWith stoppingPackage with
+  | some (.stopped (.callbackFailure 7) bundle session) =>
+      session.serial == 0 && bundle.tree.pending.length == 1
+  | _ => false
+#guard match firstWith unknownPackage with | some (.unknown _) => true | _ => false
+#guard (firstWith rootPackage { limits with proof := { proofLimits with maxChronology := 0 } }).isNone
+#guard (firstWith rootPackage { limits with result := { resultLimits with maxNodes := 0 } }).isNone
+
+def staleAction := { rootAction with generation := 1 }
+#guard match State.Branch.startWithin stateLimits program input.facts with
+  | .ok branch => match makeSession branch scope rootBindings
+      (offer 0 .forward staleAction) with
+    | .error _ => true
+    | .ok _ => false
+  | .error _ => false
+
+def splitWith (package : Driver.Package Fact Nat Nat Nat (List Nat)) :
+    Option (Driver.Step Fact Nat Nat Nat (List Nat)) := do
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).toOption
+  let bundle ← (Driver.Bundle.startWithin limits resultMeasure scope branch).toOption
+  let session ← (makeSession branch scope rootBindings (offer 0 .forward rootAction)).toOption
+  let decision ← choose? session
+  let .continued bundle session ← (Driver.runWithin envelope policyMeasure limits resultMeasure
+    .depthFirst rootPackage bundle session decision).toOption | none
+  let session ← (Search.Session.refreshWithin envelope policyMeasure session
+    #[offer 1 .split splitAction] {} false).toOption
+  let decision ← choose? session
+  (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst package
+    bundle session decision).toOption
+
+#guard match splitWith splitPackage with | some (.split _) => true | _ => false
+#guard (splitWith badSplitSchemaPackage).isNone
+#guard (splitWith staleSplitSeedPackage).isNone
+
+private def orCode (code : Nat) (result : Except ε α) : Except Nat α :=
+  result.mapError fun _ => code
+
+private def driverCode (base : Nat) : Driver.Error → Nat
+  | .search _ => base + 1
+  | .result _ => base + 2
+  | .proof _ => base + 3
+  | .mismatch => base + 4
+
+private def runWith
+    (selectedSplit : Driver.Package Fact Nat Nat Nat (List Nat)) :
+    Except Nat (Driver.Bundle Fact Nat (List Nat) ×
+    Search.Result.Tree Fact Nat (List Nat) Proof.Key × Proof.TreeRecipe Fact) := do
+  let branch ← orCode 1 (State.Branch.startWithin stateLimits program input.facts)
+  let bundle ← orCode 2 (Driver.Bundle.startWithin limits resultMeasure scope branch)
+  let session ← orCode 3 (makeSession branch scope rootBindings
+    (offer 0 .forward rootAction))
+  let some decision := choose? session | throw 4
+  let step ← orCode 5 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+    rootPackage bundle session decision)
+  let .continued bundle session := step | throw 6
+  let session ← orCode 7 (Search.Session.refreshWithin envelope policyMeasure session
+    #[offer 1 .split splitAction] {} false)
+  let some decision := choose? session | throw 8
+  let step ← orCode 9 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+    selectedSplit bundle session decision)
+  let .split bundle := step | throw 10
+  let some (_, left) := Search.Result.current? bundle.tree | throw 11
+  let session ← orCode 12 (makeSession left.branch left.scope leftBindings
+    (offer 2 .forward childAction))
+  let some decision := choose? session | throw 13
+  let step ← (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+    childPackage bundle session decision).mapError (driverCode 140)
+  let .continued bundle session := step | throw 15
+  let session ← orCode 16 (Search.Session.refreshWithin envelope policyMeasure session
+    #[offer 3 .forward targetAction] {} false)
+  let some decision := choose? session | throw 17
+  let step ← orCode 18 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+    targetPackage bundle session decision)
+  let .terminal bundle := step | throw 19
+  let some (_, right) := Search.Result.current? bundle.tree | throw 20
+  let session ← orCode 21 (makeSession right.branch right.scope rightBindings
+    (offer 4 .backward refuteAction))
+  let some decision := choose? session | throw 22
+  let step ← orCode 23 (Driver.runWithin envelope policyMeasure limits resultMeasure .depthFirst
+    refutePackage bundle session decision)
+  let .terminal bundle := step | throw 24
+  pure (bundle, bundle.tree, bundle.recipe)
+
+private def runE := runWith splitPackage
+
+def run? := runE.toOption
+
+def replayRun := do
+  let some (_, tree, recipe) := run? | throw Proof.Error.wrongTree
+  let some registry := registry? | throw Proof.Error.invalidInput
+  Proof.replayTree resultLimits resultMeasure proofLimits treeLimits registry
+    factDomain laws input tree recipe
+
+private def replayWithSplit (selectedSplit : Driver.Package Fact Nat Nat Nat (List Nat)) := do
+  let (_, tree, recipe) ← runWith selectedSplit
+  let some registry := registry? | throw 25
+  (Proof.replayTree resultLimits resultMeasure proofLimits treeLimits registry
+    factDomain laws input tree recipe).mapError fun _ => 26
+
+private def changeRootBody (recipe : Proof.TreeRecipe Fact) : Option (Proof.TreeRecipe Fact) := do
+  let events ← recipe.events[0]?
+  let event ← events.head?
+  let changed := match event with
+    | .fact step => Proof.Event.fact { step with body := [12] }
+    | other => other
+  pure { recipe with events := recipe.events.set! 0 (changed :: events.drop 1) }
+
+private def changeLeftSide (recipe : Proof.TreeRecipe Fact) : Option (Proof.TreeRecipe Fact) := do
+  let edge ← recipe.edges[1]?
+  pure { recipe with edges := recipe.edges.set! 1 { edge with side := some .right } }
+
+private def replayMutated
+    (change : Proof.TreeRecipe Fact → Option (Proof.TreeRecipe Fact)) := do
+  let (_, tree, recipe) ← runE.mapError fun _ => Proof.Error.wrongTree
+  let some changed := change recipe | throw Proof.Error.wrongTree
+  let some registry := registry? | throw Proof.Error.invalidInput
+  Proof.replayTree resultLimits resultMeasure proofLimits treeLimits registry
+    factDomain laws input tree changed
+
+#guard runE.isOk
+#guard replayRun.isOk
+#guard match replayWithSplit badSplitPlanPackage with | .error 26 => true | _ => false
+#guard match replayMutated changeRootBody with | .error .malformedBody => true | _ => false
+#guard match replayMutated changeLeftSide with | .error .wrongTree => true | _ => false
+
+def evidence : Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  match replayRun with
+  | .ok evidence => evidence
+  | .error _ =>
+      { proof := by
+          intro valuation model assumptions
+          have source := assumptions { node := n1, fact := .yes } (by
+            simp [Proof.initialBase, input, n1])
+          simpa [semantics, contains, input, n3, model.2.2.1, model.2.2.2] using source }
+
+theorem driverCanary :
+    semantics.Entails input.program (Proof.initialBase input) input.target :=
+  evidence.proof
+
+/--
+info: 'Hex.IntervalMathlib.DriverConformance.driverCanary' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms driverCanary
+
+end Hex.IntervalMathlib.DriverConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -524,6 +524,7 @@ lean_lib HexConformance where
       `HexInterval.FeaturePolicyConformance,
       `HexInterval.SearchConformance,
       `HexIntervalMathlib.ProgramProofConformance,
+      `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.RuleConformance,
       `HexIntervalMathlib.FrontendConformance,
       `HexIntervalMathlib.TacticConformance,

--- a/progress/20260821T205300Z.md
+++ b/progress/20260821T205300Z.md
@@ -1,0 +1,39 @@
+# Authenticated callback-to-recipe driver
+
+## Accomplished
+
+- Added a sealed accepted-callback witness and a retained-tree transition that
+  binds its exact before/after branch to the current frontier head while
+  charging cumulative search work.
+- Added the supported Mathlib driver which executes one already-selected
+  package callback exactly once and transactionally aligns its continue,
+  split, target, refute, unknown, or stop command with the retained result tree
+  and a separately untrusted proof recipe.
+- Allowed checked child-local fact histories without weakening immutable
+  parent/side/seed reconstruction, and updated retained-tree replay to consume
+  the exact node-local chronology.
+- Added an end-to-end root-update, split, child-update, target/refute, and
+  ordinary-theorem conformance vertical with owner, dependency, schema,
+  version, plan, body, side, seed, callback, and resource mutations.
+- Corrected current-state module maps, experimental boundaries, child-history
+  semantics, and retained reference-cost wording.
+- Restacked the exact feature onto the current main while preserving the
+  complete Dusart provider, inventory, Lake registration, and SPEC additions.
+
+## Current frontier
+
+One exact authenticated package invocation can now advance or settle the
+sealed retained tree and its proof recipe together, and the supported proof
+fold replays the resulting child-local chronology into an ordinary theorem.
+
+## Next step
+
+Build the bounded autonomous controller which generates offers, repeatedly
+selects package actions, and returns a complete checked bundle; then connect
+that controller to public tactic split search.
+
+## Blockers
+
+None for the one-step driver. Callback construction and arbitrary decoded
+value equality remain explicitly non-preemptible, and offer generation,
+policy iteration, and tactic integration remain outside this edge.

--- a/progress/20260821T212707Z.md
+++ b/progress/20260821T212707Z.md
@@ -1,0 +1,33 @@
+# Bounded retained driver recipes
+
+## Accomplished
+
+- Added an independent logical byte/work budget for the complete proof recipe
+  retained beside a driver result tree.
+- Required callers to measure complete event and edge encodings, including
+  nested facts, actions, schemas, dependency versions, body naturals, and
+  split seeds; every transition now remeasures the complete bundle and checks
+  its sealed cached cost before retaining a replacement.
+- Added exact byte and work one-over guards, including oversized proposed-fact
+  and proof-body values which were previously invisible to structural limits.
+- Added current-head/session, callback echo, stop-code, and split-node resource
+  guards and extended the ordinary-import sealed-module checker to the driver.
+- Reconciled both current-state Mathlib SPECs with the supported one-callback
+  driver, child-local propagation, recursive replay, and remaining autonomous
+  controller boundary.
+
+## Current frontier
+
+The one-step supported driver retains only recipes that pass both structural
+proof limits and a caller-supplied complete logical encoding budget. Runtime
+tree state and proof recipes remain separate untrusted data until replay.
+
+## Next step
+
+After this repair is reviewed and merged, resume the bounded deterministic
+offer-generation and policy-iteration controller edge.
+
+## Blockers
+
+None. Callback execution, logical measurement, arbitrary-value equality, and
+construction of caller values remain explicitly non-preemptible envelopes.

--- a/progress/20260821T212707Z.md
+++ b/progress/20260821T212707Z.md
@@ -15,6 +15,10 @@
 - Reconciled both current-state Mathlib SPECs with the supported one-callback
   driver, child-local propagation, recursive replay, and remaining autonomous
   controller boundary.
+- Corrected the retained-child lifecycle contract: versions, generations, and
+  history reset only at split creation, after which a sealed accepted callback
+  may advance the live head. Added direct constructor-seal and wrong-before,
+  empty-update, and settled-head rejection guards for that transition.
 
 ## Current frontier
 

--- a/progress/20260821T212707Z.md
+++ b/progress/20260821T212707Z.md
@@ -19,6 +19,9 @@
   history reset only at split creation, after which a sealed accepted callback
   may advance the live head. Added direct constructor-seal and wrong-before,
   empty-update, and settled-head rejection guards for that transition.
+- Pinned child program version alongside its immutable seed/program/generation
+  dimensions, and added changed-measure cache rejection plus an exact seeded-
+  edge recipe byte one-over guard.
 
 ## Current frontier
 

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -646,5 +646,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "07e7dc9c548e343756b4342f6741e7e9b4f6a164",
     "reason": "Additionally registers the Mathlib-free source-correlated Dusart exponential checker, its proof-only real-semantics companion, and conformance module on top of the retained supported Proof, Search, Policy, State, Trace, Chebyshev, LogTables, FKS2, BKLNW, and public interval registrations; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "37dc87228818a40b72aea27b575f2e355e45444d",
+    "reason": "Additionally registers the supported proof-only authenticated callback-to-recipe driver conformance module on top of the current Dusart, public interval, Search, Proof, and PNT registrations; it does not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -33,6 +33,7 @@ IMPORT_ALL_RE = re.compile(
 # directory convention. There are currently no required exceptions.
 SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexInterval.Search": frozenset(),
+    "HexIntervalMathlib.Driver": frozenset(),
     "HexIntervalMathlib.Proof": frozenset(),
 }
 


### PR DESCRIPTION
## Summary

- retain a sealed accepted-callback witness and atomically advance the exact retained frontier head
- add a supported one-step Mathlib driver that aligns each runtime command with its separately bounded proof recipe
- support exact continue, split, target, refute, unknown, and stop outcomes, all revalidated against the same authenticated session/request and package owner
- replay live child-local propagation through a root-update → split → child-update → target/refute ordinary-theorem canary

## Trust and resource boundary

The callback result, retained runtime tree, and recipe remain decoded untrusted data. The driver binds exact action keys, ordered dependencies, scopes, program/fact versions, generations, owners, bodies, plans, sides, and seeds, then `Proof.replayTree` independently resolves package-owned schemas before producing evidence. Failures and resource one-overs return no replacement bundle; callback failure/stop preserves the preceding runtime/proof state. Callback construction and arbitrary decoded-value equality remain explicitly non-preemptible.

## Scope

This edge executes one already-selected authenticated action. Autonomous offer generation, repeated policy iteration, and public tactic split-search integration remain deliberately deferred.

## Verification

- `lake build HexConformance` (9,589 jobs)
- focused Search/Proof/Driver/DriverConformance build
- DAG checker and regression test
- published trust-surface check
- factor-sweep freshness
- PNT inventory and 29 inventory unit tests
- diff and banned-proof scans
