### PR TITLE
chore: add the finite-field batch to the publish manifest

### DIFF
--- a/HexConway/README.md
+++ b/HexConway/README.md
@@ -8,8 +8,8 @@ A database of Conway polynomials for Lean 4, without Mathlib. Conway
 polynomials are the canonical irreducible polynomials `C(p, n)` used to present
 `GF(p^n)` so that the subfield embeddings agree with each other. This package
 commits a slice of Frank Lübeck's table as ordinary Lean data and proves that
-each committed entry is irreducible, primitive, and compatible with its
-divisor-degree entries. It builds on
+every committed entry is irreducible, every nontrivial entry is primitive, and
+every proper divisor-degree pair is compatible. It builds on
 [`hex-berlekamp`](https://github.com/leanprover/hex-berlekamp) for
 irreducibility certificates and
 [`hex-gfq-ring`](https://github.com/leanprover/hex-gfq-ring) for the quotient

--- a/HexConway/README.md
+++ b/HexConway/README.md
@@ -1,0 +1,122 @@
+# hex-conway
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+A database of Conway polynomials for Lean 4, without Mathlib. Conway
+polynomials are the canonical irreducible polynomials `C(p, n)` used to present
+`GF(p^n)` so that the subfield embeddings agree with each other. This package
+commits a slice of Frank Lübeck's table as ordinary Lean data and proves that
+each committed entry is irreducible, primitive, and compatible with its
+divisor-degree entries. It builds on
+[`hex-berlekamp`](https://github.com/leanprover/hex-berlekamp) for
+irreducibility certificates and
+[`hex-gfq-ring`](https://github.com/leanprover/hex-gfq-ring) for the quotient
+that compatibility is stated in. The subfield embedding `GFq p m →+* GFq p n`
+and the Mathlib-side order statements live in
+[`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-conway"
+git = "https://github.com/leanprover/hex-conway.git"
+rev = "main"
+```
+
+```lean
+import HexConway
+open Hex Hex.Conway
+
+-- The committed Conway polynomial `C(3, 4)`, with its Tier 1 proofs.
+def f : FpPoly 3 := conwayPoly 3 4 supportedEntry_3_4
+
+example : FpPoly.Irreducible f := conwayPoly_irreducible 3 4 supportedEntry_3_4
+example : 0 < FpPoly.degree f := conwayPoly_nonconstant 3 4 supportedEntry_3_4
+example : DensePoly.Monic f := conwayPoly_monic 3 4 supportedEntry_3_4
+
+-- Tier 2: `C(3, 2)` sits inside `C(3, 4)`, and the generator is primitive.
+#check compat_3_2_4
+#check primitive_3_4
+
+-- The raw table lookup, which is `none` outside the committed slice.
+#check @luebeckConwayPolynomial?
+```
+
+# Functionality
+
+- `luebeckConwayPolynomial? (p n : Nat) [ZMod64.Bounds p] : Option (FpPoly p)`
+  is the committed table, generated into ordinary Lean code. It covers 38
+  entries: `p` in `2, 3, 5, 7, 11, 13`, to degree `6` for the odd primes and to
+  degree `8` for `p = 2`.
+- `SupportedEntry p n` packages a table hit with the primality witness and the
+  proof that the lookup resolves to it. It cannot be built for an uncommitted
+  pair, which is how `conwayPoly p n h` stays total only where the table
+  covers. Each committed pair has a `supportedEntry_p_n`.
+- `conwayPoly` returns the modulus, and `conwayPoly_irreducible`,
+  `conwayPoly_nonconstant` and `conwayPoly_monic` are the facts a field
+  construction needs.
+- `Compatible p m n hm hn` is the decidable divisor-compatibility statement,
+  computed by `compatCheck`. `subfieldGen` names the norm element it is about.
+- `Primitive p n h qs es fullDigits perPrimeDigits` is primitivity, computed by
+  `primitiveCheck`, which validates the supplied factorization of `p^n - 1`
+  before running the two power conditions.
+- `rebuild_luebeckConwayPolynomial?` regenerates the coefficient table from the
+  cached Lübeck slice, and `#conway_entry_source` renders the literal, the
+  monic and degree facts, the table-hit lemma, and the Rabin certificate that a
+  new entry needs. Neither runs during a build.
+
+# Verification
+
+Every one of the 38 committed entries carries an irreducibility certificate
+that the kernel replays; `native_decide` is not used anywhere. The aggregate
+dispatch theorem is `luebeckConwayPolynomial?_irreducible`, and the API-facing
+form is
+
+```lean
+theorem conwayPoly_irreducible
+    (p n : Nat) [ZMod64.Bounds p] (h : SupportedEntry p n) :
+    FpPoly.Irreducible (conwayPoly p n h)
+```
+
+Divisor compatibility is proved for every committed pair `(p, m, n)` with
+`m ∣ n` and `m < n`: 52 theorems `compat_p_m_n`, plus `not_compatible_11_4_6`
+as a negative control so the check is visibly not vacuous. The `Bool` is
+promoted to a statement about field elements, which is the well-definedness
+input a subfield embedding needs:
+
+```lean
+theorem eval_conwayPoly_subfieldGen_eq_zero
+    {p m n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (hm : SupportedEntry p m) (hn : SupportedEntry p n)
+    (hcompat : Compatible p m n hm hn) :
+    FpPoly.Quotient.Internal.eval
+        (g := conwayPoly p n hn) (hmonic := conwayPoly_monic p n hn)
+        (hg_pos := conwayPoly_degree_pos p n hn)
+        (conwayPoly p m hm) (subfieldGen p m n hn) =
+      FpPoly.Quotient.zero (g := conwayPoly p n hn)
+        (hmonic := conwayPoly_monic p n hn)
+        (hg_pos := conwayPoly_degree_pos p n hn)
+```
+
+Primitivity is proved for the 37 committed entries with `p^n > 2`, one theorem
+`primitive_p_n` each. `C(2, 1)` is excluded because its multiplicative group is
+trivial. Because `primitiveCheck` validates that the supplied divisors multiply
+back to `p^n - 1`, a short prime list cannot make the check pass.
+
+On-demand search for pairs the table does not cover is specified but not
+implemented. There is no API for it, and no `(p, n)` outside the committed
+slice can be constructed. The transport of primitivity into Mathlib's
+`orderOf` language, and the canonical embedding `conwayEmbed`, live in
+[`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib). See the
+[SPEC](SPEC/hex-conway.md) for the tier boundaries and the proof budget that
+sets the size of the committed slice.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexGF2/README.md
+++ b/HexGF2/README.md
@@ -1,0 +1,112 @@
+# hex-gf2
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Packed polynomials over `F_2`, and the finite fields `GF(2^n)` they present,
+implemented without Mathlib. Coefficients are the bits of a `UInt64` array, so
+addition is a word-wise XOR and multiplication runs on carry-less word products
+rather than on per-coefficient modular arithmetic. The only dependency is
+[`hex-basic`](https://github.com/leanprover/hex-basic). The ring equivalence
+with Mathlib's `Polynomial (ZMod 2)`, along with finiteness and cardinality,
+lives in [`hex-gf2-mathlib`](https://github.com/leanprover/hex-gf2-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-gf2"
+git = "https://github.com/leanprover/hex-gf2.git"
+rev = "main"
+```
+
+```lean
+import HexGF2
+open Hex
+
+-- `GF(2^8)` on AES's modulus `x^8 + x^4 + x^3 + x + 1`, packed into one word.
+abbrev AES : Type :=
+  GF2n 8 0x1B (by decide) (by decide) GF2Poly.aes_modulus_irreducible
+
+def a : AES := GF2n.reduce 0x53
+def b : AES := GF2n.reduce 0xCA
+def c : AES := a * b⁻¹
+
+#eval (a + b).val                             -- 153: addition is XOR
+#eval (GF2Poly.ofUInt64Monic 0x1B 8).degree   -- 8
+
+example (h : a ≠ 0) : a * a⁻¹ = 1 := GF2n.mul_inv_cancel a h
+```
+
+# Functionality
+
+- `GF2Poly` is a normalized `Array UInt64` of coefficient bits. Degree is
+  derived by `GF2Poly.degree?` and `GF2Poly.degree` rather than cached, so
+  equality of elements is equality of word arrays (`GF2Poly.ext_words`).
+- Arithmetic: XOR addition, `GF2Poly.mul` as a schoolbook convolution of
+  carry-less word products, and `GF2Poly.shiftLeft` and `GF2Poly.shiftRight`
+  for multiplication and division by `x^k`.
+- Euclidean operations: `GF2Poly.divMod`, `div`, `mod`, `gcd` and `xgcd`, with
+  the `Div`, `Mod` and `Dvd` instances they back.
+- `Hex.clmul` is the 64-by-64 carry-less multiply. It is `@[extern]`, and the C
+  wrapper picks `_mm_clmulepi64_si128` on x86-64, `vmull_p64` on aarch64, or a
+  portable shift-and-XOR, by compile-time feature detection. `Hex.pureClmul` is
+  the Lean reference semantics that the proofs use.
+- `GF2n n irr hn hn64 hirr` holds `GF(2^n)` for `n < 64` in one word;
+  `GF2nPoly f hirr` covers any degree over `GF2Poly`. Both supply reduction,
+  inversion, division, and a square-and-multiply `pow`.
+- `GF2Poly.rabinTest` decides irreducibility, and
+  `checkIrreducibilityCertificate` replays a supplied certificate instead;
+  `checkIrreducibilityCertificateLinear` is the kernel-reducible variant.
+- The moduli cryptography uses are committed with their certificates and
+  irreducibility proofs: `gf16Modulus`, `aesModulus`, `gf65kModulus`, and
+  `ghashModulus`.
+
+# Verification
+
+Irreducibility is proved rather than tabulated. The Rabin test is sound, and so
+is certificate replay, which is what lets a committed modulus be checked by the
+kernel without `native_decide`:
+
+```lean
+theorem rabinTest_imp_irreducible (f : GF2Poly) (hrabin : rabinTest f = true) :
+    GF2Poly.Irreducible f
+
+theorem checkIrreducibilityCertificate_imp_irreducible
+    (f : GF2Poly) (cert : IrreducibilityCertificate)
+    (hcheck : checkIrreducibilityCertificate f cert = true) :
+    GF2Poly.Irreducible f
+```
+
+The packed quotient carries `Lean.Grind.Semiring`, `Lean.Grind.Ring` and
+`Lean.Grind.CommRing` instances for every modulus the type admits. The field
+laws need more: `GF2Poly.Irreducible` is satisfied by the constant `1`, and the
+quotient by a constant is trivial, so nonconstancy is a separate hypothesis and
+the field laws are functions rather than instances.
+
+```lean
+def fieldOfDegreePos (hdeg : 0 < f.degree) : Lean.Grind.Field (GF2nPoly f hirr)
+
+theorem isCharPOfDegreePos (hdeg : 0 < f.degree) :
+    Lean.Grind.IsCharP (GF2nPoly f hirr) 2
+```
+
+For the single-word representation, `GF2n.mul_inv_cancel` gives inverse
+cancellation directly. Division, gcd and extended gcd have proved
+specifications: `GF2Poly.div_mul_add_mod`, `mod_degree_lt`, `gcd_dvd_left`,
+`dvd_gcd`, and `xgcd_bezout`.
+
+Correctness of the compiled `clmul` is trusted, as the GMP externs in
+`hex-arith` are. `clmul_eq_pureClmul` is the equation the proofs rely on, and
+the compiled wrapper is cross-checked against `Hex.pureClmul` by a conformance
+driver and by a C self-test that compiles both wrapper paths. See the
+[SPEC](SPEC/hex-gf2.md) for the representation invariant, the extern contract,
+and the committed-modulus table.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexGF2Mathlib/README.md
+++ b/HexGF2Mathlib/README.md
@@ -1,0 +1,125 @@
+# hex-gf2-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+The Mathlib correspondence layer for
+[`hex-gf2`](https://github.com/leanprover/hex-gf2). It relates the packed
+bitwise polynomials and their `GF(2^n)` wrappers to the generic quotient-field
+construction from
+[`hex-gfq-field`](https://github.com/leanprover/hex-gfq-field), and reaches
+Mathlib's `Polynomial (ZMod 2)` by composing with
+[`hex-poly-fp-mathlib`](https://github.com/leanprover/hex-poly-fp-mathlib). It
+also carries finiteness, cardinality, and Mathlib's `CommRing` and `Field`
+structure on the packed types.
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-gf2-mathlib"
+git = "https://github.com/leanprover/hex-gf2-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexGF2Mathlib
+open Hex
+
+-- Packed `F₂[x]` as Mathlib's polynomial ring, with the packed operations kept.
+noncomputable example : GF2Poly ≃+* Polynomial (ZMod 2) :=
+  HexGF2Mathlib.GF2Poly.equivPolynomial
+
+example (p q : GF2Poly) : p * q = GF2Poly.mul p q := rfl
+
+-- A single-word `GF(2^n)` is the generic quotient field, and has `2 ^ n` elements.
+example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
+    {hirr : GF2Poly.Irreducible (GF2Poly.ofUInt64Monic irr n)} :
+    Fintype.card (GF2n n irr hn hn64 hirr) = 2 ^ n :=
+  HexGF2Mathlib.GF2n.fintype_card
+```
+
+# Functionality
+
+- `GF2Poly.equiv` unpacks and repacks between the packed bitwise
+  representation and the generic dense one, with `toFpPoly` and `ofFpPoly` as
+  the named directions and transport lemmas for coefficients, degree,
+  arithmetic and irreducibility.
+- `GF2Poly.equivPolynomial` composes that with the prime-field equivalence from
+  [`hex-poly-fp-mathlib`](https://github.com/leanprover/hex-poly-fp-mathlib),
+  which is where a Mathlib user starts.
+- `GF2n.equiv` and `GF2nPoly.equiv` identify the single-word and
+  arbitrary-degree packed `GF(2^n)` wrappers with the generic
+  `GFqField.FiniteField` over the transported modulus.
+- `Fintype` instances for both wrappers, their cardinality theorems, and the
+  computable `finEquiv` indexings they are built from.
+- `CommRing Hex.GF2Poly`, and `Field (Hex.GF2nPoly f hirr)` for a nonconstant
+  modulus, built through Mathlib's minimal-axioms constructors.
+
+The equivalences are Mathlib's `≃+*`, not a project-local record, so they
+compose with other `RingEquiv`s and are accepted by Mathlib's equivalence APIs.
+
+# Verification
+
+The equivalences are the content. The packed polynomial representation
+corresponds to the generic one, and composing reaches Mathlib:
+
+```lean
+def equiv : Hex.GF2Poly ≃+* Hex.FpPoly 2
+
+noncomputable def equivPolynomial : Hex.GF2Poly ≃+* Polynomial (ZMod 2)
+```
+
+`equivPolynomial` is `noncomputable` because Mathlib's polynomial
+multiplication is; the packed side stays executable. The algebraic instances
+keep the executable operations rather than transported copies, so
+`p * q = GF2Poly.mul p q` closes by `rfl`.
+
+The single-word wrapper, in namespace `HexGF2Mathlib.GF2n`:
+
+```lean
+def equiv : Hex.GF2n n irr hn hn64 hirr ≃+*
+    GenericFiniteField (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
+
+theorem fintype_card :
+    Fintype.card (Hex.GF2n n irr hn hn64 hirr) = 2 ^ n
+```
+
+The arbitrary-degree wrapper, in namespace `HexGF2Mathlib.GF2nPoly`:
+
+```lean
+def equiv : Hex.GF2nPoly f hirr ≃+* GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)
+
+theorem fintype_card :
+    Fintype.card (Hex.GF2nPoly f hirr) = 2 ^ f.degree
+```
+
+The cardinalities are read off the representation, `GF2n` from its `val` bound
+and `GF2nPoly` through its reduced-representative subtype, rather than
+transported across the ring equivalence. The `Fintype` instances are
+deliberately `noncomputable`: the carriers have `2 ^ n` elements, so a compiled
+`Finset.univ` over one is a footgun. The `Equiv`s underneath stay computable.
+
+The `Field` instance on `GF2nPoly` takes `Fact (0 < f.degree)`, and the
+hypothesis is not redundant: `GF2Poly.Irreducible` admits the constant `1`, and
+the quotient by a constant is the trivial ring where `0 = 1`.
+
+Two things are absent. `GF2n` has no Mathlib `Field` instance, because hex-gf2
+does not prove its ring laws as bare theorems the way it does for `GF2Poly` and
+`GF2nPoly`, so reaching Mathlib from a `GF2n` today means going through
+`GF2n.equiv`. There is no `EuclideanDomain GF2Poly` either; hex-gf2 already
+defines `Div` and `Mod` on `GF2Poly` and the class supplies its own, so the two
+have to be reconciled rather than stacked.
+
+Use [`hex-gf2`](https://github.com/leanprover/hex-gf2) alone for computation;
+this package is for theorem statements and interoperability involving Mathlib.
+See the [SPEC](SPEC/hex-gf2-mathlib.md) for the correspondence contract and the
+reason the finiteness argument does not go through the ring equivalence.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexGFq/README.md
+++ b/HexGFq/README.md
@@ -1,0 +1,117 @@
+# hex-gfq
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Canonical finite fields for Lean 4, without Mathlib. This is the layer that
+picks the irreducible polynomial for you: write `GFqC 3 5` and get `GF(3^5)`
+presented by its Conway polynomial, with no modulus and no irreducibility proof
+to supply. It combines
+[`hex-gfq-field`](https://github.com/leanprover/hex-gfq-field) for the generic
+quotient-field construction,
+[`hex-conway`](https://github.com/leanprover/hex-conway) for the modulus, and
+[`hex-gf2`](https://github.com/leanprover/hex-gf2) for a packed binary backend.
+The ring equivalence between the two binary models, and the correspondence with
+Mathlib's finite fields, live in
+[`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-gfq"
+git = "https://github.com/leanprover/hex-gfq.git"
+rev = "main"
+```
+
+```lean
+import HexGFq
+open Hex
+
+-- Canonical `GF(3^5)`; instance search picks the committed Conway entry.
+abbrev F : Type := GFqC 3 5
+
+def α : F := GFqC.ofPoly #p[0, 1]
+def β : F := α ^ 5 + α + 1
+
+example : GFqC.frob α = α ^ 3 := GFqC.frob_eq_pow α
+
+-- Canonical `GF(2^8)` on the packed bitwise backend, same Conway modulus.
+abbrev B : Type := GF2q 8
+
+def b : B := GF2q.ofWord 0x53
+def c : B := b * b + 1
+def d := GF2q.toGFq c
+```
+
+# Functionality
+
+- `GFqC p n` is the spelling to reach for. It resolves through a
+  `GFq.CommittedEntry` instance, one per committed Conway pair: `p` in
+  `2, 3, 5, 7, 11, 13`, to degree `6` for the odd primes and to degree `8` for
+  `p = 2`. Outside that range there is no instance, so the constructor fails at
+  synthesis rather than inventing a field.
+- `GFq p n h` takes the `Conway.SupportedEntry` explicitly, for proofs that
+  need to name the witness. `GFqC` is defined as `GFq p n h.entry`.
+- `GFq.ofPoly` and `GFq.repr` move between polynomials and field elements, with
+  `repr_add`, `repr_mul`, `repr_pow`, `repr_inv_zero` and the rest reducing a
+  representative to a `GFqRing.reduceMod` of the Conway modulus. `GFq.frob` is
+  the `p`-th power map. `GFqC` mirrors all of it.
+- `GF2q n` is the optimized characteristic-two constructor: the same Conway
+  modulus, represented by `hex-gf2`'s single-word packed `GF2n`. It resolves
+  for `n` from `1` to `8` through `GFq.PackedGF2Entry`. `GF2q.ofWord` and
+  `GF2q.repr` are the packed-word views.
+- `GF2q.toGFq` maps the packed model into the generic `GFq 2 n` model for the
+  same entry. It is one-way here, since the ring equivalence is Mathlib's
+  `≃+*`; the two-sided `GF2q.equivGFq` is in
+  [`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib).
+
+# Verification
+
+The field type is built directly from the Conway table's proofs, so a `GFq`
+that elaborates is a field:
+
+```lean
+abbrev GFq (p n : Nat) [ZMod64.Bounds p] (h : Conway.SupportedEntry p n) : Type :=
+  GFqField.FiniteField (Conway.conwayPoly p n h)
+    (Conway.conwayPoly_nonconstant p n h)
+    h.prime
+    (Conway.conwayPoly_irreducible p n h)
+```
+
+The field laws come with it: `GFq.mul_inv_cancel`, `GFq.inv_mul_cancel`,
+`GFq.div_eq_mul_inv` and `GFq.inv_zero` restate
+[`hex-gfq-field`](https://github.com/leanprover/hex-gfq-field)'s results at the
+Conway-backed type, and `GFq.ext` says two elements agree exactly when their
+representatives do.
+
+The packed binary constructor is the part with its own proof obligation. Each
+`PackedGF2Entry` instance carries an irreducibility proof for the packed
+modulus, replayed from a Rabin certificate by the kernel, and a proof that the
+packed word denotes the same polynomial as the committed Conway entry:
+
+```lean
+class PackedGF2Entry (n : Nat) where
+  entry : SupportedEntry 2 n
+  lower : UInt64
+  conway_eq_packed : conwayPoly 2 n entry = packedGF2FpPoly lower n
+  degree_pos : 0 < n
+  degree_lt_word : n < 64
+  packed_irreducible : GF2Poly.Irreducible (GF2Poly.ofUInt64Monic lower n)
+```
+
+So `GF2q n` and `GFq 2 n` are two presentations of one field, not two fields.
+Note that `GF2q 8` uses the Conway modulus `x^8 + x^4 + x^3 + x^2 + 1`, not
+AES's `x^8 + x^4 + x^3 + x + 1`; for a non-Conway model use `FiniteField` from
+[`hex-gfq-field`](https://github.com/leanprover/hex-gfq-field) or `GF2n`
+directly from [`hex-gf2`](https://github.com/leanprover/hex-gf2). See the
+[SPEC](SPEC/hex-gfq.md) for the coverage table and the reason `conwayPoly` is
+not a two-argument total function.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexGFqField/README.md
+++ b/HexGFqField/README.md
@@ -1,0 +1,111 @@
+# hex-gfq-field
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Executable finite fields `F_p[x] / (f)` for Lean 4, without Mathlib. The
+modulus is any polynomial you can prove irreducible, so the package is not tied
+to a particular choice of modulus. It adds inversion, division, exponentiation
+and Frobenius to the canonical quotient-ring representation from
+[`hex-gfq-ring`](https://github.com/leanprover/hex-gfq-ring), which it reuses
+unchanged; the committed example field additionally cites
+[`hex-berlekamp`](https://github.com/leanprover/hex-berlekamp)'s certificate
+checker. Finiteness, cardinality, and the correspondence with Mathlib's
+abstract finite fields live in
+[`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib); for a
+canonical modulus chosen for you, see
+[`hex-gfq`](https://github.com/leanprover/hex-gfq).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-gfq-field"
+git = "https://github.com/leanprover/hex-gfq-field.git"
+rev = "main"
+```
+
+```lean
+import HexGFqField
+open Hex Hex.GFqField
+
+-- `GF(5^4) = F_5[x] / (x^4 + 2)`, from the committed example modulus.
+abbrev F : Type := Example.F
+
+def α : F := Example.ofPoly #p[0, 1]
+def β : F := α ^ 4 + α + 1
+def γ : F := β / α
+
+example (h : β ≠ 0) : β * β⁻¹ = 1 := mul_inv_cancel h
+example : frob α = α ^ 5 := frob_eq_pow α
+
+-- Any modulus works: supply positive degree, primality, and irreducibility.
+#check @FiniteField
+```
+
+# Functionality
+
+- `FiniteField f hf hp hirr` is the field, indexed by the modulus `f`, its
+  positive degree `hf`, the primality witness `hp` for the characteristic, and
+  the irreducibility proof `hirr`. It wraps `GFqRing.PolyQuotient f hf`, so
+  there is one representation and one equality story across the ring and field
+  layers. `ofQuotient`, `toQuotient`, `ofPoly` and `repr` move between the
+  three views, and equality is decidable by comparing representatives.
+- Ring operations delegate to the quotient: `add`, `mul`, `neg`, `sub`,
+  `natCast`, `intCast`, `nsmul` and `zsmul`, each with its instance and a
+  `repr_*` and `toQuotient_*` lemma.
+- `pow` is square-and-multiply, so a Frobenius-sized exponent costs `O(log n)`
+  field multiplications rather than `n` of them. `zpow` extends it to `Int`.
+- `inv` is extended GCD in `F_p[x]` through `invPoly`, normalized by the
+  constant unit factor of the gcd, with the usual junk value at zero. `div` is
+  multiplication by `inv`.
+- `frob x` is `x ^ p`.
+- `GFqField.Example` commits one small field, `GF(5^4)` presented as
+  `F_5[x] / (x^4 + 2)`, with its Rabin certificate and
+  `Example.modulus_irreducible`, so that examples and conformance drivers do
+  not each rebuild a certificate.
+
+# Verification
+
+The field laws are proved, not asserted. Inverse cancellation is the result the
+rest rests on:
+
+```lean
+theorem mul_inv_cancel
+    {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
+    {x : FiniteField f hf hp hirr} (hx : x ≠ 0) :
+    x * x⁻¹ = 1
+```
+
+with `inv_mul_cancel` on the other side, `div_eq_mul_inv` connecting division,
+and `zero_ne_one` giving nontriviality. Those assemble into the bundled
+instances, which hold for every modulus the type admits, because the type
+already carries both the irreducibility proof and the positive-degree
+hypothesis:
+
+```lean
+instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f} :
+    Lean.Grind.Field (FiniteField f hf hp hirr)
+
+instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f} :
+    Lean.Grind.IsCharP (FiniteField f hf hp hirr) p
+```
+
+`frob_eq_pow` holds by `rfl`, so a statement about Frobenius and a statement
+about the `p`-th power are the same statement. Both hypotheses are load-bearing:
+irreducibility alone would admit a nonzero constant modulus, whose quotient is
+trivial, and the field laws would be false there.
+
+`Fintype` and cardinality are deliberately absent, and belong to
+[`hex-gfq-mathlib`](https://github.com/leanprover/hex-gfq-mathlib). See the
+[SPEC](SPEC/hex-gfq-field.md) for the layering rule against
+[`hex-gfq-ring`](https://github.com/leanprover/hex-gfq-ring) and the comparator
+scope.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexGFqMathlib/README.md
+++ b/HexGFqMathlib/README.md
@@ -1,0 +1,147 @@
+# hex-gfq-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+The Mathlib correspondence layer for
+[`hex-gfq`](https://github.com/leanprover/hex-gfq). It puts Mathlib's `Field`
+structure, finiteness and cardinality on the executable quotient-field
+construction, identifies the canonical Conway fields with Mathlib's
+`GaloisField`, and defines the canonical embedding of one committed Conway
+field into another. The packed binary model reaches Mathlib through
+[`hex-gf2-mathlib`](https://github.com/leanprover/hex-gf2-mathlib), and the
+polynomial-level steps route through
+[`hex-poly-fp-mathlib`](https://github.com/leanprover/hex-poly-fp-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-gfq-mathlib"
+git = "https://github.com/leanprover/hex-gfq-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexGFqMathlib
+open Hex
+
+-- The packed binary Conway field is Mathlib's `GaloisField 2 n`.
+noncomputable example (n : Nat) [GFq.PackedGF2Entry n] :
+    GF2q n ≃+* GaloisField 2 n :=
+  GF2q.equivGaloisField
+
+-- The generic Conway field has the cardinality its name promises.
+example {p n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (h : Conway.SupportedEntry p n) :
+    Fintype.card (GFq p n h) = p ^ n :=
+  HexGFqMathlib.GFq.fintype_card_eq_pow h
+```
+
+# Functionality
+
+- `FiniteField.field`, the Mathlib `Field` instance on
+  `GFqField.FiniteField f hf hp hirr`, built from the executable
+  `Lean.Grind.Field` laws so the operations stay the executable ones. `npow` is
+  pinned to the executable power rather than left at Mathlib's `npowRec`, so
+  the two exponentiations on the type cannot diverge.
+- `FiniteField.fintype`, `FiniteField.fintype_card` and
+  `GFq.fintype_card_eq_pow`, the cardinality chain that runs from the
+  reduced-representative subtype up to `p ^ n`.
+- `GFq.equivGaloisField`, `GF2q.equivGFq` and `GF2q.equivGaloisField`: the
+  generic Conway field against Mathlib's, the packed binary field against the
+  generic one, and their composite.
+- `ofPolyHom`, `constHom` and `substHom`, the reduction, constant-embedding and
+  substitution ring homomorphisms into the executable field. These are what a
+  Mathlib construction needing a `RingHom` out of the executable side is
+  pointed at.
+- `conwayEmbed`, the embedding of the degree-`m` Conway field into the
+  degree-`n` one for a committed divisor pair, instantiated at `GF(2^2)` and
+  `GF(2^3)` inside `GF(2^6)`, `GF(13)` inside `GF(13^6)`, and `GF(2^4)` inside
+  `GF(2^8)`.
+- The component lemmas that move
+  [`hex-conway`](https://github.com/leanprover/hex-conway)'s executable
+  primitivity check towards Mathlib's `orderOf` vocabulary.
+
+# Verification
+
+The executable field carries Mathlib's `Field` structure, and the carrier is
+finite with the cardinality its construction promises:
+
+```lean
+noncomputable instance field :
+    Field (Hex.GFqField.FiniteField f hf hp hirr)
+
+theorem fintype_card_eq_pow (h : Hex.Conway.SupportedEntry p n) :
+    Fintype.card (Hex.GFq p n h) = p ^ n
+```
+
+The `Fintype` instances are deliberately `noncomputable`, for the same reason
+as elsewhere in the family: `p ^ n` elements behind a compiled `Finset.univ` is
+a footgun. The `Equiv`s they are built from stay computable.
+
+Cardinality is the whole input to the Mathlib correspondence.
+`equivGaloisField` applies `FiniteField.ringEquivOfCardEq`, which asks only
+that the two counts agree, so it needs `Fact p.Prime` and `n ≠ 0` as
+hypotheses, neither of which the executable side carries:
+
+```lean
+noncomputable def equivGaloisField [Fact p.Prime]
+    (h : Hex.Conway.SupportedEntry p n) (hn : n ≠ 0) :
+    _root_.RingEquiv (Hex.GFq p n h) (GaloisField p n)
+```
+
+The packed binary constructor reaches the same place in two legs, the first
+built on hex-gf2-mathlib's `GF2n.equiv` and computable, the second inheriting
+the choice `ringEquivOfCardEq` makes:
+
+```lean
+def equivGFq : RingEquiv (GF2q n) (GFq 2 n h.entry)
+
+noncomputable def equivGaloisField : RingEquiv (GF2q n) (GaloisField 2 n)
+```
+
+The subfield embedding is a genuine ring homomorphism, on a committed divisor
+pair carrying a `Conway.Compatible` witness rather than a bare `m ∣ n` proof:
+
+```lean
+noncomputable def conwayEmbed (p m n : Nat) [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p]
+    (hm : Hex.Conway.SupportedEntry p m) (hn : Hex.Conway.SupportedEntry p n)
+    (hcompat : Hex.Conway.Compatible p m n hm hn) :
+    Hex.GFq p m hm →+* Hex.GFq p n hn
+```
+
+`Compatible` is the decidable check that composing `C(p, m)` with
+`Conway.normX` reduces to zero, and `substHom_conwayPoly_eq_zero` promotes that
+`Bool` to the well-definedness input the embedding needs.
+
+Be clear about what `normX` is not. It is a computed representative, the
+product of `n / m` successive Frobenius images of the residue of `x`, reduced
+at each step. Reading it as the field norm `α ^ ((p^n - 1) / (p^m - 1))` is the
+design rationale for the definition, not a theorem proved here or in hex-conway,
+which is explicit that two evaluation and Frobenius bridges are missing first.
+Nothing in this package depends on that reading; the root property is what the
+embedding uses.
+
+The primitivity transport is likewise partial. `ofPolyHom_linPowMod`,
+`ofPolyHom_digitPowMod`, `ofPolyHom_eq_one_iff`, `mathlibPrime_of_hexPrime` and
+`mem_of_prime_dvd_primePowerProduct` are the ingredients Mathlib's
+`orderOf_eq_of_pow_and_pow_div_prime` needs, each carried across `ofPolyHom`
+separately. But no declaration here consumes a `Conway.Primitive` witness or
+produces the per-prime hypothesis function that theorem quantifies over, so the
+glue from `Primitive.check` to those hypotheses does not exist yet, and the
+per-entry conclusion `orderOf α = p ^ n - 1` is correspondingly not assembled.
+
+Use [`hex-gfq`](https://github.com/leanprover/hex-gfq) alone for computation;
+this package is for theorem statements and interoperability involving Mathlib.
+See the [SPEC](SPEC/hex-gfq-mathlib.md) for the representation choice and the
+proof strategy behind each equivalence.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -20,6 +20,10 @@ import HexManual.Chapters.HexRealRoots
 import HexManual.Chapters.HexMatrix
 import HexManual.Chapters.HexRowReduce
 import HexManual.Chapters.HexBerlekamp
+import HexManual.Chapters.HexGF2
+import HexManual.Chapters.HexGFqField
+import HexManual.Chapters.HexConway
+import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexDeterminant
 import HexManual.Chapters.HexBareiss
 import HexManual.Chapters.HexGramSchmidt
@@ -28,10 +32,6 @@ import HexManual.Chapters.HexBerlekampZassenhaus
 import HexManual.Chapters.FactorTactics
 -- Unreleased libraries (dependency order).
 import HexManual.Chapters.HexResultant
-import HexManual.Chapters.HexGF2
-import HexManual.Chapters.HexGFqField
-import HexManual.Chapters.HexConway
-import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexRCF
 import HexManual.Chapters.HexNumberField
 import HexManual.Chapters.HexNumberFieldTower
@@ -92,6 +92,14 @@ contracts and, for mature libraries, supply their proofs.
 
 {include 0 HexManual.Chapters.HexBerlekamp}
 
+{include 0 HexManual.Chapters.HexGF2}
+
+{include 0 HexManual.Chapters.HexGFqField}
+
+{include 0 HexManual.Chapters.HexConway}
+
+{include 0 HexManual.Chapters.HexGFq}
+
 {include 0 HexManual.Chapters.HexDeterminant}
 
 {include 0 HexManual.Chapters.HexBareiss}
@@ -130,14 +138,6 @@ split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexResultant}
-
-{include 2 HexManual.Chapters.HexGF2}
-
-{include 2 HexManual.Chapters.HexGFqField}
-
-{include 2 HexManual.Chapters.HexConway}
-
-{include 2 HexManual.Chapters.HexGFq}
 
 {include 2 HexManual.Chapters.HexRCF}
 

--- a/progress/20260822T032311Z_finite-field-batch-readmes.md
+++ b/progress/20260822T032311Z_finite-field-batch-readmes.md
@@ -1,0 +1,46 @@
+# Released-repo READMEs for the computational finite-field batch
+
+## Accomplished
+
+Authored four `<Lib>/README.md` files against `SPEC/readme.md`:
+
+- `HexGF2/README.md` (`hex-gf2`)
+- `HexConway/README.md` (`hex-conway`)
+- `HexGFqField/README.md` (`hex-gfq-field`)
+- `HexGFq/README.md` (`hex-gfq`)
+
+Each has the five required sections, a `[[require]]` block naming its released
+repository, a Quickstart snippet under 20 lines, headline theorem signatures
+quoted verbatim in the Verification section, and the standard Contributing
+paragraph.
+
+Every Quickstart snippet was elaborated against a full build with
+`lake env lean` and reported no errors.
+`python3 scripts/release/check_released_manifest.py` still passes; the four
+repositories have no `released.yml` entries yet, so the manifest does not track
+these files.
+
+Three SPEC claims were softened to match the implementation:
+
+- `hex-gf2`: `GF2Poly.mul` is schoolbook only, so the README does not mention
+  Karatsuba; the packed-vs-generic speedup figures are not quoted, since those
+  benches live at the monorepo bench root rather than in the library tree.
+- `hex-gf2`: the Euclidean-domain story is described through the proved
+  specification lemmas, because there is no bundled instance.
+- `hex-conway`: Tier 3 on-demand search is stated as specified but not
+  implemented, with no API promised.
+
+## Current frontier
+
+The four files are committed on `finite-field-batch-readmes`. A second agent is
+adding two more READMEs on the same branch.
+
+## Next step
+
+Add the corresponding `released.yml` entries, with `component:` labels, when
+these libraries are released. That is what puts the READMEs under
+`check_released_manifest.py` and into the aggregate README table.
+
+## Blockers
+
+None.

--- a/progress/20260822T032905Z_finite-field-batch-mathlib-readmes.md
+++ b/progress/20260822T032905Z_finite-field-batch-mathlib-readmes.md
@@ -1,0 +1,53 @@
+# Released-repo READMEs for the finite-field Mathlib layers
+
+## Accomplished
+
+Authored two `<Lib>/README.md` files against `SPEC/readme.md`, on the same
+branch as the four computational READMEs:
+
+- `HexGF2Mathlib/README.md` (`hex-gf2-mathlib`)
+- `HexGFqMathlib/README.md` (`hex-gfq-mathlib`)
+
+Both have the five required sections, a `[[require]]` block naming the released
+repository, a Quickstart that states the headline correspondence rather than an
+executable surface, and Verification signatures copied verbatim from the
+sources: `GF2Poly.equiv`, `GF2Poly.equivPolynomial`, the two `GF2n`/`GF2nPoly`
+field equivalences and their `fintype_card` theorems; `FiniteField.field`,
+`GFq.fintype_card_eq_pow`, `GFq.equivGaloisField`, `GF2q.equivGFq`,
+`GF2q.equivGaloisField` and `conwayEmbed`.
+
+Both Quickstart snippets were elaborated against a full build with
+`lake env lean` and reported no errors.
+`python3 scripts/release/check_released_manifest.py` still passes; neither
+repository has a `released.yml` entry yet, so the manifest does not track these
+files.
+
+Two SPEC claims were carried through with their caveats intact rather than
+flattened into results:
+
+- `hex-gfq-mathlib`: `Conway.normX`'s reading as the field norm
+  `α ^ ((p^n - 1) / (p^m - 1))` is stated as design rationale, not a theorem,
+  and the README says which bridges hex-conway is still missing.
+- `hex-gfq-mathlib`: the primitivity transport is described as component
+  lemmas only, with the absence of the `Primitive.check`-to-`orderOf` glue and
+  of the per-entry `orderOf α = p ^ n - 1` conclusion stated outright.
+
+One naming correction: the SPEC attributes
+`eval_conwayPoly_subfieldGen_eq_zero` to this library, but that theorem lives
+in `HexConway/Compatibility.lean`. The README names this library's own
+`substHom_conwayPoly_eq_zero` instead.
+
+## Current frontier
+
+Six READMEs are now committed on `finite-field-batch-readmes`: the four
+computational ones and these two correspondence layers. Nothing is pushed.
+
+## Next step
+
+Add `released.yml` entries when these libraries are released. `*-mathlib`
+companions take no `component:` label; they appear in the row of the
+computational library they bridge.
+
+## Blockers
+
+None.

--- a/progress/20260822T034500Z_finite-field-batch-manifest.md
+++ b/progress/20260822T034500Z_finite-field-batch-manifest.md
@@ -1,0 +1,36 @@
+# Finite-field batch: publish manifest entries
+
+## Accomplished
+
+- Authored the six released-repo READMEs (HexGF2, HexConway, HexGFqField,
+  HexGFq, HexGF2Mathlib, HexGFqMathlib) per SPEC/readme.md, with
+  compile-checked Quickstart snippets and honest scoping of SPEC
+  overclaims (no Karatsuba, no bundled Euclidean-domain instance, Conway
+  Tier 3 absent, normX field-norm reading unproved, primitivity glue
+  absent).
+- Added the six release-manifest entries after hex-berlekamp in
+  topological order (hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib,
+  hex-gfq, hex-gfq-mathlib) with mechanically verified pin closures;
+  hex-gf2 is `lakefile: lean` with `precompile_modules: true` and ships
+  the NTL comparator driver sources; the aggregate pins gain all six.
+- Moved the HexGF2, HexGFqField, HexConway, and HexGFq chapters from the
+  draft include level to the released level in HexManual.lean.
+- check_released_manifest.py: 42 split repositories + 1 aggregate, valid.
+  check_manual_split.py: 23 released chapters, 4 draft, consistent.
+  check_dag.py: clean.
+
+## Current frontier
+
+- The seven bootstrap skeletons are pushed on the released repos' mains;
+  the two baselined existing mirrors (aggregate, hex-berlekamp-mathlib)
+  still need their coordinated require edits before a sync.
+
+## Next step
+
+- Merge this batch, then the staged publish per the release plan (token
+  verification, local staging build, pinned-SHA dry run, real run).
+
+## Blockers
+
+- Publishing-token widening for the seven new repositories awaits
+  org-owner approval.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -336,6 +336,77 @@ repos:
     pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring]
     lakefile: toml
 
+  - repo: leanprover/hex-conway
+    component: Conway polynomials
+    lib: HexConway
+    umbrella: true
+    spec: hex-conway
+    bench: true
+    conformance: true
+    fixtures: [HexConway]
+    oracles: [conway_luebeck.py, conway_polynomials_table.py, common.py, luebeck_conway_cache.json, update_luebeck_conway_cache.py]
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp]
+    lakefile: toml
+
+  - repo: leanprover/hex-gfq-field
+    component: Finite fields `F_p[x]/(f)`
+    lib: HexGFqField
+    umbrella: true
+    spec: hex-gfq-field
+    bench: true
+    conformance: true
+    fixtures: [HexGFqField]
+    oracles: [gfqfield_flint.py, common.py, flint_bench_driver.py]
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp]
+    lakefile: toml
+
+  - repo: leanprover/hex-gf2
+    component: Packed GF(2) polynomials
+    lib: HexGF2
+    precompile_modules: true
+    umbrella: true
+    spec: hex-gf2
+    bench: true
+    conformance: true
+    fixtures: [HexGF2]
+    oracles: [gf2_flint.py, common.py, gf2_ntl_bench_driver.cc, setup_gf2_ntl_driver.sh]
+    pins: [hex-basic]
+    lakefile: lean
+
+  - repo: leanprover/hex-gf2-mathlib
+    lib: HexGF2Mathlib
+    umbrella: true
+    spec: hex-gf2-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-gfq-field, hex-gf2, hex-poly-mathlib, hex-mod-arith-mathlib, hex-poly-fp-mathlib]
+    lakefile: toml
+
+  - repo: leanprover/hex-gfq
+    component: Canonical finite fields
+    lib: HexGFq
+    umbrella: true
+    spec: hex-gfq
+    bench: true
+    conformance: true
+    fixtures: [HexGFq]
+    oracles: [gfq_flint.py, common.py]
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2]
+    lakefile: toml
+
+  - repo: leanprover/hex-gfq-mathlib
+    lib: HexGFqMathlib
+    umbrella: true
+    spec: hex-gfq-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gfq, hex-poly-mathlib, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gf2-mathlib]
+    lakefile: toml
+
   - repo: leanprover/hex-determinant
     component: Determinants
     lib: HexDeterminant
@@ -520,5 +591,5 @@ repos:
   - repo: leanprover/hex
     pins_only: true
     readme_template: scripts/release/hex-README.md
-    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
     lakefile: toml


### PR DESCRIPTION
This PR add the six finite-field-batch libraries to the publish manifest and author their released-repo READMEs. The entries sit after hex-berlekamp in topological order (hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib) with pin closures the manifest checker verifies against `libraries.yml`; hex-gf2 uses the lean lakefile form for its `extern_lib` and precompiled modules and ships the NTL comparator driver sources as oracles; the aggregate pins gain all six. The four computational chapters move from the draft include level to the released level in `HexManual.lean`, with their imports moved into the released block.

The six READMEs follow `SPEC/readme.md`, with Quickstart snippets verified to elaborate against a full build. They scope claims to what the code proves: hex-gf2's multiplication is a schoolbook convolution of carry-less word products, its Euclidean structure is the specification lemmas rather than a bundled instance, hex-conway's on-demand Tier 3 search is specified but has no API, `GF2q 8` uses the Conway modulus rather than AES's, the `Conway.normX` field-norm reading is design rationale rather than a theorem, and the primitivity transport supplies component lemmas without the glue from `Primitive.check` to Mathlib's order hypotheses.

`check_released_manifest.py` passes with 42 split repositories plus the aggregate, and `check_manual_split.py` reports 23 released chapters consistent with the manifest. The seven bootstrap skeletons are already pushed on the released repositories' mains; the coordinated require edits to the two baselined existing mirrors (`leanprover/hex`, `hex-berlekamp-mathlib`) follow separately before any sync is dispatched.

🤖 Prepared with Claude Code
