### PR TITLE
feat(sparse-poly): arithmetic on canonical sparse polynomials

### DIFF
--- a/HexSparsePoly.lean
+++ b/HexSparsePoly.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexSparsePoly.Basic
+public import HexSparsePoly.Arith
 
 public section
 

--- a/HexSparsePoly/Arith.lean
+++ b/HexSparsePoly/Arith.lean
@@ -1,0 +1,735 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexSparsePoly.Basic
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Arithmetic on canonical sparse polynomials: addition and subtraction as
+linear merges, negation, scalar and monomial multiplication as filtered
+coefficient maps, multiplication as the canonicalised pairwise product,
+binary powering, the operator instances, and the ring laws.
+-/
+
+namespace Hex
+
+open scoped Hex
+
+universe u
+
+namespace SparsePoly
+
+variable {R : Type u} [Zero R] [DecidableEq R]
+
+/-- Linear merge of two sorted term lists: `fl` maps a coefficient
+present only on the left, `fr` one present only on the right, `fb`
+combines a collision, and zero results are dropped. `add` and `sub` are
+instances. -/
+def mergeWith (fl fr : R → R) (fb : R → R → R) :
+    List (Nat × R) → List (Nat × R) → List (Nat × R)
+  | [], l₂ =>
+      l₂.filterMap fun t => if fr t.2 = 0 then none else some (t.1, fr t.2)
+  | a :: as, [] =>
+      (a :: as).filterMap fun t =>
+        if fl t.2 = 0 then none else some (t.1, fl t.2)
+  | a :: as, b :: bs =>
+      if a.1 < b.1 then
+        if fl a.2 = 0 then mergeWith fl fr fb as (b :: bs)
+        else (a.1, fl a.2) :: mergeWith fl fr fb as (b :: bs)
+      else if b.1 < a.1 then
+        if fr b.2 = 0 then mergeWith fl fr fb (a :: as) bs
+        else (b.1, fr b.2) :: mergeWith fl fr fb (a :: as) bs
+      else
+        if fb a.2 b.2 = 0 then mergeWith fl fr fb as bs
+        else (a.1, fb a.2 b.2) :: mergeWith fl fr fb as bs
+termination_by l₁ l₂ => l₁.length + l₂.length
+decreasing_by all_goals simp +arith
+
+/-- Every exponent stored by the merge comes from one of the inputs. -/
+theorem exp_mem_mergeWith {fl fr : R → R} {fb : R → R → R}
+    {l₁ l₂ : List (Nat × R)} {t : Nat × R}
+    (ht : t ∈ mergeWith fl fr fb l₁ l₂) :
+    (∃ u ∈ l₁, t.1 = u.1) ∨ ∃ u ∈ l₂, t.1 = u.1 := by
+  induction l₁, l₂ using mergeWith.induct fl fr fb with
+  | case1 l₂ =>
+      rw [mergeWith] at ht
+      obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+      right
+      refine ⟨u, hu, ?_⟩
+      split at hut
+      · cases hut
+      · cases hut
+        rfl
+  | case2 a as =>
+      rw [mergeWith] at ht
+      obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+      left
+      refine ⟨u, hu, ?_⟩
+      split at hut
+      · cases hut
+      · cases hut
+        rfl
+  | case3 a as b bs hab hz ih =>
+      rw [mergeWith, if_pos hab, if_pos hz] at ht
+      rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+      · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+      · exact Or.inr ⟨u, hu, hut⟩
+  | case4 a as b bs hab hz ih =>
+      rw [mergeWith, if_pos hab, if_neg hz] at ht
+      rcases List.mem_cons.mp ht with rfl | ht'
+      · exact Or.inl ⟨a, List.mem_cons_self .., rfl⟩
+      · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+        · exact Or.inr ⟨u, hu, hut⟩
+  | case5 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz] at ht
+      rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+      · exact Or.inl ⟨u, hu, hut⟩
+      · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+  | case6 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz] at ht
+      rcases List.mem_cons.mp ht with rfl | ht'
+      · exact Or.inr ⟨b, List.mem_cons_self .., rfl⟩
+      · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · exact Or.inl ⟨u, hu, hut⟩
+        · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+  | case7 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz] at ht
+      rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+      · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+      · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+  | case8 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz] at ht
+      rcases List.mem_cons.mp ht with rfl | ht'
+      · exact Or.inl ⟨a, List.mem_cons_self .., rfl⟩
+      · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+        · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
+
+/-- The merge of two canonical term lists is canonical. -/
+theorem mergeWith_canonical {fl fr : R → R} {fb : R → R → R}
+    {l₁ l₂ : List (Nat × R)}
+    (hs₁ : l₁.Pairwise (fun a b => a.1 < b.1))
+    (hs₂ : l₂.Pairwise (fun a b => a.1 < b.1)) :
+    (mergeWith fl fr fb l₁ l₂).Pairwise (fun a b => a.1 < b.1) ∧
+      ∀ t ∈ mergeWith fl fr fb l₁ l₂, t.2 ≠ 0 := by
+  induction l₁, l₂ using mergeWith.induct fl fr fb with
+  | case1 l₂ =>
+      rw [mergeWith]
+      constructor
+      · refine List.Pairwise.filterMap _ ?_ hs₂
+        intro a b hab x hx y hy
+        split at hx
+        · cases hx
+        · split at hy
+          · cases hy
+          · cases hx
+            cases hy
+            exact hab
+      · intro t ht
+        obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+        split at hut
+        · cases hut
+        · cases hut
+          rename_i hz
+          exact hz
+  | case2 a as =>
+      rw [mergeWith]
+      constructor
+      · refine List.Pairwise.filterMap _ ?_ hs₁
+        intro x y hxy u hu v hv
+        split at hu
+        · cases hu
+        · split at hv
+          · cases hv
+          · cases hu
+            cases hv
+            exact hxy
+      · intro t ht
+        obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+        split at hut
+        · cases hut
+        · cases hut
+          rename_i hz
+          exact hz
+  | case3 a as b bs hab hz ih =>
+      rw [mergeWith, if_pos hab, if_pos hz]
+      exact ih (List.pairwise_cons.mp hs₁).2 hs₂
+  | case4 a as b bs hab hz ih =>
+      rw [mergeWith, if_pos hab, if_neg hz]
+      rw [List.pairwise_cons] at hs₁
+      obtain ⟨hpw, hnz⟩ := ih hs₁.2 hs₂
+      refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+      · intro t ht
+        rcases exp_mem_mergeWith ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · have := hs₁.1 u hu
+          omega
+        · rcases List.mem_cons.mp hu with rfl | hu'
+          · omega
+          · have := (List.pairwise_cons.mp hs₂).1 u hu'
+            omega
+      · intro t ht
+        rcases List.mem_cons.mp ht with rfl | ht'
+        · exact hz
+        · exact hnz t ht'
+  | case5 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz]
+      exact ih hs₁ (List.pairwise_cons.mp hs₂).2
+  | case6 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz]
+      rw [List.pairwise_cons] at hs₂
+      obtain ⟨hpw, hnz⟩ := ih hs₁ hs₂.2
+      refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+      · intro t ht
+        rcases exp_mem_mergeWith ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · rcases List.mem_cons.mp hu with rfl | hu'
+          · omega
+          · have := (List.pairwise_cons.mp hs₁).1 u hu'
+            omega
+        · have := hs₂.1 u hu
+          omega
+      · intro t ht
+        rcases List.mem_cons.mp ht with rfl | ht'
+        · exact hz
+        · exact hnz t ht'
+  | case7 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz]
+      exact ih (List.pairwise_cons.mp hs₁).2 (List.pairwise_cons.mp hs₂).2
+  | case8 a as b bs hab hba hz ih =>
+      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz]
+      rw [List.pairwise_cons] at hs₁ hs₂
+      obtain ⟨hpw, hnz⟩ := ih hs₁.2 hs₂.2
+      refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+      · intro t ht
+        rcases exp_mem_mergeWith ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
+        · have := hs₁.1 u hu
+          omega
+        · have := hs₂.1 u hu
+          omega
+      · intro t ht
+        rcases List.mem_cons.mp ht with rfl | ht'
+        · exact hz
+        · exact hnz t ht'
+
+/-- Coefficient description of the zero-filtered coefficient map used by
+the merge's one-sided cases. -/
+theorem coeffList_filterMap_map {f : R → R} {l : List (Nat × R)}
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (hf0 : f 0 = 0) (e : Nat) :
+    coeffList
+        (l.filterMap fun t => if f t.2 = 0 then none else some (t.1, f t.2))
+        e = f (coeffList l e) := by
+  induction l with
+  | nil => simpa [coeffList] using hf0.symm
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      by_cases hz : f a.2 = 0
+      · simp only [List.filterMap_cons, if_pos hz]
+        by_cases hae : a.1 = e
+        · have hrest0 : coeffList
+              (as.filterMap fun t =>
+                if f t.2 = 0 then none else some (t.1, f t.2)) e = 0 := by
+            refine coeffList_eq_zero ?_
+            intro t ht
+            obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+            split at hut
+            · cases hut
+            · cases hut
+              have := hs.1 u hu
+              omega
+          rw [hrest0]
+          simp only [coeffList, if_pos hae]
+          exact hz.symm
+        · rw [ih hs.2]
+          simp only [coeffList, if_neg hae]
+      · simp only [List.filterMap_cons, if_neg hz]
+        by_cases hae : a.1 = e
+        · simp only [coeffList, if_pos hae]
+        · simp only [coeffList, if_neg hae]
+          exact ih hs.2
+
+/-- Coefficient description of the merge. The three compatibility
+hypotheses identify the structural choices with the pointwise `fb`
+against an absent side's `0`. -/
+theorem coeffList_mergeWith {fl fr : R → R} {fb : R → R → R}
+    {l₁ l₂ : List (Nat × R)}
+    (hs₁ : l₁.Pairwise (fun a b => a.1 < b.1))
+    (hs₂ : l₂.Pairwise (fun a b => a.1 < b.1))
+    (hb00 : fb 0 0 = 0) (hbl : ∀ x, fb x 0 = fl x) (hbr : ∀ y, fb 0 y = fr y)
+    (e : Nat) :
+    coeffList (mergeWith fl fr fb l₁ l₂) e =
+      fb (coeffList l₁ e) (coeffList l₂ e) := by
+  have hfl0 : fl 0 = 0 := by rw [← hbl, hb00]
+  have hfr0 : fr 0 = 0 := by rw [← hbr, hb00]
+  induction l₁, l₂ using mergeWith.induct fl fr fb with
+  | case1 l₂ =>
+      rw [mergeWith, coeffList_filterMap_map hs₂ hfr0]
+      show _ = fb (coeffList [] e) _
+      rw [show coeffList ([] : List (Nat × R)) e = 0 from rfl, hbr]
+  | case2 a as =>
+      rw [mergeWith, coeffList_filterMap_map hs₁ hfl0]
+      rw [show coeffList ([] : List (Nat × R)) e = 0 from rfl, hbl]
+  | case3 a as b bs hab hz ih =>
+      rw [List.pairwise_cons] at hs₁
+      rw [mergeWith, if_pos hab, if_pos hz, ih hs₁.2 hs₂]
+      by_cases hae : a.1 = e
+      · have htail : coeffList as e = 0 := by
+          refine coeffList_eq_zero ?_
+          intro t ht
+          have := hs₁.1 t ht
+          omega
+        have hright : coeffList (b :: bs) e = 0 :=
+          coeffList_eq_zero_of_lt_head hs₂ (by omega)
+        rw [htail, hright, hb00]
+        simp only [coeffList, if_pos hae]
+        rw [hbl, hz]
+      · simp only [coeffList, if_neg hae]
+  | case4 a as b bs hab hz ih =>
+      rw [List.pairwise_cons] at hs₁
+      rw [mergeWith, if_pos hab, if_neg hz]
+      by_cases hae : a.1 = e
+      · have hright : coeffList (b :: bs) e = 0 :=
+          coeffList_eq_zero_of_lt_head hs₂ (by omega)
+        rw [hright]
+        simp only [coeffList, if_pos hae]
+        rw [hbl]
+      · simp only [coeffList, if_neg hae]
+        exact ih hs₁.2 hs₂
+  | case5 a as b bs hab hba hz ih =>
+      rw [List.pairwise_cons] at hs₂
+      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz, ih hs₁ hs₂.2]
+      by_cases hbe : b.1 = e
+      · have htail : coeffList bs e = 0 := by
+          refine coeffList_eq_zero ?_
+          intro t ht
+          have := hs₂.1 t ht
+          omega
+        have hleft : coeffList (a :: as) e = 0 :=
+          coeffList_eq_zero_of_lt_head hs₁ (by omega)
+        rw [htail, hleft, hb00]
+        simp only [coeffList, if_pos hbe]
+        rw [hbr, hz]
+      · simp only [coeffList, if_neg hbe]
+  | case6 a as b bs hab hba hz ih =>
+      rw [List.pairwise_cons] at hs₂
+      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz]
+      by_cases hbe : b.1 = e
+      · have hleft : coeffList (a :: as) e = 0 :=
+          coeffList_eq_zero_of_lt_head hs₁ (by omega)
+        rw [hleft]
+        simp only [coeffList, if_pos hbe]
+        rw [hbr]
+      · simp only [coeffList, if_neg hbe]
+        exact ih hs₁ hs₂.2
+  | case7 a as b bs hab hba hz ih =>
+      have habeq : a.1 = b.1 := by omega
+      rw [List.pairwise_cons] at hs₁ hs₂
+      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz, ih hs₁.2 hs₂.2]
+      by_cases hae : a.1 = e
+      · have htail₁ : coeffList as e = 0 := by
+          refine coeffList_eq_zero ?_
+          intro t ht
+          have := hs₁.1 t ht
+          omega
+        have htail₂ : coeffList bs e = 0 := by
+          refine coeffList_eq_zero ?_
+          intro t ht
+          have := hs₂.1 t ht
+          omega
+        rw [htail₁, htail₂, hb00]
+        simp only [coeffList, if_pos hae, if_pos (habeq ▸ hae)]
+        exact hz.symm
+      · simp only [coeffList, if_neg hae, if_neg (habeq ▸ hae)]
+  | case8 a as b bs hab hba hz ih =>
+      have habeq : a.1 = b.1 := by omega
+      rw [List.pairwise_cons] at hs₁ hs₂
+      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz]
+      by_cases hae : a.1 = e
+      · simp only [coeffList, if_pos hae, if_pos (habeq ▸ hae)]
+      · simp only [coeffList, if_neg hae, if_neg (habeq ▸ hae)]
+        exact ih hs₁.2 hs₂.2
+
+/-- The canonical-form invariant, list-level: exponents strictly
+increase. -/
+theorem pairwise_toList (s : SparsePoly R) :
+    s.terms.toList.Pairwise (fun a b => a.1 < b.1) :=
+  s.canonical.1
+
+/-- The canonical-form invariant, list-level: no stored coefficient is
+zero. -/
+theorem nonzero_toList (s : SparsePoly R) :
+    ∀ t ∈ s.terms.toList, t.2 ≠ 0 :=
+  fun t ht => s.canonical.2 t (Array.mem_def.mpr ht)
+
+/-- Package a canonical term list as a polynomial. -/
+def ofCanonicalList (l : List (Nat × R))
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (hnz : ∀ t ∈ l, t.2 ≠ 0) :
+    SparsePoly R where
+  terms := l.toArray
+  canonical :=
+    ⟨by simpa using hs,
+     fun t ht => hnz t (by simpa using Array.mem_def.mp ht)⟩
+
+@[simp] theorem coeff_ofCanonicalList (l : List (Nat × R))
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) (hnz : ∀ t ∈ l, t.2 ≠ 0)
+    (e : Nat) : (ofCanonicalList l hs hnz).coeff e = coeffList l e := by
+  unfold ofCanonicalList coeff
+  rw [List.toList_toArray]
+
+/-- Map exponents and coefficients over a term list, dropping the terms
+whose new coefficient is zero. `neg`, `scale`, and `mulMonomial` are
+instances (with the identity exponent map or a shift). -/
+def mapTerms (g : Nat → Nat) (f : Nat → R → R) (l : List (Nat × R)) :
+    List (Nat × R) :=
+  l.filterMap fun t =>
+    if f t.1 t.2 = 0 then none else some (g t.1, f t.1 t.2)
+
+/-- Every exponent stored by the map is the image of a stored one. -/
+theorem exp_mem_mapTerms {g : Nat → Nat} {f : Nat → R → R}
+    {l : List (Nat × R)} {t : Nat × R} (ht : t ∈ mapTerms g f l) :
+    ∃ u ∈ l, t.1 = g u.1 := by
+  obtain ⟨u, hu, hut⟩ := List.mem_filterMap.mp ht
+  refine ⟨u, hu, ?_⟩
+  split at hut
+  · cases hut
+  · cases hut
+    rfl
+
+/-- The map of a canonical term list along a strictly monotone exponent
+map is canonical. -/
+theorem mapTerms_canonical {g : Nat → Nat} {f : Nat → R → R}
+    {l : List (Nat × R)} (hs : l.Pairwise (fun a b => a.1 < b.1))
+    (hmono : ∀ a ∈ l, ∀ b ∈ l, a.1 < b.1 → g a.1 < g b.1) :
+    (mapTerms g f l).Pairwise (fun a b => a.1 < b.1) ∧
+      ∀ t ∈ mapTerms g f l, t.2 ≠ 0 := by
+  induction l with
+  | nil => simp [mapTerms]
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      obtain ⟨hpw, hnz⟩ := ih hs.2 fun x hx y hy =>
+        hmono x (List.mem_cons_of_mem _ hx) y (List.mem_cons_of_mem _ hy)
+      by_cases hz : f a.1 a.2 = 0
+      · rw [show mapTerms g f (a :: as) = mapTerms g f as from by
+          simp only [mapTerms, List.filterMap_cons, if_pos hz]]
+        exact ⟨hpw, hnz⟩
+      · rw [show mapTerms g f (a :: as) =
+            (g a.1, f a.1 a.2) :: mapTerms g f as from by
+          simp only [mapTerms, List.filterMap_cons, if_neg hz]]
+        refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
+        · intro t ht
+          obtain ⟨u, hu, hut⟩ := exp_mem_mapTerms ht
+          rw [hut]
+          exact hmono a (List.mem_cons_self ..) u (List.mem_cons_of_mem _ hu)
+            (hs.1 u hu)
+        · intro t ht
+          rcases List.mem_cons.mp ht with rfl | ht'
+          · exact hz
+          · exact hnz t ht'
+
+/-- Coefficient of the mapped list at a mapped exponent, for an exponent
+map injective into the stored exponents. -/
+theorem coeffList_mapTerms_apply {g : Nat → Nat} {f : Nat → R → R}
+    {l : List (Nat × R)} {e : Nat}
+    (hs : l.Pairwise (fun a b => a.1 < b.1))
+    (hinj : ∀ u ∈ l, g u.1 = g e → u.1 = e) (hf0 : f e 0 = 0) :
+    coeffList (mapTerms g f l) (g e) = f e (coeffList l e) := by
+  induction l with
+  | nil => simpa [mapTerms, coeffList] using hf0.symm
+  | cons a as ih =>
+      rw [List.pairwise_cons] at hs
+      have ih' := ih hs.2 fun u hu => hinj u (List.mem_cons_of_mem _ hu)
+      by_cases hz : f a.1 a.2 = 0
+      · rw [show mapTerms g f (a :: as) = mapTerms g f as from by
+          simp only [mapTerms, List.filterMap_cons, if_pos hz]]
+        by_cases hae : a.1 = e
+        · have htail : coeffList (mapTerms g f as) (g e) = 0 := by
+            refine coeffList_eq_zero ?_
+            intro t ht
+            obtain ⟨u, hu, hut⟩ := exp_mem_mapTerms ht
+            rw [hut]
+            intro hgu
+            have := hinj u (List.mem_cons_of_mem _ hu) hgu
+            have := hs.1 u hu
+            omega
+          rw [htail]
+          simp only [coeffList, if_pos hae]
+          rw [← hae, hz]
+        · rw [ih']
+          simp only [coeffList, if_neg hae]
+      · rw [show mapTerms g f (a :: as) =
+            (g a.1, f a.1 a.2) :: mapTerms g f as from by
+          simp only [mapTerms, List.filterMap_cons, if_neg hz]]
+        by_cases hae : a.1 = e
+        · simp only [coeffList, if_pos (show g a.1 = g e from by rw [hae]),
+            if_pos hae]
+          rw [hae]
+        · simp only [coeffList,
+            if_neg (fun h : g a.1 = g e =>
+              hae (hinj a (List.mem_cons_self ..) h)),
+            if_neg hae]
+          exact ih'
+
+/-- The mapped list stores nothing outside the image of the exponent
+map. -/
+theorem coeffList_mapTerms_of_ne {g : Nat → Nat} {f : Nat → R → R}
+    {l : List (Nat × R)} {x : Nat} (hx : ∀ u ∈ l, g u.1 ≠ x) :
+    coeffList (mapTerms g f l) x = 0 := by
+  refine coeffList_eq_zero ?_
+  intro t ht
+  obtain ⟨u, hu, hut⟩ := exp_mem_mapTerms ht
+  rw [hut]
+  exact hx u hu
+
+/-- Add two sparse polynomials by a linear merge of the sorted term
+arrays, `O(s + t)`: sums at a matching exponent, and a zero sum stores
+nothing. -/
+def add [Add R] (s t : SparsePoly R) : SparsePoly R :=
+  ofCanonicalList (mergeWith id id (· + ·) s.terms.toList t.terms.toList)
+    (mergeWith_canonical s.pairwise_toList t.pairwise_toList).1
+    (mergeWith_canonical s.pairwise_toList t.pairwise_toList).2
+
+instance [Add R] : Add (SparsePoly R) where
+  add := add
+
+/-- Coefficient law for {name}`add`, under the pointwise hypotheses it
+needs; the `Lean.Grind.Semiring` form is `coeff_add`. -/
+theorem coeff_add' [Add R] (h00 : (0 : R) + 0 = 0)
+    (hl : ∀ x : R, x + 0 = x) (hr : ∀ y : R, 0 + y = y)
+    (s t : SparsePoly R) (e : Nat) :
+    (s + t).coeff e = s.coeff e + t.coeff e := by
+  show (s.add t).coeff e = _
+  unfold add
+  rw [coeff_ofCanonicalList]
+  have h := coeffList_mergeWith (fl := id) (fr := id) (fb := (· + ·))
+    s.pairwise_toList t.pairwise_toList h00 hl hr e
+  rw [h]
+  rfl
+
+@[simp, grind =] theorem coeff_add {S : Type u} [Lean.Grind.Semiring S]
+    [DecidableEq S] (s t : SparsePoly S) (e : Nat) :
+    (s + t).coeff e = s.coeff e + t.coeff e :=
+  coeff_add' (by grind) (by grind) (by grind) s t e
+
+/-- Subtract two sparse polynomials by a linear merge, `O(s + t)`. -/
+def sub [Sub R] (s t : SparsePoly R) : SparsePoly R :=
+  ofCanonicalList
+    (mergeWith id (fun y => 0 - y) (· - ·) s.terms.toList t.terms.toList)
+    (mergeWith_canonical s.pairwise_toList t.pairwise_toList).1
+    (mergeWith_canonical s.pairwise_toList t.pairwise_toList).2
+
+instance [Sub R] : Sub (SparsePoly R) where
+  sub := sub
+
+/-- Coefficient law for {name}`sub`, under the pointwise hypotheses it
+needs; the `Lean.Grind.Ring` form is `coeff_sub`. -/
+theorem coeff_sub' [Sub R] (h00 : (0 : R) - 0 = 0)
+    (hl : ∀ x : R, x - 0 = x) (s t : SparsePoly R) (e : Nat) :
+    (s - t).coeff e = s.coeff e - t.coeff e := by
+  show (s.sub t).coeff e = _
+  unfold sub
+  rw [coeff_ofCanonicalList]
+  have h := coeffList_mergeWith (fl := id) (fr := fun y => (0 : R) - y)
+    (fb := (· - ·)) s.pairwise_toList t.pairwise_toList h00 hl
+    (fun y => rfl) e
+  rw [h]
+  rfl
+
+@[simp, grind =] theorem coeff_sub {S : Type u} [Lean.Grind.Ring S]
+    [DecidableEq S] (s t : SparsePoly S) (e : Nat) :
+    (s - t).coeff e = s.coeff e - t.coeff e :=
+  coeff_sub' (by grind) (by grind) s t e
+
+/-- Negate a sparse polynomial: subtraction from zero, compiled as one
+filtered coefficient map. Over a ring the exponents and the term count
+are unchanged; `[Sub R]` alone does not supply that, so the zero filter
+stays. -/
+def neg [Sub R] (s : SparsePoly R) : SparsePoly R :=
+  ofCanonicalList (mapTerms id (fun _ c => 0 - c) s.terms.toList)
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => h).1
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => h).2
+
+instance [Sub R] : Neg (SparsePoly R) where
+  neg := neg
+
+/-- Coefficient law for {name}`neg`, under the pointwise hypothesis it
+needs; the `Lean.Grind.Ring` form is `coeff_neg`. -/
+theorem coeff_neg' [Sub R] (h00 : (0 : R) - 0 = 0) (s : SparsePoly R)
+    (e : Nat) : (-s).coeff e = 0 - s.coeff e := by
+  show (s.neg).coeff e = _
+  unfold neg
+  rw [coeff_ofCanonicalList]
+  exact coeffList_mapTerms_apply (g := id) s.pairwise_toList
+    (fun u _ h => h) h00
+
+@[simp, grind =] theorem coeff_neg {S : Type u} [Lean.Grind.Ring S]
+    [DecidableEq S] (s : SparsePoly S) (e : Nat) :
+    (-s).coeff e = 0 - s.coeff e :=
+  coeff_neg' (by grind) s e
+
+/-- Multiply every coefficient by `c`, dropping the products that
+vanish: `c = 0` gives the zero polynomial, and a zero divisor `c` can
+delete an interior term while leaving its neighbours. -/
+def scale [Mul R] (c : R) (s : SparsePoly R) : SparsePoly R :=
+  ofCanonicalList (mapTerms id (fun _ x => c * x) s.terms.toList)
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => h).1
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => h).2
+
+/-- Coefficient law for {name}`scale`, under the pointwise hypothesis it
+needs; the `Lean.Grind.Semiring` form is `coeff_scale`. -/
+theorem coeff_scale' [Mul R] (hc0 : ∀ c : R, c * 0 = 0) (c : R)
+    (s : SparsePoly R) (e : Nat) : (scale c s).coeff e = c * s.coeff e := by
+  unfold scale
+  rw [coeff_ofCanonicalList]
+  exact coeffList_mapTerms_apply (g := id) s.pairwise_toList
+    (fun u _ h => h) (hc0 c)
+
+@[simp, grind =] theorem coeff_scale {S : Type u} [Lean.Grind.Semiring S]
+    [DecidableEq S] (c : S) (s : SparsePoly S) (e : Nat) :
+    (scale c s).coeff e = c * s.coeff e :=
+  coeff_scale' (by grind) c s e
+
+/-- Multiply by the monomial `c · x^e`: add `e` to every exponent and
+multiply every coefficient by `c`. The exponent shift is strictly
+monotone, so the only canonicalisation is the zero filter. This is the
+cheap shift `mul` is built from, `O(s)`. -/
+def mulMonomial [Mul R] (e : Nat) (c : R) (s : SparsePoly R) :
+    SparsePoly R :=
+  ofCanonicalList (mapTerms (fun e' => e + e') (fun _ x => c * x)
+      s.terms.toList)
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => by omega).1
+    (mapTerms_canonical s.pairwise_toList fun _ _ _ _ h => by omega).2
+
+/-- Coefficient law for {name}`mulMonomial`, under the pointwise
+hypothesis it needs; the `Lean.Grind.Semiring` form is
+`coeff_mulMonomial`. -/
+theorem coeff_mulMonomial' [Mul R] (hc0 : ∀ c : R, c * 0 = 0)
+    (s : SparsePoly R) (e : Nat) (c : R) (f : Nat) :
+    (mulMonomial e c s).coeff f =
+      if e ≤ f then c * s.coeff (f - e) else 0 := by
+  unfold mulMonomial
+  rw [coeff_ofCanonicalList]
+  by_cases hef : e ≤ f
+  · rw [if_pos hef]
+    have happly := coeffList_mapTerms_apply (g := fun e' => e + e')
+      (f := fun _ x => c * x) (l := s.terms.toList) (e := f - e)
+      s.pairwise_toList (fun u _ h => by omega) (hc0 c)
+    rw [show e + (f - e) = f from by omega] at happly
+    rw [happly]
+    rfl
+  · rw [if_neg hef]
+    exact coeffList_mapTerms_of_ne fun u _ h => by omega
+
+@[simp, grind =] theorem coeff_mulMonomial {S : Type u}
+    [Lean.Grind.Semiring S] [DecidableEq S] (s : SparsePoly S) (e : Nat)
+    (c : S) (f : Nat) :
+    (mulMonomial e c s).coeff f =
+      if e ≤ f then c * s.coeff (f - e) else 0 :=
+  coeff_mulMonomial' (by grind) s e c f
+
+/-- Multiply two sparse polynomials: the canonicalised pairwise product.
+Every pair of exponents contributes, exponent sums collide freely, and
+{name}`ofTerms` combines the collisions and drops what cancels. The
+`@[csimp]` implementation is selected by the Phase-4
+sparse-multiplication bench family; until then compiled code runs this
+specification through {name}`ofTerms`'s sort-and-combine twin. -/
+def mul [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R :=
+  ofTerms (s.terms.flatMap fun a => t.terms.map fun b =>
+    (a.1 + b.1, a.2 * b.2))
+
+instance [Add R] [Mul R] : Mul (SparsePoly R) where
+  mul := mul
+
+/-- Raise to a power by binary powering over {name}`mul`. A caller
+wanting `f(x^k)` should use `substPow`, never `pow`: the cost
+difference is the whole reason this library exists. -/
+def pow [One R] [Add R] [Mul R] (s : SparsePoly R) (n : Nat) :
+    SparsePoly R :=
+  if _h : n = 0 then 1
+  else if n % 2 = 1 then s.mul (pow (s.mul s) (n / 2))
+  else pow (s.mul s) (n / 2)
+termination_by n
+decreasing_by all_goals omega
+
+instance [One R] [Add R] [Mul R] : Pow (SparsePoly R) Nat where
+  pow := pow
+
+/-- Divisibility by existence of a cofactor, matching the `DensePoly`
+convention. -/
+instance [Add R] [Mul R] : Dvd (SparsePoly R) where
+  dvd p q := ∃ r, q = p * r
+
+theorem dvd_def [Add R] [Mul R] (p q : SparsePoly R) :
+    p ∣ q ↔ ∃ r, q = p * r :=
+  Iff.rfl
+
+section Laws
+
+variable {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+
+theorem add_comm (s t : SparsePoly S) : s + t = t + s := by
+  apply ext_coeff
+  intro e
+  simp only [coeff_add]
+  grind
+
+theorem add_assoc (s t u : SparsePoly S) : s + t + u = s + (t + u) := by
+  apply ext_coeff
+  intro e
+  simp only [coeff_add]
+  grind
+
+@[simp, grind =] theorem add_zero (s : SparsePoly S) : s + 0 = s := by
+  apply ext_coeff
+  intro e
+  simp only [coeff_add, coeff_zero]
+  grind
+
+@[simp, grind =] theorem zero_add (s : SparsePoly S) : 0 + s = s := by
+  apply ext_coeff
+  intro e
+  simp only [coeff_add, coeff_zero]
+  grind
+
+/-- `mul_comm`, `mul_assoc`, `mul_one`, `mul_zero`, and the two
+distributive laws are stated here and proved in the conversions
+milestone, where `coeff_mul` becomes available by transport through
+`toDense` (see SPEC §Conversion): redoing the convolution over the
+sparse term arrays would duplicate the dense proof. -/
+theorem mul_assoc (s t u : SparsePoly S) : s * t * u = s * (t * u) := by
+  sorry
+
+@[simp, grind =] theorem mul_one (s : SparsePoly S) : s * 1 = s := by
+  sorry
+
+@[simp, grind =] theorem one_mul (s : SparsePoly S) : 1 * s = s := by
+  sorry
+
+@[simp, grind =] theorem mul_zero (s : SparsePoly S) : s * 0 = 0 := by
+  sorry
+
+@[simp, grind =] theorem zero_mul (s : SparsePoly S) : 0 * s = 0 := by
+  sorry
+
+theorem left_distrib (s t u : SparsePoly S) :
+    s * (t + u) = s * t + s * u := by
+  sorry
+
+theorem right_distrib (s t u : SparsePoly S) :
+    (s + t) * u = s * u + t * u := by
+  sorry
+
+theorem mul_comm {C : Type u} [Lean.Grind.CommRing C] [DecidableEq C]
+    (s t : SparsePoly C) : s * t = t * s := by
+  sorry
+
+end Laws
+
+end SparsePoly
+
+end Hex

--- a/progress/20260822T033256Z_sparse-poly-arith.md
+++ b/progress/20260822T033256Z_sparse-poly-arith.md
@@ -1,0 +1,34 @@
+# hex-sparse-poly: arithmetic (milestone 2)
+
+## Accomplished
+
+- `HexSparsePoly/Arith.lean`: the generic sorted-merge combinator
+  `mergeWith` with its canonicality and coefficient lemmas, the generic
+  filtered coefficient map `mapTerms` likewise, and on top of them
+  `add`/`sub` (linear merges), `neg`, `scale`, `mulMonomial`, `mul` as
+  the SPEC's pairwise-product specification through `ofTerms`, binary
+  `pow`, and the `Add`/`Sub`/`Neg`/`Mul`/`Pow`/`Dvd` instances.
+- Coefficient laws in the house two-tier shape: raw forms under explicit
+  pointwise hypotheses (`coeff_add'`, `coeff_sub'`, `coeff_neg'`,
+  `coeff_scale'`, `coeff_mulMonomial'`) plus `Lean.Grind.Semiring`/
+  `Ring` wrappers, all proved.
+- Additive ring laws (`add_comm`, `add_assoc`, `add_zero`, `zero_add`)
+  proved via `ext_coeff` + `grind`.
+
+## Current frontier
+
+The multiplicative laws (`mul_assoc`, `mul_one`, `one_mul`, `mul_zero`,
+`zero_mul`, both distributivities, `mul_comm`) are stated with `sorry`,
+deliberately: the SPEC proves `coeff_mul` by transport through
+`toDense_mul` in milestone 3, and these follow from it. Eight sorries,
+all in `Arith.lean` §Laws.
+
+## Next step
+
+Milestone 3 (`HexSparsePoly/Dense.lean`): the conversions, homomorphism
+laws, round trips, then discharge the eight multiplicative-law sorries
+by transport.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR land milestone 2 of the hex-sparse-poly SPEC: a generic sorted-merge combinator `mergeWith` and filtered coefficient map `mapTerms`, each with canonicality and coefficient lemmas proved once and instantiated by `add` and `sub` (linear `O(s + t)` merges), `neg`, `scale`, and `mulMonomial`; `mul` as the SPEC's canonicalised pairwise-product specification through `ofTerms` (its `@[csimp]` twin is deliberately deferred to the Phase-4 sparse-multiplication bench that selects among the three candidate shapes); binary `pow`; and the `Add`/`Sub`/`Neg`/`Mul`/`Pow`/`Dvd` instances. Coefficient laws follow the house two-tier shape: raw forms under explicit pointwise hypotheses plus `Lean.Grind.Semiring`/`Ring` wrappers. The additive ring laws are proved; the eight multiplicative laws are stated with `sorry` because the SPEC proves `coeff_mul` by transport through `toDense_mul` in milestone 3, where they are discharged.

🤖 Prepared with Claude Code