### PR TITLE
feat(interval): add checked executable package assembly

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -13,6 +13,7 @@ public import HexInterval.State
 public import HexInterval.Trace
 public import HexInterval.Policy
 public import HexInterval.Search
+public import HexInterval.Executable
 
 public section
 
@@ -49,10 +50,14 @@ checked current parent snapshot and one exact seed delta, retains explicit
 target/refutation/unknown terminals, and carries no theorem authority. A
 deliberate `import all HexInterval.Search` is trusted implementation access,
 not decoded-runtime authority, and repository checks reject accidental uses.
-Concrete callbacks and offer generation, policy implementations, a complete
-branch-search loop, and measurement-selected storage remain experimental. The
-Mathlib companion supplies a bounded authenticated callback-to-tree-recipe
-step driver; package callbacks and their recipe data remain untrusted. Exact public interval
+The supported executable assembly now joins explicit stable-key package
+declarations, private caches, checked callback routes, bounded raw replay
+formats, and an exact concrete application table for one program. Its raw
+quotations are not Mathlib proof events or evidence. Offer generation, policy
+implementations, a complete branch-search loop, and measurement-selected
+storage remain experimental. The Mathlib companion supplies a bounded
+authenticated callback-to-tree-recipe step driver; package callbacks and their
+recipe data remain untrusted. Exact public interval
 splitting is already supported; the Mathlib companion separately owns flat
 forward replay and checked retained-tree proof folding.
 -/

--- a/HexInterval/Executable.lean
+++ b/HexInterval/Executable.lean
@@ -1,0 +1,683 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.State
+
+@[expose] public section
+
+/-!
+# Checked executable package assembly
+
+This module is the supported Mathlib-free assembly boundary for executable
+function packages. It joins stable operation and rule declarations, private
+package caches, exact callback routes, and the concrete application table for
+one checked program. It does not generate offers, choose a policy, mutate a
+branch, or grant theorem evidence.
+
+Callbacks may return bounded raw replay quotations. A quotation contains only
+its role, package-local schema number, and natural-number body. It deliberately
+does not contain a Mathlib proof event. A later companion layer must correlate
+each quotation with an accepted runtime transition and a package-owned theorem
+schema before it can contribute evidence.
+
+Package callbacks and measure functions are trusted executable configuration
+and remain non-preemptible. Decoded programs, bindings, actions, requests,
+quotations, and callback results receive no authority from that fact: every
+public transition below rechecks their complete structural correspondence.
+
+Here "sealed" means sealed at the ordinary/public import boundary. Lean's
+deliberate `import all HexInterval.Executable` exposes private constructors to
+trusted source, which is already outside the decoded-runtime threat model. A
+repository static check rejects that escape hatch outside an exact reviewed
+allowlist.
+-/
+
+namespace Hex.Interval.Executable
+
+/-- Logical retained cost supplied by the package which owns the measured
+cache or result. These numbers are resource policy, never theorem evidence. -/
+structure Cost where
+  bytes : Nat := 0
+  work : Nat := 0
+  deriving DecidableEq, Repr
+
+namespace Cost
+
+def add (left right : Cost) : Cost :=
+  { bytes := left.bytes + right.bytes, work := left.work + right.work }
+
+instance : Add Cost := ⟨add⟩
+
+def allowed (bytes work : Nat) (cost : Cost) : Bool :=
+  cost.bytes ≤ bytes && cost.work ≤ work
+
+end Cost
+
+/-- The future semantic consumer of one raw quotation. -/
+inductive Role where
+  | fact
+  | equality
+  | instance
+  deriving DecidableEq, Repr
+
+/-- Complete stable address of one replay representation. -/
+structure ReplayKey where
+  rule : RuleKey
+  role : Role
+  schema : Nat
+  deriving DecidableEq, Repr
+
+/-- A bounded Mathlib-free replay quotation. It is inert data until a later
+companion authenticates its runtime identity and theorem schema. -/
+structure Quote where
+  role : Role
+  schema : Nat
+  body : List Nat
+  deriving DecidableEq, Repr
+
+/-- One cache-independent representation declared by a handler. The validator
+checks encoding shape only; it cannot establish a mathematical proposition. -/
+structure ReplayFormat where
+  role : Role
+  schema : Nat
+  validateBody : List Nat → Bool
+
+namespace ReplayFormat
+
+def sameAddress (left right : ReplayFormat) : Bool :=
+  left.role == right.role && left.schema == right.schema
+
+def key (rule : RuleKey) (format : ReplayFormat) : ReplayKey :=
+  { rule, role := format.role, schema := format.schema }
+
+def accepts (format : ReplayFormat) (quote : Quote) : Bool :=
+  format.role == quote.role && format.schema == quote.schema &&
+    format.validateBody quote.body
+
+end ReplayFormat
+
+/-- One package result paired with raw, still-untrusted replay quotations. -/
+structure Plan (Result : Type) where
+  result : Result
+  quotes : Array Quote := #[]
+
+/-- A registration resolved against one concrete program node. Structural
+inputs and matcher epoch are retained explicitly; the initial compiler emits
+only local and scoped applications, for which both fields are empty. -/
+structure Application where
+  rule : RuleId
+  node : NodeId
+  kind : ActionKind
+  watches : List NodeId
+  writes : List NodeId
+  structuralInputs : List StructuralInput := []
+  matcherEpoch : Option Nat := none
+  effort : Nat
+  generation : Nat := 0
+  deriving Repr
+
+namespace Application
+
+def same (left right : Application) : Bool :=
+  left.rule == right.rule && left.node == right.node && left.kind == right.kind &&
+    left.watches == right.watches && left.writes == right.writes &&
+      left.structuralInputs == right.structuralInputs &&
+        left.matcherEpoch == right.matcherEpoch && left.effort == right.effort &&
+          left.generation == right.generation
+
+/-- Authenticate every action field owned by one exact application-table row. -/
+def accepts (id : ApplicationId) (application : Application) (action : Action) : Bool :=
+  action.application == id && action.rule == application.rule &&
+    action.node == application.node && action.kind == application.kind &&
+      action.inputs.map (·.node) == application.watches &&
+        action.writes == application.writes &&
+          action.structuralInputs == application.structuralInputs &&
+            action.matcherEpoch == application.matcherEpoch &&
+              action.effort == application.effort &&
+                action.generation == application.generation
+
+end Application
+
+/-- Package-owned logical measures. `metadata` charges the immutable package
+declarations, `application` charges each concrete application owned by one of
+its handlers, `cache` charges the retained private cache, and `result` charges
+one callback result before it is returned. -/
+structure Measure (Cache Result : Type) where
+  metadata : Cost
+  application : Application → Cost
+  cache : Cache → Cost
+  result : Result → Cost
+
+/-- One registration and the only callback allowed to interpret its rule key. -/
+structure Handler (Fact Result Cache : Type) where
+  registration : Registration
+  invoke : Cache → RuleRequest Fact → Plan Result × Cache
+  /-- Package-owned semantic veto for a structurally valid scoped binding.
+  Local registrations do not call this hook. -/
+  acceptsScope : Program → ScopeBinding → Bool := fun _ _ => false
+  formats : Array ReplayFormat := #[]
+
+/-- An independently assembled executable package with one private cache type. -/
+structure Package (Fact Result : Type) where
+  Cache : Type
+  cache : Cache
+  operations : Array Operation := #[]
+  requiredOperations : Array Operation := #[]
+  handlers : Array (Handler Fact Result Cache)
+  measure : Measure Cache Result
+
+/-- Exact route from a flattened rule identifier to its package handler. -/
+structure Route where
+  package : Nat
+  handler : Nat
+  deriving DecidableEq, Repr
+
+/-- Every old application, including structural inputs and creation generation,
+must remain an exact prefix after an accepted program extension. -/
+def applicationsPrefix (before after : Array Application) : Bool := Id.run do
+  if after.size < before.size then return false
+  for index in [0:before.size] do
+    let some old := before[index]? | return false
+    let some new := after[index]? | return false
+    if !old.same new then return false
+  return true
+
+/-- Independent assembly and invocation caps. `state` owns structural table
+dimensions; the remaining fields bound package-owned logical measurements and
+raw quotation encodings. -/
+structure Limits where
+  state : State.Limits
+  maxPackages : Nat
+  maxMetadataBytes : Nat
+  maxMetadataWork : Nat
+  maxCacheBytes : Nat
+  maxCacheWork : Nat
+  maxResultBytes : Nat
+  maxResultWork : Nat
+  maxQuotes : Nat
+  maxQuoteCells : Nat
+  maxAtom : Nat
+  maxSchema : Nat
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | state (resource : State.Resource)
+  | packages
+  | metadataBytes
+  | metadataWork
+  | cacheBytes
+  | cacheWork
+  | resultBytes
+  | resultWork
+  | quotes
+  | quoteCells
+  | atom
+  | schema
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | invalidProgram
+  | invalidRegistrations
+  | invalidBindings
+  | programRejected
+  | duplicateOperation (key : OpKey)
+  | duplicateRule (key : RuleKey)
+  | duplicateFormat (key : ReplayKey)
+  | undeclaredHead (rule : RuleKey) (head : OpKey)
+  | invalidApplication
+  | invalidRequest
+  | wrongRoute
+  | undeclaredFormat (key : ReplayKey)
+  | invalidBody (key : ReplayKey)
+  | nonExtension
+  | staleGeneration
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+/-- One checked registry snapshot. Its constructor is private so routes cannot
+be transplanted independently of packages and flattened registrations. -/
+structure Registry (Fact Result : Type) where
+  private mk ::
+  packages : Array (Package Fact Result)
+  operations : Array Operation
+  registrations : Array Registration
+  routes : Array Route
+  metadataCost : Cost
+  cacheCost : Cost
+
+/-- The sealed correspondence between one program, executable registry, scope
+bindings, and concrete application table. -/
+structure Assembly (Fact Result : Type) where
+  private mk ::
+  program : Program
+  bindings : Array ScopeBinding
+  registry : Registry Fact Result
+  applications : Array Application
+
+/-- A successful callback result retains the exact selected route, owner, and
+validated raw quotations. No field is theorem evidence. -/
+structure Invocation (Result : Type) where
+  private mk ::
+  route : Route
+  rule : RuleKey
+  result : Result
+  quotes : Array Quote
+
+private def makeRegistry (packages : Array (Package Fact Result))
+    (operations : Array Operation) (registrations : Array Registration)
+    (routes : Array Route) (metadataCost cacheCost : Cost) : Registry Fact Result :=
+  { packages, operations, registrations, routes, metadataCost, cacheCost }
+
+private def makeAssembly (program : Program) (bindings : Array ScopeBinding)
+    (registry : Registry Fact Result) (applications : Array Application) :
+    Assembly Fact Result :=
+  { program, bindings, registry, applications }
+
+private def makeInvocation (route : Route) (rule : RuleKey)
+    (result : Result) (quotes : Array Quote) : Invocation Result :=
+  { route, rule, result, quotes }
+
+private def replacePackage (registry : Registry Fact Result) (index : Nat)
+    (package : Package Fact Result) (cacheCost : Cost) : Registry Fact Result :=
+  { registry with
+    packages := registry.packages.set! index package
+    cacheCost }
+
+private def listWithin (limit : Nat) : List α → Bool
+  | [] => true
+  | _ :: items => limit != 0 && listWithin (limit - 1) items
+
+private def checkProgramLimits (limits : State.Limits) (program : Program) :
+    Except Error Unit := do
+  if limits.maxOperations < program.operations.size then
+    throw (.resource (.state .operations))
+  if limits.maxNodes < program.nodes.size then throw (.resource (.state .nodes))
+  if program.operations.any (fun operation => !listWithin limits.maxArity operation.inputs) ||
+      program.nodes.any (fun node => !listWithin limits.maxArity node.args) then
+    throw (.resource (.state .arity))
+  let some depths := program.depths? | throw .invalidProgram
+  if depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (.resource (.state .nodeDepth))
+
+private def addOperations : List Operation → Array Operation →
+    Except Error (Array Operation)
+  | [], operations => pure operations
+  | operation :: rest, operations =>
+      if operations.any (fun existing => existing.key == operation.key) then
+        throw (.duplicateOperation operation.key)
+      else
+        addOperations rest (operations.push operation)
+
+private def declaresOperation (operations required : Array Operation) (key : OpKey) : Bool :=
+  operations.any (fun operation => operation.key == key) ||
+    required.any (fun operation => operation.key == key)
+
+private def duplicateFormat? (rule : RuleKey) : List ReplayFormat → Option ReplayKey
+  | [] => none
+  | format :: formats =>
+      if formats.any (fun other => format.sameAddress other) then
+        some (format.key rule)
+      else
+        duplicateFormat? rule formats
+
+private def validateHandlers (operations required : Array Operation) :
+    List (Handler Fact Result Cache) → Except Error Unit
+  | [] => pure ()
+  | handler :: handlers =>
+      if !declaresOperation operations required handler.registration.head then
+        throw (.undeclaredHead handler.registration.key handler.registration.head)
+      else
+        match duplicateFormat? handler.registration.key handler.formats.toList with
+        | some key => throw (.duplicateFormat key)
+        | none => validateHandlers operations required handlers
+
+private def addHandlers (packageIndex : Nat) : Nat →
+    List (Handler Fact Result Cache) → Array Registration → Array Route →
+      Except Error (Array Registration × Array Route)
+  | _, [], registrations, routes => pure (registrations, routes)
+  | handlerIndex, handler :: rest, registrations, routes =>
+      if registrations.any (fun existing => existing.key == handler.registration.key) then
+        throw (.duplicateRule handler.registration.key)
+      else
+        addHandlers packageIndex (handlerIndex + 1) rest
+          (registrations.push handler.registration)
+          (routes.push { package := packageIndex, handler := handlerIndex })
+
+private def flatten : Nat → List (Package Fact Result) → Array Operation →
+    Array Registration → Array Route →
+      Except Error (Array Operation × Array Registration × Array Route)
+  | _, [], operations, registrations, routes =>
+      pure (operations, registrations, routes)
+  | packageIndex, package :: rest, operations, registrations, routes => do
+      validateHandlers package.operations package.requiredOperations package.handlers.toList
+      let operations ← addOperations package.operations.toList operations
+      let (registrations, routes) ←
+        addHandlers packageIndex 0 package.handlers.toList registrations routes
+      flatten (packageIndex + 1) rest operations registrations routes
+
+private def packagePreflight (limits : Limits) (packages : Array (Package Fact Result)) :
+    Except Error (Cost × Cost) := do
+  if limits.maxPackages < packages.size then throw (.resource .packages)
+  if limits.state.maxRegistryEntries < packages.size then
+    throw (.resource (.state .registryEntries))
+  let mut operationCount := 0
+  let mut ruleCount := 0
+  let mut formatCount := 0
+  let mut metadataCells := packages.size
+  let mut metadataCost : Cost := {}
+  let mut cacheCost : Cost := {}
+  for package in packages do
+    operationCount := operationCount + package.operations.size
+    if limits.state.maxOperations < operationCount then
+      throw (.resource (.state .operations))
+    ruleCount := ruleCount + package.handlers.size
+    if limits.state.maxRules < ruleCount then throw (.resource (.state .rules))
+    let packageFormats := package.handlers.foldl
+      (fun count handler => count + handler.formats.size) 0
+    formatCount := formatCount + packageFormats
+    if limits.state.maxReplayFormats < formatCount then
+      throw (.resource (.state .replayFormats))
+    metadataCells := metadataCells + package.operations.size +
+      package.requiredOperations.size + package.handlers.size + packageFormats
+    if limits.state.maxRegistryEntries < metadataCells then
+      throw (.resource (.state .registryEntries))
+    if package.operations.any
+        (fun operation => !listWithin limits.state.maxArity operation.inputs) ||
+        package.requiredOperations.any
+          (fun operation => !listWithin limits.state.maxArity operation.inputs) then
+      throw (.resource (.state .arity))
+    if package.handlers.any (fun handler =>
+        handler.registration.binding == .local &&
+          (!listWithin (limits.state.maxArity + 1) handler.registration.watches ||
+            !listWithin (limits.state.maxArity + 1) handler.registration.writes)) then
+      throw (.resource (.state .arity))
+    if package.handlers.any (fun handler =>
+        handler.registration.binding == .scoped &&
+          (!listWithin limits.state.maxScopeNodes handler.registration.watches ||
+            !listWithin limits.state.maxScopeNodes handler.registration.writes)) then
+      throw (.resource (.state .scopes))
+    if package.handlers.any (fun handler =>
+        handler.registration.binding == .global &&
+          (!listWithin 0 handler.registration.watches ||
+            !listWithin 0 handler.registration.writes)) then
+      throw (.resource (.state .arity))
+    if package.handlers.any (fun handler =>
+        limits.state.maxEffort < handler.registration.initialEffort) then
+      throw (.resource (.state .effort))
+    if package.handlers.any (fun handler =>
+        handler.formats.any (fun format => limits.maxSchema < format.schema)) then
+      throw (.resource .schema)
+    metadataCost := metadataCost + package.measure.metadata
+    cacheCost := cacheCost + package.measure.cache package.cache
+    if !metadataCost.allowed limits.maxMetadataBytes limits.maxMetadataWork then
+      if limits.maxMetadataBytes < metadataCost.bytes then throw (.resource .metadataBytes)
+      else throw (.resource .metadataWork)
+    if !cacheCost.allowed limits.maxCacheBytes limits.maxCacheWork then
+      if limits.maxCacheBytes < cacheCost.bytes then throw (.resource .cacheBytes)
+      else throw (.resource .cacheWork)
+  pure (metadataCost, cacheCost)
+
+private opaque buildRegistry (limits : Limits) (packages : Array (Package Fact Result)) :
+    Except Error (Registry Fact Result) :=
+  match packagePreflight limits packages with
+  | .error error => .error error
+  | .ok (metadataCost, cacheCost) =>
+      match flatten 0 packages.toList #[] #[] #[] with
+      | .error error => .error error
+      | .ok (operations, registrations, routes) =>
+          .ok (makeRegistry packages operations registrations routes metadataCost cacheCost)
+
+def operationAccepted (program : Program) (expected : Operation) : Bool :=
+  (program.operationWithKey? expected.key).any fun actual =>
+    actual.inputs == expected.inputs && actual.output == expected.output
+
+def Registry.acceptsProgram (registry : Registry Fact Result) (program : Program) : Bool :=
+  registry.operations.all (operationAccepted program) &&
+    registry.packages.all fun package =>
+      package.requiredOperations.all (operationAccepted program)
+
+private def Registry.acceptsBinding (registry : Registry Fact Result)
+    (program : Program) (binding : ScopeBinding) : Bool :=
+  match Registration.find? registry.registrations binding.rule with
+  | none => false
+  | some (ruleId, registration) =>
+      match registry.routes[ruleId.index]? with
+      | none => false
+      | some route =>
+          match registry.packages[route.package]? with
+          | none => false
+          | some package =>
+              match package.handlers[route.handler]? with
+              | none => false
+              | some handler =>
+                  registration.binding == .scoped &&
+                    registration.same handler.registration &&
+                      ScopeBinding.check program registry.registrations binding &&
+                        handler.acceptsScope program binding
+
+private def Registry.acceptsBindings (registry : Registry Fact Result)
+    (program : Program) (bindings : Array ScopeBinding) : Bool :=
+  ScopeBinding.checkAll program registry.registrations bindings &&
+    bindings.all (registry.acceptsBinding program)
+
+private def compileWithin (limit : Nat) (program : Program)
+    (rules : Array Registration) (bindings : Array ScopeBinding) (generation : Nat := 0) :
+    Except Error (Array Application) := do
+  let mut applications := #[]
+  for binding in bindings do
+    if limit ≤ applications.size then throw (.resource (.state .applications))
+    let some (ruleId, rule) := Registration.find? rules binding.rule
+      | throw .invalidBindings
+    applications := applications.push
+      { rule := ruleId, node := binding.anchor, kind := rule.kind
+        watches := binding.watches, writes := binding.writes
+        effort := rule.initialEffort, generation }
+  for nodeIndex in [0:program.nodes.size] do
+    let some node := program.nodes[nodeIndex]? | throw .invalidProgram
+    let some operation := program.operation? node.op | throw .invalidProgram
+    for ruleIndex in [0:rules.size] do
+      let some rule := rules[ruleIndex]? | throw .invalidRegistrations
+      if rule.binding == .local && rule.head == operation.key then
+        if limit ≤ applications.size then throw (.resource (.state .applications))
+        let some watches := Slot.resolveAll? { index := nodeIndex } node rule.watches
+          | throw .invalidRegistrations
+        let some writes := Slot.resolveAll? { index := nodeIndex } node rule.writes
+          | throw .invalidRegistrations
+        applications := applications.push
+          { rule := { index := ruleIndex }, node := { index := nodeIndex }, kind := rule.kind
+            watches, writes, effort := rule.initialEffort, generation }
+  pure applications
+
+private def compileSuffixWithin (limit start generation : Nat) (program : Program)
+    (rules : Array Registration) : Except Error (Array Application) := do
+  let mut applications := #[]
+  for nodeIndex in [start:program.nodes.size] do
+    let some node := program.nodes[nodeIndex]? | throw .invalidProgram
+    let some operation := program.operation? node.op | throw .invalidProgram
+    for ruleIndex in [0:rules.size] do
+      let some rule := rules[ruleIndex]? | throw .invalidRegistrations
+      if rule.binding == .local && rule.head == operation.key then
+        if limit ≤ applications.size then throw (.resource (.state .applications))
+        let some watches := Slot.resolveAll? { index := nodeIndex } node rule.watches
+          | throw .invalidRegistrations
+        let some writes := Slot.resolveAll? { index := nodeIndex } node rule.writes
+          | throw .invalidRegistrations
+        applications := applications.push
+          { rule := { index := ruleIndex }, node := { index := nodeIndex }, kind := rule.kind
+            watches, writes, effort := rule.initialEffort, generation }
+  pure applications
+
+private def applicationCost (registry : Registry Fact Result)
+    (applications : Array Application) : Except Error Cost := do
+  let mut cost : Cost := {}
+  for index in [0:applications.size] do
+    let some application := applications[index]? | throw .invalidApplication
+    let some route := registry.routes[application.rule.index]? | throw .wrongRoute
+    let some package := registry.packages[route.package]? | throw .wrongRoute
+    cost := cost + package.measure.application application
+  pure cost
+
+/-- Assemble packages, checked program, scopes, routes, and the initial exact
+application table transactionally. Global structural matcher registrations are
+retained and routable but deliberately receive no application until a later
+matcher-owned structural batch is supported. -/
+opaque buildWithin (limits : Limits) (packages : Array (Package Fact Result))
+    (program : Program) (bindings : Array ScopeBinding := #[]) :
+    Except Error (Assembly Fact Result) :=
+  match checkProgramLimits limits.state program with
+  | .error error => .error error
+  | .ok _ =>
+    if !program.check then .error .invalidProgram
+    else match buildRegistry limits packages with
+      | .error error => .error error
+      | .ok registry =>
+          if !registry.acceptsProgram program then .error .programRejected
+          else if !Registration.check program registry.registrations then
+            .error .invalidRegistrations
+          else if limits.state.maxApplications < bindings.size then
+            .error (.resource (.state .applications))
+          else if bindings.any (fun binding =>
+              !listWithin limits.state.maxScopeNodes binding.watches ||
+                !listWithin limits.state.maxScopeNodes binding.writes) then
+            .error (.resource (.state .scopes))
+          else if !registry.acceptsBindings program bindings then .error .invalidBindings
+          else match compileWithin limits.state.maxApplications program
+              registry.registrations bindings with
+            | .error error => .error error
+            | .ok applications => match applicationCost registry applications with
+              | .error error => .error error
+              | .ok applicationCost =>
+                  let metadataCost := registry.metadataCost + applicationCost
+                  if !metadataCost.allowed limits.maxMetadataBytes limits.maxMetadataWork then
+                    if limits.maxMetadataBytes < metadataCost.bytes then
+                      .error (.resource .metadataBytes)
+                    else .error (.resource .metadataWork)
+                  else
+                    .ok (makeAssembly program bindings { registry with metadataCost } applications)
+
+/-- Extend only the program-node suffix and its local applications. Existing
+bindings, registry routes, caches, and application rows are retained exactly.
+The fresh generation must strictly exceed every retained application
+generation. -/
+opaque Assembly.extendWithin (limits : Limits) (assembly : Assembly Fact Result)
+    (program : Program) (generation : Nat) : Except Error (Assembly Fact Result) :=
+  match checkProgramLimits limits.state program with
+  | .error error => .error error
+  | .ok _ =>
+      if !program.check then .error .invalidProgram
+      else
+        if limits.state.maxApplications < assembly.bindings.size ||
+            limits.state.maxApplications < assembly.applications.size then
+          .error (.resource (.state .applications))
+        else if !State.programPrefix assembly.program program then .error .nonExtension
+        else if limits.state.maxGeneration < generation ||
+            assembly.applications.any (fun application => generation ≤ application.generation) then
+          .error .staleGeneration
+        else if !assembly.registry.acceptsProgram program then .error .programRejected
+        else if !Registration.check program assembly.registry.registrations then
+          .error .invalidRegistrations
+        else if !assembly.registry.acceptsBindings program assembly.bindings then
+          .error .invalidBindings
+        else
+          let room := limits.state.maxApplications - assembly.applications.size
+          match compileSuffixWithin room assembly.program.nodes.size generation program
+              assembly.registry.registrations with
+          | .error error => .error error
+          | .ok suffix =>
+              let applications := assembly.applications ++ suffix
+              if !applicationsPrefix assembly.applications applications then .error .nonExtension
+              else match applicationCost assembly.registry applications with
+                | .error error => .error error
+                | .ok applicationCost =>
+                    let packageCost := assembly.registry.packages.foldl
+                      (fun cost package => cost + package.measure.metadata) (Cost.mk 0 0)
+                    let metadataCost := packageCost + applicationCost
+                    if !metadataCost.allowed limits.maxMetadataBytes limits.maxMetadataWork then
+                      if limits.maxMetadataBytes < metadataCost.bytes then
+                        .error (.resource .metadataBytes)
+                      else .error (.resource .metadataWork)
+                    else
+                      .ok (makeAssembly program assembly.bindings
+                        { assembly.registry with metadataCost } applications)
+
+private def quoteCells (quotes : Array Quote) : Nat :=
+  quotes.foldl (fun total quote => total + quote.body.length) 0
+
+private def validateQuotes (limits : Limits) (rule : RuleKey)
+    (formats : Array ReplayFormat) (quotes : Array Quote) : Except Error Unit := do
+  if limits.maxQuotes < quotes.size then throw (.resource .quotes)
+  if limits.maxQuoteCells < quoteCells quotes then throw (.resource .quoteCells)
+  for quote in quotes do
+    if limits.maxSchema < quote.schema then throw (.resource .schema)
+    if quote.body.any (fun atom => limits.maxAtom < atom) then throw (.resource .atom)
+    let some format := formats.find? (fun format =>
+        format.role == quote.role && format.schema == quote.schema)
+      | throw (.undeclaredFormat { rule, role := quote.role, schema := quote.schema })
+    if !format.accepts quote then
+      throw (.invalidBody { rule, role := quote.role, schema := quote.schema })
+
+/-- Execute the exact handler selected by an authenticated application row.
+The request must repeat the assembled operation/node program and every
+application-owned action field. Program version and generation side tables in
+the request's `ProgramView` remain controller-owned snapshot data: this layer
+checks their internal request validity but does not claim to own them. Callback
+and measure execution are non-preemptible; failure returns no replacement
+assembly, so a rejected cache/result/quotation cannot partially commit. -/
+opaque Assembly.invokeWithin (limits : Limits) (assembly : Assembly Fact Result)
+    (request : RuleRequest Fact) : Except Error (Invocation Result × Assembly Fact Result) :=
+  if request.program.operations != assembly.program.operations ||
+      request.program.nodes != assembly.program.nodes then .error .invalidRequest
+  else
+    let id := request.action.application
+    match assembly.applications[id.index]? with
+    | none => .error .invalidApplication
+    | some application =>
+        if request.action.rule != application.rule then .error .wrongRoute
+        else if !application.accepts id request.action then .error .invalidApplication
+        else match assembly.registry.registrations[application.rule.index]? with
+          | none => .error .wrongRoute
+          | some registration =>
+              if !RuleRequest.accepts registration request then .error .invalidRequest
+              else match assembly.registry.routes[application.rule.index]? with
+                | none => .error .wrongRoute
+                | some route => match assembly.registry.packages[route.package]? with
+                  | none => .error .wrongRoute
+                  | some package => match package.handlers[route.handler]? with
+                    | none => .error .wrongRoute
+                    | some handler =>
+                        if !registration.same handler.registration then .error .wrongRoute
+                        else
+                          let (plan, cache) := handler.invoke package.cache request
+                          match validateQuotes limits registration.key handler.formats plan.quotes with
+                          | .error error => .error error
+                          | .ok _ =>
+                              let resultCost := package.measure.result plan.result
+                              if !resultCost.allowed limits.maxResultBytes limits.maxResultWork then
+                                if limits.maxResultBytes < resultCost.bytes then
+                                  .error (.resource .resultBytes)
+                                else .error (.resource .resultWork)
+                              else
+                                let oldCache := package.measure.cache package.cache
+                                let newCache := package.measure.cache cache
+                                let cacheCost : Cost :=
+                                  { bytes := assembly.registry.cacheCost.bytes - oldCache.bytes +
+                                      newCache.bytes
+                                    work := assembly.registry.cacheCost.work - oldCache.work +
+                                      newCache.work }
+                                if !cacheCost.allowed limits.maxCacheBytes limits.maxCacheWork then
+                                  if limits.maxCacheBytes < cacheCost.bytes then
+                                    .error (.resource .cacheBytes)
+                                  else .error (.resource .cacheWork)
+                                else
+                                  let package := { package with cache }
+                                  let registry := replacePackage assembly.registry route.package package cacheCost
+                                  .ok (makeInvocation route registration.key plan.result plan.quotes,
+                                    makeAssembly assembly.program assembly.bindings registry
+                                      assembly.applications)
+
+end Hex.Interval.Executable

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -113,12 +113,16 @@ regenerates bounded deterministic offer snapshots, and iterates a replaceable
 policy over the sealed tree/session bundle. Its current end-to-end conformance
 uses toy fact-event callbacks: concrete built-in arithmetic `Driver.Package`
 callbacks and application generators have not yet been supplied. Invoking this
-path from the public tactic remains later controller work. The first
-concrete supported registry is the Mathlib arithmetic package for one
+path from the public tactic remains later controller work. The Mathlib-free
+executable layer separately supports explicit stable-key package assembly,
+private caches, exact routes and concrete local/scoped application rows, with
+bounded raw replay-format declarations that do not embed a Mathlib proof event.
+The first concrete supported theorem registry is the Mathlib arithmetic package for one
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. Automatic arbitrary-function package
-discovery, Mathlib-free package drafts, equality/instance runtime events,
+discovery and theorem assembly, concrete built-in arithmetic callback packages
+and application generators, equality/instance runtime events, executable
 program extension, concrete policy algorithms and default scheduling, payload
 storage, and the optimized backing store remain experimental. The narrow
 direct-forward tactic does not yet invoke the supported controller.
@@ -140,7 +144,7 @@ it exercises the existing research experiment, but the exact function and
 certificate shape remain open to evidence from implementation.
 
 Exact-rational planning, projection, replay, and optimization therefore remain
-deferred while package assembly, cache ownership, payload freezing, structural
+deferred while semantic package/replay assembly, payload freezing, structural
 matching, policy traces, and non-polynomial replay are still being tested; no
 registry, scheduler, instantiation, or policy interface may depend on the
 eventual rational representation. The checked dyadic interval domain is
@@ -3181,16 +3185,30 @@ The checked `Envelope` is supplied to each session transition and is not stored
 inside the session value. A later call may supply different, including tighter,
 limits while the cumulative accepted-step count remains part of the session.
 
-The current supported session retains generation stamps for compact
-`ApplicationId`s but not the concrete application table compiled by the
-experimental controller. Search therefore treats the compact identifier as an
+The supported `Search.Session` retains generation stamps for compact
+`ApplicationId`s but not a concrete application table. Search therefore treats
+the compact identifier as an
 opaque scheduler handle: it authenticates its bounds and generation while
 independently checking the action's rule key and local rule id, anchor,
 operation, kind, reads, writes, and structural inputs. A callback must not use
 the compact application id as authority for a rule or anchor. Retaining and
-checking the exact application table is an obligation for the supported
-controller/package assembly; the present Search contract does not claim that
-correspondence.
+checking the exact application table is not part of the Search contract. The
+separate supported `Executable.Assembly` now seals a checked program, exact
+package routes/caches, bindings, and concrete application rows, and its
+`invokeWithin` rechecks the selected identifier against the row's rule, anchor,
+kind, reads, writes, structural inputs, matcher epoch, effort, and creation
+generation before routing a callback. The current one-step Driver does not yet
+own that assembly, so autonomous Search-to-package correspondence remains the
+next controller edge. Assembly owns only the operation/node program: request
+program version and generation side tables remain controller-owned snapshot
+data and receive only the request-internal checks supplied by `ProgramView` and
+`RuleRequest`.
+
+As with Search, sealing is an ordinary/public-import boundary. Deliberate
+`import all HexInterval.Executable` exposes its private constructors to trusted
+Lean source and is not part of the decoded runtime threat model. The repository
+DAG check rejects that escape hatch outside an exact reviewed allowlist,
+currently empty; both conformance and bench paths are regression-tested.
 
 `prepareWithin` authenticates the session once, revalidates the external policy
 decision against that already-checked immutable view, and returns only the
@@ -5383,7 +5401,7 @@ their declared cost inside a scheduler bound.
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. The built-in
   arithmetic package and direct-forward reifier/tactic are supported below;
-  arbitrary-function package discovery, Mathlib-free runtime packages,
+  arbitrary-function theorem packages, executable-to-proof quotation,
   split-search tactic integration, and default registries remain experimental.
 - `HexIntervalMathlib/Driver.lean`: supported one-step execution of an exact
   already-selected package action, atomic retained-source advancement/split/
@@ -5411,9 +5429,10 @@ their declared cost inside a scheduler bound.
   trusted compatibility epoch, not callback-object identity: same-key
   assemblies deliberately declare replaceable implementations whose results
   still cross the runtime and proof checks. Automatic discovery,
-  program extension, equality/instance runtime events, Mathlib-free raw
-  packages, concrete built-in arithmetic driver callbacks/application
-  generators, and split-search tactic syntax remain later work; the current
+  program extension, equality/instance runtime events, wiring the supported
+  Mathlib-free executable assembly into this controller, concrete built-in
+  arithmetic driver callbacks/application generators, and split-search tactic
+  syntax remain later work; the current
   autonomous theorem uses toy fact-event packages. All offers in one immutable
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
@@ -5474,6 +5493,14 @@ their declared cost inside a scheduler bound.
   registrations, scope bindings, validated immutable program/request views,
   and exact read/write projections. It has no callbacks, outcomes, policy, or
   proof evidence.
+- `HexInterval/Executable.lean`: supported sealed Mathlib-free assembly of
+  explicit stable-key operations, registrations, heterogeneous private package
+  caches, exact handler routes, scoped/local application rows, package-owned
+  logical measures, and bounded raw `(role, schema, body)` replay quotations.
+  Invocation rechecks complete application/request correspondence and commits
+  a cache replacement only after result and quotation admission. The initial
+  compiler does not create global structural-matcher applications; offer
+  generation and theorem-event correlation remain later layers.
 - `HexInterval/Trace.lean`: supported exact fact/instance chronology and
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt
@@ -5500,21 +5527,26 @@ their declared cost inside a scheduler bound.
   target/refute/unknown terminals. It contains no concrete callback, offer
   generator, semantic split/refutation theorem,
   policy algorithm, storage choice, proof recipe, or proof replay.
-- `HexInterval/Experiment/Propagator.lean`: current experimental concrete
-  applications, callbacks, outcomes, untrusted proposals and replies, and
+- `HexInterval/Experiment/Propagator.lean`: current experimental callbacks,
+  outcomes, untrusted proposals and replies, matcher applications, and full
   extension admission. Its engine extends and mutates only through the
   supported state/trace contracts, while its public record remains an
   inspectable experimental storage candidate.
 - `HexInterval/Experiment/{PackageRegistry,PolicyDriver,PolicySession,
   StagedPolicy,AdaptivePolicy,FeaturePolicy,BranchTree}.lean`: current
-   provisional package callback, policy implementation, semantic session,
+   earlier package/payload callback, policy implementation, semantic session,
    target driver, and split-construction designs. Optimized storage, concrete
-   automatic package discovery/program extension, Mathlib-free package
-   protocols, and a default policy will be selected from measurements; none is
+   automatic package discovery/program extension, executable-to-proof
+   quotation, and a default policy will be selected from measurements; none is
    frozen by the decoded supported snapshots.
-- `conformance/HexInterval/{Conformance,SearchConformance,MinMaxConformance,
+- `conformance/HexInterval/{Conformance,ExecutableConformance,SearchConformance,
+  MinMaxConformance,
   EmitFixtures}.lean`:
-  Lean-only checks and oracle fixtures.
+  Lean-only checks and oracle fixtures. Executable conformance includes
+  heterogeneous arithmetic/arbitrary-operation routes, scoped acceptance and
+  default refusal, exact application-field and replay-format mutations,
+  append-prefix stability, resource-first program/binding admission, and
+  exact resource one-overs.
 - `conformance/HexIntervalMathlib/ProgramProofConformance.lean`: supported
   program-model, registry, chronology, refutation, binary-cover/tree replay,
   target-closure, mutation, Meta-state restoration, and guarded

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -83,9 +83,10 @@ resource-first deterministic offers from the authenticated current head, and
 runs bounded repeated policy selection over the sealed tree/session bundle.
 Its current vertical uses toy fact-event packages; concrete built-in arithmetic
 `Driver.Package` callbacks and application generators remain to be implemented.
-Mathlib-free raw packages, automatic discovery/program extension,
-equality/instance runtime events, and public-tactic split search remain later
-edges.
+The separate Mathlib-free `Executable.Assembly` accepts explicit raw callback
+packages, but wiring it to this controller and correlating its inert quotations
+with theorem events, automatic discovery/program extension, equality/instance
+runtime events, and public-tactic split search remain later edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -221,8 +222,14 @@ performs the final check when the caller installs the expression.
 Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The built-in arithmetic package registry and
 its supported branch/session `Cause`-to-`Proof.Event` quotation ship below.
-Automatic arbitrary-function package discovery, Mathlib-free raw packages,
-equality/instance runtime recipes, and default registries remain experimental.
+The Mathlib-free `Executable.Assembly` supports explicit arbitrary-operation
+callback packages and raw replay formats, but those raw quotations are not
+`Proof.Event`s and are not yet correlated with this theorem registry.
+The assembly constructors are sealed under ordinary imports; deliberate
+`import all HexInterval.Executable` is a repository-guarded trusted-source
+escape hatch, not decoded runtime or proof authority.
+Automatic arbitrary-function theorem-package discovery, equality/instance
+runtime recipes, and default registries remain experimental.
 The supported explicit fact-event controller can produce and replay
 search-selected recipes, while the tactic below remains a deliberately narrow
 direct forward client rather than that generic search bridge.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -41,7 +41,14 @@ granting runtime state evidence authority. The current package fixes one
 natural exponent and one dyadic constant, shared respectively by every node at
 the built-in power and constant operation indices; duplicate package
 registration and operation keys cannot provide another such parameterization.
-Arbitrary-function package discovery, Mathlib-free runtime packages,
+The Mathlib-free `Executable.Assembly` now supports explicit stable-key
+arbitrary-operation callback packages, private caches, exact concrete
+application rows, and bounded raw replay formats. Those raw quotations are not
+Mathlib proof events and are not yet correlated with this theorem registry.
+Its constructors are sealed under ordinary imports; deliberate `import all
+HexInterval.Executable` is a repository-guarded trusted-source escape hatch,
+not decoded runtime authority.
+Arbitrary-function theorem-package discovery, executable-to-proof quotation,
 split-search tactic integration, and default package discovery remain
 experimental. The supported callback driver executes one already-selected
 authenticated package action and atomically advances a sealed result tree and
@@ -3266,6 +3273,10 @@ the fixed soundness and trust contracts.
 
 ## File organization
 
+- `HexInterval/Executable.lean`: sealed explicit executable packages, checked
+  handler routes and concrete application tables, package-owned cache/result
+  measures, append-stable local program extension, and inert bounded raw replay
+  quotations. It does not generate offers or construct proof events.
 - `HexIntervalMathlib/Interval.lean`: real membership, cut lemmas, and exact
   semantics for construction, intersection, hull, and negation.
 - `HexIntervalMathlib/Addition.lean` and

--- a/conformance/HexInterval/ExecutableConformance.lean
+++ b/conformance/HexInterval/ExecutableConformance.lean
@@ -1,0 +1,511 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Executable
+
+/-!
+Conformance for the sealed executable package/application assembly. The
+fixture combines a built-in-style addition package with an independently
+declared sine-shaped operation; the Mathlib-free layer treats both only by
+stable keys and typed signatures.
+-/
+
+namespace Hex.Interval.ExecutableConformance
+
+open Executable
+
+def real : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "hex.interval.source" }
+def addKey : OpKey := { name := "hex.interval.add" }
+def sineKey : OpKey := { name := "fixture.sine" }
+
+def addRuleKey : RuleKey := { name := "hex.interval.add.forward" }
+def sineRuleKey : RuleKey := { name := "fixture.sine.forward" }
+
+def sourceOperation : Operation := { key := sourceKey, inputs := [], output := real }
+def addOperation : Operation := { key := addKey, inputs := [real, real], output := real }
+def sineOperation : Operation := { key := sineKey, inputs := [real], output := real }
+
+def addRegistration : Registration :=
+  { key := addRuleKey, head := addKey, kind := .forward
+    watches := [.argument 0, .argument 1], writes := [.result] }
+
+def sineRegistration : Registration :=
+  { key := sineRuleKey, head := sineKey, kind := .forward
+    watches := [.argument 0], writes := [.result] }
+
+def factFormat : ReplayFormat :=
+  { role := .fact, schema := 1, validateBody := fun body => body == [1] }
+
+def arithmeticMeasure (metadata : Nat) : Measure Nat Nat :=
+  { metadata := { bytes := metadata, work := metadata }
+    application := fun _ => { bytes := 1, work := 1 }
+    cache := fun value => { bytes := value, work := value }
+    result := fun _ => { bytes := 1, work := 1 } }
+
+def sineMeasure : Measure (List Nat) Nat :=
+  { metadata := { bytes := 20, work := 20 }
+    application := fun _ => { bytes := 1, work := 1 }
+    cache := fun values => { bytes := values.length, work := values.length }
+    result := fun _ => { bytes := 1, work := 1 } }
+
+def addHandler : Handler Nat Nat Nat :=
+  { registration := addRegistration
+    invoke := fun cache _ =>
+      ({ result := 10 + cache, quotes := #[{ role := .fact, schema := 1, body := [1] }] },
+        cache + 1)
+    formats := #[factFormat] }
+
+def sineHandler : Handler Nat Nat (List Nat) :=
+  { registration := sineRegistration
+    invoke := fun cache _ =>
+      ({ result := 100 + cache.length,
+          quotes := #[{ role := .fact, schema := 1, body := [1] }] },
+        1 :: cache)
+    formats := #[factFormat] }
+
+def arithmeticPackage : Package Nat Nat :=
+  { Cache := Nat, cache := 0
+    operations := #[sourceOperation, addOperation]
+    handlers := #[addHandler]
+    measure := arithmeticMeasure 10 }
+
+def sinePackage : Package Nat Nat :=
+  { Cache := List Nat, cache := []
+    operations := #[sineOperation]
+    handlers := #[sineHandler]
+    measure := sineMeasure }
+
+def program : Program :=
+  { operations := #[sourceOperation, addOperation, sineOperation]
+    nodes :=
+      #[{ domain := real, op := { index := 0 }, args := [] },
+        { domain := real, op := { index := 0 }, args := [] },
+        { domain := real, op := { index := 1 }, args := [{ index := 0 }, { index := 1 }] },
+        { domain := real, op := { index := 2 }, args := [{ index := 2 }] }] }
+
+def extendedProgram : Program :=
+  { program with nodes := program.nodes ++
+      #[{ domain := real, op := { index := 1 }, args := [{ index := 1 }, { index := 2 }] },
+        { domain := real, op := { index := 2 }, args := [{ index := 4 }] }] }
+
+def shortProgram : Program :=
+  { program with nodes := program.nodes.extract 0 3 }
+
+def oversizedInvalidProgram : Program :=
+  { program with nodes := program.nodes ++
+      #[{ domain := real, op := { index := 99 }, args := [] },
+        { domain := real, op := { index := 99 }, args := [] },
+        { domain := real, op := { index := 99 }, args := [] }] }
+
+def scopedRegistration : Registration :=
+  { sineRegistration with watches := [], writes := [], binding := .scoped }
+
+def scopedBinding : ScopeBinding :=
+  { rule := sineRuleKey, anchor := { index := 3 }
+    watches := [{ index := 2 }], writes := [{ index := 3 }] }
+
+def defaultScopedHandler : Handler Nat Nat (List Nat) :=
+  { sineHandler with registration := scopedRegistration }
+
+def scopedHandler : Handler Nat Nat (List Nat) :=
+  { defaultScopedHandler with acceptsScope := fun actual binding =>
+      actual.operations == program.operations && actual.nodes == program.nodes &&
+        binding == scopedBinding }
+
+def defaultScopedPackage : Package Nat Nat :=
+  { sinePackage with handlers := #[defaultScopedHandler] }
+
+def scopedPackage : Package Nat Nat :=
+  { sinePackage with handlers := #[scopedHandler] }
+
+def fullAddRegistration : Registration :=
+  { addRegistration with watches := [.result, .argument 0, .argument 1] }
+
+def fullAddHandler : Handler Nat Nat Nat :=
+  { addHandler with registration := fullAddRegistration }
+
+def fullAddPackage : Package Nat Nat :=
+  { arithmeticPackage with handlers := #[fullAddHandler] }
+
+def oversizedAddRegistration : Registration :=
+  { addRegistration with
+    watches := [.result, .argument 0, .argument 1, .result] }
+
+def oversizedAddHandler : Handler Nat Nat Nat :=
+  { addHandler with registration := oversizedAddRegistration }
+
+def oversizedAddPackage : Package Nat Nat :=
+  { arithmeticPackage with handlers := #[oversizedAddHandler] }
+
+def effortRegistration : Registration :=
+  { addRegistration with initialEffort := 1 }
+
+def effortHandler : Handler Nat Nat Nat :=
+  { addHandler with registration := effortRegistration }
+
+def effortPackage : Package Nat Nat :=
+  { arithmeticPackage with handlers := #[effortHandler] }
+
+def undeclaredHeadPackage : Package Nat Nat :=
+  { sinePackage with operations := #[], requiredOperations := #[] }
+
+def mismatchedSineOperation : Operation :=
+  { sineOperation with inputs := [real, real] }
+
+def rejectedProgramPackage : Package Nat Nat :=
+  { sinePackage with operations := #[], requiredOperations := #[mismatchedSineOperation] }
+
+def stateLimits : State.Limits :=
+  { maxOperations := 3
+    maxNodes := 6
+    maxRules := 2
+    maxRegistryEntries := 9
+    maxReplayFormats := 2
+    maxArity := 2
+    maxScopeNodes := 1
+    maxApplications := 4
+    maxQueueEntries := 8
+    maxActions := 8
+    maxAcceptedFacts := 8
+    maxRetainedSuggestions := 0
+    maxEffort := 0
+    maxObservationValue := 8
+    maxDiagnosticValue := 8
+    maxOutcomeCandidates := 2
+    maxOutcomeSuggestions := 0
+    maxProposalItems := 0
+    maxInstances := 1
+    maxGeneration := 1
+    maxNodeDepth := 4
+    maxEqualities := 1
+    splitEndpointLimit := { maxEndpointHeight := 8, maxAlignmentShift := 8 } }
+
+def limits : Limits :=
+  { state := stateLimits
+    maxPackages := 2
+    maxMetadataBytes := 32
+    maxMetadataWork := 32
+    maxCacheBytes := 3
+    maxCacheWork := 3
+    maxResultBytes := 1
+    maxResultWork := 1
+    maxQuotes := 1
+    maxQuoteCells := 1
+    maxAtom := 1
+    maxSchema := 1 }
+
+def assembly? (limits : Limits := limits) : Option (Assembly Nat Nat) :=
+  (buildWithin limits #[arithmeticPackage, sinePackage] program).toOption
+
+def scopedAssembly? (limits : Limits := limits)
+    (package : Package Nat Nat := scopedPackage) : Option (Assembly Nat Nat) :=
+  (buildWithin limits #[package] program #[scopedBinding]).toOption
+
+def buildError (limits : Limits) (packages : Array (Package Nat Nat))
+    (actualProgram : Program := program) (bindings : Array ScopeBinding := #[]) : Option Error :=
+  match buildWithin limits packages actualProgram bindings with
+  | .ok _ => none
+  | .error error => some error
+
+def extendError (limits : Limits) (actualProgram : Program) (generation : Nat) : Option Error :=
+  match assembly? with
+  | none => none
+  | some assembly =>
+      match assembly.extendWithin limits actualProgram generation with
+      | .ok _ => none
+      | .error error => some error
+
+def programView : ProgramView :=
+  { programVersion := 0
+    operations := program.operations
+    nodes := program.nodes
+    generations := #[0, 0, 0, 0]
+    depths := #[0, 0, 1, 2] }
+
+def addAction : Action :=
+  { serial := 0, programVersion := 0, application := { index := 0 }
+    rule := { index := 0 }, key := addRuleKey, node := { index := 2 }
+    kind := .forward, effort := 0
+    inputs := [{ node := { index := 0 }, version := 0 },
+      { node := { index := 1 }, version := 0 }]
+    writes := [{ index := 2 }] }
+
+def addRequest : RuleRequest Nat :=
+  { action := addAction, program := programView
+    inputs := [{ node := { index := 0 }, fact := 2, version := 0 },
+      { node := { index := 1 }, fact := 3, version := 0 }]
+    writes := [{ index := 2 }] }
+
+def sineAction : Action :=
+  { serial := 1, programVersion := 0, application := { index := 1 }
+    rule := { index := 1 }, key := sineRuleKey, node := { index := 3 }
+    kind := .forward, effort := 0
+    inputs := [{ node := { index := 2 }, version := 0 }]
+    writes := [{ index := 3 }] }
+
+def sineRequest : RuleRequest Nat :=
+  { action := sineAction, program := programView
+    inputs := [{ node := { index := 2 }, fact := 5, version := 0 }]
+    writes := [{ index := 3 }] }
+
+def quoteHandler (quote : Quote) : Handler Nat Nat Nat :=
+  { addHandler with invoke := fun cache _ =>
+      ({ result := 10 + cache, quotes := #[quote] }, cache + 1) }
+
+def quotePackage (quote : Quote) : Package Nat Nat :=
+  { arithmeticPackage with handlers := #[quoteHandler quote] }
+
+def invokePackageError (limits : Limits) (package : Package Nat Nat)
+    (request : RuleRequest Nat := addRequest) : Option Error :=
+  match buildWithin limits #[package] program with
+  | .error error => some error
+  | .ok assembly =>
+      match assembly.invokeWithin limits request with
+      | .ok _ => none
+      | .error error => some error
+
+def invokeError (request : RuleRequest Nat) : Option Error :=
+  match assembly? with
+  | none => none
+  | some assembly =>
+      match Assembly.invokeWithin limits assembly request with
+      | .ok _ => none
+      | .error error => some error
+
+#guard program.check
+#guard programView.check
+#guard assembly?.isSome
+#guard match assembly? with | some assembly => assembly.applications.size == 2 | none => false
+#guard match assembly? with
+  | some assembly => assembly.applications[0]?.map (·.node) == some { index := 2 }
+  | none => false
+#guard match assembly? with
+  | some assembly => assembly.applications[1]?.map (·.node) == some { index := 3 }
+  | none => false
+
+-- A binary local registration may mention its result plus both arguments:
+-- the exact port boundary is `maxArity + 1`, not `maxArity`.
+#guard buildError limits #[fullAddPackage] == none
+#guard buildError limits #[oversizedAddPackage] == some (.resource (.state .arity))
+
+-- Initial effort is admitted at the exact boundary and refused one below.
+#guard buildError limits #[effortPackage] == some (.resource (.state .effort))
+#guard buildError { limits with state := { stateLimits with maxEffort := 1 } }
+    #[effortPackage] == none
+
+-- Explicit scoped assembly succeeds only through the package-owned semantic
+-- hook. Its default hook fails closed, and count/port caps run before it.
+#guard scopedAssembly?.isSome
+#guard match scopedAssembly? with
+  | some assembly =>
+      assembly.applications[0]?.map (fun application =>
+        (application.node, application.watches, application.writes)) ==
+          some ({ index := 3 }, [{ index := 2 }], [{ index := 3 }])
+  | none => false
+#guard buildError limits #[defaultScopedPackage] program #[scopedBinding] ==
+  some .invalidBindings
+#guard buildError { limits with state := { stateLimits with maxScopeNodes := 0 } }
+    #[scopedPackage] program #[scopedBinding] == some (.resource (.state .scopes))
+#guard buildError { limits with state := { stateLimits with maxApplications := 0 } }
+    #[scopedPackage] program #[scopedBinding] == some (.resource (.state .applications))
+
+-- Registry/program correspondence and append-only ownership fail closed.
+#guard match buildError limits #[undeclaredHeadPackage] with
+  | some (.undeclaredHead rule head) => rule == sineRuleKey && head == sineKey
+  | _ => false
+#guard buildError limits #[rejectedProgramPackage] == some .programRejected
+#guard extendError limits shortProgram 1 == some .nonExtension
+
+-- Structural caps precede full program validation in both public builders.
+#guard buildError limits #[arithmeticPackage, sinePackage] oversizedInvalidProgram ==
+  some (.resource (.state .nodes))
+#guard extendError limits oversizedInvalidProgram 1 == some (.resource (.state .nodes))
+
+-- Exact application routing updates only the selected private cache. The
+-- second addition observes cache `1` even though sine ran between the calls.
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin limits addRequest with
+      | .error _ => false
+      | .ok (add, assembly) =>
+          add.result == 10 && add.rule == addRuleKey && add.route == { package := 0, handler := 0 } &&
+            match assembly.invokeWithin limits sineRequest with
+            | .error _ => false
+            | .ok (sine, assembly) =>
+                sine.result == 100 && sine.route == { package := 1, handler := 0 } &&
+                  match assembly.invokeWithin limits addRequest with
+                  | .error _ => false
+                  | .ok (again, _) => again.result == 11
+
+-- Transplanted application identity, compact route, stable rule, anchor,
+-- creation generation, and structural fields all reject independently.
+#guard invokeError { addRequest with action := { addAction with application := { index := 1 } } }
+  == some .wrongRoute
+#guard invokeError { addRequest with action := { addAction with application := { index := 99 } } }
+  == some .invalidApplication
+#guard invokeError { addRequest with action := { addAction with rule := { index := 1 } } }
+  == some .wrongRoute
+#guard invokeError { addRequest with action := { addAction with key := sineRuleKey } }
+  == some .invalidRequest
+#guard invokeError { addRequest with action := { addAction with node := { index := 3 } } }
+  == some .invalidApplication
+#guard invokeError { addRequest with action := { addAction with generation := 1 } }
+  == some .invalidApplication
+#guard invokeError { addRequest with action := { addAction with inputs := [] } }
+  == some .invalidApplication
+#guard invokeError { addRequest with action := { addAction with writes := [] } }
+  == some .invalidApplication
+#guard invokeError
+    { addRequest with action := { addAction with
+        structuralInputs := [{ key := .node { index := 0 }, generation := 0 }]
+        matcherEpoch := some 0 } } == some .invalidApplication
+
+def duplicateOperationPackage : Package Nat Nat :=
+  { sinePackage with operations := #[addOperation], requiredOperations := #[sineOperation] }
+
+def duplicateRuleHandler : Handler Nat Nat (List Nat) :=
+  { sineHandler with registration := { sineRegistration with key := addRuleKey } }
+
+def duplicateRulePackage : Package Nat Nat :=
+  { sinePackage with handlers := #[duplicateRuleHandler] }
+
+def duplicateFormatHandler : Handler Nat Nat (List Nat) :=
+  { sineHandler with formats := #[factFormat, factFormat] }
+
+def duplicateFormatPackage : Package Nat Nat :=
+  { sinePackage with handlers := #[duplicateFormatHandler] }
+
+def duplicateFormatLimits : Limits :=
+  { limits with state :=
+      { stateLimits with maxReplayFormats := 3, maxRegistryEntries := 10 } }
+
+#guard
+  match buildWithin
+      { limits with state := { stateLimits with maxRegistryEntries := 10 } }
+      #[arithmeticPackage, duplicateOperationPackage] program with
+  | .error (.duplicateOperation key) => key == addKey
+  | _ => false
+#guard
+  match buildWithin limits #[arithmeticPackage, duplicateRulePackage] program with
+  | .error (.duplicateRule key) => key == addRuleKey
+  | _ => false
+#guard
+  match buildWithin duplicateFormatLimits
+      #[arithmeticPackage, duplicateFormatPackage] program with
+  | .error (.duplicateFormat key) =>
+      key == { rule := sineRuleKey, role := .fact, schema := 1 }
+  | _ => false
+
+-- Quotations must use an exact declared role/schema address and pass that
+-- declaration's package-owned body decoder.
+#guard invokePackageError limits
+    (quotePackage { role := .equality, schema := 1, body := [1] }) ==
+  some (.undeclaredFormat { rule := addRuleKey, role := .equality, schema := 1 })
+#guard invokePackageError { limits with maxSchema := 2 }
+    (quotePackage { role := .fact, schema := 2, body := [1] }) ==
+  some (.undeclaredFormat { rule := addRuleKey, role := .fact, schema := 2 })
+#guard invokePackageError limits
+    (quotePackage { role := .fact, schema := 1, body := [0] }) ==
+  some (.invalidBody { rule := addRuleKey, role := .fact, schema := 1 })
+
+-- Append-only program growth preserves every old application byte-for-byte
+-- and assigns the exact fresh generation to the local suffix.
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.extendWithin
+          { limits with maxMetadataBytes := 34, maxMetadataWork := 34 }
+          extendedProgram 1 with
+      | .error _ => false
+      | .ok extended =>
+          applicationsPrefix assembly.applications extended.applications &&
+            extended.applications.size == 4 &&
+              extended.applications[2]?.map (·.generation) == some 1 &&
+                extended.applications[3]?.map (·.generation) == some 1
+
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.extendWithin limits extendedProgram 0 with
+      | .error .staleGeneration => true
+      | _ => false
+
+-- Exact one-over guards for every retained assembly dimension and reply stage.
+#guard assembly? { limits with maxPackages := 1 } |>.isNone
+#guard assembly? { limits with state := { stateLimits with maxOperations := 2 } } |>.isNone
+#guard assembly? { limits with state := { stateLimits with maxRules := 1 } } |>.isNone
+#guard assembly? { limits with state := { stateLimits with maxReplayFormats := 1 } } |>.isNone
+#guard assembly? { limits with state := { stateLimits with maxRegistryEntries := 8 } } |>.isNone
+#guard assembly? { limits with state := { stateLimits with maxApplications := 1 } } |>.isNone
+#guard assembly? { limits with maxMetadataBytes := 31 } |>.isNone
+#guard assembly? { limits with maxMetadataWork := 31 } |>.isNone
+
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxResultBytes := 0 } addRequest with
+      | .error (.resource .resultBytes) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxQuotes := 0 } addRequest with
+      | .error (.resource .quotes) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxQuoteCells := 0 } addRequest with
+      | .error (.resource .quoteCells) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxAtom := 0 } addRequest with
+      | .error (.resource .atom) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxSchema := 0 } addRequest with
+      | .error (.resource .schema) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin
+          { limits with maxCacheBytes := 0, maxCacheWork := 3 } addRequest with
+      | .error (.resource .cacheBytes) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin
+          { limits with maxCacheBytes := 3, maxCacheWork := 0 } addRequest with
+      | .error (.resource .cacheWork) => true
+      | _ => false
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.invokeWithin { limits with maxResultWork := 0 } addRequest with
+      | .error (.resource .resultWork) => true
+      | _ => false
+
+end Hex.Interval.ExecutableConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -534,6 +534,7 @@ lean_lib HexConformance where
     ++ #[`HexInterval.PolicyFeatureConformance,
       `HexInterval.FeaturePolicyConformance,
       `HexInterval.SearchConformance,
+      `HexInterval.ExecutableConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/20260822T013600Z_interval-executable-assembly.md
+++ b/progress/20260822T013600Z_interval-executable-assembly.md
@@ -1,0 +1,35 @@
+# Executable package assembly
+
+## Accomplished
+
+- Added a supported Mathlib-free sealed assembly joining stable operation and
+  rule keys, exact callback routes, private package caches, and the concrete
+  application table for one checked program.
+- Added bounded inert replay quotations whose role, schema, and natural-number
+  body are authenticated against package-owned formats without embedding
+  Mathlib proof events.
+- Added append-only program extension with exact old-application prefix
+  preservation and fresh-generation checks.
+- Added conformance for a built-in arithmetic package and an independently
+  keyed sine-shaped package, including route/application mutations, duplicate
+  declarations, append stability, and resource one-overs.
+- Updated the supported and aggregate SPECs and registered the conformance
+  target and proof-only Lake freshness exemption.
+
+## Current frontier
+
+The package/application correspondence is now explicit and sealed, but it is
+not yet owned by the search driver. It can execute only an already selected and
+fully authenticated application request.
+
+## Next step
+
+Connect this assembly to autonomous offer generation and policy iteration,
+then correlate accepted raw quotations with runtime transitions and
+Mathlib-side theorem events at the proof boundary.
+
+## Blockers
+
+None for this bounded assembly slice. Global structural matcher application
+batches, theorem-event quotation, autonomous scheduling, and tactic
+integration deliberately remain outside its contract.

--- a/progress/20260822T020022Z_interval-executable-assembly-review.md
+++ b/progress/20260822T020022Z_interval-executable-assembly-review.md
@@ -1,0 +1,32 @@
+# Executable assembly review repair
+
+## Accomplished
+
+- Guarded the sealed `HexInterval.Executable` ordinary-import boundary against
+  `import all` in both conformance and bench paths, with unit coverage.
+- Made program dimension checks precede full validation in assembly and
+  extension, capped scoped-binding arrays before semantic callbacks, and used
+  bounded list-prefix checks for program and registration ports.
+- Corrected local registration capacity to `maxArity + 1` and enforced initial
+  effort limits.
+- Renamed the raw encoding declaration to `ReplayFormat` and added exact
+  undeclared-role, undeclared-schema, invalid-body, scoped acceptance/default
+  refusal, application lookup, program rejection, extension, and resource
+  boundary guards.
+- Clarified that assembly owns operation/node correspondence while controller
+  snapshots own program version and generation side tables.
+
+## Current frontier
+
+The repaired executable assembly remains a standalone checked callback layer;
+the supported controller does not yet own it or correlate raw quotations with
+proof events.
+
+## Next step
+
+Obtain fresh exact-head review and CI, then connect autonomous offer generation
+to the sealed assembly without weakening the raw-quotation trust boundary.
+
+## Blockers
+
+None in this repair.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -658,5 +658,11 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "dfcd8629a933ac9f3721bbcc261be34211bcf3a6",
     "reason": "Additionally registers the supported HexIntervalMathlib autonomous fact-event controller conformance module and the Mathlib-free source-correlated FKS2 theorem-6.2 nested-log checker, proof-only real-semantics companion, and conformance module on top of the retained mu, positive-exp, supported driver, Dusart, Chebyshev, LogTables, FKS2, and public interval registrations; these proof-only modules do not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "c1b4237b4c1ba380a09cc31d1d3e5467a669431f",
+    "reason": "Additionally registers the Mathlib-free supported HexInterval executable package/application assembly conformance module on top of the retained autonomous controller, PNT, and public interval registrations; it does not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -32,6 +32,7 @@ IMPORT_ALL_RE = re.compile(
 # every owning exception must be an exact reviewed path rather than a suffix or
 # directory convention. There are currently no required exceptions.
 SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
+    "HexInterval.Executable": frozenset(),
     "HexInterval.Search": frozenset(),
     "HexIntervalMathlib.Driver": frozenset(),
     "HexIntervalMathlib.Controller": frozenset(),

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -15,6 +15,10 @@ class SealedImportAllTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             cases = [
+                (Path("conformance/HexInterval/BypassExecutable.lean"),
+                    "HexInterval.Executable"),
+                (Path("bench/HexInterval/BypassExecutable.lean"),
+                    "HexInterval.Executable"),
                 (Path("conformance/HexInterval/Bypass.lean"), "HexInterval.Search"),
                 (Path("bench/HexInterval/Bypass.lean"), "HexInterval.Search"),
                 (Path("conformance/HexIntervalMathlib/Bypass.lean"),
@@ -31,6 +35,10 @@ class SealedImportAllTest(unittest.TestCase):
             self.assertEqual(
                 check_sealed_import_all(root, files),
                 [
+                    "conformance/HexInterval/BypassExecutable.lean:1 uses `import all "
+                    "HexInterval.Executable` outside its exact trusted-internals allowlist",
+                    "bench/HexInterval/BypassExecutable.lean:1 uses `import all "
+                    "HexInterval.Executable` outside its exact trusted-internals allowlist",
                     "conformance/HexInterval/Bypass.lean:1 uses `import all "
                     "HexInterval.Search` outside its exact trusted-internals allowlist",
                     "bench/HexInterval/Bypass.lean:1 uses `import all "


### PR DESCRIPTION
## Summary

- add a supported Mathlib-free sealed package/application assembly with exact stable-key routing, private heterogeneous caches, concrete application rows, and package-owned logical measures
- authenticate the complete ApplicationId-to-rule/anchor/watch/write/structural/generation correspondence and preserve exact application prefixes across checked program extension
- add bounded raw replay format declarations plus arithmetic and independent sine-shaped package conformance, mutations, and resource one-overs

## Trust boundary

The raw replay quote is deliberately inert `(role, schema, body)` data. It is not a Mathlib `Proof.Event`, theorem evidence, or proof authority. Correlating a quote with an accepted runtime transition and a package-owned theorem schema remains a later Mathlib companion boundary.

Controller integration, autonomous scheduling and public tactic integration, raw-quote-to-proof correlation, and global structural matcher application batches remain future work.

## Validation

- `lake build HexInterval.ExecutableConformance`
- `lake build HexInterval HexConformance` (9,603 jobs)
- DAG, Phase 4, line-count, copyright, trust-surface, freshness, release-manifest/manual-split, and Mathlib-free bench checks
- Mathlib-free bench-checker unit tests (27 tests)