### PR TITLE
spec: generalize Bareiss over integral domains

### DIFF
--- a/HexBareiss/SPEC/hex-bareiss.md
+++ b/HexBareiss/SPEC/hex-bareiss.md
@@ -1,27 +1,267 @@
 # hex-bareiss (depends on hex-determinant, hex-matrix)
 
-The executable Bareiss determinant (fraction-free Gaussian elimination) over
-`Int`, plus the bordered-minor support its correctness development relies on.
+The executable Bareiss determinant (fraction-free Gaussian elimination), plus
+the bordered-minor support its correctness development relies on. The recurrence
+is specified over an arbitrary commutative coefficient ring carrying an exact
+quotient; `Int` is the specialization every current consumer uses, and its
+names, signatures, values and compiled code are unchanged by the generalization.
 
-**Algorithm.** The Bareiss recurrence at step k is:
-```
-a_{ij}^{(k)} = (a_{kk}^{(k-1)} · a_{ij}^{(k-1)} - a_{ik}^{(k-1)} · a_{kj}^{(k-1)}) / a_{k-1,k-1}^{(k-2)}
-```
-where `/` is `Int.divExact` (GMP-backed `mpz_divexact`) — the division is always
-exact, and the divisibility proof is carried. Public API performs row pivoting;
-`bareissData` records the determinant and the row-swap count.
+## Coefficient contract
 
-**Mathlib-free vs. Mathlib-bridge proof surface.** The following theorems live
-exclusively in the `*-mathlib` bridge layer and **must not** be restated,
-reproven, or specialized inside `hex-bareiss`, regardless of how convenient that
-would be for a downstream Mathlib-free consumer:
+Executable operations and correctness laws are kept apart, exactly as in
+[hex-resultant](https://github.com/kim-em/hex-dev/blob/main/HexResultant/SPEC/hex-resultant.md).
+
+**Operations.** Each executable definition takes only the unbundled classes it
+calls, and the exact quotient is a plain function argument rather than a class:
+
+| definition | operation classes | quotient |
+|---|---|---|
+| `findPivot?`, `findPivotAux` | `[Zero R] [DecidableEq R]` | none |
+| `stepMatrixWith` | `[Zero R] [Sub R] [Mul R]` | `quot : R → R → R` |
+| `pivotLoopWith`, `noPivotLoopWith` | `[Zero R] [DecidableEq R] [Sub R] [Mul R]` | `quot` |
+| `BareissData.sign` | `[One R] [Neg R]` | none |
+| `BareissData.det` | `[Zero R] [One R] [Neg R] [Mul R]` | none |
+| `bareissWith`, `bareissNoPivotWith` | `[Zero R] [One R] [Neg R] [DecidableEq R] [Sub R] [Mul R]` | `quot` |
+
+`DecidableEq R` appears only where a zero test is genuinely performed: pivot
+search and the loop's zero-pivot branch. No `Div R` appears in the executable
+layer at all. See [§Exact quotients](#exact-quotients-obligation-totality-and-the-int-fast-path)
+for why the quotient is an argument and not a `Div`-derived operation.
+
+**Laws.** Every correctness theorem takes
+`[Lean.Grind.CommRing R] [DecidableEq R]` plus the single hypothesis
+
+```lean
+(quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+```
+
+That is `Hex.ExactDivLaws.mul_div_cancel_right` in unbundled form. A carrier
+with `[Div R] [Hex.ExactDivLaws R]` discharges it by `Hex.exactDiv_mul_right`;
+`Int` discharges it for `Hex.Matrix.exactDiv` by `Int.mul_ediv_cancel`.
+
+**What is deliberately not assumed.** No `IsDomain`, no `NoZeroDivisors`, no
+nontriviality class, and no divisibility hypothesis anywhere. Bareiss is an
+integral-domain algorithm, but the domain property is a *consequence* of the
+exact-quotient law rather than a separate assumption:
+
+| fact the development needs | where it comes from |
+|---|---|
+| nonzero products stay nonzero | `Hex.ExactDivLaws.mul_ne_zero` |
+| cancel a nonzero right factor | `Hex.ExactDivLaws.mul_right_cancel` |
+| `(1 : R) ≠ 0` for the `prevPivot = 1` seed | a case split on `(1 : R) = 0`, discharged through `Hex.one_ne_zero_of_nonzero` |
+
+The last row is the one place where the `Int` development uses a `decide` that
+does not survive generalization: the initial no-pivot invariant asserts
+`prevPivot ≠ 0` at `prevPivot = 1`. The generic form takes `(1 : R) ≠ 0` as a
+hypothesis on the *invariant* lemmas, and each public theorem opens with a case
+split on `(1 : R) = 0`. In the trivial branch every element of `R` is `0` (the
+contrapositive of `Hex.one_ne_zero_of_nonzero`), so both sides of the
+correctness statement are `0` and the theorem holds without any nontriviality
+assumption on the carrier. No new law is needed in the shared exact-division
+package for this.
+
+Every lemma named above lives in
+[`HexBasic/ExactDiv.lean`](https://github.com/leanprover/hex-basic/blob/main/HexBasic/ExactDiv.lean),
+below this library, so generalizing adds one `public import HexBasic.ExactDiv`
+and no new entry in
+[`libraries.yml`](https://github.com/kim-em/hex-dev/blob/main/libraries.yml).
+`hex-bareiss` stays at `deps: [HexDeterminant, HexMatrix]` and the graph stays
+acyclic. In particular the recursive `ExactDivLaws (DensePoly R)` instance lives
+in `hex-resultant`, which is *not* below `hex-bareiss`: a polynomial-matrix
+instantiation (a characteristic-polynomial or Smith-form consumer) belongs in a
+library that already depends on both, never here.
+
+## Algorithm
+
+Write `a⁽ᵏ⁾` for the matrix after `k` elimination steps and `p₍ₖ₎` for the pivot
+consumed at step `k`, with `p₍₋₁₎ = 1`. For `i, j > k`:
+
+```
+a⁽ᵏ⁺¹⁾_{ij} = quot (p₍ₖ₎ · a⁽ᵏ⁾_{ij} − a⁽ᵏ⁾_{ik} · a⁽ᵏ⁾_{kj}) p₍ₖ₋₁₎
+```
+
+Entries with `i ≤ k` or `j < k` are copied unchanged; entries with `i > k` and
+`j = k` are set to `0`. `stepMatrixWith` takes `p₍ₖ₎` and `p₍ₖ₋₁₎` as the
+explicit arguments `pivot` and `prevPivot`, so the step function itself does not
+read the pivot out of the matrix.
+
+**State and data.** `BareissState R n` carries `step`, `matrix`, `prevPivot`,
+`rowSwaps` and `singularStep`; `BareissData R n` is the terminal `matrix`,
+`rowSwaps` and `singularStep`. Both gain the coefficient parameter `R`, so
+existing `BareissState n` / `BareissData n` occurrences become
+`BareissState Int n` / `BareissData Int n`. That is the only source-visible
+break the generalization introduces, it is mechanical, and it changes no value.
+
+**Two loops.** `noPivotLoopWith` aborts at a zero diagonal pivot and records the
+step; `pivotLoopWith` first tries a row swap. Both are fuelled by `n` and are
+equal whenever the no-pivot run records no singular step.
+
+## Zero-pivot detection, row swaps, and sign
+
+`findPivot? M col start` scans column `col` from row `start` downwards and
+returns the first row whose entry is nonzero, or `none`. It needs only
+`[Zero R] [DecidableEq R]`: an equality test against `0`, never an ordering, a
+norm, or a unit test. No pivot *choice* heuristic is specified: the first
+nonzero entry is the pivot, and that choice is part of the observable behavior
+because it determines `rowSwaps` and hence the sign.
+
+At step `k`, if `a⁽ᵏ⁾_{kk} = 0` the loop calls `findPivot?` on column `k` from
+row `k + 1`:
+
+- a row `r` is returned: swap rows `k` and `r`, increment `rowSwaps`, continue;
+- `none`: set `singularStep := some k` and stop.
+
+`BareissData.sign` is `1` when `rowSwaps` is even and `-1` when it is odd, and
+`BareissData.det` is `0` on a recorded singular step, `sign * a_{n-1,n-1}`
+otherwise. Only `[One R] [Neg R]` is needed: the sign is an element of `R`, not
+an `Int` multiplier, so nothing here needs a `IntCast` or a characteristic
+assumption.
+
+`singularStep = some k` means the algorithm proved a determinant-zero
+certificate, not that it gave up: column `k` of `a⁽ᵏ⁾` is zero at and below the
+diagonal, and the correctness development turns that into `det M = 0`. That
+step is where `ExactDivLaws.mul_right_cancel` is consumed, replacing today's
+`Int.mul_eq_zero`.
+
+## Exact quotients: obligation, totality, and the `Int` fast path
+
+**Obligation.** Every division performed by a run has a nonzero denominator
+(`prevPivot` is either the seed `1` or a pivot the loop already tested nonzero)
+and an exact numerator. Exactness is not checked at runtime and is not a
+hypothesis on the input: it is the Desnanot-Jacobi identity, discharged once in
+the bridge layer. Concretely, under the bordered-minor invariant the numerator
+at step `k` equals `p₍ₖ₋₁₎ · det (borderedMinor source (k+1) hnext i j)`, and
+`hquot` returns the second factor.
+
+**Totality.** The quotient is total, and both supplied quotients agree on the
+junk branch: `Hex.Matrix.exactDiv a 0 = 0` and `Hex.exactDiv a 0 = 0`. A junk
+state therefore has deterministic behavior but carries no algebraic claim.
+
+**Why the quotient is an argument.** The natural generalization would take
+`[Div R]` and call `Hex.exactDiv`. It is value-correct, since at `Int` the two
+quotients are equal,
+
+```lean
+theorem exactDiv_int_eq (a b : Int) : Hex.exactDiv a b = Hex.Matrix.exactDiv a b
+```
+
+but it is not code-generation-correct. `Hex.exactDiv` is
+`if b = 0 then 0 else a / b`, whose `/` compiles to the `Div R` dictionary
+entry, which for `Int` is `Int.ediv` and hence `lean_int_ediv`. Today's
+`Hex.Matrix.exactDiv` is `@[extern "lean_int_div_exact"]`, matching
+`Int.divExact`, which the Lean runtime routes to `lean_int_big_div_exact` on
+multi-limb operands. Exact division of an `m`-limb numerator is linear in `m`
+where general division is not, and Bareiss entries at rung `n` are `n × n`
+minors, so the difference is not a fixed-size constant. The `[Div R]` form also
+pays a `DecidableEq R` zero test on every one of the ~`n³/3` divisions, which
+`Hex.Matrix.exactDiv` does not.
+
+Passing `quot` as an argument keeps one algorithm and one proof while letting
+each carrier supply its best primitive. In practice `quot` is a section
+`variable`, so threading it through the state machine costs no syntax at the
+definition sites. The two instantiations are:
+
+```lean
+-- generic, from the shared Div-derived wrapper
+bareissWith Hex.exactDiv M      -- needs [Div R] [Hex.ExactDivLaws R] for the law only
+
+-- Int, from the GMP-backed exact quotient
+def bareiss (M : Matrix Int n n) : Int := bareissWith Hex.Matrix.exactDiv M
+```
+
+No generic `Div`-derived alias for `bareissWith Hex.exactDiv` is introduced, so
+that every generic call site names the quotient it is using. `Hex.exactDiv`,
+`Hex.ExactDivLaws` and the cancellation lemmas are reused unchanged; nothing is
+added to the shared exact-division package, and nothing about it is redesigned.
+
+If a measurement (see [§Benchmarks](#benchmark-changes)) shows the
+`lean_int_div_exact` advantage is inside bench noise at every rung, the simpler
+`[Div R]`-and-`Hex.exactDiv` form is preferable and this section should be
+amended rather than worked around.
+
+## Degenerate dimensions
+
+The loop condition is `state.step + 1 < n`, so it runs `n - 1` steps.
+
+- `n = 0`: no step, `singularStep = none`, the diagonal is empty, and
+  `bareiss M = sign = 1`, matching the empty product `det M = 1`.
+- `n = 1`: no step and no pivot search. `bareiss M = 1 * M[0][0] = M[0][0]`,
+  including when `M[0][0] = 0`; the zero-pivot branch is never reached, so a
+  `1 × 1` zero matrix returns `0` through the ordinary diagonal path rather
+  than through `singularStep`.
+- `n ≥ 2`: the general case above.
+
+No division occurs when `n ≤ 1`, so at those dimensions correctness does not
+touch the exact-quotient law at all.
+
+## Complexity
+
+Step `k` updates the `(n - 1 - k)²` entries with `i, j > k`, each costing two
+multiplications, one subtraction and one exact division, so a full run performs
+
+```
+Σ_{k=0}^{n-2} (n - 1 - k)² = (n-1)·n·(2n-1)/6  ≈  n³/3
+```
+
+exact divisions and subtractions and twice that many multiplications, plus at
+most `n²/2` zero tests in pivot search. The count is coefficient-independent.
+
+**No intermediate expression swell.** The invariant is that `a⁽ᵏ⁾_{ij}` is the
+determinant of `borderedMinor source k _ i j`, a `(k+1) × (k+1)` minor of the
+*input*. Entries are therefore bounded by whatever bounds minors of the input;
+nothing grows beyond the size of the answer's own subdeterminants. That is the
+whole point of the fraction-free recurrence and it is exactly the invariant the
+correctness proof carries, so the complexity claim and the correctness claim are
+the same statement.
+
+Over `Int` with `‖M‖∞ ≤ B`, Hadamard's bound gives
+`|a⁽ᵏ⁾_{ij}| ≤ (k+1)^((k+1)/2) · B^(k+1)`, i.e. bit length
+`O(n · (log n + log B))`, so a run costs `O(n³)` operations on integers of that
+size. Over a general commutative ring there is no size measure and no
+ring-independent bit bound; the minor identity above is the only size statement
+this SPEC makes.
+
+## `Int` specialization
+
+`Hex.Matrix.exactDiv : Int → Int → Int` stays exactly as it is, including its
+`@[extern "lean_int_div_exact"]` binding and `exactDiv_eq_divExact`. It is
+public `Int` API in its own right (`HexGramSchmidt/Int/Scaled.lean` calls it
+directly) and is not folded into the generic layer.
+
+`bareiss`, `bareissData`, `bareissNoPivot` and `bareissNoPivotData` keep their
+current names and `Matrix Int n n` signatures, now *defined* as the
+`Hex.Matrix.exactDiv` instantiations of their `*With` counterparts. Every
+downstream `Int` call site, every committed conformance fixture value, and the
+compiled inner loop are unchanged.
+
+The array-storage layer (`BareissArrayState`, `matrixToRows`, `rowsToMatrix`,
+`getEntry`) generalizes to `Array (Array R)`. One change is needed:
+`getEntry rows row col` is `rows[row]![col]!` today, which requires
+`Inhabited R`; the generic form is
+
+```lean
+def getEntry [Zero R] (rows : Array (Array R)) (row col : Nat) : R :=
+  (rows.getD row #[]).getD col 0
+```
+
+which needs only the `Zero R` already in scope. At `Int` the junk value is `0`
+either way, so the exported behavior `HexGramSchmidt.Int` relies on is
+unchanged.
+
+## Mathlib-free vs. Mathlib-bridge proof surface
+
+The following theorems live exclusively in the `*-mathlib` bridge layer and
+**must not** be restated, reproven, or specialized inside `hex-bareiss`,
+regardless of how convenient that would be for a downstream Mathlib-free
+consumer. Generalizing the coefficient ring does not move the boundary: it moves
+the same theorems, with `Int` replaced by `R`.
 
 | Theorem (or theorem family) | Mathlib-free layer obligation |
 |---|---|
-| `bareiss_eq_det` — any equation of the form `bareiss M = det M` over the Leibniz `det` | forbidden in `hex-bareiss` |
-| `det_eq` — `Hex.det M = Matrix.det (matrixEquiv M)` | forbidden in `hex-bareiss` |
+| `bareissWith_eq_det`, and any equation of the form `bareissWith quot M = det M` over the Leibniz `det`, at any carrier including `Int` | forbidden in `hex-bareiss` |
+| `det_eq`, i.e. `Hex.det M = Matrix.det (matrixEquiv M)` | forbidden in `hex-bareiss` |
 | Desnanot–Jacobi in any form (unscaled, scaled, bordered-minor) that connects `Hex.det` of submatrices through an adjugate identity | forbidden in `hex-bareiss` |
-| `NonzeroBareissPivots`, `BareissNoPivotInvariant`, and the no-pivot bordered-minor invariant proof chain culminating in `bareissNoPivot_eq_det` | forbidden in `hex-bareiss` |
+| `NonzeroBareissPivots`, `BareissNoPivotInvariant`, and the no-pivot bordered-minor invariant proof chain culminating in `bareissNoPivotWith_eq_det` | forbidden in `hex-bareiss` |
 
 A Mathlib-free consumer that *appears to require* a theorem on this list is the
 failure mode caught by
@@ -32,7 +272,9 @@ manufacture a Mathlib-free proof of the listed theorem.
 
 Row-operation lemmas (`det_rowSwap`, `det_rowScale`, `det_rowAdd`, in
 `hex-determinant`) and equalities purely between Hex-local definitions are
-unaffected by this list.
+unaffected by this list. So is `stepMatrixWith_borderedMinor_update`, which
+stays Mathlib-free: it takes the determinant identity as the hypothesis
+`hexact` rather than proving it.
 
 **Proof path governs placement, not just statement.** A theorem whose
 *statement* is purely Hex-local (e.g. `bareiss (rowAdd M i j c) = bareiss M`,
@@ -42,29 +284,101 @@ list above. The shortest-path test in
 [PLAN/Conventions.md §Library placement is a hard precondition question 2](https://github.com/kim-em/hex-dev/blob/main/PLAN/Conventions.md#library-placement-is-a-hard-precondition)
 governs **proof obligations**, not statement surface.
 
-**Proof that `bareiss M = det M`:** Via the bordered-minor invariant. Define
+## Proof that `bareissWith quot M = det M`
+
+Via the bordered-minor invariant, unchanged in shape from the `Int`
+development. Define
 `μ(k; i, j) := det M[rows 0..k-1 ∪ {i} | cols 0..k-1 ∪ {j}]`. The invariant
-`a^{(k)}_{ij} = μ(k; i, j)` holds by induction, where the induction step is the
+`a⁽ᵏ⁾_{ij} = μ(k; i, j)` holds by induction, where the induction step is the
 Desnanot–Jacobi identity:
+
 ```
 μ(k+1; i, j) · μ(k-1; k-1, k-1)
   = μ(k; k, k) · μ(k; i, j) − μ(k; i, k) · μ(k; k, j)
 ```
-for `i, j ≥ k+1`, with `μ(-1; -1, -1) := 1`. At `k = n-1` this gives `det M`.
-Exact division follows: `μ(k+1; i, j)` is an integer whenever the previous pivot
-`μ(k-1; k-1, k-1) ≠ 0`.
 
-Do not reprove Desnanot–Jacobi locally — track
+for `i, j ≥ k+1`, with `μ(-1; -1, -1) := 1`. At `k = n-1` this gives `det M`.
+Exactness follows: the numerator is `μ(k-1; k-1, k-1) · μ(k+1; i, j)`, and
+`hquot` returns `μ(k+1; i, j)` because the previous pivot `μ(k-1; k-1, k-1)` is
+nonzero.
+
+The only determinant identity consumed is
+`HexMatrixMathlib.desnanot_jacobi_borderedMinor`, which is already stated over
+an arbitrary Mathlib `CommRing` and needs no nondegeneracy hypothesis. **No new
+determinant identity, and no change to `hex-determinant-mathlib`, is required by
+this generalization.** In particular the general Sylvester identity remains
+absent and remains unnecessary: fraction-free elimination uses only the `2 × 2`
+bordered-minor case, which is Desnanot-Jacobi. Do not introduce a second
+determinant identity development, and do not rename anything to claim Sylvester;
+see
+[hex-determinant-mathlib §Sylvester's determinant identity: absent](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md).
+
+Do not reprove Desnanot-Jacobi locally. Track
 https://github.com/leanprover-community/mathlib4/pull/37716
 (`Mathlib.LinearAlgebra.Matrix.Determinant.DesnanotJacobi`). If merged, import
 it; otherwise prove using Mathlib's `Matrix.adjugate`.
 
 Implementation split (the proofs live in the Mathlib bridge layer):
-1. `bareissNoPivot_eq_det`: under `NonzeroBareissPivots M`, prove via the
-   invariant + Desnanot–Jacobi.
-2. `bareissDet_eq_det`: public API with row pivoting. If pivot search fails at
+1. `bareissNoPivotWith_eq_det`: under nonzero pivots, prove via the invariant +
+   Desnanot–Jacobi.
+2. `bareissWith_eq_det`: public API with row pivoting. If pivot search fails at
    step k, prove `det M = 0`; otherwise compose row swaps into a permutation,
    apply the no-pivot theorem, use `det_rowSwap` for sign.
+
+## Changes required of a later implementation
+
+These are obligations on the implementation issue, not on this SPEC. Until it
+lands, `HexBareiss/README.md` and `HexBareissMathlib/README.md` continue to
+describe the shipped `Int`-only surface, which is accurate; they are updated by
+the implementation, not ahead of it.
+
+### Conformance changes
+
+The committed fixture file `conformance-fixtures/HexBareiss/bareiss.jsonl` and
+the `scripts/oracle/matrix_flint.py` `bareiss` oracle tuple in
+`scripts/ci/run_oracles.sh` stay **byte-identical**: `Int` values do not change,
+so a re-emit is a regression signal, not a step.
+
+`conformance/HexBareiss/Conformance.lean` gains guards that
+`bareissWith Hex.exactDiv M = bareiss M` on the existing fixture matrices. That
+is the executable witness for `exactDiv_int_eq`, and the regression guard for
+the claim that the `Int` specialization is value-preserving. It is the only
+generic-path conformance available at this depth: `Int` is the sole carrier with
+an `ExactDivLaws` instance in scope below `hex-bareiss`, since the `DensePoly`
+instance lives in `hex-resultant` above it. Conformance for a genuinely
+different carrier belongs to the library that first instantiates it.
+
+### Manual changes
+
+`HexManual/Chapters/HexBareiss.lean` cites `Hex.Matrix.BareissData`,
+`BareissData.sign`, `BareissData.det`, `bareissData`, `bareiss`,
+`bareissNoPivotData`, `bareissNoPivot`, `borderedMinor`,
+`bareissData_eq_finish_pivotLoop`, `bareiss_eq_bareissData_det`,
+`HexMatrixMathlib.bareiss_eq_det` and `HexMatrixMathlib.bareissDet_eq_det`
+through `{docstring}` and `{name}` roles. Every one of those names survives the
+generalization, so no chapter rewrite is forced; the docstrings they render do
+change, and the chapter must still build.
+
+### Benchmark changes
+
+`runBareissDet*` and the paired FLINT rungs keep their current definitions on
+`Int` unchanged: they are the instrument that detects a regression, so they may
+not be rewritten in the same change that could cause one.
+
+Add an internal A/B rung, `bareissWith Hex.exactDiv` at two sizes in the upper
+half of the existing ladder (the entries are multi-limb there, which is where
+`lean_int_div_exact` can differ), and record the ratio against the matching
+`runBareissDet` rung in `reports/hex-bareiss-performance.md`. This is an
+internal comparison, not an external comparator, so
+`HexBareiss.phase4.comparators` in `libraries.yml` is unchanged and no new
+input family is declared.
+
+Both rungs stay Mathlib-free and extend the script of the existing single
+bench job; no new workflow, job, or `strategy.matrix` (see
+[SPEC/CI.md](https://github.com/kim-em/hex-dev/blob/main/SPEC/CI.md)). If the
+two extra rungs push the `Bench verify` step past its wallclock cap, they belong
+on the scheduled timing workflow instead, per
+[SPEC/benchmarking.md](https://github.com/kim-em/hex-dev/blob/main/SPEC/benchmarking.md).
 
 ## External comparators
 
@@ -79,6 +393,9 @@ Bareiss fraction-free elimination. The comparator is `informational`: the ratio
 is recorded for orientation but is not a Phase-4 gate. Wired via a
 persistent-subprocess Python driver per
 [the benchmarking spec's "External comparators" section](https://github.com/kim-em/hex-dev/blob/main/SPEC/benchmarking.md#external-comparators).
+
+It applies to the `Int` specialization only. A generic carrier has no external
+determinant comparator, and none is proposed.
 
 Structured metadata in the project
 [`libraries.yml`](https://github.com/kim-em/hex-dev/blob/main/libraries.yml)

--- a/HexBareiss/SPEC/hex-bareiss.md
+++ b/HexBareiss/SPEC/hex-bareiss.md
@@ -4,7 +4,7 @@ The executable Bareiss determinant (fraction-free Gaussian elimination), plus
 the bordered-minor support its correctness development relies on. The recurrence
 is specified over an arbitrary commutative coefficient ring carrying an exact
 quotient; `Int` is the specialization every current consumer uses, and its
-names, signatures, values and compiled code are unchanged by the generalization.
+names, signatures and values are unchanged by the generalization.
 
 ## Coefficient contract
 
@@ -12,7 +12,10 @@ Executable operations and correctness laws are kept apart, exactly as in
 [hex-resultant](https://github.com/kim-em/hex-dev/blob/main/HexResultant/SPEC/hex-resultant.md).
 
 **Operations.** Each executable definition takes only the unbundled classes it
-calls, and the exact quotient is a plain function argument rather than a class:
+calls, and the exact quotient is a plain function argument rather than a class.
+The table covers the principal algorithm operations, not every definition in
+the library: the array-storage layer, `finish`, the initial states and the
+`@[csimp]` implementation variants take the classes their own bodies call.
 
 | definition | operation classes | quotient |
 |---|---|---|
@@ -28,7 +31,7 @@ search and the loop's zero-pivot branch. No `Div R` appears in the executable
 layer at all. See [§Exact quotients](#exact-quotients-obligation-totality-and-the-int-fast-path)
 for why the quotient is an argument and not a `Div`-derived operation.
 
-**Laws.** Every correctness theorem takes
+**Laws.** Each loop-correctness and headline theorem takes
 `[Lean.Grind.CommRing R] [DecidableEq R]` plus the single hypothesis
 
 ```lean
@@ -37,12 +40,15 @@ for why the quotient is an argument and not a `Div`-derived operation.
 
 That is `Hex.ExactDivLaws.mul_div_cancel_right` in unbundled form. A carrier
 with `[Div R] [Hex.ExactDivLaws R]` discharges it by `Hex.exactDiv_mul_right`;
-`Int` discharges it for `Hex.Matrix.exactDiv` by `Int.mul_ediv_cancel`.
+`Int` discharges it for `Hex.Matrix.exactDiv` by `Int.mul_ediv_cancel`. Purely
+structural lemmas (entry formulas, fuel composition, loop equalities) and the
+`hexact`-premise update lemma need less than this and should not be given the
+full binder list.
 
-**What is deliberately not assumed.** No `IsDomain`, no `NoZeroDivisors`, no
-nontriviality class, and no divisibility hypothesis anywhere. Bareiss is an
-integral-domain algorithm, but the domain property is a *consequence* of the
-exact-quotient law rather than a separate assumption:
+**What is deliberately not assumed.** No public `IsDomain`, `NoZeroDivisors`
+or nontriviality hypothesis, and no divisibility hypothesis anywhere. Bareiss is
+an integral-domain algorithm, but the cancellation and no-zero-divisor facts are
+*consequences* of the exact-quotient law rather than separate assumptions:
 
 | fact the development needs | where it comes from |
 |---|---|
@@ -50,7 +56,20 @@ exact-quotient law rather than a separate assumption:
 | cancel a nonzero right factor | `Hex.ExactDivLaws.mul_right_cancel` |
 | `(1 : R) ≠ 0` for the `prevPivot = 1` seed | a case split on `(1 : R) = 0`, discharged through `Hex.one_ne_zero_of_nonzero` |
 
-The last row is the one place where the `Int` development uses a `decide` that
+The law package is stated over `[Div R] [Hex.ExactDivLaws R]`, so a theorem
+whose binders carry only the unbundled `quot` and `hquot` cannot invoke those
+lemmas directly. The bridge builds the package locally instead:
+
+```lean
+letI : Div R := ⟨quot⟩
+haveI : Hex.ExactDivLaws R := ⟨hquot⟩
+```
+
+The facts it then derives (`mul_ne_zero`, `mul_right_cancel`) do not mention
+`/`, so the local `Div` never escapes into a statement and never competes with a
+carrier's own `Div` instance.
+
+The `(1 : R) ≠ 0` row is the one place where the `Int` development uses a `decide` that
 does not survive generalization: the initial no-pivot invariant asserts
 `prevPivot ≠ 0` at `prevPivot = 1`. The generic form takes `(1 : R) ≠ 0` as a
 hypothesis on the *invariant* lemmas, and each public theorem opens with a case
@@ -59,6 +78,14 @@ contrapositive of `Hex.one_ne_zero_of_nonzero`), so both sides of the
 correctness statement are `0` and the theorem holds without any nontriviality
 assumption on the carrier. No new law is needed in the shared exact-division
 package for this.
+
+**One `IsDomain` instance is still required, locally.** The failed-pivot branch
+proves `det M = 0` through Mathlib's `Matrix.exists_mulVec_eq_zero_iff`, which
+is stated for `[CommRing A] [IsDomain A]`. In the nontrivial branch the instance
+is constructed rather than assumed: `Nontrivial R` from `(1 : R) ≠ 0`,
+`NoZeroDivisors R` from the derived `mul_ne_zero`, then
+`NoZeroDivisors.to_isDomain`. This is a `haveI` inside one proof, not a binder
+on any public statement.
 
 Every lemma named above lives in
 [`HexBasic/ExactDiv.lean`](https://github.com/leanprover/hex-basic/blob/main/HexBasic/ExactDiv.lean),
@@ -87,10 +114,12 @@ read the pivot out of the matrix.
 
 **State and data.** `BareissState R n` carries `step`, `matrix`, `prevPivot`,
 `rowSwaps` and `singularStep`; `BareissData R n` is the terminal `matrix`,
-`rowSwaps` and `singularStep`. Both gain the coefficient parameter `R`, so
-existing `BareissState n` / `BareissData n` occurrences become
-`BareissState Int n` / `BareissData Int n`. That is the only source-visible
-break the generalization introduces, it is mechanical, and it changes no value.
+`rowSwaps` and `singularStep`; `BareissArrayState R` is the array-storage
+counterpart. All three gain the coefficient parameter `R`, so existing
+`BareissState n`, `BareissData n` and `BareissArrayState` occurrences become
+`BareissState Int n`, `BareissData Int n` and `BareissArrayState Int`. Those
+three arity changes are the source-visible break the generalization introduces;
+they are mechanical, compile-time visible, and change no value.
 
 **Two loops.** `noPivotLoopWith` aborts at a zero diagonal pivot and records the
 step; `pivotLoopWith` first tries a row swap. Both are fuelled by `n` and are
@@ -133,9 +162,25 @@ the bridge layer. Concretely, under the bordered-minor invariant the numerator
 at step `k` equals `p₍ₖ₋₁₎ · det (borderedMinor source (k+1) hnext i j)`, and
 `hquot` returns the second factor.
 
-**Totality.** The quotient is total, and both supplied quotients agree on the
-junk branch: `Hex.Matrix.exactDiv a 0 = 0` and `Hex.exactDiv a 0 = 0`. A junk
-state therefore has deterministic behavior but carries no algebraic claim.
+**Totality, and where it stops.** Both quotients are total *as Lean
+definitions*: `Hex.exactDiv a 0 = 0` by its guard, and `Hex.Matrix.exactDiv a 0`
+reduces through `Int.ediv` to `0`. The two are equal at `Int`.
+
+They are not both total in *compiled* code, and the SPEC does not claim they
+are. `Hex.exactDiv` keeps its zero guard after compilation. `Hex.Matrix.exactDiv`
+is `@[extern "lean_int_div_exact"]`, and that entry point guards a zero
+denominator only on the small-integer path; with a multi-limb numerator and a
+zero denominator it reaches `lean_int_big_div_exact`, whose `d != 0` check is a
+`lean_assert` (compiled out in release) before it calls GMP's `mpz_divexact`,
+which has no zero-denominator contract. This is a pre-existing property of
+`Hex.Matrix.exactDiv`, which drops the `y ∣ x` argument that `Int.divExact`
+carries; the generalization neither creates nor removes it.
+
+The consequence for this SPEC is a precondition, not a value: the native exact
+quotient is specified only for a nonzero denominator dividing its numerator. A
+run never violates that, because the loop records `singularStep` and stops
+before dividing by a zero pivot. Nothing downstream may rely on a zero-denominator
+call to `Hex.Matrix.exactDiv` returning `0` in compiled code.
 
 **Why the quotient is an argument.** The natural generalization would take
 `[Div R]` and call `Hex.exactDiv`. It is value-correct, since at `Int` the two
@@ -145,16 +190,18 @@ quotients are equal,
 theorem exactDiv_int_eq (a b : Int) : Hex.exactDiv a b = Hex.Matrix.exactDiv a b
 ```
 
-but it is not code-generation-correct. `Hex.exactDiv` is
+but it discards the carrier's exact-division primitive. `Hex.exactDiv` is
 `if b = 0 then 0 else a / b`, whose `/` compiles to the `Div R` dictionary
 entry, which for `Int` is `Int.ediv` and hence `lean_int_ediv`. Today's
 `Hex.Matrix.exactDiv` is `@[extern "lean_int_div_exact"]`, matching
-`Int.divExact`, which the Lean runtime routes to `lean_int_big_div_exact` on
-multi-limb operands. Exact division of an `m`-limb numerator is linear in `m`
-where general division is not, and Bareiss entries at rung `n` are `n × n`
-minors, so the difference is not a fixed-size constant. The `[Div R]` form also
+`Int.divExact`, which the runtime routes to `lean_int_big_div_exact` and thence
+to GMP's `mpz_divexact`. GMP documents exact division as faster than general
+division when exactness is known, though it also documents the implementation as
+basecase rather than subquadratic, so the advantage is a constant factor of
+unstated size rather than a change of order. The `[Div R]` form additionally
 pays a `DecidableEq R` zero test on every one of the ~`n³/3` divisions, which
-`Hex.Matrix.exactDiv` does not.
+`Hex.Matrix.exactDiv` does not. How much either costs at the benched rungs is
+what the A/B rung below is for; this SPEC does not assert a figure.
 
 Passing `quot` as an argument keeps one algorithm and one proof while letting
 each carrier supply its best primitive. In practice `quot` is a section
@@ -173,6 +220,15 @@ No generic `Div`-derived alias for `bareissWith Hex.exactDiv` is introduced, so
 that every generic call site names the quotient it is using. `Hex.exactDiv`,
 `Hex.ExactDivLaws` and the cancellation lemmas are reused unchanged; nothing is
 added to the shared exact-division package, and nothing about it is redesigned.
+
+A function-valued parameter can compile to an indirect call through the inner
+loop, so the `Int` specialization is *not* asserted to produce byte-identical
+code to today's. What it is asserted to do is call the same primitive.
+`@[specialize]` on the loop functions is the mechanism for recovering a direct
+call at the `Hex.Matrix.exactDiv` instantiation, and the A/B rung is what
+confirms it; if neither holds up, keeping a monomorphic `Int` implementation
+behind `@[implemented_by]` (alongside the existing `@[csimp]` array path) is the
+fallback, at the cost of a second implementation to keep in step.
 
 If a measurement (see [§Benchmarks](#benchmark-changes)) shows the
 `lean_int_div_exact` advantage is inside bench noise at every rung, the simpler
@@ -204,15 +260,22 @@ multiplications, one subtraction and one exact division, so a full run performs
 ```
 
 exact divisions and subtractions and twice that many multiplications, plus at
-most `n²/2` zero tests in pivot search. The count is coefficient-independent.
+most `n²/2` zero tests in pivot search. The count is coefficient-independent, and it is the cost of a full
+non-aborted run; a run that records `singularStep` performs fewer. The `n²/2`
+figure covers pivot search only, not the loop's own diagonal zero test at each
+step.
 
-**No intermediate expression swell.** The invariant is that `a⁽ᵏ⁾_{ij}` is the
-determinant of `borderedMinor source k _ i j`, a `(k+1) × (k+1)` minor of the
-*input*. Entries are therefore bounded by whatever bounds minors of the input;
-nothing grows beyond the size of the answer's own subdeterminants. That is the
-whole point of the fraction-free recurrence and it is exactly the invariant the
-correctness proof carries, so the complexity claim and the correctness claim are
-the same statement.
+**No denominator swell, and controlled stored-entry growth.** The invariant is
+that `a⁽ᵏ⁾_{ij}` is the determinant of `borderedMinor source k _ i j`, a
+`(k+1) × (k+1)` minor of the *input*. Every stored entry is therefore a minor of
+the input, never a ratio and never an accumulated product; that is what
+"fraction-free" means, and it is exactly the invariant the correctness proof
+carries, so the complexity claim and the correctness claim are the same
+statement. Two qualifications: each step transiently builds a difference of two
+products of stored entries before dividing, so the numerator is about twice the
+size of the entry it becomes; and an intermediate minor can be larger than the
+final determinant, so this bounds growth rather than making it monotone in the
+answer.
 
 Over `Int` with `‖M‖∞ ≤ B`, Hadamard's bound gives
 `|a⁽ᵏ⁾_{ij}| ≤ (k+1)^((k+1)/2) · B^(k+1)`, i.e. bit length
@@ -231,8 +294,8 @@ directly) and is not folded into the generic layer.
 `bareiss`, `bareissData`, `bareissNoPivot` and `bareissNoPivotData` keep their
 current names and `Matrix Int n n` signatures, now *defined* as the
 `Hex.Matrix.exactDiv` instantiations of their `*With` counterparts. Every
-downstream `Int` call site, every committed conformance fixture value, and the
-compiled inner loop are unchanged.
+downstream `Int` call site and every committed conformance fixture value is
+unchanged, and the inner loop calls the same division primitive.
 
 The array-storage layer (`BareissArrayState`, `matrixToRows`, `rowsToMatrix`,
 `getEntry`) generalizes to `Array (Array R)`. One change is needed:
@@ -305,8 +368,11 @@ nonzero.
 The only determinant identity consumed is
 `HexMatrixMathlib.desnanot_jacobi_borderedMinor`, which is already stated over
 an arbitrary Mathlib `CommRing` and needs no nondegeneracy hypothesis. **No new
-determinant identity, and no change to `hex-determinant-mathlib`, is required by
-this generalization.** In particular the general Sylvester identity remains
+determinant identity is required by this generalization**, and the audited
+Desnanot-Jacobi statement itself needs no change. One declaration beside it does:
+`HexMatrixMathlib.bareissExactDiv_borderedMinor_of_mul_eq` in `CorePlucker.lean`
+is fixed to `Int` and must be generalized in place, with an `Int` corollary
+retained. In particular the general Sylvester identity remains
 absent and remains unnecessary: fraction-free elimination uses only the `2 × 2`
 bordered-minor case, which is Desnanot-Jacobi. Do not introduce a second
 determinant identity development, and do not rename anything to claim Sylvester;
@@ -339,14 +405,21 @@ the `scripts/oracle/matrix_flint.py` `bareiss` oracle tuple in
 `scripts/ci/run_oracles.sh` stay **byte-identical**: `Int` values do not change,
 so a re-emit is a regression signal, not a step.
 
-`conformance/HexBareiss/Conformance.lean` gains guards that
-`bareissWith Hex.exactDiv M = bareiss M` on the existing fixture matrices. That
-is the executable witness for `exactDiv_int_eq`, and the regression guard for
-the claim that the `Int` specialization is value-preserving. It is the only
-generic-path conformance available at this depth: `Int` is the sole carrier with
-an `ExactDivLaws` instance in scope below `hex-bareiss`, since the `DensePoly`
-instance lives in `hex-resultant` above it. Conformance for a genuinely
-different carrier belongs to the library that first instantiates it.
+`conformance/HexBareiss/Conformance.lean` gains two kinds of guard.
+
+First, `bareissWith Hex.exactDiv M = bareiss M` on the existing fixture
+matrices: the executable witness for `exactDiv_int_eq`, and the regression guard
+for the claim that the `Int` specialization is value-preserving.
+
+Second, a genuinely different carrier. `Rat` qualifies and is available at this
+depth without new dependencies: `Lean.Grind.Field Rat` is a core instance, so
+`Hex.instExactDivLawsField` supplies `ExactDivLaws Rat`, and
+`Lean.Grind.Field Rat`, `ExactDivLaws Rat`, `DecidableEq Rat` and `Div Rat` all
+resolve with only `HexBareiss` and `HexBasic.ExactDiv` imported. Cover ordinary
+elimination, a row swap, a singular input, and `n = 0` and `n = 1`. The
+`DensePoly` carrier stays out of reach here, since its `ExactDivLaws` instance
+lives in `hex-resultant` above this library; conformance for it belongs to the
+library that first instantiates it.
 
 ### Manual changes
 

--- a/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
+++ b/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
@@ -3,20 +3,111 @@
 Mathlib bridge for `hex-bareiss`: proves the row-pivoted Bareiss determinant
 correct against both Mathlib's determinant and our executable Leibniz
 determinant, via the no-pivot bordered-minor invariant and the determinant
-correspondence from `hex-determinant-mathlib`.
+correspondence from `hex-determinant-mathlib`. The proofs are stated over an
+arbitrary commutative coefficient ring with an exact quotient; `Int` is a
+corollary, with no hypotheses beyond what it has today.
 
-**No-pivot invariant and core correctness:**
+## Coefficient contract
+
+Every theorem here takes `[CommRing R] [DecidableEq R]` (Mathlib's `CommRing`,
+which supplies the `Lean.Grind.CommRing` instance the Mathlib-free layer's
+`Hex.Matrix.det` needs) together with the exact quotient and its single law,
+exactly as specified in
+[hex-bareiss §Coefficient contract](https://github.com/leanprover/hex-bareiss/blob/main/SPEC/hex-bareiss.md):
+
 ```lean
-structure NonzeroBareissPivots (M : Hex.Matrix Int n n) : Prop
-def BareissNoPivotInvariant ...
-theorem bareissNoPivot_eq_det ...          -- under NonzeroBareissPivots
-theorem bareiss_eq_mathlib_det (M : Hex.Matrix Int n n) :
-    Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M)
+(quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
 ```
 
-**Headline correspondence theorems** (the preferred surface for downstream
-Mathlib-side callers):
+There is no `IsDomain`, `NoZeroDivisors` or nontriviality hypothesis. The
+coefficient facts the development needs are all supplied by
+[`HexBasic/ExactDiv.lean`](https://github.com/leanprover/hex-basic/blob/main/HexBasic/ExactDiv.lean),
+and they apply verbatim under a Mathlib `CommRing`; the two instance paths to
+`Zero R` and `Mul R` agree, so `[CommRing R] [Div R] [Hex.ExactDivLaws R]` is a
+usable binder list with no diamond to work around.
+
+`Int.mul_eq_zero` is the only named `Int` lemma this library uses today. Three
+further places rely on `Int` being concrete, and each has a replacement:
+
+| site | today | generic replacement |
+|---|---|---|
+| `borderedMinor_zero_column_succ_det_eq_zero_of_entries` | `Int.mul_eq_zero` on `det(borderedMinor) * prevPivot = 0` | `Hex.ExactDivLaws.mul_right_cancel` against `0 * prevPivot` |
+| `bareissNoPivotInvariant_initial` | `decide` for `(1 : Int) ≠ 0` | hypothesis `(1 : R) ≠ 0`, plus a trivial-ring case split at each public theorem |
+| `bareissNoPivot_eq_det` sign step | `decide` for `(if 0 % 2 = 0 then 1 else -1) = 1` | `rfl` after the `rowSwaps = 0` rewrite; not `Int`-specific in substance |
+| `failedBareissColumn_at_pivot` | `norm_num` for `(-1 : Int) ^ (k + k) = 1` | `pow_mul` and `neg_one_sq` over any `CommRing` |
+
+The no-zero-divisor property, where the development needs it, is
+`Hex.ExactDivLaws.mul_ne_zero`.
+
+**The nontriviality seed.** `BareissNoPivotInvariant` asserts
+`prevPivot ≠ 0`, and the initial state has `prevPivot = 1`, so
+`bareissNoPivotInvariant_initial` and `bareissPivotInvariant_initial` each gain
+a hypothesis `(1 : R) ≠ 0`. It is not pushed onto the public theorems: each
+opens with `by_cases h1 : (1 : R) = 0`, and in the trivial branch every element
+of `R` is `0` (`by_contra` plus `Hex.one_ne_zero_of_nonzero`), so both sides of
+the correctness statement are `0`:
+
 ```lean
+theorem eq_zero_of_one_eq_zero [CommRing R] (h1 : (1 : R) = 0) (a : R) : a = 0 := by
+  by_contra ha
+  exact Hex.one_ne_zero_of_nonzero ha h1
+```
+
+Nothing is added to the shared exact-division package for this.
+
+## No-pivot invariant and core correctness
+
+```lean
+def NonzeroBareissPivots [CommRing R] (M : Hex.Matrix R n n) : Prop :=
+  ∀ k : Fin n,
+    Hex.Matrix.det
+      (Hex.Matrix.principalSubmatrix M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) ≠ 0
+
+structure BareissNoPivotInvariant [CommRing R]
+    (quot : R → R → R) (source : Hex.Matrix R n n)
+    (state : Hex.Matrix.BareissState R n) : Prop
+
+theorem bareissNoPivotWith_eq_det [CommRing R] [DecidableEq R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
+    Hex.Matrix.bareissNoPivotWith quot M = Matrix.det (matrixEquiv M)
+```
+
+`NonzeroBareissPivots` is unchanged in content: every leading principal minor up
+to size `n` is nonzero. The invariant gains `quot` because the state it
+constrains is produced by `noPivotLoopWith quot`.
+
+## Headline correspondence theorems
+
+The preferred surface for downstream Mathlib-side callers:
+
+```lean
+theorem bareissWith_eq_det [CommRing R] [DecidableEq R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) :
+    Hex.Matrix.bareissWith quot M = Hex.Matrix.det M
+
+theorem bareissWith_eq_mathlib_det [CommRing R] [DecidableEq R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) :
+    Hex.Matrix.bareissWith quot M = Matrix.det (matrixEquiv M)
+```
+
+Neither carries a nondegeneracy hypothesis: row pivoting handles the singular
+case, and the zero-pivot branch is turned into `det M = 0` rather than being
+excluded. `bareissWith_eq_mathlib_det` is `bareissWith_eq_det` composed with
+`det_eq` (from `hex-determinant-mathlib`), so it holds outright.
+
+**`Int` corollaries.** Today's four public theorems keep their names, statements
+and hypothesis-free form:
+
+```lean
+theorem bareissNoPivot_eq_det (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
+    Hex.Matrix.bareissNoPivot M = Matrix.det (matrixEquiv M)
+
+theorem bareiss_eq_mathlib_det (M : Hex.Matrix Int n n) :
+    Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M)
+
 theorem bareissDet_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M)
 
@@ -24,7 +115,63 @@ theorem bareiss_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Hex.Matrix.det M
 ```
 
-`bareiss_eq_det` is proven Mathlib-side by composing `bareiss_eq_mathlib_det`
-with `det_eq` (from `hex-determinant-mathlib`), so it holds outright. These are
-the theorems on the forbidden list in the Mathlib-free `hex-bareiss` SPEC: they
-must live here, never restated or reproven in the executable layer.
+The first two are in `HexBareissMathlib/Bareiss.lean`; `bareissDet_eq_det` and
+`bareiss_eq_det` are in the umbrella `HexBareissMathlib.lean`, which is where
+they must stay.
+
+Each is the generic theorem instantiated at `quot := Hex.Matrix.exactDiv`, whose
+law is `Int.mul_ediv_cancel`. `Hex.Matrix.bareiss` is by definition
+`bareissWith Hex.Matrix.exactDiv`, so these are applications, not restatements.
+Nothing downstream (`HexGramSchmidtMathlib/Update.lean`,
+`HexGramSchmidtMathlib/Int/RowAdd.lean`) needs to change.
+
+**Other carriers.** A Mathlib `Field K` with `DecidableEq K` instantiates
+through `Hex.instExactDivLawsField` and `Hex.exactDiv_mul_right`; so does any
+`[CommRing R] [Div R] [Hex.ExactDivLaws R]`. Both were checked to elaborate.
+
+These are the theorems on the forbidden list in the Mathlib-free `hex-bareiss`
+SPEC: they must live here, never restated or reproven in the executable layer.
+The forbidden list is about the *statement shape*, not the coefficient ring: a
+Mathlib-free `bareissWith quot M = det M` at any carrier, `Int` included, is
+still forbidden below this layer.
+
+## Determinant identity boundary
+
+The only determinant identity consumed is
+`HexMatrixMathlib.desnanot_jacobi_borderedMinor`, in `CorePlucker.lean`, which
+is already stated over an arbitrary Mathlib `CommRing` with no nondegeneracy
+hypothesis. **The generalization requires no change to
+`hex-determinant-mathlib`'s identity surface**, and must not introduce a second
+determinant identity development. The general Sylvester identity stays absent
+and stays unnecessary: fraction-free elimination uses only the `2 × 2`
+bordered-minor case, which *is* Desnanot-Jacobi. See
+[hex-determinant-mathlib §Sylvester's determinant identity: absent](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md).
+
+One declaration next to it does need generalizing rather than duplicating:
+`HexMatrixMathlib.bareissExactDiv_borderedMinor_of_mul_eq` in `CorePlucker.lean`
+is a thin `Int` re-export of the Mathlib-free
+`Hex.Matrix.bareissExactDiv_borderedMinor_of_mul_eq`, which packages the
+Desnanot-Jacobi product identity as the `hexact` premise of
+`Hex.Matrix.stepMatrix_borderedMinor_update`. In generic form it takes `quot`
+and `hquot` in place of the fixed `exactDiv`, and `prevPivot ≠ 0` remains the
+only nondegeneracy hypothesis anywhere in this surface:
+
+```lean
+theorem exactQuot_borderedMinor_of_mul_eq [CommRing R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : R)
+    (hprev_ne : prevPivot ≠ 0)
+    (hdesnanot : det (borderedMinor source (k + 1) hnext i j) * prevPivot = …) :
+    quot … prevPivot = det (borderedMinor source (k + 1) hnext i j)
+```
+
+Its `Int` instantiation keeps the existing name, so `HexGramSchmidtMathlib`'s
+use of the surrounding lemmas is unaffected. Renaming away from
+`bareissExactDiv…` is deliberate: the operation is no longer fixed to
+`exactDiv`, and a five-qualifier name that restates its call site is the naming
+smell the project conventions call out.
+
+Both `CorePlucker.lean` consumers of `desnanot_jacobi_borderedMinor`
+(`HexBareissMathlib/Bareiss.lean` and `HexGramSchmidtMathlib/Int/Augmented.lean`)
+continue to work: the second stays at `Int` and picks up the corollary.

--- a/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
+++ b/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
@@ -19,12 +19,40 @@ exactly as specified in
 (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
 ```
 
-There is no `IsDomain`, `NoZeroDivisors` or nontriviality hypothesis. The
-coefficient facts the development needs are all supplied by
-[`HexBasic/ExactDiv.lean`](https://github.com/leanprover/hex-basic/blob/main/HexBasic/ExactDiv.lean),
-and they apply verbatim under a Mathlib `CommRing`; the two instance paths to
-`Zero R` and `Mul R` agree, so `[CommRing R] [Div R] [Hex.ExactDivLaws R]` is a
-usable binder list with no diamond to work around.
+No public `IsDomain`, `NoZeroDivisors` or nontriviality hypothesis appears. The
+coefficient facts the development needs are supplied by
+[`HexBasic/ExactDiv.lean`](https://github.com/leanprover/hex-basic/blob/main/HexBasic/ExactDiv.lean)
+and apply under a Mathlib `CommRing`: the two instance paths to `Zero R` and
+`Mul R` agree, so `[CommRing R] [Div R] [Hex.ExactDivLaws R]` is a usable binder
+list with no diamond to work around.
+
+Those lemmas are stated over `[Div R] [Hex.ExactDivLaws R]`, though, and the
+generic theorems here carry only the unbundled `quot` and `hquot`. They do not
+apply directly; the package is built locally inside each proof that needs it:
+
+```lean
+letI : Div R := ⟨quot⟩
+haveI : Hex.ExactDivLaws R := ⟨hquot⟩
+```
+
+The derived facts (`mul_ne_zero`, `mul_right_cancel`) do not mention `/`, so the
+local `Div` never escapes into a statement.
+
+**One `IsDomain` instance is constructed, not assumed.**
+`det_eq_zero_of_bareiss_failed_column` closes the failed-pivot branch through
+Mathlib's `Matrix.exists_mulVec_eq_zero_iff`, which is stated for
+`[CommRing A] [IsDomain A]`. In the nontrivial branch:
+
+```lean
+theorem isDomain_of_quot [CommRing R] (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a) (h1 : (1 : R) ≠ 0) :
+    IsDomain R
+```
+
+built from `Nontrivial R` (out of `h1`) and `NoZeroDivisors R` (out of the
+derived `mul_ne_zero`), then `NoZeroDivisors.to_isDomain`. It is a `haveI`
+inside that one proof and never a binder on a public statement, which is what
+makes "no public `IsDomain` hypothesis" true rather than a slogan.
 
 `Int.mul_eq_zero` is the only named `Int` lemma this library uses today. Three
 further places rely on `Int` being concrete, and each has a replacement:
@@ -64,8 +92,7 @@ def NonzeroBareissPivots [CommRing R] (M : Hex.Matrix R n n) : Prop :=
       (Hex.Matrix.principalSubmatrix M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) ≠ 0
 
 structure BareissNoPivotInvariant [CommRing R]
-    (quot : R → R → R) (source : Hex.Matrix R n n)
-    (state : Hex.Matrix.BareissState R n) : Prop
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n) : Prop
 
 theorem bareissNoPivotWith_eq_det [CommRing R] [DecidableEq R]
     (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
@@ -74,8 +101,14 @@ theorem bareissNoPivotWith_eq_det [CommRing R] [DecidableEq R]
 ```
 
 `NonzeroBareissPivots` is unchanged in content: every leading principal minor up
-to size `n` is nonzero. The invariant gains `quot` because the state it
-constrains is produced by `noPivotLoopWith quot`.
+to size `n` is nonzero.
+
+`BareissNoPivotInvariant` stays **quotient-independent**. Its five fields
+(`singular_none`, `step_le`, `prevPivot_eq`, `prevPivot_ne`, `trailing_eq`) are
+purely relational between `source` and `state`, and the state stores no
+quotient, so parameterizing the invariant by `quot` would add an argument no
+field mentions. `quot` and `hquot` belong on the step and loop *preservation*
+lemmas, which are the statements that actually run `stepMatrixWith quot`.
 
 ## Headline correspondence theorems
 
@@ -98,8 +131,10 @@ case, and the zero-pivot branch is turned into `det M = 0` rather than being
 excluded. `bareissWith_eq_mathlib_det` is `bareissWith_eq_det` composed with
 `det_eq` (from `hex-determinant-mathlib`), so it holds outright.
 
-**`Int` corollaries.** Today's four public theorems keep their names, statements
-and hypothesis-free form:
+**`Int` corollaries.** Today's four public theorems keep their names and
+statements verbatim, and gain no new coefficient hypotheses.
+`bareissNoPivot_eq_det` keeps the `NonzeroBareissPivots` premise it already has;
+the other three remain premise-free:
 
 ```lean
 theorem bareissNoPivot_eq_det (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
@@ -171,6 +206,11 @@ use of the surrounding lemmas is unaffected. Renaming away from
 `bareissExactDiv…` is deliberate: the operation is no longer fixed to
 `exactDiv`, and a five-qualifier name that restates its call site is the naming
 smell the project conventions call out.
+
+Because that declaration is described by name in
+[hex-determinant-mathlib §Desnanot-Jacobi: the four public forms](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md),
+the implementation owes that SPEC a matching amendment. It is deliberately not
+amended ahead of the code: today it describes what is actually there.
 
 Both `CorePlucker.lean` consumers of `desnanot_jacobi_borderedMinor`
 (`HexBareissMathlib/Bareiss.lean` and `HexGramSchmidtMathlib/Int/Augmented.lean`)

--- a/progress/20260821T224741Z_issue-9324.md
+++ b/progress/20260821T224741Z_issue-9324.md
@@ -55,6 +55,52 @@ no `libraries.yml` change. The `ExactDivLaws (DensePoly R)` instance lives in
 instantiation belongs to a library that depends on both. `python3
 scripts/check_dag.py` passes.
 
+## Corrections from the Codex second opinion
+
+Five substantive amendments, each verified against the code before applying:
+
+- **`IsDomain` is genuinely needed, locally.**
+  `det_eq_zero_of_bareiss_failed_column` closes the failed-pivot branch through
+  Mathlib's `Matrix.exists_mulVec_eq_zero_iff`, which requires `[IsDomain A]`.
+  The original SPEC's "no `IsDomain` anywhere" was wrong. It is now "no *public*
+  `IsDomain` hypothesis", with the instance constructed inside the nontrivial
+  branch from `Nontrivial` plus the derived `NoZeroDivisors`. Checked to
+  elaborate.
+
+- **Unbundled `quot`/`hquot` cannot invoke the bundled law lemmas.**
+  `ExactDivLaws.mul_ne_zero` and `mul_right_cancel` need
+  `[Div R] [ExactDivLaws R]`. The fix, `letI : Div R := ⟨quot⟩` plus
+  `haveI : Hex.ExactDivLaws R := ⟨hquot⟩` inside the proof, is now specified and
+  was checked to elaborate; the derived facts never mention `/`.
+
+- **The native exact quotient is not total.** `lean_int_div_exact` guards a zero
+  denominator only on the scalar path. With a multi-limb numerator it reaches
+  `lean_int_big_div_exact`, whose `d != 0` check is a `lean_assert` (compiled
+  out in release) before it calls GMP `mpz_divexact`, which has no
+  zero-denominator contract (verified in `~/lean4/src/runtime/object.cpp:1747`).
+  The SPEC no longer claims junk-branch totality for the compiled `Int` path; it
+  states a precondition instead. This is a pre-existing property of
+  `Hex.Matrix.exactDiv`, which drops `Int.divExact`'s divisibility argument.
+
+- **`Rat` is a usable second conformance carrier.** `Lean.Grind.Field Rat` is a
+  core instance, so `Hex.instExactDivLawsField` supplies `ExactDivLaws Rat`.
+  Verified that `Lean.Grind.Field Rat`, `ExactDivLaws Rat`, `DecidableEq Rat`
+  and `Div Rat` all resolve with only `HexBareiss` and `HexBasic.ExactDiv`
+  imported. The conformance obligation now names it, so the generic path gets
+  exercised at a carrier that is not `Int`.
+
+- **Smaller corrections.** `BareissArrayState` also gains `R` (three arity
+  changes, not two); `BareissNoPivotInvariant` stays quotient-independent, since
+  none of its five fields mentions the quotient; the GMP advantage is a constant
+  factor of unstated size, not linear-vs-quadratic, and identical generated code
+  is not claimed (a function-valued parameter can compile to an indirect call,
+  with `@[specialize]` the mechanism and the A/B rung the evidence);
+  "no intermediate expression swell" narrowed to stored entries, since each step
+  transiently builds a numerator about twice the size of the entry it becomes;
+  `hex-determinant-mathlib` *does* need work, namely generalizing
+  `bareissExactDiv_borderedMinor_of_mul_eq` in `CorePlucker.lean`, so only the
+  identity itself is unchanged.
+
 ## Current frontier
 
 Both SPECs are written. `lake build HexBareiss HexBareissMathlib` is green

--- a/progress/20260821T224741Z_issue-9324.md
+++ b/progress/20260821T224741Z_issue-9324.md
@@ -1,0 +1,75 @@
+# 2026-08-21 22:47 UTC — SPEC: generic Bareiss over integral domains (#9324)
+
+## Accomplished
+
+Rewrote `HexBareiss/SPEC/hex-bareiss.md` and
+`HexBareissMathlib/SPEC/hex-bareiss-mathlib.md` to specify the Bareiss
+recurrence over an arbitrary commutative coefficient ring with an exact
+quotient, keeping `Int` as a specialization. No Lean code changed; this is a
+SPEC-only issue by construction.
+
+The specification was sanity-checked by elaborating every proposed signature
+against current `main` in two throwaway module files (not committed): the
+Mathlib-free operations with real bodies, and the Mathlib-side statements with
+`sorry` proofs. Both compiled with no type errors.
+
+## Findings that shaped the SPEC
+
+**The exact-division package supplies everything the proofs need.** Auditing
+`Int.*` uses across both libraries turned up exactly one named `Int` lemma,
+`Int.mul_eq_zero`, plus two `decide`s and one `norm_num`. `ExactDivLaws`
+already implies the no-zero-divisor property (`ExactDivLaws.mul_ne_zero`) and
+right cancellation, so **no `IsDomain` or `NoZeroDivisors` hypothesis is
+needed**: the domain property is a consequence of the exact-quotient law, not a
+separate assumption.
+
+**The nontriviality seed is real and needs a decision.** `BareissNoPivotInvariant`
+asserts `prevPivot ≠ 0` at the initial `prevPivot = 1`, which `Int` discharges
+by `decide`. The SPEC puts `(1 : R) ≠ 0` on the invariant lemmas and has each
+public theorem open with a case split; in the trivial branch every element of
+`R` is `0` by the contrapositive of `Hex.one_ne_zero_of_nonzero`, so both sides
+of the correctness statement are `0`. Checked to elaborate.
+
+**Naively using `[Div R]` + `Hex.exactDiv` would regress `Int` performance.**
+Today's `Hex.Matrix.exactDiv` is `@[extern "lean_int_div_exact"]`, which the
+runtime routes to `lean_int_big_div_exact` on multi-limb operands; the
+`Div`-derived wrapper compiles to `lean_int_ediv` and additionally pays a
+`DecidableEq` zero test on each of the ~n³/3 divisions. The two agree in value
+(`Hex.exactDiv a b = Hex.Matrix.exactDiv a b` at `Int`, proved in the scratch
+check), so this is a code-generation gap, not a semantic one. The SPEC therefore
+makes the quotient an explicit `quot : R → R → R` argument with the law as an
+explicit hypothesis, so one algorithm and one proof serve both carriers and
+`Hex.Matrix.bareiss` keeps its exact current definition, values and compiled
+inner loop.
+
+**No determinant-identity work is required.** `desnanot_jacobi_borderedMinor`
+is already stated over an arbitrary Mathlib `CommRing` with no nondegeneracy
+hypothesis, so the generalization needs no change to
+`hex-determinant-mathlib`'s identity surface. The general Sylvester identity
+stays absent and stays unnecessary.
+
+**The dependency graph is unaffected.** `HexBasic.ExactDiv` is already below
+`hex-bareiss` through `HexMatrix`, so generalizing adds one `public import` and
+no `libraries.yml` change. The `ExactDivLaws (DensePoly R)` instance lives in
+`hex-resultant`, which is *not* below `hex-bareiss`, so a polynomial-matrix
+instantiation belongs to a library that depends on both. `python3
+scripts/check_dag.py` passes.
+
+## Current frontier
+
+Both SPECs are written. `lake build HexBareiss HexBareissMathlib` is green
+(unchanged; no Lean edits), `python3 scripts/check_dag.py` and
+`git diff --check` pass.
+
+## Next step
+
+A separate implementation issue: thread `quot` through `stepMatrix`,
+`pivotLoop`, `noPivotLoop`, `BareissState`, `BareissData`, generalize the
+bridge proofs, add the conformance guard that
+`bareissWith Hex.exactDiv M = bareiss M` on the existing fixtures, and add the
+internal A/B bench rung that measures the `lean_int_div_exact` advantage rather
+than assuming it. The committed fixture file must stay byte-identical.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR updates `HexBareiss/SPEC/hex-bareiss.md` and
`HexBareissMathlib/SPEC/hex-bareiss-mathlib.md` to specify the Bareiss
fraction-free recurrence over an arbitrary commutative coefficient ring
carrying an exact quotient, with `Int` kept as a specialization whose names,
signatures and values are unchanged. No Lean code changes.

Executable operations are separated from correctness assumptions: each
definition takes only the unbundled classes it calls, and the exact quotient is
an explicit `quot : R → R → R` argument whose single law
`∀ a b, b ≠ 0 → quot (a * b) b = a` is the hypothesis the loop-correctness and
headline theorems take. The SPEC pins zero-pivot detection and row-swap sign,
the exact-quotient obligation and the precondition on its native `Int`
implementation, the degenerate `n = 0` and `n = 1` cases, the
`(n-1)·n·(2n-1)/6` operation count and the bordered-minor identity that bounds
stored-entry growth, and the conformance, benchmark and manual changes a later
implementation owes.

Every proposed signature was elaboration-checked against current `main` before
being written down, which settled five things:

- The refactored exact-division package supplies the cancellation and
  no-zero-divisor facts, so those are consequences of the exact-quotient law
  rather than assumptions. One `IsDomain` instance is still required, because
  the failed-pivot branch goes through `Matrix.exists_mulVec_eq_zero_iff`; it is
  constructed inside that proof from `Nontrivial` plus the derived
  `NoZeroDivisors`, never assumed on a public statement.
- The bundled law lemmas need `[Div R] [ExactDivLaws R]`, so a proof carrying
  only `quot` and `hquot` builds the package locally with
  `letI : Div R := ⟨quot⟩`; the derived facts never mention `/`.
- `BareissNoPivotInvariant` asserts `prevPivot ≠ 0` at the initial
  `prevPivot = 1`, so the invariant lemmas take `(1 : R) ≠ 0` and each public
  theorem opens with a trivial-ring case split that collapses both sides to `0`.
- Deriving the quotient from `[Div R]` would discard the carrier's exact-division
  primitive: `Hex.Matrix.exactDiv` is `@[extern "lean_int_div_exact"]`, reaching
  GMP `mpz_divexact`, while the wrapper compiles to `lean_int_ediv` plus a
  `DecidableEq` zero test on each of the ~n³/3 divisions. Passing the quotient as
  an argument keeps one algorithm and one proof; the size of the advantage is
  left to the specified A/B bench rung rather than asserted.
- `desnanot_jacobi_borderedMinor` is already `CommRing`-generic, so the audited
  identity is reused unchanged and no second determinant identity development is
  introduced. `bareissExactDiv_borderedMinor_of_mul_eq` beside it is fixed to
  `Int` and is recorded as an implementation obligation.

Conformance gains a `Rat` carrier alongside `Int`: `Lean.Grind.Field Rat` is a
core instance, so `Hex.instExactDivLawsField` supplies `ExactDivLaws Rat` with
no new dependency, and the generic path gets exercised at a carrier that is not
`Int`.

`HexBasic.ExactDiv` is already below `hex-bareiss` through `HexMatrix`, so the
graph is unaffected; `python3 scripts/check_dag.py` and `git diff --check` pass
and `lake build HexBareiss HexBareissMathlib` is green.

Closes #9324

🤖 Prepared with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwvFqYhSBziQ5ogHWUG12t