### PR TITLE
feat(interval): add bounded autonomous controller

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -96,7 +96,8 @@ uses the dyadic grid `2⁻¹⁶`; programmatic clients may choose another precis
 within the explicit envelope. Because each computed arithmetic layer is
 followed by an internal regularization layer, its term-depth cap `32` admits
 about 16 nested arithmetic operations along one expression spine. Generic
-search-selected recipes and broader local-context parsing remain experimental.
+public-tactic search-selected recipes and broader local-context parsing remain
+experimental.
 The supported proof companion can separately consume a checked retained
 `Search.Result.Tree` plus caller-supplied proof chronology: its registry
 authenticates package-owned binary cover and refutation schemas, its checked
@@ -106,17 +107,21 @@ leaves, and joins siblings only through the exact cover. The supported
 one-step driver now invokes an already-selected authenticated package callback
 and transactionally retains its exact runtime command and separately checked
 recipe data together. It can advance root and child-local fact histories before
-splitting or settling. Offer generation, autonomous search iteration, and
-invoking this path from the public tactic remain later controller work. The first
+splitting or settling. The supported explicit controller aligns a stable
+fact-event application table with same-order runtime and proof registries,
+regenerates bounded deterministic offer snapshots, and iterates a replaceable
+policy over the sealed tree/session bundle. Its current end-to-end conformance
+uses toy fact-event callbacks: concrete built-in arithmetic `Driver.Package`
+callbacks and application generators have not yet been supplied. Invoking this
+path from the public tactic remains later controller work. The first
 concrete supported registry is the Mathlib arithmetic package for one
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
-division, and regularization operations. Arbitrary-function package assembly,
-concrete callback implementations and offer generation, concrete policy
-algorithms and default scheduling, the complete branch-search loop,
-payload storage, and the optimized backing store remain experimental.
-Supported authenticated sessions and the narrow direct-forward tactic do not
-yet supply that missing controller bridge.
+division, and regularization operations. Automatic arbitrary-function package
+discovery, Mathlib-free package drafts, equality/instance runtime events,
+program extension, concrete policy algorithms and default scheduling, payload
+storage, and the optimized backing store remain experimental. The narrow
+direct-forward tactic does not yet invoke the supported controller.
 In particular, the current instantiation proposal's package-supplied numeric
 policy family is not part of the supported action contract.
 
@@ -4071,9 +4076,11 @@ transition can then replace the current node's source only with the after-state
 of an accepted callback tied to that exact source branch. The supported
 one-step driver appends the same callback's fact events to that node's recipe
 in the same transaction. Non-root target/refutation leaves and later splits
-may therefore consume child-local fact history after exact replay. This is not
-yet an autonomous controller: offer generation, repeated policy-driven
-iteration, and public-tactic split search remain separate work.
+may therefore consume child-local fact history after exact replay. The
+supported explicit controller now regenerates deterministic authenticated
+fact-event offers and repeats policy-driven iteration over that sealed bundle.
+Automatic package discovery, equality/instance runtime events, program
+extension, and public-tactic split search remain separate work.
 
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
@@ -5376,8 +5383,8 @@ their declared cost inside a scheduler bound.
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. The built-in
   arithmetic package and direct-forward reifier/tactic are supported below;
-  arbitrary-function packages, autonomous search orchestration, split-search
-  tactic integration, and default registries remain experimental.
+  arbitrary-function package discovery, Mathlib-free runtime packages,
+  split-search tactic integration, and default registries remain experimental.
 - `HexIntervalMathlib/Driver.lean`: supported one-step execution of an exact
   already-selected package action, atomic retained-source advancement/split/
   terminal updates, and bounded alignment of the sealed result tree with its
@@ -5385,6 +5392,33 @@ their declared cost inside a scheduler bound.
   independent byte/work caps charge all retained event and edge payloads over
   the complete bundle. It does not generate offers, choose a policy, or run an
   autonomous search loop.
+- `HexIntervalMathlib/Controller.lean`: supported explicit assembly of one
+  stable fact-event application table with exactly aligned runtime callbacks
+  and proof registrations. It resource-first regenerates deterministic offers,
+  derives age from sealed session chronology, revalidates exact
+  `ApplicationId` routing, and iterates a replaceable policy over the sealed
+  session/tree bundle under a cumulative choice cap. A caller-owned logical
+  measure bounds the initial policy state and every callback successor against
+  independent byte/pair/work caps before retention; constructing and measuring
+  the arbitrary state remains non-preemptible. The choice cap is per sealed
+  `Controller.State` lineage: explicit `State.startWithin` starts a new handle
+  at zero from a sealed current bundle, and pure states can be reused to explore
+  separately bounded successors. It is not a process-global budget. Its
+  registry key is a
+  trusted compatibility epoch, not callback-object identity: same-key
+  assemblies deliberately declare replaceable implementations whose results
+  still cross the runtime and proof checks. Automatic discovery,
+  program extension, equality/instance runtime events, Mathlib-free raw
+  packages, concrete built-in arithmetic driver callbacks/application
+  generators, and split-search tactic syntax remain later work; the current
+  autonomous theorem uses toy fact-event packages. All offers in one immutable
+  snapshot share its controller-owned serial as age. A malformed generator
+  draft aborts the whole regeneration transaction. Dismissing a non-split
+  offer marks the snapshot incomplete, while dismissing a split probe does not.
+  Policy stop returns a resumable sealed state; exhausting `maxChoices` is a
+  resource error. Up to `maxChoices` selected transitions each repeat complete
+  retained-tree/bundle validation, so reference validation cost is multiplied
+  by that cap.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry
   assembly, and state-to-proof quotation for negation, addition, subtraction,
@@ -5466,8 +5500,9 @@ their declared cost inside a scheduler bound.
   StagedPolicy,AdaptivePolicy,FeaturePolicy,BranchTree}.lean`: current
    provisional package callback, policy implementation, semantic session,
    target driver, and split-construction designs. Optimized storage, concrete
-   offer generation, package protocols, and a default policy will be selected
-   from measurements; none is frozen by the decoded supported snapshots.
+   automatic package discovery/program extension, Mathlib-free package
+   protocols, and a default policy will be selected from measurements; none is
+   frozen by the decoded supported snapshots.
 - `conformance/HexInterval/{Conformance,SearchConformance,MinMaxConformance,
   EmitFixtures}.lean`:
   Lean-only checks and oracle fixtures.

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5402,8 +5402,11 @@ their declared cost inside a scheduler bound.
   independent byte/pair/work caps before retention; constructing and measuring
   the arbitrary state remains non-preemptible. The choice cap is per sealed
   `Controller.State` lineage: explicit `State.startWithin` starts a new handle
-  at zero from a sealed current bundle, and pure states can be reused to explore
-  separately bounded successors. It is not a process-global budget. Its
+  from a sealed current bundle and resets choices, the dismissal latch, and the
+  search session's serial, steps, and diagnostic trace even when the retained
+  head/scope is unchanged. Pure states can be reused to explore separately
+  bounded successors. It is not a process-global budget, and the new handle
+  inherits no proof-closure or saturation claim from an older handle. Its
   registry key is a
   trusted compatibility epoch, not callback-object identity: same-key
   assemblies deliberately declare replaceable implementations whose results
@@ -5415,12 +5418,15 @@ their declared cost inside a scheduler bound.
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
   offer sets a controller-owned incomplete bit which survives later accepted
-  refreshes in that scope; it clears only when a split or terminal transition
-  moves to the next retained scope. Dismissing a split probe does not set it.
+  refreshes in that scope within the returned handle lineage; a split or
+  terminal transition to the next retained scope clears it. Explicit
+  `State.startWithin` also resets it by creating a new lineage, including at the
+  same retained scope. Dismissing a split probe does not set it.
   Policy stop returns a resumable sealed state; exhausting `maxChoices` is a
-  resource error. Up to `maxChoices` selected transitions each repeat complete
-  retained-tree/bundle validation, so reference validation cost is multiplied
-  by that cap. `Run.complete` means the runtime tree has no pending frontier,
+  resource error. Each selected reference transition authenticates the entry
+  session, validates the current and replacement retained bundle/tree in the
+  driver, then authenticates the regenerated session, so those repeated costs
+  are multiplied by the choice cap. `Run.complete` means the runtime tree has no pending frontier,
   not that proof replay has closed the theorem.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5414,11 +5414,14 @@ their declared cost inside a scheduler bound.
   autonomous theorem uses toy fact-event packages. All offers in one immutable
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
-  offer marks the snapshot incomplete, while dismissing a split probe does not.
+  offer sets a controller-owned incomplete bit which survives later accepted
+  refreshes in that scope; it clears only when a split or terminal transition
+  moves to the next retained scope. Dismissing a split probe does not set it.
   Policy stop returns a resumable sealed state; exhausting `maxChoices` is a
   resource error. Up to `maxChoices` selected transitions each repeat complete
   retained-tree/bundle validation, so reference validation cost is multiplied
-  by that cap.
+  by that cap. `Run.complete` means the runtime tree has no pending frontier,
+  not that proof replay has closed the theorem.
 - `HexIntervalMathlib/Rule.lean`: the supported stable-key arithmetic package,
   exact real operation meanings, package-owned fact schemas, checked registry
   assembly, and state-to-proof quotation for negation, addition, subtraction,

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -18,6 +18,7 @@ public import HexIntervalMathlib.Split
 public import HexIntervalMathlib.Inverse
 public import HexIntervalMathlib.Division
 public import HexIntervalMathlib.Driver
+public import HexIntervalMathlib.Controller
 public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
@@ -37,6 +38,12 @@ enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
+`HexIntervalMathlib.Controller` supplies explicit stable application-table,
+runtime/proof-registry alignment and bounded deterministic policy iteration
+over the sealed retained tree, including caller-measured caps on each retained
+policy state. Its current conformance callbacks are toy packages; concrete
+built-in arithmetic driver adapters, package discovery, and public split-search
+tactic integration remain separate.
 `HexIntervalMathlib.Frontend` supplies bounded recursive arithmetic reification,
 source-driven version-zero facts, and flat programmatic replay/closure
 combinators.

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -31,10 +31,13 @@ construction.  The controller never creates proof evidence; its untrusted bundle
 `Proof.replayTree` with an independently checked proof registry from the same
 trusted compatibility epoch. Runtime registry object identity is not required.
 
-`maxChoices` is cumulative only within one returned sealed `State` lineage.
-`State.startWithin` deliberately starts a new handle at zero from any sealed
-current bundle, and pure Lean values may be reused to explore alternative
-bounded successors. This is not a global or process-persistent budget.
+`maxChoices` and non-split dismissal incompleteness are cumulative only within
+one returned sealed `State` lineage. `State.startWithin` deliberately starts a
+new handle from any sealed current bundle: it resets choices, the dismissal
+latch, and the search session's serial, steps, and trace even when the retained
+head and scope are unchanged. Pure Lean values may be reused to explore
+alternative bounded successors. This is not a global or process-persistent
+budget, nor does restarting inherit any proof-closure or saturation claim.
 
 This is the supported autonomous programmatic loop.  Goal reification and the
 public tactic currently use the separate flat forward path; split-search tactic
@@ -106,7 +109,8 @@ structure PolicyLimit where
 /-- Bounds specific to application enumeration and autonomous policy choices.
 All state, policy, search, result-tree, proof, and recipe bounds remain in the
 supported envelopes passed to the transitions. `maxChoices` applies to one
-sealed `State` lineage and resets only through explicit `State.startWithin`. -/
+sealed `State` lineage; explicit `State.startWithin` creates a new lineage and
+resets it together with the dismissal latch and search-session chronology. -/
 structure Limits where
   maxChoices : Nat
   policyState : PolicyLimit
@@ -128,6 +132,11 @@ inductive Error where
   | driver (error : Driver.Error)
   | mismatch
   deriving DecidableEq, Repr
+
+private def liftCheck.{u} (result : Except Error Unit) : Except Error PUnit.{u + 1} :=
+  match result with
+  | .error error => .error error
+  | .ok _ => .ok PUnit.unit
 
 /-- Ordinary-import-sealed alignment of one program, theorem registry, runtime
 packages, and deterministic application table. -/
@@ -207,14 +216,8 @@ opaque Registry.buildWithin
     throw (.resource (.state .registryEntries))
   if stateLimits.maxEqualities < equalityGenerations.size then
     throw (.resource (.state .equalities))
-  let programError := match preflightProgram stateLimits program with
-    | .error error => some error
-    | .ok _ => none
-  if let some error := programError then throw error
-  let registrationError := match preflightRegistrations stateLimits proof.registrations with
-    | .error error => some error
-    | .ok _ => none
-  if let some error := registrationError then throw error
+  liftCheck (preflightProgram stateLimits program)
+  liftCheck (preflightRegistrations stateLimits proof.registrations)
   if proof.registrations.size != packages.size then
     throw .invalidRegistry
   if stateLimits.maxGeneration < matcherEpoch ||
@@ -313,6 +316,16 @@ private def generate [DecidableEq Fact] [DecidableEq Cause]
       throw (.resource (.state .matcherVisits))
     if envelope.state.maxEffort < draft.effort then
       throw (.resource (.state .effort))
+    if !allDistinct draft.inputs || !allDistinct draft.writes ||
+        !allDistinct draft.structuralInputs then
+      throw (.invalidApplication applicationId)
+    if (branch.program.node? draft.node).isNone ||
+        draft.writes.any (fun node => (branch.program.node? node).isNone) then
+      throw (.invalidApplication applicationId)
+    let matcherValid := match registration.matchWatch with
+      | .none => draft.structuralInputs.isEmpty
+      | .network => !draft.structuralInputs.isEmpty
+    if !matcherValid then throw (.invalidApplication applicationId)
     let some inputs := seenInputs? branch draft.inputs
       | throw (.invalidApplication applicationId)
     let some structuralInputs := structuralInputs? registry branch draft.structuralInputs
@@ -372,7 +385,9 @@ private def refresh [DecidableEq Fact] [DecidableEq Cause]
 /-- Sealed live alignment of a retained runtime/proof bundle, its declared
 registry compatibility epoch, exact current session, and cumulative
 policy-choice accounting. `dismissedIncomplete` is sticky for the current
-scope: accepting another action cannot erase an earlier non-split dismissal. -/
+scope within this returned state lineage: accepting another action cannot erase
+an earlier non-split dismissal. Explicit `State.startWithin` creates a new
+lineage and resets it even when it starts from the same retained head. -/
 structure State (Fact Cause OfferId SemanticKey Plan : Type) where
   private mk ::
   compatibility : Key
@@ -382,7 +397,11 @@ structure State (Fact Cause OfferId SemanticKey Plan : Type) where
   dismissedIncomplete : Bool
 
 /-- Start a new autonomous-controller handle at the exact current retained-tree
-head. This explicit operation starts a fresh per-lineage choice counter. -/
+head. This explicit operation resets the per-lineage choice counter and
+dismissal latch and rebuilds a search session with serial zero, zero accepted
+steps, and an empty diagnostic trace. The retained bundle head and scope may be
+the same as an older handle; the new handle does not inherit that handle's
+incompleteness, proof-closure, or saturation status. -/
 opaque State.startWithin [DecidableEq Fact] [DecidableEq Cause]
     (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
     (registry : Registry Fact semantics Cause SemanticKey Plan)
@@ -430,15 +449,19 @@ inductive Run (Fact Cause OfferId SemanticKey Plan PolicyState : Type)
 the retained tree closes, honestly stops, reaches an unknown leaf, or exhausts
 the cumulative choice cap.  Dismissal removes exactly one offer from the
 current immutable snapshot. Dismissing a non-split offer marks that snapshot
-incomplete; dismissing a split probe does not. That incompleteness survives
-accepted refreshes in the same scope and clears only when a split or terminal
-transition moves to the next retained scope. A policy stop returns a resumable
-sealed state, whereas choice-cap exhaustion is a resource error. `policyStateMeasure`
+incomplete; dismissing a split probe does not. Within one returned state
+lineage, that incompleteness survives accepted refreshes in the same scope and
+clears when a split or terminal transition moves to the next retained scope.
+Explicit `State.startWithin` creates a new lineage and resets the latch even at
+the same retained head. A policy stop returns a resumable sealed state, whereas
+choice-cap exhaustion is a resource error. `policyStateMeasure`
 is non-preemptible, but its declared byte, pair, and work cost must fit before
 the initial state or any callback successor is retained. In the reference
-implementation, up to `maxChoices` selected steps each repeat complete bundle
-and retained-tree validation, so total validation cost scales linearly with the
-choice cap as well as with the retained-tree validation cost. -/
+implementation, choice authenticates the entry session; each selected driver
+step validates the current and replacement retained bundles/trees, and the
+regenerated session is authenticated again. Thus total reference validation
+cost scales linearly with the choice cap as well as with these repeated
+session and retained-tree validation passes. -/
 opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey]
     [DecidableEq Plan]
     (limits : Limits) (envelope : Search.Envelope)

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -1,0 +1,486 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Driver
+
+@[expose] public section
+
+/-!
+# Bounded autonomous package controller
+
+This module aligns a stable table of package-owned application generators with
+both the supported runtime driver and an exact supported proof registry.  An
+application generator may inspect the current authenticated branch, but it
+cannot choose its compact application/rule identity, serial, program version,
+or dependency generations: the controller reconstructs those fields and
+`Search.Session` authenticates the resulting action before a policy can see it.
+
+The controller deterministically enumerates the table, asks a replaceable
+policy to select or dismiss one of the already-authenticated offers, invokes
+the exactly aligned runtime package, and repeats over the sealed retained tree.
+Runtime callbacks, generator callbacks, policy callbacks, equality on caller
+types, and logical measurement callbacks remain non-preemptible.  Their
+results are revalidated before retention, and a caller-owned logical measure
+bounds every retained policy-state successor after its non-preemptible
+construction.  The controller never creates proof evidence; its untrusted bundle must still cross
+`Proof.replayTree` with an independently checked proof registry from the same
+trusted compatibility epoch. Runtime registry object identity is not required.
+
+`maxChoices` is cumulative only within one returned sealed `State` lineage.
+`State.startWithin` deliberately starts a new handle at zero from any sealed
+current bundle, and pure Lean values may be reused to explore alternative
+bounded successors. This is not a global or process-persistent budget.
+
+This is the supported autonomous programmatic loop.  Goal reification and the
+public tactic currently use the separate flat forward path; split-search tactic
+integration remains a later edge.  The current runtime driver accepts fact
+events only.  The shipped vertical uses toy fact-event callbacks; concrete
+built-in arithmetic `Driver.Package` callbacks and application generators are
+not yet supplied. Mathlib-free raw package drafts, equality/instance actions,
+program-extension discovery, and automatic package discovery remain later
+interfaces; this module assembles an explicit Mathlib runtime/proof registry.
+-/
+
+namespace Hex.Interval.Controller
+
+open Proof
+
+variable {Fact Cause SemanticKey Plan PolicyState : Type}
+
+/-- Stable compatibility declaration for one explicit runtime/proof assembly.
+Assemblies built with the same key are deliberately treated as interchangeable
+trusted implementations of that epoch; the key is not object identity or a
+hash of Lean callback bodies. Callback results remain fully revalidated. -/
+structure Key where
+  name : String
+  version : Nat
+  deriving DecidableEq, Repr
+
+/-- Stable policy identity for one slot in the exact application table. -/
+abbrev OfferId := ApplicationId
+
+/-- Package-generated policy metadata and action ports.  Identity, rule,
+chronology, age, and dependency generations are controller-owned. Every offer
+in one immutable snapshot receives that snapshot's single session serial as its
+age. A malformed draft aborts generation transactionally; no prefix is
+retained. -/
+structure Draft (SemanticKey : Type) where
+  key : SemanticKey
+  offerClass : Policy.OfferClass
+  score : Int := 0
+  node : NodeId
+  effort : Nat
+  inputs : List NodeId
+  writes : List NodeId := []
+  structuralInputs : List StructuralKey := []
+
+/-- One stable application slot.  `binding` is consulted on every branch and
+must remain unchanged during updates within one scope.  `offer` may return
+`none` when the application is currently inapplicable.  Both callbacks are
+non-preemptible; all returned lists are capped before traversal. -/
+structure Application (Fact Cause SemanticKey : Type) where
+  generation : Nat := 0
+  binding : Policy.ScopeId → State.Branch Fact Cause → Option ScopeBinding := fun _ _ => none
+  offer : Policy.ScopeId → State.Branch Fact Cause → Option (Draft SemanticKey)
+
+/-- One exact fact-event rule owns one runtime callback and a deterministic
+application suffix.  Proof schemas remain in the separately built
+`Proof.Registry`; this is explicit assembly, not automatic discovery. -/
+structure Package (Fact Cause SemanticKey Plan : Type) where
+  runtime : Driver.Package Fact Cause OfferId SemanticKey Plan
+  applications : Array (Application Fact Cause SemanticKey)
+
+/-- Independent logical caps for one retained policy-state value. Measurement
+and construction of the arbitrary caller type remain non-preemptible. -/
+structure PolicyLimit where
+  bytes : Nat
+  pairs : Nat
+  work : Nat
+  deriving DecidableEq, Repr
+
+/-- Bounds specific to application enumeration and autonomous policy choices.
+All state, policy, search, result-tree, proof, and recipe bounds remain in the
+supported envelopes passed to the transitions. `maxChoices` applies to one
+sealed `State` lineage and resets only through explicit `State.startWithin`. -/
+structure Limits where
+  maxChoices : Nat
+  policyState : PolicyLimit
+  driver : Driver.Limits
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | applications
+  | choices
+  | policyState
+  | state (resource : State.Resource)
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | invalidRegistry
+  | invalidApplication (application : ApplicationId)
+  | resource (resource : Resource)
+  | search (error : Search.Error)
+  | driver (error : Driver.Error)
+  | mismatch
+  deriving DecidableEq, Repr
+
+/-- Ordinary-import-sealed alignment of one program, theorem registry, runtime
+packages, and deterministic application table. -/
+structure Registry (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause SemanticKey Plan : Type) where
+  private mk ::
+  key : Key
+  program : Program
+  proof : Proof.Registry semantics Plan
+  packages : Array (Package Fact Cause SemanticKey Plan)
+  applications : Array (RuleId × Application Fact Cause SemanticKey)
+  applicationGenerations : Array Nat
+  equalityGenerations : Array Nat
+  matcherEpoch : Nat
+
+private def flattenWithin (limit : Nat)
+    (packages : Array (Package Fact Cause SemanticKey Plan)) :
+    Except Error (Array (RuleId × Application Fact Cause SemanticKey)) := do
+  let mut applications := #[]
+  for ruleIndex in [0:packages.size] do
+    let some package := packages[ruleIndex]? | throw .invalidRegistry
+    for application in package.applications do
+      if limit ≤ applications.size then throw (.resource .applications)
+      applications := applications.push ({ index := ruleIndex }, application)
+  pure applications
+
+private def preflightProgram (limits : State.Limits) (program : Program) :
+    Except Error Unit := do
+  if limits.maxOperations < program.operations.size then
+    throw (.resource (.state .operations))
+  if limits.maxNodes < program.nodes.size then throw (.resource (.state .nodes))
+  if program.operations.any (fun operation =>
+      !Search.listWithin limits.maxArity operation.inputs) ||
+      program.nodes.any (fun node => !Search.listWithin limits.maxArity node.args) then
+    throw (.resource (.state .arity))
+
+private def preflightRegistrations (limits : State.Limits)
+    (registrations : Array Registration) : Except Error Unit := do
+  if limits.maxRules < registrations.size then throw (.resource (.state .rules))
+  for registration in registrations do
+    let portLimit := match registration.binding with
+      | .local => limits.maxArity + 1
+      | .scoped => limits.maxScopeNodes
+      | .global => 0
+    if !Search.listWithin portLimit registration.watches ||
+        !Search.listWithin portLimit registration.writes then
+      throw (.resource (.state (if registration.binding == .scoped then .scopes else .arity)))
+
+private def preflightBranch (limits : State.Limits) (branch : State.Branch Fact Cause) :
+    Except Error Unit := do
+  preflightProgram limits branch.baseProgram
+  preflightProgram limits branch.program
+  if limits.maxAcceptedFacts < branch.history.size then
+    throw (.resource (.state .acceptedFacts))
+  if limits.maxNodes < branch.initialFacts.size || limits.maxNodes < branch.seeds.size ||
+      limits.maxNodes < branch.versions.size || limits.maxNodes < branch.generations.size ||
+      limits.maxNodes < branch.depths.size then
+    throw (.resource (.state .nodes))
+  if branch.depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (.resource (.state .nodeDepth))
+  if branch.generations.any (fun generation => limits.maxGeneration < generation) then
+    throw (.resource (.state .generation))
+
+/-- Build one exact runtime/proof package alignment.  Runtime package order is
+the proof registration order, so a compact `RuleId` resolves to the same
+stable key on both sides. -/
+opaque Registry.buildWithin
+    (stateLimits : State.Limits) (key : Key) (program : Program)
+    (proof : Proof.Registry semantics Plan)
+    (packages : Array (Package Fact Cause SemanticKey Plan))
+    (equalityGenerations : Array Nat := #[]) (matcherEpoch : Nat := 0) :
+    Except Error (Registry Fact semantics Cause SemanticKey Plan) := do
+  if stateLimits.maxRules < packages.size ||
+      stateLimits.maxRules < proof.registrations.size then
+    throw (.resource (.state .rules))
+  if stateLimits.maxRegistryEntries < packages.size then
+    throw (.resource (.state .registryEntries))
+  if stateLimits.maxEqualities < equalityGenerations.size then
+    throw (.resource (.state .equalities))
+  let programError := match preflightProgram stateLimits program with
+    | .error error => some error
+    | .ok _ => none
+  if let some error := programError then throw error
+  let registrationError := match preflightRegistrations stateLimits proof.registrations with
+    | .error error => some error
+    | .ok _ => none
+  if let some error := registrationError then throw error
+  if proof.registrations.size != packages.size then
+    throw .invalidRegistry
+  if stateLimits.maxGeneration < matcherEpoch ||
+      equalityGenerations.any (fun generation => stateLimits.maxGeneration < generation) then
+    throw (.resource (.state .generation))
+  for index in [0:packages.size] do
+    let some package := packages[index]? | throw .invalidRegistry
+    let some registration := proof.registrations[index]? | throw .invalidRegistry
+    if package.runtime.rule != registration.key then throw .invalidRegistry
+  match flattenWithin stateLimits.maxApplications packages with
+  | .error error => throw error
+  | .ok applications =>
+      let generations := applications.map (·.2.generation)
+      if generations.any (fun generation => stateLimits.maxGeneration < generation) then
+        throw (.resource (.state .generation))
+      if !program.check || !Registration.check program proof.registrations then
+        throw .invalidRegistry
+      pure
+        { key, program, proof, packages, applications,
+          applicationGenerations := generations, equalityGenerations, matcherEpoch }
+
+private def structuralGeneration?
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (branch : State.Branch Fact Cause) : StructuralKey → Option Nat
+  | .node node => branch.generations[node.index]?
+  | .application application => registry.applicationGenerations[application.index]?
+  | .equality equality => registry.equalityGenerations[equality.index]?
+
+private def seenInputs? (branch : State.Branch Fact Cause)
+    (nodes : List NodeId) : Option (List SeenVersion) :=
+  nodes.mapM fun node => do
+    let version ← branch.versions[node.index]?
+    pure { node, version }
+
+private def structuralInputs?
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (branch : State.Branch Fact Cause) (keys : List StructuralKey) :
+    Option (List StructuralInput) :=
+  keys.mapM fun key => do
+    let generation ← structuralGeneration? registry branch key
+    pure { key, generation }
+
+private def offerClass (kind : ActionKind) : Policy.OfferClass :=
+  match kind with
+  | .split => .split
+  | .instantiate => .instantiate
+  | .improve | .shave | .regularize => .retry
+  | _ => .invoke
+
+private structure Generated (OfferId SemanticKey : Type) where
+  offers : Array (Search.Offer OfferId SemanticKey)
+  bindings : Array ScopeBinding
+
+private def generate [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (branch : State.Branch Fact Cause) (scope : Policy.ScopeId) (serial : Nat) :
+    Except Error (Generated OfferId SemanticKey) := do
+  preflightBranch envelope.state branch
+  if !branch.check then throw .mismatch
+  if branch.program != registry.program then throw .mismatch
+  let mut offers := #[]
+  let mut bindings := #[]
+  for index in [0:registry.applications.size] do
+    let applicationId : ApplicationId := { index }
+    let some (ruleId, application) := registry.applications[index]?
+      | throw (.invalidApplication applicationId)
+    let some registration := registry.proof.registrations[ruleId.index]?
+      | throw (.invalidApplication applicationId)
+    let binding := application.binding scope branch
+    let draft := application.offer scope branch
+    match registration.binding, binding, draft with
+    | .scoped, some exact, _ =>
+        if !Search.listWithin envelope.state.maxScopeNodes exact.watches ||
+            !Search.listWithin envelope.state.maxScopeNodes exact.writes then
+          throw (.resource (.state .scopes))
+        if exact.rule != registration.key then throw (.invalidApplication applicationId)
+        if !bindings.contains exact then
+          if envelope.state.maxApplications ≤ bindings.size then
+            throw (.resource .applications)
+          bindings := bindings.push exact
+    | .scoped, none, none => pure ()
+    | .local, none, _ | .global, none, _ => pure ()
+    | _, _, _ => throw (.invalidApplication applicationId)
+    let some draft := draft | continue
+    let portLimit := match registration.binding with
+      | .local => envelope.state.maxArity + 1
+      | .scoped => envelope.state.maxScopeNodes
+      | .global => 0
+    let portResource := if registration.binding == .scoped then State.Resource.scopes
+      else State.Resource.arity
+    if !Search.listWithin portLimit draft.inputs ||
+        !Search.listWithin portLimit draft.writes then
+      throw (.resource (.state portResource))
+    if !Search.listWithin envelope.state.matcherBatchSize draft.structuralInputs then
+      throw (.resource (.state .matcherVisits))
+    if envelope.state.maxEffort < draft.effort then
+      throw (.resource (.state .effort))
+    let some inputs := seenInputs? branch draft.inputs
+      | throw (.invalidApplication applicationId)
+    let some structuralInputs := structuralInputs? registry branch draft.structuralInputs
+      | throw (.invalidApplication applicationId)
+    if draft.offerClass != offerClass registration.kind then
+      throw (.invalidApplication applicationId)
+    let action : Action :=
+      { serial, programVersion := branch.programVersion, application := applicationId,
+        rule := ruleId, key := registration.key, node := draft.node,
+        kind := registration.kind, effort := draft.effort,
+        generation := application.generation, inputs, writes := draft.writes,
+        structuralInputs,
+        matcherEpoch := if registration.matchWatch == .network
+          then some registry.matcherEpoch else none }
+    let view : Policy.OfferView OfferId SemanticKey :=
+      { id := applicationId, key := draft.key, offerClass := draft.offerClass,
+        age := serial, score := draft.score }
+    if envelope.policy.maxOffers ≤ offers.size then
+      throw (.search (.policy .offerLimit))
+    offers := offers.push { view, action }
+  pure { offers, bindings }
+
+/-- Compose the controller-owned application identifier cost with a
+caller-owned semantic-key measure. -/
+def policyMeasure (key : SemanticKey → Policy.Cost) :
+    Policy.Measure OfferId SemanticKey :=
+  { id := fun id => { bytes := id.index + 1, work := 1 }, key }
+
+private def checkPolicyWithin (limits : PolicyLimit)
+    (measure : PolicyState → Policy.Cost) (state : PolicyState) : Except Error Unit := do
+  let cost := measure state
+  if limits.bytes < cost.bytes || limits.pairs < cost.pairs || limits.work < cost.work then
+    throw (.resource .policyState)
+
+private def startSession [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) :
+    Except Error (Search.Session Fact Cause OfferId SemanticKey) := do
+  let generated ← generate envelope registry branch scope 0
+  Search.Session.startWithin envelope measure branch registry.proof.registrations
+    generated.bindings registry.applicationGenerations registry.equalityGenerations
+    registry.matcherEpoch scope generated.offers |>.mapError Error.search
+
+private def refresh [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (session : Search.Session Fact Cause OfferId SemanticKey) :
+    Except Error (Search.Session Fact Cause OfferId SemanticKey) := do
+  let generated ← generate envelope registry session.branch session.scope session.serial
+  if generated.bindings != session.bindings then throw .mismatch
+  Search.Session.refreshWithin envelope measure session generated.offers {} false
+    |>.mapError Error.search
+
+/-- Sealed live alignment of a retained runtime/proof bundle, its declared
+registry compatibility epoch, exact current session, and cumulative
+policy-choice accounting. -/
+structure State (Fact Cause OfferId SemanticKey Plan : Type) where
+  private mk ::
+  compatibility : Key
+  bundle : Driver.Bundle Fact Cause Plan
+  session : Search.Session Fact Cause OfferId SemanticKey
+  choices : Nat
+
+/-- Start a new autonomous-controller handle at the exact current retained-tree
+head. This explicit operation starts a fresh per-lineage choice counter. -/
+opaque State.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (bundle : Driver.Bundle Fact Cause Plan) :
+    Except Error (State Fact Cause OfferId SemanticKey Plan) := do
+  let some (_, source) := Search.Result.current? bundle.tree | throw .mismatch
+  let session ← startSession envelope measure registry source.scope source.branch
+  pure { compatibility := registry.key, bundle, session, choices := 0 }
+
+private def nextState [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (bundle : Driver.Bundle Fact Cause Plan) (choices : Nat) :
+    Except Error (Option (State Fact Cause OfferId SemanticKey Plan)) := do
+  match Search.Result.current? bundle.tree with
+  | none => pure none
+  | some (_, source) =>
+      let session ← startSession envelope measure registry source.scope source.branch
+      pure (some { compatibility := registry.key, bundle, session, choices })
+
+private def runtime?
+    (registry : Registry Fact semantics Cause SemanticKey Plan) (id : OfferId) :
+    Option (Driver.Package Fact Cause OfferId SemanticKey Plan) := do
+  let (rule, _) ← registry.applications[id.index]?
+  let package ← registry.packages[rule.index]?
+  let registration ← registry.proof.registrations[rule.index]?
+  if package.runtime.rule == registration.key then
+    pure package.runtime
+  else none
+
+inductive Run (Fact Cause OfferId SemanticKey Plan PolicyState : Type)
+  | complete (bundle : Driver.Bundle Fact Cause Plan) (policy : PolicyState)
+  | stopped (stop : Search.Stop Unit Unit)
+      (state : State Fact Cause OfferId SemanticKey Plan) (policy : PolicyState)
+  | unknown (bundle : Driver.Bundle Fact Cause Plan) (policy : PolicyState)
+
+/-- Run deterministic offer regeneration and replaceable policy selection until
+the retained tree closes, honestly stops, reaches an unknown leaf, or exhausts
+the cumulative choice cap.  Dismissal removes exactly one offer from the
+current immutable snapshot. Dismissing a non-split offer marks that snapshot
+incomplete; dismissing a split probe does not. A later accepted transition
+regenerates the next complete snapshot. A policy stop returns a resumable sealed
+state, whereas choice-cap exhaustion is a resource error. `policyStateMeasure`
+is non-preemptible, but its declared byte, pair, and work cost must fit before
+the initial state or any callback successor is retained. In the reference
+implementation, up to `maxChoices` selected steps each repeat complete bundle
+and retained-tree validation, so total validation cost scales linearly with the
+choice cap as well as with the retained-tree validation cost. -/
+opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey]
+    [DecidableEq Plan]
+    (limits : Limits) (envelope : Search.Envelope)
+    (keyMeasure : SemanticKey → Policy.Cost)
+    (policyStateMeasure : PolicyState → Policy.Cost)
+    (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Driver.Measure Fact) (order : Search.Order)
+    (registry : Registry Fact semantics Cause SemanticKey Plan)
+    (policy : Policy.Interface Fact PolicyState OfferId SemanticKey)
+    (policyState : PolicyState)
+    (initial : State Fact Cause OfferId SemanticKey Plan) :
+    Except Error (Run Fact Cause OfferId SemanticKey Plan PolicyState) := do
+  if initial.compatibility != registry.key then throw .mismatch
+  checkPolicyWithin limits.policyState policyStateMeasure policyState
+  let measure := policyMeasure keyMeasure
+  let rec loop (fuel : Nat) (state : State Fact Cause OfferId SemanticKey Plan)
+      (policyState : PolicyState) :
+      Except Error (Run Fact Cause OfferId SemanticKey Plan PolicyState) := do
+    if state.choices >= limits.maxChoices then throw (.resource .choices)
+    match fuel with
+    | 0 => throw (.resource .choices)
+    | fuel + 1 =>
+      let choice ← Search.chooseWithin envelope measure policy policyState state.session
+        |>.mapError Error.search
+      match choice with
+      | .stopped stop next =>
+          checkPolicyWithin limits.policyState policyStateMeasure next
+          pure (.stopped stop state next)
+      | .dismiss decision next =>
+          checkPolicyWithin limits.policyState policyStateMeasure next
+          let offers := state.session.offers.filter fun offer => offer.view.id != decision.id
+          if offers.size + 1 != state.session.offers.size then throw .mismatch
+          let incomplete := state.session.incomplete || decision.offerClass != .split
+          let session ← Search.Session.refreshWithin envelope measure state.session offers
+            state.session.remaining incomplete |>.mapError Error.search
+          loop fuel { state with session, choices := state.choices + 1 } next
+      | .select decision next =>
+          checkPolicyWithin limits.policyState policyStateMeasure next
+          let some package := runtime? registry decision.id | throw .mismatch
+          let step ← Driver.runWithin envelope measure limits.driver resultMeasure recipeMeasure
+            order package state.bundle state.session decision |>.mapError Error.driver
+          let choices := state.choices + 1
+          match step with
+          | .continued bundle session =>
+              let session ← refresh envelope measure registry session
+              loop fuel { compatibility := state.compatibility, bundle, session, choices } next
+          | .split bundle | .terminal bundle =>
+              match ← nextState envelope measure registry bundle choices with
+              | none => pure (.complete bundle next)
+              | some state => loop fuel state next
+          | .unknown bundle => pure (.unknown bundle next)
+          | .stopped stop bundle session =>
+              pure (.stopped stop
+                { compatibility := state.compatibility, bundle, session, choices } next)
+  loop limits.maxChoices initial policyState
+
+end Hex.Interval.Controller

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -360,22 +360,26 @@ private def startSession [DecidableEq Fact] [DecidableEq Cause]
 private def refresh [DecidableEq Fact] [DecidableEq Cause]
     (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
     (registry : Registry Fact semantics Cause SemanticKey Plan)
-    (session : Search.Session Fact Cause OfferId SemanticKey) :
+    (session : Search.Session Fact Cause OfferId SemanticKey)
+    (dismissedIncomplete : Bool) :
     Except Error (Search.Session Fact Cause OfferId SemanticKey) := do
   let generated ← generate envelope registry session.branch session.scope session.serial
   if generated.bindings != session.bindings then throw .mismatch
-  Search.Session.refreshWithin envelope measure session generated.offers {} false
+  Search.Session.refreshWithin envelope measure session generated.offers {}
+    dismissedIncomplete
     |>.mapError Error.search
 
 /-- Sealed live alignment of a retained runtime/proof bundle, its declared
 registry compatibility epoch, exact current session, and cumulative
-policy-choice accounting. -/
+policy-choice accounting. `dismissedIncomplete` is sticky for the current
+scope: accepting another action cannot erase an earlier non-split dismissal. -/
 structure State (Fact Cause OfferId SemanticKey Plan : Type) where
   private mk ::
   compatibility : Key
   bundle : Driver.Bundle Fact Cause Plan
   session : Search.Session Fact Cause OfferId SemanticKey
   choices : Nat
+  dismissedIncomplete : Bool
 
 /-- Start a new autonomous-controller handle at the exact current retained-tree
 head. This explicit operation starts a fresh per-lineage choice counter. -/
@@ -386,7 +390,9 @@ opaque State.startWithin [DecidableEq Fact] [DecidableEq Cause]
     Except Error (State Fact Cause OfferId SemanticKey Plan) := do
   let some (_, source) := Search.Result.current? bundle.tree | throw .mismatch
   let session ← startSession envelope measure registry source.scope source.branch
-  pure { compatibility := registry.key, bundle, session, choices := 0 }
+  pure
+    { compatibility := registry.key, bundle, session, choices := 0,
+      dismissedIncomplete := false }
 
 private def nextState [DecidableEq Fact] [DecidableEq Cause]
     (envelope : Search.Envelope) (measure : Policy.Measure OfferId SemanticKey)
@@ -397,7 +403,9 @@ private def nextState [DecidableEq Fact] [DecidableEq Cause]
   | none => pure none
   | some (_, source) =>
       let session ← startSession envelope measure registry source.scope source.branch
-      pure (some { compatibility := registry.key, bundle, session, choices })
+      pure (some
+        { compatibility := registry.key, bundle, session, choices,
+          dismissedIncomplete := false })
 
 private def runtime?
     (registry : Registry Fact semantics Cause SemanticKey Plan) (id : OfferId) :
@@ -409,6 +417,9 @@ private def runtime?
     pure package.runtime
   else none
 
+/-- Controller termination. `complete` means only that the sealed runtime tree
+has no pending frontier; it is not proof closure or evidence. The retained tree
+and recipe must still pass `Proof.replayTree`. -/
 inductive Run (Fact Cause OfferId SemanticKey Plan PolicyState : Type)
   | complete (bundle : Driver.Bundle Fact Cause Plan) (policy : PolicyState)
   | stopped (stop : Search.Stop Unit Unit)
@@ -419,9 +430,10 @@ inductive Run (Fact Cause OfferId SemanticKey Plan PolicyState : Type)
 the retained tree closes, honestly stops, reaches an unknown leaf, or exhausts
 the cumulative choice cap.  Dismissal removes exactly one offer from the
 current immutable snapshot. Dismissing a non-split offer marks that snapshot
-incomplete; dismissing a split probe does not. A later accepted transition
-regenerates the next complete snapshot. A policy stop returns a resumable sealed
-state, whereas choice-cap exhaustion is a resource error. `policyStateMeasure`
+incomplete; dismissing a split probe does not. That incompleteness survives
+accepted refreshes in the same scope and clears only when a split or terminal
+transition moves to the next retained scope. A policy stop returns a resumable
+sealed state, whereas choice-cap exhaustion is a resource error. `policyStateMeasure`
 is non-preemptible, but its declared byte, pair, and work cost must fit before
 the initial state or any callback successor is retained. In the reference
 implementation, up to `maxChoices` selected steps each repeat complete bundle
@@ -459,10 +471,12 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey
           checkPolicyWithin limits.policyState policyStateMeasure next
           let offers := state.session.offers.filter fun offer => offer.view.id != decision.id
           if offers.size + 1 != state.session.offers.size then throw .mismatch
-          let incomplete := state.session.incomplete || decision.offerClass != .split
+          let dismissedIncomplete :=
+            state.dismissedIncomplete || decision.offerClass != .split
           let session ← Search.Session.refreshWithin envelope measure state.session offers
-            state.session.remaining incomplete |>.mapError Error.search
-          loop fuel { state with session, choices := state.choices + 1 } next
+            state.session.remaining dismissedIncomplete |>.mapError Error.search
+          loop fuel
+            { state with session, choices := state.choices + 1, dismissedIncomplete } next
       | .select decision next =>
           checkPolicyWithin limits.policyState policyStateMeasure next
           let some package := runtime? registry decision.id | throw .mismatch
@@ -471,8 +485,10 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey
           let choices := state.choices + 1
           match step with
           | .continued bundle session =>
-              let session ← refresh envelope measure registry session
-              loop fuel { compatibility := state.compatibility, bundle, session, choices } next
+              let session ← refresh envelope measure registry session state.dismissedIncomplete
+              loop fuel
+                { compatibility := state.compatibility, bundle, session, choices,
+                  dismissedIncomplete := state.dismissedIncomplete } next
           | .split bundle | .terminal bundle =>
               match ← nextState envelope measure registry bundle choices with
               | none => pure (.complete bundle next)
@@ -480,7 +496,8 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey
           | .unknown bundle => pure (.unknown bundle next)
           | .stopped stop bundle session =>
               pure (.stopped stop
-                { compatibility := state.compatibility, bundle, session, choices } next)
+                { compatibility := state.compatibility, bundle, session, choices,
+                  dismissedIncomplete := state.dismissedIncomplete } next)
   loop limits.maxChoices initial policyState
 
 end Hex.Interval.Controller

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -312,9 +312,12 @@ fact-event Mathlib assembly whose conformance callbacks are toy packages, not
 the missing concrete built-in arithmetic driver adapters, automatic package
 discovery, or public split-search tactic. Every immutable offer snapshot has
 one constant controller-owned serial age; any malformed draft aborts its whole
-regeneration. Dismissing a non-split offer marks the snapshot incomplete,
-whereas dismissing a split probe does not. Policy stop returns a resumable
-sealed chunk boundary, while `maxChoices` exhaustion is a resource error. The
+regeneration. Dismissing a non-split offer sets a controller-owned incomplete
+bit which survives accepted refreshes in the same scope and clears only on the
+next split/terminal scope transition; dismissing a split probe does not set it.
+Policy stop returns a resumable sealed chunk boundary, while `maxChoices`
+exhaustion is a resource error. `Run.complete` says only that no pending runtime
+frontier remains; proof closure still requires replay. The
 reference cost of up to `maxChoices` selected transitions includes complete
 retained-tree/bundle validation each time. The
 current retained-tree builder repeatedly

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -77,8 +77,15 @@ provenance. That runtime tree is not evidence. This companion now separately
 checks package-owned split/refutation recipes, recursively replays and joins a
 checked tree, and provides a one-selected-callback driver which advances the
 retained source and appends the callback's exact fact events in one
-transaction. Autonomous offer generation, repeated policy iteration, and
-public-tactic split search remain later edges.
+transaction. Its supported `Controller` explicitly aligns stable application
+generators with the same-order runtime and proof registries, regenerates
+resource-first deterministic offers from the authenticated current head, and
+runs bounded repeated policy selection over the sealed tree/session bundle.
+Its current vertical uses toy fact-event packages; concrete built-in arithmetic
+`Driver.Package` callbacks and application generators remain to be implemented.
+Mathlib-free raw packages, automatic discovery/program extension,
+equality/instance runtime events, and public-tactic split search remain later
+edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -214,9 +221,11 @@ performs the final check when the caller installs the expression.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The built-in arithmetic package registry and
 its supported branch/session `Cause`-to-`Proof.Event` quotation ship below.
-Arbitrary-function package discovery, generic search-selected recipes, and
-default registries remain experimental. The supported tactic below is a
-deliberately narrow direct forward client, not the generic search bridge.
+Automatic arbitrary-function package discovery, Mathlib-free raw packages,
+equality/instance runtime recipes, and default registries remain experimental.
+The supported explicit fact-event controller can produce and replay
+search-selected recipes, while the tactic below remains a deliberately narrow
+direct forward client rather than that generic search bridge.
 Further arithmetic images and useful bounded nonsingleton division require their own
 operation-specific semantic theorems before promotion. An image operation must
 at least prove successful-result cut semantics and sound real-image enclosure;
@@ -256,10 +265,10 @@ exactly one natural exponent and one dyadic constant: every node at the
 built-in power operation index shares that exponent, and every node at the
 built-in constant index shares that value. Duplicate package registration and
 operation keys cannot add another parameterization. Arbitrary-function package
-discovery, autonomous offer generation and policy iteration, split-search
-tactic integration, and default package discovery remain experimental. The
+discovery, Mathlib-free runtime packages, split-search tactic integration, and
+default package discovery remain experimental. The
 supported direct-forward reifier and tactic syntax are a narrow client of this
-registry, not the missing autonomous controller.
+registry, not the autonomous split-search tactic.
 
 The supported proof fold also accepts a `Search.Result.Tree` only after the
 tree passes `Tree.check` under the exact caller-supplied search limits and
@@ -280,8 +289,34 @@ caller-owned `Driver.Measure` must charge complete logical encodings of every
 retained event and edge, including nested facts, actions, schemas, dependency
 versions, body naturals, and seed data; independent recipe byte/work caps are
 rechecked across the complete bundle on every transition. Measurement and
-callback execution remain explicitly non-preemptible. Autonomous offer
-generation, policy iteration, and tactic integration remain later work. The
+callback execution remain explicitly non-preemptible.
+`HexIntervalMathlib.Controller` supplies the next supported explicit-assembly
+layer: its sealed registry declares one stable compatibility key, exact
+application slot to rule/runtime route, and same-order proof registration; its
+sealed state rejects a selected compact identifier or live session transplanted
+across registry keys. The key is deliberately a trusted compatibility epoch,
+not callback-object identity: separately built registries using the same key
+assert interchangeable implementations, whose returned data still crosses all
+runtime and proof checks. Generator/policy/equality callbacks remain
+non-preemptible, while program, branch, registration, binding, action-port,
+structural-input, application, offer, and retained-result caps are checked
+before controller-owned traversal or allocation. A caller-owned logical
+policy-state measure is also non-preemptible, but the initial value and every
+callback successor must fit explicit byte/pair/work caps before retention.
+Offer age is the bounded
+sealed session serial rather than package data. The choice cap is cumulative
+per returned sealed state lineage; explicit `State.startWithin` creates a new
+zeroed handle from a sealed bundle, and pure state reuse creates separately
+bounded successors rather than a global budget. This current controller is a
+fact-event Mathlib assembly whose conformance callbacks are toy packages, not
+the missing concrete built-in arithmetic driver adapters, automatic package
+discovery, or public split-search tactic. Every immutable offer snapshot has
+one constant controller-owned serial age; any malformed draft aborts its whole
+regeneration. Dismissing a non-split offer marks the snapshot incomplete,
+whereas dismissing a split probe does not. Policy stop returns a resumable
+sealed chunk boundary, while `maxChoices` exhaustion is a resource error. The
+reference cost of up to `maxChoices` selected transitions includes complete
+retained-tree/bundle validation each time. The
 current retained-tree builder repeatedly
 validates retained branches and pairwise scope uniqueness; incremental
 construction therefore has the documented `Θ(N² * B + N³)` reference cost,

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -306,20 +306,25 @@ callback successor must fit explicit byte/pair/work caps before retention.
 Offer age is the bounded
 sealed session serial rather than package data. The choice cap is cumulative
 per returned sealed state lineage; explicit `State.startWithin` creates a new
-zeroed handle from a sealed bundle, and pure state reuse creates separately
-bounded successors rather than a global budget. This current controller is a
+handle from a sealed bundle and resets choices, the dismissal latch, and the
+search session's serial, steps, and trace even at the same retained head/scope.
+Pure state reuse creates separately bounded successors rather than a global
+budget, and a new handle does not inherit proof closure or saturation. This current controller is a
 fact-event Mathlib assembly whose conformance callbacks are toy packages, not
 the missing concrete built-in arithmetic driver adapters, automatic package
 discovery, or public split-search tactic. Every immutable offer snapshot has
 one constant controller-owned serial age; any malformed draft aborts its whole
 regeneration. Dismissing a non-split offer sets a controller-owned incomplete
-bit which survives accepted refreshes in the same scope and clears only on the
-next split/terminal scope transition; dismissing a split probe does not set it.
+bit which survives accepted refreshes in the same scope within one returned
+handle lineage. The next split/terminal scope transition clears it, and an
+explicit new `State.startWithin` lineage resets it even at the same scope;
+dismissing a split probe does not set it.
 Policy stop returns a resumable sealed chunk boundary, while `maxChoices`
 exhaustion is a resource error. `Run.complete` says only that no pending runtime
 frontier remains; proof closure still requires replay. The
-reference cost of up to `maxChoices` selected transitions includes complete
-retained-tree/bundle validation each time. The
+reference cost of up to `maxChoices` selected transitions includes entry
+session authentication, current and replacement retained-tree/bundle
+validation, and regenerated-session authentication each time. The
 current retained-tree builder repeatedly
 validates retained branches and pairwise scope uniqueness; incremental
 construction therefore has the documented `Θ(N² * B + N³)` reference cost,

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -3301,8 +3301,11 @@ the fixed soundness and trust contracts.
   for each retained policy state. The current conformance vertical uses toy
   fact-event packages; concrete built-in arithmetic driver callbacks and
   application generators are not yet shipped. Non-split dismissal is sticky
-  across accepted refreshes in one scope, while split dismissal is not; a new
-  split/terminal scope clears the sticky bit. `Run.complete` means an empty
+  across accepted refreshes in one scope within a returned sealed state
+  lineage, while split dismissal is not; a new split/terminal scope clears the
+  sticky bit. Explicit `State.startWithin` creates a new handle and resets that
+  bit, choices, serial, steps, and trace even at the same retained head/scope;
+  it carries no proof-closure or saturation claim. `Run.complete` means an empty
   pending runtime frontier, not proof closure. It does not yet provide
   Mathlib-free raw package drafts, equality/instance applications,
   program-extension or package discovery, or public-tactic split search.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -3300,9 +3300,12 @@ the fixed soundness and trust contracts.
   the sealed session/tree bundle, including caller-measured byte/pair/work caps
   for each retained policy state. The current conformance vertical uses toy
   fact-event packages; concrete built-in arithmetic driver callbacks and
-  application generators are not yet shipped. It does not yet provide Mathlib-free raw
-  package drafts, equality/instance applications, program-extension or package
-  discovery, or public-tactic split search.
+  application generators are not yet shipped. Non-split dismissal is sticky
+  across accepted refreshes in one scope, while split dismissal is not; a new
+  split/terminal scope clears the sticky bit. `Run.complete` means an empty
+  pending runtime frontier, not proof closure. It does not yet provide
+  Mathlib-free raw package drafts, equality/instance applications,
+  program-extension or package discovery, or public-tactic split search.
 - `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
 - `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
   enclosures.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -41,7 +41,7 @@ granting runtime state evidence authority. The current package fixes one
 natural exponent and one dyadic constant, shared respectively by every node at
 the built-in power and constant operation indices; duplicate package
 registration and operation keys cannot provide another such parameterization.
-Arbitrary-function package discovery, a complete autonomous search loop,
+Arbitrary-function package discovery, Mathlib-free runtime packages,
 split-search tactic integration, and default package discovery remain
 experimental. The supported callback driver executes one already-selected
 authenticated package action and atomically advances a sealed result tree and
@@ -50,6 +50,14 @@ the complete encoding of every retained event and edge—including nested facts,
 actions, schema keys, dependency versions, body naturals, and seed data—and
 independent recipe byte/work caps are rechecked over the complete bundle on
 every transition. Measurement and callback execution remain non-preemptible.
+The supported explicit controller aligns a stable fact-event application table
+with the runtime and proof registries, regenerates bounded deterministic offers,
+and repeats policy selection over the sealed tree/session bundle. A
+caller-owned logical measure caps the initial policy state and every callback
+successor before retention; arbitrary-state construction and measurement remain
+non-preemptible. The current live controller theorem uses toy callbacks;
+concrete built-in arithmetic `Driver.Package` callbacks and application
+generators are still missing.
 The driver does not choose or enumerate offers.
 The supported direct-forward reifier and tactic are a narrow
 client rather than that missing generic bridge. The supported proof layer can
@@ -3286,6 +3294,15 @@ the fixed soundness and trust contracts.
   recipe. Its explicit logical event/edge measure and independent byte/work
   caps cover the complete retained recipe bundle. Offer generation, policy
   selection, and the autonomous search loop remain outside this module.
+- `HexIntervalMathlib/Controller.lean`: explicit fact-event runtime/proof
+  registry alignment, stable application-generator identities, resource-first
+  deterministic offer snapshots, and bounded repeated policy selection over
+  the sealed session/tree bundle, including caller-measured byte/pair/work caps
+  for each retained policy state. The current conformance vertical uses toy
+  fact-event packages; concrete built-in arithmetic driver callbacks and
+  application generators are not yet shipped. It does not yet provide Mathlib-free raw
+  package drafts, equality/instance applications, program-extension or package
+  discovery, or public-tactic split search.
 - `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
 - `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
   enclosures.

--- a/conformance/HexIntervalMathlib/ControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ControllerConformance.lean
@@ -283,8 +283,8 @@ def choiceOneOver : Bool :=
                   match Controller.runWithin { controllerLimits with maxChoices := 0 } envelope
                       keyCost unitCost resultMeasure recipeMeasure .depthFirst registry firstPolicy ()
                       state with
-                  | .error _ => true
-                  | .ok _ => false
+                  | .error (.resource .choices) => true
+                  | _ => false
 
 /-- The live successful canary needs all five selections; four is the exact
 one-under cap rather than a degenerate zero-step refusal. -/
@@ -478,6 +478,113 @@ def structuralBatchRejected : Bool :=
           | .error (.resource (.state .matcherVisits)) => true
           | _ => false
 
+def networkRegistration : Registration :=
+  { key := forwardRule
+    head := sourceKey
+    kind := .instantiate
+    watches := []
+    writes := []
+    binding := .global
+    matchWatch := .network
+    watchesProgram := true }
+
+def networkProof? : Option (Proof.Registry semantics (List Nat)) :=
+  let changed : Proof.Package semantics (List Nat) :=
+    { package with registrations := registrations.set! 0 networkRegistration }
+  (Proof.Registry.buildWithin proofLimits program #[changed]).toOption
+
+private def networkApplication
+    (structuralInputs : List StructuralKey) : Controller.Application Fact Nat Nat :=
+  { offer := fun selectedScope _ =>
+      if selectedScope == scope then
+        some
+          { key := 45
+            offerClass := .instantiate
+            node := n2
+            effort := 0
+            inputs := []
+            writes := []
+            structuralInputs }
+      else none }
+
+private def networkRegistry?
+    (structuralInputs : List StructuralKey) := do
+  let proof ← networkProof?
+  let changed := withForward #[networkApplication structuralInputs]
+  (Controller.Registry.buildWithin stateLimits controllerKey program proof changed).toOption
+
+def networkEnvelope : Search.Envelope :=
+  { envelope with state := { stateLimits with matcherBatchSize := 1 } }
+
+def emptyNetworkRejected : Bool :=
+  match networkRegistry? [] with
+  | none => false
+  | some registry =>
+      match stateStartWith networkEnvelope registry with
+      | .error (.invalidApplication ⟨0⟩) => true
+      | _ => false
+
+def networkStructuralAccepted : Bool :=
+  match networkRegistry? [.node n1] with
+  | none => false
+  | some registry =>
+      match stateStartWith networkEnvelope registry with
+      | .error _ => false
+      | .ok state =>
+          match state.session.offers[0]? with
+          | none => false
+          | some offer =>
+              offer.action.kind == .instantiate && offer.action.inputs.isEmpty &&
+                offer.action.writes.isEmpty && offer.action.matcherEpoch == some 0 &&
+                offer.action.structuralInputs ==
+                  [{ key := .node n1, generation := 0 }]
+
+private def malformedDraftApplication
+    (inputs writes : List NodeId) (structuralInputs : List StructuralKey)
+    (node : NodeId := n2) : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    offer := fun selectedScope _ =>
+      if selectedScope == scope then
+        some
+          { key := 44
+            offerClass := .invoke
+            node
+            effort := 0
+            inputs
+            writes
+            structuralInputs }
+      else none }
+
+private def malformedDraftRejected
+    (application : Controller.Application Fact Nat Nat)
+    (candidateEnvelope : Search.Envelope := envelope) : Bool :=
+  let changed := withForward #[application, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith candidateEnvelope registry with
+          | .error (.invalidApplication ⟨0⟩) => true
+          | _ => false
+
+def duplicateInputsRejected : Bool :=
+  malformedDraftRejected (malformedDraftApplication [n1, n1] [n2] [])
+
+def duplicateWritesRejected : Bool :=
+  malformedDraftRejected (malformedDraftApplication [n1] [n2, n2] [])
+
+def duplicateStructuralRejected : Bool :=
+  let structuralEnvelope : Search.Envelope :=
+    { envelope with state := { stateLimits with matcherBatchSize := 2 } }
+  malformedDraftRejected
+    (malformedDraftApplication [n1] [n2] [.node n1, .node n1]) structuralEnvelope
+
+def missingNodeRejected : Bool :=
+  malformedDraftRejected
+    (malformedDraftApplication [n1] [n2] [] { index := program.nodes.size })
+
 def wrongClassApplication : Controller.Application Fact Nat Nat :=
   { forwardApplication with
     offer := fun selectedScope branch =>
@@ -556,6 +663,14 @@ def dismissFirstSelectSecond : Policy.Interface Fact Nat Controller.OfferId Nat 
         | none => .stop 1
       | _ => .stop stage }
 
+private def retainedFactApplication
+    (bundle : Driver.Bundle Fact Nat (List Nat)) (application : Nat) : Bool :=
+  match bundle.recipe.events[0]? with
+  | none => false
+  | some events => events.any fun
+      | .fact step => step.action.application.index == application
+      | _ => false
+
 def twoOffersOrdered : Bool :=
   match twoOfferRegistry? with
   | none => false
@@ -585,9 +700,40 @@ def dismissThenSelectSticky : Bool :=
               stopped.choices == 2 && stopped.dismissedIncomplete &&
                 stopped.session.incomplete && stopped.session.serial == 1 &&
                 version? stopped.session.branch n2 == some 1 &&
+                retainedFactApplication stopped.bundle 1 &&
                 (match stopped.session.offers[0]? with
                 | some offer => offer.view.id.index == 2 && offer.view.offerClass == .split
                 | none => false)
+          | _ => false
+
+/-- Starting explicitly from the same stopped bundle creates a new run handle:
+the retained pending head remains, while controller and search chronology reset
+without inheriting the old handle's incompleteness or any closure claim. -/
+def restartResetsHandle : Bool :=
+  match twoOfferRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith twoOfferEnvelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits twoOfferEnvelope keyCost
+              (fun _ => { bytes := 1 }) resultMeasure recipeMeasure .depthFirst registry
+              dismissFirstSelectSecond 0 state with
+          | .ok (.stopped (.policyStop 1) sticky 2) =>
+              match Controller.State.startWithin twoOfferEnvelope
+                  (Controller.policyMeasure keyCost) registry sticky.bundle with
+              | .error _ => false
+              | .ok restarted =>
+                  sticky.choices == 2 && sticky.dismissedIncomplete &&
+                    sticky.session.serial == 1 && sticky.session.steps == 1 &&
+                    restarted.session.scope == sticky.session.scope &&
+                    restarted.choices == 0 && !restarted.dismissedIncomplete &&
+                    restarted.session.serial == 0 && restarted.session.steps == 0 &&
+                    restarted.session.trace.events.isEmpty &&
+                    restarted.session.trace.bytes == 0 && restarted.session.trace.work == 0 &&
+                    !restarted.session.trace.truncated && !restarted.session.incomplete &&
+                    (Search.Result.current? restarted.bundle.tree).isSome &&
+                    restarted.session.offers.size == 1
           | _ => false
 
 def stickyClearsAtSplit : Bool :=
@@ -686,6 +832,12 @@ def sameKeyReplacementChecked : Bool :=
 #guard hugeBindingRejected
 #guard effortOneOver
 #guard structuralBatchRejected
+#guard emptyNetworkRejected
+#guard networkStructuralAccepted
+#guard duplicateInputsRejected
+#guard duplicateWritesRejected
+#guard duplicateStructuralRejected
+#guard missingNodeRejected
 #guard wrongClassRejected
 #guard transplantRejected
 #guard matcherEpochRejected
@@ -693,6 +845,7 @@ def sameKeyReplacementChecked : Bool :=
 #guard dismissedSplitComplete
 #guard twoOffersOrdered
 #guard dismissThenSelectSticky
+#guard restartResetsHandle
 #guard stickyClearsAtSplit
 #guard ageIsSerial
 #guard sameKeyReplacementChecked

--- a/conformance/HexIntervalMathlib/ControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ControllerConformance.lean
@@ -87,6 +87,21 @@ def targetApplication : Controller.Application Fact Nat Nat :=
             writes := [n3] }
       else none }
 
+/-- A second root offer for the same runtime rule. Its table position and
+semantic key make the simultaneous snapshot order observable. -/
+def secondForwardApplication : Controller.Application Fact Nat Nat :=
+  { binding := forwardApplication.binding
+    offer := fun selectedScope branch =>
+      if selectedScope == scope && version? branch n2 == some 0 then
+        some
+          { key := 13
+            offerClass := .invoke
+            node := n2
+            effort := 0
+            inputs := [n1]
+            writes := [n2] }
+      else none }
+
 def splitApplication : Controller.Application Fact Nat Nat :=
   { binding := fun selectedScope _ =>
       if selectedScope == scope then
@@ -192,6 +207,19 @@ def controllerRegistry? := do
   let proof ← registry?
   (Controller.Registry.buildWithin stateLimits controllerKey program proof packages).toOption
 
+def twoOfferPackages : Array (Controller.Package Fact Nat Nat (List Nat)) :=
+  #[{ runtime := forwardRuntime,
+      applications := #[forwardApplication, secondForwardApplication] },
+    { runtime := splitRuntime, applications := #[splitApplication] },
+    { runtime := refuteRuntime, applications := #[refuteApplication] }]
+
+def twoOfferRegistry? := do
+  let proof ← registry?
+  (Controller.Registry.buildWithin stateLimits controllerKey program proof twoOfferPackages).toOption
+
+def twoOfferEnvelope : Search.Envelope :=
+  { envelope with policy := { policyLimits with maxOffers := 2 } }
+
 def run := do
   let some registry := controllerRegistry? | throw 1
   let branch ← (State.Branch.startWithin stateLimits program input.facts).mapError fun _ => 2
@@ -258,9 +286,32 @@ def choiceOneOver : Bool :=
                   | .error _ => true
                   | .ok _ => false
 
+/-- The live successful canary needs all five selections; four is the exact
+one-under cap rather than a degenerate zero-step refusal. -/
+def choiceFiveNeedsCap : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match State.Branch.startWithin stateLimits program input.facts with
+      | .error _ => false
+      | .ok branch =>
+          match Driver.Bundle.startWithin limits resultMeasure recipeMeasure scope branch with
+          | .error _ => false
+          | .ok bundle =>
+              match Controller.State.startWithin envelope (Controller.policyMeasure keyCost)
+                  registry bundle with
+              | .error _ => false
+              | .ok state =>
+                  match Controller.runWithin { controllerLimits with maxChoices := 4 } envelope
+                      keyCost unitCost resultMeasure recipeMeasure .depthFirst registry firstPolicy
+                      () state with
+                  | .error (.resource .choices) => true
+                  | _ => false
+
 #guard wrongOwnerRejected
 #guard generationRejected
 #guard choiceOneOver
+#guard choiceFiveNeedsCap
 
 private def withForward
     (applications : Array (Controller.Application Fact Nat Nat)) :
@@ -376,6 +427,57 @@ def hugeBindingRejected : Bool :=
           | .error (.resource (.state .scopes)) => true
           | _ => false
 
+def hugeEffortApplication : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    offer := fun selectedScope _ =>
+      if selectedScope == scope then
+        some
+          { key := 42
+            offerClass := .invoke
+            node := n2
+            effort := stateLimits.maxEffort + 1
+            inputs := [n1]
+            writes := [n2] }
+      else none }
+
+def effortOneOver : Bool :=
+  let changed := withForward #[hugeEffortApplication, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith envelope registry with
+          | .error (.resource (.state .effort)) => true
+          | _ => false
+
+def structuralApplication : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    offer := fun selectedScope _ =>
+      if selectedScope == scope then
+        some
+          { key := 43
+            offerClass := .invoke
+            node := n2
+            effort := 0
+            inputs := [n1]
+            writes := [n2]
+            structuralInputs := [.node n1] }
+      else none }
+
+def structuralBatchRejected : Bool :=
+  let changed := withForward #[structuralApplication, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith envelope registry with
+          | .error (.resource (.state .matcherVisits)) => true
+          | _ => false
+
 def wrongClassApplication : Controller.Application Fact Nat Nat :=
   { forwardApplication with
     offer := fun selectedScope branch =>
@@ -442,6 +544,71 @@ def dismissThenStop : Policy.Interface Fact Bool Controller.OfferId Nat :=
         | none => .stop false }
 
 def boolCost (_ : Bool) : Policy.Cost := { bytes := 1, work := 1 }
+
+def dismissFirstSelectSecond : Policy.Interface Fact Nat Controller.OfferId Nat :=
+  { choose := fun stage view =>
+      match stage with
+      | 0 => match view.offers[0]? with
+        | some offer => .dismiss offer 1
+        | none => .stop 0
+      | 1 => match view.offers[0]? with
+        | some offer => .select offer 2
+        | none => .stop 1
+      | _ => .stop stage }
+
+def twoOffersOrdered : Bool :=
+  match twoOfferRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith twoOfferEnvelope registry with
+      | .error _ => false
+      | .ok state =>
+          match state.session.offers[0]?, state.session.offers[1]? with
+          | some first, some second =>
+              state.session.offers.size == 2 && first.view.id.index == 0 &&
+                first.view.key == 10 && second.view.id.index == 1 && second.view.key == 13
+          | _, _ => false
+
+/-- Dismissing the first non-split offer remains sticky after accepting the
+second simultaneous offer and regenerating the current root snapshot. -/
+def dismissThenSelectSticky : Bool :=
+  match twoOfferRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith twoOfferEnvelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits twoOfferEnvelope keyCost
+              (fun _ => { bytes := 1 }) resultMeasure recipeMeasure .depthFirst registry
+              dismissFirstSelectSecond 0 state with
+          | .ok (.stopped (.policyStop 1) stopped 2) =>
+              stopped.choices == 2 && stopped.dismissedIncomplete &&
+                stopped.session.incomplete && stopped.session.serial == 1 &&
+                version? stopped.session.branch n2 == some 1 &&
+                (match stopped.session.offers[0]? with
+                | some offer => offer.view.id.index == 2 && offer.view.offerClass == .split
+                | none => false)
+          | _ => false
+
+def stickyClearsAtSplit : Bool :=
+  match twoOfferRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith twoOfferEnvelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits twoOfferEnvelope keyCost
+              (fun _ => { bytes := 1 }) resultMeasure recipeMeasure .depthFirst registry
+              dismissFirstSelectSecond 0 state with
+          | .ok (.stopped (.policyStop 1) sticky 2) =>
+              match Controller.runWithin controllerLimits twoOfferEnvelope keyCost
+                  (fun _ => { bytes := 1 }) resultMeasure recipeMeasure .depthFirst registry
+                  oneThenStop 0 sticky with
+              | .ok (.stopped (.policyStop 1) child 1) =>
+                  child.choices == 3 && child.session.scope == leftScope &&
+                    !child.dismissedIncomplete && !child.session.incomplete
+              | _ => false
+          | _ => false
 
 def dismissedInvokeIncomplete : Bool :=
   match controllerRegistry? with
@@ -517,11 +684,16 @@ def sameKeyReplacementChecked : Bool :=
 #guard offerOneOver
 #guard hugeDraftRejected
 #guard hugeBindingRejected
+#guard effortOneOver
+#guard structuralBatchRejected
 #guard wrongClassRejected
 #guard transplantRejected
 #guard matcherEpochRejected
 #guard dismissedInvokeIncomplete
 #guard dismissedSplitComplete
+#guard twoOffersOrdered
+#guard dismissThenSelectSticky
+#guard stickyClearsAtSplit
 #guard ageIsSerial
 #guard sameKeyReplacementChecked
 

--- a/conformance/HexIntervalMathlib/ControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ControllerConformance.lean
@@ -1,0 +1,544 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Controller
+import HexIntervalMathlib.DriverConformance
+
+/-!
+# Autonomous controller conformance
+
+The generator table drives the existing nontrivial root-update, split,
+child-update, target, and sibling-refutation canary without caller-selected
+actions.  The resulting sealed bundle replays through the separately aligned
+proof registry to the same ordinary theorem.
+-/
+
+namespace Hex.IntervalMathlib.ControllerConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+open Hex.IntervalMathlib.DriverConformance
+
+/-- error: Unknown constant `Hex.Interval.Controller.Registry.mk` -/
+#guard_msgs in
+#check Controller.Registry.mk
+
+/-- error: Unknown constant `Hex.Interval.Controller.State.mk` -/
+#guard_msgs in
+#check Controller.State.mk
+
+/-- error: Unknown constant `Hex.Interval.Controller.Draft.age` -/
+#guard_msgs in
+#check Controller.Draft.age
+
+/-- error: Unknown constant `Hex.Interval.Controller.runWithin.loop` -/
+#guard_msgs in
+#check Controller.runWithin.loop
+
+private def version? (branch : State.Branch Fact Nat) (node : NodeId) : Option Nat :=
+  branch.versions[node.index]?
+
+private def scopedBinding (rule : RuleKey) (anchor : NodeId)
+    (inputs writes : List NodeId) : Option ScopeBinding :=
+  some { rule, anchor, watches := inputs, writes }
+
+def forwardApplication : Controller.Application Fact Nat Nat :=
+  { binding := fun selectedScope _ =>
+      if selectedScope == scope then
+        scopedBinding forwardRule n2 [n1] [n2]
+      else if selectedScope == leftScope then
+        scopedBinding forwardRule n3 [n0] [n3]
+      else none
+    offer := fun selectedScope branch =>
+      if selectedScope == scope && version? branch n2 == some 0 then
+        some
+          { key := 10
+            offerClass := .invoke
+            node := n2
+            effort := 0
+            inputs := [n1]
+            writes := [n2] }
+      else if selectedScope == leftScope && version? branch n3 == some 0 then
+        some
+          { key := 11
+            offerClass := .invoke
+            node := n3
+            effort := 0
+            inputs := [n0]
+            writes := [n3] }
+      else none }
+
+def targetApplication : Controller.Application Fact Nat Nat :=
+  { binding := fun selectedScope _ =>
+      if selectedScope == leftScope then
+        scopedBinding forwardRule n3 [n3] [n3]
+      else none
+    offer := fun selectedScope branch =>
+      if selectedScope == leftScope && version? branch n3 == some 1 then
+        some
+          { key := 12
+            offerClass := .invoke
+            node := n3
+            effort := 0
+            inputs := [n3]
+            writes := [n3] }
+      else none }
+
+def splitApplication : Controller.Application Fact Nat Nat :=
+  { binding := fun selectedScope _ =>
+      if selectedScope == scope then
+        scopedBinding splitRule n0 [n1, n0] []
+      else none
+    offer := fun selectedScope branch =>
+      if selectedScope == scope && version? branch n2 == some 1 then
+        some
+          { key := 20
+            offerClass := .split
+            node := n0
+            effort := 0
+            inputs := [n1, n0] }
+      else none }
+
+def refuteApplication : Controller.Application Fact Nat Nat :=
+  { binding := fun selectedScope _ =>
+      if selectedScope == rightScope then scopedBinding refuteRule n0 [n0] [] else none
+    offer := fun selectedScope _ =>
+      if selectedScope == rightScope then
+        some
+          { key := 30
+            offerClass := .invoke
+            node := n0
+            effort := 0
+            inputs := [n0] }
+      else none }
+
+private def updateC (request : Search.Request Fact Controller.OfferId Nat)
+    (node : NodeId) (previous : SeenVersion) (fact : Fact) (version cause : Nat) :
+    State.Update Fact Nat :=
+  { programVersion := request.programVersion, node, previous, fact, version, cause }
+
+private def eventC (request : Search.Request Fact Controller.OfferId Nat)
+    (item : State.Update Fact Nat) : Proof.Event Fact :=
+  .fact
+    { scope := request.scope, programVersion := request.programVersion,
+      action := request.action, node := item.node, previous := item.previous,
+      version := item.version, proposed := item.fact, installed := item.fact,
+      assumptions := request.action.inputs, schema := factKey, body := [11] }
+
+private def outcomeC (request : Search.Request Fact Controller.OfferId Nat)
+    (updates : Array (State.Update Fact Nat)) :
+    Search.Outcome Fact Nat Controller.OfferId Nat :=
+  { scope := request.scope, serial := request.serial,
+    programVersion := request.programVersion, offer := request.offer,
+    action := request.action, updates }
+
+def forwardRuntime : Driver.Package Fact Nat Controller.OfferId Nat (List Nat) :=
+  { rule := forwardRule
+    invoke := fun request =>
+      if request.scope == scope then
+        let item := updateC request n2 (seen n2 0) .yes 1 1
+        .continue { outcome := outcomeC request #[item], events := [eventC request item] }
+      else if request.scope == leftScope && request.action.inputs == [seen n0 0] then
+        let item := updateC request n3 (seen n3 0) .yes 1 2
+        .continue { outcome := outcomeC request #[item], events := [eventC request item] }
+      else
+        .target { outcome := outcomeC request #[], events := [] }
+          { scope := request.scope, programVersion := request.programVersion,
+            seen := seen n3 1 } }
+
+def splitRuntime : Driver.Package Fact Nat Controller.OfferId Nat (List Nat) :=
+  { rule := splitRule
+    invoke := fun request =>
+      .split
+        { echo := { outcome := outcomeC request #[], events := [] }
+          runtime :=
+            { scope := request.scope, programVersion := request.programVersion,
+              action := request.action, parent := seen n0 0, plan := [22],
+              schema := splitKey, body := [22] }
+          left := { node := n0, previous := seen n0 0, fact := .yes }
+          right := { node := n0, previous := seen n0 0, fact := .empty } } }
+
+def refuteRuntime : Driver.Package Fact Nat Controller.OfferId Nat (List Nat) :=
+  { rule := refuteRule
+    invoke := fun request =>
+      .refute { outcome := outcomeC request #[], events := [] }
+        { scope := request.scope, programVersion := request.programVersion,
+          seen := seen n0 0, schema := refuteKey, body := [33] } }
+
+def packages : Array (Controller.Package Fact Nat Nat (List Nat)) :=
+  #[{ runtime := forwardRuntime, applications := #[forwardApplication, targetApplication] },
+    { runtime := splitRuntime, applications := #[splitApplication] },
+    { runtime := refuteRuntime, applications := #[refuteApplication] }]
+
+def controllerLimits : Controller.Limits :=
+  { maxChoices := 5, policyState := { bytes := 4, pairs := 4, work := 4 }, driver := limits }
+
+def keyCost (_ : Nat) : Policy.Cost := { bytes := 1, work := 1 }
+
+def unitCost (_ : Unit) : Policy.Cost := { bytes := 1, work := 1 }
+
+def firstPolicy : Policy.Interface Fact Unit Controller.OfferId Nat :=
+  { choose := fun _ view =>
+      match view.offers[0]? with
+      | some offer => .select offer ()
+      | none => .stop () }
+
+def controllerKey : Controller.Key := { name := "controller-canary", version := 1 }
+
+def controllerRegistry? := do
+  let proof ← registry?
+  (Controller.Registry.buildWithin stateLimits controllerKey program proof packages).toOption
+
+def run := do
+  let some registry := controllerRegistry? | throw 1
+  let branch ← (State.Branch.startWithin stateLimits program input.facts).mapError fun _ => 2
+  let bundle ← (Driver.Bundle.startWithin limits resultMeasure recipeMeasure scope branch)
+    |>.mapError fun _ => 3
+  let measure := Controller.policyMeasure keyCost
+  let state ← (Controller.State.startWithin envelope measure registry bundle).mapError fun _ => 4
+  let result ← (Controller.runWithin controllerLimits envelope keyCost unitCost resultMeasure
+    recipeMeasure .depthFirst registry firstPolicy () state).mapError fun _ => 5
+  let .complete bundle _ := result | throw 6
+  pure bundle
+
+def replayRun := do
+  let some registry := controllerRegistry? | throw Proof.Error.invalidInput
+  let bundle ← run |>.mapError fun _ => Proof.Error.wrongTree
+  Proof.replayTree resultLimits resultMeasure proofLimits treeLimits registry.proof
+    factDomain laws input bundle.tree bundle.recipe
+
+#guard match run with | .ok _ => true | .error _ => false
+#guard match replayRun with | .ok _ => true | .error _ => false
+
+def wrongOwnerPackages : Array (Controller.Package Fact Nat Nat (List Nat)) :=
+  #[{ runtime := { forwardRuntime with rule := splitRule },
+      applications := #[forwardApplication, targetApplication] },
+    { runtime := splitRuntime, applications := #[splitApplication] },
+    { runtime := refuteRuntime, applications := #[refuteApplication] }]
+
+def wrongOwnerRejected : Bool :=
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof wrongOwnerPackages with
+      | .error _ => true
+      | .ok _ => false
+
+def generationRejected : Bool :=
+  let tooNew : Controller.Application Fact Nat Nat :=
+    { forwardApplication with generation := stateLimits.maxGeneration + 1 }
+  match packages[0]?, registry? with
+  | some first, some proof =>
+      let changed := packages.set! 0 { first with applications := #[tooNew] }
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error (.resource (.state .generation)) => true
+      | _ => false
+  | _, _ => false
+
+def choiceOneOver : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match State.Branch.startWithin stateLimits program input.facts with
+      | .error _ => false
+      | .ok branch =>
+          match Driver.Bundle.startWithin limits resultMeasure recipeMeasure scope branch with
+          | .error _ => false
+          | .ok bundle =>
+              let measure := Controller.policyMeasure keyCost
+              match Controller.State.startWithin envelope measure registry bundle with
+              | .error _ => false
+              | .ok state =>
+                  match Controller.runWithin { controllerLimits with maxChoices := 0 } envelope
+                      keyCost unitCost resultMeasure recipeMeasure .depthFirst registry firstPolicy ()
+                      state with
+                  | .error _ => true
+                  | .ok _ => false
+
+#guard wrongOwnerRejected
+#guard generationRejected
+#guard choiceOneOver
+
+private def withForward
+    (applications : Array (Controller.Application Fact Nat Nat)) :
+    Array (Controller.Package Fact Nat Nat (List Nat)) :=
+  match packages[0]? with
+  | none => #[]
+  | some first => packages.set! 0 { first with applications }
+
+def providerOneOver : Bool :=
+  let tooMany := withForward #[forwardApplication, targetApplication, forwardApplication,
+    targetApplication, forwardApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof tooMany with
+      | .error (.resource .applications) => true
+      | _ => false
+
+private def stateStartWith
+    (candidateEnvelope : Search.Envelope)
+    (registry : Controller.Registry Fact semantics Nat Nat (List Nat)) := do
+  let branch ← State.Branch.startWithin stateLimits program input.facts
+    |>.mapError fun _ => Controller.Error.mismatch
+  let bundle ← Driver.Bundle.startWithin limits resultMeasure recipeMeasure scope branch
+    |>.mapError Controller.Error.driver
+  Controller.State.startWithin candidateEnvelope (Controller.policyMeasure keyCost)
+    registry bundle
+
+def listCost (values : List Nat) : Policy.Cost :=
+  { bytes := values.length, pairs := values.length, work := values.length }
+
+def hugeStatePolicy : Policy.Interface Fact (List Nat) Controller.OfferId Nat :=
+  { choose := fun _ _ => .stop (List.replicate 5 0) }
+
+def hugeInitialPolicyRejected : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith envelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits envelope keyCost listCost resultMeasure
+              recipeMeasure .depthFirst registry hugeStatePolicy (List.replicate 5 0) state with
+          | .error (.resource .policyState) => true
+          | _ => false
+
+def hugeNextPolicyRejected : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith envelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits envelope keyCost listCost resultMeasure
+              recipeMeasure .depthFirst registry hugeStatePolicy [] state with
+          | .error (.resource .policyState) => true
+          | _ => false
+
+#guard hugeInitialPolicyRejected
+#guard hugeNextPolicyRejected
+
+def offerOneOver : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      let tight : Search.Envelope :=
+        { envelope with policy := { policyLimits with maxOffers := 0 } }
+      match stateStartWith tight registry with
+      | .error (.search (.policy .offerLimit)) => true
+      | _ => false
+
+def hugeDraftApplication : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    offer := fun selectedScope _ =>
+      if selectedScope == scope then
+        some
+          { key := 40
+            offerClass := .invoke
+            node := n2
+            effort := 0
+            inputs := List.replicate 3 n1
+            writes := [n2] }
+      else none }
+
+def hugeDraftRejected : Bool :=
+  let changed := withForward #[hugeDraftApplication, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith envelope registry with
+          | .error (.resource (.state .scopes)) => true
+          | _ => false
+
+def hugeBindingApplication : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    binding := fun selectedScope _ =>
+      if selectedScope == scope then
+        scopedBinding forwardRule n2 (List.replicate 3 n1) [n2]
+      else none }
+
+def hugeBindingRejected : Bool :=
+  let changed := withForward #[hugeBindingApplication, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith envelope registry with
+          | .error (.resource (.state .scopes)) => true
+          | _ => false
+
+def wrongClassApplication : Controller.Application Fact Nat Nat :=
+  { forwardApplication with
+    offer := fun selectedScope branch =>
+      if selectedScope == scope && version? branch n2 == some 0 then
+        some
+          { key := 41
+            offerClass := .split
+            node := n2
+            effort := 0
+            inputs := [n1]
+            writes := [n2] }
+      else none }
+
+def wrongClassRejected : Bool :=
+  let changed := withForward #[wrongClassApplication, targetApplication]
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof changed with
+      | .error _ => false
+      | .ok registry =>
+          match stateStartWith envelope registry with
+          | .error (.invalidApplication ⟨0⟩) => true
+          | _ => false
+
+def transplantRejected : Bool :=
+  match registry?, controllerRegistry? with
+  | some proof, some registry =>
+      let otherKey : Controller.Key := { name := "controller-canary", version := 2 }
+      match Controller.Registry.buildWithin stateLimits otherKey program proof packages with
+      | .error _ => false
+      | .ok other =>
+          match stateStartWith envelope registry with
+          | .error _ => false
+          | .ok state =>
+              match Controller.runWithin controllerLimits envelope keyCost unitCost resultMeasure
+                  recipeMeasure .depthFirst other firstPolicy () state with
+              | .error .mismatch => true
+              | _ => false
+  | _, _ => false
+
+def matcherEpochRejected : Bool :=
+  match registry? with
+  | none => false
+  | some proof =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof packages
+          #[] (stateLimits.maxGeneration + 1) with
+      | .error (.resource (.state .generation)) => true
+      | _ => false
+
+def oneThenStop : Policy.Interface Fact Nat Controller.OfferId Nat :=
+  { choose := fun count view =>
+      if count == 0 then
+        match view.offers[0]? with
+        | some offer => .select offer 1
+        | none => .stop count
+      else .stop count }
+
+def dismissThenStop : Policy.Interface Fact Bool Controller.OfferId Nat :=
+  { choose := fun dismissed view =>
+      if dismissed then .stop true else
+        match view.offers[0]? with
+        | some offer => .dismiss offer true
+        | none => .stop false }
+
+def boolCost (_ : Bool) : Policy.Cost := { bytes := 1, work := 1 }
+
+def dismissedInvokeIncomplete : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith envelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits envelope keyCost boolCost resultMeasure
+              recipeMeasure .depthFirst registry dismissThenStop false state with
+          | .ok (.stopped (.policyStop 0) state true) =>
+              state.choices == 1 && state.session.incomplete && state.session.offers.isEmpty
+          | _ => false
+
+def dismissedSplitComplete : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith envelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits envelope keyCost (fun _ => { bytes := 1 })
+              resultMeasure recipeMeasure .depthFirst registry oneThenStop 0 state with
+          | .ok (.stopped (.policyStop 1) splitState 1) =>
+              match Controller.runWithin controllerLimits envelope keyCost boolCost resultMeasure
+                  recipeMeasure .depthFirst registry dismissThenStop false splitState with
+              | .ok (.stopped (.policyStop 0) stopped true) =>
+                  stopped.choices == 2 && !stopped.session.incomplete &&
+                    stopped.session.offers.isEmpty
+              | _ => false
+          | _ => false
+
+def ageIsSerial : Bool :=
+  match controllerRegistry? with
+  | none => false
+  | some registry =>
+      match stateStartWith envelope registry with
+      | .error _ => false
+      | .ok state =>
+          match Controller.runWithin controllerLimits envelope keyCost (fun _ => { bytes := 1 })
+              resultMeasure recipeMeasure .depthFirst registry oneThenStop 0 state with
+          | .ok (.stopped (.policyStop 1) state 1) =>
+              state.session.serial == 1 && state.session.offers.all fun offer =>
+                offer.view.age == state.session.serial &&
+                  offer.action.serial == state.session.serial
+          | _ => false
+
+def stoppingForward : Driver.Package Fact Nat Controller.OfferId Nat (List Nat) :=
+  { rule := forwardRule, invoke := fun _ => .stop 7 }
+
+/-- Same-key assembly replacement is a deliberate trusted compatibility
+declaration, not callback-body identity. The replacement still crosses the
+checked callback and stop-code boundary. -/
+def sameKeyReplacementChecked : Bool :=
+  let replacement := match packages[0]? with
+    | none => #[]
+    | some first => packages.set! 0 { first with runtime := stoppingForward }
+  match registry?, controllerRegistry? with
+  | some proof, some original =>
+      match Controller.Registry.buildWithin stateLimits controllerKey program proof replacement with
+      | .error _ => false
+      | .ok other =>
+          match stateStartWith envelope original with
+          | .error _ => false
+          | .ok state =>
+              match Controller.runWithin controllerLimits envelope keyCost unitCost resultMeasure
+                  recipeMeasure .depthFirst other firstPolicy () state with
+              | .ok (.stopped (.callbackFailure 7) _ _) => true
+              | _ => false
+  | _, _ => false
+
+#guard providerOneOver
+#guard offerOneOver
+#guard hugeDraftRejected
+#guard hugeBindingRejected
+#guard wrongClassRejected
+#guard transplantRejected
+#guard matcherEpochRejected
+#guard dismissedInvokeIncomplete
+#guard dismissedSplitComplete
+#guard ageIsSerial
+#guard sameKeyReplacementChecked
+
+def evidence : Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  match replayRun with
+  | .ok evidence => evidence
+  | .error _ => Hex.IntervalMathlib.DriverConformance.evidence
+
+theorem controllerCanary :
+    semantics.Entails input.program (Proof.initialBase input) input.target :=
+  evidence.proof
+
+/--
+info: 'Hex.IntervalMathlib.ControllerConformance.controllerCanary' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms controllerCanary
+
+end Hex.IntervalMathlib.ControllerConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -536,6 +536,7 @@ lean_lib HexConformance where
       `HexInterval.SearchConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
+      `HexIntervalMathlib.ControllerConformance,
       `HexIntervalMathlib.RuleConformance,
       `HexIntervalMathlib.FrontendConformance,
       `HexIntervalMathlib.TacticConformance,

--- a/progress/20260821T225244Z.md
+++ b/progress/20260821T225244Z.md
@@ -1,0 +1,49 @@
+# Supported autonomous fact-event controller
+
+## Accomplished
+
+- Added a supported Mathlib controller which aligns a stable application table
+  with same-order runtime packages and proof registrations, regenerates
+  authenticated offers from the current sealed branch, and repeatedly applies
+  a replaceable policy through the retained-tree driver.
+- Made resource admission precede controller-owned traversal and retention for
+  programs, registrations, branches, bindings, applications, action ports,
+  structural inputs, offers, generations, effort, and cumulative choices.
+- Made application identity, rule routing, action chronology, dependency
+  generations, matcher epoch, and offer age controller-owned rather than
+  callback-owned.
+- Added a caller-owned logical policy-state measure and independent byte, pair,
+  and work caps for the initial state and every callback successor before
+  retention, with huge-state rejection guards.
+- Defined registry keys as explicit trusted compatibility epochs: wrong-key
+  state transplants fail, while same-key replacement callbacks remain allowed
+  and their outputs still cross the supported runtime and proof checks.
+- Added a nontrivial conformance vertical covering root propagation, splitting,
+  child-local propagation, target and refutation leaves, recursive proof replay,
+  and an ordinary theorem, plus malformed and one-over guards.
+- Made dismissal conservative for non-split offers, pinned the internal loop's
+  ordinary-import invisibility, and documented that the live vertical still
+  uses toy callbacks rather than shipped built-in arithmetic driver adapters.
+- Updated the supported umbrella, file maps, current-state specifications,
+  conformance registration, and ordinary-import sealed-module check.
+- Recorded the exact proof-only Lake transition for the new conformance target;
+  the measured factorization executable dependency graph is unchanged.
+
+## Current frontier
+
+The supported programmatic controller now provides deterministic autonomous
+offer generation and policy iteration for explicitly assembled Mathlib
+fact-event packages. Its choice budget is cumulative per returned sealed state
+lineage; starting a new handle or reusing a pure prior state creates a separate
+bounded lineage rather than a process-global budget.
+
+## Next step
+
+Mechanically restack this edge onto current main, then review publication of the
+controller before connecting the public tactic to split search.
+
+## Blockers
+
+None. Automatic package discovery, Mathlib-free raw package drafts,
+equality/instance runtime events, program extension, default policy selection,
+and public tactic split-search integration remain separate work.

--- a/progress/20260822T003148Z.md
+++ b/progress/20260822T003148Z.md
@@ -4,8 +4,9 @@
 
 - Moved non-split dismissal incompleteness into the sealed controller state so
   an accepted action and offer regeneration in the same scope cannot erase it.
-- Cleared the sticky incomplete bit only when a split or terminal transition
-  advances the retained-tree head to a new scope.
+- Cleared the sticky incomplete bit on a split or terminal transition to a new
+  retained scope within a returned state lineage. Explicitly starting a new
+  handle is a separate reset boundary, including at the same retained scope.
 - Added a genuine two-offer snapshot with stable table order, dismiss-first and
   select-second behavior, accepted regeneration, sticky-state persistence, and
   split-scope clearing guards.
@@ -17,8 +18,8 @@
 ## Current frontier
 
 The explicit fact-event controller now preserves conservative incompleteness
-through every accepted refresh in one scope and resets it only with the next
-authenticated retained-tree scope.
+through every accepted refresh in one scope within a returned handle. A new
+handle deliberately resets it together with controller/search chronology.
 
 ## Next step
 

--- a/progress/20260822T003148Z.md
+++ b/progress/20260822T003148Z.md
@@ -1,0 +1,31 @@
+# Controller dismissal lifetime hardening
+
+## Accomplished
+
+- Moved non-split dismissal incompleteness into the sealed controller state so
+  an accepted action and offer regeneration in the same scope cannot erase it.
+- Cleared the sticky incomplete bit only when a split or terminal transition
+  advances the retained-tree head to a new scope.
+- Added a genuine two-offer snapshot with stable table order, dismiss-first and
+  select-second behavior, accepted regeneration, sticky-state persistence, and
+  split-scope clearing guards.
+- Added the exact successful five-choice versus four-choice-cap discriminator,
+  an effort one-over guard, and a structural-input batch refusal guard.
+- Clarified that controller completion means an empty pending runtime frontier,
+  not proof closure.
+
+## Current frontier
+
+The explicit fact-event controller now preserves conservative incompleteness
+through every accepted refresh in one scope and resets it only with the next
+authenticated retained-tree scope.
+
+## Next step
+
+Obtain fresh exact-head review and CI, then merge the controller before adding
+concrete built-in arithmetic callback/application adapters.
+
+## Blockers
+
+None. Concrete built-in arithmetic driver adapters and public tactic split
+search remain separate work.

--- a/progress/20260822T010049Z.md
+++ b/progress/20260822T010049Z.md
@@ -1,0 +1,32 @@
+# Controller run-handle and draft validation repair
+
+## Accomplished
+
+- Made the dismissal-incomplete lifetime exact: it is sticky within one sealed
+  controller-state lineage, while explicit `State.startWithin` creates a new
+  handle and resets controller choices/latch plus search serial/steps/trace.
+- Added a same-head restart discriminator showing that the pending runtime head
+  remains while the new handle inherits neither incompleteness nor proof closure.
+- Rejected duplicate Draft inputs, writes, and structural inputs, absent output
+  nodes, and mismatched matcher structure as `invalidApplication` before Search
+  session construction; retained resource-first list caps and added a valid
+  network/structural-input application discriminator.
+- Pinned the selected second offer's retained fact event to application id 1 and
+  made the zero-choice refusal assert the exact controller resource.
+- Corrected current-state resource prose to include entry/replacement bundle
+  validation and regenerated-session authentication on selected steps.
+
+## Current frontier
+
+The explicit fact-event controller has an honest per-handle dismissal contract
+and attributes bounded malformed generator output at the controller boundary.
+
+## Next step
+
+Complete full affected builds and static gates, then update PR #9361 and monitor
+its exact-head automatic CI.
+
+## Blockers
+
+None. Concrete built-in arithmetic driver adapters and public tactic split
+search remain later work.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -656,7 +656,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "6c284c54c8f55ac42b1150b3b279a84b5361aca9",
-    "reason": "Additionally registers the Mathlib-free source-correlated FKS2 theorem-6.2 nested-log checker, its proof-only real-semantics companion, and conformance module on top of the retained mu, positive-exp, supported driver, Dusart, Chebyshev, LogTables, FKS2, and public interval registrations; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+    "current_blob": "dfcd8629a933ac9f3721bbcc261be34211bcf3a6",
+    "reason": "Additionally registers the supported HexIntervalMathlib autonomous fact-event controller conformance module and the Mathlib-free source-correlated FKS2 theorem-6.2 nested-log checker, proof-only real-semantics companion, and conformance module on top of the retained mu, positive-exp, supported driver, Dusart, Chebyshev, LogTables, FKS2, and public interval registrations; these proof-only modules do not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -34,6 +34,7 @@ IMPORT_ALL_RE = re.compile(
 SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexInterval.Search": frozenset(),
     "HexIntervalMathlib.Driver": frozenset(),
+    "HexIntervalMathlib.Controller": frozenset(),
     "HexIntervalMathlib.Proof": frozenset(),
 }
 


### PR DESCRIPTION
## Summary

- add a supported explicit fact-event controller whose stable application table aligns same-order runtime packages and proof registrations
- regenerate bounded authenticated offers from the sealed current branch and iterate a replaceable policy through the retained-tree driver
- route every selected ApplicationId through the exact application-to-rule table and revalidate runtime results before retaining them
- measure and cap the initial policy state and every callback successor before retention
- exercise root propagation, splitting, child-local propagation, target and refutation leaves, and ordinary-theorem replay end to end

## Resource and trust boundary

Generator, runtime, policy, equality, and logical-measure callbacks remain explicitly non-preemptible. Controller-owned traversal and retention are resource-first for programs, registrations, branches, bindings, action ports, structural inputs, applications, offers, generations, effort, policy state, and cumulative choices. Runtime bundles and recipes remain untrusted until the supported proof replay checks them. Registry keys are trusted compatibility epochs rather than callback-object hashes; same-key replacements remain independently checked. Choice accounting is per returned sealed State lineage, not process-global. Policy stop returns a resumable chunk boundary; exhausting maxChoices is a resource error. Malformed drafts abort regeneration transactionally.

Dismissal is conservative: dropping an invoke, retry, instantiate, or equality offer marks the snapshot incomplete, while dropping a split probe does not. Every offer in one immutable snapshot has the same controller-owned serial age.

## Scope

This is the generic autonomous propagator framework for explicitly assembled Mathlib fact-event packages. Its end-to-end conformance uses toy callbacks. Concrete built-in arithmetic Driver.Package callbacks and application generators are not yet shipped. Automatic package discovery, Mathlib-free raw package drafts, equality and instance runtime events, program extension, default policy selection, and public tactic split-search integration remain separate work.

## Verification

- lake build HexIntervalMathlib HexConformance (9592 jobs)
- lake build HexIntervalMathlib.ControllerConformance
- DAG checker and regression
- trust-surface check
- factor-sweep freshness check
- PNT inventory and unit tests
- git diff --check
