### PR TITLE
doc: correct SPEC and record staleness ahead of the finite-field release

### DIFF
--- a/HexGF2/SPEC/hex-gf2.md
+++ b/HexGF2/SPEC/hex-gf2.md
@@ -1,11 +1,14 @@
-# hex-gf2 (GF(2) packed arithmetic, depends on hex-poly)
+# hex-gf2 (GF(2) packed arithmetic, depends on hex-basic)
 
 Packed bitwise representation of polynomials over F_2. Addition is
 XOR, multiplication uses carry-less multiply. Substantially faster
 than the generic `FpPoly 2` path (up to 64x for addition-heavy
-workloads). Actual speedups depend on workload; benchmarks comparing
-`GF2Poly` vs `FpPoly 2` for Berlekamp matrix construction and
-polynomial GCD are planned.
+workloads). Actual speedups depend on workload. Benchmarks comparing
+`GF2Poly` vs `FpPoly 2` for polynomial GCD and Berlekamp matrix
+construction exist, but they are cross-library, so their
+registrations live in `bench/HexGF2Bench.lean` at the executable
+root, outside the per-library `bench/HexGF2/` tree. The per-library
+suite covers the packed core and the NTL comparator registrations.
 
 **Contents:**
 

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -67,9 +67,10 @@ side stays executable.
 
 No external comparator is required.
 
-**Justification:** `proof-only-layer` per
+**Justification:** `correspondence-only-layer` per
 `SPEC/benchmarking.md §"Comparator naming"`. This library introduces no new
 arithmetic algorithm: it states correspondences between representations that
-hex-gf2 and hex-gfq-field implement, and their performance is measured in those
-libraries. The encoding and decoding functions it does define exist to state
-those correspondences, not as a computational surface anyone races.
+hex-gf2 and hex-gfq-field implement, and those two are the computational
+performance owners, where the arithmetic is measured. The encoding and decoding
+functions it does define exist to state those correspondences, not as a
+computational surface anyone races.

--- a/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
+++ b/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
@@ -2,7 +2,10 @@
 
 Supplies the finiteness and cardinality layer for the quotient-field
 construction, the Mathlib `Field` instance on it, and the correspondence with
-Mathlib's `GaloisField`.
+Mathlib's `GaloisField`. It also builds on hex-conway's Tier 2 evidence twice
+over: the subfield embedding between committed Conway fields, and the lemmas
+needed to transport the executable primitivity check into Mathlib's order
+vocabulary.
 
 **Contents:**
 
@@ -17,6 +20,16 @@ Mathlib's `GaloisField`.
   the above with `conwayPoly_degree`.
 - `GFq.equivGaloisField : GFq p n h ≃+* GaloisField p n`.
 - `GF2q.equivGFq : GF2q n ≃+* GFq 2 n h.entry`, the packed-to-generic leg.
+- `ofPolyHom`, `constHom`, and `substHom`, the reduction, constant-embedding,
+  and substitution ring homomorphisms into
+  `GFqField.FiniteField f hf hp hirr`, which is what a Mathlib construction
+  needing a `RingHom` out of the executable side is pointed at.
+- `conwayEmbed : GFq p m →+* GFq p n`, the embedding of the degree-`m` Conway
+  field into the degree-`n` one for a committed divisor pair carrying a
+  `Conway.Compatible` witness, instantiated at four such pairs.
+- The component lemmas needed to transport hex-conway's executable primitivity
+  check to the hypotheses of Mathlib's
+  `orderOf_eq_of_pow_and_pow_div_prime`.
 
 The `Fintype` instances are deliberately `noncomputable`. The carriers have
 `p ^ degree f` elements, so a compiled `Finset.univ` over one is a footgun
@@ -41,6 +54,50 @@ therefore needs `[Fact p.Prime]` and `n ≠ 0`, both of which `GaloisField.card`
 requires and neither of which the executable side carries, so they are
 hypotheses on the equivalence rather than on the field type.
 
+## The Conway subfield embedding
+
+`Subfield.lean` defines the map hex-conway's Tier 2 evidence licenses.
+`Conway.normX` is a computed representative: the product of `k = n / m`
+successive Frobenius images of the residue of `x`, reduced modulo `C(p, n)` at
+each step, structured that way so the kernel can replay it. Reading it as the
+field norm `α ^ ((p^n - 1) / (p^m - 1))` is the design rationale for the
+definition, not a theorem; hex-conway is explicit that two evaluation and
+Frobenius bridges are missing before that identity can be proved, so this SPEC
+does not lean on it. What compatibility does prove, in
+`eval_conwayPoly_subfieldGen_eq_zero`, is that `C(p, m)` vanishes at the class
+of `normX`, and that root property is the well-definedness input the embedding
+needs.
+
+`conwayEmbed` is the resulting ring homomorphism `GFq p m →+* GFq p n`. Its
+domain is a committed divisor pair carrying a `Conway.Compatible` witness
+rather than a bare `m ∣ n` proof: `Compatible` is the decidable check that
+composing `C(p, m)` with `normX` reduces to zero, and that is what makes the
+substitution well defined. The multiplicative content is Mathlib's:
+`Polynomial.eval₂RingHom` is a ring homomorphism by construction, so all the
+Hex side has to supply is that the executable substitution agrees with it,
+which is additive and monomial data. `GF(2^2)` and `GF(2^3)` inside `GF(2^6)`,
+`GF(13)` inside `GF(13^6)`, and `GF(2^4)` inside `GF(2^8)` are checked here as
+examples.
+
+## Primitivity transport
+
+`Primitivity.lean` supplies the lemmas needed to transport hex-conway's
+executable order check across `ofPolyHom`. The check runs on `FpPoly`
+representatives with structural powers, while `orderOf` is about Mathlib's `^`
+in the field, so each ingredient travels separately: `ofPolyHom_linPowMod` and
+`ofPolyHom_digitPowMod` move the powers through `map_mul` and `map_pow`,
+`ofPolyHom_eq_one_iff` turns "not one" on a reduced representative into "not
+one" in the field, `mathlibPrime_of_hexPrime` converts the Mathlib-free
+primality predicate, and `mem_of_prime_dvd_primePowerProduct` shows that a
+validated prime-power product lists every prime dividing it, so a short prime
+list cannot weaken the test.
+
+Two things are deliberately recorded as absent. No declaration here consumes a
+`Conway.Primitive` witness or produces the per-prime hypothesis function
+Mathlib's `orderOf_eq_of_pow_and_pow_div_prime` quantifies over, so the glue
+from `Primitive.check` to those hypotheses does not exist yet; and the
+per-entry `orderOf α = p ^ n - 1` conclusion is correspondingly not assembled.
+
 ## Namespaces
 
 Declarations live in `HexGFqMathlib`, except `GF2q.equivGFq`, which extends
@@ -50,7 +107,8 @@ Declarations live in `HexGFqMathlib`, except `GF2q.equivGFq`, which extends
 
 No external comparator is required.
 
-**Justification:** `proof-only-layer` per
+**Justification:** `correspondence-only-layer` per
 `SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
-arithmetic algorithm; it transports facts about constructions whose performance
-is measured in hex-gfq-field and hex-gf2.
+arithmetic algorithm; it transports facts about constructions implemented
+elsewhere. The computational performance owners are hex-gfq-field and hex-gf2,
+where those constructions are measured.

--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -50,7 +50,9 @@ than about the representation.
 
 No external comparator is required.
 
-**Justification:** `proof-only-layer` per
+**Justification:** `correspondence-only-layer` per
 `SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
-arithmetic algorithm; it transports values between two representations whose
-performance is measured in hex-poly-fp and in Mathlib respectively.
+arithmetic algorithm; it transports values between two representations. The
+computational performance owner is hex-poly-fp, which implements and measures
+the executable side of the correspondence; the other side is Mathlib's own
+`Polynomial`.

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -31,8 +31,7 @@ example that exercises the advertised user story end-to-end.
   using `hex-berlekamp`'s Rabin test or `hex-conway`'s tabulated
   polynomials.
 - **Tutorials:** AES modulus irreducibility (anchored to
-  `hex-berlekamp`); prime splitting via Kummer-Dedekind (anchored to
-  `hex-gfq`).
+  `hex-berlekamp`).
 
 ### Release 3: Certified integer factorization
 
@@ -45,6 +44,9 @@ example that exercises the advertised user story end-to-end.
 - **Integration example:** `Examples/Release3.lean` — factor a handful
   of integer polynomials end-to-end, including at least one case that
   benefits from Hensel lifting beyond the baseline `mod p` step.
+- **Tutorials:** prime splitting via Kummer-Dedekind (anchored to
+  `hex-berlekamp-zassenhaus`, per the anchor table in
+  [Phase7.md](Phase7.md)).
 
 ### Release 4: Conditional lattice factorization
 

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -85,7 +85,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
-- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and the transport of coefficients, degree, monicity, and ring operations across it
+- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and the transport of coefficients, monicity, and ring operations across it
 - **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`; the `Polynomial (ZMod p)` extension for `factor_poly` / `irreducibility`
 - **hex-hensel-mathlib**: Hensel correctness, uniqueness, `coprime_mod_p_lifts`
 - **hex-lll-mathlib**: lattice = `Submodule ℤ`, short vector bound

--- a/libraries.yml
+++ b/libraries.yml
@@ -194,7 +194,7 @@ libraries:
         - name: adjacent-swap-scalars
           description: Adjacent-swap denominator, pivot coefficient, Gram-determinant quotient, and scaled-coefficient numerator helper formulas.
   HexGF2:
-    deps: [HexPoly, HexBasic]
+    deps: [HexBasic]
     mathlib: false
     done_through: 7
     status: active
@@ -490,6 +490,12 @@ libraries:
     # phases it has not completed is the drift these phases exist to prevent.
     # HexBerlekampMathlib is unaffected in practice: at done_through 3 it is
     # already blocked from Phase 4 by HexBerlekamp, also at 3.
+    # HexGF2Mathlib picked up the same new dependency edge (its
+    # equivPolynomial routes through fpPolyEquiv), and it too is unaffected in
+    # practice, for the opposite reason: it was at done_through 4 when the edge
+    # was added and is now at 5, so it is past every phase status.py gates on
+    # dependencies (1, 3, and 4). Its recorded 1/3/4 predate the extraction and
+    # are not re-derived against this entry.
     done_through: 0
     status: active
   HexBerlekampMathlib:

--- a/progress/20260822T023054Z_spec-fixes-finite-field-release.md
+++ b/progress/20260822T023054Z_spec-fixes-finite-field-release.md
@@ -1,0 +1,99 @@
+# SPEC and record staleness fixes ahead of the finite-field release batch
+
+## Accomplished
+
+Cleared eight release-readiness staleness items across SPECs, `PLAN/`, and
+`libraries.yml`. Each claim was checked against the source before editing.
+
+- `HexGF2/SPEC/hex-gf2.md`: the header named hex-poly as the dependency.
+  Every import under `HexGF2/` is `HexBasic` or `Std`, so the header now
+  names hex-basic. The same paragraph called the packed-versus-generic
+  `GF2Poly` / `FpPoly 2` comparisons "planned"; they are registered in
+  `bench/HexGF2Bench.lean` under the `packed-vs-generic-comparison` input
+  family, so the paragraph now says they exist and locates them by layout:
+  cross-library, therefore at the executable root rather than in the
+  per-library `bench/HexGF2/` tree.
+- `libraries.yml`: `HexGF2.deps` dropped `HexPoly`. No file under
+  `HexGF2/`, `bench/HexGF2/`, or `conformance/HexGF2/` imports a `HexPoly`
+  module. `bench/HexGF2Bench.lean` imports `HexPolyFp`, which is the
+  executable-root cross-library comparison and not a `HexGF2` dependency.
+  `scripts/check_dag.py` and `scripts/status.py` agree: the status output
+  is byte-identical before and after.
+- Comparator-absence tags: `HexPolyFpMathlib`, `HexGF2Mathlib`, and
+  `HexGFqMathlib` all cited `proof-only-layer`, which is not one of the
+  reasons `SPEC/benchmarking.md` §"Comparator naming" enumerates. All three
+  now cite `correspondence-only-layer`, the sixth reason a parallel policy PR
+  is adding for a zero-bench correspondence layer, and each names its
+  computational performance owners: hex-poly-fp; hex-gf2 and hex-gfq-field;
+  hex-gfq-field and hex-gf2. `mathlib-bridge` was the first candidate and is
+  wrong here, since `SPEC/benchmarking.md` defines it through a within-Lean
+  `compare` group and none of these three has one. This PR must therefore
+  land after the policy PR, so the tag is defined before anything references
+  it.
+- `SPEC/Libraries/README.md`: the hex-poly-fp-mathlib index line advertised
+  degree transport. `HexPolyFpMathlib/Basic.lean` has coefficient, monicity,
+  derivative, divisibility, and ring-operation transport, but no
+  `degree`/`natDegree` lemma, so "degree" is gone from the line.
+- `HexGFqMathlib/SPEC/hex-gfq-mathlib.md`: the SPEC covered only
+  `Basic.lean` and `GF2q.lean`. Added Contents entries and two sections for
+  `Subfield.lean` (the ring homomorphisms out of `FpPoly p`, and
+  `conwayEmbed`, the degree-`m` into degree-`n` Conway embedding) and
+  `Primitivity.lean` (the component lemmas that would transport hex-conway's
+  executable order check onto the hypotheses of Mathlib's
+  `orderOf_eq_of_pow_and_pow_div_prime`). Both sections record what is
+  *not* proved, since a first draft of them overstated the Lean content on
+  two counts. `Conway.normX` is a computed Frobenius-product representative;
+  identifying it with the field norm `α ^ ((p^n - 1) / (p^m - 1))` is design
+  rationale, and `HexConway/Compatibility.lean` names the two missing
+  Frobenius and evaluation bridges explicitly. What is proved is that
+  `C(p, m)` vanishes at its class, which is what `conwayEmbed` consumes, and
+  `conwayEmbed`'s hypothesis is a `Conway.Compatible` witness on a committed
+  divisor pair, not an `m ∣ n` proof. In `Primitivity.lean`, no declaration
+  consumes a `Conway.Primitive` witness or produces the per-prime hypothesis
+  function Mathlib's order lemma quantifies over, so both the glue from
+  `Primitive.check` and the per-entry `orderOf` conclusion are recorded as
+  absent.
+- `PLAN/Releases.md`: the prime-splitting tutorial was anchored to hex-gfq,
+  contradicting the anchor table at `PLAN/Phase7.md:137`. Since the
+  authoritative anchor is hex-berlekamp-zassenhaus, a Release 3 library, the
+  tutorial bullet moved from Release 2 to Release 3 rather than just
+  swapping the anchor name in place: the readiness predicate treats a
+  release's tutorials as subsumed by its own libraries' Phase 7.
+- `libraries.yml`: the `HexPolyFpMathlib` extraction comment named only
+  `HexBerlekampMathlib` as an affected dependent. `HexGF2Mathlib` gained the
+  same edge in the same PR (its `equivPolynomial` composes with
+  `HexPolyFpMathlib.fpPolyEquiv`) while sitting at `done_through` 4, so the
+  comment now covers it too.
+
+## Current frontier
+
+Branch `spec-fixes-finite-field-release`, committed locally, not pushed.
+`check_released_manifest.py`, `check_dag.py`, and `status.py` all pass, and
+`status.py`'s output is unchanged by the dependency edit.
+
+## Next step
+
+Open the PR, and sequence it after the policy PR that defines
+`correspondence-only-layer`, so the tag these three SPECs cite is never a
+dangling reference. No mechanical check enforces comparator-absence tags
+today, so nothing goes red either way; the ordering is about the text being
+true when it lands.
+
+Two adjacent staleness items were found and deliberately left alone, since
+they belong to the planned-graph layer of
+`SPEC/Libraries/README.md` rather than to the release batch:
+
+- line 146 lists hex-gf2's dependencies as "hex-poly, hex-basic,
+  hex-finite-field", but that section describes the planned graph including
+  libraries that do not exist yet (hex-finite-field among them), so it is
+  not simply a stale copy of `libraries.yml`.
+- line 190 lists hex-gfq-mathlib's dependencies as hex-gfq alone, while
+  `libraries.yml` has `[HexGFq, HexGF2Mathlib]` and the SPEC header names
+  hex-gf2-mathlib.
+
+Both want a decision about whether that section tracks `libraries.yml` or
+the planned graph, which is a larger question than this batch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR clears eight staleness items that a release-readiness audit turned up in the finite-field library batch. The hex-gf2 SPEC header names hex-basic, which is what the library actually imports, rather than hex-poly; the same paragraph stops calling the packed-versus-generic `GF2Poly` / `FpPoly 2` comparisons "planned" and instead locates them by layout, since they are cross-library and so live in `bench/HexGF2Bench.lean` at the executable root rather than in the per-library `bench/HexGF2/` tree. `HexGF2.deps` drops `HexPoly` to match the imports.

The three correspondence SPECs that justified comparator absence with `proof-only-layer`, which `SPEC/benchmarking.md` §"Comparator naming" does not enumerate, now cite `correspondence-only-layer` and name their computational performance owners: hex-poly-fp for hex-poly-fp-mathlib, hex-gf2 and hex-gfq-field for hex-gf2-mathlib, hex-gfq-field and hex-gf2 for hex-gfq-mathlib. This depends on https://github.com/kim-em/hex-dev/pull/9366, which adds `correspondence-only-layer` to the enumeration, and should land after it.

The hex-poly-fp-mathlib index line drops degree from the list of what transports across the equivalence, because no degree or natDegree lemma exists. The hex-gfq-mathlib SPEC gains coverage of `Subfield.lean` and `Primitivity.lean`, which it had never mentioned: the ring homomorphisms out of `FpPoly p`, `conwayEmbed` as the embedding of a committed Conway divisor pair carrying a `Conway.Compatible` witness, and the component lemmas that would carry hex-conway's executable order check to the hypotheses of Mathlib's `orderOf_eq_of_pow_and_pow_div_prime`. Both sections say what is not proved: `Conway.normX` is a computed Frobenius-product representative whose identity with the field norm hex-conway leaves open, and nothing yet connects a `Conway.Primitive` witness to Mathlib's order hypotheses or assembles the per-entry `orderOf` conclusion.

The prime-splitting tutorial moves from Release 2 to Release 3 in `PLAN/Releases.md`, since the authoritative anchor table in `PLAN/Phase7.md` anchors it to hex-berlekamp-zassenhaus and the readiness predicate treats a release's tutorials as subsumed by its own libraries' Phase 7. Finally, the `HexPolyFpMathlib` extraction comment names `HexGF2Mathlib` alongside `HexBerlekampMathlib`: it gained the same dependency edge in the same PR, since its `equivPolynomial` composes with `fpPolyEquiv`.

🤖 Prepared with Claude Code
