### PR TITLE
feat(sparse-poly): canonical construction with proved csimp twins

### DIFF
--- a/HexSparsePoly/Basic.lean
+++ b/HexSparsePoly/Basic.lean
@@ -418,6 +418,894 @@ function are equal. Everything below is proved from this. -/
   cases Array.toList_inj.mp hlist
   rfl
 
+/-- The coefficient stored at an exponent after adding `c` to a stored
+coefficient `d` there, where `d = 0` encodes "absent": a zero sum (and a
+zero insertion) leaves the exponent absent, encoded as `0` again. On a
+canonical representation the stored coefficient is `0` exactly when the
+term is absent, so this is the whole observable effect of `addTerm` at
+its target exponent. -/
+def addCoeff [Add R] (d c : R) : R :=
+  if d = 0 then (if c = 0 then 0 else c)
+  else (if d + c = 0 then 0 else d + c)
+
+/-- Ordered insert of `c · x^e` into a sorted term list: insert a new
+term when `c ≠ 0` and `e` is absent, replace the stored coefficient by
+the sum when the sum is nonzero, and delete the term when the sum is
+zero. -/
+def addTermList [Add R] : List (Nat × R) → Nat → R → List (Nat × R)
+  | [], e, c => if c = 0 then [] else [(e, c)]
+  | t :: ts, e, c =>
+      if e < t.1 then (if c = 0 then t :: ts else (e, c) :: t :: ts)
+      else if t.1 = e then
+        (if t.2 + c = 0 then ts else (t.1, t.2 + c) :: ts)
+      else t :: addTermList ts e c
+
+/-- Every exponent stored after an insert was stored before or is the
+inserted one. -/
+theorem exp_mem_addTermList [Add R] {l : List (Nat × R)} {e : Nat} {c : R}
+    {t : Nat × R} (ht : t ∈ addTermList l e c) :
+    t.1 = e ∨ ∃ u ∈ l, t.1 = u.1 := by
+  induction l generalizing t with
+  | nil =>
+      simp only [addTermList] at ht
+      split at ht
+      · cases ht
+      · rcases List.mem_cons.mp ht with rfl | h'
+        · exact Or.inl rfl
+        · cases h'
+  | cons a as ih =>
+      simp only [addTermList] at ht
+      split at ht
+      · split at ht
+        · exact Or.inr ⟨t, ht, rfl⟩
+        · rcases List.mem_cons.mp ht with rfl | h'
+          · exact Or.inl rfl
+          · exact Or.inr ⟨t, h', rfl⟩
+      · split at ht
+        · split at ht
+          · exact Or.inr ⟨t, List.mem_cons_of_mem _ ht, rfl⟩
+          · rcases List.mem_cons.mp ht with rfl | h'
+            · exact Or.inr ⟨a, List.mem_cons_self .., rfl⟩
+            · exact Or.inr ⟨t, List.mem_cons_of_mem _ h', rfl⟩
+        · rcases List.mem_cons.mp ht with rfl | h'
+          · exact Or.inr ⟨t, List.mem_cons_self .., rfl⟩
+          · rcases ih h' with h | ⟨u, hu, he⟩
+            · exact Or.inl h
+            · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, he⟩
+
+/-- The ordered insert preserves both halves of the canonical
+invariant. This is the proof the whole library rests on: every
+specialised operation re-establishes what {name}`addTermList` establishes
+here for arbitrary input. -/
+theorem addTermList_canonical [Add R] {l : List (Nat × R)}
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (hnz : ∀ t ∈ l, t.2 ≠ 0)
+    (e : Nat) (c : R) :
+    (addTermList l e c).Pairwise (fun a b => a.1 < b.1) ∧
+      ∀ t ∈ addTermList l e c, t.2 ≠ 0 := by
+  induction l with
+  | nil =>
+      simp only [addTermList]
+      split
+      · simp
+      · rename_i hc
+        constructor
+        · simp
+        · intro t ht
+          rcases List.mem_cons.mp ht with rfl | h'
+          · exact hc
+          · cases h'
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      obtain ⟨hpw, hnztail⟩ :=
+        ih hs.2 (fun t ht => hnz t (List.mem_cons_of_mem _ ht))
+      have hnza : a.2 ≠ 0 := hnz a (List.mem_cons_self ..)
+      simp only [addTermList]
+      split
+      · rename_i hlt
+        split
+        · exact ⟨List.pairwise_cons.mpr ⟨hs.1, hs.2⟩, hnz⟩
+        · rename_i hc
+          refine ⟨List.pairwise_cons.mpr ⟨?_, List.pairwise_cons.mpr hs⟩, ?_⟩
+          · intro t ht
+            rcases List.mem_cons.mp ht with rfl | h'
+            · exact hlt
+            · have := hs.1 t h'
+              omega
+          · intro t ht
+            rcases List.mem_cons.mp ht with rfl | h'
+            · exact hc
+            · exact hnz t h'
+      · split
+        · rename_i hnlt heq
+          split
+          · exact ⟨hs.2, fun t ht => hnz t (List.mem_cons_of_mem _ ht)⟩
+          · rename_i hsum
+            refine ⟨List.pairwise_cons.mpr ⟨hs.1, hs.2⟩, ?_⟩
+            intro t ht
+            rcases List.mem_cons.mp ht with rfl | h'
+            · exact hsum
+            · exact hnz t (List.mem_cons_of_mem _ h')
+        · rename_i hnlt hne
+          refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+          · intro t ht
+            rcases exp_mem_addTermList ht with h | ⟨u, hu, hue⟩
+            · omega
+            · have := hs.1 u hu
+              omega
+          · intro t ht
+            rcases List.mem_cons.mp ht with rfl | h'
+            · exact hnza
+            · exact hnztail t h'
+
+/-- Add `c · x^e` to `s`, combining with an existing term at `e` and
+deleting the term when the sum is zero.
+
+Kernel-facing specification (a single ordered `List` insert); compiled
+code uses `Hex.SparsePoly.addTermImpl`, the value-equal binary search and
+in-place array update selected by `Hex.SparsePoly.addTerm_eq_impl`. -/
+noncomputable def addTerm [Add R] (s : SparsePoly R) (e : Nat) (c : R) :
+    SparsePoly R where
+  terms := (addTermList s.terms.toList e c).toArray
+  canonical := by
+    obtain ⟨h1, h2⟩ := addTermList_canonical s.canonical.1
+      (fun t ht => s.canonical.2 t (Array.mem_def.mpr ht)) e c
+    exact ⟨by simpa using h1, fun t ht => h2 t (by simpa using Array.mem_def.mp ht)⟩
+
+/-- Equal term arrays give equal polynomials: the proof field is
+irrelevant. -/
+theorem eq_of_terms_eq {s t : SparsePoly R} (h : s.terms = t.terms) :
+    s = t := by
+  cases s with | mk ts hts =>
+  cases t with | mk tt htt =>
+  cases h
+  rfl
+
+/-- The whole observable effect of the ordered insert: the coefficient
+at `e` becomes {name}`addCoeff` of the stored coefficient and `c`, and
+every other coefficient is unchanged. -/
+theorem coeffList_addTermList [Add R] {l : List (Nat × R)}
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (hnz : ∀ t ∈ l, t.2 ≠ 0)
+    (e : Nat) (c : R) (f : Nat) :
+    coeffList (addTermList l e c) f =
+      if f = e then addCoeff (coeffList l e) c else coeffList l f := by
+  induction l with
+  | nil =>
+      by_cases hc : c = 0
+      · by_cases hf : f = e
+        · subst hf
+          simp [addTermList, coeffList, addCoeff, hc]
+        · simp [addTermList, coeffList, addCoeff, hc, hf]
+      · by_cases hf : f = e
+        · subst hf
+          simp [addTermList, coeffList, addCoeff, hc]
+        · have hef : ¬e = f := fun h => hf h.symm
+          simp [addTermList, coeffList, addCoeff, hc, hef, hf]
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      have hnza : a.2 ≠ 0 := hnz a (List.mem_cons_self ..)
+      have hnztail : ∀ t ∈ as, t.2 ≠ 0 :=
+        fun t ht => hnz t (List.mem_cons_of_mem _ ht)
+      rcases Nat.lt_trichotomy e a.1 with hlt | heq | hgt
+      · -- `e` sits below the head: insert in front (or do nothing).
+        have hcoeff_e : coeffList (a :: as) e = 0 :=
+          coeffList_eq_zero_of_lt_head (List.pairwise_cons.mpr hs) hlt
+        by_cases hc : c = 0
+        · simp only [addTermList, if_pos hlt, if_pos hc]
+          by_cases hf : f = e
+          · subst hf
+            rw [if_pos rfl, hcoeff_e, addCoeff]
+            simp [hc]
+          · rw [if_neg hf]
+        · simp only [addTermList, if_pos hlt, if_neg hc]
+          by_cases hf : f = e
+          · subst hf
+            rw [if_pos rfl, hcoeff_e, addCoeff]
+            simp only [coeffList, if_pos rfl]
+            simp [hc]
+          · rw [if_neg hf]
+            simp only [coeffList]
+            rw [if_neg (fun h : e = f => hf h.symm)]
+      · -- the head is the target: combine or delete.
+        have hcoeff_e : coeffList (a :: as) e = a.2 := by
+          simp only [coeffList, if_pos heq.symm]
+        have htail_e : coeffList as e = 0 := by
+          have := coeffList_tail_eq_zero
+            (a := a) (as := as) (List.pairwise_cons.mpr hs)
+          rw [← heq] at this
+          exact this
+        have hnotlt : ¬ e < a.1 := by omega
+        by_cases hsum : a.2 + c = 0
+        · simp only [addTermList, if_neg hnotlt, if_pos heq.symm, if_pos hsum]
+          by_cases hf : f = e
+          · subst hf
+            rw [if_pos rfl, hcoeff_e, addCoeff, if_neg hnza, if_pos hsum,
+              htail_e]
+          · rw [if_neg hf]
+            simp only [coeffList]
+            rw [if_neg (fun h : a.1 = f => hf (by omega))]
+        · simp only [addTermList, if_neg hnotlt, if_pos heq.symm, if_neg hsum]
+          by_cases hf : f = e
+          · subst hf
+            rw [if_pos rfl, hcoeff_e, addCoeff, if_neg hnza, if_neg hsum]
+            simp only [coeffList, if_pos heq.symm]
+          · rw [if_neg hf]
+            simp only [coeffList]
+            rw [if_neg (fun h : a.1 = f => hf (by omega)),
+              if_neg (fun h : a.1 = f => hf (by omega))]
+      · -- the head sits below the target: recurse into the tail.
+        have hnotlt : ¬ e < a.1 := by omega
+        have hne : ¬ a.1 = e := by omega
+        simp only [addTermList, if_neg hnotlt, if_neg hne]
+        by_cases hf : f = e
+        · subst hf
+          rw [if_pos rfl]
+          simp only [coeffList, if_neg hne]
+          rw [ih hs.2 hnztail, if_pos rfl]
+        · rw [if_neg hf]
+          simp only [coeffList]
+          by_cases haf : a.1 = f
+          · rw [if_pos haf, if_pos haf]
+          · rw [if_neg haf, if_neg haf, ih hs.2 hnztail, if_neg hf]
+
+/-- Coefficient description of {name}`addTerm`: {name}`addCoeff` at the
+target exponent, unchanged elsewhere. -/
+theorem coeff_addTerm [Add R] (s : SparsePoly R) (e : Nat) (c : R)
+    (f : Nat) :
+    (s.addTerm e c).coeff f =
+      if f = e then addCoeff (s.coeff e) c else s.coeff f := by
+  unfold coeff addTerm
+  simp only [List.toList_toArray]
+  exact coeffList_addTermList s.canonical.1
+    (fun t ht => s.canonical.2 t (Array.mem_def.mpr ht)) e c f
+
+/-- Binary-search worker for `addTermImpl`: the least index in
+`[lo, hi)` whose exponent is at least `e` (or `hi` when there is none),
+on an array sorted by strictly increasing exponent. -/
+def lowerBound (ts : Array (Nat × R)) (e : Nat) (lo hi : Nat) : Nat :=
+  if _h : lo < hi then
+    match ts[(lo + hi) / 2]? with
+    | some t =>
+        if t.1 < e then lowerBound ts e ((lo + hi) / 2 + 1) hi
+        else lowerBound ts e lo ((lo + hi) / 2)
+    | none => lo
+  else lo
+termination_by hi - lo
+decreasing_by all_goals omega
+
+omit [DecidableEq R] in
+/-- On a sorted range, {name}`lowerBound` splits the indices: every
+exponent below the returned position is below `e`, every exponent at or
+beyond it is at least `e`. -/
+theorem lowerBound_spec (ts : Array (Nat × R)) (e : Nat)
+    (hs : ts.toList.Pairwise (fun a b => a.1 < b.1)) (lo hi : Nat)
+    (hlohi : lo ≤ hi) (hhi : hi ≤ ts.size)
+    (hbelow : ∀ i, (h : i < ts.size) → i < lo → ts[i].1 < e)
+    (habove : ∀ i, (h : i < ts.size) → hi ≤ i → e ≤ ts[i].1) :
+    lo ≤ lowerBound ts e lo hi ∧ lowerBound ts e lo hi ≤ hi ∧
+      (∀ i, (h : i < ts.size) → i < lowerBound ts e lo hi → ts[i].1 < e) ∧
+      (∀ i, (h : i < ts.size) → lowerBound ts e lo hi ≤ i → e ≤ ts[i].1) := by
+  have hidx : ∀ i j, (hij : i < j) → (hj : j < ts.size) →
+      (ts[i]'(by omega)).1 < ts[j].1 := by
+    intro i j hij hj
+    have := List.pairwise_iff_getElem.mp hs i j
+      (by simpa using by omega) (by simpa using hj) hij
+    simpa using this
+  unfold lowerBound
+  split
+  · rename_i hlt
+    have hmid : (lo + hi) / 2 < ts.size := by omega
+    split
+    · rename_i t heq
+      obtain ⟨_, hval⟩ := Array.getElem?_eq_some_iff.mp heq
+      subst hval
+      by_cases h1 : (ts[(lo + hi) / 2]).1 < e
+      · rw [if_pos h1]
+        have := lowerBound_spec ts e hs ((lo + hi) / 2 + 1) hi
+          (by omega) hhi ?_ habove
+        · exact ⟨by omega, this.2.1, this.2.2.1, this.2.2.2⟩
+        · intro i hi' hilt
+          rcases Nat.lt_trichotomy i ((lo + hi) / 2) with h' | h' | h'
+          · have := hidx i ((lo + hi) / 2) h' hmid
+            omega
+          · subst h'
+            exact h1
+          · omega
+      · rw [if_neg h1]
+        have := lowerBound_spec ts e hs lo ((lo + hi) / 2)
+          (by omega) (by omega) hbelow ?_
+        · exact ⟨this.1, by omega, this.2.2.1, this.2.2.2⟩
+        · intro i hi' hile
+          rcases Nat.lt_trichotomy ((lo + hi) / 2) i with h' | h' | h'
+          · have := hidx ((lo + hi) / 2) i h' hi'
+            omega
+          · subst h'
+            omega
+          · omega
+    · rename_i heq
+      have := Array.getElem?_eq_none_iff.mp heq
+      omega
+  · rename_i hnlt
+    have hlohi' : lo = hi := by omega
+    subst hlohi'
+    exact ⟨Nat.le_refl _, Nat.le_refl _, fun i h hi => hbelow i h hi,
+      fun i h hi => habove i h hi⟩
+termination_by hi - lo
+decreasing_by all_goals omega
+
+omit [DecidableEq R] in
+/-- {name}`lowerBound` never exceeds `hi`, with no sortedness needed:
+this is what makes the insertion index valid. -/
+theorem lowerBound_le (ts : Array (Nat × R)) (e : Nat) (lo hi : Nat)
+    (h : lo ≤ hi) : lowerBound ts e lo hi ≤ hi := by
+  unfold lowerBound
+  split
+  · rename_i hlt
+    split
+    · rename_i t heq
+      split
+      · exact lowerBound_le ts e ((lo + hi) / 2 + 1) hi (by omega)
+      · exact Nat.le_trans
+          (lowerBound_le ts e lo ((lo + hi) / 2) (by omega)) (by omega)
+    · omega
+  · omega
+termination_by hi - lo
+decreasing_by all_goals omega
+
+/-- The ordered insert, described at the splice position: with `p`
+splitting the sorted list into exponents below `e` and at least `e`, the
+insert is an index-`p` erase, set, insert, or append. This is the
+list-level shape that the in-place array implementation mirrors. -/
+theorem addTermList_splice [Add R] {l : List (Nat × R)} {e : Nat}
+    {p : Nat}
+    (hbelow : ∀ i, (h : i < l.length) → i < p → l[i].1 < e)
+    (habove : ∀ i, (h : i < l.length) → p ≤ i → e ≤ l[i].1) (c : R) :
+    addTermList l e c =
+      match l[p]? with
+      | some t =>
+          if t.1 = e then
+            (if t.2 + c = 0 then l.eraseIdx p else l.set p (e, t.2 + c))
+          else (if c = 0 then l else l.insertIdx p (e, c))
+      | none => if c = 0 then l else l ++ [(e, c)] := by
+  induction l generalizing p with
+  | nil =>
+      simp only [addTermList, List.getElem?_nil]
+      rfl
+  | cons a as ih =>
+      cases p with
+      | zero =>
+          have hae : e ≤ a.1 := habove 0 (by simp) (Nat.zero_le _)
+          simp only [List.getElem?_cons_zero]
+          by_cases heq : a.1 = e
+          · have hnotlt : ¬ e < a.1 := by omega
+            simp only [addTermList, if_neg hnotlt, if_pos heq, if_pos heq]
+            rw [heq]
+            simp
+          · have hlt : e < a.1 := by omega
+            simp only [addTermList, if_pos hlt, if_neg heq]
+            by_cases hc : c = 0
+            · rw [if_pos hc, if_pos hc]
+            · rw [if_neg hc, if_neg hc]
+              rfl
+      | succ q =>
+          have ha : a.1 < e := hbelow 0 (by simp) (Nat.succ_pos _)
+          have hnotlt : ¬ e < a.1 := by omega
+          have hne : ¬ a.1 = e := by omega
+          simp only [addTermList, if_neg hnotlt, if_neg hne,
+            List.getElem?_cons_succ]
+          rw [ih (p := q) ?_ ?_]
+          · cases has : as[q]? with
+            | some t =>
+                simp only
+                by_cases hte : t.1 = e
+                · rw [if_pos hte, if_pos hte]
+                  by_cases hsum : t.2 + c = 0
+                  · rw [if_pos hsum, if_pos hsum, List.eraseIdx_cons_succ]
+                  · rw [if_neg hsum, if_neg hsum, List.set_cons_succ]
+                · rw [if_neg hte, if_neg hte]
+                  by_cases hc : c = 0
+                  · rw [if_pos hc, if_pos hc]
+                  · rw [if_neg hc, if_neg hc, List.insertIdx_succ_cons]
+            | none =>
+                simp only
+                by_cases hc : c = 0
+                · rw [if_pos hc, if_pos hc]
+                · rw [if_neg hc, if_neg hc, List.cons_append]
+          · intro i h hip
+            have := hbelow (i + 1) (by simpa using by omega) (by omega)
+            simpa using this
+          · intro i h hpi
+            have := habove (i + 1) (by simpa using by omega) (by omega)
+            simpa using this
+
+/-- In-place array worker for `addTermImpl`: binary search for the
+splice position, then a single erase, set, insert, or push. `O(log t)`
+search plus an `O(t)` shift. -/
+def addTermArray [Add R] (ts : Array (Nat × R)) (e : Nat) (c : R) :
+    Array (Nat × R) :=
+  match hp : ts[lowerBound ts e 0 ts.size]? with
+  | some t =>
+      if t.1 = e then
+        if t.2 + c = 0 then
+          ts.eraseIdx (lowerBound ts e 0 ts.size)
+            (by obtain ⟨h, -⟩ := Array.getElem?_eq_some_iff.mp hp; exact h)
+        else
+          ts.set (lowerBound ts e 0 ts.size) (e, t.2 + c)
+            (by obtain ⟨h, -⟩ := Array.getElem?_eq_some_iff.mp hp; exact h)
+      else if c = 0 then ts
+      else
+        ts.insertIdx (lowerBound ts e 0 ts.size) (e, c)
+          (lowerBound_le ts e 0 ts.size (Nat.zero_le _))
+  | none =>
+      if c = 0 then ts else ts.push (e, c)
+
+/-- On a sorted array the in-place worker computes exactly the ordered
+`List` insert. -/
+theorem addTermArray_eq [Add R] {ts : Array (Nat × R)}
+    (hs : ts.toList.Pairwise (fun a b => a.1 < b.1)) (e : Nat) (c : R) :
+    addTermArray ts e c = (addTermList ts.toList e c).toArray := by
+  obtain ⟨-, -, hbelow, habove⟩ := lowerBound_spec ts e hs 0 ts.size
+    (Nat.zero_le _) (Nat.le_refl _) (by omega) (by intro i h hi; omega)
+  have hsplice := addTermList_splice (l := ts.toList) (e := e)
+    (p := lowerBound ts e 0 ts.size)
+    (fun i h hip => hbelow i (by simpa using h) hip)
+    (fun i h hpi => habove i (by simpa using h) hpi) c
+  rw [← Array.toList_inj]
+  simp only [List.toList_toArray, hsplice]
+  unfold addTermArray
+  split
+  · rename_i t hp
+    have hp' : ts.toList[lowerBound ts e 0 ts.size]? = some t := by
+      rw [Array.getElem?_toList, hp]
+    simp only [hp']
+    by_cases hte : t.1 = e
+    · rw [if_pos hte, if_pos hte]
+      by_cases hsum : t.2 + c = 0
+      · rw [if_pos hsum, if_pos hsum, Array.toList_eraseIdx]
+      · rw [if_neg hsum, if_neg hsum, Array.toList_set]
+    · rw [if_neg hte, if_neg hte]
+      by_cases hc : c = 0
+      · rw [if_pos hc, if_pos hc]
+      · rw [if_neg hc, if_neg hc, Array.toList_insertIdx]
+  · rename_i hp
+    have hp' : ts.toList[lowerBound ts e 0 ts.size]? = none := by
+      rw [Array.getElem?_toList, hp]
+    simp only [hp']
+    by_cases hc : c = 0
+    · rw [if_pos hc, if_pos hc]
+    · rw [if_neg hc, if_neg hc, Array.toList_push]
+
+/-- Runtime implementation of {name}`addTerm`: binary search and one
+in-place array splice (value-equal to {name}`addTerm` by
+`addTerm_eq_impl`, registered `@[csimp]`). -/
+def addTermImpl [Add R] (s : SparsePoly R) (e : Nat) (c : R) :
+    SparsePoly R where
+  terms := addTermArray s.terms e c
+  canonical := by
+    rw [addTermArray_eq s.canonical.1]
+    exact (s.addTerm e c).canonical
+
+/-- The ordered-`List` specification and the in-place splice compute the
+same polynomial. -/
+theorem addTerm_eq_addTermImpl [Add R] (s : SparsePoly R) (e : Nat)
+    (c : R) : addTerm s e c = addTermImpl s e c :=
+  eq_of_terms_eq (addTermArray_eq s.canonical.1 e c).symm
+
+/-- Register the in-place splice as the compiled implementation of
+{name}`addTerm`. -/
+@[csimp]
+theorem addTerm_eq_impl : @addTerm = @addTermImpl := by
+  funext R _ _ _ s e c
+  exact addTerm_eq_addTermImpl s e c
+
+/-- The canonical polynomial with the given terms. Exponents may repeat
+and may appear in any order, and coefficients at equal exponents are
+summed and zero results are dropped.
+
+Kernel-facing specification (a fold of {name}`addTerm`); compiled code
+uses `Hex.SparsePoly.ofTermsImpl`, the value-equal stable sort and
+combining pass selected by `Hex.SparsePoly.ofTerms_eq_impl`. -/
+noncomputable def ofTerms [Add R] (ts : Array (Nat × R)) : SparsePoly R :=
+  ts.foldl (fun s t => s.addTerm t.1 t.2) 0
+
+@[simp, grind =] theorem coeff_zero (e : Nat) :
+    (0 : SparsePoly R).coeff e = 0 :=
+  rfl
+
+/-- Coefficient description of the {name}`addTerm` fold, with no algebra
+assumed: at each exponent it is the {name}`addCoeff` fold, in input
+order, over the terms at that exponent. -/
+theorem coeff_foldl_addTerm [Add R] (l : List (Nat × R))
+    (s : SparsePoly R) (e : Nat) :
+    (l.foldl (fun s t => s.addTerm t.1 t.2) s).coeff e =
+      (l.filter (fun t => t.1 = e)).foldl (fun acc t => addCoeff acc t.2)
+        (s.coeff e) := by
+  induction l generalizing s with
+  | nil => rfl
+  | cons t ts ih =>
+      simp only [List.foldl_cons]
+      rw [ih]
+      by_cases hte : t.1 = e
+      · rw [List.filter_cons_of_pos (by simpa using hte),
+          List.foldl_cons, coeff_addTerm, if_pos hte.symm, hte]
+      · rw [List.filter_cons_of_neg (by simpa using hte),
+          coeff_addTerm, if_neg (fun h : e = t.1 => hte h.symm)]
+
+/-- Coefficient description of {name}`ofTerms`, with no algebra assumed. -/
+theorem coeff_ofTerms_addCoeff [Add R] (ts : Array (Nat × R)) (e : Nat) :
+    (ofTerms ts).coeff e =
+      (ts.toList.filter (fun t => t.1 = e)).foldl
+        (fun acc t => addCoeff acc t.2) 0 := by
+  unfold ofTerms
+  rw [← Array.foldl_toList]
+  exact coeff_foldl_addTerm ts.toList 0 e
+
+/-- Once `0` is a left identity for `+`, the delete-and-reinsert step is
+plain addition. -/
+theorem addCoeff_eq_add [Add R] (hzero : ∀ c : R, 0 + c = c) (d c : R) :
+    addCoeff d c = d + c := by
+  unfold addCoeff
+  by_cases hd : d = 0
+  · subst hd
+    by_cases hc : c = 0
+    · subst hc
+      rw [if_pos rfl, if_pos rfl, hzero]
+    · rw [if_pos rfl, if_neg hc, hzero]
+  · by_cases hs : d + c = 0
+    · rw [if_neg hd, if_pos hs, hs]
+    · rw [if_neg hd, if_neg hs]
+
+/-- The coefficient of `ofTerms ts` at `e` is the sum, in input order, of
+the coefficients of the terms of `ts` at `e`. The `hzero` hypothesis is
+what identifies a fresh insertion `c` with the fold's `0 + c`; a
+coefficient type with `Lean.Grind.Semiring` discharges it from
+`add_zero` and `add_comm`. -/
+theorem coeff_ofTerms [Add R] (hzero : ∀ c : R, 0 + c = c)
+    (ts : Array (Nat × R)) (e : Nat) :
+    (ofTerms ts).coeff e =
+      (ts.filter (fun t => t.1 = e)).foldl (fun a t => a + t.2) 0 := by
+  rw [coeff_ofTerms_addCoeff, ← Array.foldl_toList, Array.toList_filter]
+  simp only [addCoeff_eq_add hzero]
+
+/-- Combining worker for `ofTermsImpl`: walk a `≤`-sorted term list with
+the run exponent `e` and its accumulated coefficient `acc`, replaying the
+{name}`addCoeff` semantics of the {name}`addTerm` fold within each
+equal-exponent block and emitting the nonzero results. -/
+def combineRun [Add R] (e : Nat) (acc : R) : List (Nat × R) → List (Nat × R)
+  | [] => if acc = 0 then [] else [(e, acc)]
+  | t :: ts =>
+      if t.1 = e then combineRun e (addCoeff acc t.2) ts
+      else if acc = 0 then combineRun t.1 (addCoeff 0 t.2) ts
+      else (e, acc) :: combineRun t.1 (addCoeff 0 t.2) ts
+
+/-- Combine the equal-exponent blocks of a `≤`-sorted term list in one
+pass, dropping zero results. -/
+def combineSorted [Add R] : List (Nat × R) → List (Nat × R)
+  | [] => []
+  | t :: ts => combineRun t.1 (addCoeff 0 t.2) ts
+
+/-- The combining pass emits a canonical list whose exponents all lie at
+or above the run exponent. -/
+theorem combineRun_canonical [Add R] {l : List (Nat × R)} {e : Nat}
+    {acc : R} (hs : l.Pairwise (fun a b => a.1 ≤ b.1))
+    (hge : ∀ t ∈ l, e ≤ t.1) :
+    (combineRun e acc l).Pairwise (fun a b => a.1 < b.1) ∧
+      (∀ t ∈ combineRun e acc l, t.2 ≠ 0) ∧
+      ∀ t ∈ combineRun e acc l, e ≤ t.1 := by
+  induction l generalizing e acc with
+  | nil =>
+      by_cases hacc : acc = 0
+      · simp [combineRun, hacc]
+      · refine ⟨?_, ?_, ?_⟩ <;> simp [combineRun, hacc]
+  | cons t ts ih =>
+      rw [List.pairwise_cons] at hs
+      have hts : ∀ u ∈ ts, t.1 ≤ u.1 := hs.1
+      by_cases hte : t.1 = e
+      · simp only [combineRun, if_pos hte]
+        exact ih hs.2 fun u hu => Nat.le_trans (hte ▸ hts u hu) (Nat.le_refl _)
+      · have hlt : e < t.1 := by
+          have := hge t (List.mem_cons_self ..)
+          omega
+        obtain ⟨hpw, hnz, hge'⟩ := ih (e := t.1) (acc := addCoeff 0 t.2)
+          hs.2 hts
+        by_cases hacc : acc = 0
+        · simp only [combineRun, if_neg hte, if_pos hacc]
+          exact ⟨hpw, hnz, fun u hu => by have := hge' u hu; omega⟩
+        · simp only [combineRun, if_neg hte, if_neg hacc]
+          refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_, ?_⟩
+          · intro u hu
+            have := hge' u hu
+            omega
+          · intro u hu
+            rcases List.mem_cons.mp hu with rfl | hu'
+            · exact hacc
+            · exact hnz u hu'
+          · intro u hu
+            rcases List.mem_cons.mp hu with rfl | hu'
+            · exact Nat.le_refl _
+            · have := hge' u hu'
+              omega
+
+/-- Coefficient description of the combining pass: the run's own
+exponent reads its accumulator folded over the rest of its block, and
+every other exponent reads its whole block folded from `0`. -/
+theorem coeffList_combineRun [Add R] {l : List (Nat × R)} {e : Nat}
+    {acc : R} (hs : l.Pairwise (fun a b => a.1 ≤ b.1))
+    (hge : ∀ t ∈ l, e ≤ t.1) (f : Nat) :
+    coeffList (combineRun e acc l) f =
+      if f = e then
+        (l.filter (fun t => t.1 = e)).foldl (fun a t => addCoeff a t.2) acc
+      else
+        (l.filter (fun t => t.1 = f)).foldl (fun a t => addCoeff a t.2) 0 := by
+  induction l generalizing e acc with
+  | nil =>
+      by_cases hf : f = e
+      · subst hf
+        by_cases hacc : acc = 0
+        · simp [combineRun, hacc, coeffList]
+        · simp [combineRun, hacc, coeffList]
+      · by_cases hacc : acc = 0
+        · simp [combineRun, hacc, coeffList, hf]
+        · have hef : ¬e = f := fun h => hf h.symm
+          simp [combineRun, hacc, coeffList, hf, hef]
+  | cons t ts ih =>
+      rw [List.pairwise_cons] at hs
+      have hts : ∀ u ∈ ts, t.1 ≤ u.1 := hs.1
+      by_cases hte : t.1 = e
+      · rw [show combineRun e acc (t :: ts) = combineRun e (addCoeff acc t.2) ts
+          from by rw [combineRun, if_pos hte]]
+        rw [ih hs.2 (fun u hu => hte ▸ hts u hu)]
+        by_cases hf : f = e
+        · subst hf
+          rw [if_pos rfl, if_pos rfl,
+            List.filter_cons_of_pos (by simpa using hte), List.foldl_cons]
+        · rw [if_neg hf, if_neg hf,
+            List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf (by omega))]
+      · have hlt : e < t.1 := by
+          have := hge t (List.mem_cons_self ..)
+          omega
+        have hfilter_e : ts.filter (fun u => u.1 = e) = [] := by
+          rw [List.filter_eq_nil_iff]
+          intro u hu
+          have := hts u hu
+          simp only [decide_eq_true_eq]
+          omega
+        have ihspec := ih (e := t.1) (acc := addCoeff 0 t.2) hs.2 hts
+        by_cases hacc : acc = 0
+        · rw [show combineRun e acc (t :: ts) =
+              combineRun t.1 (addCoeff 0 t.2) ts
+            from by rw [combineRun, if_neg hte, if_pos hacc]]
+          rw [ihspec]
+          by_cases hf1 : f = t.1
+          · subst hf1
+            rw [if_pos rfl, if_neg (by omega),
+              List.filter_cons_of_pos (by simp), List.foldl_cons]
+          · rw [if_neg hf1]
+            by_cases hfe : f = e
+            · subst hfe
+              rw [if_pos rfl,
+                List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm),
+                hfilter_e, hacc]
+            · rw [if_neg hfe,
+                List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm)]
+        · rw [show combineRun e acc (t :: ts) =
+              (e, acc) :: combineRun t.1 (addCoeff 0 t.2) ts
+            from by rw [combineRun, if_neg hte, if_neg hacc]]
+          simp only [coeffList]
+          by_cases hfe : f = e
+          · subst hfe
+            rw [if_pos rfl, if_pos rfl,
+              List.filter_cons_of_neg (by simpa using fun h : t.1 = f => by omega),
+              hfilter_e]
+            rfl
+          · rw [if_neg (fun h : e = f => hfe h.symm), if_neg hfe, ihspec]
+            by_cases hf1 : f = t.1
+            · subst hf1
+              rw [if_pos rfl, List.filter_cons_of_pos (by simp),
+                List.foldl_cons]
+            · rw [if_neg hf1,
+                List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm)]
+
+/-- Coefficient description of {name}`combineSorted` on a `≤`-sorted
+list: each exponent reads its block folded from `0`. -/
+theorem coeffList_combineSorted [Add R] {l : List (Nat × R)}
+    (hs : l.Pairwise (fun a b => a.1 ≤ b.1)) (f : Nat) :
+    coeffList (combineSorted l) f =
+      (l.filter (fun t => t.1 = f)).foldl (fun a t => addCoeff a t.2) 0 := by
+  cases l with
+  | nil => rfl
+  | cons t ts =>
+      rw [List.pairwise_cons] at hs
+      rw [show combineSorted (t :: ts) = combineRun t.1 (addCoeff 0 t.2) ts
+          from rfl,
+        coeffList_combineRun hs.2 hs.1]
+      by_cases hf : f = t.1
+      · subst hf
+        rw [if_pos rfl, List.filter_cons_of_pos (by simp), List.foldl_cons]
+      · rw [if_neg hf,
+          List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf h.symm)]
+
+omit [Zero R] [DecidableEq R] in
+/-- Stability of the exponent sort, in the form the combining pass needs:
+sorting by exponent does not reorder the terms within any one exponent's
+block. -/
+theorem filter_exp_mergeSort {l : List (Nat × R)} (e : Nat) :
+    (l.mergeSort (fun a b => a.1 ≤ b.1)).filter (fun t => t.1 = e) =
+      l.filter (fun t => t.1 = e) := by
+  have htrans : ∀ a b c : Nat × R,
+      (fun a b : Nat × R => (a.1 ≤ b.1 : Bool)) a b →
+      (fun a b : Nat × R => (a.1 ≤ b.1 : Bool)) b c →
+      (fun a b : Nat × R => (a.1 ≤ b.1 : Bool)) a c := by
+    intro a b c hab hbc
+    simp only [decide_eq_true_eq] at *
+    omega
+  have htotal : ∀ a b : Nat × R,
+      ((fun a b : Nat × R => (a.1 ≤ b.1 : Bool)) a b ||
+       (fun a b : Nat × R => (a.1 ≤ b.1 : Bool)) b a) := by
+    intro a b
+    simp only [Bool.or_eq_true, decide_eq_true_eq]
+    omega
+  have hpw : (l.filter (fun t => t.1 = e)).Pairwise
+      (fun a b : Nat × R => (a.1 ≤ b.1 : Bool) = true) := by
+    have hmem : ∀ t ∈ l.filter (fun t => t.1 = e), t.1 = e := by
+      intro t ht
+      simpa using (List.mem_filter.mp ht).2
+    refine List.pairwise_of_forall_mem_list ?_
+    intro a ha b hb
+    simp only [decide_eq_true_eq]
+    rw [hmem a ha, hmem b hb]
+    exact Nat.le_refl _
+  have hsub : (l.filter (fun t => t.1 = e)).Sublist
+      (l.mergeSort (fun a b => a.1 ≤ b.1)) :=
+    List.sublist_mergeSort htrans htotal hpw List.filter_sublist
+  have hsub2 : (l.filter (fun t => t.1 = e)).Sublist
+      ((l.mergeSort (fun a b => a.1 ≤ b.1)).filter (fun t => t.1 = e)) := by
+    have := hsub.filter (fun t => t.1 = e)
+    rwa [List.filter_eq_self.mpr (fun a ha => (List.mem_filter.mp ha).2)] at this
+  have hperm : ((l.mergeSort (fun a b => a.1 ≤ b.1)).filter
+      (fun t => t.1 = e)).Perm (l.filter (fun t => t.1 = e)) :=
+    (List.mergeSort_perm l _).filter _
+  exact (hsub2.eq_of_length hperm.length_eq.symm).symm
+
+/-- Runtime implementation of {name}`ofTerms`: stable sort by exponent,
+then one combining pass, `O(m log m)` on `m` input terms against the
+specification's `O(m²)` worst case (value-equal to {name}`ofTerms` by
+`ofTerms_eq_impl`, registered `@[csimp]`). Stability is load-bearing:
+it is what makes the per-block fold agree with the input-order fold of
+the specification with no algebra assumed. -/
+def ofTermsImpl [Add R] (ts : Array (Nat × R)) : SparsePoly R where
+  terms :=
+    (combineSorted (ts.toList.mergeSort (fun a b => a.1 ≤ b.1))).toArray
+  canonical := by
+    have hs : (ts.toList.mergeSort (fun a b => a.1 ≤ b.1)).Pairwise
+        (fun a b => a.1 ≤ b.1) := by
+      have := List.pairwise_mergeSort (le := fun a b : Nat × R => (a.1 ≤ b.1 : Bool))
+        (fun a b c hab hbc => by
+          simp only [decide_eq_true_eq] at *
+          omega)
+        (fun a b => by
+          simp only [Bool.or_eq_true, decide_eq_true_eq]
+          omega)
+        ts.toList
+      exact this.imp fun h => by simpa using h
+    constructor
+    · rw [List.toList_toArray]
+      cases hsort : ts.toList.mergeSort (fun a b => a.1 ≤ b.1) with
+      | nil => simp [combineSorted]
+      | cons t rest =>
+          rw [hsort] at hs
+          rw [List.pairwise_cons] at hs
+          exact (combineRun_canonical hs.2 hs.1).1
+    · intro t ht
+      have ht' := Array.mem_def.mp ht
+      rw [List.toList_toArray] at ht'
+      cases hsort : ts.toList.mergeSort (fun a b => a.1 ≤ b.1) with
+      | nil =>
+          rw [hsort] at ht'
+          cases ht'
+      | cons u rest =>
+          rw [hsort] at hs ht'
+          rw [List.pairwise_cons] at hs
+          exact (combineRun_canonical hs.2 hs.1).2.1 t ht'
+
+/-- The {name}`addTerm` fold and the stable sort-and-combine pass build
+the same polynomial, with no algebra assumed. -/
+theorem ofTerms_eq_ofTermsImpl [Add R] (ts : Array (Nat × R)) :
+    ofTerms ts = ofTermsImpl ts := by
+  apply ext_coeff
+  intro e
+  rw [coeff_ofTerms_addCoeff]
+  have hs : (ts.toList.mergeSort (fun a b => a.1 ≤ b.1)).Pairwise
+      (fun a b => a.1 ≤ b.1) := by
+    have := List.pairwise_mergeSort (le := fun a b : Nat × R => (a.1 ≤ b.1 : Bool))
+      (fun a b c hab hbc => by
+        simp only [decide_eq_true_eq] at *
+        omega)
+      (fun a b => by
+        simp only [Bool.or_eq_true, decide_eq_true_eq]
+        omega)
+      ts.toList
+    exact this.imp fun h => by simpa using h
+  show _ = coeffList (ofTermsImpl ts).terms.toList e
+  rw [show (ofTermsImpl ts).terms =
+      (combineSorted (ts.toList.mergeSort (fun a b => a.1 ≤ b.1))).toArray
+    from rfl, List.toList_toArray, coeffList_combineSorted hs,
+    filter_exp_mergeSort]
+
+/-- Register the stable sort-and-combine pass as the compiled
+implementation of {name}`ofTerms`. -/
+@[csimp]
+theorem ofTerms_eq_impl : @ofTerms = @ofTermsImpl := by
+  funext R _ _ _ ts
+  exact ofTerms_eq_ofTermsImpl ts
+
+/-- The monomial `c · x^e`. The zero coefficient collapses to the zero
+polynomial. -/
+def monomial (e : Nat) (c : R) : SparsePoly R :=
+  if hc : c = 0 then 0
+  else
+    { terms := #[(e, c)]
+      canonical := by
+        constructor
+        · simp
+        · intro t ht
+          have := Array.mem_def.mp ht
+          simp only [List.mem_cons] at this
+          rcases this with rfl | h'
+          · exact hc
+          · cases h' }
+
+/-- The constant polynomial with value `c`. The zero constant collapses
+to the zero polynomial. -/
+def C (c : R) : SparsePoly R :=
+  monomial 0 c
+
+/-- The variable `x`. -/
+def X [One R] : SparsePoly R :=
+  monomial 1 1
+
+instance [One R] : One (SparsePoly R) where
+  one := C 1
+
+/-- Characterising lemma for monomials: coefficient `c` at `e`, zero
+elsewhere, even when `c = 0`. -/
+@[simp, grind =] theorem coeff_monomial (e : Nat) (c : R) (f : Nat) :
+    (monomial e c).coeff f = if f = e then c else 0 := by
+  unfold monomial
+  by_cases hc : c = 0
+  · rw [dif_pos hc]
+    by_cases hf : f = e
+    · rw [if_pos hf, coeff_zero, hc]
+    · rw [if_neg hf, coeff_zero]
+  · rw [dif_neg hc]
+    show coeffList [(e, c)] f = _
+    simp only [coeffList]
+    by_cases hf : f = e
+    · rw [if_pos (hf ▸ rfl), if_pos hf]
+    · rw [if_neg (fun h : e = f => hf h.symm), if_neg hf]
+
+@[simp, grind =] theorem coeff_C (c : R) (f : Nat) :
+    (C c).coeff f = if f = 0 then c else 0 :=
+  coeff_monomial 0 c f
+
+@[simp, grind =] theorem coeff_one [One R] (f : Nat) :
+    (1 : SparsePoly R).coeff f = if f = 0 then 1 else 0 :=
+  coeff_C 1 f
+
+@[simp, grind =] theorem coeff_X [One R] (f : Nat) :
+    (X : SparsePoly R).coeff f = if f = 1 then 1 else 0 :=
+  coeff_monomial 1 1 f
+
 end SparsePoly
+
+/-- `#sp[(e₀, c₀), (e₁, c₁), …]` constructs the canonical sparse
+polynomial with the given `(exponent, coefficient)` terms: any order,
+repeated exponents summed, zero coefficients dropped, mirroring `#p[…]`
+for `DensePoly`. -/
+syntax (name := sparsePolyLiteral) "#sp[" term,* "]" : term
+
+macro_rules
+  | `(#sp[$terms,*]) => `(Hex.SparsePoly.ofTerms #[$terms,*])
+
+
 
 end Hex

--- a/HexSparsePoly/KernelTests.lean
+++ b/HexSparsePoly/KernelTests.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexSparsePoly
+
+public section
+
+/-!
+Downstream module-boundary checks for the kernel-reduction closure of
+`Hex.SparsePoly`: `SparsePolyCanonical`, `addTerm`, `ofTerms`, `coeff`,
+and the `DecidableEq` instance must reduce under `decide` from a module
+that only imports the public library. A failure here means an `@[expose]`
+or `@[csimp]` boundary regressed.
+-/
+
+namespace Hex.SparsePoly.KernelTests
+
+open Hex
+open scoped Hex
+
+abbrev P := SparsePoly Int
+
+example : SparsePolyCanonical (#[(0, 5), (3, 1)] : Array (Nat × Int)) := by
+  decide +kernel
+
+example : ¬ SparsePolyCanonical (#[(3, 1), (0, 5)] : Array (Nat × Int)) := by
+  decide +kernel
+
+example : ¬ SparsePolyCanonical (#[(0, 0)] : Array (Nat × Int)) := by
+  decide +kernel
+
+-- `ofTerms` canonicalises: unsorted input, repeated exponents summed,
+-- zeros dropped.
+example : (#sp[(3, 1), (0, 5)] : P) = #sp[(0, 5), (3, 1)] := by
+  decide +kernel
+
+example : (#sp[(1, 2), (1, 3)] : P) = #sp[(1, 5)] := by
+  decide +kernel
+
+example : (#sp[(0, 0)] : P) = 0 := by
+  decide +kernel
+
+example : (#sp[(1, 2), (1, -2)] : P) = 0 := by
+  decide +kernel
+
+-- `addTerm` inserts, combines, and deletes.
+example : ((0 : P).addTerm 5 3).coeff 5 = 3 := by
+  decide +kernel
+
+example : ((#sp[(5, 3)] : P).addTerm 5 (-3)) = 0 := by
+  decide +kernel
+
+-- `coeff` reduces at a large exponent: the cost is the term count, not
+-- the degree.
+example : (#sp[(0, 5), (1000000, 3)] : P).coeff 1000000 = 3 := by
+  decide +kernel
+
+example : (#sp[(0, 5), (1000000, 3)] : P).coeff 999999 = 0 := by
+  decide +kernel
+
+-- The `DecidableEq` instance reduces across the module boundary.
+example : (0 : P) ≠ #sp[(0, 1)] := by
+  decide +kernel
+
+example : decide (#sp[(2, 7)] = (#sp[(2, 7)] : P)) = true := by
+  decide +kernel
+
+end Hex.SparsePoly.KernelTests

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -623,14 +623,21 @@ lean_lib HexReleaseTests where
     `HexRealRootsMathlib.IsolateRootsTests,
     `HexRealRootsMathlib.IsolateRootsElabTests,
     `HexRootsMathlib.Examples,
-    `HexMvPoly.KernelTests,
-    `HexSparsePoly.KernelTests]
+    `HexMvPoly.KernelTests]
 
 -- Complete development imports for the two factorization packages. Their
 -- ordinary umbrellas deliberately expose only the supported release API.
 lean_lib HexFactorizationModules where
   globs := #[`HexBerlekampZassenhaus.All,
     `HexBerlekampZassenhausMathlib.All]
+
+-- HexSparsePoly is not yet a published split repository, so its
+-- verification-only kernel probes stay separate from the
+-- release-manifest-backed target above; they join HexReleaseTests (and the
+-- release manifest's test_modules) when the split repository is published.
+@[default_target]
+lean_lib HexSparsePolyTests where
+  globs := #[`HexSparsePoly.KernelTests]
 
 -- HexRCF is not yet a published split repository, so its verification-only
 -- modules stay separate from the release-manifest-backed target above.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -623,7 +623,8 @@ lean_lib HexReleaseTests where
     `HexRealRootsMathlib.IsolateRootsTests,
     `HexRealRootsMathlib.IsolateRootsElabTests,
     `HexRootsMathlib.Examples,
-    `HexMvPoly.KernelTests]
+    `HexMvPoly.KernelTests,
+    `HexSparsePoly.KernelTests]
 
 -- Complete development imports for the two factorization packages. Their
 -- ordinary umbrellas deliberately expose only the supported release API.

--- a/progress/20260822T032028Z_sparse-poly-canonical.md
+++ b/progress/20260822T032028Z_sparse-poly-canonical.md
@@ -1,0 +1,39 @@
+# hex-sparse-poly: canonical construction (milestone 1 complete)
+
+## Accomplished
+
+- `addTerm`: ordered-`List` insert specification, the invariant
+  preservation proof (`addTermList_canonical`), the coefficient
+  description (`coeff_addTerm` via `addCoeff`), and the in-place
+  `addTermImpl` (binary-search `lowerBound` plus one erase/set/insert/
+  push splice) behind a proved `@[csimp]` equality
+  (`addTermList_splice` + `lowerBound_spec`).
+- `ofTerms` as the fold-of-`addTerm` specification, its no-algebra
+  coefficient description (`coeff_ofTerms_addCoeff`), the SPEC's
+  `coeff_ofTerms` under `hzero`, and the stable sort-and-combine
+  `ofTermsImpl` (`List.mergeSort` + `combineRun`) behind a proved
+  `@[csimp]` equality, with the stability argument
+  (`filter_exp_mergeSort` from core's `sublist_mergeSort`).
+- `monomial`, `C`, `X`, `One`, the `#sp[…]` literal, and their
+  coefficient lemmas.
+- `HexSparsePoly/KernelTests.lean` (in the `HexReleaseTests` globs):
+  `decide +kernel` probes for the whole SPEC kernel-exposure closure
+  from a downstream module.
+
+All proofs complete; zero `sorry` in the library.
+
+## Current frontier
+
+Milestone 1 of `HexSparsePoly/SPEC/hex-sparse-poly.md` is done.
+
+## Next step
+
+Milestone 2 (`HexSparsePoly/Arith.lean`): `add` as a linear merge,
+`neg`/`sub`/`scale`/`mulMonomial`, `mul` as the pairwise-product
+specification (its `@[csimp]` twin waits for the Phase-4
+sparse-multiplication bench), `pow`, the operator instances, and the
+ring laws.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -772,5 +772,11 @@
     "baseline_blob": null,
     "current_blob": "aa8588a6a6a6db3e4393346d885e1f81ccd2aaff",
     "reason": "Adds the standalone SplitMix64 and unbiased bounded-sampling API for future randomized consumers. Existing factorization code does not reference its declarations, so the measured factorization service runtime is unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "ff87edbbbf7524190b536ae4ce92a57968275aa9",
+    "current_blob": "c5d22d5cbafc71a28f5c47536cdd1d06bf16f7e6",
+    "reason": "Adds the HexSparsePolyTests kernel-probe lean_lib on top of the reviewed main registrations; no factorization module, executable, or build-flag changes."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -62,6 +62,7 @@ UMBRELLA_BUILD_TARGETS = {
     "HexFactorizationModules",
     "HexReleaseTests",
     "HexRCFTests",
+    "HexSparsePolyTests",
     "HexReleaseExamples",
 }
 

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -35,6 +35,7 @@ BUILD_ONLY_LIBS = {
     "HexFactorizationModules",
     "HexReleaseTests",
     "HexRCFTests",
+    "HexSparsePolyTests",
     "HexReleaseExamples",
 }
 EXTERNAL_IMPORT_ROOTS = {"Mathlib", "Verso"}


### PR DESCRIPTION
This PR complete milestone 1 of [HexSparsePoly/SPEC/hex-sparse-poly.md](https://github.com/kim-em/hex-dev/blob/sparse-poly-canonical/HexSparsePoly/SPEC/hex-sparse-poly.md): `addTerm` lands as the ordered-`List` insert specification with its invariant-preservation proof and coefficient description, compiled through the in-place `addTermImpl` (binary-search `lowerBound` plus a single erase/set/insert/push splice) behind a proved `@[csimp]` equality; `ofTerms` lands as the fold-of-`addTerm` specification with the SPEC's `coeff_ofTerms` characterisation, compiled through the stable sort-and-combine `ofTermsImpl` whose agreement proof leans on core's `sublist_mergeSort` stability lemmas and assumes no algebra on the coefficients; and `monomial`, `C`, `X`, the `One` instance, and the `#sp[…]` literal land with their coefficient lemmas. `HexSparsePoly/KernelTests.lean` joins the `HexReleaseTests` globs with `decide +kernel` probes for the SPEC's whole kernel-exposure closure from a downstream module. All proofs are complete; no `sorry`.

🤖 Prepared with Claude Code