### PR TITLE
feat(sparse-poly): activate HexSparsePoly with the representation core

### DIFF
--- a/HexSparsePoly.lean
+++ b/HexSparsePoly.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexSparsePoly.Basic
+
+public section
+
+/-!
+Canonical sparse univariate polynomials: a sorted array of
+`(exponent, coefficient)` terms with strictly increasing exponents and no
+stored zero coefficients, for inputs whose exponents are large and whose
+number of nonzero coefficients is small.
+-/

--- a/HexSparsePoly/Basic.lean
+++ b/HexSparsePoly/Basic.lean
@@ -1,0 +1,423 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBasic.ArrayDecEq
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+The canonical sparse representation of univariate polynomials: a sorted
+array of `(exponent, coefficient)` terms with strictly increasing
+exponents and no stored zero coefficients, its constructors, accessors,
+and ordered term-iteration API.
+-/
+
+namespace Hex
+
+open scoped Hex
+
+universe u v
+
+/-- A term array is canonical when its exponents are strictly increasing
+and no stored coefficient is zero. -/
+def SparsePolyCanonical {R : Type u} [Zero R] [DecidableEq R]
+    (terms : Array (Nat × R)) : Prop :=
+  terms.toList.Pairwise (fun a b => a.1 < b.1) ∧ ∀ t ∈ terms, t.2 ≠ 0
+
+/-- A univariate polynomial over `R` as a canonical sorted array of
+`(exponent, coefficient)` terms, ascending in exponent. Exponents are
+`Nat`, so degrees like `10^6` cost nothing to store; only `toDense`
+materialises a coefficient vector.
+
+Per design principle 10, consumers read `terms` through the API
+(`coeff`, `support`, `numTerms`, `degree?`, `leadingCoeff`, and the
+ordered `toTerms` and `foldTerms`), not directly, so the representation
+can change. -/
+structure SparsePoly (R : Type u) [Zero R] [DecidableEq R] where
+  /-- The stored `(exponent, coefficient)` terms in strictly increasing
+  exponent order, with no zero coefficients. -/
+  terms : Array (Nat × R)
+  /-- Proof that `terms` is canonical. -/
+  canonical : SparsePolyCanonical terms
+
+namespace SparsePoly
+
+variable {R : Type u} [Zero R] [DecidableEq R]
+
+/- The comparison routes through `Hex.instDecidableEqArray` from
+`HexBasic/ArrayDecEq.lean`, which compares the term `List`s so the kernel
+can reduce it across a module boundary, and whose `@[csimp]` redirect
+restores the in-place `Array` comparison in compiled code. `Prod`'s
+`DecidableEq` is written out in `Init.Core` rather than derived, so it is
+not a second stall; the conformance module-boundary probe checks that. -/
+instance : DecidableEq (SparsePoly R) := fun a b =>
+  match decEq a.terms b.terms with
+  | isTrue h =>
+      isTrue (by
+        cases a with | mk ta ca =>
+        cases b with | mk tb cb =>
+        cases h
+        rfl)
+  | isFalse h =>
+      isFalse (by
+        intro hab
+        apply h
+        rw [hab])
+
+/-- The zero polynomial: the empty term array. -/
+def zero : SparsePoly R where
+  terms := #[]
+  canonical := by
+    constructor
+    · simp
+    · intro t ht
+      simp at ht
+
+instance : Zero (SparsePoly R) where
+  zero := zero
+
+/-- The number of stored terms, which is the size of the support. -/
+def numTerms (s : SparsePoly R) : Nat :=
+  s.terms.size
+
+/-- `true` exactly when the polynomial is zero. -/
+def isZero (s : SparsePoly R) : Bool :=
+  s.terms.isEmpty
+
+/-- The stored exponents in increasing order; exactly the exponents whose
+coefficient is nonzero. -/
+def support (s : SparsePoly R) : Array Nat :=
+  s.terms.map (·.1)
+
+/-- The degree, or `none` for the zero polynomial. The terms ascend in
+exponent, so the degree is the last stored exponent. -/
+def degree? (s : SparsePoly R) : Option Nat :=
+  s.terms.back?.map (·.1)
+
+/-- The leading coefficient, which is `0` for the zero polynomial. -/
+def leadingCoeff (s : SparsePoly R) : R :=
+  match s.terms.back? with
+  | some t => t.2
+  | none => 0
+
+/-- The stored terms in increasing exponent order. -/
+def toTerms (s : SparsePoly R) : List (Nat × R) :=
+  s.terms.toList
+
+/-- Fold over the stored terms in increasing exponent order, `O(t)`. -/
+def foldTerms {β : Type v} (s : SparsePoly R) (f : β → Nat → R → β)
+    (init : β) : β :=
+  s.terms.foldl (fun acc t => f acc t.1 t.2) init
+
+/-- The coefficient at exponent `e` in a term list: the first stored match,
+`0` when absent. On a canonical list the match is unique. -/
+def coeffList : List (Nat × R) → Nat → R
+  | [], _ => 0
+  | t :: ts, e => if t.1 = e then t.2 else coeffList ts e
+
+/-- The coefficient at `e`. Kernel-facing specification (an ordered
+`List` lookup); compiled code uses `Hex.SparsePoly.coeffImpl`, the
+value-equal binary search selected by `Hex.SparsePoly.coeff_eq_impl`. -/
+noncomputable def coeff (s : SparsePoly R) (e : Nat) : R :=
+  coeffList s.terms.toList e
+
+/-- Binary-search worker for `coeffImpl`: find the coefficient at
+exponent `e` among indices in `[lo, hi)` of a term array sorted by
+strictly increasing exponent. -/
+def coeffSearch (ts : Array (Nat × R)) (e : Nat) (lo hi : Nat) : R :=
+  if _h : lo < hi then
+    match ts[(lo + hi) / 2]? with
+    | some t =>
+        if t.1 = e then t.2
+        else if t.1 < e then coeffSearch ts e ((lo + hi) / 2 + 1) hi
+        else coeffSearch ts e lo ((lo + hi) / 2)
+    | none => 0
+  else 0
+termination_by hi - lo
+decreasing_by all_goals omega
+
+/-- Runtime implementation of {name}`coeff`: binary search on the sorted
+term array, `O(log t)` (value-equal to {name}`coeff` by `coeff_eq_impl`,
+registered `@[csimp]`). -/
+def coeffImpl (s : SparsePoly R) (e : Nat) : R :=
+  coeffSearch s.terms e 0 s.terms.size
+
+omit [DecidableEq R] in
+/-- A term list with no term at exponent `e` has coefficient `0` there. -/
+theorem coeffList_eq_zero {l : List (Nat × R)} {e : Nat}
+    (h : ∀ t ∈ l, t.1 ≠ e) : coeffList l e = 0 := by
+  induction l with
+  | nil => rfl
+  | cons a as ih =>
+      have ha : a.1 ≠ e := h a (List.mem_cons_self ..)
+      simp only [coeffList, if_neg ha]
+      exact ih fun t ht => h t (List.mem_cons_of_mem _ ht)
+
+omit [DecidableEq R] in
+/-- On a list with strictly increasing exponents, a stored term at
+exponent `e` is the coefficient there. -/
+theorem coeffList_eq_of_mem {l : List (Nat × R)} {t : Nat × R} {e : Nat}
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (ht : t ∈ l) (he : t.1 = e) :
+    coeffList l e = t.2 := by
+  induction l with
+  | nil => cases ht
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      cases ht with
+      | head => simp only [coeffList, if_pos he]
+      | tail _ hmem =>
+          have hlt : a.1 < t.1 := hs.1 t hmem
+          have hne : a.1 ≠ e := by omega
+          simp only [coeffList, if_neg hne]
+          exact ih hs.2 hmem
+
+omit [DecidableEq R] in
+/-- On the range that the sortedness invariant confines the matching
+exponent to, the binary search agrees with the ordered `List` lookup. -/
+theorem coeffSearch_eq_coeffList (ts : Array (Nat × R)) (e : Nat)
+    (hs : ts.toList.Pairwise (fun a b => a.1 < b.1)) (lo hi : Nat)
+    (hhi : hi ≤ ts.size)
+    (hrange : ∀ i, (h : i < ts.size) → ts[i].1 = e → lo ≤ i ∧ i < hi) :
+    coeffSearch ts e lo hi = coeffList ts.toList e := by
+  unfold coeffSearch
+  split
+  · rename_i hlt
+    have hmid : (lo + hi) / 2 < ts.size := by omega
+    split
+    · rename_i t heq
+      obtain ⟨_, hval⟩ := Array.getElem?_eq_some_iff.mp heq
+      subst hval
+      by_cases h1 : (ts[(lo + hi) / 2]).1 = e
+      · rw [if_pos h1]
+        refine (coeffList_eq_of_mem hs ?_ h1).symm
+        exact List.mem_iff_getElem.mpr
+          ⟨(lo + hi) / 2, by simpa using hmid, by simp⟩
+      · rw [if_neg h1]
+        have hidx : ∀ i j, (hij : i < j) → (hj : j < ts.size) →
+            (ts[i]'(by omega)).1 < ts[j].1 := by
+          intro i j hij hj
+          have := List.pairwise_iff_getElem.mp hs i j
+            (by simpa using by omega) (by simpa using hj) hij
+          simpa using this
+        by_cases h2 : (ts[(lo + hi) / 2]).1 < e
+        · rw [if_pos h2]
+          refine coeffSearch_eq_coeffList ts e hs _ _ hhi ?_
+          intro i hisz hie
+          obtain ⟨-, hupper⟩ := hrange i hisz hie
+          refine ⟨?_, hupper⟩
+          rcases Nat.lt_trichotomy i ((lo + hi) / 2) with hlt' | heq' | hgt'
+          · have := hidx i ((lo + hi) / 2) hlt' hmid
+            omega
+          · subst heq'
+            exact absurd hie h1
+          · omega
+        · rw [if_neg h2]
+          refine coeffSearch_eq_coeffList ts e hs _ _ (by omega) ?_
+          intro i hisz hie
+          obtain ⟨hlower, -⟩ := hrange i hisz hie
+          refine ⟨hlower, ?_⟩
+          rcases Nat.lt_trichotomy ((lo + hi) / 2) i with hlt' | heq' | hgt'
+          · have := hidx ((lo + hi) / 2) i hlt' hisz
+            omega
+          · subst heq'
+            exact absurd hie h1
+          · omega
+    · rename_i heq
+      have := Array.getElem?_eq_none_iff.mp heq
+      omega
+  · rename_i hnlt
+    refine (coeffList_eq_zero ?_).symm
+    intro t htmem hte
+    obtain ⟨i, hilen, hit⟩ := List.mem_iff_getElem.mp htmem
+    have hisz : i < ts.size := by simpa using hilen
+    have : ts[i].1 = e := by
+      rw [← Array.getElem_toList (by simpa using hisz)]
+      rw [hit]
+      exact hte
+    have := hrange i hisz this
+    omega
+termination_by hi - lo
+decreasing_by all_goals omega
+
+/-- The kernel-facing `List` lookup and the binary search compute the same
+coefficient on every canonical polynomial. -/
+theorem coeff_eq_coeffImpl (s : SparsePoly R) (e : Nat) :
+    coeff s e = coeffImpl s e := by
+  unfold coeff coeffImpl
+  exact (coeffSearch_eq_coeffList s.terms e s.canonical.1 0 s.terms.size
+    (Nat.le_refl _) (fun i h _ => ⟨Nat.zero_le _, h⟩)).symm
+
+/-- Register the binary search as the compiled implementation of
+{name}`coeff`. -/
+@[csimp]
+theorem coeff_eq_impl : @coeff = @coeffImpl := by
+  funext R _ _ s e
+  exact coeff_eq_coeffImpl s e
+
+/-- Linear canonicality check on a term list: adjacent exponents strictly
+increase and no stored coefficient is zero. The pairwise form of the
+invariant is the one induction wants; this adjacent form is the one an
+`O(t)` check wants, and `isCanonicalList_iff` is the equivalence. -/
+def isCanonicalList : List (Nat × R) → Bool
+  | [] => true
+  | [t] => decide (t.2 ≠ 0)
+  | a :: b :: ts =>
+      decide (a.2 ≠ 0) && decide (a.1 < b.1) && isCanonicalList (b :: ts)
+
+/-- The adjacent-pair check decides the pairwise invariant: `<` on `Nat`
+is transitive, so strict increase between neighbours is strict increase
+between every pair. -/
+theorem isCanonicalList_iff {l : List (Nat × R)} :
+    isCanonicalList l = true ↔
+      (l.Pairwise (fun a b => a.1 < b.1) ∧ ∀ t ∈ l, t.2 ≠ 0) := by
+  induction l with
+  | nil => simp [isCanonicalList]
+  | cons a as ih =>
+      cases as with
+      | nil => simp [isCanonicalList]
+      | cons b bs =>
+          simp only [isCanonicalList, Bool.and_eq_true, decide_eq_true_eq]
+          constructor
+          · rintro ⟨⟨ha0, hab⟩, hrest⟩
+            obtain ⟨hpw, hnz⟩ := ih.mp hrest
+            refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+            · intro t ht
+              rcases List.mem_cons.mp ht with rfl | ht'
+              · exact hab
+              · have hb : b.1 < t.1 := (List.pairwise_cons.mp hpw).1 t ht'
+                omega
+            · intro t ht
+              rcases List.mem_cons.mp ht with rfl | ht'
+              · exact ha0
+              · exact hnz t ht'
+          · rintro ⟨hpw, hnz⟩
+            rw [List.pairwise_cons] at hpw
+            refine ⟨⟨hnz a (List.mem_cons_self ..),
+              hpw.1 b (List.mem_cons_self ..)⟩, ?_⟩
+            exact ih.mpr ⟨hpw.2, fun t ht => hnz t (List.mem_cons_of_mem _ ht)⟩
+
+/-- Linear canonicality check on a term array, `O(t)`. -/
+def isCanonical (ts : Array (Nat × R)) : Bool :=
+  isCanonicalList ts.toList
+
+/-- The `O(t)` adjacent-pair check decides {name}`SparsePolyCanonical`. -/
+theorem isCanonical_iff {ts : Array (Nat × R)} :
+    isCanonical ts = true ↔ SparsePolyCanonical ts := by
+  unfold isCanonical SparsePolyCanonical
+  rw [isCanonicalList_iff]
+  constructor
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1, fun t ht => h2 t (Array.mem_def.mp ht)⟩
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1, fun t ht => h2 t (Array.mem_def.mpr ht)⟩
+
+instance (ts : Array (Nat × R)) : Decidable (SparsePolyCanonical ts) :=
+  decidable_of_iff _ isCanonical_iff
+
+omit [DecidableEq R] in
+/-- A sorted term list has coefficient `0` below its head exponent. -/
+theorem coeffList_eq_zero_of_lt_head {b : Nat × R} {bs : List (Nat × R)}
+    {e : Nat} (hs : (b :: bs).Pairwise (fun x y => x.1 < y.1))
+    (he : e < b.1) : coeffList (b :: bs) e = 0 := by
+  refine coeffList_eq_zero ?_
+  intro t ht
+  rcases List.mem_cons.mp ht with rfl | ht'
+  · omega
+  · have := (List.pairwise_cons.mp hs).1 t ht'
+    omega
+
+omit [DecidableEq R] in
+/-- The tail of a sorted term list has coefficient `0` at the head's
+exponent: strict increase means the head's exponent never recurs. -/
+theorem coeffList_tail_eq_zero {a : Nat × R} {as : List (Nat × R)}
+    (hs : (a :: as).Pairwise (fun x y => x.1 < y.1)) :
+    coeffList as a.1 = 0 := by
+  refine coeffList_eq_zero ?_
+  intro t ht
+  have := (List.pairwise_cons.mp hs).1 t ht
+  omega
+
+omit [DecidableEq R] in
+/-- Two canonical term lists with the same coefficient function are equal.
+This is the list-level content of `SparsePoly.ext_coeff`: strict exponent
+increase forbids duplicates and fixes the order, and the zero-free
+condition makes every stored term observable. -/
+theorem coeffList_ext {l₁ l₂ : List (Nat × R)}
+    (hs₁ : l₁.Pairwise (fun a b => a.1 < b.1))
+    (hs₂ : l₂.Pairwise (fun a b => a.1 < b.1))
+    (hnz₁ : ∀ t ∈ l₁, t.2 ≠ 0) (hnz₂ : ∀ t ∈ l₂, t.2 ≠ 0)
+    (h : ∀ e, coeffList l₁ e = coeffList l₂ e) : l₁ = l₂ := by
+  induction l₁ generalizing l₂ with
+  | nil =>
+      cases l₂ with
+      | nil => rfl
+      | cons b bs =>
+          have hb := h b.1
+          simp only [coeffList] at hb
+          exact absurd hb.symm (hnz₂ b (List.mem_cons_self ..))
+  | cons a as ih =>
+      cases l₂ with
+      | nil =>
+          have ha := h a.1
+          simp only [coeffList] at ha
+          exact absurd ha (hnz₁ a (List.mem_cons_self ..))
+      | cons b bs =>
+          have hexp : a.1 = b.1 := by
+            rcases Nat.lt_trichotomy a.1 b.1 with hlt | heq | hgt
+            · exfalso
+              have ha := h a.1
+              rw [coeffList_eq_zero_of_lt_head hs₂ hlt] at ha
+              simp only [coeffList] at ha
+              exact hnz₁ a (List.mem_cons_self ..) ha
+            · exact heq
+            · exfalso
+              have hb := h b.1
+              rw [coeffList_eq_zero_of_lt_head hs₁ hgt] at hb
+              simp only [coeffList] at hb
+              exact hnz₂ b (List.mem_cons_self ..) hb.symm
+          have hcoeff : a.2 = b.2 := by
+            have ha := h a.1
+            simp only [coeffList, if_pos hexp.symm] at ha
+            exact ha
+          have htail : as = bs := by
+            refine ih (List.pairwise_cons.mp hs₁).2
+              (List.pairwise_cons.mp hs₂).2
+              (fun t ht => hnz₁ t (List.mem_cons_of_mem _ ht))
+              (fun t ht => hnz₂ t (List.mem_cons_of_mem _ ht)) ?_
+            intro e
+            by_cases heq : e = a.1
+            · subst heq
+              rw [coeffList_tail_eq_zero hs₁, hexp, coeffList_tail_eq_zero hs₂]
+            · have hna : ¬(a.1 = e) := fun hc => heq hc.symm
+              have hnb : ¬(b.1 = e) := by
+                intro hc
+                exact heq (by omega)
+              have he := h e
+              simp only [coeffList, if_neg hna, if_neg hnb] at he
+              exact he
+          rw [Prod.ext hexp hcoeff, htail]
+
+/-- Extensionality: canonical representations of the same coefficient
+function are equal. Everything below is proved from this. -/
+@[ext] theorem ext_coeff {s t : SparsePoly R}
+    (h : ∀ e, s.coeff e = t.coeff e) : s = t := by
+  cases s with | mk ts hts =>
+  cases t with | mk tt htt =>
+  have hlist : ts.toList = tt.toList := by
+    refine coeffList_ext hts.1 htt.1 ?_ ?_ h
+    · intro t ht
+      exact hts.2 t (Array.mem_def.mpr ht)
+    · intro t ht
+      exact htt.2 t (Array.mem_def.mpr ht)
+  cases Array.toList_inj.mp hlist
+  rfl
+
+end SparsePoly
+
+end Hex

--- a/HexSparsePoly/SPEC/hex-sparse-poly.md
+++ b/HexSparsePoly/SPEC/hex-sparse-poly.md
@@ -7,13 +7,13 @@ coefficients is small. Mathlib-free. The companion
 `Polynomial R` and the correspondence lemmas.
 
 This SPEC expands the "Sparse univariate polynomials" bullet of
-[future-work](../future-work.md). It sits beside
+[future-work](../../SPEC/future-work.md). It sits beside
 [hex-poly](../../HexPoly/SPEC/hex-poly.md) rather than inside it, and it
 converts to and from `DensePoly R` explicitly at a named boundary. It
 does **not** introduce a common interface over the two representations.
 The reasoning is under "No swappable polynomial abstraction" below, and
 the same decision is recorded in
-[future-work](../future-work.md) under "Swappable polynomial
+[future-work](../../SPEC/future-work.md) under "Swappable polynomial
 representations (deferred)".
 
 ## Why this library exists
@@ -41,7 +41,7 @@ cyclotomics is exactly the one this representation stores well: `Φ_p`
 has degree `p − 1` and all `p` of its coefficients are `1`, so it is
 dense, and the `p^k` members are that dense polynomial with its
 exponents scaled. The
-cyclotomic library specified in [hex-cyclotomic](hex-cyclotomic.md)
+cyclotomic library specified in [hex-cyclotomic](../../SPEC/Libraries/hex-cyclotomic.md)
 builds `ZPoly` and leaves sparse output to an adapter over this library
 at a consumer that holds both. That adapter is downstream and is not a
 dependency in either direction: nothing here knows what a cyclotomic
@@ -84,7 +84,7 @@ which is a condition on one end of the array. This library maintains
 condition on every adjacent pair and every entry. An interface that
 tried to state a shared canonical-form law would state neither.
 
-The resolution is the one [future-work](../future-work.md) already
+The resolution is the one [future-work](../../SPEC/future-work.md) already
 records: build the second representation with explicit conversions
 first, and reconsider a common interface only after several real
 consumers have shown which operations belong in it. Today there is one
@@ -782,7 +782,7 @@ The remainder-degree statements use `degree?.getD 0` because that is the
 shape `DensePoly.DivModLaws` states them in, and `degree?_toDense` is
 what moves them across. `divExactMonic?_eq_some` needs no `t ≠ 0` side
 condition, unlike the `divExact?` of
-[hex-poly-z-gcd](hex-poly-z-gcd.md): a monic divisor is nonzero.
+[hex-poly-z-gcd](../../SPEC/Libraries/hex-poly-z-gcd.md): a monic divisor is nonzero.
 
 **No claim is made that any of this stays sparse.** Sparsity survives
 in special cases and not in general, and the special cases are what make
@@ -808,7 +808,7 @@ with a two-term input of degree `10^6` should expect a gcd to cost what a
 dense gcd at degree `10^6` costs.
 
 This is a deliberate placement rather than a gap to be filled later.
-[future-work](../future-work.md) records that a sparse division
+[future-work](../../SPEC/future-work.md) records that a sparse division
 algorithm should be measured before it is committed to, and the
 "convert-gcd" bench family below is that measurement: it records the
 conversion share of the total, which is the number that says whether a
@@ -817,7 +817,7 @@ exists, this SPEC authorises the conversion route and nothing more.
 
 Exact division by an arbitrary, possibly nonmonic integer polynomial is
 not specified here. That is hex-poly-z's `divExact?`, which
-[hex-poly-z-gcd](hex-poly-z-gcd.md) schedules, and a consumer that wants
+[hex-poly-z-gcd](../../SPEC/Libraries/hex-poly-z-gcd.md) schedules, and a consumer that wants
 it already depends on hex-poly-z and can apply it to `toDense`. Adding a
 second one here would be inventing an operation this library has no
 consumer for.
@@ -904,7 +904,7 @@ not an optimisation. See the representation section.
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). Two Lean drivers, as
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). Two Lean drivers, as
 [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md) has:
 `conformance/HexSparsePoly/Conformance.lean`, holding the `#guard`
 property checks, registered in `HexConformance`; and
@@ -993,7 +993,7 @@ Euclidean algorithm.
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexSparsePoly/Bench.lean`. Native only, plus a small kernel
 family for the `decide` closure listed under kernel exposure.
 
@@ -1114,7 +1114,7 @@ sort-by-key with a combining fold that the `@[csimp]` twin uses proves
 reusable, it belongs in hex-basic rather than here, in the same way that
 [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md) puts its reusable map
 algorithms in `HexBasic/ExtTreeMap.lean`. The sparse matrix work
-described in [future-work](../future-work.md) canonicalises coordinate
+described in [future-work](../../SPEC/future-work.md) canonicalises coordinate
 form the same way and would be the second consumer. Write it here
 first and promote it when that happens.
 
@@ -1233,7 +1233,7 @@ derivative theorems are stated against the dense operations.
   the merge and of `coeff`. `Array (Nat × R)` keeps the invariant and
   the proofs in one place and cannot desynchronise the lengths. This is
   the same choice coordinate form faces in the sparse matrix item of
-  [future-work](../future-work.md), and design principle 10 is what
+  [future-work](../../SPEC/future-work.md), and design principle 10 is what
   keeps it changeable: no consumer reads `terms`.
 - **Whether descending exponent order would suit the consumers better.**
   Leading-term algorithms want the top term first, and evaluation reads

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -364,7 +364,7 @@ hex-poly ──────────────────┘              
 `hex-basic` for the `List.foldl` algebra its canonicalisation proof
 uses. There is no interface over the two representations: callers name
 the one they hold and convert explicitly, for the reasons in
-[hex-sparse-poly §No swappable polynomial abstraction](hex-sparse-poly.md).
+[hex-sparse-poly §No swappable polynomial abstraction](../../HexSparsePoly/SPEC/hex-sparse-poly.md).
 Its companion is defined by composing `toDense` with hex-poly-mathlib's
 equivalence, so it depends on that library rather than reproving the
 ring structure.
@@ -558,7 +558,7 @@ for developments whose source-local move has not happened yet.
 - [hex-modular-matrix.md](hex-modular-matrix.md): multi-modular determinant, certified rank, and Dixon p-adic linear solving (the Mathlib companion is specified in the same file)
 - [hex-poly](../../HexPoly/SPEC/hex-poly.md): dense polynomial library, operations, GCD, CRT
 - [hex-poly-mathlib](../../HexPolyMathlib/SPEC/hex-poly-mathlib.md): `DensePoly R ≃+* Polynomial R`
-- [hex-sparse-poly.md](hex-sparse-poly.md): canonical sparse univariate polynomials, the operations that keep sparsity, and the dense conversions (the Mathlib companion is specified in the same file)
+- [hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md): canonical sparse univariate polynomials, the operations that keep sparsity, and the dense conversions (the Mathlib companion is specified in the same file)
 - [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md): canonical distributed multivariate polynomials with explicit monomial orders
 - [hex-mv-poly-mathlib](../../HexMvPolyMathlib/SPEC/hex-mv-poly-mathlib.md): `MvPoly n R cmp ≃+* MvPolynomial (Fin n) R`, `aeval`, and operation correspondence
 - [hex-mv-gcd](hex-mv-gcd.md): multivariate gcd with cofactors, content and primitive part, exact division, squarefree decomposition

--- a/SPEC/Libraries/hex-cyclotomic.md
+++ b/SPEC/Libraries/hex-cyclotomic.md
@@ -17,7 +17,7 @@ in "The index is a checked factorization" below.
 **Cyclotomic polynomials are already in the tree as literals.** They
 appear as hard-coded factorisation fixtures, as benchmark inputs for
 `hex-berlekamp-zassenhaus`, and as the shape the sparse representation
-of [hex-sparse-poly](hex-sparse-poly.md) is designed around. Nothing
+of [hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md) is designed around. Nothing
 constructs them. A fixture that spells out all 49 coefficients of the
 degree-48 `Φ₁₀₅`
 is a fixture nobody can extend, and an irreducibility benchmark whose
@@ -562,7 +562,7 @@ two are nonzero.
 ## Sparse output is an adapter, not a dependency
 
 `hex-cyclotomic` does not depend on
-[hex-sparse-poly](hex-sparse-poly.md). Dense `ZPoly` is the default
+[hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md). Dense `ZPoly` is the default
 output because every consumer in the tree today (Berlekamp-Zassenhaus
 inputs, the evaluation the factorization split wants, the conformance
 fixtures) holds dense polynomials, and because the sparse library's own
@@ -767,7 +767,7 @@ The irreducibility check pulls in `hex-berlekamp-zassenhaus`, which
 runs the other way for the benchmark inputs. The monorepo hides this;
 the released split repository would not, so the manifest entry records
 the conformance-only pin. This is the same arrangement
-[hex-sparse-poly](hex-sparse-poly.md) makes for `ZMod64`.
+[hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md) makes for `ZMod64`.
 
 ## Benchmarking
 
@@ -927,7 +927,7 @@ theorem degree_substPow (hk : 0 < k), monic_substPow (hk : 0 < k)
 `[Add R]` is there for `k = 0`, which sums the coefficients. That case
 is not reachable from this library, since the kernel exponent
 `n / rad n` is at least `1`, but it is reachable from
-[hex-sparse-poly](hex-sparse-poly.md), whose `substPow` takes `[Add R]`
+[hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md), whose `substPow` takes `[Add R]`
 for exactly this reason and whose SPEC lists the collapse as a
 canonicalisation case. Mathlib agrees: `Polynomial.expand R 0 f` is
 `C (f.eval 1)`. The degree and monicity statements carry `0 < k`, since

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -87,6 +87,8 @@ lean_lib HexPoly where
 
 lean_lib HexMvPoly where
 
+lean_lib HexSparsePoly where
+
 lean_lib HexModArith where
   precompileModules := true
   -- See `HexArith`: the `hexmodarithffi` extern_lib links in automatically, so

--- a/libraries.yml
+++ b/libraries.yml
@@ -127,6 +127,32 @@ libraries:
           description: Sparse rename, partial-evaluation, and substitution cases where distinct source terms collide.
         - name: sum-of-squares-arithmetic
           description: Representative sum-of-squares-shaped identities measured as compiled Mathlib-free arithmetic.
+  HexSparsePoly:
+    deps: [HexPoly, HexBasic]
+    mathlib: false
+    done_through: 0
+    status: active
+    phase4:
+      comparators:
+        - tool: SymPy sparse ring elements (sympy.polys.rings)
+          class: informational
+          rationale: "SymPy is the conformance oracle and is Python, so the ratio is reported for context and does not determine acceptance."
+        - tool: FLINT fmpz_poly via python-flint
+          class: informational
+          rationale: "fmpz_poly is dense, so above the crossover the comparison measures the choice of representation rather than the quality of either implementation. Recorded on the crossover family only."
+      input_families:
+        - name: sparse-arithmetic
+          description: addition and multiplication of 2 to 64 term inputs at degrees 10^3 to 10^6
+        - name: sparse-multiplication
+          description: low-collision and high-collision products across the three candidate implementations
+        - name: crossover
+          description: the same operations against DensePoly with the term count swept from 2 to the degree, locating one crossover per operation
+        - name: evaluation
+          description: gap Horner against dense Horner across the same sweep
+        - name: substitution-power
+          description: substPow on the cyclotomic shapes against the dense route
+        - name: convert-gcd
+          description: gcd and divMod through the conversions on the sparse-remainder x^n-1 pair and on generic sparse pairs, recording the conversion share separately
   HexMatrix:
     deps: [HexBasic]
     mathlib: false
@@ -432,6 +458,11 @@ libraries:
           description: Rename and substitution identities whose distinct source terms collide in the destination support.
         - name: kernel-sos-certificates
           description: Representative sum-of-squares certificate identities checked from a downstream module with decide +kernel.
+  HexSparsePolyMathlib:
+    deps: [HexSparsePoly, HexPolyMathlib, HexPoly]
+    mathlib: true
+    done_through: 0
+    status: planned
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true

--- a/progress/20260822T030530Z_sparse-poly-basic.md
+++ b/progress/20260822T030530Z_sparse-poly-basic.md
@@ -1,0 +1,34 @@
+# hex-sparse-poly: activation and the representation core
+
+## Accomplished
+
+- Activated `HexSparsePoly` (`libraries.yml` entry with the SPEC's phase4
+  comparator/input-family block, `lean_lib`, umbrella) and seeded
+  `HexSparsePolyMathlib` as `planned`.
+- Moved the SPEC to `HexSparsePoly/SPEC/hex-sparse-poly.md` and rewrote
+  its and its referrers' relative links for the new location.
+- `HexSparsePoly/Basic.lean`: `SparsePolyCanonical`, `SparsePoly`, the
+  hand-written `DecidableEq` over hex-basic's scoped kernel-reducible
+  array instance, `Zero`, the accessors (`numTerms`, `isZero`, `support`,
+  `degree?`, `leadingCoeff`, `toTerms`, `foldTerms`), `coeff` as the
+  `List`-shaped kernel-facing specification with the binary-search
+  `coeffImpl` behind a proved `@[csimp]` equality, the linear
+  `isCanonical` check deciding `SparsePolyCanonical`, and `ext_coeff`
+  via `coeffList_ext`. No `sorry`.
+
+## Current frontier
+
+Milestone 1 of the SPEC is half landed: the representation and its
+observation API are in; `addTerm` / `ofTerms` with their `@[csimp]`
+twins, `monomial` / `C` / `X`, the `#sp[…]` literal, `coeff_ofTerms`,
+and the kernel-exposure probe module are next.
+
+## Next step
+
+`addTerm` as the ordered-`List` insert specification plus the
+binary-search/in-place `addTermImpl`, with the invariant-preservation
+proof; then `ofTerms` and its stable sort-and-combine twin.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -664,5 +664,17 @@
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
     "current_blob": "abbfb2327a8ee1c28a6fa20dcf5a285cd782284c",
     "reason": "Additionally registers the bounded Mathlib-free Ramanujan theta range and point checkers, their proof-only direct Chebyshev semantics, and conformance module on top of the retained supported HexInterval executable package/application assembly, autonomous controller, PNT, and public interval registrations; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "4ce3130da10d9cefc0ba753006e63cede695d423",
+    "reason": "Registers the new HexSparsePoly lean_lib; no factorization module, executable, or build-flag changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
+    "current_blob": "840c7e2481a6fa5ca2f77e43a666ec010feeb70b",
+    "reason": "Adds HexSparsePoly.KernelTests to the HexReleaseTests globs on top of the HexSparsePoly lean_lib registration; no factorization module, executable, or build-flag changes."
   }
 ]


### PR DESCRIPTION
This PR activate the hex-sparse-poly library specified in [HexSparsePoly/SPEC/hex-sparse-poly.md](https://github.com/kim-em/hex-dev/blob/sparse-poly-basic/HexSparsePoly/SPEC/hex-sparse-poly.md) and land the first half of its milestone 1: the SPEC moves to its per-library location with links rewritten, `libraries.yml` gains the `HexSparsePoly` entry (active, with the SPEC's phase-4 comparator and input-family block) and the `HexSparsePolyMathlib` companion entry (planned), and `HexSparsePoly/Basic.lean` lands `SparsePolyCanonical`, `SparsePoly`, a hand-written `DecidableEq` over hex-basic's scoped kernel-reducible array instance, the observation API (`coeff`, `support`, `numTerms`, `degree?`, `leadingCoeff`, `isZero`, `toTerms`, `foldTerms`), `coeff` as the `List`-shaped kernel-facing specification with the `O(log t)` binary-search `coeffImpl` behind a proved `@[csimp]` equality, the linear `isCanonical` check deciding `SparsePolyCanonical`, and coefficient extensionality `ext_coeff`. All proofs are complete; no `sorry`.

🤖 Prepared with Claude Code