### PR TITLE
doc: define Phase 3/4 exit criteria for correspondence-only mathlib layers

### DIFF
--- a/PLAN/Phase3.md
+++ b/PLAN/Phase3.md
@@ -80,6 +80,40 @@ Reviewer checklist for Phase 3 PRs:
   issue for any deliberately uncovered op (with the conformance
   docstring not claiming it as covered).
 
+### Correspondence-only mathlib layers
+
+The criteria and checklist above presuppose an executable surface to
+conform to. A `mathlib: true` library whose API is correspondence
+statements alone, with no executable reifier, certificate checker, or
+tactic of its own, has no conformance module at all:
+`conformance/HexFooMathlib/Conformance.lean` must not exist, per
+[SPEC/testing.md §Banned anti-patterns](../SPEC/testing.md#banned-anti-patterns).
+For such a library Phase 3 is done when all of:
+
+1. `conformance/HexFooMathlib/Conformance.lean` is absent, and no
+   `HexConformance` glob in `lakefile.lean` names it.
+   `scripts/conformance_targets.py` discovers targets by that
+   filename, so the library is absent from the conformance CI list.
+
+2. The PR audits whatever checks the layer carried and cites, for each
+   operation the layer transports, the coverage that lives in the
+   named computational owner or owners (more than one owner is normal,
+   since a layer may transport operations from several Mathlib-free
+   libraries). A check that exercises only the layer's own conversion
+   or index helpers has no executable destination to migrate to and is
+   deleted rather than moved; it is ceremonial, not coverage.
+
+3. `lake build HexFooMathlib` is green on the PR and remains green on
+   `main`.
+
+4. Record completion by bumping `libraries.yml[L].done_through` to
+   `3` in the same PR.
+
+A Mathlib-importing library that owns an executable reifier,
+certificate checker, or tactic is not correspondence-only. It takes the
+ordinary criteria, with its library SPEC defining that runtime contract
+and its CI reachability.
+
 ## Oracle wiring (forward reference)
 
 Default oracle assignments live in

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -172,9 +172,10 @@ For library `hex-foo`, Phase 4 is done when:
   [SPEC/benchmarking.md §"Comparator naming"](../SPEC/benchmarking.md#comparator-naming):
   every required comparator is named with its class (optionally
   scoped per bench target), or the absence is declared with exactly
-  one of the five enumerated reasons (`implementation-is-extern`,
+  one of the six enumerated reasons (`implementation-is-extern`,
   `structural-layer`, `input-source-only`, `mathlib-bridge`,
-  `no-comparable-surface-in-named-comparator`). Missing declarations
+  `no-comparable-surface-in-named-comparator`,
+  `correspondence-only-layer`). Missing declarations
   block Phase-4 completion;
 - the [Attribution rule](../SPEC/benchmarking.md#the-attribution-rule)
   is satisfied: every dominant profiled cost maps to a registered
@@ -200,6 +201,44 @@ For library `hex-foo`, Phase 4 is done when:
 If any of these fail, the right action is rollback per
 [Conventions.md](Conventions.md), not a SPEC-text edit weakening
 the criterion.
+
+### Correspondence-only mathlib layers
+
+The criteria above presuppose that the library advertises at least one
+operation in one of the two evidence tracks. A **correspondence-only
+mathlib layer** advertises zero: it is a `mathlib: true` library whose
+API is correspondence statements alone, with no compiled operation and
+no proof or tactic operation of its own.
+[SPEC/benchmarking.md §Mathlib-free benches](../SPEC/benchmarking.md#mathlib-free-benches)
+forbids it a `HexFooMathlib/Bench.lean`, a `HexFooMathlib/Bench/`
+directory, and a `lean_exe *mathlib*_bench` entry, so it has no
+compiled track, and owning no proof surface it has no proof track
+either. For such a library Phase 4 is done when:
+
+- the library's SPEC declares the external-comparator absence with the
+  `correspondence-only-layer` reason from
+  [SPEC/benchmarking.md §"Comparator naming"](../SPEC/benchmarking.md#comparator-naming),
+  naming the computational performance owner or owners whose bench
+  targets carry the evidence for the operations this layer transports;
+- `libraries.yml[L]` declares no `phase4` block, and no headline report
+  at `reports/<lib>-performance.md` is required, per
+  [SPEC/benchmarking.md §Headline reports](../SPEC/benchmarking.md#headline-reports).
+  A report committed before the layer was classified may stay as a
+  historical artefact.
+
+The deliverables, the compiled-track exit criteria, and the
+empty-Concerns criterion do not apply; there is no track for them to
+attach to.
+
+The exemption is narrow, and every other `mathlib: true` library takes
+ordinary track assignment per [§Evidence tracks](#evidence-tracks) in
+whichever shape its SPEC declares: compiled-only, proof-only (an
+elaboration or tactic surface evidenced by fresh-module probes, as with
+HexRealRootsMathlib's `isolate_roots` term elaborator), or mixed. A
+library declaring a `libraries.yml` `proof_probes` root is normally
+outside the exemption, since those probes measure a proof surface it
+owns; so is a library owning an executable reifier, certificate
+checker, or tactic.
 
 ### Audit reset
 

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -634,9 +634,9 @@ which bench target each comparator covers. This is the common shape
 when an external tool exposes some of a library's surfaces as
 user-callable functions but not others.
 
-Where a bench target has no external comparator, the per-library
-SPEC declares the absence with a library-specific reason identifying
-exactly one of:
+Where a bench target has no external comparator, or where the library
+has no bench target at all, the per-library SPEC declares the absence
+with a library-specific reason identifying exactly one of:
 
 - **implementation-is-extern** — the surface is an external library
   via `@[extern]`; there is nothing algorithmically distinct to
@@ -654,6 +654,14 @@ exactly one of:
   declares a comparator for some surfaces but the named comparator
   tool does not expose this specific surface as a callable function
   (the tool builds it internally but doesn't surface it as user API).
+- **correspondence-only-layer** — the library is a correspondence-only
+  mathlib layer and therefore has zero bench targets (see
+  [§Mathlib-free benches](#mathlib-free-benches)), so there is no
+  surface of its own to compare. The declaration names the
+  computational performance owner or owners whose bench targets carry
+  the evidence for the operations it transports; more than one owner is
+  normal, since a layer may transport operations from several
+  Mathlib-free libraries.
 
 Generic "not applicable" is not a valid declaration. Unwired-but-
 required comparators are declared with the `blocked` state per
@@ -961,6 +969,14 @@ report at `reports/<lib>-performance.md`. The report is the
 single, scannable place a reviewer can land on to see whether
 Phase-4 coverage is real and what is known about the library's
 performance shape.
+
+A correspondence-only mathlib layer is the one exception: it has zero
+bench targets and no proof-track probes of its own, so it has nothing
+to report, and no headline report is required of it. Its performance
+evidence lives in the computational owners named by its
+`correspondence-only-layer` declaration ([§Comparator
+naming](#comparator-naming)). A report already committed for such a
+library is a historical artefact and need not be deleted.
 
 The report contains five subsections:
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -142,7 +142,9 @@ Each library has up to three conformance-tree modules:
 
 - `conformance/HexFoo/Conformance.lean` (module `HexFoo.Conformance`) —
   the `core` profile, specified above. Every library at
-  `done_through ≥ 2` has one.
+  `done_through ≥ 2` has one, except a correspondence-only
+  `mathlib: true` layer, which must not (see §Banned anti-patterns and
+  [PLAN/Phase3.md §Correspondence-only mathlib layers](../PLAN/Phase3.md)).
 - `conformance/HexFoo/CrossCheck.lean` (module `HexFoo.CrossCheck`) —
   the heavier cross-check sweeps: representation-correspondence
   campaigns, fast-vs-fast agreement over deterministic input streams,
@@ -427,12 +429,16 @@ subsection. Default oracle assignments:
   Lübeck flat-file cache for triple-source independence
   (Lean ≡ PARI ≡ Lübeck). No random generation.
 
-The `-mathlib` bridge libraries are not the primary target of
-external conformance testing. They rely mainly on internal
-equivalence / property tests plus the coverage of the computational
-libraries they bridge. Their `core` profile is a set of `#guard`
-assertions that the bridge theorems hold on committed small
-instances.
+The `-mathlib` libraries are not the primary target of external
+conformance testing. A correspondence-only layer among them has no
+`core` profile at all: its coverage is the coverage of the
+computational owners it transports from, and a conformance module of
+its own is banned (see §Banned anti-patterns and
+[PLAN/Phase3.md §Correspondence-only mathlib layers](../PLAN/Phase3.md)).
+A Mathlib-importing library that owns a runtime of its own, an
+executable reifier, certificate checker, or tactic, does have a `core`
+profile, exercising that runtime against the contract its library SPEC
+states rather than restating bridge theorems.
 
 ## Profile sizes
 

--- a/progress/20260822T022704Z_phase-policy-correspondence-layers.md
+++ b/progress/20260822T022704Z_phase-policy-correspondence-layers.md
@@ -1,0 +1,56 @@
+# Phase 3/4 exit criteria for correspondence-only mathlib layers
+
+## Accomplished
+
+Defined a **correspondence-only mathlib layer** as a `mathlib: true`
+library advertising zero operations in either Phase-4 evidence track,
+and gave it written exit criteria.
+
+- `PLAN/Phase3.md`, new `### Correspondence-only mathlib layers`: no
+  `conformance/HexFooMathlib/Conformance.lean` and no `HexConformance`
+  glob naming it; the PR audits whatever checks the layer carried and
+  cites the coverage living in the named computational owners, with
+  bridge-only conversion and index-helper checks deleted rather than
+  migrated; `lake build HexFooMathlib` green; `done_through` bumped in
+  the same PR.
+- `PLAN/Phase4.md`, new `### Correspondence-only mathlib layers`: no
+  bench targets (`SPEC/benchmarking.md §Mathlib-free benches`), an
+  external-comparator absence declared with the new
+  `correspondence-only-layer` reason naming the computational owners,
+  no `phase4` block, and no required headline report. The deliverables,
+  the compiled-track criteria, and the empty-Concerns criterion do not
+  apply. The exemption is narrow: compiled-only, proof-only, and mixed
+  libraries all take ordinary track assignment, and a declared
+  `proof_probes` root normally puts a library outside the exemption.
+- `SPEC/benchmarking.md`: added `correspondence-only-layer` as a sixth
+  comparator-absence reason, since the other five are scoped to a bench
+  target and this class has none; widened the absence-declaration
+  lead-in to cover a library with no bench target at all; exempted such
+  a layer from the headline-report requirement.
+- `SPEC/testing.md`: corrected the two places that still promised these
+  layers a `core` conformance profile, both now distinguishing a
+  correspondence-only layer from a Mathlib-importing library that owns
+  a runtime.
+
+## Current frontier
+
+The policy now matches what `scripts/conformance_targets.py` enforces
+and what HexHenselMathlib, HexGFqMathlib, and HexModArithMathlib
+actually did on their way to `done_through: 7`. No script or Lean
+change was needed.
+
+## Next step
+
+`HexPolyFpMathlib` can record Phase 3 and Phase 4 against these
+criteria. Its SPEC spells the comparator-absence reason
+`proof-only-layer`, as do `HexGF2Mathlib`'s and `HexGFqMathlib`'s; all
+three move to `correspondence-only-layer` and gain their owner names
+(`hex-gf2` and `hex-gfq-field` for HexGF2Mathlib). Separately,
+`scripts/check_phase4.py` exempts every `mathlib: true` library with no
+`phase4` block and no report, without checking correspondence-only
+status; a follow-up issue proposes an explicit classification the
+validators can key off.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR give written exit criteria to correspondence-only mathlib layers, whose Phase 3 and Phase 4 records have so far rested on precedent: `PLAN/Phase3.md` required a `Conformance.lean` of every Phase-3 completion and `PLAN/Phase4.md` required bench-track assignment and a headline report, while `SPEC/testing.md` bans a conformance module in such a layer and `SPEC/benchmarking.md` bans it bench targets, and the layers already at `done_through: 7` (HexHenselMathlib, HexGFqMathlib, HexModArithMathlib) carry neither. Define the class as a `mathlib: true` library advertising zero operations in either Phase-4 evidence track. Phase 3 is satisfied by the absent conformance module and glob plus an audit citing, per transported operation, the coverage in the named computational owners, with layer-only checks deleted rather than migrated (the HO-39 shape). Phase 4 is satisfied by the absent bench targets, a comparator-absence declaration, no `phase4` block, and no required headline report, which is the shape `scripts/check_phase4.py` already exempts. Add `correspondence-only-layer` as a sixth comparator-absence reason in `SPEC/benchmarking.md`, since the existing five are scoped to a bench target, and correct the two places in `SPEC/testing.md` that still promised these layers a core conformance profile. Libraries with proof or tactic surfaces of their own (e.g. an elaborator evidenced by `proof_probes`) take ordinary track assignment and are outside the exemption.

This is a policy change to the phase doctrine, not a routine doc fix.

🤖 Prepared with Claude Code