### PR TITLE
chore: record Phase 5 completion for HexResultant and HexRCF

### DIFF
--- a/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
+++ b/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
@@ -9,6 +9,28 @@ algebraic value is a root of an eliminant, but tower norms, root-product bounds,
 specialization, and Trager factorization also depend on the value of the
 resultant, including its units, powers, and signs.
 
+## Headline correctness theorem
+
+`Hex.DensePoly.toPolynomial_resultant`: the executable subresultant
+resultant agrees with Mathlib's `Polynomial.resultant` under the
+dense-polynomial correspondence, with the executable default formal
+degrees (`f.degree?.getD 0`, `g.degree?.getD 0`) made explicit. This is
+the end-to-end post-condition of the public API: exact agreement of
+values, units, powers, and signs included, not merely simultaneous
+vanishing. It needs no monicity, coprimality, or nonzero hypotheses on
+`f` and `g`; its typeclass context is the executable algorithm's own
+(`CommRing R`, `IsDomain R`, `DecidableEq R`, `Div R`,
+`Hex.ExactDivLaws R`). It is built from
+`coeffMinor_zero_eq_resultant` through the ordered Brown-Traub chain
+correspondence.
+
+The remaining public theorems below are either load-bearing for the
+headline proof (the `SubresultantMinor` and `PseudoDivMod` transport
+lemmas) or independently justified consumer surface for number-field
+soundness (`resultant_eq_zero_iff_common_root`, `eval_resultant`, the
+specialization and discriminant facts), per the intermediate-lemma rule
+in PLAN/Conventions.md §Headline correctness theorem.
+
 ## Public theorems
 
 The exact typeclass assumptions follow the executable algorithm: `R` is a

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -534,7 +534,19 @@ Lean's kernel: it checks `check_sound`, the reduction proof
 original goal. No unverified result of the compiled builder or reifier
 is accepted as a proof.
 
-## Soundness theorem structure
+## Headline correctness theorem
+
+`Hex.RCF.check_sound`: every certificate accepted by the public Boolean
+checker proves its sentence, `cert.check s = true → s.toProp`. This is
+the library's single end-to-end post-condition. The kernel checks it
+together with the reduction proof `check s cert = true` and the
+reifier-produced equivalence with the original goal, so no unverified
+output of the compiled builder or reifier is trusted. `decide_sound`
+and `exists_cert_of_decide` are convenience wrappers over the same
+certificate path, not independent claims (see the preceding section);
+the per-constructor soundness lemmas and replay theorems below are
+load-bearing clauses of the headline proof, per the intermediate-lemma
+rule in PLAN/Conventions.md §Headline correctness theorem.
 
 `check_sound` factors exactly along the algorithm:
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -552,7 +552,7 @@ libraries:
   HexResultant:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:
@@ -633,7 +633,7 @@ libraries:
   HexRCF:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
     proof_probes: [bench/HexRCF/ProofProbe]
     phase4:

--- a/progress/20260822T034500Z_wave-dag-and-headline-audit.md
+++ b/progress/20260822T034500Z_wave-dag-and-headline-audit.md
@@ -1,0 +1,89 @@
+# Release wave: dependency DAG, bump queue, and headline-theorem audit
+
+Reference artifact for the done_through-7 release wave (13 libraries:
+Resultant, ResultantMathlib, NumberField x2, NumberFieldTower x2, RCF,
+Berlekamp, BerlekampMathlib, BerlekampZassenhaus, BZMathlib,
+RootsMathlib, PolyFpMathlib). Each later bump PR cites its edge here.
+
+## Phase-dependency edges driving the order
+
+Dep-coupled phases are 1, 3, 4 (PLAN/Conventions.md); 2, 5, 6, 7 are
+local. The binding edges for this wave:
+
+- Berlekamp P4 -> BZ P4 -> {NumberField, Tower} P4.
+- PolyFpMathlib P4 -> BerlekampMathlib P4 -> BZMathlib P4 ->
+  {NumberFieldMathlib, TowerMathlib} P4.
+- RootsMathlib P3/P4 and ResultantMathlib P3/P4 -> NumberFieldMathlib
+  P3/P4; those plus NumberFieldMathlib -> TowerMathlib P3/P4.
+- BZ P1/P3 -> NumberField cluster P1/P3.
+- RCF has no unmet dep edges (RealRootsMathlib is at 4).
+
+## Bump queue (libraries.yml is a hot file; bumps land one at a time)
+
+1. HexResultant 4->5, HexRCF 4->5 (this PR).
+2. HexRootsMathlib 0->2, then 2->4.
+3. HexResultantMathlib 3->4->5.
+4. HexBerlekamp 3->4 (after comparator reclassification).
+5. HexBerlekampZassenhaus 0->4.
+6. HexPolyFpMathlib 0->4 (includes the headline-theorem work below).
+7. HexBerlekampMathlib 3->4 (proof-track evidence).
+8. HexBerlekampZassenhausMathlib 2->3->4.
+9. NumberField cluster 0->1->2->3->4->5.
+10. Phase 6 bumps per library as hygiene PRs land.
+11. Phase 7 bumps, serialized, after chapters/headings/READMEs/
+    tutorials; manual-split and released.yml changes last.
+
+## Headline-theorem audit (PLAN/Conventions.md, binds at done_through >= 4)
+
+House pattern: the designation lives in the companion's SPEC as a
+"## Headline correctness theorem" section naming one theorem
+(exemplars: HexLLLMathlib, HexBareissMathlib). Verdicts:
+
+- HexResultant pair: theorem exists (`toPolynomial_resultant`,
+  HexResultantMathlib/Sylvester.lean); designation added in this PR.
+- HexRCF (integrated): theorem exists (`check_sound`,
+  HexRCF/Soundness.lean); designation added in this PR.
+- HexPolyFp pair: REAL GAP. HexPolyFp is at 7 but its companion has no
+  end-to-end theorem (correspondence lemmas only), and the companion
+  SPEC's "What belongs here" section currently forbids one. The
+  PolyFpMathlib ladder PR must state and prove a Mathlib-side
+  square-free-decomposition headline over `Polynomial (ZMod p)` and
+  amend that SPEC section.
+- HexBerlekamp pair: two co-equal key theorems; designate one
+  (candidate `fpIsIrreducible_iff`,
+  HexBerlekampMathlib/Irreducibility.lean:951) in the companion SPEC
+  before the P4 bump.
+- HexBerlekampZassenhaus pair: five-theorem family with #print axioms
+  guards already; collapse into one designated headline (product +
+  normalization + irreducibility + uniqueness over `ZPoly.factorize`)
+  before the BZMathlib P4 bump.
+- HexNumberField pair: per-operation headlines only; designate one
+  end-to-end embedding-correctness statement before the P4 bump.
+- HexNumberFieldTower pair: designate `NumberTower.factor?_sound`
+  (Factor.lean:642) before the P4 bump.
+
+Per-theorem `#print axioms` guards are BZ-SPEC practice, not a
+Conventions requirement; the release-wide trust check is
+scripts/release/check_trust_surface.py. Add guards opportunistically in
+the Phase-6 passes.
+
+## Accomplished
+
+- Audited headline-theorem designations across the seven pairs (above).
+- Recorded the wave DAG and bump queue.
+- Bumped HexResultant and HexRCF to done_through 5 with their
+  designation sections added.
+
+## Current frontier
+
+- check_phase7 integrated-Mathlib fix in review (#9375); Berlekamp
+  comparator re-measurement queued on chungus2 behind machine idleness.
+
+## Next step
+
+- HexRootsMathlib Phase-2 review; Berlekamp comparator
+  reclassification PR once refreshed measurements land.
+
+## Blockers
+
+- Timing refresh waits for the bench host to go quiet.


### PR DESCRIPTION
This PR bump HexResultant and HexRCF to `done_through: 5` and add the headline-correctness-theorem designations PLAN/Conventions.md requires at `done_through >= 4`. Both libraries are sorry-free, build in the merge-gating CI, and their Phase-3 conformance suites pass, which is the entire Phase-5 exit per PLAN/Phase5.md; their Phase-4 headline reports conform with empty Concerns. The resultant companion SPEC now designates `Hex.DensePoly.toPolynomial_resultant` and the hex-rcf SPEC designates `Hex.RCF.check_sound`, both long since proved; the sections follow the HexLLLMathlib designation shape. The accompanying progress file records the release-wave dependency DAG, the serialized bump queue, and the full seven-pair headline-theorem audit that later wave PRs cite.

🤖 Prepared with Claude Code