### PR TITLE
fix: let integrated mathlib libraries carry their own Phase-7 chapter

### DIFF
--- a/scripts/check_phase7.py
+++ b/scripts/check_phase7.py
@@ -7,9 +7,11 @@ anchored to it exists. Nothing checked either, so both drifted.
 
 Three rules, applied to every library with `done_through >= 7`:
 
-* **Chapter.** A `mathlib: true` companion needs a
-  `# The Mathlib correspondence` section in its computational partner's
-  chapter; every other library needs `HexManual/Chapters/<Lib>.lean`.
+* **Chapter.** A `mathlib: true` companion named `<X>Mathlib` needs a
+  `# The Mathlib correspondence` section in `<X>`'s chapter. A `mathlib: true`
+  library without that suffix is integrated (HexRCF): it has no computational
+  partner and carries its own chapter like any other library. Every other
+  library needs `HexManual/Chapters/<Lib>.lean`.
 * **Reachable.** `HexManual.lean` imports the chapter, so `lake build
   HexManual` elaborates it.
 * **Tutorials.** Every tutorial anchored to the library exists, is imported by
@@ -141,7 +143,10 @@ def check(root: Path) -> list[str]:
 
         chapter = root / "HexManual" / "Chapters" / f"{name}.lean"
         partner = partner_chapter(root, name)
-        if library.mathlib:
+        # An integrated `mathlib: true` library (no `Mathlib` suffix, e.g.
+        # HexRCF) has no computational partner; it carries its own chapter and
+        # falls through to the plain-library branch.
+        if library.mathlib and name.endswith("Mathlib"):
             if partner is None:
                 errors.append(
                     f"{name}: done_through 7, but no computational partner chapter exists to "

--- a/scripts/test_check_phase7.py
+++ b/scripts/test_check_phase7.py
@@ -34,6 +34,10 @@ def build_root(
     tutorial_import: bool = True,
     tutorial_include: bool = True,
     chapter: bool = True,
+    integrated: bool = False,
+    integrated_chapter: bool = True,
+    companion: bool = False,
+    companion_heading: bool = True,
 ) -> Path:
     (tmp / "PLAN").mkdir(parents=True, exist_ok=True)
     (tmp / "HexManual" / "Chapters").mkdir(parents=True, exist_ok=True)
@@ -41,22 +45,47 @@ def build_root(
     (tmp / "HexGF2" / "SPEC").mkdir(parents=True, exist_ok=True)
 
     (tmp / "HexGF2" / "SPEC" / "hex-gf2.md").write_text("# hex-gf2\n", encoding="utf-8")
-    (tmp / "libraries.yml").write_text(
+    libraries = (
         "libraries:\n"
         "  HexGF2:\n"
         "    deps: []\n"
         "    mathlib: false\n"
         f"    done_through: {done_through}\n"
-        "    status: active\n",
-        encoding="utf-8",
+        "    status: active\n"
     )
+    if integrated:
+        # A `mathlib: true` library without the `Mathlib` suffix (HexRCF): no
+        # computational partner; it carries its own chapter.
+        libraries += (
+            "  HexRCF:\n"
+            "    deps: []\n"
+            "    mathlib: true\n"
+            "    done_through: 7\n"
+            "    status: active\n"
+        )
+    if companion:
+        libraries += (
+            "  HexGF2Mathlib:\n"
+            "    deps: [HexGF2]\n"
+            "    mathlib: true\n"
+            "    done_through: 7\n"
+            "    status: active\n"
+        )
+    (tmp / "libraries.yml").write_text(libraries, encoding="utf-8")
     (tmp / "PLAN" / "Phase7.md").write_text(table, encoding="utf-8")
+    heading = "# The Mathlib correspondence\n" if companion_heading else ""
     if chapter:
-        (tmp / "HexManual" / "Chapters" / "HexGF2.lean").write_text("chapter\n", encoding="utf-8")
+        (tmp / "HexManual" / "Chapters" / "HexGF2.lean").write_text(
+            "chapter\n" + heading, encoding="utf-8"
+        )
+    if integrated and integrated_chapter:
+        (tmp / "HexManual" / "Chapters" / "HexRCF.lean").write_text("chapter\n", encoding="utf-8")
     if tutorial:
         (tmp / "HexManual" / "Tutorials" / "AESField.lean").write_text("tut\n", encoding="utf-8")
 
     manual = ["import HexManual.Chapters.HexGF2"]
+    if integrated:
+        manual.append("import HexManual.Chapters.HexRCF")
     if tutorial_import:
         manual.append("import HexManual.Tutorials.AESField")
     if tutorial_include:
@@ -149,6 +178,26 @@ class CheckTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             errors = check(build_root(Path(raw), table=table))
         self.assertTrue(any("matches no library SPEC slug" in error for error in errors))
+
+    def test_integrated_mathlib_library_carries_its_own_chapter(self) -> None:
+        """A `mathlib: true` library without the `Mathlib` suffix (HexRCF) has
+        no computational partner; its own chapter satisfies Phase 7."""
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), integrated=True))
+        self.assertEqual(errors, [])
+
+    def test_integrated_mathlib_library_missing_chapter_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), integrated=True, integrated_chapter=False))
+        self.assertTrue(any("HexRCF: done_through 7, but no HexManual/Chapters" in error
+                            for error in errors))
+
+    def test_companion_needs_correspondence_heading_in_partner_chapter(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertEqual(check(build_root(Path(raw), companion=True)), [])
+        with tempfile.TemporaryDirectory() as raw:
+            errors = check(build_root(Path(raw), companion=True, companion_heading=False))
+        self.assertTrue(any("has no '# The Mathlib correspondence'" in error for error in errors))
 
     def test_misspelled_slug_does_not_resolve(self) -> None:
         """Hyphen-insensitive matching would resolve `hex-g-f2`; exact slugs do not."""


### PR DESCRIPTION
This PR fix `scripts/check_phase7.py` for integrated Mathlib libraries. The checker derives a companion's partner chapter by stripping a literal `Mathlib` suffix, so a `mathlib: true` library without that suffix — HexRCF, which has no computational partner by design — could never satisfy Phase 7: `partner_chapter` returned `None` and the checker demanded a nonexistent partner chapter. Treat a suffix-less `mathlib: true` library as carrying its own chapter, like any plain library, and add regression tests for the integrated pass/fail cases plus the unchanged companion-heading requirement.

🤖 Prepared with Claude Code