### PR TITLE
doc: complete HexGF2Mathlib Phases 6 and 7

### DIFF
--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -52,8 +52,8 @@ The degree hypothesis is not redundant. `Hex.GF2Poly.Irreducible` asks that `f`
 be nonzero with no factorization into two positive-degree parts, which the
 constant `1` satisfies, and `Hex.GF2nPoly 1 _` is the trivial ring where
 `0 = 1`. Carried as a `Fact` so that instance synthesis can find it: a caller
-with a genuine modulus supplies it once, and every committed
-the committed packed entries in `hex-gfq` has `degree_pos` to build it from. -/
+with a genuine modulus supplies it once, and the committed packed entries in
+`hex-gfq` carry `degree_pos` to build it from. -/
 noncomputable instance field [hdeg : Fact (0 < f.degree)] :
     Field (Hex.GF2nPoly f hirr) :=
   Field.ofMinimalAxioms (Hex.GF2nPoly f hirr)

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -30,10 +30,7 @@ namespace HexGF2Mathlib
 
 open Hex
 
-universe u v w
-
 namespace GF2Poly
-
 
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by
@@ -115,11 +112,13 @@ theorem coeff_toFpPoly (p : Hex.GF2Poly) (i : Nat) :
       rw [hcoeff]
       rfl
 
+/-- Unpacking the packed zero gives the generic zero. -/
 @[simp, grind =]
 theorem toFpPoly_zero :
     toFpPoly (0 : Hex.GF2Poly) = 0 := by
   rfl
 
+/-- Repacking the generic zero gives the packed zero. -/
 @[simp, grind =]
 theorem ofFpPoly_zero :
     ofFpPoly (0 : Hex.FpPoly 2) = 0 := by
@@ -141,6 +140,7 @@ private theorem coeff_one_eq (i : Nat) :
     have : i ≠ 0 := by omega
     simp [this]
 
+/-- Unpacking the packed unit gives the generic unit. -/
 @[simp, grind =]
 theorem toFpPoly_one :
     toFpPoly (1 : Hex.GF2Poly) = 1 := by
@@ -274,6 +274,8 @@ theorem coeff_ofFpPoly (p : Hex.FpPoly 2) (j : Nat) :
     have hz : p.coeff j = 0 := hpc
     simp [Hex.GF2Poly.coeffWords, hget, hz]
 
+/-- Unpacking then repacking recovers the packed polynomial: `ofFpPoly` is a left
+inverse of `toFpPoly`. -/
 @[simp, grind =]
 theorem ofFpPoly_toFpPoly (p : Hex.GF2Poly) :
     ofFpPoly (toFpPoly p) = p := by
@@ -284,6 +286,8 @@ theorem ofFpPoly_toFpPoly (p : Hex.GF2Poly) :
   | false => simp
   | true => simp [zmod2_one_ne_zero]
 
+/-- Repacking then unpacking recovers the generic polynomial. The generic side is
+degree-normalized, so no trailing zero coefficients are introduced. -/
 @[simp, grind =]
 theorem toFpPoly_ofFpPoly (p : Hex.FpPoly 2) :
     toFpPoly (ofFpPoly p) = p := by
@@ -294,6 +298,8 @@ theorem toFpPoly_ofFpPoly (p : Hex.FpPoly 2) :
   · simp [hz]
   · simp [ho, zmod2_one_ne_zero]
 
+/-- Unpacking is additive: packed `XOR` addition becomes generic coefficientwise
+addition. Half of the `RingEquiv` obligation for `equiv`. -/
 @[simp, grind =]
 theorem toFpPoly_add (p q : Hex.GF2Poly) :
     toFpPoly (p + q) = toFpPoly p + toFpPoly q := by
@@ -388,6 +394,10 @@ private theorem foldl_add_range_eq_of_ge (term : Nat → Hex.ZMod64 2) (A B m : 
   obtain ⟨b, rfl⟩ : ∃ b, B = m + b := ⟨B - m, by omega⟩
   rw [foldl_add_range_reduce term m hzero a, foldl_add_range_reduce term m hzero b]
 
+/-- Unpacking is multiplicative: the packed carry-less product becomes the
+generic convolution product. The other half of the `RingEquiv` obligation for
+`equiv`, and the reason the packed representation may be used as a drop-in for
+`FpPoly 2` in ring-level reasoning. -/
 @[simp, grind =]
 theorem toFpPoly_mul (p q : Hex.GF2Poly) :
     toFpPoly (p * q) = toFpPoly p * toFpPoly q := by
@@ -442,11 +452,13 @@ def equiv : Hex.GF2Poly ≃+* Hex.FpPoly 2 where
   map_mul' := toFpPoly_mul
   map_add' := toFpPoly_add
 
+/-- The forward direction of `equiv` is `toFpPoly`. -/
 @[simp, grind =]
 theorem equiv_apply (p : Hex.GF2Poly) :
     equiv p = toFpPoly p := by
   rfl
 
+/-- The inverse direction of `equiv` is `ofFpPoly`. -/
 @[simp, grind =]
 theorem equiv_symm_apply (p : Hex.FpPoly 2) :
     equiv.symm p = ofFpPoly p := by
@@ -527,14 +539,16 @@ theorem irreducible_toFpPoly {p : Hex.GF2Poly} (h : Hex.GF2Poly.Irreducible p) :
     · exact Or.inl (hupgrade a ha_ne hda)
     · exact Or.inr (hupgrade b hb_ne hdb)
 
-/-- Interpret a packed polynomial as the natural number with the same binary
-coefficient bits. This gives correspondence modules a finite index for
-bounded-degree representatives without changing the executable `HexGF2`
-representation. -/
+/-- Little-endian place-value sum of a packed word list, starting at word index
+`i`: word `k` contributes at bit offset `64 * (i + k)`. -/
 private def wordsToNatAux : List UInt64 → Nat → Nat
   | [], _ => 0
   | w :: ws, i => w.toNat * 2 ^ (64 * i) + wordsToNatAux ws (i + 1)
 
+/-- Interpret a packed polynomial as the natural number with the same binary
+coefficient bits. This gives correspondence modules a finite index for
+bounded-degree representatives without changing the executable `HexGF2`
+representation. -/
 def toNat (p : Hex.GF2Poly) : Nat :=
   wordsToNatAux p.toWords.toList 0
 
@@ -592,13 +606,6 @@ private theorem word_shift_lt_next (w : UInt64) (i : Nat) :
   have h := Nat.shiftLeft_lt (x := w.toNat) (n := 64) (m := 64 * i) hw
   simpa [Nat.shiftLeft_eq, show 64 + 64 * i = 64 * (i + 1) by omega] using h
 
-private theorem word_shift_testBit_eq_false_of_next_le
-    (w : UInt64) {i j : Nat} (hj : 64 * (i + 1) ≤ j) :
-    (w.toNat * 2 ^ (64 * i)).testBit j = false := by
-  exact Nat.testBit_eq_false_of_lt
-    (Nat.lt_of_lt_of_le (word_shift_lt_next w i)
-      (Nat.pow_le_pow_right (by decide : 0 < 2) hj))
-
 private theorem wordsToNatAux_testBit_getD :
     ∀ (ws : List UInt64) (i wordIdx bitIdx : Nat), bitIdx < 64 →
       (wordsToNatAux ws i).testBit (64 * (i + wordIdx) + bitIdx) =
@@ -633,6 +640,9 @@ private theorem wordsToNatAux_testBit_getD :
       · exact Nat.lt_of_lt_of_le (word_shift_lt_next w i) (le_rfl)
       · exact wordsToNatAux_dvd_shift ws (i + 1)
 
+/-- The binary index and the packed representation agree bit for bit: bit `j` of
+`toNat p` is the coefficient of `x ^ j`. This is the characterising lemma for
+`toNat`, and callers should use it rather than unfolding the word fold. -/
 theorem toNat_testBit_eq_coeff (p : Hex.GF2Poly) (j : Nat) :
     (toNat p).testBit j = p.coeff j := by
   unfold toNat
@@ -663,12 +673,6 @@ private theorem div_word_mod_testBit (n wordIdx bitIdx : Nat) (hbit : bitIdx < 6
   simp [hbit, Nat.testBit, Nat.shiftRight_eq_div_pow, Nat.div_div_eq_div_mul,
     Nat.pow_add]
 
-private theorem div_word_testBit (n wordIdx bitIdx : Nat) (hbit : bitIdx < 64) :
-    (UInt64.ofNat (n / 2 ^ (64 * wordIdx))).toNat.testBit bitIdx =
-      n.testBit (64 * wordIdx + bitIdx) := by
-  rw [UInt64.toNat_ofNat']
-  exact div_word_mod_testBit n wordIdx bitIdx hbit
-
 private theorem div_lt_wordCount_of_lt_degree {degree j : Nat} (hj : j < degree) :
     j / 64 < (degree + 63) / 64 := by
   rw [Nat.div_lt_iff_lt_mul (by decide : 0 < 64)]
@@ -678,6 +682,8 @@ private theorem div_lt_wordCount_of_lt_degree {degree j : Nat} (hj : j < degree)
     omega
   omega
 
+/-- Below the degree bound, `ofNatBelowDegree` reproduces the binary digits of
+its input: the characterising lemma for the decoding direction. -/
 theorem coeff_ofNatBelowDegree_of_lt (degree n j : Nat) (hj : j < degree) :
     (ofNatBelowDegree degree n).coeff j = n.testBit j := by
   unfold ofNatBelowDegree
@@ -698,6 +704,9 @@ theorem coeff_ofNatBelowDegree_of_lt (degree n j : Nat) (hj : j < degree) :
   change ((n / 2 ^ (64 * (j / 64))) % 2 ^ 64).testBit (j % 64) = n.testBit j
   rw [div_word_mod_testBit n (j / 64) (j % 64) hbit, hdecomp]
 
+/-- At or above the degree bound, a decoded index has no coefficients: together
+with `coeff_ofNatBelowDegree_of_lt` this pins down `ofNatBelowDegree` on every
+index, and it is what makes the decoded value a reduced representative. -/
 theorem coeff_ofNatBelowDegree_eq_false_of_bound
     {degree n j : Nat} (hn : n < 2 ^ degree) (hj : degree ≤ j) :
     (ofNatBelowDegree degree n).coeff j = false := by
@@ -828,8 +837,12 @@ noncomputable def equivPolynomial : Hex.GF2Poly ≃+* Polynomial (ZMod 2) :=
   equiv.trans HexPolyFpMathlib.fpPolyEquiv
 
 /-- The forward direction of `equivPolynomial` transports the packed value
-through the generic representation. -/
-@[simp, grind =]
+through the generic representation.
+
+Deliberately not `@[simp]`: `coeff_equivPolynomial` below is the coefficient
+normal form, and a `simp` set containing both would rewrite past its left-hand
+side and leave a `toZMod` applied to an `if`. -/
+@[grind =]
 theorem equivPolynomial_apply (q : Hex.GF2Poly) :
     equivPolynomial q = HexPolyFpMathlib.fpPolyEquiv (toFpPoly q) := by
   rfl

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -27,9 +27,47 @@ name the generic field over `F_2`. Stated once here rather than inside each
 namespace, since the two copies were identical. -/
 private theorem prime_two : Hex.Nat.Prime 2 := by decide
 
-namespace GF2n
+/-- `2` is a prime modulus, so `Hex.ZMod64 2` is a field and the generic
+quotient-field construction applies to `Hex.FpPoly 2`. -/
+instance instPrimeModulusTwo : Hex.ZMod64.PrimeModulus 2 :=
+  Hex.ZMod64.primeModulusOfPrime prime_two
 
-instance : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two
+/-- Degree is preserved across the `GF2Poly → FpPoly 2` bridge. -/
+private theorem degree_toFpPoly (p : Hex.GF2Poly) :
+    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly p) = p.degree := by
+  unfold Hex.FpPoly.degree Hex.GF2Poly.degree
+  rw [HexGF2Mathlib.GF2Poly.degree?_toFpPoly]
+
+/-- Packed remainder reduction transports across the `GF2Poly ≃+* FpPoly 2`
+conversion layer to the generic quotient-ring reduction `GFqRing.reduceMod`.
+Shared by the single-word and arbitrary-degree correspondences below. -/
+private theorem toFpPoly_reduceMod (p g : Hex.GF2Poly) (hgdeg : 0 < g.degree) :
+    HexGF2Mathlib.GF2Poly.toFpPoly (p % g) =
+      Hex.GFqRing.reduceMod (HexGF2Mathlib.GF2Poly.toFpPoly g)
+        (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
+  have hgne : g ≠ 0 := by
+    intro h; rw [h] at hgdeg; simp [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] at hgdeg
+  have hgdeg' : 0 < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
+    rw [degree_toFpPoly]; exact hgdeg
+  have hdeglt :
+      Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly (p % g)) <
+        Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
+    rw [degree_toFpPoly, degree_toFpPoly]
+    rcases Hex.GF2Poly.mod_degree_lt p g hgne with hz | hlt
+    · rw [Hex.GF2Poly.eq_zero_of_isZero hz]
+      simpa [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] using hgdeg
+    · exact hlt
+  have heucl :
+      HexGF2Mathlib.GF2Poly.toFpPoly p =
+        HexGF2Mathlib.GF2Poly.toFpPoly (p % g) +
+          HexGF2Mathlib.GF2Poly.toFpPoly (p / g) * HexGF2Mathlib.GF2Poly.toFpPoly g := by
+    conv_lhs => rw [← Hex.GF2Poly.div_mul_add_mod p g]
+    rw [HexGF2Mathlib.GF2Poly.toFpPoly_add, HexGF2Mathlib.GF2Poly.toFpPoly_mul,
+      Hex.FpPoly.add_comm]
+  rw [heucl, Hex.GFqRing.reduceMod_add_mul_self_right _ hgdeg']
+  exact (Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ hdeglt).symm
+
+namespace GF2n
 
 variable {n : Nat} {irr : UInt64}
 variable {hn : 0 < n} {hn64 : n < 64}
@@ -92,12 +130,6 @@ polynomial remainder, and the packed conversions round-trip on reduced
 representatives. These let the four `≃+*` obligations follow by composing the
 `GF2Poly ≃+* FpPoly 2` bridge with the `GFqField` quotient layer. -/
 
-/-- Degree is preserved across the `GF2Poly → FpPoly 2` bridge. -/
-private theorem degree_toFpPoly (p : Hex.GF2Poly) :
-    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly p) = p.degree := by
-  unfold Hex.FpPoly.degree Hex.GF2Poly.degree
-  rw [HexGF2Mathlib.GF2Poly.degree?_toFpPoly]
-
 /-- Degree is preserved across the `FpPoly 2 → GF2Poly` bridge. -/
 private theorem degree_ofFpPoly (P : Hex.FpPoly 2) :
     (HexGF2Mathlib.GF2Poly.ofFpPoly P).degree = Hex.FpPoly.degree P := by
@@ -145,34 +177,6 @@ private theorem ofUInt64_reduceWide_val (hi lo : UInt64) :
       = Hex.GF2Poly.ofWords #[lo, hi] % Hex.GF2Poly.ofUInt64Monic irr n :=
   ofUInt64_canonicalWordLT_packedReduceWord (n := n) (irr := irr) (hn64 := hn64) (hirr := hirr)
     (Hex.GF2Poly.ofWords #[lo, hi])
-
-/-- `toFpPoly` commutes with the polynomial remainder: the bridge carries the
-`GF2Poly` modulus reduction to the `FpPoly` quotient reduction. -/
-private theorem toFpPoly_mod (p q : Hex.GF2Poly) (hq : 0 < q.degree) :
-    HexGF2Mathlib.GF2Poly.toFpPoly (p % q)
-      = Hex.GFqRing.reduceMod (HexGF2Mathlib.GF2Poly.toFpPoly q)
-          (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
-  have hqne : q ≠ 0 := by
-    intro h; rw [h] at hq; simp [Hex.GF2Poly.degree] at hq
-  have hfdeg : 0 < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) := by
-    rw [degree_toFpPoly]; exact hq
-  have hdecomp : (p / q) * q + p % q = p := Hex.GF2Poly.div_mul_add_mod p q
-  have e1 :
-      HexGF2Mathlib.GF2Poly.toFpPoly (p % q)
-          + HexGF2Mathlib.GF2Poly.toFpPoly (p / q) * HexGF2Mathlib.GF2Poly.toFpPoly q
-        = HexGF2Mathlib.GF2Poly.toFpPoly p := by
-    rw [← HexGF2Mathlib.GF2Poly.toFpPoly_mul, ← HexGF2Mathlib.GF2Poly.toFpPoly_add,
-      Hex.GF2Poly.add_comm, hdecomp]
-  have hdeg :
-      Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly (p % q))
-        < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) := by
-    rw [degree_toFpPoly, degree_toFpPoly]
-    rcases Hex.GF2Poly.mod_degree_lt p q hqne with h | h
-    · rw [Hex.GF2Poly.eq_zero_of_isZero h, Hex.GF2Poly.degree_zero]; exact hq
-    · exact h
-  rw [← e1, Hex.GFqRing.reduceMod_add_mul_self_right (HexGF2Mathlib.GF2Poly.toFpPoly q) hfdeg
-      (HexGF2Mathlib.GF2Poly.toFpPoly (p % q)) (HexGF2Mathlib.GF2Poly.toFpPoly (p / q)),
-    Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ hdeg]
 
 /-- Reading back the low word of a reduced packed polynomial round-trips. -/
 private theorem ofUInt64_toWords_getD_of_reduced (p : Hex.GF2Poly)
@@ -267,7 +271,7 @@ private theorem toFpPoly_mod_modulus (p : Hex.GF2Poly) :
     HexGF2Mathlib.GF2Poly.toFpPoly (p % Hex.GF2Poly.ofUInt64Monic irr n)
       = Hex.GFqRing.reduceMod (modulusFpPoly (n := n) (irr := irr))
           (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
-  rw [toFpPoly_mod p (Hex.GF2Poly.ofUInt64Monic irr n)
+  rw [toFpPoly_reduceMod p (Hex.GF2Poly.ofUInt64Monic irr n)
     (by rw [Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]; exact hn)]
   rfl
 
@@ -285,6 +289,8 @@ private theorem reduceMod_modulusFpPoly_toFpPoly_of_reduced (p : Hex.GF2Poly)
   · rw [Hex.GF2Poly.eq_zero_of_isZero h, Hex.GF2Poly.degree_zero]; exact hn
   · exact h
 
+/-- Embedding a single-word element in the generic model and repacking recovers
+it: the packed `val` is already the canonical representative. -/
 @[simp, grind =]
 theorem ofGeneric_toGeneric (x : Hex.GF2n n irr hn hn64 hirr) :
     ofGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
@@ -308,6 +314,8 @@ theorem ofGeneric_toGeneric (x : Hex.GF2n n irr hn hn64 hirr) :
     (hxred.imp_right
       (fun h => by rw [Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]; exact h))
 
+/-- Repacking a generic element and re-embedding recovers it: the round trip
+loses nothing because both sides store the same reduced residue. -/
 @[simp, grind =]
 theorem toGeneric_ofGeneric
     (x : GenericFiniteField (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)) :
@@ -333,6 +341,8 @@ theorem toGeneric_ofGeneric
     ofUInt64_toWords_getD_of_reduced _ hofred, HexGF2Mathlib.GF2Poly.toFpPoly_ofFpPoly,
     Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ (Hex.GFqField.degree_repr_lt_degree x)]
 
+/-- The single-word embedding is additive: packed `XOR`-then-reduce agrees with
+addition in the generic quotient field. -/
 @[simp, grind =]
 theorem toGeneric_add (x y : Hex.GF2n n irr hn hn64 hirr) :
     toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) (x + y) =
@@ -345,6 +355,8 @@ theorem toGeneric_add (x y : Hex.GF2n n irr hn hn64 hirr) :
   rw [ofUInt64_add_val, toFpPoly_mod_modulus (hn := hn) (hn64 := hn64),
     HexGF2Mathlib.GF2Poly.toFpPoly_add, Hex.GFqRing.reduceMod_idem]
 
+/-- The single-word embedding is multiplicative: the packed carry-less
+multiply-then-reduce agrees with multiplication in the generic quotient field. -/
 @[simp, grind =]
 theorem toGeneric_mul (x y : Hex.GF2n n irr hn hn64 hirr) :
     toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) (x * y) =
@@ -389,7 +401,7 @@ def finEquiv : Hex.GF2n n irr hn hn64 hirr ≃ Fin (2 ^ n) where
 -- Deliberately `noncomputable`: the field has `2 ^ n` elements for `n < 64`,
 -- so a compiled `Finset.univ` over it is a footgun rather than a feature.
 -- `finEquiv` above stays computable, which is what callers actually want.
-noncomputable instance : Fintype (Hex.GF2n n irr hn hn64 hirr) :=
+noncomputable instance instFintype : Fintype (Hex.GF2n n irr hn hn64 hirr) :=
   Fintype.ofEquiv (Fin (2 ^ n)) (finEquiv (n := n) (irr := irr)
     (hn := hn) (hn64 := hn64) (hirr := hirr)).symm
 
@@ -437,12 +449,15 @@ def reducedPackedRepOfIndex (i : Fin (2 ^ f.degree)) : ReducedPackedRep f :=
   ⟨HexGF2Mathlib.GF2Poly.ofNatBelowDegree f.degree i.1,
     HexGF2Mathlib.GF2Poly.ofNatBelowDegree_reduced f.degree i⟩
 
+/-- Decoding a bounded index and re-encoding it returns the index. -/
 @[simp, grind =]
 theorem reducedPackedRepIndex_ofIndex (i : Fin (2 ^ f.degree)) :
     reducedPackedRepIndex (f := f) (reducedPackedRepOfIndex (f := f) i) = i := by
   apply Fin.ext
   exact HexGF2Mathlib.GF2Poly.toNat_ofNatBelowDegree f.degree i
 
+/-- Encoding a reduced representative and decoding it returns the
+representative. -/
 @[simp, grind =]
 theorem reducedPackedRepOfIndex_index (x : ReducedPackedRep f) :
     reducedPackedRepOfIndex (f := f) (reducedPackedRepIndex (f := f) x) = x := by
@@ -517,9 +532,8 @@ def ofGeneric (x : GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)) :
 
 /-- `FpPoly.degree` of a transported packed polynomial equals its packed degree. -/
 theorem degree_toFpPoly (q : Hex.GF2Poly) :
-    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) = q.degree := by
-  unfold Hex.FpPoly.degree Hex.GF2Poly.degree
-  rw [HexGF2Mathlib.GF2Poly.degree?_toFpPoly]
+    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) = q.degree :=
+  _root_.HexGF2Mathlib.degree_toFpPoly q
 
 /-- **Reduction-compatibility bridge.** Packed remainder reduction modulo `f`
 transports across the `GF2Poly ≃+* FpPoly 2` conversion layer to the generic
@@ -529,29 +543,8 @@ already-proved packed-level ring equivalence. -/
 theorem toFpPoly_reduceMod (p g : Hex.GF2Poly) (hgdeg : 0 < g.degree) :
     HexGF2Mathlib.GF2Poly.toFpPoly (p % g) =
       Hex.GFqRing.reduceMod (HexGF2Mathlib.GF2Poly.toFpPoly g)
-        (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
-  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two
-  have hgne : g ≠ 0 := by
-    intro h; rw [h] at hgdeg; simp [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] at hgdeg
-  have hgdeg' : 0 < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
-    rw [degree_toFpPoly]; exact hgdeg
-  have hdeglt :
-      Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly (p % g)) <
-        Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
-    rw [degree_toFpPoly, degree_toFpPoly]
-    rcases Hex.GF2Poly.mod_degree_lt p g hgne with hz | hlt
-    · rw [Hex.GF2Poly.eq_zero_of_isZero hz]
-      simpa [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] using hgdeg
-    · exact hlt
-  have heucl :
-      HexGF2Mathlib.GF2Poly.toFpPoly p =
-        HexGF2Mathlib.GF2Poly.toFpPoly (p % g) +
-          HexGF2Mathlib.GF2Poly.toFpPoly (p / g) * HexGF2Mathlib.GF2Poly.toFpPoly g := by
-    conv_lhs => rw [← Hex.GF2Poly.div_mul_add_mod p g]
-    rw [HexGF2Mathlib.GF2Poly.toFpPoly_add, HexGF2Mathlib.GF2Poly.toFpPoly_mul,
-      Hex.FpPoly.add_comm]
-  rw [heucl, Hex.GFqRing.reduceMod_add_mul_self_right _ hgdeg']
-  exact (Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ hdeglt).symm
+        (HexGF2Mathlib.GF2Poly.toFpPoly p) :=
+  _root_.HexGF2Mathlib.toFpPoly_reduceMod p g hgdeg
 
 /-- Equality of generic finite-field elements from equality of canonical
 representatives. -/
@@ -566,7 +559,6 @@ model is simply its packed value, transported to `FpPoly 2`. -/
 theorem repr_toGeneric (x : Hex.GF2nPoly f hirr) :
     Hex.GFqField.repr (toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x) =
       HexGF2Mathlib.GF2Poly.toFpPoly x.val := by
-  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two
   unfold toGeneric
   rw [Hex.GFqField.repr_ofPoly]
   apply Hex.GFqRing.reduceMod_eq_self_of_degree_lt
@@ -578,6 +570,8 @@ theorem repr_toGeneric (x : Hex.GF2nPoly f hirr) :
     simpa [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] using hdeg
   · exact hlt
 
+/-- Embedding a packed residue in the generic model and repacking recovers it:
+the packed value is already reduced modulo `f`. -/
 @[simp, grind =]
 theorem ofGeneric_toGeneric (x : Hex.GF2nPoly f hirr) :
     ofGeneric (f := f) (hirr := hirr) (hdeg := hdeg)
@@ -588,11 +582,11 @@ theorem ofGeneric_toGeneric (x : Hex.GF2nPoly f hirr) :
   rw [Hex.GF2nPoly.reducePoly_val_eq_mod]
   exact Hex.GF2Poly.mod_eq_self_of_reduced x.val f x.val_reduced
 
+/-- Repacking a generic element and re-embedding recovers it. -/
 @[simp, grind =]
 theorem toGeneric_ofGeneric (x : GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg)
       (ofGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x) = x := by
-  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two
   apply eq_of_repr_eq
   rw [repr_toGeneric]
   unfold ofGeneric
@@ -601,6 +595,7 @@ theorem toGeneric_ofGeneric (x : GenericFiniteField (f := f) (hirr := hirr) (hde
   exact Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _
     (Hex.GFqField.degree_repr_lt_degree x)
 
+/-- The packed-quotient embedding is additive. -/
 @[simp, grind =]
 theorem toGeneric_add (x y : Hex.GF2nPoly f hirr) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) (x + y) =
@@ -611,6 +606,7 @@ theorem toGeneric_add (x y : Hex.GF2nPoly f hirr) :
     Hex.GF2nPoly.add_val, toFpPoly_reduceMod _ _ hdeg, HexGF2Mathlib.GF2Poly.toFpPoly_add,
     show modulusFpPoly (f := f) = HexGF2Mathlib.GF2Poly.toFpPoly f from rfl]
 
+/-- The packed-quotient embedding is multiplicative. -/
 @[simp, grind =]
 theorem toGeneric_mul (x y : Hex.GF2nPoly f hirr) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) (x * y) =
@@ -640,7 +636,7 @@ def finEquiv : Hex.GF2nPoly f hirr ≃ Fin (2 ^ f.degree) :=
 
 -- `noncomputable` for the same reason, and more sharply: a GHASH-sized
 -- modulus puts `2 ^ 128` elements behind `Finset.univ`.
-noncomputable instance : Fintype (Hex.GF2nPoly f hirr) :=
+noncomputable instance instFintype : Fintype (Hex.GF2nPoly f hirr) :=
   Fintype.ofEquiv (Fin (2 ^ f.degree)) (finEquiv (f := f) (hirr := hirr)).symm
 
 /-- The packed quotient by `f` has `2 ^ deg f` elements, counted through its

--- a/HexManual/Chapters/HexGF2.lean
+++ b/HexManual/Chapters/HexGF2.lean
@@ -452,7 +452,7 @@ Where `HexGF2` fits in the executable DAG:
   which unpacks `GF2Poly` into the generic `FpPoly 2` representation,
   identifies both `GF2n` and `GF2nPoly` with the quotient-field
   construction from {ref "hex-gfq-field"}[`HexGFqField`], and carries the
-  finiteness and cardinality results for the packed types. Nothing in
-  this chapter depends on it: the packed arithmetic, the Euclidean
-  algorithms, and the Rabin certificates above are all executable and
-  Mathlib-free.
+  finiteness and cardinality results for the packed types. The
+  executable API documented above does not depend on it: the packed
+  arithmetic, the Euclidean algorithms, and the Rabin certificates are
+  all executable and Mathlib-free.

--- a/libraries.yml
+++ b/libraries.yml
@@ -511,7 +511,7 @@ libraries:
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGFqField, HexPolyFpMathlib]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexGFqMathlib:
     deps: [HexGFq, HexGF2Mathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -511,7 +511,7 @@ libraries:
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGFqField, HexPolyFpMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexGFqMathlib:
     deps: [HexGFq, HexGF2Mathlib]

--- a/progress/20260822T031916Z_gf2-mathlib-phase-6-7.md
+++ b/progress/20260822T031916Z_gf2-mathlib-phase-6-7.md
@@ -1,0 +1,66 @@
+# HexGF2Mathlib Phase 6 and Phase 7
+
+## Accomplished
+
+**Phase 6 (proof polishing), `done_through` 5 → 6.**
+
+- Repaired the garbled `GF2nPoly.field` docstring in
+  `HexGF2Mathlib/Algebra.lean`; the sentence now says what is true, that the
+  committed `PackedGF2Entry` instances in `hex-gfq` carry `degree_pos`.
+- Gave `GF2Poly.toNat` its own docstring; the text it wanted had been left on
+  the private `wordsToNatAux` helper, which now describes the place-value fold
+  it actually performs.
+- Documented every public theorem the library exports. Mathlib's `docBlameThm`
+  reported 23 undocumented theorems before and reports none after.
+- Deduplicated two proofs that existed twice. `degree_toFpPoly` and the packed-
+  remainder transport are now single private theorems at `HexGF2Mathlib`
+  namespace level; the public `GF2nPoly.degree_toFpPoly` and
+  `GF2nPoly.toFpPoly_reduceMod` keep their names and delegate. The
+  `PrimeModulus 2` instance moved up beside them, which made two `letI`
+  re-derivations of it redundant.
+- Removed the unused `universe u v w` and two unreferenced private helpers
+  (`div_word_testBit`, `word_shift_testBit_eq_false_of_next_le`).
+- Named the two `Fintype` instances and the `PrimeModulus 2` instance so the
+  `defsWithUnderscore` linter is clean.
+- Demoted `equivPolynomial_apply` from `@[simp]` (it keeps `@[grind =]`) so
+  `coeff_equivPolynomial` is reachable as the coefficient normal form;
+  `simpNF` had flagged it as shadowed.
+- Adjudicated the zero-reference public lemmas rather than deleting them:
+  `toFpPoly_one`, `ofFpPoly_zero`, `equiv_apply`, `equiv_symm_apply`, and
+  `equivPolynomial_symm_apply` are `@[simp, grind =]` members of complete API
+  families (zero/one normalization; the apply/symm-apply pair for each
+  equivalence), so they stay.
+- The performance-regression exit criterion does not apply: the library's own
+  SPEC declares it a `correspondence-only-layer` with no external comparator,
+  and it ships no bench or conformance target. No `native_decide`, no `axiom`,
+  no `sorry`. Its irreducibility claim is `GF2Poly.irreducible_toFpPoly`, which
+  transports `hex-gf2`'s Lean-checked certificates rather than trusting an
+  oracle.
+
+**Phase 7 (user-facing documentation), `done_through` 6 → 7.**
+
+The deliverable already existed: the `# The Mathlib correspondence` section
+(tag `hex-gf2-mathlib`) in `HexManual/Chapters/HexGF2.lean`. Verified it still
+elaborates after the Phase 6 edits, which matters because it pulls eleven
+docstrings out of this library, one of which (`GF2nPoly.field`) changed.
+`HexGF2Mathlib` is not in `scripts/release/released.yml`, so
+`PLAN/Phase7.md`'s released-repo README requirement does not apply and
+`HexGF2Mathlib/README.md` is correctly absent.
+
+## Current frontier
+
+`libraries.yml` records `HexGF2Mathlib.done_through: 7`. `check_dag.py`,
+`check_phase7.py`, and `check_manual_split.py` all pass. Mathlib's `#lint`
+(14 default linters plus `docBlameThm`) reports 0 errors in 72 declarations.
+
+## Next step
+
+`HexGFqMathlib` is already at 7, so nothing downstream is unblocked by this.
+The `.claude/skills/hex-lean-mathlib-boundary` skill still claims (around line
+676) that `HexGF2Mathlib` declares its own `RingEquiv`/`TypeEquiv` shadowing
+Mathlib's; that has not been true since the library moved to Mathlib's `≃+*`,
+and the note should be corrected or dropped.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR take `HexGF2Mathlib` from `done_through: 5` to `7`. It repairs the garbled `GF2nPoly.field` docstring, documents every public theorem the library exports, moves the `toNat` docstring off the private word-fold helper onto `toNat` itself, and drops an unused `universe` declaration together with two unreferenced private helpers.

Two proofs existed twice. `degree_toFpPoly` and the packed-remainder transport now live once each as private theorems at `HexGF2Mathlib` namespace level; the public `GF2nPoly.degree_toFpPoly` and `GF2nPoly.toFpPoly_reduceMod` keep their names and delegate, and the `PrimeModulus 2` instance moves up beside them, which retires two `letI` re-derivations of it.

Mathlib's `#lint` reported four findings this closes: two `Fintype` instances carrying generated names with underscores, now named; `toNat` missing a docstring; and `coeff_equivPolynomial` shadowed in the simp set by `equivPolynomial_apply`, which is demoted to `@[grind =]` so the coefficient normal form is reachable. The full default suite plus `docBlameThm` now reports 0 errors in 72 declarations. The zero-reference `@[simp]` lemmas that survive complete API families rather than being dead code, and stay.

Phase 7 needs no new prose: `scripts/check_phase7.py` requires a `mathlib: true` companion's correspondence to sit in its computational partner's chapter, and the `# The Mathlib correspondence` section of `HexManual/Chapters/HexGF2.lean` already provides it. It pulls eleven docstrings out of this library, so `lake build HexManual` is the check that the Phase 6 edits left it intact; it is green. One stale sentence in that chapter claiming nothing in it depends on `HexGF2Mathlib` is corrected to scope the claim to the executable API. `HexGF2Mathlib` is not yet listed in `scripts/release/released.yml`, so the released-repo README obligation does not apply to this PR.

🤖 Prepared with Claude Code
