### PR TITLE
feat(interval): add sealed typed runtime events

### DIFF
--- a/HexInterval.lean
+++ b/HexInterval.lean
@@ -14,6 +14,7 @@ public import HexInterval.Trace
 public import HexInterval.Policy
 public import HexInterval.Search
 public import HexInterval.Executable
+public import HexInterval.Runtime
 
 public section
 
@@ -53,7 +54,12 @@ not decoded-runtime authority, and repository checks reject accidental uses.
 The supported executable assembly now joins explicit stable-key package
 declarations, private caches, checked callback routes, bounded raw replay
 formats, and an exact concrete application table for one program. Its raw
-quotations are not Mathlib proof events or evidence. Offer generation, policy
+quotations are not Mathlib proof events or evidence. A separate sealed
+Mathlib-free runtime transition owns that assembly together with branch state
+and an exact equality descriptor arena. It atomically admits typed fact,
+equality, transport, and append-only instance events and can retain the sealed
+transition in a result-tree child without weakening generic child validation.
+Offer generation, policy
 implementations, a complete branch-search loop, and measurement-selected
 storage remain experimental. The Mathlib companion supplies a bounded
 authenticated callback-to-tree-recipe step driver; package callbacks and their

--- a/HexInterval/Executable.lean
+++ b/HexInterval/Executable.lean
@@ -193,6 +193,13 @@ def applicationsPrefix (before after : Array Application) : Bool := Id.run do
     if !old.same new then return false
   return true
 
+/-- Every old scoped binding remains at the same compact address. -/
+def bindingsPrefix (before after : Array ScopeBinding) : Bool := Id.run do
+  if after.size < before.size then return false
+  for index in [0:before.size] do
+    if before[index]? != after[index]? then return false
+  return true
+
 /-- Independent assembly and invocation caps. `state` owns structural table
 dimensions; the remaining fields bound package-owned logical measurements and
 raw quotation encodings. -/
@@ -264,6 +271,9 @@ structure Assembly (Fact Result : Type) where
   bindings : Array ScopeBinding
   registry : Registry Fact Result
   applications : Array Application
+  /-- Global creation generation, retained even when an extension appends no
+  concrete application row. -/
+  generation : Nat
 
 /-- A successful callback result retains the exact selected route, owner, and
 validated raw quotations. No field is theorem evidence. -/
@@ -280,9 +290,10 @@ private def makeRegistry (packages : Array (Package Fact Result))
   { packages, operations, registrations, routes, metadataCost, cacheCost }
 
 private def makeAssembly (program : Program) (bindings : Array ScopeBinding)
-    (registry : Registry Fact Result) (applications : Array Application) :
+    (registry : Registry Fact Result) (applications : Array Application)
+    (generation : Nat) :
     Assembly Fact Result :=
-  { program, bindings, registry, applications }
+  { program, bindings, registry, applications, generation }
 
 private def makeInvocation (route : Route) (rule : RuleKey)
     (result : Result) (quotes : Array Quote) : Invocation Result :=
@@ -518,6 +529,21 @@ private def compileSuffixWithin (limit start generation : Nat) (program : Progra
             watches, writes, effort := rule.initialEffort, generation }
   pure applications
 
+private def compileBindingSuffixWithin (limit start generation : Nat)
+    (rules : Array Registration) (bindings : Array ScopeBinding) :
+    Except Error (Array Application) := do
+  let mut applications := #[]
+  for index in [start:bindings.size] do
+    if limit ≤ applications.size then throw (.resource (.state .applications))
+    let some binding := bindings[index]? | throw .invalidBindings
+    let some (ruleId, rule) := Registration.find? rules binding.rule
+      | throw .invalidBindings
+    applications := applications.push
+      { rule := ruleId, node := binding.anchor, kind := rule.kind
+        watches := binding.watches, writes := binding.writes
+        effort := rule.initialEffort, generation }
+  pure applications
+
 private def applicationCost (registry : Registry Fact Result)
     (applications : Array Application) : Except Error Cost := do
   let mut cost : Cost := {}
@@ -564,38 +590,96 @@ opaque buildWithin (limits : Limits) (packages : Array (Package Fact Result))
                       .error (.resource .metadataBytes)
                     else .error (.resource .metadataWork)
                   else
-                    .ok (makeAssembly program bindings { registry with metadataCost } applications)
+                    .ok (makeAssembly program bindings { registry with metadataCost } applications 0)
 
-/-- Extend only the program-node suffix and its local applications. Existing
-bindings, registry routes, caches, and application rows are retained exactly.
-The fresh generation must strictly exceed every retained application
-generation. -/
-opaque Assembly.extendWithin (limits : Limits) (assembly : Assembly Fact Result)
-    (program : Program) (generation : Nat) : Except Error (Assembly Fact Result) :=
+/-- Re-admit every retained executable resource under a possibly tighter
+limit before a higher layer invokes a callback. The assembly is already
+structurally sealed; this pass rechecks package/cache metadata, program and
+application dimensions, and the complete application cost without rebuilding
+routes or callback caches. -/
+opaque Assembly.preflightWithin (limits : Limits) (assembly : Assembly Fact Result) :
+    Except Error Unit := do
+  match checkProgramLimits limits.state assembly.program with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
+  if limits.state.maxApplications < assembly.bindings.size ||
+      limits.state.maxApplications < assembly.applications.size then
+    throw (.resource (.state .applications))
+  if assembly.bindings.any (fun binding =>
+      !listWithin limits.state.maxScopeNodes binding.watches ||
+        !listWithin limits.state.maxScopeNodes binding.writes) then
+    throw (.resource (.state .scopes))
+  let portLimit := Nat.max (limits.state.maxArity + 1) limits.state.maxScopeNodes
+  if assembly.applications.any (fun application =>
+      !listWithin portLimit application.watches ||
+        !listWithin portLimit application.writes) then
+    throw (.resource (.state .arity))
+  if assembly.applications.any (fun application =>
+      !listWithin limits.state.matcherBatchSize application.structuralInputs) then
+    throw (.resource (.state .matcherVisits))
+  if assembly.applications.any (fun application =>
+      limits.state.maxEffort < application.effort) then
+    throw (.resource (.state .effort))
+  if assembly.applications.any (fun application =>
+      limits.state.maxGeneration < application.generation) then
+    throw (.resource (.state .generation))
+  if limits.state.maxGeneration < assembly.generation then
+    throw (.resource (.state .generation))
+  let (packageCost, _) ← packagePreflight limits assembly.registry.packages
+  let applicationCost ← applicationCost assembly.registry assembly.applications
+  let metadataCost := packageCost + applicationCost
+  if !metadataCost.allowed limits.maxMetadataBytes limits.maxMetadataWork then
+    if limits.maxMetadataBytes < metadataCost.bytes then
+      throw (.resource .metadataBytes)
+    else throw (.resource .metadataWork)
+  pure ()
+
+/-- Extend an assembly by exact append-only program and scoped-binding
+suffixes. Old bindings, applications, routes, and caches remain at their
+original compact addresses. Fresh scoped applications precede fresh local
+node applications in the appended table; their generation must strictly
+exceed the retained global assembly generation, including after an extension
+which creates no application row. -/
+opaque Assembly.extendAllWithin (limits : Limits) (assembly : Assembly Fact Result)
+    (program : Program) (bindings : Array ScopeBinding) (generation : Nat) :
+    Except Error (Assembly Fact Result) := do
+  match assembly.preflightWithin limits with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
   match checkProgramLimits limits.state program with
   | .error error => .error error
   | .ok _ =>
       if !program.check then .error .invalidProgram
       else
-        if limits.state.maxApplications < assembly.bindings.size ||
+        if limits.state.maxApplications < bindings.size ||
             limits.state.maxApplications < assembly.applications.size then
           .error (.resource (.state .applications))
+        else if bindings.any (fun binding =>
+            !listWithin limits.state.maxScopeNodes binding.watches ||
+              !listWithin limits.state.maxScopeNodes binding.writes) then
+          .error (.resource (.state .scopes))
         else if !State.programPrefix assembly.program program then .error .nonExtension
-        else if limits.state.maxGeneration < generation ||
+        else if !bindingsPrefix assembly.bindings bindings then .error .nonExtension
+        else if limits.state.maxGeneration < generation || generation ≤ assembly.generation ||
             assembly.applications.any (fun application => generation ≤ application.generation) then
           .error .staleGeneration
         else if !assembly.registry.acceptsProgram program then .error .programRejected
         else if !Registration.check program assembly.registry.registrations then
           .error .invalidRegistrations
-        else if !assembly.registry.acceptsBindings program assembly.bindings then
+        else if !assembly.registry.acceptsBindings program bindings then
           .error .invalidBindings
         else
           let room := limits.state.maxApplications - assembly.applications.size
-          match compileSuffixWithin room assembly.program.nodes.size generation program
-              assembly.registry.registrations with
+          match compileBindingSuffixWithin room assembly.bindings.size generation
+              assembly.registry.registrations bindings with
           | .error error => .error error
-          | .ok suffix =>
-              let applications := assembly.applications ++ suffix
+          | .ok bindingSuffix =>
+            let room := room - bindingSuffix.size
+            match compileSuffixWithin room assembly.program.nodes.size generation program
+                assembly.registry.registrations with
+            | .error error => .error error
+            | .ok nodeSuffix =>
+              let applications := assembly.applications ++ bindingSuffix ++ nodeSuffix
               if !applicationsPrefix assembly.applications applications then .error .nonExtension
               else match applicationCost assembly.registry applications with
                 | .error error => .error error
@@ -608,8 +692,14 @@ opaque Assembly.extendWithin (limits : Limits) (assembly : Assembly Fact Result)
                         .error (.resource .metadataBytes)
                       else .error (.resource .metadataWork)
                     else
-                      .ok (makeAssembly program assembly.bindings
-                        { assembly.registry with metadataCost } applications)
+                      .ok (makeAssembly program bindings
+                        { assembly.registry with metadataCost } applications generation)
+
+/-- Extend only the program-node suffix and its local applications. Existing
+bindings, registry routes, caches, and application rows are retained exactly. -/
+opaque Assembly.extendWithin (limits : Limits) (assembly : Assembly Fact Result)
+    (program : Program) (generation : Nat) : Except Error (Assembly Fact Result) :=
+  assembly.extendAllWithin limits program assembly.bindings generation
 
 private def quoteCells (quotes : Array Quote) : Nat :=
   quotes.foldl (fun total quote => total + quote.body.length) 0
@@ -747,7 +837,10 @@ checks their internal request validity but does not claim to own them. Callback
 and measure execution are non-preemptible; failure returns no replacement
 assembly, so a rejected cache/result/quotation cannot partially commit. -/
 opaque Assembly.invokeWithin (limits : Limits) (assembly : Assembly Fact Result)
-    (request : RuleRequest Fact) : Except Error (Invocation Result × Assembly Fact Result) :=
+    (request : RuleRequest Fact) : Except Error (Invocation Result × Assembly Fact Result) := do
+  match assembly.preflightWithin limits with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
   if request.program.operations != assembly.program.operations ||
       request.program.nodes != assembly.program.nodes then .error .invalidRequest
   else
@@ -796,6 +889,6 @@ opaque Assembly.invokeWithin (limits : Limits) (assembly : Assembly Fact Result)
                                   let registry := replacePackage assembly.registry route.package package cacheCost
                                   .ok (makeInvocation route registration.key plan.result plan.quotes,
                                     makeAssembly assembly.program assembly.bindings registry
-                                      assembly.applications)
+                                      assembly.applications assembly.generation)
 
 end Hex.Interval.Executable

--- a/HexInterval/Runtime.lean
+++ b/HexInterval/Runtime.lean
@@ -1,0 +1,529 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Executable
+
+@[expose] public section
+
+/-!
+# Typed runtime events
+
+This module is the supported Mathlib-free transition boundary between one
+checked executable assembly and versioned branch state. Package callbacks
+return typed raw events rather than proof objects. The engine authenticates
+the exact application, ordered fact dependencies, write authority,
+append-only program/binding/application suffixes, and an explicit equality
+descriptor arena before committing the whole callback result.
+
+Equality endpoints are exact in-program node identities, but the raw
+descriptor is not a theorem that those nodes denote equal values. Transport is
+only structural substitution through an admitted oriented descriptor: it has
+no quote and copies the fact of an exact currently live source version to the
+opposite endpoint. Semantic equality authority remains with later
+package-schema replay.
+
+The sealed `Applied` value is runtime provenance, not theorem evidence. It
+contains enough exact data for a later Mathlib companion to quote fact,
+equality, transport, and instance proof steps, whose package-owned schemas
+must still be checked independently. Callback execution, arbitrary facts,
+causes, and package measures remain non-preemptible.
+-/
+
+namespace Hex.Interval.Runtime
+
+/-- One admitted structural equality. Compact identity is its exact array
+position; endpoints, creation generation, and originating action are retained
+instead of being inferred from a generation table. -/
+structure Equality where
+  left : NodeId
+  right : NodeId
+  generation : Nat
+  origin : Action
+  assumptions : List SeenVersion
+  quote : Executable.Quote
+  deriving DecidableEq, Repr
+
+/-- A theorem-package fact proposal annotation paired with the exact installed
+meet/update. `proposed` need not equal `update.fact`; a later package schema and
+proof adapter must independently correlate or rederive the annotation from the
+installed update. -/
+structure FactStep (Fact Cause : Type) where
+  action : Action
+  update : State.Update Fact Cause
+  proposed : Fact
+  quote : Executable.Quote
+  deriving DecidableEq
+
+/-- A new equality at the next compact equality address. -/
+structure EqualityStep where
+  action : Action
+  equality : EqualityId
+  left : NodeId
+  right : NodeId
+  generation : Nat
+  assumptions : List SeenVersion
+  quote : Executable.Quote
+  deriving DecidableEq, Repr
+
+/-- An engine-owned structural fact transport across one previously admitted
+equality. `source` must be the exact current version and its fact must equal the
+installed update fact; transport carries no independent quotation. -/
+structure TransportStep (Fact Cause : Type) where
+  action : Action
+  update : State.Update Fact Cause
+  equality : EqualityId
+  source : SeenVersion
+  deriving DecidableEq
+
+/-- One exact append-only program extension. The explicit suffix lists pin the
+compact identities which a later proof quotation must reproduce. -/
+structure InstanceStep (Fact : Type) where
+  action : Action
+  after : Program
+  freshFacts : Array Fact
+  bindings : Array ScopeBinding
+  newNodes : List NodeId
+  newBindings : List ScopeBinding
+  newApplications : List ApplicationId
+  generation : Nat
+  quote : Executable.Quote
+  deriving DecidableEq
+
+/-- Ordered raw runtime chronology returned by one callback. -/
+inductive Event (Fact Cause : Type)
+  | fact (step : FactStep Fact Cause)
+  | equality (step : EqualityStep)
+  | transport (step : TransportStep Fact Cause)
+  | instance (step : InstanceStep Fact)
+  deriving DecidableEq
+
+/-- One callback result. Contradiction is runtime status only and requires at
+least one accepted fact or transport update. -/
+structure Batch (Fact Cause : Type) where
+  events : Array (Event Fact Cause)
+  contradiction : Bool := false
+  deriving DecidableEq
+
+/-- Runtime-event limits. Package metadata/results/quotations and every
+structural state dimension retain their independent executable/state caps. -/
+structure Limits where
+  executable : Executable.Limits
+  maxEvents : Nat
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | state (resource : Hex.Interval.State.Resource)
+  | events
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | executable (error : Executable.Error)
+  | state (error : State.BranchError)
+  | malformed
+  | stale
+  | unauthorized
+  | wrongEquality
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+/-- Sealed exact equality table. It can grow only through `stepWithin`. -/
+structure Arena where
+  private mk ::
+  items : Array Equality
+
+/-- Sealed live runtime state. Assembly callbacks/caches, the branch, and the
+equality arena therefore cannot be transplanted independently. The generation
+base authenticates the inherited global assembly generation corresponding to
+this branch's local program version zero. -/
+structure State (Fact Cause : Type) where
+  private mk ::
+  assembly : Executable.Assembly Fact (Batch Fact Cause)
+  branch : Hex.Interval.State.Branch Fact Cause
+  arena : Arena
+  generationBase : Nat
+  serial : Nat
+  instances : Nat
+
+/-- Ordinary-import-sealed record of one accepted atomic callback result.
+Every field is plain runtime data; theorem authority still belongs to later
+schema replay. -/
+structure Applied (Fact Cause : Type) where
+  private mk ::
+  before : Hex.Interval.State.Branch Fact Cause
+  after : Hex.Interval.State.Branch Fact Cause
+  beforeBindings : Array ScopeBinding
+  afterBindings : Array ScopeBinding
+  beforeApplications : Array Executable.Application
+  afterApplications : Array Executable.Application
+  beforeGeneration : Nat
+  afterGeneration : Nat
+  beforeEqualities : Array Equality
+  afterEqualities : Array Equality
+  action : Action
+  events : Array (Event Fact Cause)
+  quotes : Array Executable.Quote
+  serial : Nat
+
+private def makeArena (items : Array Equality) : Arena := { items }
+
+private def makeState (assembly : Executable.Assembly Fact (Batch Fact Cause))
+    (branch : Hex.Interval.State.Branch Fact Cause) (arena : Arena)
+    (generationBase serial instances : Nat) : State Fact Cause :=
+  { assembly, branch, arena, generationBase, serial, instances }
+
+private def makeApplied (before after : Hex.Interval.State.Branch Fact Cause)
+    (beforeBindings afterBindings : Array ScopeBinding)
+    (beforeApplications afterApplications : Array Executable.Application)
+    (beforeGeneration afterGeneration : Nat)
+    (beforeEqualities afterEqualities : Array Equality) (action : Action)
+    (events : Array (Event Fact Cause)) (quotes : Array Executable.Quote)
+    (serial : Nat) : Applied Fact Cause :=
+  { before, after, beforeBindings, afterBindings, beforeApplications,
+    afterApplications, beforeGeneration, afterGeneration, beforeEqualities,
+    afterEqualities, action, events, quotes, serial }
+
+variable {Fact Cause : Type}
+
+def State.equalities (state : State Fact Cause) : Array Equality :=
+  state.arena.items
+
+private def listWithin {α : Type} : Nat → List α → Bool
+  | _, [] => true
+  | 0, _ :: _ => false
+  | limit + 1, _ :: rest => listWithin limit rest
+
+private def fromBranch {α : Type} : Except State.BranchError α → Except Error α
+  | .ok value => .ok value
+  | .error error => .error (.state error)
+
+private def preflightBranch (limits : State.Limits)
+    (branch : Hex.Interval.State.Branch Fact Cause) : Except Error Unit := do
+  if limits.maxOperations < branch.baseProgram.operations.size ||
+      limits.maxOperations < branch.program.operations.size then
+    throw (.resource (.state .operations))
+  if limits.maxNodes < branch.baseProgram.nodes.size ||
+      limits.maxNodes < branch.program.nodes.size ||
+      limits.maxNodes < branch.initialFacts.size || limits.maxNodes < branch.seeds.size ||
+      limits.maxNodes < branch.versions.size || limits.maxNodes < branch.generations.size ||
+      limits.maxNodes < branch.depths.size then throw (.resource (.state .nodes))
+  if limits.maxAcceptedFacts < branch.history.size then
+    throw (.resource (.state .acceptedFacts))
+  if branch.baseProgram.operations.any
+      (fun operation => !listWithin limits.maxArity operation.inputs) ||
+      branch.program.operations.any
+        (fun operation => !listWithin limits.maxArity operation.inputs) ||
+      branch.baseProgram.nodes.any (fun node => !listWithin limits.maxArity node.args) ||
+      branch.program.nodes.any (fun node => !listWithin limits.maxArity node.args) then
+    throw (.resource (.state .arity))
+  pure ()
+
+private def preflightAction (limits : State.Limits) (action : Action) :
+    Except Error Unit := do
+  if !listWithin (Nat.max (limits.maxArity + 1) limits.maxScopeNodes) action.inputs ||
+      !listWithin (Nat.max (limits.maxArity + 1) limits.maxScopeNodes) action.writes then
+    throw (.resource (.state .arity))
+  if !listWithin limits.matcherBatchSize action.structuralInputs then
+    throw (.resource (.state .matcherVisits))
+  if limits.maxEffort < action.effort then throw (.resource (.state .effort))
+  if limits.maxGeneration < action.generation then
+    throw (.resource (.state .generation))
+
+private def preflightEvent (limits : Limits) :
+    Event Fact Cause → Except Error Unit
+  | .fact step =>
+      preflightAction limits.executable.state step.action
+  | .transport step =>
+      preflightAction limits.executable.state step.action
+  | .equality step => do
+      preflightAction limits.executable.state step.action
+      if limits.executable.state.maxGeneration < step.generation then
+        throw (.resource (.state .generation))
+      if !listWithin (Nat.max (limits.executable.state.maxArity + 1)
+          limits.executable.state.maxScopeNodes) step.assumptions then
+        throw (.resource (.state .arity))
+      pure ()
+  | .instance step => do
+      preflightAction limits.executable.state step.action
+      if limits.executable.state.maxOperations < step.after.operations.size then
+        throw (.resource (.state .operations))
+      if limits.executable.state.maxNodes < step.after.nodes.size ||
+          limits.executable.state.maxNodes < step.freshFacts.size ||
+          !listWithin limits.executable.state.maxNodes step.newNodes then
+        throw (.resource (.state .nodes))
+      if step.after.operations.any (fun operation =>
+          !listWithin limits.executable.state.maxArity operation.inputs) ||
+          step.after.nodes.any (fun node =>
+            !listWithin limits.executable.state.maxArity node.args) then
+        throw (.resource (.state .arity))
+      if limits.executable.state.maxApplications < step.bindings.size ||
+          !listWithin limits.executable.state.maxApplications step.newBindings ||
+          !listWithin limits.executable.state.maxApplications step.newApplications then
+        throw (.resource (.state .applications))
+      if step.bindings.any (fun binding =>
+          !listWithin limits.executable.state.maxScopeNodes binding.watches ||
+            !listWithin limits.executable.state.maxScopeNodes binding.writes) ||
+          step.newBindings.any (fun binding =>
+            !listWithin limits.executable.state.maxScopeNodes binding.watches ||
+              !listWithin limits.executable.state.maxScopeNodes binding.writes) then
+        throw (.resource (.state .scopes))
+      if limits.executable.state.maxGeneration < step.generation then
+        throw (.resource (.state .generation))
+      pure ()
+
+private def current (branch : Hex.Interval.State.Branch Fact Cause)
+    (seen : SeenVersion) : Bool :=
+  branch.versions[seen.node.index]? == some seen.version &&
+    (branch.factAt? seen).isSome
+
+private def inputsCurrent (branch : Hex.Interval.State.Branch Fact Cause)
+    (inputs : List SeenVersion) : Bool :=
+  inputs.all (current branch)
+
+private def inputsAvailable (branch : Hex.Interval.State.Branch Fact Cause)
+    (inputs : List SeenVersion) : Bool :=
+  inputs.all fun seen => (branch.factAt? seen).isSome
+
+private def expectedNodes (start count : Nat) : List NodeId :=
+  (List.range count).map fun offset => { index := start + offset }
+
+private def expectedApplications (start count : Nat) : List ApplicationId :=
+  (List.range count).map fun offset => { index := start + offset }
+
+private def suffix {α : Type} (before after : Array α) : List α :=
+  (List.range (after.size - before.size)).filterMap fun offset =>
+    after[before.size + offset]?
+
+private def quoteOf : Event Fact Cause → Option Executable.Quote
+  | .fact step => some step.quote
+  | .equality step => some step.quote
+  | .instance step => some step.quote
+  | .transport _ => none
+
+private def eventQuotes (events : Array (Event Fact Cause)) : Array Executable.Quote :=
+  events.toList.filterMap quoteOf |>.toArray
+
+private def inputViews (branch : Hex.Interval.State.Branch Fact Cause)
+    (inputs : List SeenVersion) : Option (List (FactView Fact)) :=
+  inputs.mapM fun seen => do
+    let fact ← branch.factAt? seen
+    pure { node := seen.node, fact, version := seen.version }
+
+private def request? (limits : Limits) (state : State Fact Cause)
+    (action : Action) : Option (RuleRequest Fact) := do
+  if action.serial != state.serial || action.programVersion != state.branch.programVersion then
+    none
+  if !listWithin (Nat.max (limits.executable.state.maxArity + 1)
+      limits.executable.state.maxScopeNodes) action.inputs ||
+      !listWithin (Nat.max (limits.executable.state.maxArity + 1)
+        limits.executable.state.maxScopeNodes) action.writes ||
+      !listWithin limits.executable.state.matcherBatchSize action.structuralInputs then
+    none
+  let application ← state.assembly.applications[action.application.index]?
+  if !application.accepts action.application action || !inputsCurrent state.branch action.inputs then
+    none
+  let inputs ← inputViews state.branch action.inputs
+  pure
+    { action
+      program :=
+        { programVersion := state.branch.programVersion
+          operations := state.branch.program.operations
+          nodes := state.branch.program.nodes
+          generations := state.branch.generations
+          depths := state.branch.depths }
+      inputs
+      writes := action.writes }
+
+/-- Start from one exact version-zero branch and its already-assembled program.
+Equality identity starts empty; importing a decoded equality arena is
+deliberately unsupported. Application creation generations remain global to the
+sealed assembly. The assembly generation at restart is authenticated as the
+fixed base corresponding to branch-local program version zero; later strict
+global generations are rebased onto consecutive local branch generations
+without weakening either chronology. Callback serial and equality identity
+also restart at zero. -/
+opaque State.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (assembly : Executable.Assembly Fact (Batch Fact Cause))
+    (branch : Hex.Interval.State.Branch Fact Cause) : Except Error (State Fact Cause) := do
+  match assembly.preflightWithin limits.executable with
+  | .error error => throw (.executable error)
+  | .ok _ => pure ⟨⟩
+  match preflightBranch limits.executable.state branch with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
+  if branch.programVersion != 0 || branch.program != assembly.program || !branch.check then
+    throw .malformed
+  pure (makeState assembly branch (makeArena #[]) assembly.generation 0 0)
+
+private structure Cursor (Fact Cause : Type) where
+  assembly : Executable.Assembly Fact (Batch Fact Cause)
+  branch : Hex.Interval.State.Branch Fact Cause
+  equalities : Array Equality
+  generationBase : Nat
+  instances : Nat
+
+private def pushFact (limits : Limits) (cursor : Cursor Fact Cause)
+    (action : Action) (step : FactStep Fact Cause) (contradiction : Bool) :
+    Except Error (Cursor Fact Cause) :=
+  if step.action != action || action.programVersion != cursor.branch.programVersion ||
+      step.update.programVersion != cursor.branch.programVersion ||
+      !action.writes.contains step.update.node || step.quote.role != .fact then
+    .error .unauthorized
+  else
+    match fromBranch (Hex.Interval.State.Branch.pushWithin limits.executable.state
+        cursor.branch step.update contradiction) with
+    | .error error => .error error
+    | .ok nextBranch => .ok
+        { assembly := cursor.assembly
+          branch := nextBranch
+          equalities := cursor.equalities
+          generationBase := cursor.generationBase
+          instances := cursor.instances }
+
+private def pushEquality (limits : Limits) (cursor : Cursor Fact Cause)
+    (action : Action) (step : EqualityStep) : Except Error (Cursor Fact Cause) := do
+  if limits.executable.state.maxEqualities <= cursor.equalities.size then
+    throw (.resource (.state .equalities))
+  if step.action != action || action.programVersion != cursor.branch.programVersion ||
+      step.equality.index != cursor.equalities.size || step.left == step.right ||
+      step.assumptions != action.inputs || !inputsAvailable cursor.branch step.assumptions ||
+      step.generation != action.generation || step.quote.role != .equality then
+    throw .wrongEquality
+  let some left := cursor.branch.program.node? step.left | throw .wrongEquality
+  let some right := cursor.branch.program.node? step.right | throw .wrongEquality
+  if left.domain != right.domain then throw .wrongEquality
+  let equality : Equality :=
+    { left := step.left, right := step.right, generation := step.generation,
+      origin := step.action, assumptions := step.assumptions, quote := step.quote }
+  pure { cursor with equalities := cursor.equalities.push equality }
+
+private def pushTransport [DecidableEq Fact] (limits : Limits) (cursor : Cursor Fact Cause)
+    (action : Action) (step : TransportStep Fact Cause) (contradiction : Bool) :
+    Except Error (Cursor Fact Cause) :=
+  if step.action != action || action.programVersion != cursor.branch.programVersion ||
+      step.update.programVersion != cursor.branch.programVersion ||
+      !action.writes.contains step.update.node || !action.inputs.contains step.source ||
+      !current cursor.branch step.source ||
+      cursor.branch.factAt? step.source != some step.update.fact then .error .unauthorized
+  else match cursor.equalities[step.equality.index]? with
+    | none => .error .wrongEquality
+    | some equality =>
+      let oriented :=
+        (step.update.node == equality.left && step.source.node == equality.right) ||
+          (step.update.node == equality.right && step.source.node == equality.left)
+      if !oriented then .error .wrongEquality
+      else match fromBranch (Hex.Interval.State.Branch.pushWithin
+          limits.executable.state cursor.branch step.update contradiction) with
+        | .error error => .error error
+        | .ok nextBranch => .ok
+            { assembly := cursor.assembly
+              branch := nextBranch
+              equalities := cursor.equalities
+              generationBase := cursor.generationBase
+              instances := cursor.instances }
+
+private def pushInstance (limits : Limits) (cursor : Cursor Fact Cause)
+    (action : Action) (step : InstanceStep Fact) : Except Error (Cursor Fact Cause) :=
+  if limits.executable.state.maxInstances <= cursor.instances then
+    .error (.resource (.state .instances))
+  else if step.action != action || action.kind != .instantiate ||
+      action.programVersion != cursor.branch.programVersion || step.quote.role != .instance then
+    .error .unauthorized
+  else if step.generation != cursor.assembly.generation + 1 ||
+      step.generation != cursor.generationBase + cursor.branch.programVersion + 1 then
+    .error .malformed
+  else if step.newNodes.isEmpty && step.newBindings.isEmpty &&
+      step.newApplications.isEmpty then
+    .error .malformed
+  else if step.newNodes != expectedNodes cursor.branch.program.nodes.size
+      (step.after.nodes.size - cursor.branch.program.nodes.size) ||
+      step.newBindings != suffix cursor.assembly.bindings step.bindings then
+    .error .malformed
+  else match cursor.assembly.extendAllWithin limits.executable step.after
+      step.bindings step.generation with
+    | .error error => .error (.executable error)
+    | .ok assembly =>
+      let freshApplicationCount := assembly.applications.size - cursor.assembly.applications.size
+      if step.newApplications != expectedApplications cursor.assembly.applications.size
+          freshApplicationCount then .error .malformed
+      else match fromBranch (Hex.Interval.State.Branch.extendWithin
+          limits.executable.state cursor.branch step.after step.freshFacts
+            (cursor.branch.programVersion + 1)) with
+        | .error error => .error error
+        | .ok nextBranch => .ok
+            { assembly := assembly
+              branch := nextBranch
+              equalities := cursor.equalities
+              generationBase := cursor.generationBase
+              instances := cursor.instances + 1 }
+
+private def preflightBatch (limits : Limits) (batch : Batch Fact Cause) :
+    Except Error Unit := do
+  if limits.maxEvents < batch.events.size then throw (.resource .events)
+  if batch.events.isEmpty then throw .malformed
+  for event in batch.events do
+    match preflightEvent limits event with
+    | .error error => throw error
+    | .ok _ => pure ⟨⟩
+  if batch.contradiction && !batch.events.any (fun
+      | .fact _ | .transport _ => true
+      | _ => false) then throw .malformed
+
+private def applyEvents [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (state : State Fact Cause) (action : Action)
+    (batch : Batch Fact Cause) : Except Error (Cursor Fact Cause) := do
+  let mut cursor : Cursor Fact Cause :=
+    { assembly := state.assembly, branch := state.branch,
+      equalities := state.arena.items, generationBase := state.generationBase,
+      instances := state.instances }
+  for event in batch.events do
+    cursor ← match event with
+      | .fact step => pushFact limits cursor action step batch.contradiction
+      | .equality step => pushEquality limits cursor action step
+      | .transport step => pushTransport limits cursor action step batch.contradiction
+      | .instance step => pushInstance limits cursor action step
+  pure cursor
+
+/-- Execute the exact assembled callback once and commit its whole typed raw
+event batch transactionally. The callback result cannot partially update the
+branch, equality arena, assembly cache, or compact application table. -/
+opaque State.stepWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (state : State Fact Cause) (action : Action) :
+    Except Error (Applied Fact Cause × State Fact Cause) := do
+  if limits.executable.state.maxActions <= state.serial then
+    throw (.resource (.state .actions))
+  match preflightBranch limits.executable.state state.branch with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
+  if limits.executable.state.maxEqualities < state.arena.items.size then
+    throw (.resource (.state .equalities))
+  if limits.executable.state.maxInstances < state.instances then
+    throw (.resource (.state .instances))
+  if state.assembly.generation != state.generationBase + state.branch.programVersion then
+    throw .malformed
+  let some request := request? limits state action | throw .stale
+  let (invocation, assembly) ← state.assembly.invokeWithin limits.executable request
+    |>.mapError Error.executable
+  match preflightBatch limits invocation.result with
+  | .error error => throw error
+  | .ok _ => pure ⟨⟩
+  if invocation.rule != action.key || eventQuotes invocation.result.events != invocation.quotes then
+    throw .malformed
+  /- Structural events extend the exact post-callback assembly, preserving
+  the cache returned by that same single invocation. -/
+  let invoked := makeState assembly state.branch state.arena state.generationBase
+    state.serial state.instances
+  let cursor ← applyEvents limits invoked action invocation.result
+  let next := makeState cursor.assembly cursor.branch (makeArena cursor.equalities)
+    state.generationBase (state.serial + 1) cursor.instances
+  let applied := makeApplied state.branch cursor.branch state.assembly.bindings
+    cursor.assembly.bindings state.assembly.applications cursor.assembly.applications
+    state.assembly.generation cursor.assembly.generation state.arena.items cursor.equalities
+    action invocation.result.events invocation.quotes state.serial
+  pure (applied, next)
+
+end Hex.Interval.Runtime

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -126,8 +126,10 @@ The first concrete supported theorem registry is the Mathlib arithmetic package 
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. Automatic arbitrary-function package
-discovery and theorem assembly, equality/instance runtime events, executable
-program extension, concrete policy algorithms and default scheduling, payload
+discovery and theorem assembly, quotation of the supported typed
+equality/instance/program-extension runtime events into proof schemas, wiring
+those events into the autonomous controller, concrete policy algorithms and
+default scheduling, payload
 storage, and the optimized backing store remain experimental. The narrow
 direct-forward tactic does not yet invoke the supported controller.
 In particular, the current instantiation proposal's package-supplied numeric
@@ -3204,8 +3206,15 @@ kind, reads, writes, structural inputs, matcher epoch, effort, and creation
 generation before routing a callback. `Controller.Executable` now retains that
 assembly as a sticky handle, generates offers from its exact row order, and
 passes a replacement private cache onward only after Search, Driver, and
-quotation/schema checks accept the transition. Assembly owns only the
-operation/node program: request
+quotation/schema checks accept the fact-only transition. Assembly separately
+retains the global
+generation cursor, so a node-only extension cannot lose its generation merely
+because it creates no concrete application. The supported `Runtime.State` owns that
+assembly together with the exact branch, equality arena, callback serial, and
+admitted-instance count. Its checked `stepWithin` is the Mathlib-free bridge
+from one exact application row to an atomic typed event batch; autonomous offer
+generation for typed batches still belongs to a separate controller. Assembly
+owns only the operation/node program: request
 program version and generation side tables remain controller-owned snapshot
 data and receive only the request-internal checks supplied by `ProgramView` and
 `RuleRequest`. Search also never decrements its `remaining` budget view; the
@@ -3217,6 +3226,9 @@ As with Search, sealing is an ordinary/public-import boundary. Deliberate
 Lean source and is not part of the decoded runtime threat model. The repository
 DAG check rejects that escape hatch outside an exact reviewed allowlist,
 currently empty; both conformance and bench paths are regression-tested.
+`Runtime.State`, `Runtime.Arena`, and `Runtime.Applied` use the same
+ordinary-import seal. Deliberate `import all HexInterval.Runtime` is an empty-
+allowlist trusted-internals escape hatch, not decoded-runtime authority.
 
 `prepareWithin` authenticates the session once, revalidates the external policy
 decision against that already-checked immutable view, and returns only the
@@ -3270,7 +3282,8 @@ the stronger leaf protocol for public-import clients.
 
 `Search.Result.Tree` is the supported retained-result prerequisite for a later
 proof-tree fold. Its private constructor keeps the exact node array, sealed
-`FrontierState Result.Id`, cumulative advance count, accounting, and logical
+`FrontierState Result.Id`, cumulative advance count, sealed typed-runtime
+transition chain, accounting, and logical
 cost together; callers cannot transplant a raw frontier, reset counters, or
 supply a complete child snapshot. `Result.startWithin` admits one checked root.
 `Result.advanceWithin` consumes a sealed `Applied` transition whose before
@@ -3306,10 +3319,53 @@ pass `Branch.check`. Its cumulative equation is exactly
 `steps = advances + splits + terminals`, rather than equality between a live
 advanced child and its creation-time versions or history.
 
+`Runtime.Applied` is the only supported program-changing retained transition.
+It binds the exact before/after branches, before/after binding and application
+tables, before/after equality arenas, selected action, typed events, accepted
+raw quotations, and serial. The typed vocabulary covers fact proposals, exact
+equality descriptors (endpoints, generation, origin action, ordered
+assumptions, and raw quote), transport through an admitted equality, and
+instance events with exact program, fact, binding, node, and application
+suffixes. `Runtime.State.stepWithin` invokes the assembled callback exactly
+once and commits its returned cache and complete batch only after every event
+and suffix validates. The equality table grows only at its next compact
+address; generation arrays alone are never equality authority. These values
+remain runtime provenance, not theorem evidence, and contain no Mathlib
+`Proof.Event`. `Result.advanceRuntimeWithin` retains a sealed transition at the
+exact current head. For a split child, validation reconstructs the exact
+creation branch and reaches its live branch only through that retained runtime
+chain. Consecutive transitions at one node must chain the exact binding,
+application, global-generation, and equality tables plus the next callback
+serial; independently sealed same-branch transitions cannot be spliced.
+An admitted raw equality authenticates exact existing same-domain endpoint
+identities and their creation record; it does not itself establish a semantic
+equality theorem. A transport event carries no quote. It must orient its write
+and source across those exact endpoints, name an exact currently live source
+version already owned by the selected action, and install precisely that
+source fact. The later package-owned equality schema remains the only theorem
+authority for the substitution.
+Generic child validation is not weakened to accept arbitrary program
+extensions. Fact-only accepted history may still advance within one pinned
+program phase. Branch program version, callback serial, admitted-instance
+count, and the equality arena restart at zero for a new child. Application
+creation generations remain global to the inherited sealed assembly. Runtime
+restart authenticates that inherited assembly generation as the fixed base for
+branch-local program version zero. Each accepted instance advances both
+chronologies once: its global generation is `base + localProgramVersion + 1`,
+while `Branch.extendWithin` stores the corresponding next local generation.
+Thus a child split after an extension can reuse the inherited exact rows and
+still admit the next strict global extension without assigning an impossible
+generation to its restarted local branch.
+
 Result limits independently bound retained nodes, each package body, declared
-logical bytes and work, plus the existing search and state resources. Count
-caps are checked before retained arrays and body lists are traversed. Adapter
-measurement, equality, and construction of arbitrary facts, causes, plans,
+logical bytes and work, plus the existing search and runtime resources. The
+runtime envelope's `maxEvents` bounds each retained typed batch. Runtime
+creation separately bounds quotation count by `Executable.Limits.maxQuotes`
+and the aggregate cell count across all quotation bodies by `maxQuoteCells`;
+the retained-tree layer currently re-caps the retained quotation count with
+`Result.Limits.maxBodyCells` and uses that same limit for every retained body.
+Count caps are checked before retained arrays and body lists are traversed.
+Adapter measurement, equality, and construction of arbitrary facts, causes, plans,
 schemas, and bodies remain explicitly non-preemptible; packages must bound
 those values before return. The split plan, schema, refutation record, target
 record, and runtime contradiction state are untrusted data, never evidence.
@@ -4105,8 +4161,9 @@ in the same transaction. Non-root target/refutation leaves and later splits
 may therefore consume child-local fact history after exact replay. The
 supported explicit controller now regenerates deterministic authenticated
 fact-event offers and repeats policy-driven iteration over that sealed bundle.
-Automatic package discovery, equality/instance runtime events, program
-extension, and public-tactic split search remain separate work.
+Automatic package discovery, proof quotation/controller scheduling of the
+supported equality/instance/program-extension runtime events, and public-tactic
+split search remain separate work.
 
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
@@ -5320,14 +5377,33 @@ candidates, and `b` the number of live branch states.
   equality on caller-selected facts, causes, identifiers, and keys
   remain non-preemptible.
 - The current `Search.Result.Tree` reference builders validate the complete
-  retained prefix before and after every split or settlement. If `N` nodes are
-  retained incrementally and `B` is the bounded per-node branch/state
-  validation cost, the repeated branch-validation term is `Θ(N² * B)`.
-  The current pairwise retained-scope uniqueness scan adds `Θ(N³)` across
-  the same incremental construction, for a combined `Θ(N² * B + N³)`
-  reference cost. This is not an incremental tree-store bound. `maxNodes`
-  therefore stays small and measurement-gated until a production
-  representation avoids repeated full-prefix validation.
+  retained prefix before and after every split, settlement, or runtime
+  transition. Let `N` be the retained node count, `R` the retained typed-runtime
+  transition count, and `B` the bounded branch/state validation and comparison
+  cost. One complete check includes the existing node branch work, an `N * R`
+  scan because each node filters the full retained transition array, and
+  `R * B` transition-branch comparisons. The retained root branch is also
+  measured once as a distinct authenticated cost, in addition to node sources
+  and runtime-chain branches. If nodes are retained incrementally, the repeated
+  branch-validation term remains `Θ(N² * B)` and pairwise scope uniqueness adds
+  `Θ(N³)`. If `R` runtime transitions are retained incrementally, repeated
+  transition comparison contributes the conservative `O(R² * B)` term, while
+  repeated per-node filtering contributes `O(N * R²)` at the final node cap.
+  Thus a conservative combined reference upper bound is
+  `O(N² * B + N³ + N * R² + R² * B)`. This is not an incremental tree-store
+  bound. Node and runtime limits therefore stay small and measurement-gated
+  until a production representation avoids repeated full-prefix validation.
+  Retained typed-runtime transitions add caller-measured branch states,
+  actions, facts, and quotation cells to this complete-tree scan. Cost
+  recomputation makes one linear pass over the retained runtime array and its
+  bounded suffix/event cells: it charges the first `before` branch once per
+  node and each successive `after` branch once, so an adjacent
+  `after`/`before` boundary is not duplicated. Each accepted quote is charged
+  once from the sealed transition quote array, not again from its typed event;
+  it also charges the separately retained authenticated root branch once.
+  These cost-accounting scans do not remove the `N * R`, `R * B`, or repeated
+  `R² * B` validation terms above. Arbitrary fact/cause equality and caller
+  measurement remain non-preemptible.
 - One `Controller.Executable` offer regeneration reconstructs and validates
   the retained branch snapshot and executable program context once. It then
   scans the flat applications with per-row identity, port, registration,
@@ -5462,9 +5538,10 @@ their declared cost inside a scheduler bound.
   `Controller.Resource.narrow budget` refusal before retaining any update,
   rather than collapsing into `noChange` or mismatch. This adapter is
   deliberately fact-only, and its `Run` exposes only a resumable stopped
-  result: typed equality and instance events, target/refutation/split/unknown
-  terminal correlation, automatic discovery, program extension, and
-  split-search tactic syntax remain later work. All offers in one immutable
+  result: quotation and controller scheduling of the separately supported typed
+  equality, instance, and program-extension runtime events,
+  target/refutation/split/unknown terminal correlation, automatic discovery,
+  and split-search tactic syntax remain later work. All offers in one immutable
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
   offer sets a controller-owned incomplete bit which survives later accepted
@@ -5535,7 +5612,14 @@ their declared cost inside a scheduler bound.
   a cache replacement only after result and quotation admission. The initial
   compiler does not create global structural-matcher applications. Fact-event
   correlation is supplied by `HexIntervalMathlib.Controller.Executable`; typed
-  equality/instance correlation remains later work.
+  equality/instance correlation and offer generation for typed batches remain
+  later layers.
+- `HexInterval/Runtime.lean`: supported sealed Mathlib-free ownership of one
+  executable assembly, branch, and exact equality arena; atomic typed fact,
+  equality, transport, and append-only instance events; exact application,
+  binding, node, generation, and equality authority; and sealed before/after
+  transitions retained by `Search.Result.Tree`. Raw quotations remain inert
+  data pending a separately checked Mathlib proof adapter.
 - `HexInterval/Trace.lean`: supported exact fact/instance chronology and
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt
@@ -5558,7 +5642,8 @@ their declared cost inside a scheduler bound.
   a separately sealed parent/depth/scope-checked leaf frontier, immutable parent
   restoration, sealed cumulative step/split/leaf/frontier/depth/scope
   accounting, and a sealed bounded retained result tree with exact single-delta
-  child reconstruction, authenticated fact-history advancement, and
+  child reconstruction, authenticated fact-history advancement, sealed
+  typed-runtime program-extension chains, and
   target/refute/unknown terminals. It contains no concrete callback, offer
   generator, semantic split/refutation theorem,
   policy algorithm, storage choice, proof recipe, or proof replay.
@@ -5574,7 +5659,7 @@ their declared cost inside a scheduler bound.
    automatic package discovery/program extension, executable-to-proof
    quotation, and a default policy will be selected from measurements; none is
    frozen by the decoded supported snapshots.
-- `conformance/HexInterval/{Conformance,ExecutableConformance,SearchConformance,
+- `conformance/HexInterval/{Conformance,ExecutableConformance,RuntimeConformance,SearchConformance,
   MinMaxConformance,
   EmitFixtures}.lean`:
   Lean-only checks and oracle fixtures. Executable conformance includes
@@ -5582,6 +5667,11 @@ their declared cost inside a scheduler bound.
   default refusal, exact application-field and replay-format mutations,
   append-prefix stability, resource-first program/binding admission, and
   exact resource one-overs.
+  Runtime conformance pins an instance-to-equality-to-fact-to-transport chain,
+  exact compact descriptor/suffix mutations, and the same chain retained in a
+  restarted split child. A post-extension split separately proves that restart
+  preserves nonzero assembly generations while resetting branch-local version,
+  serial, equality, and instance state.
 - `conformance/HexIntervalMathlib/ProgramProofConformance.lean`: supported
   program-model, registry, chronology, refutation, binary-cover/tree replay,
   target-closure, mutation, Meta-state restoration, and guarded

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexInterval.Policy
+public import HexInterval.Runtime
 
 @[expose] public section
 
@@ -928,12 +929,15 @@ structure Measure (Fact Cause Plan Schema : Type) where
   body : Nat → Cost
   code : Nat → Cost
 
-/-- Retained-result limits layered over branch and search limits. `maxNodes`
-bounds the complete retained tree, while `maxBodyCells` bounds each opaque
-package body before its logical cost is measured. -/
+/-- Retained-result limits layered over runtime and search limits. `maxNodes`
+bounds the complete retained tree, `runtime.maxEvents` bounds each retained
+atomic batch, and `maxBodyCells` currently bounds both the retained quote count
+and each opaque package body before its logical cost is measured. Runtime quote
+creation remains separately bounded by `runtime.executable.maxQuotes` and
+`runtime.executable.maxQuoteCells`. -/
 structure Limits where
   search : Search.Limits
-  state : State.Limits
+  runtime : Runtime.Limits
   maxNodes : Nat
   maxBodyCells : Nat
   maxBytes : Nat
@@ -941,8 +945,12 @@ structure Limits where
   maxCode : Nat
   deriving DecidableEq, Repr
 
+def Limits.state (limits : Limits) : State.Limits :=
+  limits.runtime.executable.state
+
 inductive Resource where
   | nodes
+  | events
   | body
   | bytes
   | work
@@ -1034,14 +1042,22 @@ are supplied per transition rather than retained in this pure value: a later
 call may tighten or relax them, and reusing an old tree may create alternative
 bounded lineages but cannot duplicate a scope within either lineage. The
 reference builders revalidate the complete retained prefix before and after
-each transition; `maxNodes` therefore remains small and measurement-gated. -/
+each transition; node validation filters the complete retained runtime array
+for every node, so `maxNodes` and retained transition counts remain small and
+measurement-gated. -/
 structure Tree (Fact Cause Plan Schema : Type) where
   private mk ::
   nodes : Array (Node Fact Cause Plan Schema)
   private live : FrontierState Id
+  /-- Authenticated root branch supplied to `startWithin`, retained so the
+  first root runtime transition cannot choose its own origin. -/
+  private root : State.Branch Fact Cause
   /-- Accepted callback-update transitions retained independently of binary
   splits and terminal settlement. -/
   private advances : Nat
+  /-- Sealed typed runtime transitions, retained in exact acceptance order and
+  bound to the tree node which was current when each transition committed. -/
+  private runtime : Array (Id × Runtime.Applied Fact Cause)
   cost : Cost
 
 opaque Tree.frontier (tree : Tree Fact Cause Plan Schema) : Frontier Id :=
@@ -1056,11 +1072,19 @@ opaque Tree.pending (tree : Tree Fact Cause Plan Schema) : List Id :=
 opaque Tree.isEmpty (tree : Tree Fact Cause Plan Schema) : Bool :=
   tree.live.isEmpty
 
+/-- Opaque ordinary-import view of the exact retained typed transitions. -/
+opaque Tree.transitions (tree : Tree Fact Cause Plan Schema) :
+    Array (Id × Runtime.Applied Fact Cause) :=
+  tree.runtime
+
 def sumCost (items : List Cost) : Cost :=
   items.foldl (init := {}) (fun total item => total + item)
 
 def bodyCost (measure : Measure Fact Cause Plan Schema) (body : List Nat) : Cost :=
   sumCost (body.map measure.body)
+
+private def cellCost (measure : Measure Fact Cause Plan Schema) (count : Nat) : Cost :=
+  sumCost (List.replicate count measure.node)
 
 def sourceCost (measure : Measure Fact Cause Plan Schema)
     (source : Source Fact Cause) : Cost :=
@@ -1081,9 +1105,57 @@ def nodeCost (measure : Measure Fact Cause Plan Schema) :
       sourceCost measure source + measure.action recipe.action + measure.plan recipe.plan +
         measure.schema recipe.schema + bodyCost measure recipe.body
 
-def Tree.recomputeCost (measure : Measure Fact Cause Plan Schema)
+private def runtimeEventCost (measure : Measure Fact Cause Plan Schema) :
+    Runtime.Event Fact Cause → Cost
+  | .fact step =>
+      measure.node + measure.action step.action + measure.fact step.proposed +
+        measure.fact step.update.fact
+  | .equality step =>
+      measure.node + cellCost measure step.assumptions.length + measure.action step.action
+  | .transport step =>
+      measure.node + measure.action step.action + measure.fact step.update.fact
+  | .instance step =>
+      measure.node + cellCost measure
+        (step.bindings.size + step.newNodes.length + step.newBindings.length +
+          step.newApplications.length) + measure.action step.action +
+        sumCost (step.freshFacts.toList.map measure.fact)
+
+private def runtimeCost (measure : Measure Fact Cause Plan Schema)
+    (includeBefore : Bool) (transition : Runtime.Applied Fact Cause) : Cost :=
+  measure.node + (if includeBefore then measure.branch transition.before else {}) +
+    measure.branch transition.after +
+    cellCost measure
+      (transition.beforeBindings.size + transition.afterBindings.size +
+        transition.beforeApplications.size + transition.afterApplications.size +
+        transition.beforeEqualities.size + transition.afterEqualities.size +
+        transition.quotes.size + 2) +
+    measure.action transition.action +
+      sumCost (transition.quotes.toList.map fun quote =>
+        bodyCost measure (quote.schema :: quote.body)) +
+      sumCost (transition.events.toList.map (runtimeEventCost measure))
+
+private def runtimeCosts (measure : Measure Fact Cause Plan Schema) (nodeCount : Nat)
+    (runtime : Array (Id × Runtime.Applied Fact Cause)) : Cost := Id.run do
+  let mut total : Cost := {}
+  let mut seen := Array.replicate nodeCount false
+  for entry in runtime do
+    let includeBefore := seen[entry.1.index]? != some true
+    if includeBefore then seen := seen.set! entry.1.index true
+    total := total + runtimeCost measure includeBefore entry.2
+  return total
+
+private def Tree.computeCost (measure : Measure Fact Cause Plan Schema)
     (tree : Tree Fact Cause Plan Schema) : Cost :=
-  sumCost (tree.nodes.toList.map (nodeCost measure))
+  measure.branch tree.root + sumCost (tree.nodes.toList.map (nodeCost measure)) +
+    runtimeCosts measure tree.nodes.size tree.runtime
+
+/-- Recompute the complete caller-declared logical cost of one sealed tree.
+Runtime entries are scanned once: the first `before` branch and each `after`
+branch are charged per node-chain position, and accepted quote bodies are
+charged once from `Applied.quotes` rather than duplicated by typed events. -/
+opaque Tree.recomputeCost (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) : Cost :=
+  tree.computeCost measure
 
 def withinCost (limits : Limits) (cost : Cost) : Bool :=
   cost.bytes ≤ limits.maxBytes && cost.work ≤ limits.maxWork
@@ -1105,7 +1177,7 @@ private def actionWithin (limits : State.Limits) (action : Action) : Bool :=
   let portLimit := Nat.max (limits.maxArity + 1) limits.maxScopeNodes
   listWithin portLimit action.inputs && listWithin portLimit action.writes &&
     listWithin limits.matcherBatchSize action.structuralInputs &&
-    action.effort ≤ limits.maxEffort
+    action.effort ≤ limits.maxEffort && action.generation ≤ limits.maxGeneration
 
 private opaque Split.check (limits : Limits) (source : Source Fact Cause)
     (recipe : Split Plan Schema) : Bool :=
@@ -1148,8 +1220,133 @@ private def childBranchWithin [DecidableEq Fact] (limits : Limits)
   | .ok branch => pure branch
   | .error error => throw (.state error)
 
+private def historyPrefix [DecidableEq Fact] [DecidableEq Cause]
+    (before after : Array (State.Update Fact Cause)) : Bool := Id.run do
+  if after.size < before.size then return false
+  for index in [0:before.size] do
+    if before[index]? != after[index]? then return false
+  return true
+
+/-- Fact-only movement inside one exact program phase. Program changes are
+accepted only by an intervening sealed runtime transition. -/
+private def samePhase [DecidableEq Fact] [DecidableEq Cause]
+    (before after : State.Branch Fact Cause) : Bool :=
+  before.baseProgram == after.baseProgram && before.initialFacts == after.initialFacts &&
+    before.programVersion == after.programVersion && before.program == after.program &&
+    before.seeds == after.seeds && before.generations == after.generations &&
+    before.depths == after.depths && historyPrefix before.history after.history &&
+    (!before.contradictory || after.contradictory) && before.check && after.check
+
+private def stepsFor (runtime : Array (Id × Runtime.Applied Fact Cause)) (id : Id) :
+    List (Runtime.Applied Fact Cause) :=
+  runtime.toList.filterMap fun entry => if entry.1 == id then some entry.2 else none
+
+private def applicationsSame (before after : Array Executable.Application) : Bool :=
+  before.size == after.size && Executable.applicationsPrefix before after
+
+private def equalityPrefix (before after : Array Runtime.Equality) : Bool := Id.run do
+  if after.size < before.size then return false
+  for index in [0:before.size] do
+    if before[index]? != after[index]? then return false
+  return true
+
+private def transitionShape (transition : Runtime.Applied Fact Cause) : Bool :=
+  transition.serial == transition.action.serial &&
+    Executable.bindingsPrefix transition.beforeBindings transition.afterBindings &&
+    Executable.applicationsPrefix transition.beforeApplications transition.afterApplications &&
+    transition.beforeGeneration ≤ transition.afterGeneration &&
+    transition.beforeGeneration + transition.after.programVersion ==
+      transition.afterGeneration + transition.before.programVersion &&
+    equalityPrefix transition.beforeEqualities transition.afterEqualities
+
+private def follows (before after : Runtime.Applied Fact Cause) : Bool :=
+  after.serial == before.serial + 1 &&
+    before.afterBindings == after.beforeBindings &&
+    applicationsSame before.afterApplications after.beforeApplications &&
+    before.afterGeneration == after.beforeGeneration &&
+    before.afterEqualities == after.beforeEqualities
+
+private def runtimeChain [DecidableEq Fact] [DecidableEq Cause]
+    (runtime : Array (Id × Runtime.Applied Fact Cause)) (id : Id)
+    (origin live : State.Branch Fact Cause) : Bool := Id.run do
+  let mut current := origin
+  let mut previous? : Option (Runtime.Applied Fact Cause) := none
+  for transition in stepsFor runtime id do
+    if !transitionShape transition || !samePhase current transition.before ||
+        !transition.after.check then return false
+    match previous? with
+    | none => if transition.serial != 0 then return false
+    | some previous => if !follows previous transition then return false
+    current := transition.after
+    previous? := some transition
+  return samePhase current live
+
+private def runtimeBindingWithin (limits : State.Limits) (binding : ScopeBinding) : Bool :=
+  listWithin limits.maxScopeNodes binding.watches &&
+    listWithin limits.maxScopeNodes binding.writes
+
+private def runtimeApplicationWithin (limits : State.Limits)
+    (application : Executable.Application) : Bool :=
+  listWithin (Nat.max (limits.maxArity + 1) limits.maxScopeNodes) application.watches &&
+    listWithin (Nat.max (limits.maxArity + 1) limits.maxScopeNodes) application.writes &&
+    listWithin limits.matcherBatchSize application.structuralInputs &&
+    application.effort ≤ limits.maxEffort && application.generation ≤ limits.maxGeneration
+
+private def runtimeEqualityWithin (limits : Limits) (equality : Runtime.Equality) : Bool :=
+  equality.generation ≤ limits.state.maxGeneration &&
+    actionWithin limits.state equality.origin && bodyWithin limits equality.quote.body &&
+    listWithin (Nat.max (limits.state.maxArity + 1) limits.state.maxScopeNodes)
+      equality.assumptions
+
+private def runtimePreflight (limits : Limits) (nodeCount : Nat)
+    (entry : Id × Runtime.Applied Fact Cause) : Bool :=
+  let transition := entry.2
+  entry.1.index < nodeCount && entry.1.index < limits.maxNodes &&
+    transition.events.size ≤ limits.runtime.maxEvents && !transition.events.isEmpty &&
+    transitionShape transition &&
+    transition.beforeBindings.size ≤ limits.state.maxApplications &&
+    transition.afterBindings.size ≤ limits.state.maxApplications &&
+    transition.beforeBindings.all (runtimeBindingWithin limits.state) &&
+    transition.afterBindings.all (runtimeBindingWithin limits.state) &&
+    transition.beforeApplications.size ≤ limits.state.maxApplications &&
+    transition.afterApplications.size ≤ limits.state.maxApplications &&
+    transition.beforeApplications.all (runtimeApplicationWithin limits.state) &&
+    transition.afterApplications.all (runtimeApplicationWithin limits.state) &&
+    transition.beforeGeneration ≤ transition.afterGeneration &&
+    transition.afterGeneration ≤ limits.state.maxGeneration &&
+    transition.beforeEqualities.size ≤ limits.state.maxEqualities &&
+    transition.afterEqualities.size ≤ limits.state.maxEqualities &&
+    transition.beforeEqualities.all (runtimeEqualityWithin limits) &&
+    transition.afterEqualities.all (runtimeEqualityWithin limits) &&
+    transition.quotes.size ≤ limits.maxBodyCells &&
+    transition.quotes.all (fun quote => bodyWithin limits quote.body) &&
+    (preflightBranch limits.state transition.before).isOk &&
+    (preflightBranch limits.state transition.after).isOk &&
+    actionWithin limits.state transition.action &&
+    transition.events.all fun event => match event with
+      | .fact step => bodyWithin limits step.quote.body && actionWithin limits.state step.action
+      | .equality step =>
+          bodyWithin limits step.quote.body && actionWithin limits.state step.action &&
+            listWithin (Nat.max (limits.state.maxArity + 1) limits.state.maxScopeNodes)
+              step.assumptions
+      | .transport step => actionWithin limits.state step.action
+      | .instance step =>
+          bodyWithin limits step.quote.body && actionWithin limits.state step.action &&
+            step.freshFacts.size <= limits.state.maxNodes &&
+            step.bindings.size <= limits.state.maxApplications &&
+            step.bindings.all (fun binding =>
+              listWithin limits.state.maxScopeNodes binding.watches &&
+                listWithin limits.state.maxScopeNodes binding.writes) &&
+            listWithin limits.state.maxNodes step.newNodes &&
+            listWithin limits.state.maxApplications step.newBindings &&
+            step.newBindings.all (fun binding =>
+              listWithin limits.state.maxScopeNodes binding.watches &&
+                listWithin limits.state.maxScopeNodes binding.writes) &&
+            listWithin limits.state.maxApplications step.newApplications
+
 private opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (parentId : Id) (parent : Source Fact Cause)
+    (runtime : Array (Id × Runtime.Applied Fact Cause)) (childId : Id)
     (side : Side) (child : Source Fact Cause) : Bool :=
   child.parent == some parentId && child.side == some side &&
     child.depth == parent.depth + 1 &&
@@ -1159,17 +1356,7 @@ private opaque childMatches [DecidableEq Fact] [DecidableEq Cause]
         match (childBranchWithin limits parent seed).toOption with
         | none => false
         | some initial =>
-            /- `child.branch` may have advanced through sealed accepted-update
-            transitions since creation. Its checked history reconstructs the
-            live snapshot; this edge pins the immutable base program, initial
-            facts, checked program, seeds, generations, depths, and program
-            version from the seeded creation branch. -/
-            initial.baseProgram == child.branch.baseProgram &&
-              initial.initialFacts == child.branch.initialFacts &&
-              initial.program == child.branch.program && initial.seeds == child.branch.seeds &&
-              initial.generations == child.branch.generations &&
-              initial.depths == child.branch.depths &&
-              initial.programVersion == child.branch.programVersion
+            runtimeChain runtime childId initial child.branch
 
 def pendingIds (tree : Tree Fact Cause Plan Schema) : List Id :=
   (List.range tree.nodes.size).filterMap fun index =>
@@ -1197,15 +1384,20 @@ private def nodePreflight (limits : Limits) (node : Node Fact Cause Plan Schema)
         bodyWithin limits split.body && actionWithin limits.state split.action
 
 /-- Validate the complete retained shape, exact parent/child seed relation,
-terminal records, cumulative search accounting, and adapter-declared cost. -/
+terminal records, cumulative search accounting, and adapter-declared cost.
+The transparent reference implementation scans the retained runtime array for
+each node and compares every selected transition branch. -/
 opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (measure : Measure Fact Cause Plan Schema)
     (tree : Tree Fact Cause Plan Schema) : Bool := Id.run do
-  if tree.nodes.isEmpty || limits.maxNodes < tree.nodes.size then return false
+  if tree.nodes.isEmpty || limits.maxNodes < tree.nodes.size ||
+      tree.runtime.any (fun entry => tree.nodes.size ≤ entry.1.index) then return false
   let some frontierCount := (frontierCountWithin limits.search tree.live.frontier).toOption
     | return false
   if !tree.accounting.check limits.search frontierCount ||
-      tree.nodes.any (fun node => !nodePreflight limits node) then return false
+      !(preflightBranch limits.state tree.root).isOk ||
+      tree.nodes.any (fun node => !nodePreflight limits node) ||
+      tree.runtime.any (fun entry => !runtimePreflight limits tree.nodes.size entry) then return false
   let some root := tree.nodes[0]? | return false
   let rootSource := root.source
   if rootSource.depth != 0 || rootSource.parent.isSome || rootSource.side.isSome ||
@@ -1217,6 +1409,14 @@ opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
     let source := node.source
     if !source.branch.check || limits.search.maxDepth < source.depth ||
         source.scope.index != rootSource.scope.index + index then return false
+    let id : Id := { index }
+    let nodeSteps := stepsFor tree.runtime id
+    if index == 0 then
+      if !runtimeChain tree.runtime id tree.root source.branch then return false
+    else match nodeSteps with
+      | [] => pure ()
+      | first :: _ =>
+          if !runtimeChain tree.runtime id first.before source.branch then return false
     scopes := source.scope :: scopes
     match node with
     | .pending _ => pure ()
@@ -1231,8 +1431,9 @@ opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
         if leftSeed.node != recipe.parent.node || rightSeed.node != recipe.parent.node ||
             leftSeed.previous != recipe.parent || rightSeed.previous != recipe.parent ||
             leftSeed.fact == rightSeed.fact ||
-            !childMatches limits { index } source .left leftNode.source ||
-            !childMatches limits { index } source .right rightNode.source then return false
+            !childMatches limits { index } source tree.runtime left .left leftNode.source ||
+            !childMatches limits { index } source tree.runtime right .right rightNode.source then
+          return false
         incoming := incoming.set! left.index (incoming[left.index]! + 1)
         incoming := incoming.set! right.index (incoming[right.index]! + 1)
   if !allDistinct scopes || incoming[0]? != some 0 then return false
@@ -1248,7 +1449,7 @@ opaque Tree.check [DecidableEq Fact] [DecidableEq Cause]
       tree.accounting.leaves != splits + 1 ||
       tree.accounting.scopes != tree.nodes.size ||
       tree.accounting.nextScope != rootSource.scope.index + tree.nodes.size then return false
-  let cost := tree.recomputeCost measure
+  let cost := tree.computeCost measure
   return tree.cost == cost && withinCost limits cost
 
 private def checked [DecidableEq Fact] [DecidableEq Cause]
@@ -1267,9 +1468,11 @@ opaque startWithin [DecidableEq Fact] [DecidableEq Cause]
   let source : Source Fact Cause := { scope, depth := 0, branch }
   let nodes : Array (Node Fact Cause Plan Schema) := #[.pending source]
   let live <- (FrontierState.startWithin limits.search scope ({ index := 0 } : Id)).mapError fromSearch
-  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  let initial : Tree Fact Cause Plan Schema :=
+    { nodes, live, root := branch, advances := 0, runtime := #[], cost := {} }
+  let cost := initial.computeCost measure
   throwCost limits cost
-  checked limits measure { nodes, live, advances := 0, cost }
+  checked limits measure { initial with cost }
 
 opaque current? (tree : Tree Fact Cause Plan Schema) : Option (Id × Source Fact Cause) := do
   let id ← tree.live.head?
@@ -1299,9 +1502,46 @@ opaque advanceWithin [DecidableEq Fact] [DecidableEq Cause]
   if head != id then throw .malformed
   let nextSource := { source with branch := transition.after.branch }
   let nodes := tree.nodes.set! id.index (.pending nextSource)
-  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  let next : Tree Fact Cause Plan Schema :=
+    { nodes, live, root := tree.root, advances := tree.advances + 1,
+      runtime := tree.runtime, cost := {} }
+  let cost := next.computeCost measure
   throwCost limits cost
-  checked limits measure { nodes, live, advances := tree.advances + 1, cost }
+  checked limits measure { next with cost }
+
+/-- Retain one sealed typed runtime transition at the exact current tree head.
+Unlike generic fact updates, an accepted program extension is remembered in
+the private transition chain used to reconstruct non-root child state. -/
+opaque advanceRuntimeWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Measure Fact Cause Plan Schema)
+    (tree : Tree Fact Cause Plan Schema) (transition : Runtime.Applied Fact Cause) :
+    Except Error (Tree Fact Cause Plan Schema) := do
+  let tree ← checked limits measure tree
+  let some (id, source) := current? tree | throw .terminal
+  if transition.events.size > limits.runtime.maxEvents then
+    throw (.resource .events)
+  if
+      transition.quotes.size > limits.maxBodyCells ||
+      transition.quotes.any (fun quote => !bodyWithin limits quote.body) ||
+      transition.events.any (fun event => match event with
+        | .fact step => !bodyWithin limits step.quote.body
+        | .equality step => !bodyWithin limits step.quote.body
+        | .transport _ => false
+        | .instance step => !bodyWithin limits step.quote.body) then
+    throw (.resource .body)
+  if !runtimePreflight limits tree.nodes.size (id, transition) ||
+      transition.before != source.branch ||
+      !transition.after.check then throw .malformed
+  let (head, live) ← tree.live.advanceHeadWithin limits.search |>.mapError fromSearch
+  if head != id then throw .malformed
+  let nextSource := { source with branch := transition.after }
+  let nodes := tree.nodes.set! id.index (.pending nextSource)
+  let runtime := tree.runtime.push (id, transition)
+  let next : Tree Fact Cause Plan Schema :=
+    { nodes, live, root := tree.root, advances := tree.advances + 1, runtime, cost := {} }
+  let cost := next.computeCost measure
+  throwCost limits cost
+  checked limits measure { next with cost }
 
 /-- Restore the exact retained parent source by append-only node identity. -/
 def restoreParent? (tree : Tree Fact Cause Plan Schema) (child : Id) :
@@ -1347,9 +1587,12 @@ opaque splitWithin [DecidableEq Fact] [DecidableEq Cause]
     { index := tree.accounting.nextScope + 1 } rightSeed
   let nodes := (tree.nodes.set! parentId.index (.split parent recipe leftId rightId))
     |>.push (.pending left) |>.push (.pending right)
-  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  let next : Tree Fact Cause Plan Schema :=
+    { nodes, live, root := tree.root, advances := tree.advances,
+      runtime := tree.runtime, cost := {} }
+  let cost := next.computeCost measure
   throwCost limits cost
-  checked limits measure { nodes, live, advances := tree.advances, cost }
+  checked limits measure { next with cost }
 
 /-- Retain one exact terminal and remove the stable frontier head
 transactionally. Target and refutation records are authenticated runtime data,
@@ -1367,9 +1610,12 @@ opaque settleWithin [DecidableEq Fact] [DecidableEq Cause]
   let (head, live) ← tree.live.settleHeadWithin limits.search |>.mapError fromSearch
   if head != id then throw .terminal
   let nodes := tree.nodes.set! id.index (.terminal source ending)
-  let cost := sumCost (nodes.toList.map (nodeCost measure))
+  let next : Tree Fact Cause Plan Schema :=
+    { nodes, live, root := tree.root, advances := tree.advances,
+      runtime := tree.runtime, cost := {} }
+  let cost := next.computeCost measure
   throwCost limits cost
-  checked limits measure { nodes, live, advances := tree.advances, cost }
+  checked limits measure { next with cost }
 
 end Result
 

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -86,9 +86,14 @@ and application generators; it has no concrete built-in arithmetic
 `Driver.Package`. Concrete built-in arithmetic reaches the controller only
 through the separate `Controller.Executable` adapter, which consumes a sealed
 Mathlib-free `Executable.Assembly` and correlates accepted fact quotations with
-independently replayed theorem schemas. Automatic discovery/program extension,
-equality/instance runtime events, and public-tactic split search remain later
-edges.
+independently replayed theorem schemas. The Mathlib-free `Runtime.State`
+separately owns an executable assembly and
+atomically validates typed fact/equality/transport/instance batches, including
+an exact equality descriptor arena and append-only application/binding/node
+suffixes; `Search.Result.Tree` retains its sealed transition in a child.
+Wiring those typed batches to this controller and correlating their inert
+quotations with theorem events, automatic discovery/program extension, and
+public-tactic split search remain later edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -239,6 +244,10 @@ fixed-point `noChange` and malformed narrowing remain mismatches at this
 fact-only boundary. Its public `Run` currently contains only a resumable
 `stopped` result. Driver target, refutation, split, and unknown outcomes are
 rejected as mismatches until separate typed terminal correlation is added.
+The separate Mathlib-free typed runtime authenticates and retains raw
+fact/equality/transport/instance chronology without importing this proof
+module; conversion of those typed events to package-owned proof schemas remains
+a later edge.
 The assembly constructors are sealed under ordinary imports; deliberate
 `import all HexInterval.Executable` is a repository-guarded trusted-source
 escape hatch, not decoded runtime or proof authority.

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -45,6 +45,11 @@ The Mathlib-free `Executable.Assembly` now supports explicit stable-key
 arbitrary-operation callback packages, private caches, exact concrete
 application rows, and bounded raw replay formats. Those raw quotations are not
 Mathlib proof events and are not yet correlated with this theorem registry.
+The supported Mathlib-free typed runtime now authenticates atomic
+fact/equality/transport/instance batches, exact equality descriptors, and
+append-only application/binding/node suffixes, and retains their sealed
+before/after transition in the result tree. A later checked adapter must still
+resolve those inert quotations through this theorem registry.
 Its constructors are sealed under ordinary imports; deliberate `import all
 HexInterval.Executable` is a repository-guarded trusted-source escape hatch,
 not decoded runtime authority.
@@ -3346,6 +3351,10 @@ the fixed soundness and trust contracts.
   handler routes and concrete application tables, package-owned cache/result
   measures, append-stable local program extension, and inert bounded raw replay
   quotations. It does not generate offers or construct proof events.
+- `HexInterval/Runtime.lean`: sealed Mathlib-free atomic typed callback events,
+  exact equality descriptors and append-only instance suffixes, and retained
+  before/after runtime provenance. It deliberately contains no Mathlib proof
+  event or evidence.
 - `HexIntervalMathlib/Interval.lean`: real membership, cut lemmas, and exact
   semantics for construction, intersection, hull, and negation.
 - `HexIntervalMathlib/Addition.lean` and

--- a/conformance/HexInterval/ExecutableConformance.lean
+++ b/conformance/HexInterval/ExecutableConformance.lean
@@ -427,9 +427,25 @@ def duplicateFormatLimits : Limits :=
       | .error _ => false
       | .ok extended =>
           applicationsPrefix assembly.applications extended.applications &&
+            assembly.generation == 0 && extended.generation == 1 &&
             extended.applications.size == 4 &&
               extended.applications[2]?.map (·.generation) == some 1 &&
                 extended.applications[3]?.map (·.generation) == some 1
+
+-- A version-only extension still advances the sealed global generation even
+-- when no application row exists to carry it, so restart cannot reuse it.
+#guard
+  match assembly? with
+  | none => false
+  | some assembly =>
+      match assembly.extendWithin limits program 1 with
+      | .error _ => false
+      | .ok extended =>
+          extended.generation == 1 &&
+            applicationsPrefix assembly.applications extended.applications &&
+            match extended.extendWithin limits program 1 with
+            | .error .staleGeneration => true
+            | _ => false
 
 #guard
   match assembly? with

--- a/conformance/HexInterval/RuntimeConformance.lean
+++ b/conformance/HexInterval/RuntimeConformance.lean
@@ -1,0 +1,961 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Search
+
+/-!
+Conformance for the sealed Mathlib-free typed runtime transition. The fixture
+builds the structural shape `sin x = sin (-(-x))` without interpreting sine:
+an instance appends two nodes and two scoped applications, an equality admits
+their exact descriptor, a fact improves the first node, and transport installs
+that fact at the second node. The complete chain runs at a root and in a fresh
+split child. A second split after root extension restarts over nonzero assembly
+generation, admits the next strict instance, and completes a fresh
+equality/fact/transport chain on the new local generation-one suffix.
+-/
+
+namespace Hex.Interval.RuntimeConformance
+
+open Hex.Interval.Runtime Executable Search.Result
+
+def real : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "fixture.source" }
+def negKey : OpKey := { name := "fixture.neg" }
+def sineKey : OpKey := { name := "fixture.sine" }
+def sineNegKey : OpKey := { name := "fixture.sine-neg" }
+
+def instantiateKey : RuleKey := { name := "fixture.sine.instantiate" }
+def equalityKey : RuleKey := { name := "fixture.sine.equality" }
+def transportKey : RuleKey := { name := "fixture.sine.transport" }
+def factKey : RuleKey := { name := "fixture.sine.fact" }
+
+def sourceOperation : Operation := { key := sourceKey, inputs := [], output := real }
+def negOperation : Operation := { key := negKey, inputs := [real], output := real }
+def sineOperation : Operation := { key := sineKey, inputs := [real], output := real }
+def sineNegOperation : Operation := { key := sineNegKey, inputs := [real], output := real }
+
+def program : Program :=
+  { operations := #[sourceOperation, negOperation, sineOperation, sineNegOperation]
+    nodes :=
+      #[{ domain := real, op := { index := 0 }, args := [] },
+        { domain := real, op := { index := 1 }, args := [{ index := 0 }] }] }
+
+def extendedProgram : Program :=
+  { program with nodes := program.nodes ++
+      #[{ domain := real, op := { index := 2 }, args := [{ index := 0 }] },
+        { domain := real, op := { index := 3 }, args := [{ index := 1 }] }] }
+
+def twiceExtendedProgram : Program :=
+  { extendedProgram with nodes := extendedProgram.nodes ++
+      #[{ domain := real, op := { index := 2 }, args := [{ index := 0 }] },
+        { domain := real, op := { index := 3 }, args := [{ index := 1 }] }] }
+
+def instantiateRegistration : Registration :=
+  { key := instantiateKey, head := negKey, kind := .instantiate,
+    watches := [.argument 0], writes := [] }
+
+def equalityRegistration : Registration :=
+  { key := equalityKey, head := sineNegKey, kind := .rewrite,
+    watches := [], writes := [], binding := .scoped }
+
+def transportRegistration : Registration :=
+  { key := transportKey, head := sineNegKey, kind := .rewrite,
+    watches := [], writes := [], binding := .scoped }
+
+def factRegistration : Registration :=
+  { key := factKey, head := sineKey, kind := .forward,
+    watches := [.result], writes := [.result] }
+
+def equalityBinding : ScopeBinding :=
+  { rule := equalityKey, anchor := { index := 3 },
+    watches := [{ index := 2 }, { index := 3 }], writes := [] }
+
+def transportBinding : ScopeBinding :=
+  { rule := transportKey, anchor := { index := 3 },
+    watches := [{ index := 2 }], writes := [{ index := 3 }] }
+
+def bindings : Array ScopeBinding := #[equalityBinding, transportBinding]
+
+def nextEqualityBinding : ScopeBinding :=
+  { rule := equalityKey, anchor := { index := 5 },
+    watches := [{ index := 4 }, { index := 5 }], writes := [] }
+
+def nextTransportBinding : ScopeBinding :=
+  { rule := transportKey, anchor := { index := 5 },
+    watches := [{ index := 4 }], writes := [{ index := 5 }] }
+
+def nextBindings : Array ScopeBinding :=
+  bindings ++ #[nextEqualityBinding, nextTransportBinding]
+
+def instanceQuote : Quote := { role := .instance, schema := 1, body := [11] }
+def equalityQuote : Quote := { role := .equality, schema := 2, body := [22] }
+def factQuote : Quote := { role := .fact, schema := 3, body := [33] }
+
+def actionFor (request : RuleRequest Nat) : Action := request.action
+
+def instantiateBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  if request.program.nodes.size == program.nodes.size then
+    { events := #[.instance
+        { action := actionFor request
+          after := extendedProgram
+          freshFacts := #[30, 40]
+          bindings
+          newNodes := [{ index := 2 }, { index := 3 }]
+          newBindings := [equalityBinding, transportBinding]
+          newApplications := [{ index := 1 }, { index := 2 }, { index := 3 }]
+          generation := 1
+          quote := instanceQuote }] }
+  else
+    { events := #[.instance
+        { action := actionFor request
+          after := twiceExtendedProgram
+          freshFacts := #[50, 60]
+          bindings := nextBindings
+          newNodes := [{ index := 4 }, { index := 5 }]
+          newBindings := [nextEqualityBinding, nextTransportBinding]
+          newApplications := [{ index := 4 }, { index := 5 }, { index := 6 }]
+          generation := 2
+          quote := instanceQuote }] }
+
+private def endpoint (fallback : Nat) : List SeenVersion → NodeId
+  | [] => { index := fallback }
+  | seen :: _ => seen.node
+
+def equalityBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.equality
+      { action := actionFor request
+        equality := { index := 0 }
+        left := endpoint 0 request.action.inputs
+        right := endpoint 0 request.action.inputs.tail
+        generation := request.action.generation
+        assumptions := request.action.inputs
+        quote := equalityQuote }] }
+
+def factBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  let value := if request.action.node.index == 2 then 31 else 51
+  { events := #[.fact
+      { action := actionFor request
+        update :=
+          { programVersion := request.action.programVersion, node := request.action.node,
+            previous := { node := request.action.node, version := 0 },
+            fact := value, version := 1, cause := 101 }
+        proposed := value
+        quote := factQuote }] }
+
+def transportBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  let source := request.action.inputs.head?.getD
+    { node := request.action.node, version := 0 }
+  let value := if request.action.node.index == 3 then 31 else 51
+  { events := #[.transport
+      { action := actionFor request
+        update :=
+          { programVersion := request.action.programVersion, node := request.action.node,
+            previous := { node := request.action.node, version := 0 },
+            fact := value, version := 1, cause := 102 }
+        equality := { index := 0 }
+        source }] }
+
+def format (role : Role) (schema atom : Nat) : ReplayFormat :=
+  { role, schema, validateBody := fun body => body == [atom] }
+
+def handler (registration : Registration) (role : Role) (schema atom : Nat)
+    (invoke : RuleRequest Nat → Batch Nat Nat) : Handler Nat (Batch Nat Nat) Unit :=
+  { registration
+    invoke := fun cache request =>
+      ({ result := invoke request,
+         quotes := if role == .fact || role == .equality || role == .instance then
+           #[{ role, schema, body := [atom] }] else #[] }, cache)
+    acceptsScope := fun actual binding =>
+      (actual == extendedProgram &&
+          (binding == equalityBinding || binding == transportBinding)) ||
+        (actual == twiceExtendedProgram &&
+          (binding == equalityBinding || binding == transportBinding ||
+            binding == nextEqualityBinding || binding == nextTransportBinding))
+    formats := if role == .fact || role == .equality || role == .instance then
+      #[format role schema atom] else #[] }
+
+def transportHandler : Handler Nat (Batch Nat Nat) Unit :=
+  { registration := transportRegistration
+    invoke := fun cache request =>
+      ({ result := transportBatch request, quotes := #[] }, cache)
+    acceptsScope := fun actual binding =>
+      (actual == extendedProgram && binding == transportBinding) ||
+        (actual == twiceExtendedProgram &&
+          (binding == transportBinding || binding == nextTransportBinding))
+    formats := #[] }
+
+def runtimePackage : Package Nat (Batch Nat Nat) :=
+  { Cache := Unit
+    cache := ()
+    operations := #[sourceOperation, negOperation, sineOperation, sineNegOperation]
+    handlers :=
+      #[handler instantiateRegistration .instance 1 11 instantiateBatch,
+        handler equalityRegistration .equality 2 22 equalityBatch,
+        transportHandler,
+        handler factRegistration .fact 3 33 factBatch]
+    measure :=
+      { metadata := { bytes := 8, work := 8 }
+        application := fun _ => { bytes := 1, work := 1 }
+        cache := fun _ => {}
+        result := fun result =>
+          { bytes := result.events.size, work := result.events.size } } }
+
+def packageWith (instanceHandler equalityHandler transportHandler factHandler :
+    Handler Nat (Batch Nat Nat) Unit) : Package Nat (Batch Nat Nat) :=
+  { runtimePackage with
+    handlers := #[instanceHandler, equalityHandler, transportHandler, factHandler] }
+
+def wrongInstanceBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.instance
+      { action := request.action
+        after := extendedProgram
+        freshFacts := #[30, 40]
+        bindings
+        newNodes := [{ index := 2 }, { index := 3 }]
+        newBindings := [equalityBinding, transportBinding]
+        newApplications := [{ index := 1 }, { index := 3 }, { index := 2 }]
+        generation := 1
+        quote := instanceQuote }] }
+
+def wrongBindingBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.instance
+      { action := request.action
+        after := extendedProgram
+        freshFacts := #[30, 40]
+        bindings
+        newNodes := [{ index := 2 }, { index := 3 }]
+        newBindings := [transportBinding, equalityBinding]
+        newApplications := [{ index := 1 }, { index := 2 }, { index := 3 }]
+        generation := 1
+        quote := instanceQuote }] }
+
+def changedProgram : Program :=
+  { extendedProgram with
+    nodes := extendedProgram.nodes.set! 1
+      { domain := real, op := { index := 0 }, args := [] } }
+
+def wrongProgramBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.instance
+      { action := request.action
+        after := changedProgram
+        freshFacts := #[30, 40]
+        bindings
+        newNodes := [{ index := 2 }, { index := 3 }]
+        newBindings := [equalityBinding, transportBinding]
+        newApplications := [{ index := 1 }, { index := 2 }, { index := 3 }]
+        generation := 1
+        quote := instanceQuote }] }
+
+def wrongGenerationBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.instance
+      { action := request.action
+        after := extendedProgram
+        freshFacts := #[30, 40]
+        bindings
+        newNodes := [{ index := 2 }, { index := 3 }]
+        newBindings := [equalityBinding, transportBinding]
+        newApplications := [{ index := 1 }, { index := 2 }, { index := 3 }]
+        generation := 0
+        quote := instanceQuote }] }
+
+def emptyInstanceBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.instance
+      { action := request.action
+        after := program
+        freshFacts := #[]
+        bindings := #[]
+        newNodes := []
+        newBindings := []
+        newApplications := []
+        generation := 1
+        quote := instanceQuote }] }
+
+def twoEventBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  let events := (instantiateBatch request).events
+  { events := events ++ events }
+
+def wrongEqualityBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.equality
+      { action := request.action
+        equality := { index := 0 }
+        left := { index := 2 }
+        right := { index := 2 }
+        generation := 1
+        assumptions := request.action.inputs
+        quote := equalityQuote }] }
+
+def wrongOriginBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.equality
+      { action := { request.action with serial := 0 }
+        equality := { index := 0 }
+        left := { index := 2 }
+        right := { index := 3 }
+        generation := 1
+        assumptions := request.action.inputs
+        quote := equalityQuote }] }
+
+def wrongAssumptionsBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.equality
+      { action := request.action
+        equality := { index := 0 }
+        left := { index := 2 }
+        right := { index := 3 }
+        generation := 1
+        assumptions := []
+        quote := equalityQuote }] }
+
+def wrongEqualityGenerationBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.equality
+      { action := request.action
+        equality := { index := 0 }
+        left := { index := 2 }
+        right := { index := 3 }
+        generation := 0
+        assumptions := request.action.inputs
+        quote := equalityQuote }] }
+
+def wrongFactBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.fact
+      { action := request.action
+        update :=
+          { programVersion := 1, node := { index := 3 },
+            previous := { node := { index := 3 }, version := 0 },
+            fact := 31, version := 1, cause := 101 }
+        proposed := 31
+        quote := factQuote }] }
+
+def wrongTransportBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.transport
+      { action := request.action
+        update :=
+          { programVersion := 1, node := { index := 3 },
+            previous := { node := { index := 3 }, version := 0 },
+            fact := 31, version := 1, cause := 102 }
+        equality := { index := 1 }
+        source := { node := { index := 2 }, version := 1 } }] }
+
+def wrongTransportValueBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  { events := #[.transport
+      { action := request.action
+        update :=
+          { programVersion := request.action.programVersion, node := { index := 3 },
+            previous := { node := { index := 3 }, version := 0 },
+            fact := 999, version := 1, cause := 102 }
+        equality := { index := 0 }
+        source := { node := { index := 2 }, version := 1 } }] }
+
+def wrongInstanceHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 wrongInstanceBatch
+
+def wrongBindingHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 wrongBindingBatch
+
+def wrongProgramHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 wrongProgramBatch
+
+def wrongGenerationHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 wrongGenerationBatch
+
+def emptyInstanceHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 emptyInstanceBatch
+
+def twoEventHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler instantiateRegistration .instance 1 11 twoEventBatch
+
+def wrongEqualityHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler equalityRegistration .equality 2 22 wrongEqualityBatch
+
+def wrongOriginHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler equalityRegistration .equality 2 22 wrongOriginBatch
+
+def wrongAssumptionsHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler equalityRegistration .equality 2 22 wrongAssumptionsBatch
+
+def wrongEqualityGenerationHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler equalityRegistration .equality 2 22 wrongEqualityGenerationBatch
+
+def wrongFactHandler : Handler Nat (Batch Nat Nat) Unit :=
+  handler factRegistration .fact 3 33 wrongFactBatch
+
+def wrongTransportHandler : Handler Nat (Batch Nat Nat) Unit :=
+  { transportHandler with invoke := fun cache request =>
+      ({ result := wrongTransportBatch request, quotes := #[] }, cache) }
+
+def wrongTransportValueHandler : Handler Nat (Batch Nat Nat) Unit :=
+  { transportHandler with invoke := fun cache request =>
+      ({ result := wrongTransportValueBatch request, quotes := #[] }, cache) }
+
+def stateLimits : Hex.Interval.State.Limits :=
+  { maxOperations := 4, maxNodes := 6, maxRules := 4,
+    maxRegistryEntries := 32, maxReplayFormats := 3, maxArity := 1,
+    maxScopeNodes := 2, maxApplications := 7, maxQueueEntries := 8,
+    maxActions := 8, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 4, maxRetainedSuggestions := 0, maxEffort := 0,
+    maxObservationValue := 8, maxDiagnosticValue := 8,
+    maxOutcomeCandidates := 4, maxOutcomeSuggestions := 0,
+    maxProposalItems := 0, maxInstances := 1, maxGeneration := 2,
+    maxNodeDepth := 2, maxEqualities := 1,
+    splitEndpointLimit := { maxEndpointHeight := 8, maxAlignmentShift := 8 } }
+
+def executableLimits : Executable.Limits :=
+  { state := stateLimits, maxPackages := 1,
+    maxMetadataBytes := 32, maxMetadataWork := 32,
+    maxCacheBytes := 0, maxCacheWork := 0,
+    maxResultBytes := 1, maxResultWork := 1,
+    maxQuotes := 1, maxQuoteCells := 1, maxAtom := 33, maxSchema := 3 }
+
+def limits : Runtime.Limits := { executable := executableLimits, maxEvents := 1 }
+
+def assembly? : Option (Assembly Nat (Batch Nat Nat)) :=
+  (Executable.buildWithin executableLimits #[runtimePackage] program).toOption
+
+def assemblyWith? (package : Package Nat (Batch Nat Nat)) :
+    Option (Assembly Nat (Batch Nat Nat)) :=
+  (Executable.buildWithin executableLimits #[package] program).toOption
+
+def branch? : Option (Hex.Interval.State.Branch Nat Nat) :=
+  (Hex.Interval.State.Branch.startWithin stateLimits program #[10, 20]).toOption
+
+def runtime? : Option (Runtime.State Nat Nat) :=
+  match assembly?, branch? with
+  | some assembly, some branch =>
+      (Runtime.State.startWithin limits assembly branch).toOption
+  | _, _ => none
+
+def runtimeWith? (package : Package Nat (Batch Nat Nat)) : Option (Runtime.State Nat Nat) :=
+  match assemblyWith? package, branch? with
+  | some assembly, some branch =>
+      (Runtime.State.startWithin limits assembly branch).toOption
+  | _, _ => none
+
+#guard assembly?.isSome
+#guard branch?.isSome
+#guard runtime?.isSome
+
+def action (serial programVersion application rule : Nat) (key : RuleKey)
+    (node : Nat) (kind : ActionKind) (generation : Nat)
+    (inputs : List SeenVersion) (writes : List NodeId := []) : Action :=
+  { serial, programVersion, application := { index := application },
+    rule := { index := rule }, key, node := { index := node }, kind,
+    effort := 0, generation, inputs, writes }
+
+def instanceAction : Action :=
+  action 0 0 0 0 instantiateKey 1 .instantiate 0
+    [{ node := { index := 0 }, version := 0 }]
+
+def equalityAction : Action :=
+  action 1 1 1 1 equalityKey 3 .rewrite 1
+    [{ node := { index := 2 }, version := 0 },
+     { node := { index := 3 }, version := 0 }]
+
+def factAction : Action :=
+  action 2 1 3 3 factKey 2 .forward 1
+    [{ node := { index := 2 }, version := 0 }] [{ index := 2 }]
+
+def transportAction : Action :=
+  action 3 1 2 2 transportKey 3 .rewrite 1
+    [{ node := { index := 2 }, version := 1 }] [{ index := 3 }]
+
+def run? : Option (Array (Runtime.Applied Nat Nat) × Runtime.State Nat Nat) := do
+  let state ← runtime?
+  let (instanceStep, state) ← (state.stepWithin limits instanceAction).toOption
+  let (equalityStep, state) ← (state.stepWithin limits equalityAction).toOption
+  let (factStep, state) ← (state.stepWithin limits factAction).toOption
+  let (transportStep, state) ← (state.stepWithin limits transportAction).toOption
+  pure (#[instanceStep, equalityStep, factStep, transportStep], state)
+
+#guard run?.any fun result =>
+  let state := result.2
+  state.branch.program == extendedProgram && state.branch.programVersion == 1 &&
+    state.branch.snapshot.facts == #[10, 20, 31, 31] &&
+    state.branch.versions == #[0, 0, 1, 1] && state.equalities.size == 1 &&
+    state.equalities[0]?.any fun equality =>
+      equality.left == { index := 2 } && equality.right == { index := 3 } &&
+        equality.generation == 1 && equality.origin == equalityAction
+
+#guard run?.any fun result =>
+  match result.1[0]?, result.1[1]? with
+  | some instanceStep, some equalityStep =>
+      instanceStep.beforeBindings.isEmpty && instanceStep.afterBindings == bindings &&
+        instanceStep.beforeApplications.size == 1 &&
+        instanceStep.afterApplications.size == 4 &&
+        instanceStep.beforeGeneration == 0 && instanceStep.afterGeneration == 1 &&
+        instanceStep.beforeEqualities.isEmpty && instanceStep.afterEqualities.isEmpty &&
+        equalityStep.beforeBindings == equalityStep.afterBindings &&
+        equalityStep.beforeApplications.size == equalityStep.afterApplications.size &&
+        equalityStep.beforeGeneration == 1 && equalityStep.afterGeneration == 1 &&
+        equalityStep.beforeEqualities.isEmpty && equalityStep.afterEqualities.size == 1
+  | _, _ => false
+
+private def runtimeError (actualLimits : Runtime.Limits) (actual : Action) : Option Runtime.Error :=
+  match runtime? with
+  | none => none
+  | some state => match state.stepWithin actualLimits actual with
+    | .error error => some error
+    | .ok _ => none
+
+#guard runtimeError limits { instanceAction with serial := 1 } == some .stale
+#guard runtimeError { limits with executable :=
+    { executableLimits with state := { stateLimits with maxActions := 0 } } }
+  instanceAction == some (.resource (.state .actions))
+#guard runtimeError { limits with maxEvents := 0 } instanceAction ==
+  some (.resource .events)
+#guard runtimeError { limits with executable :=
+    { executableLimits with state := { stateLimits with maxInstances := 0 } } }
+  instanceAction == some (.resource (.state .instances))
+
+private def startError (actualLimits : Runtime.Limits) : Option Runtime.Error :=
+  match assembly?, branch? with
+  | some assembly, some branch => match Runtime.State.startWithin actualLimits assembly branch with
+    | .error error => some error
+    | .ok _ => none
+  | _, _ => none
+
+#guard startError { limits with executable :=
+    { executableLimits with state := { stateLimits with maxApplications := 0 } } } ==
+  some (.executable (.resource (.state .applications)))
+
+-- A resource rejection returns no cache/state replacement: the same sealed
+-- state still accepts the exact action under the original envelope.
+#guard runtime?.any fun state =>
+  match state.stepWithin { limits with maxEvents := 0 } instanceAction,
+      state.stepWithin limits instanceAction with
+  | .error (.resource .events), .ok (_, next) => next.serial == 1
+  | _, _ => false
+
+private def firstError (package : Package Nat (Batch Nat Nat))
+    (actualLimits : Runtime.Limits := limits) : Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some state => match state.stepWithin actualLimits instanceAction with
+    | .error error => some error
+    | .ok _ => none
+
+private def equalityError (package : Package Nat (Batch Nat Nat))
+    (actualLimits : Runtime.Limits := limits) : Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some state => match state.stepWithin limits instanceAction with
+    | .error _ => none
+    | .ok (_, state) => match state.stepWithin actualLimits equalityAction with
+      | .error error => some error
+      | .ok _ => none
+
+private def transportError (package : Package Nat (Batch Nat Nat)) : Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some state => match state.stepWithin limits instanceAction with
+    | .error _ => none
+    | .ok (_, state) => match state.stepWithin limits equalityAction with
+      | .error _ => none
+      | .ok (_, state) => match state.stepWithin limits factAction with
+        | .error _ => none
+        | .ok (_, state) => match state.stepWithin limits transportAction with
+          | .error error => some error
+          | .ok _ => none
+
+private def factError (package : Package Nat (Batch Nat Nat))
+    (actualLimits : Runtime.Limits := limits) : Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some state => match state.stepWithin limits instanceAction with
+    | .error _ => none
+    | .ok (_, state) => match state.stepWithin limits equalityAction with
+      | .error _ => none
+      | .ok (_, state) => match state.stepWithin actualLimits factAction with
+        | .error error => some error
+        | .ok _ => none
+
+-- Exact appended application order, equality descriptor endpoints/origin,
+-- transport identity, and independent arena/application caps are load-bearing.
+#guard firstError (packageWith wrongInstanceHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch)) == some .malformed
+
+#guard firstError (packageWith wrongBindingHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch)) == some .malformed
+
+#guard firstError (packageWith wrongProgramHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch)) ==
+  some (.executable .nonExtension)
+
+#guard firstError (packageWith wrongGenerationHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch)) == some .malformed
+
+#guard firstError (packageWith emptyInstanceHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch)) == some .malformed
+
+#guard equalityError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    wrongEqualityHandler transportHandler
+    (handler factRegistration .fact 3 33 factBatch)) == some .wrongEquality
+
+#guard equalityError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    wrongOriginHandler transportHandler
+    (handler factRegistration .fact 3 33 factBatch)) == some .wrongEquality
+
+#guard equalityError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    wrongAssumptionsHandler transportHandler
+    (handler factRegistration .fact 3 33 factBatch)) == some .wrongEquality
+
+#guard equalityError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    wrongEqualityGenerationHandler transportHandler
+    (handler factRegistration .fact 3 33 factBatch)) == some .wrongEquality
+
+#guard factError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler wrongFactHandler) == some .unauthorized
+
+#guard transportError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    wrongTransportHandler (handler factRegistration .fact 3 33 factBatch)) ==
+  some .wrongEquality
+
+#guard transportError (packageWith
+    (handler instantiateRegistration .instance 1 11 instantiateBatch)
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    wrongTransportValueHandler (handler factRegistration .fact 3 33 factBatch)) ==
+  some .unauthorized
+
+#guard equalityError runtimePackage
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxEqualities := 0 } } } ==
+  some (.resource (.state .equalities))
+
+#guard runtimeError
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxApplications := 3 } } }
+    instanceAction == some (.executable (.resource (.state .applications)))
+
+#guard firstError runtimePackage
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxNodes := 3 } } } ==
+  some (.resource (.state .nodes))
+
+#guard firstError runtimePackage
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxGeneration := 0 } } } ==
+  some (.resource (.state .generation))
+
+#guard factError runtimePackage
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxAcceptedFacts := 0 } } } ==
+  some (.state (.resource .acceptedFacts))
+
+-- The whole returned event count is admitted before the first malformed
+-- duplicate could run, even when the executable result envelope is relaxed.
+#guard firstError (packageWith twoEventHandler
+    (handler equalityRegistration .equality 2 22 equalityBatch)
+    transportHandler (handler factRegistration .fact 3 33 factBatch))
+    { limits with executable :=
+      { executableLimits with maxResultBytes := 2, maxResultWork := 2 } } ==
+  some (.resource .events)
+
+/-! # Retained split-child chain -/
+
+def searchLimits : Search.Limits :=
+  { maxSteps := 9, maxSplits := 1, maxLeaves := 2, maxFrontier := 2,
+    maxDepth := 1, maxScopes := 3, leafFuel := 9 }
+
+def treeLimits : Search.Result.Limits :=
+  { search := searchLimits, runtime := limits, maxNodes := 3,
+    maxBodyCells := 8, maxBytes := 4096, maxWork := 4096, maxCode := 8 }
+
+def measure : Search.Result.Measure Nat Nat Nat Nat :=
+  { node := { bytes := 1, work := 1 }
+    branch := fun branch =>
+      { bytes := branch.program.nodes.size + branch.history.size + branch.seeds.size,
+        work := branch.program.nodes.size + branch.history.size }
+    fact := fun _ => { bytes := 1, work := 1 }
+    action := fun _ => { bytes := 1, work := 1 }
+    plan := fun _ => { bytes := 1, work := 1 }
+    schema := fun _ => { bytes := 1, work := 1 }
+    body := fun _ => { bytes := 1, work := 1 }
+    code := fun _ => { bytes := 1, work := 1 } }
+
+def splitAction : Action :=
+  action 0 0 0 0 instantiateKey 0 .split 0
+    [{ node := { index := 0 }, version := 0 }]
+
+def splitRecipe : Search.Result.Split Nat Nat :=
+  { scope := { index := 5 }, programVersion := 0, action := splitAction,
+    parent := { node := { index := 0 }, version := 0 }, plan := 7,
+    schema := 8, body := [1] }
+
+def leftSeed : Search.Result.Seed Nat :=
+  { node := { index := 0 }, previous := splitRecipe.parent, fact := 11 }
+
+def rightSeed : Search.Result.Seed Nat :=
+  { node := { index := 0 }, previous := splitRecipe.parent, fact := 12 }
+
+def extendedSplitAction : Action :=
+  action 4 1 0 0 instantiateKey 0 .split 1
+    [{ node := { index := 0 }, version := 0 }]
+
+def extendedSplitRecipe : Search.Result.Split Nat Nat :=
+  { scope := { index := 5 }, programVersion := 1, action := extendedSplitAction,
+    parent := { node := { index := 0 }, version := 0 }, plan := 7,
+    schema := 8, body := [1] }
+
+def extendedLeftSeed : Search.Result.Seed Nat :=
+  { node := { index := 0 }, previous := extendedSplitRecipe.parent, fact := 11 }
+
+def extendedRightSeed : Search.Result.Seed Nat :=
+  { node := { index := 0 }, previous := extendedSplitRecipe.parent, fact := 12 }
+
+def restartedInstanceAction : Action :=
+  action 0 0 0 0 instantiateKey 1 .instantiate 0
+    [{ node := { index := 0 }, version := 0 }]
+
+def restartedEqualityAction : Action :=
+  action 1 1 4 1 equalityKey 5 .rewrite 2
+    [{ node := { index := 4 }, version := 0 },
+     { node := { index := 5 }, version := 0 }]
+
+def restartedFactAction : Action :=
+  action 2 1 6 3 factKey 4 .forward 2
+    [{ node := { index := 4 }, version := 0 }] [{ index := 4 }]
+
+def restartedTransportAction : Action :=
+  action 3 1 5 2 transportKey 5 .rewrite 2
+    [{ node := { index := 4 }, version := 1 }] [{ index := 5 }]
+
+def splitTree? : Option (Search.Result.Tree Nat Nat Nat Nat) := do
+  let branch ← branch?
+  let root ← (Search.Result.startWithin treeLimits measure { index := 5 } branch).toOption
+  (Search.Result.splitWithin treeLimits measure .depthFirst root splitRecipe leftSeed rightSeed).toOption
+
+def rootTree? : Option (Search.Result.Tree Nat Nat Nat Nat) := do
+  let branch ← branch?
+  (Search.Result.startWithin treeLimits measure { index := 5 } branch).toOption
+
+private def advanceChild (tree : Search.Result.Tree Nat Nat Nat Nat)
+    (state : Runtime.State Nat Nat) : List Action →
+    Option (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat)
+  | [] => some (tree, state)
+  | next :: rest =>
+      match state.stepWithin limits next with
+      | .error _ => none
+      | .ok (transition, state) =>
+          match Search.Result.advanceRuntimeWithin treeLimits measure tree transition with
+          | .error _ => none
+          | .ok tree => advanceChild tree state rest
+
+private def childRunFrom (tree : Search.Result.Tree Nat Nat Nat Nat)
+    (source : Search.Result.Source Nat Nat)
+    (assembly : Assembly Nat (Batch Nat Nat)) :
+    Option (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat) :=
+  match Runtime.State.startWithin limits assembly source.branch with
+  | .error _ => none
+  | .ok state =>
+      advanceChild tree state [instanceAction, equalityAction, factAction, transportAction]
+
+def rootRun? : Option (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat) :=
+  match rootTree?, assembly? with
+  | some tree, some assembly => match Search.Result.current? tree with
+    | some (_, source) => childRunFrom tree source assembly
+    | none => none
+  | _, _ => none
+
+def extendedSplit? : Option
+    (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat) :=
+  match rootRun? with
+  | none => none
+  | some (tree, state) =>
+      match Search.Result.splitWithin treeLimits measure .depthFirst tree
+          extendedSplitRecipe extendedLeftSeed extendedRightSeed with
+      | .error _ => none
+      | .ok tree => some (tree, state)
+
+private def restartedInstanceError (actualLimits : Runtime.Limits) :
+    Option Runtime.Error :=
+  match extendedSplit? with
+  | some (tree, parentState) => match Search.Result.current? tree with
+    | some (_, source) =>
+        match Runtime.State.startWithin actualLimits parentState.assembly source.branch with
+        | .error error => some error
+        | .ok state => match state.stepWithin actualLimits restartedInstanceAction with
+          | .error error => some error
+          | .ok _ => none
+    | none => none
+  | none => none
+
+def restartRun? : Option (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat) :=
+  match extendedSplit? with
+  | some (tree, parentState) => match Search.Result.current? tree with
+    | some (_, source) =>
+        match Runtime.State.startWithin limits parentState.assembly source.branch with
+        | .error _ => none
+        | .ok state => advanceChild tree state
+            [restartedInstanceAction, restartedEqualityAction,
+              restartedFactAction, restartedTransportAction]
+    | none => none
+  | none => none
+
+def childRun? : Option (Search.Result.Tree Nat Nat Nat Nat × Runtime.State Nat Nat) :=
+  match splitTree?, assembly? with
+  | some tree, some assembly => match Search.Result.current? tree with
+    | some (_, source) => childRunFrom tree source assembly
+    | none => none
+  | _, _ => none
+
+#guard rootRun?.any fun result =>
+  let tree := result.1
+  let state := result.2
+  tree.check treeLimits measure && tree.accounting.steps == 4 &&
+    state.branch.snapshot.facts == #[10, 20, 31, 31] &&
+    match Search.Result.current? tree with
+    | some ({ index := 0 }, source) => source.branch == state.branch
+    | _ => false
+
+#guard restartRun?.any fun result =>
+  let tree := result.1
+  let state := result.2
+  tree.check treeLimits measure && tree.accounting.steps == 9 &&
+    state.generationBase == 1 && state.assembly.generation == 2 &&
+    state.branch.programVersion == 1 &&
+    state.branch.baseProgram == extendedProgram &&
+    state.branch.program == twiceExtendedProgram &&
+    state.branch.generations == #[0, 0, 0, 0, 1, 1] &&
+    state.branch.snapshot.facts == #[11, 20, 31, 31, 51, 51] &&
+    state.equalities.size == 1 &&
+    match Search.Result.current? tree with
+    | some ({ index := 1 }, source) => source.branch == state.branch
+    | _ => false
+
+#guard restartRun?.any fun result =>
+  result.1.transitions.size == 8 &&
+    result.1.cost == result.1.recomputeCost measure
+
+#guard restartedInstanceError
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxApplications := 6 } } } ==
+  some (.executable (.resource (.state .applications)))
+
+#guard restartedInstanceError
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxNodes := 5 } } } ==
+  some (.resource (.state .nodes))
+
+#guard restartedInstanceError
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxGeneration := 1 } } } ==
+  some (.resource (.state .generation))
+
+#guard restartedInstanceError
+    { limits with executable :=
+      { executableLimits with state := { stateLimits with maxInstances := 0 } } } ==
+  some (.resource (.state .instances))
+
+#guard childRun?.any fun result =>
+  let tree := result.1
+  let state := result.2
+  tree.check treeLimits measure && tree.accounting.steps == 5 &&
+    state.branch.snapshot.facts == #[11, 20, 31, 31] &&
+    match Search.Result.current? tree with
+    | some ({ index := 1 }, source) => source.branch == state.branch
+    | _ => false
+
+-- Later retained-tree envelopes re-cap the complete sealed structural tables,
+-- event bodies, equality arena, action generations, and caller-declared
+-- logical cost. The restarted chain reaches generation two, so one is the
+-- exact one-over retained-generation mutation.
+#guard restartRun?.any fun result =>
+  !result.1.check
+    { treeLimits with runtime :=
+      { limits with executable :=
+        { executableLimits with state := { stateLimits with maxGeneration := 1 } } } } measure
+
+#guard childRun?.any fun result =>
+  !result.1.check
+    { treeLimits with runtime :=
+      { limits with executable :=
+        { executableLimits with state := { stateLimits with maxApplications := 3 } } } } measure
+
+#guard childRun?.any fun result =>
+  !result.1.check
+    { treeLimits with runtime :=
+      { limits with executable :=
+        { executableLimits with state := { stateLimits with maxEqualities := 0 } } } } measure
+
+#guard childRun?.any fun result =>
+  !result.1.check { treeLimits with runtime := { limits with maxEvents := 0 } } measure
+
+#guard childRun?.any fun result =>
+  !result.1.check { treeLimits with maxBodyCells := 0 } measure
+
+#guard childRun?.any fun result =>
+  0 < result.1.cost.bytes &&
+    !result.1.check { treeLimits with maxBytes := result.1.cost.bytes - 1 } measure
+
+#guard childRun?.any fun result =>
+  0 < result.1.cost.work &&
+    !result.1.check { treeLimits with maxWork := result.1.cost.work - 1 } measure
+
+#guard match rootTree?, run? with
+  | some tree, some result =>
+      match result.1[0]? with
+      | some transition =>
+          match Search.Result.advanceRuntimeWithin
+              { treeLimits with runtime := { limits with maxEvents := 0 } }
+                measure tree transition with
+          | .error (.resource .events) => true
+          | _ => false
+      | none => false
+  | _, _ => false
+
+-- Two individually sealed equality transitions with the same branch cannot be
+-- spliced: the second must start from the first one's exact equality/table
+-- suffix and next serial.
+#guard match rootTree?, run? with
+  | some tree, some result =>
+      match result.1[0]?, result.1[1]? with
+      | some instanceStep, some equalityStep =>
+          match Search.Result.advanceRuntimeWithin treeLimits measure tree instanceStep with
+          | .error _ => false
+          | .ok tree =>
+              match Search.Result.advanceRuntimeWithin treeLimits measure tree equalityStep with
+              | .error _ => false
+              | .ok tree =>
+                  match Search.Result.advanceRuntimeWithin treeLimits measure tree equalityStep with
+                  | .error .malformed => true
+                  | _ => false
+      | _, _ => false
+  | _, _ => false
+
+#guard match splitTree?, run? with
+  | some tree, some result =>
+      match result.1[0]? with
+      | some transition =>
+          match Search.Result.advanceRuntimeWithin treeLimits measure tree transition with
+          | .error .malformed => true
+          | _ => false
+      | none => false
+  | _, _ => false
+
+/-- error: Unknown constant `Hex.Interval.Runtime.Applied.mk` -/
+#guard_msgs in
+#check Runtime.Applied.mk
+
+/-- error: Unknown constant `Hex.Interval.Runtime.State.mk` -/
+#guard_msgs in
+#check Runtime.State.mk
+
+/-- error: Unknown constant `Hex.Interval.Runtime.Arena.mk` -/
+#guard_msgs in
+#check Runtime.Arena.mk
+
+end Hex.Interval.RuntimeConformance

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -612,9 +612,17 @@ open Search.Result
 #guard_msgs in
 #check Search.Applied.mk
 
+private def runtimeLimits : Runtime.Limits :=
+  { executable :=
+      { state := stateLimits, maxPackages := 0, maxMetadataBytes := 0,
+        maxMetadataWork := 0, maxCacheBytes := 0, maxCacheWork := 0,
+        maxResultBytes := 0, maxResultWork := 0, maxQuotes := 0,
+        maxQuoteCells := 0, maxAtom := 0, maxSchema := 0 }
+    maxEvents := 0 }
+
 private def limits : Search.Result.Limits :=
   { search := { searchLimits with maxSteps := 6 }
-    state := stateLimits
+    runtime := runtimeLimits
     maxNodes := 3
     maxBodyCells := 2
     maxBytes := 96
@@ -864,7 +872,10 @@ private def unknown? : Option (Tree Nat Nat Nat Nat) := do
 #guard match refinedBranch? with
   | some branch =>
       resultError (.search (.state .nodes)) <|
-        Search.Result.startWithin { limits with state := { stateLimits with maxNodes := 1 } }
+        Search.Result.startWithin
+          { limits with runtime :=
+            { runtimeLimits with executable :=
+              { runtimeLimits.executable with state := { stateLimits with maxNodes := 1 } } } }
           measure { index := 5 } branch
   | none => false
 

--- a/conformance/HexIntervalMathlib/DriverConformance.lean
+++ b/conformance/HexIntervalMathlib/DriverConformance.lean
@@ -246,8 +246,16 @@ def recipeMeasure : Driver.Measure Fact :=
       { bytes := 4 + match edge.seed with | none => 0 | some seed => factBytes seed.fact,
         work := 1 } }
 
+def runtimeLimits : Runtime.Limits :=
+  { executable :=
+      { state := stateLimits, maxPackages := 0, maxMetadataBytes := 0,
+        maxMetadataWork := 0, maxCacheBytes := 0, maxCacheWork := 0,
+        maxResultBytes := 0, maxResultWork := 0, maxQuotes := 0,
+        maxQuoteCells := 0, maxAtom := 0, maxSchema := 0 }
+    maxEvents := 0 }
+
 def resultLimits : Search.Result.Limits :=
-  { search := searchLimits, state := stateLimits, maxNodes := 3, maxBodyCells := 1,
+  { search := searchLimits, runtime := runtimeLimits, maxNodes := 3, maxBodyCells := 1,
     maxBytes := 128, maxWork := 128, maxCode := 8 }
 
 def treeLimits : Proof.TreeLimits :=

--- a/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
@@ -273,7 +273,8 @@ def recipeMeasure : Driver.Measure Hex.Interval :=
 
 def driverLimits : Driver.Limits :=
   { result :=
-      { search := searchLimits, state := stateLimits, maxNodes := 1,
+      { search := searchLimits,
+        runtime := { executable := executableLimits, maxEvents := 0 }, maxNodes := 1,
         maxBodyCells := 3, maxBytes := 512, maxWork := 512, maxCode := 8 },
     proof := proofLimits,
     tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 3, maxWork := 64 },

--- a/conformance/HexIntervalMathlib/ProgramProofConformance.lean
+++ b/conformance/HexIntervalMathlib/ProgramProofConformance.lean
@@ -532,11 +532,19 @@ def rootBranch? : Option (State.Branch TestFact Nat) := do
     { programVersion := 1, node := node1, previous := seen node1 0,
       fact := .yes, version := 1, cause := 2 }).toOption
 
+def runtimeLimits : Runtime.Limits :=
+  { executable :=
+      { state := stateLimits, maxPackages := 0, maxMetadataBytes := 0,
+        maxMetadataWork := 0, maxCacheBytes := 0, maxCacheWork := 0,
+        maxResultBytes := 0, maxResultWork := 0, maxQuotes := 0,
+        maxQuoteCells := 0, maxAtom := 0, maxSchema := 0 }
+    maxEvents := 0 }
+
 def searchLimits : Search.Result.Limits :=
   { search :=
       { maxSteps := 3, maxSplits := 1, maxLeaves := 2, maxFrontier := 2,
         maxDepth := 1, maxScopes := 3, leafFuel := 4 }
-    state := stateLimits
+    runtime := runtimeLimits
     maxNodes := 3
     maxBodyCells := 1
     maxBytes := 64

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -543,6 +543,7 @@ lean_lib HexConformance where
       `HexInterval.FeaturePolicyConformance,
       `HexInterval.SearchConformance,
       `HexInterval.ExecutableConformance,
+      `HexInterval.RuntimeConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/20260822T032409Z_interval-runtime-events.md
+++ b/progress/20260822T032409Z_interval-runtime-events.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Added a Mathlib-free, sealed typed runtime-event layer for atomic fact,
+  equality, transport, instance, and program-extension transitions.
+- Authenticated exact invocation endpoints, input generations, origins,
+  assumptions, authority, and append-only program, binding, application, and
+  equality suffixes before committing a whole batch.
+- Extended executable assemblies with a persistent global generation and
+  retained-state preflight, including zero-application extensions and restart.
+- Restricted retained search-tree validation to sealed `Runtime.Applied`
+  transitions, with exact serial and before/after table chaining.
+- Added root and restarted split-child instance-to-equality-to-fact-to-transport
+  canaries, mutation rejection, transaction retry, splice rejection, and exact
+  one-over limit coverage.
+- Rebased mechanically onto `origin/main` at `f396965d4`; the implementation
+  patch id remained `dbd5c0f2c6dafc7672421aa85a0a13fd37ad65bd`.
+- Passed focused conformance, DAG/static checks, trust-surface checks, and a
+  full `lake build` of 9,820 jobs.
+
+# Current frontier
+
+The typed runtime-event edge is complete and locally validated on current
+`origin/main`. The branch is ready for exact-head handoff and review.
+
+# Next step
+
+Integrate or publish the local commit after parent review, then run the normal
+remote review and merge workflow if requested.
+
+# Blockers
+
+None.

--- a/progress/20260822T035350Z_interval-runtime-review-repair.md
+++ b/progress/20260822T035350Z_interval-runtime-review-repair.md
@@ -1,0 +1,39 @@
+# Accomplished
+
+- Required transport to name an exact current source version and install the
+  identical source fact; added an exact `999` mismatch rejection canary.
+- Added an authenticated inherited assembly-generation base to runtime state.
+  Strict global instance generations now rebase coherently onto consecutive
+  child-local branch generations.
+- Extended the restarted split-child canary through a second instance at
+  global generation two, then a fresh equality, fact, and transport chain.
+- Added strict restarted generation, node, application, and instance one-over
+  checks.
+- Exposed an opaque ordinary-import `Tree.transitions` view and hardened tree
+  validation against out-of-tree runtime identifiers and unauthenticated root
+  origins.
+- Nested runtime limits into result limits so retained event counts use
+  `Runtime.Limits.maxEvents`; added the exact zero-event one-over.
+- Corrected retained runtime accounting to charge accepted quotes once and
+  each branch-chain position once while preserving exact cached cost checks.
+- Documented raw endpoint/transport authority, generation rebasing, runtime
+  event limits, and retained-cost asymptotics.
+- Added the exact test-only `lakefile.lean` transition to the factorization
+  freshness exemptions; the freshness gate now accepts the conformance target.
+- Passed focused runtime/search/Mathlib conformance, source/static gates, and
+  the full 9,820-job `lake build` before final restacking.
+
+# Current frontier
+
+The requested review repairs are complete locally. Upstream `main` advanced to
+`cd620596e7d0672691695d29711819f444a8f4eb`; the commit is ready for a
+mechanical restack and exact-head verification before force-pushing PR #9377.
+
+# Next step
+
+Restack on the recorded upstream head, rerun cached affected/static/full gates,
+and force-push only `agent/interval-runtime-events`.
+
+# Blockers
+
+None.

--- a/progress/20260822T044913Z_interval-runtime-contract-hardening.md
+++ b/progress/20260822T044913Z_interval-runtime-contract-hardening.md
@@ -1,0 +1,20 @@
+# Interval runtime retained-contract hardening
+
+## Accomplished
+
+- Restacked the approved typed-runtime edge onto `fc60c4bfb74062a9742eca73d3477bdec16eab90`, preserving the incoming sparse-polynomial Lake registrations and reconciling the exact factor-sweep exemption.
+- Re-capped every retained action generation through `Result.Limits.state.maxGeneration`, covering transition, typed-event, equality-origin, and split actions.
+- Added a restarted-child retained-tree generation one-over canary.
+- Corrected the retained quote-count and whole-tree runtime-validation complexity contracts, including authenticated root-branch cost.
+
+## Current frontier
+
+The typed runtime edge has the final requested contract hardenings and is ready for focused and static validation before its lease-protected PR update.
+
+## Next step
+
+Run the affected conformance builds and repository static gates, amend the single feature commit, and force-push PR #9377 if the remote base and lease remain exact.
+
+## Blockers
+
+None.

--- a/progress/20260822T050909Z_interval-runtime-doc-clarifications.md
+++ b/progress/20260822T050909Z_interval-runtime-doc-clarifications.md
@@ -1,0 +1,18 @@
+# Interval runtime contract clarifications
+
+## Accomplished
+
+- Corrected the SPEC to describe `Executable.Limits.maxQuoteCells` as an aggregate quotation-body cell cap.
+- Clarified that `Runtime.FactStep.proposed` is a package annotation which need not equal the installed update fact and requires independent later proof correlation.
+
+## Current frontier
+
+The approved typed-runtime edge now states both quotation accounting and fact-proposal authority exactly, without changing executable semantics.
+
+## Next step
+
+Run focused documentation and static checks, amend the single feature commit, and update PR #9377 with an explicit lease.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -680,7 +680,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "e2c8d787eedb211050b9a5f4dd97a8d48b874cf0",
-    "reason": "Additionally registers the supported fact-only executable-assembly controller conformance, including independent theorem replay for built-in arithmetic and an explicit arbitrary-function package, on top of the retained source-pinned FKS2 prefix-structure checker and its proof-only conformance module; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+    "current_blob": "c523b56fcf7249235b710bc86792042a57c4e26e",
+    "reason": "Additionally registers the supported fact-only executable-assembly controller conformance, including independent theorem replay for built-in arithmetic and an explicit arbitrary-function package, and the Mathlib-free typed-runtime conformance module on top of the retained source-pinned FKS2 prefix-structure checker and its proof-only conformance module. These acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -33,6 +33,7 @@ IMPORT_ALL_RE = re.compile(
 # directory convention. There are currently no required exceptions.
 SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexInterval.Executable": frozenset(),
+    "HexInterval.Runtime": frozenset(),
     "HexInterval.Search": frozenset(),
     "HexIntervalMathlib.Driver": frozenset(),
     "HexIntervalMathlib.Controller": frozenset(),

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -19,6 +19,10 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexInterval.Executable"),
                 (Path("bench/HexInterval/BypassExecutable.lean"),
                     "HexInterval.Executable"),
+                (Path("conformance/HexInterval/BypassRuntime.lean"),
+                    "HexInterval.Runtime"),
+                (Path("bench/HexInterval/BypassRuntime.lean"),
+                    "HexInterval.Runtime"),
                 (Path("conformance/HexInterval/Bypass.lean"), "HexInterval.Search"),
                 (Path("bench/HexInterval/Bypass.lean"), "HexInterval.Search"),
                 (Path("conformance/HexIntervalMathlib/Bypass.lean"),
@@ -39,6 +43,10 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexInterval.Executable` outside its exact trusted-internals allowlist",
                     "bench/HexInterval/BypassExecutable.lean:1 uses `import all "
                     "HexInterval.Executable` outside its exact trusted-internals allowlist",
+                    "conformance/HexInterval/BypassRuntime.lean:1 uses `import all "
+                    "HexInterval.Runtime` outside its exact trusted-internals allowlist",
+                    "bench/HexInterval/BypassRuntime.lean:1 uses `import all "
+                    "HexInterval.Runtime` outside its exact trusted-internals allowlist",
                     "conformance/HexInterval/Bypass.lean:1 uses `import all "
                     "HexInterval.Search` outside its exact trusted-internals allowlist",
                     "bench/HexInterval/Bypass.lean:1 uses `import all "


### PR DESCRIPTION
## Scope

- Add a Mathlib-free `HexInterval.Runtime` equality-descriptor arena and sealed typed fact, equality, transport, instance, and program-extension transitions.
- Authenticate endpoints, generations, origins, assumptions, write authority, and exact append-only program, binding, application, and equality suffixes before a resource-first whole-batch commit.
- Persist executable assembly generation across extensions and restart, including zero-application extensions.
- Retain only sealed `Runtime.Applied` transitions in `Result.Tree`; program-changing child validation requires exact serial, table, generation, and transition chaining.

## Boundaries

- No Mathlib `Proof.Event` dependency and no theorem authority is introduced.
- No Controller integration.
- No tactic integration.

## Validation

- `lake build HexInterval.ExecutableConformance HexInterval.RuntimeConformance`
- `lake build` (9,820 jobs)
- `python3 -m unittest scripts/test_check_dag.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/release/check_trust_surface.py`
- `git diff --check origin/main...HEAD`