### PR TITLE
feat(interval): adapt executable assemblies to controller facts

### DIFF
--- a/HexInterval/Executable.lean
+++ b/HexInterval/Executable.lean
@@ -739,16 +739,6 @@ opaque OfferContext.offers [DecidableEq Fact] (context : OfferContext Fact Resul
     (request : RuleRequest Fact) : Bool :=
   offersChecked context.assembly context.snapshot { request with program := context.program }
 
-/-- Authenticate a standalone snapshot/request and ask the exact routed
-handler whether it is currently applicable. Controllers enumerating a whole
-assembly should construct one `OfferContext` and reuse its checked path, so
-whole snapshot/program validation is paid once rather than once per row. -/
-opaque Assembly.offers [DecidableEq Fact] (assembly : Assembly Fact Result)
-    (snapshot : Snapshot Fact) (request : RuleRequest Fact) : Bool :=
-  match assembly.offerContext? snapshot request.program with
-  | none => false
-  | some context => context.offers request
-
 /-- Execute the exact handler selected by an authenticated application row.
 The request must repeat the assembled operation/node program and every
 application-owned action field. Program version and generation side tables in

--- a/HexInterval/Executable.lean
+++ b/HexInterval/Executable.lean
@@ -156,6 +156,12 @@ structure Measure (Cache Result : Type) where
 /-- One registration and the only callback allowed to interpret its rule key. -/
 structure Handler (Fact Result Cache : Type) where
   registration : Registration
+  /-- Cache-independent applicability check for one exact reconstructed
+  application request and its authenticated whole-state snapshot. It may veto
+  an offer but cannot choose the compact application identity, route, ports,
+  ordering, or theorem schema. The whole snapshot is scheduler data only; the
+  invocation callback still receives just its declared fact inputs. -/
+  offers : Snapshot Fact → RuleRequest Fact → Bool := fun _ _ => true
   invoke : Cache → RuleRequest Fact → Plan Result × Cache
   /-- Package-owned semantic veto for a structurally valid scoped binding.
   Local registrations do not call this hook. -/
@@ -608,6 +614,32 @@ opaque Assembly.extendWithin (limits : Limits) (assembly : Assembly Fact Result)
 private def quoteCells (quotes : Array Quote) : Nat :=
   quotes.foldl (fun total quote => total + quote.body.length) 0
 
+/-- Resolve the immutable replay formats owned by one exact flattened rule.
+This projection preserves the sealed route/package/handler correspondence while
+letting a theorem companion check format coverage without eliminating the
+package's private cache type. -/
+opaque Registry.formats? (registry : Registry Fact Result) (rule : RuleId) :
+    Option (RuleKey × Array ReplayFormat) :=
+  match registry.registrations[rule.index]?, registry.routes[rule.index]? with
+  | some registration, some route => match registry.packages[route.package]? with
+    | none => none
+    | some package => match package.handlers[route.handler]? with
+      | none => none
+      | some handler =>
+          if registration.same handler.registration then
+            some (registration.key, handler.formats)
+          else none
+  | _, _ => none
+
+/-- Count the exact routed replay-format table, failing closed if a supposedly
+sealed route can no longer be resolved. -/
+opaque Registry.formatCount? (registry : Registry Fact Result) : Option Nat := do
+  let mut count := 0
+  for index in [0:registry.registrations.size] do
+    let (_, formats) ← registry.formats? { index }
+    count := count + formats.size
+  pure count
+
 private def validateQuotes (limits : Limits) (rule : RuleKey)
     (formats : Array ReplayFormat) (quotes : Array Quote) : Except Error Unit := do
   if limits.maxQuotes < quotes.size then throw (.resource .quotes)
@@ -620,6 +652,37 @@ private def validateQuotes (limits : Limits) (rule : RuleKey)
       | throw (.undeclaredFormat { rule, role := quote.role, schema := quote.schema })
     if !format.accepts quote then
       throw (.invalidBody { rule, role := quote.role, schema := quote.schema })
+
+/-- Ask the exact routed handler whether a controller-reconstructed request is
+currently applicable. Every application, program, registration, and route
+field is authenticated before the package-owned predicate is entered. The
+predicate is scheduler data only and carries no mutation or theorem authority. -/
+opaque Assembly.offers [DecidableEq Fact] (assembly : Assembly Fact Result)
+    (snapshot : Snapshot Fact) (request : RuleRequest Fact) : Bool :=
+  if !snapshot.check assembly.program ||
+      request.program.operations != assembly.program.operations ||
+      request.program.nodes != assembly.program.nodes then false
+  else
+    let id := request.action.application
+    match assembly.applications[id.index]? with
+    | none => false
+    | some application =>
+        if request.action.rule != application.rule || !application.accepts id request.action then
+          false
+        else match assembly.registry.registrations[application.rule.index]? with
+          | none => false
+          | some registration =>
+              if !RuleRequest.accepts registration request || request.inputs.any (fun input =>
+                  snapshot.fact? input.node != some input.fact ||
+                    snapshot.version? input.node != some input.version) then false
+              else match assembly.registry.routes[application.rule.index]? with
+                | none => false
+                | some route => match assembly.registry.packages[route.package]? with
+                  | none => false
+                  | some package => match package.handlers[route.handler]? with
+                    | none => false
+                    | some handler =>
+                        registration.same handler.registration && handler.offers snapshot request
 
 /-- Execute the exact handler selected by an authenticated application row.
 The request must repeat the assembled operation/node program and every

--- a/HexInterval/Executable.lean
+++ b/HexInterval/Executable.lean
@@ -653,36 +653,101 @@ private def validateQuotes (limits : Limits) (rule : RuleKey)
     if !format.accepts quote then
       throw (.invalidBody { rule, role := quote.role, schema := quote.schema })
 
-/-- Ask the exact routed handler whether a controller-reconstructed request is
-currently applicable. Every application, program, registration, and route
-field is authenticated before the package-owned predicate is entered. The
-predicate is scheduler data only and carries no mutation or theorem authority. -/
+private def requestAcceptsChecked (registration : Registration)
+    (request : RuleRequest Fact) : Bool :=
+  if request.program.programVersion != request.action.programVersion then false
+  else match request.program.node? request.action.node with
+    | none => false
+    | some anchor =>
+        let inputNodes := request.inputs.map (fun input => input.node)
+        let seen := request.inputs.map fun input =>
+          { node := input.node, version := input.version : SeenVersion }
+        let common := registration.key == request.action.key &&
+          registration.kind == request.action.kind &&
+          request.program.operationKey? request.action.node == some registration.head &&
+          request.action.inputs == seen && request.action.writes == request.writes &&
+          match registration.matchWatch with
+          | .none =>
+              request.action.structuralInputs.isEmpty && request.action.matcherEpoch.isNone
+          | .network =>
+              !request.action.structuralInputs.isEmpty && request.action.matcherEpoch.isSome
+        common && match registration.binding with
+          | .local =>
+              Slot.resolveAll? request.action.node anchor registration.watches ==
+                  some inputNodes &&
+                Slot.resolveAll? request.action.node anchor registration.writes ==
+                  some request.writes
+          | .scoped =>
+              registration.watches.isEmpty && registration.writes.isEmpty &&
+                allDistinct inputNodes && allDistinct request.writes &&
+                inputNodes.all (fun node => (request.program.node? node).isSome) &&
+                request.writes.all (fun node => (request.program.node? node).isSome)
+          | .global =>
+              registration.watches.isEmpty && registration.writes.isEmpty &&
+                inputNodes.isEmpty && request.writes.isEmpty
+
+private def offersChecked [DecidableEq Fact] (assembly : Assembly Fact Result)
+    (snapshot : Snapshot Fact) (request : RuleRequest Fact) : Bool :=
+  let id := request.action.application
+  match assembly.applications[id.index]? with
+  | none => false
+  | some application =>
+      if request.action.rule != application.rule || !application.accepts id request.action then
+        false
+      else match assembly.registry.registrations[application.rule.index]? with
+        | none => false
+        | some registration =>
+            if !requestAcceptsChecked registration request || request.inputs.any (fun input =>
+                snapshot.fact? input.node != some input.fact ||
+                  snapshot.version? input.node != some input.version) then false
+            else match assembly.registry.routes[application.rule.index]? with
+              | none => false
+              | some route => match assembly.registry.packages[route.package]? with
+                | none => false
+                | some package => match package.handlers[route.handler]? with
+                  | none => false
+                  | some handler =>
+                      registration.same handler.registration && handler.offers snapshot request
+
+/-- One sealed, checked snapshot/program context for a complete offer-generation
+pass. Its constructor is private so package predicates can be entered through
+the cheaper per-application path only after the shared whole-state checks. -/
+structure OfferContext (Fact Result : Type) where
+  private mk ::
+  assembly : Assembly Fact Result
+  snapshot : Snapshot Fact
+  program : ProgramView
+
+/-- Authenticate the common snapshot and program view once before enumerating
+an assembly's applications. Program version remains controller-owned; the
+per-request check requires it to agree with each reconstructed action. -/
+opaque Assembly.offerContext? [DecidableEq Fact] (assembly : Assembly Fact Result)
+    (snapshot : Snapshot Fact) (program : ProgramView) : Option (OfferContext Fact Result) :=
+  if !snapshot.check assembly.program ||
+      program.operations != assembly.program.operations ||
+      program.nodes != assembly.program.nodes ||
+      program.generations.size != program.nodes.size ||
+      assembly.program.depths? != some program.depths then none
+  else some { assembly, snapshot, program }
+
+/-- Ask the exact routed handler whether one reconstructed application is
+currently applicable inside an already checked generation pass. The handler
+receives the context's authenticated program rather than caller-supplied
+program arrays. The predicate is scheduler data only and carries no mutation
+or theorem authority. -/
+opaque OfferContext.offers [DecidableEq Fact] (context : OfferContext Fact Result)
+    (request : RuleRequest Fact) : Bool :=
+  offersChecked context.assembly context.snapshot { request with program := context.program }
+
+/-- Authenticate a standalone snapshot/request and ask the exact routed
+handler whether it is currently applicable. Controllers enumerating a whole
+assembly should construct one `OfferContext` and reuse its checked path, so
+whole snapshot/program validation is paid once rather than once per row. -/
 opaque Assembly.offers [DecidableEq Fact] (assembly : Assembly Fact Result)
     (snapshot : Snapshot Fact) (request : RuleRequest Fact) : Bool :=
-  if !snapshot.check assembly.program ||
-      request.program.operations != assembly.program.operations ||
-      request.program.nodes != assembly.program.nodes then false
-  else
-    let id := request.action.application
-    match assembly.applications[id.index]? with
-    | none => false
-    | some application =>
-        if request.action.rule != application.rule || !application.accepts id request.action then
-          false
-        else match assembly.registry.registrations[application.rule.index]? with
-          | none => false
-          | some registration =>
-              if !RuleRequest.accepts registration request || request.inputs.any (fun input =>
-                  snapshot.fact? input.node != some input.fact ||
-                    snapshot.version? input.node != some input.version) then false
-              else match assembly.registry.routes[application.rule.index]? with
-                | none => false
-                | some route => match assembly.registry.packages[route.package]? with
-                  | none => false
-                  | some package => match package.handlers[route.handler]? with
-                    | none => false
-                    | some handler =>
-                        registration.same handler.registration && handler.offers snapshot request
+  match assembly.offerContext? snapshot request.program with
+  | none => false
+  | some context => context.offers request
 
 /-- Execute the exact handler selected by an authenticated application row.
 The request must repeat the assembled operation/node program and every

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -110,8 +110,11 @@ recipe data together. It can advance root and child-local fact histories before
 splitting or settling. The supported explicit controller aligns fact-event
 runtime and proof registries, regenerates bounded deterministic offer
 snapshots, and iterates a replaceable policy over the sealed tree/session
-bundle. Its executable adapter consumes the sealed Mathlib-free package
-assembly directly: package predicates decide applicability, while the
+bundle. Its explicit `Controller.Package` conformance route still uses toy
+fact-event callbacks and autonomous application generators; it has no concrete
+built-in arithmetic package. Built-in arithmetic reaches the controller only
+through its executable adapter. That route consumes the sealed Mathlib-free
+package assembly directly: package predicates decide applicability, while the
 assembly/controller derives exact flat application identity, routes, ports,
 order, and action chronology. It derives accepted updates and fact events from
 the authenticated Search request and current snapshot; raw
@@ -5323,6 +5326,14 @@ candidates, and `b` the number of live branch states.
   reference cost. This is not an incremental tree-store bound. `maxNodes`
   therefore stays small and measurement-gated until a production
   representation avoids repeated full-prefix validation.
+- One `Controller.Executable` offer regeneration reconstructs and validates
+  the retained branch snapshot and executable program context once. It then
+  scans the flat applications with per-row identity, port, registration,
+  route, fact/version, and package-predicate work. Its local generation cost
+  is therefore one whole-branch/program check plus the sum of bounded
+  application checks, not one whole-branch/program check per application.
+  Subsequent `Search.Session` start or refresh still performs its own
+  independent complete session authentication.
 - Fact comparison and contradiction checks use exact endpoint comparison. For
   the dyadic candidate, integer cost is proportional to effective endpoint
   height and the permitted exponent-alignment shift; a rational candidate must
@@ -5432,7 +5443,10 @@ their declared cost inside a scheduler bound.
   registry key is a
   trusted compatibility epoch, not callback-object identity: same-key
   assemblies deliberately declare replaceable implementations whose results
-  still cross the runtime and proof checks. `Controller.Executable` additionally
+  still cross the runtime and proof checks. This explicit `Controller.Package`
+  route still has toy fact-event callbacks and autonomous generators in its
+  conformance; concrete built-in arithmetic enters only through
+  `Controller.Executable`. That adapter additionally
   consumes a sealed `Executable.Assembly` without a caller-supplied application
   table. It derives action fields, fact versions, installed meets, assumptions,
   event scope, and `Proof.Key` addresses from the authenticated request and

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3208,7 +3208,9 @@ quotation/schema checks accept the transition. Assembly owns only the
 operation/node program: request
 program version and generation side tables remain controller-owned snapshot
 data and receive only the request-internal checks supplied by `ProgramView` and
-`RuleRequest`.
+`RuleRequest`. Search also never decrements its `remaining` budget view; the
+adapter preserves the controller-owned value stored in the session when it
+refreshes executable offers.
 
 As with Search, sealing is an ordinary/public-import boundary. Deliberate
 `import all HexInterval.Executable` exposes its private constructors to trusted
@@ -5454,10 +5456,15 @@ their declared cost inside a scheduler bound.
   bidirectional executable-format/proof-schema coverage, and a successful
   package decoder before Driver acceptance; later Proof replay independently
   invokes the theorem schema. Same-key registry substitution does not
-  transplant the sticky assembly cache. This adapter is deliberately
-  fact-only: typed equality and instance events, refutation, split outcomes,
-  automatic discovery, program extension, and split-search tactic syntax
-  remain later work. All offers in one immutable
+  transplant the sticky assembly cache. Its application-id and rule-key policy
+  costs are adapter-fixed; the caller supplies only policy-state measurement.
+  Domain `NarrowResult.resourceLimit budget` maps to the distinct
+  `Controller.Resource.narrow budget` refusal before retaining any update,
+  rather than collapsing into `noChange` or mismatch. This adapter is
+  deliberately fact-only, and its `Run` exposes only a resumable stopped
+  result: typed equality and instance events, target/refutation/split/unknown
+  terminal correlation, automatic discovery, program extension, and
+  split-search tactic syntax remain later work. All offers in one immutable
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
   offer sets a controller-owned incomplete bit which survives later accepted

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -107,22 +107,23 @@ leaves, and joins siblings only through the exact cover. The supported
 one-step driver now invokes an already-selected authenticated package callback
 and transactionally retains its exact runtime command and separately checked
 recipe data together. It can advance root and child-local fact histories before
-splitting or settling. The supported explicit controller aligns a stable
-fact-event application table with same-order runtime and proof registries,
-regenerates bounded deterministic offer snapshots, and iterates a replaceable
-policy over the sealed tree/session bundle. Its current end-to-end conformance
-uses toy fact-event callbacks: concrete built-in arithmetic `Driver.Package`
-callbacks and application generators have not yet been supplied. Invoking this
-path from the public tactic remains later controller work. The Mathlib-free
-executable layer separately supports explicit stable-key package assembly,
-private caches, exact routes and concrete local/scoped application rows, with
-bounded raw replay-format declarations that do not embed a Mathlib proof event.
+splitting or settling. The supported explicit controller aligns fact-event
+runtime and proof registries, regenerates bounded deterministic offer
+snapshots, and iterates a replaceable policy over the sealed tree/session
+bundle. Its executable adapter consumes the sealed Mathlib-free package
+assembly directly: package predicates decide applicability, while the
+assembly/controller derives exact flat application identity, routes, ports,
+order, and action chronology. It derives accepted updates and fact events from
+the authenticated Search request and current snapshot; raw
+`(role, schema, body)` quotations remain inert and receive no theorem
+authority. Built-in addition and an independently owned arbitrary-function
+package exercise this path through separate Proof replay. Invoking it from the
+public tactic remains later controller work.
 The first concrete supported theorem registry is the Mathlib arithmetic package for one
 configured constant and natural exponent plus public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. Automatic arbitrary-function package
-discovery and theorem assembly, concrete built-in arithmetic callback packages
-and application generators, equality/instance runtime events, executable
+discovery and theorem assembly, equality/instance runtime events, executable
 program extension, concrete policy algorithms and default scheduling, payload
 storage, and the optimized backing store remain experimental. The narrow
 direct-forward tactic does not yet invoke the supported controller.
@@ -3193,13 +3194,15 @@ independently checking the action's rule key and local rule id, anchor,
 operation, kind, reads, writes, and structural inputs. A callback must not use
 the compact application id as authority for a rule or anchor. Retaining and
 checking the exact application table is not part of the Search contract. The
-separate supported `Executable.Assembly` now seals a checked program, exact
+separate supported `Executable.Assembly` seals a checked program, exact
 package routes/caches, bindings, and concrete application rows, and its
 `invokeWithin` rechecks the selected identifier against the row's rule, anchor,
 kind, reads, writes, structural inputs, matcher epoch, effort, and creation
-generation before routing a callback. The current one-step Driver does not yet
-own that assembly, so autonomous Search-to-package correspondence remains the
-next controller edge. Assembly owns only the operation/node program: request
+generation before routing a callback. `Controller.Executable` now retains that
+assembly as a sticky handle, generates offers from its exact row order, and
+passes a replacement private cache onward only after Search, Driver, and
+quotation/schema checks accept the transition. Assembly owns only the
+operation/node program: request
 program version and generation side tables remain controller-owned snapshot
 data and receive only the request-internal checks supplied by `ProgramView` and
 `RuleRequest`.
@@ -5401,7 +5404,8 @@ their declared cost inside a scheduler bound.
   registry; `import all HexIntervalMathlib.Proof` is a trusted-internals escape
   hatch rejected outside the exact empty repository allowlist. The built-in
   arithmetic package and direct-forward reifier/tactic are supported below;
-  arbitrary-function theorem packages, executable-to-proof quotation,
+  explicit arbitrary-function fact packages can join the executable adapter,
+  while automatic discovery, equality/instance executable correlation,
   split-search tactic integration, and default registries remain experimental.
 - `HexIntervalMathlib/Driver.lean`: supported one-step execution of an exact
   already-selected package action, atomic retained-source advancement/split/
@@ -5428,12 +5432,18 @@ their declared cost inside a scheduler bound.
   registry key is a
   trusted compatibility epoch, not callback-object identity: same-key
   assemblies deliberately declare replaceable implementations whose results
-  still cross the runtime and proof checks. Automatic discovery,
-  program extension, equality/instance runtime events, wiring the supported
-  Mathlib-free executable assembly into this controller, concrete built-in
-  arithmetic driver callbacks/application generators, and split-search tactic
-  syntax remain later work; the current
-  autonomous theorem uses toy fact-event packages. All offers in one immutable
+  still cross the runtime and proof checks. `Controller.Executable` additionally
+  consumes a sealed `Executable.Assembly` without a caller-supplied application
+  table. It derives action fields, fact versions, installed meets, assumptions,
+  event scope, and `Proof.Key` addresses from the authenticated request and
+  exact invocation route. It requires one fact quote per proposal, exact
+  bidirectional executable-format/proof-schema coverage, and a successful
+  package decoder before Driver acceptance; later Proof replay independently
+  invokes the theorem schema. Same-key registry substitution does not
+  transplant the sticky assembly cache. This adapter is deliberately
+  fact-only: typed equality and instance events, refutation, split outcomes,
+  automatic discovery, program extension, and split-search tactic syntax
+  remain later work. All offers in one immutable
   snapshot share its controller-owned serial as age. A malformed generator
   draft aborts the whole regeneration transaction. Dismissing a non-split
   offer sets a controller-owned incomplete bit which survives later accepted
@@ -5497,10 +5507,14 @@ their declared cost inside a scheduler bound.
   explicit stable-key operations, registrations, heterogeneous private package
   caches, exact handler routes, scoped/local application rows, package-owned
   logical measures, and bounded raw `(role, schema, body)` replay quotations.
-  Invocation rechecks complete application/request correspondence and commits
+  Package-owned, cache-independent applicability predicates receive an
+  authenticated snapshot and exact reconstructed request but carry no mutation
+  or theorem authority. Invocation rechecks complete application/request
+  correspondence and commits
   a cache replacement only after result and quotation admission. The initial
-  compiler does not create global structural-matcher applications; offer
-  generation and theorem-event correlation remain later layers.
+  compiler does not create global structural-matcher applications. Fact-event
+  correlation is supplied by `HexIntervalMathlib.Controller.Executable`; typed
+  equality/instance correlation remains later work.
 - `HexInterval/Trace.lean`: supported exact fact/instance chronology and
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -567,8 +567,10 @@ inductive AppliedStep (Fact Cause OfferId SemanticKey : Type)
   | stopped (stop : Stop Unit Unit) (session : Session Fact Cause OfferId SemanticKey)
 
 /-- A payload callback is not executed when the authenticated session has
-already exhausted its step budget. -/
-inductive Invocation (Fact Cause OfferId SemanticKey Payload : Type)
+already exhausted its step budget. The payload universe is unrestricted so a
+sealed heterogeneous package handle can be returned without exposing its
+private component type. -/
+inductive Invocation.{u} (Fact Cause OfferId SemanticKey : Type) (Payload : Type u)
   | produced (step : AppliedStep Fact Cause OfferId SemanticKey) (payload : Payload)
   | stopped (stop : Stop Unit Unit) (session : Session Fact Cause OfferId SemanticKey)
 
@@ -731,7 +733,7 @@ selected request, then validate its reply while retaining the caller payload
 returned by that same invocation. Callback and payload construction remain
 non-preemptible; no returned value has mutation or proof authority before the
 checks complete. -/
-opaque invokeWithWithin [DecidableEq Fact] [DecidableEq Cause]
+opaque invokeWithWithin.{u} {Payload : Type u} [DecidableEq Fact] [DecidableEq Cause]
     [DecidableEq OfferId] [DecidableEq SemanticKey] (envelope : Envelope)
     (measure : Policy.Measure OfferId SemanticKey)
     (owner : RuleKey)
@@ -739,15 +741,20 @@ opaque invokeWithWithin [DecidableEq Fact] [DecidableEq Cause]
       Reply Fact Cause OfferId SemanticKey × Payload)
     (session : Session Fact Cause OfferId SemanticKey)
     (decision : Policy.Decision OfferId SemanticKey) :
-    Except Error (Invocation Fact Cause OfferId SemanticKey Payload) := do
-  let checked <- authenticate envelope measure session
-  let request <- prepareChecked session checked decision
-  if request.action.key != owner then throw .invalidSession
-  if session.steps >= envelope.search.maxSteps then
-    return .stopped (.resource .steps) session
-  let (reply, payload) := callback request
-  let step <- acceptAppliedChecked envelope session request reply
-  pure (.produced step payload)
+    Except Error (Invocation Fact Cause OfferId SemanticKey Payload) :=
+  match authenticate envelope measure session with
+  | .error error => .error error
+  | .ok checked => match prepareChecked session checked decision with
+    | .error error => .error error
+    | .ok request =>
+      if request.action.key != owner then .error .invalidSession
+      else if session.steps >= envelope.search.maxSteps then
+        .ok (.stopped (.resource .steps) session)
+      else
+        let (reply, payload) := callback request
+        match acceptAppliedChecked envelope session request reply with
+        | .error error => .error error
+        | .ok step => .ok (.produced step payload)
 
 /-- Invoke an arbitrary callback and then pass its decoded result through
 `acceptWithin`. Callback execution itself is deliberately non-preemptible and

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexIntervalMathlib.Driver
+public import HexInterval.Executable
 
 @[expose] public section
 
@@ -39,14 +40,14 @@ head and scope are unchanged. Pure Lean values may be reused to explore
 alternative bounded successors. This is not a global or process-persistent
 budget, nor does restarting inherit any proof-closure or saturation claim.
 
-This is the supported autonomous programmatic loop.  Goal reification and the
+This is the supported autonomous programmatic loop. Goal reification and the
 public tactic currently use the separate flat forward path; split-search tactic
-integration remains a later edge.  The current runtime driver accepts fact
-events only.  The shipped vertical uses toy fact-event callbacks; concrete
-built-in arithmetic `Driver.Package` callbacks and application generators are
-not yet supplied. Mathlib-free raw package drafts, equality/instance actions,
-program-extension discovery, and automatic package discovery remain later
-interfaces; this module assembles an explicit Mathlib runtime/proof registry.
+integration remains a later edge. The current runtime driver accepts fact
+events only. In addition to the earlier explicit runtime table, the
+`Executable` namespace below adapts a sealed Mathlib-free executable assembly
+directly, including built-in arithmetic and independently owned arbitrary
+function packages. Equality/instance actions, program-extension discovery,
+and automatic package discovery remain later interfaces.
 -/
 
 namespace Hex.Interval.Controller
@@ -522,5 +523,386 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq SemanticKey
                 { compatibility := state.compatibility, bundle, session, choices,
                   dismissedIncomplete := state.dismissedIncomplete } next)
   loop limits.maxChoices initial policyState
+
+/-! ## Sealed executable-assembly adapter -/
+
+namespace Executable
+
+/-- One package proposal. All chronology, current facts, installed meets, and
+action data are deliberately absent: the adapter derives them from the
+authenticated search request and its checked runtime fact domain. -/
+structure Proposal (Fact Cause : Type) where
+  node : NodeId
+  proposed : Fact
+  cause : Cause
+
+/-- The only callback result admitted by the current executable adapter.
+Every update must have exactly one separately returned raw quotation. -/
+structure FactOutcome (Fact Cause : Type) where
+  proposals : Array (Proposal Fact Cause)
+  diagnostic : Option Trace.Event := none
+
+abbrev RawAssembly (Fact Cause : Type) :=
+  Hex.Interval.Executable.Assembly Fact (FactOutcome Fact Cause)
+
+/-- Exact executable/theorem alignment. The executable assembly supplies the
+program, flattened registrations, routes, applications, callbacks, and private
+caches; callers cannot provide a second application or runtime table. -/
+structure Registry (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type) where
+  private mk ::
+  key : Controller.Key
+  assembly : RawAssembly Fact Cause
+  domain : FactDomain Fact
+  proof : Proof.Registry semantics Plan
+  applicationGenerations : Array Nat
+  matcherEpoch : Nat
+
+inductive Error where
+  | invalidRegistry
+  | invalidApplication (application : ApplicationId)
+  | invalidQuote
+  | missingSchema (key : Proof.Key)
+  | invalidBody (key : Proof.Key)
+  | resource (resource : Controller.Resource)
+  | search (error : Search.Error)
+  | driver (error : Driver.Error)
+  | executable (error : Hex.Interval.Executable.Error)
+  | mismatch
+  deriving DecidableEq, Repr
+
+private def sameRegistrations (left right : Array Registration) : Bool := Id.run do
+  if left.size != right.size then return false
+  for index in [0:left.size] do
+    let some a := left[index]? | return false
+    let some b := right[index]? | return false
+    if !a.same b then return false
+  return true
+
+private def proofKey (rule : RuleKey) (schema : Nat) : Proof.Key :=
+  { rule, role := .fact, bodySchema := schema }
+
+private def routeFormats? (assembly : RawAssembly Fact Cause) (rule : RuleId) :
+    Option (RuleKey × Array Hex.Interval.Executable.ReplayFormat) :=
+  assembly.registry.formats? rule
+
+private def formatCoverage
+    (assembly : RawAssembly Fact Cause) (proof : Proof.Registry semantics Plan) : Bool := Id.run do
+  for ruleIndex in [0:assembly.registry.registrations.size] do
+    let some (rule, formats) := routeFormats? assembly { index := ruleIndex } | return false
+    for format in formats do
+      if format.role != .fact then return false
+      let key := proofKey rule format.schema
+      if (proof.fact? key).isNone then return false
+  for schema in proof.facts do
+    let some (ruleId, _) := Registration.find? assembly.registry.registrations schema.key.rule
+      | return false
+    let some (_, formats) := routeFormats? assembly ruleId | return false
+    if !(formats.any fun format =>
+        format.role == .fact && format.schema == schema.key.bodySchema) then return false
+  return proof.equalities.isEmpty && proof.instances.isEmpty &&
+    proof.refuters.isEmpty && proof.splits.isEmpty
+
+private def commonMatcherEpoch? (applications : Array Hex.Interval.Executable.Application) :
+    Option Nat := Id.run do
+  let mut epoch := none
+  for application in applications do
+    match application.matcherEpoch, epoch with
+    | none, _ => pure ()
+    | some current, none => epoch := some current
+    | some current, some expected => if current != expected then return none
+  return some (epoch.getD 0)
+
+/-- Seal exact bidirectional fact-format coverage between one executable
+assembly and one theorem registry. Equality, instance, refutation, and split
+schemas are intentionally rejected at this fact-only boundary. -/
+opaque Registry.buildWithin (stateLimits : State.Limits) (key : Controller.Key)
+    (assembly : RawAssembly Fact Cause) (domain : FactDomain Fact)
+    (proof : Proof.Registry semantics Plan) :
+    Except Error (Registry Fact semantics Cause Plan) := do
+  if stateLimits.maxApplications < assembly.applications.size then
+    throw (.resource .applications)
+  if stateLimits.maxRules < assembly.registry.registrations.size ||
+      stateLimits.maxRules < proof.registrations.size then
+    throw (.resource (.state .rules))
+  let some formatCount := assembly.registry.formatCount? | throw .invalidRegistry
+  if stateLimits.maxReplayFormats < formatCount then
+    throw (.resource (.state .replayFormats))
+  if !assembly.program.check ||
+      !Registration.check assembly.program proof.registrations ||
+      !sameRegistrations assembly.registry.registrations proof.registrations ||
+      !formatCoverage assembly proof then
+    throw .invalidRegistry
+  let some matcherEpoch := commonMatcherEpoch? assembly.applications
+    | throw .invalidRegistry
+  let generations := assembly.applications.map (·.generation)
+  if stateLimits.maxGeneration < matcherEpoch ||
+      generations.any (fun generation => stateLimits.maxGeneration < generation) then
+    throw (.resource (.state .generation))
+  pure { key, assembly, domain, proof, applicationGenerations := generations, matcherEpoch }
+
+private def request? (assembly : RawAssembly Fact Cause)
+    (branch : State.Branch Fact Cause) (serial : Nat)
+    (applicationId : ApplicationId) : Option (RuleRequest Fact) := do
+  let application ← assembly.applications[applicationId.index]?
+  let registration ← assembly.registry.registrations[application.rule.index]?
+  let inputs ← application.watches.mapM fun node => do
+    let fact ← branch.snapshot.fact? node
+    let version ← branch.versions[node.index]?
+    pure { node, fact, version }
+  let action : Action :=
+    { serial, programVersion := branch.programVersion, application := applicationId,
+      rule := application.rule, key := registration.key, node := application.node,
+      kind := application.kind, effort := application.effort,
+      generation := application.generation, inputs := inputs.map fun input =>
+        { node := input.node, version := input.version },
+      writes := application.writes, structuralInputs := application.structuralInputs,
+      matcherEpoch := application.matcherEpoch }
+  pure
+    { action
+      program :=
+        { programVersion := branch.programVersion,
+          operations := branch.program.operations, nodes := branch.program.nodes,
+          generations := branch.generations, depths := branch.depths }
+      inputs
+      writes := application.writes }
+
+private def offerClass : ActionKind → Policy.OfferClass
+  | .split => .split
+  | .instantiate => .instantiate
+  | .improve | .shave | .regularize => .retry
+  | _ => .invoke
+
+private def generate [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (registry : Registry Fact semantics Cause Plan)
+    (assembly : RawAssembly Fact Cause) (branch : State.Branch Fact Cause)
+    (serial : Nat) : Except Error (Array (Search.Offer ApplicationId RuleKey)) := do
+  if !branch.check || branch.program != assembly.program ||
+      assembly.program != registry.assembly.program ||
+      assembly.bindings != registry.assembly.bindings ||
+      !sameRegistrations assembly.registry.registrations
+        registry.assembly.registry.registrations ||
+      assembly.applications.size != registry.applicationGenerations.size then
+    throw .mismatch
+  if envelope.state.maxApplications < assembly.applications.size then
+    throw (.resource .applications)
+  let mut offers := #[]
+  for index in [0:assembly.applications.size] do
+    let id : ApplicationId := { index }
+    let some request := request? assembly branch serial id
+      | throw (.invalidApplication id)
+    if request.action.generation != registry.applicationGenerations[index]? then
+      throw (.invalidApplication id)
+    if assembly.offers branch.snapshot request then
+      if envelope.policy.maxOffers ≤ offers.size then
+        throw (.search (.policy .offerLimit))
+      offers := offers.push
+        { view :=
+            { id, key := request.action.key, offerClass := offerClass request.action.kind,
+              age := serial, score := 0 }
+          action := request.action }
+  pure offers
+
+private def startSession [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure ApplicationId RuleKey)
+    (registry : Registry Fact semantics Cause Plan) (assembly : RawAssembly Fact Cause)
+    (scope : Policy.ScopeId) (branch : State.Branch Fact Cause) := do
+  let offers ← generate envelope registry assembly branch 0
+  Search.Session.startWithin envelope measure branch assembly.registry.registrations
+    assembly.bindings registry.applicationGenerations #[] registry.matcherEpoch scope offers
+    |>.mapError Error.search
+
+private def refresh [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (measure : Policy.Measure ApplicationId RuleKey)
+    (registry : Registry Fact semantics Cause Plan) (assembly : RawAssembly Fact Cause)
+    (session : Search.Session Fact Cause ApplicationId RuleKey)
+    (dismissedIncomplete : Bool) := do
+  let offers ← generate envelope registry assembly session.branch session.serial
+  Search.Session.refreshWithin envelope measure session offers session.remaining dismissedIncomplete
+    |>.mapError Error.search
+
+/-- Sticky executable handle paired with the sealed controller lineage. The
+assembly stored here, including its private package caches, is authoritative;
+passing another same-key registry never transplants its cache value. -/
+structure State (Fact Cause Plan : Type) where
+  private mk ::
+  compatibility : Controller.Key
+  assembly : RawAssembly Fact Cause
+  bundle : Driver.Bundle Fact Cause Plan
+  session : Search.Session Fact Cause ApplicationId RuleKey
+  choices : Nat
+  dismissedIncomplete : Bool
+
+def policyMeasure : Policy.Measure ApplicationId RuleKey :=
+  Controller.policyMeasure fun key =>
+    { bytes := key.name.length + key.schema + 1, pairs := 1, work := 1 }
+
+opaque State.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (envelope : Search.Envelope) (registry : Registry Fact semantics Cause Plan)
+    (bundle : Driver.Bundle Fact Cause Plan) : Except Error (State Fact Cause Plan) :=
+  match Search.Result.current? bundle.tree with
+  | none => .error .mismatch
+  | some (_, source) =>
+      match startSession envelope policyMeasure registry registry.assembly
+          source.scope source.branch with
+      | .error error => .error error
+      | .ok session => .ok
+          { compatibility := registry.key, assembly := registry.assembly, bundle, session,
+            choices := 0, dismissedIncomplete := false }
+
+private def checkPolicy (limit : Controller.PolicyLimit)
+    (measure : PolicyState → Policy.Cost) (state : PolicyState) : Except Error Unit := do
+  let cost := measure state
+  if limit.bytes < cost.bytes || limit.pairs < cost.pairs || limit.work < cost.work then
+    throw (.resource .policyState)
+
+private def liftExcept.{u, v} {ε : Type u} {α : Type v} (result : Except ε α) :
+    Except ε (ULift α) :=
+  match result with
+  | .error error => .error error
+  | .ok value => .ok (ULift.up value)
+
+private def makeCommand (program : Program) (domain : FactDomain Fact)
+    (proof : Proof.Registry semantics Plan)
+    (request : Search.Request Fact ApplicationId RuleKey)
+    (invocation : Hex.Interval.Executable.Invocation (FactOutcome Fact Cause)) :
+    Except Error (Driver.Command Fact Cause ApplicationId RuleKey Plan) := do
+  if invocation.rule != request.action.key ||
+      invocation.quotes.size != invocation.result.proposals.size then
+    throw .invalidQuote
+  let mut updates := #[]
+  let mut events := []
+  let mut facts := request.facts.facts
+  let mut versions := request.facts.versions
+  let mut contradiction := false
+  for index in [0:invocation.result.proposals.size] do
+    let some proposal := invocation.result.proposals[index]? | throw .invalidQuote
+    let some quote := invocation.quotes[index]? | throw .invalidQuote
+    if quote.role != .fact then throw .invalidQuote
+    let key := proofKey invocation.rule quote.schema
+    let some schema := proof.fact? key | throw (.missingSchema key)
+    if (schema.decode quote.body).isNone then throw (.invalidBody key)
+    if !request.action.writes.contains proposal.node then throw .mismatch
+    let some instruction := program.node? proposal.node | throw .mismatch
+    let some previous := facts[proposal.node.index]? | throw .mismatch
+    let some version := versions[proposal.node.index]? | throw .mismatch
+    let (installed, refuted) ← match domain.narrow instruction.domain previous proposal.proposed with
+      | .improved fact => pure (fact, false)
+      | .contradiction fact => pure (fact, true)
+      | _ => throw .mismatch
+    let update : State.Update Fact Cause :=
+      { programVersion := request.programVersion, node := proposal.node,
+        previous := { node := proposal.node, version }, fact := installed,
+        version := version + 1, cause := proposal.cause }
+    updates := updates.push update
+    facts := facts.set! proposal.node.index installed
+    versions := versions.set! proposal.node.index (version + 1)
+    contradiction := contradiction || refuted
+    events := events ++ [.fact
+      { scope := request.scope, programVersion := request.programVersion,
+        action := request.action, node := proposal.node,
+        previous := update.previous, version := update.version,
+        proposed := proposal.proposed, installed,
+        assumptions := request.action.inputs, schema := key, body := quote.body }]
+  let outcome : Search.Outcome Fact Cause ApplicationId RuleKey :=
+    { scope := request.scope, serial := request.serial,
+      programVersion := request.programVersion, offer := request.offer,
+      action := request.action, updates,
+      contradiction,
+      diagnostic := invocation.result.diagnostic }
+  pure (.continue { outcome, events })
+
+private def invoke [DecidableEq Fact] (limits : Hex.Interval.Executable.Limits)
+    (domain : FactDomain Fact) (proof : Proof.Registry semantics Plan)
+    (assembly : RawAssembly Fact Cause)
+    (branch : State.Branch Fact Cause)
+    (request : Search.Request Fact ApplicationId RuleKey) :
+    Driver.Command Fact Cause ApplicationId RuleKey Plan ×
+      Except Error (RawAssembly Fact Cause) :=
+  match request? assembly branch request.serial request.action.application with
+  | none => (.stop 0, .error (.invalidApplication request.action.application))
+  | some exact =>
+      let requestedFacts := request.action.inputs.mapM fun seen => request.facts.fact? seen.node
+      if exact.action != request.action then
+        (.stop 0, .error .mismatch)
+      else match requestedFacts with
+        | none => (.stop 0, .error .mismatch)
+        | some facts =>
+          if _ : facts = exact.inputs.map fun input => input.fact then
+            match assembly.invokeWithin limits exact with
+            | .error error => (.stop 0, .error (.executable error))
+            | .ok (invocation, next) =>
+                match makeCommand assembly.program domain proof request invocation with
+                | .error error => (.stop 0, .error error)
+                | .ok command => (command, .ok next)
+          else (.stop 0, .error .mismatch)
+
+inductive Run (Fact Cause Plan PolicyState : Type)
+  | stopped (stop : Search.Stop Unit Unit) (state : State Fact Cause Plan)
+      (policy : PolicyState)
+
+/-- Run the fact-only executable adapter until the policy stops or a resource
+cap is exhausted. Every accepted invocation updates the sticky assembly cache,
+then regenerates offers from that exact replacement assembly. -/
+opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (limits : Controller.Limits) (executableLimits : Hex.Interval.Executable.Limits)
+    (envelope : Search.Envelope) (policyStateMeasure : PolicyState → Policy.Cost)
+    (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Driver.Measure Fact)
+    (registry : Registry Fact semantics Cause Plan)
+    (policy : Policy.Interface Fact PolicyState ApplicationId RuleKey)
+    (policyState : PolicyState) (initial : State Fact Cause Plan) :
+    Except Error (Run Fact Cause Plan PolicyState) := do
+  if initial.compatibility != registry.key then throw .mismatch
+  let _ ← liftExcept (checkPolicy limits.policyState policyStateMeasure policyState)
+  let rec loop (fuel : Nat) (state : State Fact Cause Plan) (policyState : PolicyState) := do
+    if state.choices >= limits.maxChoices then throw (.resource .choices)
+    match fuel with
+    | 0 => throw (.resource .choices)
+    | fuel + 1 =>
+      let choice := (← liftExcept (Search.chooseWithin envelope policyMeasure policy policyState
+        state.session |>.mapError Error.search)).down
+      match choice with
+      | .stopped stop next =>
+          let _ ← liftExcept (checkPolicy limits.policyState policyStateMeasure next)
+          pure (.stopped stop state next)
+      | .dismiss decision next =>
+          let _ ← liftExcept (checkPolicy limits.policyState policyStateMeasure next)
+          let offers := state.session.offers.filter fun offer => offer.view.id != decision.id
+          if offers.size + 1 != state.session.offers.size then throw .mismatch
+          let dismissedIncomplete := state.dismissedIncomplete || decision.offerClass != .split
+          let session := (← liftExcept (Search.Session.refreshWithin envelope policyMeasure
+            state.session offers state.session.remaining dismissedIncomplete
+              |>.mapError Error.search)).down
+          loop fuel { state with session, choices := state.choices + 1, dismissedIncomplete } next
+      | .select decision next =>
+          let _ ← liftExcept (checkPolicy limits.policyState policyStateMeasure next)
+          let callback : Search.Request Fact ApplicationId RuleKey →
+              Driver.Command Fact Cause ApplicationId RuleKey Plan ×
+                Except Error (RawAssembly Fact Cause) :=
+            invoke executableLimits registry.domain registry.proof state.assembly state.session.branch
+          let produced : Driver.Produced Fact Cause ApplicationId RuleKey Plan
+              (Except Error (RawAssembly Fact Cause)) ←
+            Driver.runWithWithin envelope policyMeasure limits.driver resultMeasure
+            recipeMeasure .depthFirst decision.expected callback
+            state.bundle state.session decision |>.mapError Error.driver
+          let choices := state.choices + 1
+          match produced.payload with
+          | none => match produced.step with
+            | .stopped stop bundle session => pure (.stopped stop
+                { state with bundle, session, choices } next)
+            | _ => throw .mismatch
+          | some (.error error) => throw error
+          | some (.ok assembly) => match produced.step with
+            | .continued bundle session =>
+                let session := (← liftExcept (refresh envelope policyMeasure registry assembly
+                  session state.dismissedIncomplete)).down
+                loop fuel
+                  { compatibility := state.compatibility, assembly, bundle, session, choices,
+                    dismissedIncomplete := state.dismissedIncomplete } next
+            | _ => throw .mismatch
+  loop limits.maxChoices initial policyState
+
+end Executable
 
 end Hex.Interval.Controller

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -43,11 +43,14 @@ budget, nor does restarting inherit any proof-closure or saturation claim.
 This is the supported autonomous programmatic loop. Goal reification and the
 public tactic currently use the separate flat forward path; split-search tactic
 integration remains a later edge. The current runtime driver accepts fact
-events only. In addition to the earlier explicit runtime table, the
-`Executable` namespace below adapts a sealed Mathlib-free executable assembly
-directly, including built-in arithmetic and independently owned arbitrary
-function packages. Equality/instance actions, program-extension discovery,
-and automatic package discovery remain later interfaces.
+events only. The explicit `Controller.Package` route above still uses toy
+fact-event callbacks and application generators in conformance; it has no
+concrete built-in arithmetic driver package. The `Executable` namespace below
+is the distinct route by which built-in arithmetic and independently owned
+arbitrary-function fact packages reach this controller: it adapts a sealed
+Mathlib-free executable assembly without a caller application table.
+Equality/instance actions, program-extension discovery, and automatic package
+discovery remain later interfaces.
 -/
 
 namespace Hex.Interval.Controller
@@ -123,6 +126,7 @@ inductive Resource where
   | choices
   | policyState
   | state (resource : State.Resource)
+  | narrow (budget : Nat)
   deriving DecidableEq, Repr
 
 inductive Error where
@@ -641,17 +645,22 @@ opaque Registry.buildWithin (stateLimits : State.Limits) (key : Controller.Key)
     throw (.resource (.state .generation))
   pure { key, assembly, domain, proof, applicationGenerations := generations, matcherEpoch }
 
-private def request? (assembly : RawAssembly Fact Cause)
-    (branch : State.Branch Fact Cause) (serial : Nat)
+private def branchView (branch : State.Branch Fact Cause) : ProgramView :=
+  { programVersion := branch.programVersion,
+    operations := branch.program.operations, nodes := branch.program.nodes,
+    generations := branch.generations, depths := branch.depths }
+
+private def request? (assembly : RawAssembly Fact Cause) (snapshot : Snapshot Fact)
+    (program : ProgramView) (serial : Nat)
     (applicationId : ApplicationId) : Option (RuleRequest Fact) := do
   let application ← assembly.applications[applicationId.index]?
   let registration ← assembly.registry.registrations[application.rule.index]?
   let inputs ← application.watches.mapM fun node => do
-    let fact ← branch.snapshot.fact? node
-    let version ← branch.versions[node.index]?
+    let fact ← snapshot.fact? node
+    let version ← snapshot.version? node
     pure { node, fact, version }
   let action : Action :=
-    { serial, programVersion := branch.programVersion, application := applicationId,
+    { serial, programVersion := program.programVersion, application := applicationId,
       rule := application.rule, key := registration.key, node := application.node,
       kind := application.kind, effort := application.effort,
       generation := application.generation, inputs := inputs.map fun input =>
@@ -659,25 +668,14 @@ private def request? (assembly : RawAssembly Fact Cause)
       writes := application.writes, structuralInputs := application.structuralInputs,
       matcherEpoch := application.matcherEpoch }
   pure
-    { action
-      program :=
-        { programVersion := branch.programVersion,
-          operations := branch.program.operations, nodes := branch.program.nodes,
-          generations := branch.generations, depths := branch.depths }
-      inputs
-      writes := application.writes }
-
-private def offerClass : ActionKind → Policy.OfferClass
-  | .split => .split
-  | .instantiate => .instantiate
-  | .improve | .shave | .regularize => .retry
-  | _ => .invoke
+    { action, program, inputs, writes := application.writes }
 
 private def generate [DecidableEq Fact] [DecidableEq Cause]
     (envelope : Search.Envelope) (registry : Registry Fact semantics Cause Plan)
     (assembly : RawAssembly Fact Cause) (branch : State.Branch Fact Cause)
     (serial : Nat) : Except Error (Array (Search.Offer ApplicationId RuleKey)) := do
-  if !branch.check || branch.program != assembly.program ||
+  let some snapshot := branch.checkedSnapshot? | throw .mismatch
+  if branch.program != assembly.program ||
       assembly.program != registry.assembly.program ||
       assembly.bindings != registry.assembly.bindings ||
       !sameRegistrations assembly.registry.registrations
@@ -686,14 +684,16 @@ private def generate [DecidableEq Fact] [DecidableEq Cause]
     throw .mismatch
   if envelope.state.maxApplications < assembly.applications.size then
     throw (.resource .applications)
+  let program := branchView branch
+  let some context := assembly.offerContext? snapshot program | throw .mismatch
   let mut offers := #[]
   for index in [0:assembly.applications.size] do
     let id : ApplicationId := { index }
-    let some request := request? assembly branch serial id
+    let some request := request? assembly snapshot program serial id
       | throw (.invalidApplication id)
-    if request.action.generation != registry.applicationGenerations[index]? then
+    if registry.applicationGenerations[index]? != some request.action.generation then
       throw (.invalidApplication id)
-    if assembly.offers branch.snapshot request then
+    if context.offers request then
       if envelope.policy.maxOffers ≤ offers.size then
         throw (.search (.policy .offerLimit))
       offers := offers.push
@@ -718,6 +718,9 @@ private def refresh [DecidableEq Fact] [DecidableEq Cause]
     (session : Search.Session Fact Cause ApplicationId RuleKey)
     (dismissedIncomplete : Bool) := do
   let offers ← generate envelope registry assembly session.branch session.serial
+  -- As in the sibling explicit-package controller, regeneration performs no
+  -- engine-budgeted action. The accepted Search transition has already
+  -- updated `remaining`, so refresh carries that exact value unchanged.
   Search.Session.refreshWithin envelope measure session offers session.remaining dismissedIncomplete
     |>.mapError Error.search
 
@@ -789,6 +792,7 @@ private def makeCommand (program : Program) (domain : FactDomain Fact)
     let (installed, refuted) ← match domain.narrow instruction.domain previous proposal.proposed with
       | .improved fact => pure (fact, false)
       | .contradiction fact => pure (fact, true)
+      | .resourceLimit budget => throw (.resource (.narrow budget))
       | _ => throw .mismatch
     let update : State.Update Fact Cause :=
       { programVersion := request.programVersion, node := proposal.node,
@@ -819,7 +823,8 @@ private def invoke [DecidableEq Fact] (limits : Hex.Interval.Executable.Limits)
     (request : Search.Request Fact ApplicationId RuleKey) :
     Driver.Command Fact Cause ApplicationId RuleKey Plan ×
       Except Error (RawAssembly Fact Cause) :=
-  match request? assembly branch request.serial request.action.application with
+  match request? assembly branch.snapshot (branchView branch) request.serial
+      request.action.application with
   | none => (.stop 0, .error (.invalidApplication request.action.application))
   | some exact =>
       let requestedFacts := request.action.inputs.mapM fun seen => request.facts.fact? seen.node

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -121,6 +121,10 @@ structure Limits where
   driver : Driver.Limits
   deriving DecidableEq, Repr
 
+/-- Controller-owned resource refusals. `narrow budget` preserves the exact
+budget reported by `NarrowResult.resourceLimit`; unlike `mismatch` or a
+fixed-point `noChange`, it says the fact domain refused attempted work and no
+update was retained. -/
 inductive Resource where
   | applications
   | choices
@@ -674,6 +678,10 @@ private def generate [DecidableEq Fact] [DecidableEq Cause]
     (envelope : Search.Envelope) (registry : Registry Fact semantics Cause Plan)
     (assembly : RawAssembly Fact Cause) (branch : State.Branch Fact Cause)
     (serial : Nat) : Except Error (Array (Search.Offer ApplicationId RuleKey)) := do
+  match preflightBranch envelope.state branch with
+  | .error (.resource resource) => throw (.resource resource)
+  | .error _ => throw .mismatch
+  | .ok _ => pure ()
   let some snapshot := branch.checkedSnapshot? | throw .mismatch
   if branch.program != assembly.program ||
       assembly.program != registry.assembly.program ||
@@ -718,9 +726,9 @@ private def refresh [DecidableEq Fact] [DecidableEq Cause]
     (session : Search.Session Fact Cause ApplicationId RuleKey)
     (dismissedIncomplete : Bool) := do
   let offers ← generate envelope registry assembly session.branch session.serial
-  -- As in the sibling explicit-package controller, regeneration performs no
-  -- engine-budgeted action. The accepted Search transition has already
-  -- updated `remaining`, so refresh carries that exact value unchanged.
+  -- `Search` does not decrement `remaining`: it is a controller-owned budget
+  -- view supplied at session start/refresh. As in the sibling explicit-package
+  -- controller, this adapter deliberately carries the stored value unchanged.
   Search.Session.refreshWithin envelope measure session offers session.remaining dismissedIncomplete
     |>.mapError Error.search
 
@@ -736,6 +744,10 @@ structure State (Fact Cause Plan : Type) where
   choices : Nat
   dismissedIncomplete : Bool
 
+/-- Fixed structural measure for executable offers. Application identifiers
+cost one pair/cell through `Controller.policyMeasure`; rule keys additionally
+charge their name bytes and schema. Only policy-state measurement is supplied
+by the caller of `runWithin`. -/
 def policyMeasure : Policy.Measure ApplicationId RuleKey :=
   Controller.policyMeasure fun key =>
     { bytes := key.name.length + key.schema + 1, pairs := 1, work := 1 }
@@ -842,6 +854,10 @@ private def invoke [DecidableEq Fact] (limits : Hex.Interval.Executable.Limits)
                 | .ok command => (command, .ok next)
           else (.stop 0, .error .mismatch)
 
+/-- The current fact-only adapter exposes resumable policy/callback stops only.
+It has no typed target, refutation, split, or unknown correlation, so such
+Driver outcomes are rejected as `mismatch`; those terminal interfaces require
+their own executable quotation/schema adapters. -/
 inductive Run (Fact Cause Plan PolicyState : Type)
   | stopped (stop : Search.Stop Unit Unit) (state : State Fact Cause Plan)
       (policy : PolicyState)

--- a/HexIntervalMathlib/Driver.lean
+++ b/HexIntervalMathlib/Driver.lean
@@ -130,6 +130,14 @@ inductive Step (Fact Cause OfferId SemanticKey Plan : Type)
   | stopped (stop : Search.Stop Unit Unit) (bundle : Bundle Fact Cause Plan)
       (session : Search.Session Fact Cause OfferId SemanticKey)
 
+/-- Result of the payload-preserving driver entry point. `payload = none`
+means the authenticated step limit stopped the request before the callback was
+entered. A present payload was produced by the same single callback execution
+whose command crossed the complete driver checks. -/
+structure Produced.{u} (Fact Cause OfferId SemanticKey Plan : Type) (Payload : Type u) where
+  step : Step Fact Cause OfferId SemanticKey Plan
+  payload : Option Payload
+
 private def eventWithin (limits : Proof.Limits) : Proof.Event Fact → Except Error Unit
   | .fact step => do
       Proof.bodyCheck limits step.schema .fact step.body |>.mapError Error.proof
@@ -281,9 +289,92 @@ private def exactTarget (request : Search.Request Fact OfferId SemanticKey)
   entry.scope == request.scope && entry.programVersion == request.programVersion &&
     entry.seen.node == request.action.node && request.action.inputs.contains entry.seen
 
-/-- Execute exactly one selected package callback and atomically return its
-checked retained-tree/recipe replacement. The callback result is retained
-directly; no later cause-to-recipe reconstruction occurs. -/
+private def liftWithin.{u} {α : Type} (result : Except Error α) :
+    Except Error (ULift.{u} α) :=
+  match result with
+  | .error error => .error error
+  | .ok value => .ok (ULift.up value)
+
+/-- Execute exactly one selected callback and atomically return its checked
+retained-tree/recipe replacement together with the opaque payload produced by
+that same callback execution. A resource stop before callback entry returns no
+payload. The payload gains no authority from retention. -/
+opaque runWithWithin.{u} {Payload : Type u}
+    [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
+    [DecidableEq SemanticKey] [DecidableEq Plan]
+    (envelope : Search.Envelope) (policyMeasure : Policy.Measure OfferId SemanticKey)
+    (limits : Limits) (resultMeasure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (recipeMeasure : Measure Fact)
+    (order : Search.Order) (owner : RuleKey)
+    (callback : Search.Request Fact OfferId SemanticKey →
+      Command Fact Cause OfferId SemanticKey Plan × Payload)
+    (bundle : Bundle Fact Cause Plan)
+    (session : Search.Session Fact Cause OfferId SemanticKey)
+    (decision : Policy.Decision OfferId SemanticKey) :
+    Except Error (Produced Fact Cause OfferId SemanticKey Plan Payload) := do
+  let bundle := (← liftWithin.{u} (checked limits resultMeasure recipeMeasure bundle)).down
+  let some (id, source) := Search.Result.current? bundle.tree | throw Error.mismatch
+  if source.scope != session.scope || source.branch != session.branch then throw .mismatch
+  let invocation ← Search.invokeWithWithin envelope policyMeasure owner
+      (fun request =>
+        let (command, payload) := callback request
+        (command.reply, (command, payload))) session decision |>.mapError Error.search
+  match invocation with
+  | .stopped stop next => pure { step := .stopped stop bundle next, payload := none }
+  | .produced (.stopped stop next) (command, payload) =>
+      match command with
+      | .stop _ _ => pure { step := .stopped stop bundle next, payload := some payload }
+      | _ => throw .mismatch
+  | .produced (.applied transition) (command, payload) =>
+      match command with
+      | .stop _ _ => throw .mismatch
+      | .continue echo =>
+          let _ ← liftWithin.{u} (echoMatches limits transition echo)
+          if echo.outcome.updates.isEmpty then throw .mismatch
+          let some recipe := appendEvents bundle.recipe id.index echo.events | throw .mismatch
+          let tree := (← liftWithin.{u} (Search.Result.advanceWithin limits.result resultMeasure
+            bundle.tree transition |>.mapError Error.result)).down
+          let next := (← liftWithin.{u}
+            (bundleWithin limits resultMeasure recipeMeasure tree recipe)).down
+          pure { step := .continued next transition.after, payload := some payload }
+      | Command.split proposal =>
+          let _ ← liftWithin.{u} (echoMatches limits transition proposal.echo)
+          if !emptyEcho proposal.echo || !exactSplit transition.request proposal.runtime then
+            throw .mismatch
+          let tree := (← liftWithin.{u} (Search.Result.splitWithin limits.result resultMeasure
+            order bundle.tree proposal.runtime proposal.left proposal.right
+              |>.mapError Error.result)).down
+          let recipe := appendChildren bundle.recipe id proposal.left proposal.right
+          let next := (← liftWithin.{u}
+            (bundleWithin limits resultMeasure recipeMeasure tree recipe)).down
+          pure { step := .split next, payload := some payload }
+      | .target echo target =>
+          let _ ← liftWithin.{u} (echoMatches limits transition echo)
+          if !emptyEcho echo || !exactTarget transition.request target then throw .mismatch
+          let tree := (← liftWithin.{u} (Search.Result.settleWithin limits.result resultMeasure
+            bundle.tree (.target target) |>.mapError Error.result)).down
+          let next := (← liftWithin.{u}
+            (bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe)).down
+          pure { step := .terminal next, payload := some payload }
+      | .refute echo refute =>
+          let _ ← liftWithin.{u} (echoMatches limits transition echo)
+          if !emptyEcho echo || !exactRefute transition.request refute then throw .mismatch
+          let tree := (← liftWithin.{u} (Search.Result.settleWithin limits.result resultMeasure
+            bundle.tree (.refute refute) |>.mapError Error.result)).down
+          let next := (← liftWithin.{u}
+            (bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe)).down
+          pure { step := .terminal next, payload := some payload }
+      | .unknown echo unknown =>
+          let _ ← liftWithin.{u} (echoMatches limits transition echo)
+          if !emptyEcho echo || unknown.scope != transition.request.scope ||
+              unknown.programVersion != transition.request.programVersion then throw .mismatch
+          let tree := (← liftWithin.{u} (Search.Result.settleWithin limits.result resultMeasure
+            bundle.tree (.unknown unknown) |>.mapError Error.result)).down
+          let next := (← liftWithin.{u}
+            (bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe)).down
+          pure { step := .unknown next, payload := some payload }
+
+/-- Compatibility entry point for a stateless package callback. -/
 opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     [DecidableEq SemanticKey] [DecidableEq Plan]
     (envelope : Search.Envelope) (policyMeasure : Policy.Measure OfferId SemanticKey)
@@ -294,60 +385,8 @@ opaque runWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq OfferId]
     (session : Search.Session Fact Cause OfferId SemanticKey)
     (decision : Policy.Decision OfferId SemanticKey) :
     Except Error (Step Fact Cause OfferId SemanticKey Plan) := do
-  let bundle ← checked limits resultMeasure recipeMeasure bundle
-  let some (id, source) := Search.Result.current? bundle.tree | throw Error.mismatch
-  if source.scope != session.scope || source.branch != session.branch then throw .mismatch
-  let invocation ← Search.invokeWithWithin envelope policyMeasure package.rule
-      (fun request =>
-        let command := package.invoke request
-        (command.reply, command)) session decision |>.mapError Error.search
-  match invocation with
-  | .stopped stop next => pure (.stopped stop bundle next)
-  | .produced (.stopped stop next) command =>
-      match command with
-      | .stop _ _ => pure (.stopped stop bundle next)
-      | _ => throw .mismatch
-  | .produced (.applied transition) command =>
-      match command with
-      | .stop _ _ => throw .mismatch
-      | .continue echo =>
-          echoMatches limits transition echo
-          if echo.outcome.updates.isEmpty then throw .mismatch
-          let some recipe := appendEvents bundle.recipe id.index echo.events | throw .mismatch
-          let tree ← Search.Result.advanceWithin limits.result resultMeasure bundle.tree transition
-            |>.mapError Error.result
-          let next ← bundleWithin limits resultMeasure recipeMeasure tree recipe
-          pure (.continued next transition.after)
-      | Command.split proposal =>
-          echoMatches limits transition proposal.echo
-          if !emptyEcho proposal.echo || !exactSplit transition.request proposal.runtime then
-            throw .mismatch
-          let tree ← Search.Result.splitWithin limits.result resultMeasure order bundle.tree
-            proposal.runtime proposal.left proposal.right |>.mapError Error.result
-          let recipe := appendChildren bundle.recipe id proposal.left proposal.right
-          let next ← bundleWithin limits resultMeasure recipeMeasure tree recipe
-          pure (.split next)
-      | .target echo target =>
-          echoMatches limits transition echo
-          if !emptyEcho echo || !exactTarget transition.request target then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.target target)
-            |>.mapError Error.result
-          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
-          pure (.terminal next)
-      | .refute echo refute =>
-          echoMatches limits transition echo
-          if !emptyEcho echo || !exactRefute transition.request refute then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.refute refute)
-            |>.mapError Error.result
-          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
-          pure (.terminal next)
-      | .unknown echo unknown =>
-          echoMatches limits transition echo
-          if !emptyEcho echo || unknown.scope != transition.request.scope ||
-              unknown.programVersion != transition.request.programVersion then throw .mismatch
-          let tree ← Search.Result.settleWithin limits.result resultMeasure bundle.tree (.unknown unknown)
-            |>.mapError Error.result
-          let next ← bundleWithin limits resultMeasure recipeMeasure tree bundle.recipe
-          pure (.unknown next)
+  let produced ← runWithWithin envelope policyMeasure limits resultMeasure recipeMeasure order
+    package.rule (fun request => (package.invoke request, ())) bundle session decision
+  pure produced.step
 
 end Hex.Interval.Driver

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -229,6 +229,16 @@ callback packages and raw replay formats. Those raw quotations are not
 `Proof.Event`s and remain inert. The fact-only `Controller.Executable` adapter
 correlates an accepted request/update with an exact fact format and decoder;
 only later independent `Proof` replay invokes its theorem schema.
+`Search` never decrements its `remaining` view; executable refresh preserves
+the controller-owned value stored in the sealed session. The adapter uses a
+fixed structural `policyMeasure` for application identifiers and rule keys,
+while callers supply only the measure for their policy state. A domain
+`NarrowResult.resourceLimit budget` becomes the distinct
+`Controller.Resource.narrow budget` refusal before any update is retained;
+fixed-point `noChange` and malformed narrowing remain mismatches at this
+fact-only boundary. Its public `Run` currently contains only a resumable
+`stopped` result. Driver target, refutation, split, and unknown outcomes are
+rejected as mismatches until separate typed terminal correlation is added.
 The assembly constructors are sealed under ordinary imports; deliberate
 `import all HexInterval.Executable` is a repository-guarded trusted-source
 escape hatch, not decoded runtime or proof authority.

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -81,12 +81,14 @@ transaction. Its supported `Controller` explicitly aligns stable application
 generators with the same-order runtime and proof registries, regenerates
 resource-first deterministic offers from the authenticated current head, and
 runs bounded repeated policy selection over the sealed tree/session bundle.
-Its current vertical uses toy fact-event packages; concrete built-in arithmetic
-`Driver.Package` callbacks and application generators remain to be implemented.
-The separate Mathlib-free `Executable.Assembly` accepts explicit raw callback
-packages, but wiring it to this controller and correlating its inert quotations
-with theorem events, automatic discovery/program extension, equality/instance
-runtime events, and public-tactic split search remain later edges.
+The explicit `Controller.Package` vertical still uses toy fact-event callbacks
+and application generators; it has no concrete built-in arithmetic
+`Driver.Package`. Concrete built-in arithmetic reaches the controller only
+through the separate `Controller.Executable` adapter, which consumes a sealed
+Mathlib-free `Executable.Assembly` and correlates accepted fact quotations with
+independently replayed theorem schemas. Automatic discovery/program extension,
+equality/instance runtime events, and public-tactic split search remain later
+edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -223,8 +225,10 @@ Runtime search state, callbacks, payload bytes, and traces are untrusted and
 cannot enter `Proof.Evidence`. The built-in arithmetic package registry and
 its supported branch/session `Cause`-to-`Proof.Event` quotation ship below.
 The Mathlib-free `Executable.Assembly` supports explicit arbitrary-operation
-callback packages and raw replay formats, but those raw quotations are not
-`Proof.Event`s and are not yet correlated with this theorem registry.
+callback packages and raw replay formats. Those raw quotations are not
+`Proof.Event`s and remain inert. The fact-only `Controller.Executable` adapter
+correlates an accepted request/update with an exact fact format and decoder;
+only later independent `Proof` replay invokes its theorem schema.
 The assembly constructors are sealed under ordinary imports; deliberate
 `import all HexInterval.Executable` is a repository-guarded trusted-source
 escape hatch, not decoded runtime or proof authority.
@@ -316,10 +320,12 @@ per returned sealed state lineage; explicit `State.startWithin` creates a new
 handle from a sealed bundle and resets choices, the dismissal latch, and the
 search session's serial, steps, and trace even at the same retained head/scope.
 Pure state reuse creates separately bounded successors rather than a global
-budget, and a new handle does not inherit proof closure or saturation. This current controller is a
-fact-event Mathlib assembly whose conformance callbacks are toy packages, not
-the missing concrete built-in arithmetic driver adapters, automatic package
-discovery, or public split-search tactic. Every immutable offer snapshot has
+budget, and a new handle does not inherit proof closure or saturation. This
+explicit `Controller.Package` route is a fact-event Mathlib assembly whose
+conformance callbacks are toy packages, not concrete built-in arithmetic
+driver adapters. Built-in arithmetic reaches this controller only through the
+separate sealed `Controller.Executable` route. Automatic package discovery and
+the public split-search tactic remain absent. Every immutable offer snapshot has
 one constant controller-owned serial age; any malformed draft aborts its whole
 regeneration. Dismissing a non-split offer sets a controller-owned incomplete
 bit which survives accepted refreshes in the same scope within one returned

--- a/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
@@ -133,6 +133,8 @@ def proofLimits : Proof.Limits :=
 def proofRegistry? : Option (Proof.Registry (Rule.semantics config)) :=
   (Rule.buildWithWithin proofLimits config program #[copyProofPackage]).toOption
 
+#guard proofRegistry?.isSome
+
 def runtimeDomain : FactDomain Hex.Interval :=
   { top := fun _ => Hex.Interval.whole,
     narrow := fun _ previous proposed =>
@@ -386,6 +388,14 @@ theorem executableArithmeticAndArbitraryFunction :
     (Rule.semantics config).Entails program (Proof.initialBase input) input.target :=
   replayEvidence.proof
 
+/--
+info: 'Hex.IntervalMathlib.ExecutableControllerConformance.executableArithmeticAndArbitraryFunction' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound]
+-/
+#guard_msgs in
+#print axioms executableArithmeticAndArbitraryFunction
+
 /-! ## Mutation and exact-boundary checks -/
 
 def arithmeticWith
@@ -412,7 +422,8 @@ def buildRegistry
     (copy : Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
       copyPackage)
     (key : Controller.Key := controllerKey)
-    (limits : State.Limits := stateLimits) :
+    (limits : State.Limits := stateLimits)
+    (domain : FactDomain Hex.Interval := runtimeDomain) :
     Except Controller.Executable.Error
       (Controller.Executable.Registry Hex.Interval (Rule.semantics config) Nat (List Nat)) :=
   match buildAssembly arithmetic copy with
@@ -420,7 +431,7 @@ def buildRegistry
   | .ok assembly => match proofRegistry? with
     | none => .error .invalidRegistry
     | some proof =>
-      Controller.Executable.Registry.buildWithin limits key assembly runtimeDomain proof
+      Controller.Executable.Registry.buildWithin limits key assembly domain proof
 
 def runFresh
     (registry : Controller.Executable.Registry Hex.Interval (Rule.semantics config)
@@ -538,6 +549,26 @@ def callbackMutationRejected : Bool :=
     | _ => false)
 
 #guard callbackMutationRejected
+
+def resourceDomain : FactDomain Hex.Interval :=
+  { runtimeDomain with narrow := fun _ _ _ => .resourceLimit 7 }
+
+def noChangeDomain : FactDomain Hex.Interval :=
+  { runtimeDomain with narrow := fun _ _ _ => .noChange }
+
+def narrowDiagnosticDistinct : Bool :=
+  (match buildRegistry (domain := resourceDomain) with
+    | .ok registry => match runFresh registry with
+      | .error (.resource (.narrow 7)) => true
+      | _ => false
+    | _ => false) &&
+  (match buildRegistry (domain := noChangeDomain) with
+    | .ok registry => match runFresh registry with
+      | .error .mismatch => true
+      | _ => false
+    | _ => false)
+
+#guard narrowDiagnosticDistinct
 
 def applicationsOneOver : Bool :=
   let small := { stateLimits with maxApplications := 2 }

--- a/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
@@ -1,0 +1,651 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Controller
+import HexIntervalMathlib.Rule
+
+/-!
+# Executable assembly controller conformance
+
+The sealed adapter runs the built-in interval addition rule followed by two
+applications from an independently owned arbitrary-function package. Runtime
+callbacks return only proposals and inert quotations. The adapter derives the
+accepted updates and proof events from the authenticated search request; the
+ordinary theorem below is obtained only by a separate proof replay.
+-/
+
+namespace Hex.IntervalMathlib.ExecutableControllerConformance
+
+open Hex.Interval
+open Hex.Interval.Proof
+open Hex.Interval.Executable
+
+/-- error: Unknown constant `Hex.Interval.Controller.Executable.Registry.mk` -/
+#guard_msgs in
+#check Controller.Executable.Registry.mk
+
+/-- error: Unknown constant `Hex.Interval.Controller.Executable.State.mk` -/
+#guard_msgs in
+#check Controller.Executable.State.mk
+
+/-- error: Unknown constant `Hex.Interval.Executable.Registry.mk` -/
+#guard_msgs in
+#check Hex.Interval.Executable.Registry.mk
+
+/-- error: Unknown constant `Hex.Interval.Executable.Assembly.mk` -/
+#guard_msgs in
+#check Hex.Interval.Executable.Assembly.mk
+
+def d (value : Int) : Dyadic := .ofInt value
+def endpoint : EndpointLimit := { maxEndpointHeight := 64, maxAlignmentShift := 64 }
+
+def ready (raw : Raw) : Hex.Interval :=
+  match Hex.Interval.ofRawWithin endpoint raw with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+def singleton (value : Int) : Hex.Interval :=
+  ready (.bounds (.finite (d value) false) (.finite (d value) false))
+
+def copyOp : Operation :=
+  { key := { name := "fixture.arbitrary.copy" }, inputs := [Rule.realDomain],
+    output := Rule.realDomain }
+
+def copyMeaning : Program.Meaning ℝ :=
+  { operation := copyOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x }
+
+def config : Rule.Config :=
+  { endpoint, powerWork := { maxExponent := 8 }, exponent := 2,
+    precisionLimits :=
+      { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
+        maxTemporaryBits := 128 },
+    precision := 0, constant := d 5, extraMeanings := #[copyMeaning] }
+
+def node (op : Nat) (args : List Nat) : Node :=
+  { domain := Rule.realDomain, op := { index := op },
+    args := args.map fun index => { index } }
+
+def program : Program :=
+  { operations := Rule.operations.push copyOp,
+    nodes := #[node 0 [], node 0 [], node 2 [0, 1], node 13 [2], node 13 [3]] }
+
+def x : NodeId := { index := 0 }
+def y : NodeId := { index := 1 }
+def sum : NodeId := { index := 2 }
+def copied : NodeId := { index := 3 }
+def final : NodeId := { index := 4 }
+
+def one := singleton 1
+def two := singleton 2
+def three := singleton 3
+def initialFacts : Array Hex.Interval :=
+  #[one, two, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole]
+
+#guard program.check
+#guard Rule.ready? (Hex.Interval.addWithin endpoint one two) == some three
+
+def copyKey : RuleKey := { name := "fixture.arbitrary.copy.fact" }
+def copyRegistration : Registration :=
+  { key := copyKey, head := copyOp.key, kind := .forward,
+    watches := [.argument 0], writes := [.result] }
+def copySchemaKey : Proof.Key := { rule := copyKey, role := .fact, bodySchema := 1 }
+
+theorem copyRelation {valuation : NodeId → ℝ} {out input : NodeId}
+    (meaning : Program.MeaningAt (Rule.meanings config) valuation out
+      { domain := Rule.realDomain, op := { index := 13 }, args := [input] }) :
+    valuation out = valuation input := by
+  rcases meaning with ⟨meaning, found, related⟩
+  simp [Rule.meanings, Rule.builtinMeanings, config, copyMeaning] at found
+  subst meaning
+  simpa [copyMeaning] using related.symm
+
+def copySchema : Proof.FactSchema (Rule.semantics config) :=
+  { key := copySchemaKey, Certificate := Unit,
+    decode := fun body => if body = [20] then some () else none,
+    prove := fun context _ => match context.assumptions with
+      | [input] =>
+        if found : context.program.node? context.proposed.node = some
+            { domain := Rule.realDomain, op := { index := 13 }, args := [input.node] } then
+          if equal : context.proposed.fact = input.fact then
+            some ⟨by
+              intro valuation model assumptions
+              have relation := copyRelation
+                (Rule.nodeMeaning config model found)
+              change context.proposed.fact.Contains (valuation context.proposed.node)
+              rw [equal]
+              rw [relation]
+              simpa [Rule.semantics, Proof.Semantics.ofMeanings] using
+                assumptions input (by simp)⟩
+          else none
+        else none
+      | _ => none }
+
+def copyProofPackage : Proof.Package (Rule.semantics config) :=
+  { registrations := #[copyRegistration], facts := #[copySchema] }
+
+def proofLimits : Proof.Limits :=
+  { maxPackages := 2, maxSchemas := 13, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 3 }
+
+def proofRegistry? : Option (Proof.Registry (Rule.semantics config)) :=
+  (Rule.buildWithWithin proofLimits config program #[copyProofPackage]).toOption
+
+def runtimeDomain : FactDomain Hex.Interval :=
+  { top := fun _ => Hex.Interval.whole,
+    narrow := fun _ previous proposed =>
+      match Rule.ready? (Hex.Interval.intersectWithin endpoint previous proposed) with
+      | none => .resourceLimit 0
+      | some installed =>
+          if installed == previous then .noChange
+          else if installed == Hex.Interval.empty then .contradiction installed
+          else .improved installed }
+
+def factFormat (tag : Nat) : ReplayFormat :=
+  { role := .fact, schema := 1, validateBody := fun body => body == [tag] }
+
+def resultCost (_ : Controller.Executable.FactOutcome Hex.Interval Nat) : Cost :=
+  { bytes := 1, work := 1 }
+
+def measure : Measure Nat (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  { metadata := { bytes := 1, work := 1 },
+    application := fun _ => { bytes := 1, work := 1 },
+    cache := fun value => { bytes := value + 1, work := value + 1 },
+    result := resultCost }
+
+def dormant (registration : Registration) (tag : Nat) :
+    Handler Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { registration,
+    offers := fun _ _ => false,
+    invoke := fun cache _ =>
+      ({ result := { proposals := #[] }, quotes := #[] }, cache),
+    formats := #[factFormat tag] }
+
+def addHandler : Handler Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { registration := Rule.binaryRegistration Rule.addKey Rule.addOp,
+    offers := fun snapshot request =>
+      snapshot.version? request.action.node == some 0 &&
+        request.inputs.map (fun input => input.fact) == [one, two],
+    invoke := fun cache request =>
+      let proposals := match request.inputs with
+        | [left, right] => match Rule.ready?
+            (Hex.Interval.addWithin endpoint left.fact right.fact) with
+          | some proposed => #[{ node := request.action.node, proposed, cause := cache }]
+          | none => #[]
+        | _ => #[]
+      ({ result := { proposals },
+          quotes := proposals.map fun _ => { role := .fact, schema := 1, body := [2] } },
+        cache + 1),
+    formats := #[factFormat 2] }
+
+def arithmeticHandlers : Array
+    (Handler Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) Nat) :=
+  Rule.registrations.mapIdx fun index registration =>
+    if index == 1 then addHandler else dormant registration (index + 1)
+
+def arithmeticPackage : Package Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  { Cache := Nat, cache := 0, operations := Rule.operations,
+    handlers := arithmeticHandlers, measure }
+
+def copyHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { registration := copyRegistration,
+    offers := fun snapshot request =>
+      snapshot.version? request.action.node == some 0 &&
+        request.inputs.map (fun input => input.fact) == [three],
+    invoke := fun cache request =>
+      let proposals := match request.inputs with
+        | [input] => #[{ node := request.action.node, proposed := input.fact, cause := cache }]
+        | _ => #[]
+      ({ result := { proposals },
+          quotes := proposals.map fun _ => { role := .fact, schema := 1, body := [20] } },
+        cache + 1),
+    formats := #[factFormat 20] }
+
+def copyPackage : Package Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  { Cache := Nat, cache := 0, operations := #[copyOp], handlers := #[copyHandler], measure }
+
+def stateLimits : State.Limits :=
+  { maxOperations := 14, maxNodes := 5, maxRules := 13,
+    maxRegistryEntries := 42, maxReplayFormats := 13, maxArity := 2,
+    maxScopeNodes := 0, maxApplications := 3, maxQueueEntries := 4,
+    maxActions := 8, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 3, maxRetainedSuggestions := 0, maxEffort := 0,
+    maxObservationValue := 8, maxDiagnosticValue := 8,
+    maxOutcomeCandidates := 3, maxOutcomeSuggestions := 0, maxProposalItems := 1,
+    maxInstances := 0, maxGeneration := 0, maxNodeDepth := 3, maxEqualities := 0,
+    splitEndpointLimit := endpoint }
+
+def executableLimits : Hex.Interval.Executable.Limits :=
+  { state := stateLimits, maxPackages := 2,
+    maxMetadataBytes := 64, maxMetadataWork := 64,
+    maxCacheBytes := 16, maxCacheWork := 16,
+    maxResultBytes := 1, maxResultWork := 1,
+    maxQuotes := 1, maxQuoteCells := 1, maxAtom := 21, maxSchema := 2 }
+
+def assembly? : Option (Controller.Executable.RawAssembly Hex.Interval Nat) :=
+  (Hex.Interval.Executable.buildWithin executableLimits
+    #[arithmeticPackage, copyPackage] program).toOption
+
+def controllerKey : Controller.Key := { name := "executable-facts", version := 1 }
+
+def registry? : Option
+    (Controller.Executable.Registry Hex.Interval (Rule.semantics config) Nat (List Nat)) := do
+  let assembly ← assembly?
+  let proof ← proofRegistry?
+  (Controller.Executable.Registry.buildWithin stateLimits controllerKey assembly
+    runtimeDomain proof).toOption
+
+def searchLimits : Search.Limits :=
+  { maxSteps := 3, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
+    maxDepth := 0, maxScopes := 1, leafFuel := 3 }
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 1, maxBytes := 128, maxPairs := 32, maxWork := 128, maxScore := 0 }
+
+def envelope : Search.Envelope :=
+  { state := stateLimits, policy := policyLimits,
+    trace := { maxEvents := 4, maxBytes := 64, maxWork := 64, maxCode := 8 },
+    search := searchLimits }
+
+def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
+def resultMeasure : Search.Result.Measure Hex.Interval Nat (List Nat) Proof.Key :=
+  { node := unitCost,
+    branch := fun branch =>
+      { bytes := branch.snapshot.facts.size + branch.history.size,
+        work := branch.versions.size + branch.history.size },
+    fact := fun _ => unitCost, action := fun _ => unitCost, plan := fun _ => unitCost,
+    schema := fun _ => unitCost, body := fun _ => unitCost, code := fun _ => unitCost }
+
+def recipeMeasure : Driver.Measure Hex.Interval :=
+  { cell := unitCost, event := fun _ => { bytes := 1, work := 1 },
+    edge := fun _ => { bytes := 1, work := 1 } }
+
+def driverLimits : Driver.Limits :=
+  { result :=
+      { search := searchLimits, state := stateLimits, maxNodes := 1,
+        maxBodyCells := 3, maxBytes := 512, maxWork := 512, maxCode := 8 },
+    proof := proofLimits,
+    tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 3, maxWork := 64 },
+    recipe := { maxBytes := 64, maxWork := 64 } }
+
+def controllerLimits : Controller.Limits :=
+  { maxChoices := 4, policyState := { bytes := 4, pairs := 4, work := 4 },
+    driver := driverLimits }
+
+def scope : Policy.ScopeId := { index := 0 }
+
+def firstPolicy : Policy.Interface Hex.Interval Unit ApplicationId RuleKey :=
+  { choose := fun _ view => match view.offers[0]? with
+    | some offer => .select offer ()
+    | none => .stop () }
+
+def policyStateCost (_ : Unit) : Policy.Cost := { bytes := 1, work := 1 }
+
+def stoppedState? : Option (Controller.Executable.State Hex.Interval Nat (List Nat)) :=
+  match registry? with
+  | none => none
+  | some registry =>
+    match State.Branch.startWithin stateLimits program initialFacts with
+    | .error _ => none
+    | .ok branch =>
+      match Driver.Bundle.startWithin driverLimits resultMeasure recipeMeasure scope branch with
+      | .error _ => none
+      | .ok bundle =>
+        match Controller.Executable.State.startWithin envelope registry bundle with
+        | .error _ => none
+        | .ok state =>
+          match Controller.Executable.runWithin controllerLimits executableLimits envelope
+              policyStateCost resultMeasure recipeMeasure registry firstPolicy () state with
+          | .ok (.stopped (.policyStop 0) stopped _) => some stopped
+          | _ => none
+
+def acceptedChronology : Bool :=
+  match stoppedState? with
+  | some state =>
+      state.session.branch.snapshot.facts == #[one, two, three, three, three] &&
+        state.session.branch.versions == #[0, 0, 1, 1, 1] &&
+          state.session.branch.history.map (fun update => update.cause) == #[0, 0, 1]
+  | none => false
+
+#guard acceptedChronology
+
+def input : Proof.Input Hex.Interval :=
+  { scope, program, facts := initialFacts, target := { node := final, fact := three } }
+
+def replayEvidence? : Option (Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target)) :=
+  match proofRegistry? with
+  | none => none
+  | some registry => match stoppedState? with
+    | none => none
+    | some state => match state.bundle.recipe.events[0]? with
+      | none => none
+      | some events =>
+        (Proof.replay proofLimits registry (Rule.domain config) (Rule.laws config)
+          input events 0 program { node := final, version := 1 }).toOption
+
+#guard replayEvidence?.isSome
+
+private theorem eq_of_mem_singleton {value : Dyadic} {result : Hex.Interval} {z : ℝ}
+    (checked : Hex.Interval.singletonWithin endpoint value = .ready result)
+    (member : result.Contains z) : z = Hex.Interval.toReal value := by
+  change result.view.Contains z at member
+  rw [Hex.Interval.view_singletonWithin_ready checked,
+    Hex.Interval.contains_normalize] at member
+  exact le_antisymm member.2 member.1
+
+private theorem toReal_d (value : Int) : Hex.Interval.toReal (d value) = value := by
+  change ((Dyadic.ofInt value).toRat : ℝ) = value
+  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
+  norm_num
+
+def fallbackEvidence : Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target) :=
+  { proof := by
+      intro valuation model assumptions
+      change NodeId → ℝ at valuation
+      have xMember : one.Contains (valuation x) := assumptions
+        { node := x, fact := one } (by simp [Proof.initialBase, input, initialFacts, x])
+      have yMember : two.Contains (valuation y) := assumptions
+        { node := y, fact := two } (by simp [Proof.initialBase, input, initialFacts, y])
+      have sumRelation : valuation sum = valuation x + valuation y :=
+        Rule.binaryRelation (config := config) (valuation := valuation)
+          (node := sum) (left := x) (right := y) (index := 2)
+          (relation := fun left right => left + right)
+          (Rule.nodeMeaning config model (node := sum) (by rfl))
+          (Or.inl ⟨rfl, rfl⟩)
+      have firstCopy : valuation copied = valuation sum :=
+        copyRelation (Rule.nodeMeaning config model (node := copied) (by rfl))
+      have secondCopy : valuation final = valuation copied :=
+        copyRelation (Rule.nodeMeaning config model (node := final) (by rfl))
+      have xEq := eq_of_mem_singleton (value := d 1) (result := one) (by rfl) xMember
+      have yEq := eq_of_mem_singleton (value := d 2) (result := two) (by rfl) yMember
+      rw [toReal_d] at xEq yEq
+      have finalEq : valuation final = 3 := by
+        rw [secondCopy, firstCopy, sumRelation, xEq, yEq]
+        norm_num
+      change three.Contains (valuation final)
+      rw [finalEq]
+      have member := Rule.constant_mem
+        (limit := endpoint) (value := d 3) (result := three) (by rfl)
+      rw [toReal_d] at member
+      exact member }
+
+def replayEvidence : Proof.Evidence
+    ((Rule.semantics config).Entails program (Proof.initialBase input) input.target) :=
+  replayEvidence?.getD fallbackEvidence
+
+/-- The quotation does not prove this statement. Independent schema replay and
+the kernel theorem stored in `Proof.Evidence` do. -/
+theorem executableArithmeticAndArbitraryFunction :
+    (Rule.semantics config).Entails program (Proof.initialBase input) input.target :=
+  replayEvidence.proof
+
+/-! ## Mutation and exact-boundary checks -/
+
+def arithmeticWith
+    (handler : Handler Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) Nat) :
+    Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  { arithmeticPackage with handlers := arithmeticHandlers.set! 1 handler }
+
+def copyWith
+    (handler : Handler Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) Nat) :
+    Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  { copyPackage with handlers := #[handler] }
+
+def buildAssembly
+    (arithmetic : Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+      arithmeticPackage)
+    (copy : Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+      copyPackage)
+    (limits : Hex.Interval.Executable.Limits := executableLimits) :=
+  Hex.Interval.Executable.buildWithin limits #[arithmetic, copy] program
+
+def buildRegistry
+    (arithmetic : Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+      arithmeticPackage)
+    (copy : Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+      copyPackage)
+    (key : Controller.Key := controllerKey)
+    (limits : State.Limits := stateLimits) :
+    Except Controller.Executable.Error
+      (Controller.Executable.Registry Hex.Interval (Rule.semantics config) Nat (List Nat)) :=
+  match buildAssembly arithmetic copy with
+  | .error error => .error (.executable error)
+  | .ok assembly => match proofRegistry? with
+    | none => .error .invalidRegistry
+    | some proof =>
+      Controller.Executable.Registry.buildWithin limits key assembly runtimeDomain proof
+
+def runFresh
+    (registry : Controller.Executable.Registry Hex.Interval (Rule.semantics config)
+      Nat (List Nat))
+    (limits : Controller.Limits := controllerLimits)
+    (rawLimits : Hex.Interval.Executable.Limits := executableLimits)
+    (candidateEnvelope : Search.Envelope := envelope) :
+    Except Controller.Executable.Error
+      (Controller.Executable.Run Hex.Interval Nat (List Nat) Unit) :=
+  match State.Branch.startWithin stateLimits program initialFacts with
+  | .error _ => .error .mismatch
+  | .ok branch =>
+    match Driver.Bundle.startWithin driverLimits resultMeasure recipeMeasure scope branch with
+    | .error _ => .error .mismatch
+    | .ok bundle =>
+      match Controller.Executable.State.startWithin candidateEnvelope registry bundle with
+      | .error error => .error error
+      | .ok state => Controller.Executable.runWithin limits rawLimits candidateEnvelope
+          policyStateCost resultMeasure recipeMeasure registry firstPolicy () state
+
+def reorderedArithmetic :
+    Package Hex.Interval (Controller.Executable.FactOutcome Hex.Interval Nat) :=
+  let neg := dormant (Rule.unaryRegistration Rule.negKey Rule.negOp) 1
+  { arithmeticPackage with handlers := (arithmeticHandlers.set! 0 addHandler).set! 1 neg }
+
+def wrongKey : RuleKey := { name := "fixture.transplanted.key" }
+def wrongKeyHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with registration := { copyRegistration with key := wrongKey } }
+
+def schemaTwoHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with formats :=
+      #[{ role := .fact, schema := 2, validateBody := fun body => body == [20] }] }
+
+def equalityFormatHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with formats :=
+      #[{ role := .equality, schema := 1, validateBody := fun body => body == [20] }] }
+
+def missingFormatHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with formats := #[] }
+
+def malformedBodyHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with
+    invoke := fun cache request =>
+      let proposals := match request.inputs with
+        | [input] => #[{ node := request.action.node, proposed := input.fact, cause := cache }]
+        | _ => #[]
+      ({ result := { proposals },
+          quotes := proposals.map fun _ => { role := .fact, schema := 1, body := [21] } },
+        cache + 1),
+    formats :=
+      #[{ role := .fact, schema := 1, validateBody := fun body => body.length == 1 }] }
+
+def missingQuoteHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with invoke := fun cache request =>
+      let proposals := match request.inputs with
+        | [input] => #[{ node := request.action.node, proposed := input.fact, cause := cache }]
+        | _ => #[]
+      ({ result := { proposals }, quotes := #[] }, cache + 1) }
+
+def extraQuoteHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with invoke := fun cache request =>
+      let proposals := match request.inputs with
+        | [input] => #[{ node := request.action.node, proposed := input.fact, cause := cache }]
+        | _ => #[]
+      ({ result := { proposals },
+          quotes := #[{ role := .fact, schema := 1, body := [20] },
+            { role := .fact, schema := 1, body := [20] }] }, cache + 1) }
+
+def wrongUpdateHandler : Handler Hex.Interval
+    (Controller.Executable.FactOutcome Hex.Interval Nat) Nat :=
+  { copyHandler with invoke := fun cache _request =>
+      ({ result := { proposals := #[{ node := x, proposed := three, cause := cache }] },
+          quotes := #[{ role := .fact, schema := 1, body := [20] }] }, cache + 1) }
+
+def registryMutationRejected : Bool :=
+  (match buildRegistry reorderedArithmetic with
+    | .error .invalidRegistry => true | _ => false) &&
+  (match buildRegistry (copy := copyWith wrongKeyHandler) with
+    | .error .invalidRegistry => true | _ => false) &&
+  (match buildRegistry (copy := copyWith schemaTwoHandler) with
+    | .error .invalidRegistry => true | _ => false) &&
+  (match buildRegistry (copy := copyWith equalityFormatHandler) with
+    | .error .invalidRegistry => true | _ => false) &&
+  (match buildRegistry (copy := copyWith missingFormatHandler) with
+    | .error .invalidRegistry => true | _ => false)
+
+#guard registryMutationRejected
+
+def callbackMutationRejected : Bool :=
+  (match buildRegistry (copy := copyWith malformedBodyHandler) with
+    | .ok registry => match runFresh registry with
+      | .error (.invalidBody key) => key == copySchemaKey
+      | _ => false
+    | _ => false) &&
+  (match buildRegistry (copy := copyWith missingQuoteHandler) with
+    | .ok registry => match runFresh registry with
+      | .error .invalidQuote => true | _ => false
+    | _ => false) &&
+  (match buildRegistry (copy := copyWith extraQuoteHandler) with
+    | .ok registry =>
+      let generous := { executableLimits with maxQuotes := 2, maxQuoteCells := 2 }
+      match runFresh registry (rawLimits := generous) with
+      | .error .invalidQuote => true | _ => false
+    | _ => false) &&
+  (match buildRegistry (copy := copyWith wrongUpdateHandler) with
+    | .ok registry => match runFresh registry with
+      | .error .mismatch => true | _ => false
+    | _ => false)
+
+#guard callbackMutationRejected
+
+def applicationsOneOver : Bool :=
+  let small := { stateLimits with maxApplications := 2 }
+  match buildRegistry (limits := small) with
+  | .error (.resource .applications) => true
+  | _ => false
+
+def formatsOneOver : Bool :=
+  let small := { stateLimits with maxReplayFormats := 12 }
+  match buildRegistry (limits := small) with
+  | .error (.resource (.state .replayFormats)) => true
+  | _ => false
+
+def quoteCellsOneOver : Bool :=
+  let small := { executableLimits with maxQuoteCells := 0 }
+  match buildRegistry with
+  | .ok registry => match runFresh registry (rawLimits := small) with
+    | .error (.executable (.resource .quoteCells)) => true
+    | _ => false
+  | _ => false
+
+def resultBytesOneOver : Bool :=
+  let small := { executableLimits with maxResultBytes := 0 }
+  match buildRegistry with
+  | .ok registry => match runFresh registry (rawLimits := small) with
+    | .error (.executable (.resource .resultBytes)) => true
+    | _ => false
+  | _ => false
+
+def offersOneOver : Bool :=
+  let small := { envelope with policy := { policyLimits with maxOffers := 0 } }
+  match buildRegistry with
+  | .ok registry => match runFresh registry (candidateEnvelope := small) with
+    | .error (.search (.policy .offerLimit)) => true
+    | _ => false
+  | _ => false
+
+def quotesOneOver : Bool :=
+  match buildRegistry (copy := copyWith extraQuoteHandler) with
+  | .ok registry => match runFresh registry with
+    | .error (.executable (.resource .quotes)) => true
+    | _ => false
+  | _ => false
+
+def choicesOneOver : Bool :=
+  let small := { controllerLimits with maxChoices := 2 }
+  match buildRegistry with
+  | .ok registry => match runFresh registry (limits := small) with
+    | .error (.resource .choices) => true
+    | _ => false
+  | _ => false
+
+#guard applicationsOneOver && formatsOneOver && quoteCellsOneOver &&
+  resultBytesOneOver && offersOneOver && quotesOneOver && choicesOneOver
+
+def selectTwice : Policy.Interface Hex.Interval Nat ApplicationId RuleKey :=
+  { choose := fun count view =>
+      if count < 2 then match view.offers[0]? with
+        | some offer => .select offer (count + 1)
+        | none => .stop count
+      else .stop count }
+
+def selectOnce : Policy.Interface Hex.Interval Nat ApplicationId RuleKey :=
+  { choose := fun count view =>
+      if count == 0 then match view.offers[0]? with
+        | some offer => .select offer 1
+        | none => .stop count
+      else .stop count }
+
+def natPolicyCost (_ : Nat) : Policy.Cost := { bytes := 1, work := 1 }
+
+def partialState? : Option (Controller.Executable.State Hex.Interval Nat (List Nat)) :=
+  match registry? with
+  | none => none
+  | some registry =>
+    match State.Branch.startWithin stateLimits program initialFacts with
+    | .error _ => none
+    | .ok branch =>
+      match Driver.Bundle.startWithin driverLimits resultMeasure recipeMeasure scope branch with
+      | .error _ => none
+      | .ok bundle => match Controller.Executable.State.startWithin envelope registry bundle with
+        | .error _ => none
+        | .ok state =>
+          match Controller.Executable.runWithin controllerLimits executableLimits envelope
+              natPolicyCost resultMeasure recipeMeasure registry selectTwice 0 state with
+          | .ok (.stopped (.policyStop 1) stopped 2) => some stopped
+          | _ => none
+
+def sameKeyKeepsStickyCache : Bool :=
+  match partialState?, registry? with
+  | some retained, some fresh =>
+    match Controller.Executable.runWithin controllerLimits executableLimits envelope
+        natPolicyCost resultMeasure recipeMeasure fresh selectOnce 0 retained with
+    | .ok (.stopped (.policyStop 0) stopped 1) =>
+        stopped.session.branch.history.map (fun update => update.cause) == #[0, 0, 1]
+    | _ => false
+  | _, _ => false
+
+def wrongEpochRejected : Bool :=
+  let other : Controller.Key := { controllerKey with version := 2 }
+  match partialState?, buildRegistry (key := other) with
+  | some retained, .ok fresh =>
+    match Controller.Executable.runWithin controllerLimits executableLimits envelope
+        natPolicyCost resultMeasure recipeMeasure fresh selectOnce 0 retained with
+    | .error .mismatch => true
+    | _ => false
+  | _, _ => false
+
+#guard sameKeyKeepsStickyCache && wrongEpochRejected
+
+end Hex.IntervalMathlib.ExecutableControllerConformance

--- a/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
@@ -39,6 +39,10 @@ open Hex.Interval.Executable
 #guard_msgs in
 #check Hex.Interval.Executable.Assembly.mk
 
+/-- error: Unknown constant `Hex.Interval.Executable.OfferContext.mk` -/
+#guard_msgs in
+#check Hex.Interval.Executable.OfferContext.mk
+
 def d (value : Int) : Dyadic := .ofInt value
 def endpoint : EndpointLimit := { maxEndpointHeight := 64, maxAlignmentShift := 64 }
 
@@ -582,6 +586,14 @@ def formatsOneOver : Bool :=
   | .error (.resource (.state .replayFormats)) => true
   | _ => false
 
+def generateNodesOneOver : Bool :=
+  let small := { envelope with state := { stateLimits with maxNodes := 4 } }
+  match buildRegistry with
+  | .ok registry => match runFresh registry (candidateEnvelope := small) with
+    | .error (.resource (.state .nodes)) => true
+    | _ => false
+  | _ => false
+
 def quoteCellsOneOver : Bool :=
   let small := { executableLimits with maxQuoteCells := 0 }
   match buildRegistry with
@@ -621,7 +633,7 @@ def choicesOneOver : Bool :=
     | _ => false
   | _ => false
 
-#guard applicationsOneOver && formatsOneOver && quoteCellsOneOver &&
+#guard applicationsOneOver && formatsOneOver && generateNodesOneOver && quoteCellsOneOver &&
   resultBytesOneOver && offersOneOver && quotesOneOver && choicesOneOver
 
 def selectTwice : Policy.Interface Hex.Interval Nat ApplicationId RuleKey :=

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -546,6 +546,7 @@ lean_lib HexConformance where
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,
+      `HexIntervalMathlib.ExecutableControllerConformance,
       `HexIntervalMathlib.RuleConformance,
       `HexIntervalMathlib.FrontendConformance,
       `HexIntervalMathlib.TacticConformance,

--- a/progress/2026-08-22T05-05-11Z.md
+++ b/progress/2026-08-22T05-05-11Z.md
@@ -1,0 +1,29 @@
+# Executable controller adapter review follow-up
+
+## Accomplished
+
+- Restacked the fact-only executable controller adapter onto the then-current
+  `origin/main` and preserved the intervening metadata.
+- Removed the unused standalone assembly offer wrapper, kept the checked
+  reusable offer context, and added an exact sealed-constructor guard.
+- Preflighted branch state limits before executable offer scans and added an
+  exact node-resource diagnostic regression.
+- Documented the controller-owned remaining view, narrow-resource mapping,
+  fixed adapter policy measure, stopped-only run surface, and later typed
+  terminal boundary in source and both interval SPECs.
+- Passed focused executable/controller/PNT builds, the full 9819-job build,
+  static DAG/release/trust/conformance/PNT checks, and factor freshness.
+
+## Current frontier
+
+The review follow-up is complete locally and ready for a final main fetch,
+mechanical restack if needed, and publication to PR #9382.
+
+## Next step
+
+Fetch the exact current main, preserve patch equivalence while restacking if it
+moved, then force-push with an exact lease and observe automatic CI.
+
+## Blockers
+
+None.

--- a/progress/20260822T033322Z.md
+++ b/progress/20260822T033322Z.md
@@ -1,0 +1,46 @@
+# Executable assembly controller adapter
+
+## Accomplished
+
+- Restacked the work exactly onto `ab94e9199ea75db3614ede390b1d3d0d93dbeb7e`
+  while preserving the merged Ramanujan and policy-correspondence inventory,
+  SPEC, Lake, and exemption changes.
+- Added a fact-only `Controller.Executable` adapter over sealed
+  `Executable.Assembly`. It derives application identity, route, ports, order,
+  action chronology, fact versions, accepted meets, event assumptions, and
+  proof keys from authenticated assembly/Search state rather than a second
+  caller application table.
+- Kept raw executable quotations inert. Exact fact quote/proposal cardinality,
+  routed fact formats, proof-schema coverage, and schema decoders are checked
+  before Driver retention; independent Proof replay remains the only source of
+  the resulting theorem evidence.
+- Added payload-preserving, universe-polymorphic Search and Driver entry points
+  so a replacement heterogeneous assembly with private package caches can be
+  retained only after the same callback's complete transition checks.
+- Added an end-to-end built-in addition plus explicit arbitrary-function fact
+  package conformance. It observes sticky private cache causes `[0, 0, 1]` and
+  closes the final ordinary theorem through independent replay.
+- Covered sealed constructor boundaries; route/registration reorder, wrong
+  key/role/schema/body/cardinality/update, same-key sticky reuse, wrong epoch,
+  and exact application/format/offer/quote/cell/result/choice one-overs.
+- Passed the affected conformance build, full `lake build HexConformance`
+  (9606 jobs), DAG and file-line checks, the published trust-surface check, and
+  the DAG unit test.
+
+## Current frontier
+
+The supported executable adapter ends at authenticated fact events. Its
+`Run` therefore has only conservative stop at this layer; target, refutation,
+split, typed equality, and typed instance outcomes require their own result
+types and proof-event correlation rather than treating `Quote` as authority.
+
+## Next step
+
+Design typed executable outcome carriers and exact replay correlations for
+equality and instance events, then separately add target/refutation/split
+terminal outcomes and public-tactic integration.
+
+## Blockers
+
+None for the fact-only adapter. The remaining equality/instance boundary is an
+explicit unimplemented interface, not a premise contradiction.

--- a/progress/20260822T033927Z.md
+++ b/progress/20260822T033927Z.md
@@ -1,0 +1,34 @@
+# Executable assembly adapter restack and publication
+
+## Accomplished
+
+- Mechanically rebased the fact-only executable controller adapter from
+  `ab94e9199ea75db3614ede390b1d3d0d93dbeb7e` onto exact current `origin/main`
+  `f396965d439aeaffcb3f843d85998b23765a22b2`, preserving the merged #9367
+  finite-field release metadata.
+- Verified the old and restacked adapter commits have identical stable patch ID
+  `36ddc920bf75d65d7cdb140499d5e86fe0ecdff2` and identical raw diff SHA-256
+  `e5dd0aaca129f4a044c791ab6c53217c1823fe2929c0715b01aa828fb5328e65`.
+- Rebuilt the executable/controller adapter, current executable/controller
+  conformances, and Ramanujan-theta conformance on the new base.
+- Revalidated the DAG, file-line caps, conformance inventory, released trust
+  surface, PNT inventory, and factor-sweep freshness. Added the exact
+  `lakefile.lean` blob exemption for the new acceptance-only conformance target;
+  it does not enter the factorization service dependency graph.
+
+## Current frontier
+
+The published scope remains fact-only. Raw executable quotations are inert;
+the adapter correlates them with authenticated fact transitions and exact
+package schemas, while independent Proof replay supplies theorem evidence.
+
+## Next step
+
+Let the ordinary upstream/main pull-request CI validate the published branch.
+Typed equality/instance correlation and target/refutation/split terminal
+outcomes remain separate follow-up interfaces.
+
+## Blockers
+
+None. The optional local cactus-plot byte check was unavailable because this
+host lacks Matplotlib; pull-request CI installs its pinned plotting dependency.

--- a/progress/20260822T043436Z.md
+++ b/progress/20260822T043436Z.md
@@ -1,0 +1,46 @@
+# Executable controller review repair
+
+## Accomplished
+
+- Added an exact axiom inventory guard for the executable arithmetic and
+  arbitrary-function theorem, plus a positive proof-registry construction
+  guard before mutation checks.
+- Reworked offer regeneration around one checked branch snapshot and one
+  sealed executable offer context, so whole snapshot/program validation is
+  paid once and routed application checks reuse the private checked path.
+- Preserved the fact-only boundary while distinguishing the toy explicit
+  `Controller.Package` route from the built-in arithmetic path through
+  `Controller.Executable` in module and SPEC documentation.
+- Removed the duplicate offer-class mapping, made generation comparison use an
+  explicit `some`, documented unchanged remaining-budget refresh semantics,
+  and mapped fact-domain resource refusal to a distinct controller resource.
+- Added resource/no-change mutation coverage.
+- Mechanically restacked all three PR commits through `6ce5c3e2979889a880838684b3872286d4603326`
+  and `a263a4ad919708ef913744554600cbeff5985930`, then onto exact final
+  `origin/main` `fc60c4bfb74062a9742eca73d3477bdec16eab90`. The adapter patch retained stable
+  patch ID `36ddc920bf75d65d7cdb140499d5e86fe0ecdff2`. The final restack's only
+  reconciliation preserved both new HexSparsePoly Lake exemptions and added
+  the adapter exemption for the combined `lakefile.lean` blob
+  `ddb94c98883c98990c068057d76d31e5f27be25c`.
+- Focused executable/controller, adapter, and PNT conformances, all requested
+  static/trust/inventory/freshness gates, and a complete 9,819-job `lake build`
+  passed on that exact final base.
+- Force-pushed the clean repaired range to PR #9382; the ordinary pull-request
+  workflow started automatically, without Claude or a manual CI dispatch.
+
+## Current frontier
+
+The review repair is complete and clean on the exact current base. Raw quotes
+remain inert; only authenticated fact request/update correlation plus a checked
+fact decoder can emit replay events, whose theorem evidence still comes from
+independent `Proof` replay.
+
+## Next step
+
+Let the automatically triggered pull-request CI validate the published head.
+Typed equality/instance correlation and terminal refutation/split outcomes
+remain separate later interfaces.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -680,7 +680,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "6dd80771ae2212333b2a9b925b52056e0037ff56",
-    "current_blob": "bd7af525b37598ac25642e5703d273c6f32d80cf",
-    "reason": "Additionally registers the Mathlib-free source-pinned FKS2 prefix-structure checker and its proof-only conformance module on top of the retained Ramanujan, nested-log, controller, PNT, public interval, and HexSparsePoly library registrations; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
+    "current_blob": "e2c8d787eedb211050b9a5f4dd97a8d48b874cf0",
+    "reason": "Additionally registers the supported fact-only executable-assembly controller conformance, including independent theorem replay for built-in arithmetic and an explicit arbitrary-function package, on top of the retained source-pinned FKS2 prefix-structure checker and its proof-only conformance module; these acceptance-only modules do not enter the factorization service target or change its executable dependency graph."
   }
 ]


### PR DESCRIPTION
## Summary

- add the supported fact-only `Controller.Executable` adapter over sealed `Executable.Assembly`, with assembly-owned flat application IDs, routes, registrations, ports, and ordering
- derive actions, scope, versions, installed meets, assumptions, and `Proof.Key` addresses from authenticated Search requests and accepted updates
- retain heterogeneous private package caches only after executable quotation admission and the existing Search/Driver checks
- exercise built-in interval addition plus an explicit arbitrary-function fact package, sticky cache reuse, mutations, exact resource one-overs, sealed-constructor guards, and pre-scan branch preflight

## Authority boundary

`Executable.Quote` remains inert `(role, schema, body)` data and has no theorem authority. The adapter requires exact fact quote/proposal cardinality, routed fact formats, bidirectional fact-schema coverage, and a successful package decoder. Independent Proof replay still invokes the package theorem schema and supplies the kernel-checked theorem evidence.

This PR is deliberately fact-only. Its public `Run` exposes only resumable stopped results; Driver target, refutation, split, and unknown outcomes mismatch until separate typed terminal correlation is added. Typed equality and instance event correlation also remains a separate interface.

The explicit `Controller.Package` route still uses toy fact-event callbacks and autonomous generators. Concrete built-in arithmetic reaches the controller only through `Controller.Executable`.

## Verification

- commits 1, 3, and 4 are `git range-diff` identical across the final restack; commit 2 only reconciles the combined Lake exemption with merged FKS2 metadata
- exact base: `d94eede2b3b0a1c98eb183bbe84e57a705a80f96`
- exact head: `cc635634c9b65e1fd1640f54ef0bbc625b74ee91`
- `lake build HexInterval.ExecutableConformance HexIntervalMathlib.ControllerConformance HexIntervalMathlib.ExecutableControllerConformance HexIntervalMathlib.PntRamanujanThetaConformance HexIntervalMathlib.PntFks2StructureConformance`
- full `lake build`: 9819 jobs
- DAG, file-line, conformance-target, release-manifest/manual-split, trust-surface, PNT-inventory, and factor-sweep-freshness checks

Automatic CI is the only remote workflow run requested.