### PR TITLE
chore: record HexPolyFpMathlib phases 1 through 5

### DIFF
--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -68,7 +68,31 @@ No external comparator is required.
 
 **Justification:** `correspondence-only-layer` per
 `SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
-arithmetic algorithm; it transports values between two representations. The
-computational performance owner is hex-poly-fp, which implements and measures
-the executable side of the correspondence; the other side is Mathlib's own
-`Polynomial`.
+arithmetic algorithm; it transports values between two representations, and the
+far side is Mathlib's own `Polynomial`. Two computational performance owners
+carry the evidence, split by which library owns the operation being
+transported. `FpPoly p` is `DensePoly (ZMod64 p)`, so the split is not the one
+the library name suggests.
+
+**hex-poly** owns the dense ring surface. `+`, `-`, `neg`, `*`, `derivative`,
+`C` and `monomial` on `FpPoly p` are hex-poly's `DensePoly` operations at the
+`ZMod64 p` coefficient ring, and the transport lemmas name them as such:
+`toMathlibPolynomial_{add, sub, mul, derivative, C, monomial_one}` are stated
+about `Hex.DensePoly.*`, and `toMathlibPolynomial_X` about `Hex.FpPoly.X`,
+which is `DensePoly.monomial 1 1`. `toMathlibPolynomial_dvd` belongs here too:
+it is proved from a multiplication witness and `toMathlibPolynomial_mul`, not
+from any division or gcd. So does `commRing`, whose `sub` and `neg` fields are
+pinned to the executable `DensePoly` operations. The relevant multiplication is
+the generic schoolbook convolution; hex-poly-fp's packed `mulPacked` is an
+optional value-equal kernel, not the registered implementation of `*`.
+
+**hex-poly-fp** owns the prime-field surface above it: `linearPow`, and the
+Frobenius, modular-composition, quotient-ring, square-free and monic-gcd
+operations, together with the field-dependent gcd and modular division that
+`primeModulus_of_fact` unlocks. Of these the layer transports `linearPow`, via
+`linearPow_eq_pow`. `linearPow` has no bench target of its own, and correctly
+so: it is a structural recursion defined for kernel reduction, its call
+sites are theorems and private proof-side helpers, and the compiled
+square-free path uses `pow` instead. The
+value it denotes is `n` right-multiplications by the base, so its cost is
+hex-poly's multiplication ladder iterated a declared number of times.

--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -11,6 +11,20 @@ Mathlib's own polynomial type.
   assemble into.
 - `toMathlibPolynomial`, the forward map named for use in statements, with its
   coefficient, monicity, and `simp` lemmas.
+- Transport lemmas naming the forward map for the operations a caller reaches
+  for directly rather than through a `RingEquiv` composition: `derivative`,
+  `mul`, `add`, `sub`, `C`, the monic monomial `monomial m 1`, `X`, and `dvd`.
+- `commRing : CommRing (FpPoly p)`, built from the ring laws hex-poly-fp proves
+  rather than transported along `fpPolyEquiv`, so that the Mathlib operations
+  are the executable ones and `sub` and `neg` are the executable ones too.
+  Without it `FpPoly p →+* R` is not a well-formed type, so this is a
+  prerequisite for every downstream ring homomorphism out of the executable
+  polynomials rather than a convenience.
+- `linearPow_eq_pow`, identifying hex-poly-fp's structural `linearPow` with the
+  monoid power that `commRing` supplies, so `map_pow` applies to executable
+  powers.
+- `primeModulus_of_fact`, deriving the executable `ZMod64.PrimeModulus p`
+  witness from Mathlib's `Fact (Nat.Prime p)`.
 
 Everything below this library is Hex's own tower: `DensePoly` over `ZMod64`,
 reached through hex-poly-mathlib and hex-mod-arith-mathlib. Everything a
@@ -28,9 +42,11 @@ hex-berlekamp-mathlib re-exports the names, so call sites spelling them
 `HexBerlekampMathlib.fpPolyEquiv` resolve unchanged.
 
 The equivalence needs only `ZMod64.Bounds p`, not primality: `FpPoly p` is a
-ring for any admissible modulus, and so is `Polynomial (ZMod p)`. Lemmas that do
-need `p` prime, such as the coprimality transports, say so in their own
-hypotheses.
+ring for any admissible modulus, and so is `Polynomial (ZMod p)`. Primality
+enters only through `primeModulus_of_fact`, which carries it as an explicit
+`Fact (Nat.Prime p)` hypothesis. The coprimality transports that consume the
+resulting witness are owned by the consumers, hex-berlekamp-mathlib in
+particular, because they name that library's predicates.
 
 The dependency on hex-poly-mathlib is narrow and worth naming, since it is not
 the obvious one: the generic `DensePoly R ≃+* Polynomial R` cannot be reused

--- a/conformance/HexPolyFp/Conformance.lean
+++ b/conformance/HexPolyFp/Conformance.lean
@@ -10,7 +10,8 @@ import HexPolyFp.SquareFree
 
 /-!
 Core conformance checks for the `HexPolyFp` Frobenius, modular-composition,
-and square-free decomposition surface.
+and square-free decomposition surface, together with the structural power and
+negation that the `hex-poly-fp-mathlib` correspondence transports.
 
 Oracle: none
 Mode: always
@@ -21,6 +22,8 @@ Covered operations:
 - `composeModMonic`
 - `squareFreeDecomposition`
 - `weightedProduct`
+- `linearPow`
+- `neg` (the `Neg (FpPoly p)` instance, at `p = 5`)
 Covered properties:
 - modular exponentiation by exponent zero returns the quotient-ring identity
 - Frobenius-power exponent zero agrees with reduction of `X`
@@ -28,6 +31,9 @@ Covered properties:
 - composition of the zero polynomial is zero
 - square-free decompositions reconstruct the input from the unit and weighted factors
 - weighted products respect positive multiplicities
+- `linearPow` is exponent-additive, and exponent one is the base
+- negation is the additive inverse and an involution, and subtraction agrees
+  with adding the negation
 Covered edge cases:
 - constant monic modulus `1`
 - the indeterminate `X` and constant polynomial inputs
@@ -42,6 +48,11 @@ Covered edge cases:
 - square-free decomposition with mixed multiplicities `(2, 3)` from a
   product of four distinct linear factors
 - square-free, repeated-factor, derivative-zero, zero, and scalar square-free inputs
+- exponent zero and a zero base for `linearPow`, and the zero polynomial for
+  `neg`
+- `(x + 1)^5` over `F_5`, whose interior binomial coefficients all vanish, so
+  the result carries internal zeros
+- a degree-10 sparse input to `neg`, checking normalisation keeps the degree
 -/
 
 namespace Hex
@@ -172,6 +183,68 @@ private theorem quadModulus_monic : DensePoly.Monic quadModulus := by
   let f := polyFive #[3]
   sfSummary (squareFreeDecomposition prime_five f) = (3, []) ∧
     coeffNats (sfReconstruction (squareFreeDecomposition prime_five f)) = coeffNats f
+
+/-!
+`linearPow` and `neg` on `FpPoly 5`. Both are advertised on the executable
+side of the `hex-poly-fp-mathlib` correspondence — `linearPow` through
+`linearPow_eq_pow` and `neg` through the `neg` field that layer's `CommRing`
+instance pins to the executable operation — and neither had a check here.
+
+Expected values are binomial expansions reduced mod 5, derivable without
+running the operation.
+-/
+
+-- Typical: `(x + 1)^3 = x^3 + 3x^2 + 3x + 1`, no coefficient wrapping.
+#guard coeffNats (linearPow (polyFive #[1, 1]) 3) = [1, 3, 3, 1]
+
+-- Edge: exponent zero is `1` for any base, including the zero polynomial.
+#guard coeffNats (linearPow (polyFive #[2, 3]) 0) = [1]
+#guard coeffNats (linearPow (0 : FpPoly 5) 0) = [1]
+#guard coeffNats (linearPow (0 : FpPoly 5) 3) = []
+
+-- Adversarial: `(x + 2)^4 = x^4 + 8x^3 + 24x^2 + 32x + 16`, where every
+-- non-leading coefficient wraps mod 5 (8, 24, 32, 16 -> 3, 4, 2, 1), so a
+-- kernel that deferred reduction to the end would still have to carry the
+-- unreduced intermediates.
+#guard coeffNats (linearPow (polyFive #[2, 1]) 4) = [1, 2, 4, 3, 1]
+
+-- Adversarial: `(x + 1)^5 = x^5 + 1` over `F_5`, since `5 ∣ C(5, k)` for
+-- `0 < k < 5`. Every interior coefficient reduces to zero, so the result has
+-- internal zeros that normalisation must not trim.
+#guard coeffNats (linearPow (polyFive #[1, 1]) 5) = [1, 0, 0, 0, 0, 1]
+
+-- `linearPow` is the exponent-additive power: committed base, committed split.
+#guard
+  let b := polyFive #[2, 1]
+  linearPow b 7 = linearPow b 3 * linearPow b 4
+
+#guard linearPow (polyFive #[3, 0, 4]) 1 = polyFive #[3, 0, 4]
+
+-- Typical: negation is coefficientwise, `-3 = 2`, `-2 = 3`, `-1 = 4` mod 5.
+#guard coeffNats (-polyFive #[3, 0, 2, 1]) = [2, 0, 3, 4]
+
+-- Edge: the zero polynomial is its own negation.
+#guard coeffNats (-(0 : FpPoly 5)) = []
+
+-- Adversarial: internal zeros, and a leading coefficient whose negation is
+-- also nonzero, so normalisation must keep the degree.
+#guard coeffNats (-polyFive #[0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 2]) =
+  [0, 4, 0, 0, 2, 0, 0, 0, 0, 0, 3]
+
+-- Negation is the additive inverse, and an involution, on committed inputs.
+#guard
+  let f := polyFive #[3, 0, 2, 1]
+  (f + (-f)) = 0
+
+#guard
+  let f := polyFive #[0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 2]
+  (-(-f)) = f
+
+-- Subtraction agrees with adding the negation on a committed pair.
+#guard
+  let f := polyFive #[3, 0, 2, 1]
+  let g := polyFive #[1, 4, 4]
+  (f - g) = (f + (-g))
 
 /-!
 Degree-10 / extension-degree-6 fixtures matching the SPEC `core`

--- a/libraries.yml
+++ b/libraries.yml
@@ -486,7 +486,7 @@ libraries:
     # Extracted from HexBerlekampMathlib, so this entry started at 0: phases are
     # recorded here as they are established for this library in its own right,
     # not inherited from the library the code came from.
-    done_through: 3
+    done_through: 4
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -485,8 +485,13 @@ libraries:
     mathlib: true
     # Extracted from HexBerlekampMathlib, so this entry started at 0: phases are
     # recorded here as they are established for this library in its own right,
-    # not inherited from the library the code came from.
-    done_through: 4
+    # not inherited from the library the code came from. Phase 2 is attested by
+    # status/hex-poly-fp-mathlib.scaffolding-reviewed; phases 3 and 4 are the
+    # correspondence-only mathlib layer criteria of PLAN/Phase3.md and
+    # PLAN/Phase4.md, so there is no conformance module, no bench target and no
+    # phase4 block here, and the layer's performance owners are named in its
+    # SPEC rather than measured locally.
+    done_through: 5
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -486,7 +486,7 @@ libraries:
     # Extracted from HexBerlekampMathlib, so this entry started at 0: phases are
     # recorded here as they are established for this library in its own right,
     # not inherited from the library the code came from.
-    done_through: 2
+    done_through: 3
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -486,7 +486,7 @@ libraries:
     # Extracted from HexBerlekampMathlib, so this entry started at 0: phases are
     # recorded here as they are established for this library in its own right,
     # not inherited from the library the code came from.
-    done_through: 1
+    done_through: 2
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -483,20 +483,10 @@ libraries:
   HexPolyFpMathlib:
     deps: [HexPolyFp, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
-    # Starts at 0 rather than inheriting the phase state of the library the code
-    # was extracted from. The declarations are sorry-free and were exercised as
-    # part of HexBerlekampMathlib, but this library has not been through Phase 2
-    # scaffolding review or Phase 3 conformance in its own right, and recording
-    # phases it has not completed is the drift these phases exist to prevent.
-    # HexBerlekampMathlib is unaffected in practice: at done_through 3 it is
-    # already blocked from Phase 4 by HexBerlekamp, also at 3.
-    # HexGF2Mathlib picked up the same new dependency edge (its
-    # equivPolynomial routes through fpPolyEquiv), and it too is unaffected in
-    # practice, for the opposite reason: it was at done_through 4 when the edge
-    # was added and is now at 5, so it is past every phase status.py gates on
-    # dependencies (1, 3, and 4). Its recorded 1/3/4 predate the extraction and
-    # are not re-derived against this entry.
-    done_through: 0
+    # Extracted from HexBerlekampMathlib, so this entry started at 0: phases are
+    # recorded here as they are established for this library in its own right,
+    # not inherited from the library the code came from.
+    done_through: 1
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/progress/20260822T031132Z_poly-fp-mathlib-phase2-review.md
+++ b/progress/20260822T031132Z_poly-fp-mathlib-phase2-review.md
@@ -1,0 +1,322 @@
+# HexPolyFpMathlib Phase 2 scaffolding review
+
+## Accomplished
+
+Independent Phase 2 review of HexPolyFpMathlib per `PLAN/Phase2.md`, by an
+agent other than the author of the scaffolding. Read
+`HexPolyFpMathlib/Basic.lean` (411 lines, the only module) and
+`HexPolyFpMathlib.lean` in full against
+`HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md`, and read the consumer surface:
+`HexBerlekampMathlib/Irreducibility.lean` (re-export block and first use
+sites), `HexGF2Mathlib/Basic.lean` (`equivPolynomial`),
+`HexGFqMathlib/Subfield.lean` and `HexGFqMathlib/Primitivity.lean`.
+
+Committed `status/hex-poly-fp-mathlib.scaffolding-reviewed` and updated the
+SPEC's Contents section.
+
+### Phase 1 prohibitions: clean
+
+- No `sorry`, no `axiom`, no `@[extern]`, no `ffi/` directory.
+- Grep for `scaffold`, `for now`, `eventual`, `placeholder`, `Phase 1`,
+  `bridge for` across `HexPolyFpMathlib/`: the only hits are
+  `Mathlib.Algebra.Ring.MinimalAxioms` and the `CommRing.ofMinimalAxioms`
+  application, both substring accidents.
+- No placeholder or trivial-return body. The library has exactly two
+  data-level definitions, `fpPolyToPolynomial` (a `Finset.sum` of monomials)
+  and `polynomialToFpPoly` (`DensePoly.ofList` over `List.range (natDegree +
+  1)`), plus `fpPolyEquiv` bundling them. Each computes what its name says.
+- No wrong-complexity body: the whole library sits inside a `noncomputable
+  section` and states correspondences. The one place where an executable
+  complexity claim could leak, `commRing`'s `npow` defaulting to `npowRec`, is
+  handled by `linearPow_eq_pow`, which keeps callers on hex-poly-fp's
+  structural `linearPow` and only identifies it with the monoid power for
+  `map_pow`.
+- No native-numeric wrong-shape declaration: nothing here names `UInt64`,
+  `Fin n` or `Float`.
+
+### DAG and imports
+
+`libraries.yml[HexPolyFpMathlib].deps = [HexPolyFp, HexPolyMathlib,
+HexModArithMathlib]` matches `Basic.lean`'s imports exactly (plus
+`Mathlib.Algebra.Ring.MinimalAxioms`). `python3 scripts/check_dag.py` exits 0.
+The SPEC header names the same three plus Mathlib.
+
+### SPEC-promised declarations: none missing
+
+The Contents section promised `fpPolyToPolynomial`, `polynomialToFpPoly`,
+`fpPolyEquiv`, and `toMathlibPolynomial` with coefficient, monicity and `simp`
+lemmas. All present: `Basic.lean:43, 48, 164, 219`, `coeff_toMathlibPolynomial`
+at `:234`, `toMathlibPolynomial_monic` at `:257`, `fpPolyEquiv_apply` /
+`fpPolyEquiv_symm_apply` at `:223, :228`.
+
+`SPEC/Libraries/README.md:88` still advertises degree transport, which the
+library does not have. This is corrected by the open PR #9367 (`doc: correct
+SPEC and record staleness ahead of the finite-field release`, not merged as of
+this review), so it is recorded here rather than filed as an issue.
+
+### SPEC Contents update made
+
+Three implemented families were under-described and are now listed:
+
+- the transport lemma family `toMathlibPolynomial_{derivative, mul, add, sub,
+  C, monomial_one, X, dvd}` (`Basic.lean:289-355`);
+- `commRing : CommRing (Hex.FpPoly p)` (`Basic.lean:385`), with the reason it
+  is a prerequisite rather than a convenience;
+- `linearPow_eq_pow` (`Basic.lean:403`) and `primeModulus_of_fact`
+  (`Basic.lean:360`).
+
+Also corrected a prose claim in the Ownership section: it said "Lemmas that do
+need `p` prime, such as the coprimality transports, say so in their own
+hypotheses", but no coprimality transport lives here. The lemmas it describes
+(`isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd`,
+`toMathlibPolynomial_squareFree_coprime`) are in
+`HexBerlekampMathlib/Irreducibility.lean`, correctly, since they name
+`isUnitPolynomial`. The sentence now points at `primeModulus_of_fact`, which is
+the library's only primality-dependent declaration.
+
+This edit does not touch the comparator-justification lines that PR #9367
+rewrites, so the two do not conflict.
+
+### Consumer fit
+
+`HexBerlekampMathlib/Irreducibility.lean:38-44` re-exports 19 names. Every one
+resolves to a public declaration of this library, and the export list is
+exactly the public non-`private` surface minus `commRing` and
+`linearPow_eq_pow`. Those two are genuinely not needed under the
+`HexBerlekampMathlib.` prefix (an instance resolves without `export`, and
+`linearPow_eq_pow` postdates the re-export block's compatibility purpose), so
+the omission is coherent rather than an oversight.
+
+`HexGF2Mathlib/Basic.lean:828-853` composes `fpPolyEquiv`, and uses
+`polynomialToFpPoly`, `fpPolyEquiv_apply` and `coeff_toMathlibPolynomial`. All
+public API, no reaching around.
+
+`HexGFqMathlib/Subfield.lean` is the one place where a consumer does reach
+around, and it is symptomatic rather than sloppy. See gap 1.
+
+`HexGFqMathlib/Subfield.lean:32` and `HexGFqMathlib/Primitivity.lean:31` both
+say `open scoped HexPolyFpMathlib`. HexPolyFpMathlib declares nothing `scoped`
+(no `scoped instance`, no `scoped notation`, no notation or macro at all), so
+both lines are no-ops. The presumable intent was to bring `commRing` into
+scope, which is unnecessary because it is a global instance. Folded into gap 3
+as a cleanup.
+
+## Gaps, with drafted follow-up issues
+
+Not filed: this session was instructed to draft rather than file.
+
+---
+
+### Issue 1
+
+**Title:** `feat(hex-poly-fp-mathlib): complete the transport surface to match the generic DensePoly correspondence`
+
+**Body:**
+
+This library exists because the generic `DensePoly R ≃+* Polynomial R` in
+hex-poly-mathlib cannot be reused for `FpPoly p`: `Hex.FpPoly p` is an abbrev
+for `Hex.DensePoly (Hex.ZMod64 p)` (`HexPolyFp/Field.lean:848`), and every
+lemma in `HexPolyMathlib/PolynomialEquivalence.lean` carries `[Semiring R]
+[DecidableEq R]`, which `Hex.ZMod64 p` deliberately does not have. The
+consequence the SPEC does not acknowledge is that the FpPoly layer has to
+re-establish that surface itself, and it currently re-establishes about a
+third of it.
+
+The generic layer proves, and this library does not:
+
+- `coeff_ofPolynomial` — the inverse-direction coefficient lemma. There is no
+  `coeff_polynomialToFpPoly : (polynomialToFpPoly P).coeff n = ZMod64.ofZMod
+  (P.coeff n)` here at all, so every consumer working backwards across the
+  equivalence has to route through `RingEquiv.symm_apply_eq` and the forward
+  lemma by hand.
+- `ofPolynomial_{zero, one, C, neg, sub, add, monomial}` — the whole inverse
+  direction of the transport family.
+- `toPolynomial_monomial` at a general coefficient. This library has only
+  `toMathlibPolynomial_monomial_one` (`Basic.lean:331`), the coefficient-`1`
+  special case, which is a corollary of the general lemma rather than the
+  primitive.
+- `toPolynomial_neg`. The library has `sub` but not `neg`, which is odd given
+  that `commRing` goes out of its way to pin `neg` to the executable
+  `DensePoly.neg`.
+- `eval₂_toPolynomial` and `toPolynomial_compose`.
+- `toPolynomial_dvd_iff`. This library has only the forward direction
+  (`toMathlibPolynomial_dvd`, `Basic.lean:352`). The reverse direction is what
+  lets a Mathlib divisibility fact be reflected back onto the executable
+  representation, which is what a decision procedure needs.
+- `natDegree_toPolynomial` and `leadingCoeff_toPolynomial` — see issue 2,
+  filed separately because its evidence is different.
+
+This is not hypothetical. `HexGFqMathlib/Subfield.lean:167-183` re-derives the
+general inverse monomial transport inline:
+
+```lean
+have hsym : HexPolyFpMathlib.fpPolyEquiv.symm (Polynomial.monomial k c) =
+    (Hex.DensePoly.monomial k (HexModArithMathlib.ZMod64.ofZMod c) :
+      Hex.FpPoly p) := by
+  rw [RingEquiv.symm_apply_eq]
+  apply Polynomial.ext
+  intro i
+  rw [HexPolyFpMathlib.fpPolyEquiv_apply,
+    HexPolyFpMathlib.coeff_toMathlibPolynomial,
+    Hex.DensePoly.coeff_monomial, Polynomial.coeff_monomial]
+  ...
+```
+
+Seventeen lines of representation-level coefficient reasoning inside a file
+about Conway subfield embeddings. With a general
+`toMathlibPolynomial_monomial` it is `rw [RingEquiv.symm_apply_eq,
+toMathlibPolynomial_monomial]`. The enclosing theorem,
+`ofPolyHom_compose_eq_eval₂` (`Subfield.lean:153`), is itself doing by hand,
+via a bespoke `Polynomial.induction_on'`, work that
+`HexPolyMathlib.toPolynomial_compose` and `eval₂_toPolynomial` do generically.
+
+`HexGF2Mathlib.coeff_equivPolynomial` (`Basic.lean:850`) is the mild version
+of the same thing: it exists because "unfolding through both legs leaves a
+`toZMod` applied to an `if`", which is the sort of thing the missing forward
+lemmas would absorb.
+
+Suggested scope: add the inverse-direction coefficient lemma first, since the
+rest of the `symm` family follows from it, then the general monomial, `neg`,
+`dvd_iff`, `eval₂`, and `compose`. Whether to reach them by re-proving or by a
+shared abstraction over the two correspondence layers is an implementation
+choice; the constraint is that `ZMod64` must not acquire a Mathlib `Semiring`
+instance, which is the deliberate design decision the SPEC records.
+
+Found in the Phase 2 scaffolding review of HexPolyFpMathlib.
+
+---
+
+### Issue 2
+
+**Title:** `feat(hex-poly-fp-mathlib): own the degree and leadingCoeff transport now proved in hex-berlekamp-mathlib`
+
+**Body:**
+
+`HexBerlekampMathlib/Irreducibility.lean:52-96` proves
+
+```lean
+theorem natDegree_toMathlibPolynomial_eq_basisSize [Nontrivial (ZMod p)]
+    (f : Hex.FpPoly p) (hmonic : Hex.DensePoly.Monic f) :
+    (toMathlibPolynomial f).natDegree = Hex.Berlekamp.basisSize f
+```
+
+Only the last two lines of that proof mention Berlekamp: `unfold
+Hex.Berlekamp.basisSize Hex.DensePoly.degree?; simp [Nat.ne_of_gt hsize_pos]`,
+where `basisSize f = f.degree?.getD 0` (`HexBerlekamp/BerlekampMatrix.lean:32`).
+The preceding thirty-eight lines establish `(toMathlibPolynomial f).natDegree =
+f.size - 1` for monic `f` over a nontrivial `ZMod p`, which is a fact about the
+representation, not about factoring.
+
+hex-poly-fp-mathlib's own SPEC states the ownership rule this violates: "A
+lemma that mentions Berlekamp's `basisSize`, `isUnitPolynomial`, or Rabin's
+test belongs in hex-berlekamp-mathlib even when its conclusion is about
+`toMathlibPolynomial`, because it is a fact about the factoring algorithm
+rather than about the representation." By the contrapositive, the degree fact
+belongs here, and the Berlekamp theorem should be its two-line corollary.
+
+The Ownership section states the cost of not doing this: "None of them should
+have to depend on a factoring library to reach Mathlib." Today any consumer
+needing the degree relation must either depend on hex-berlekamp-mathlib or
+re-prove it. Neither hex-gf2-mathlib nor hex-gfq-mathlib currently needs it, so
+this is a latent rather than realised cost, but hex-gfq-mathlib is the obvious
+next claimant: the degree of a modulus is what makes a residue field the right
+size.
+
+For the shape to aim at, the generic layer has
+`HexPolyMathlib.natDegree_toPolynomial` (`PolynomialEquivalence.lean:560`),
+which is unconditional — `(toPolynomial p).natDegree = p.degree?.getD 0` — and
+`leadingCoeff_toPolynomial` (`:586`). The unconditional form should be available
+here too. What the generic proof uses in place of the
+monicity-plus-nontriviality argument is
+`Hex.DensePoly.coeff_last_ne_zero_of_pos_size` (`HexPoly/Dense.lean:417`),
+which assumes only `[Zero R] [DecidableEq R]` and so applies to `ZMod64 p`
+directly; the one extra step here is transporting `f.coeff (f.size - 1) ≠ 0`
+across `toZMod`, which is injective because `ZMod64.equiv` is an equivalence.
+So this library can state the hypothesis-free version and let Berlekamp keep
+its `[Nontrivial]`-guarded specialisation, or drop that hypothesis too.
+
+The central index line in `SPEC/Libraries/README.md` currently advertises
+degree transport for this library. PR #9367 removes that claim because the
+lemma is absent; if this issue is done instead, the claim becomes true and the
+#9367 hunk should be dropped. Sequence the two deliberately rather than
+letting one silently revert the other.
+
+Found in the Phase 2 scaffolding review of HexPolyFpMathlib. Related to issue 1
+(same root cause, different evidence).
+
+---
+
+### Issue 3
+
+**Title:** `refactor(hex-poly-fp-mathlib): drop the redundant coeff_toMathlibPolynomial_equiv and its duplicated proof`
+
+**Body:**
+
+Three small cleanups in `HexPolyFpMathlib/Basic.lean`, all instances of the
+duplication patterns `PLAN/Phase2.md` asks a scaffolding review to flag.
+
+1. `coeff_toMathlibPolynomial_equiv` (`Basic.lean:247-250`) should be deleted.
+   It is `@[simp, grind =]` with left-hand side `(toMathlibPolynomial f).coeff
+   n`, syntactically identical to `coeff_toMathlibPolynomial`'s
+   (`Basic.lean:233`), and a right-hand side `ZMod64.equiv (f.coeff n)` that is
+   not in simp normal form: `HexModArithMathlib.ZMod64.equiv_apply`
+   (`ZMod64Equiv.lean:229`) is itself `@[simp]` and rewrites `equiv a` to
+   `toZMod a`. So the lemma adds a second simp rule with the same trigger whose
+   output the simp set immediately undoes. It has no consumer: the only
+   occurrence outside its own declaration is its name in
+   `HexBerlekampMathlib/Irreducibility.lean:40`'s `export` list, so deleting it
+   costs one name there. Its `_equiv` suffix also names the spelling of the
+   right-hand side rather than the thing, which is the "name restating use-site
+   context" smell from `.claude/CLAUDE.md`.
+
+2. `coeff_toMathlibPolynomial`'s proof (`Basic.lean:236-245`) is a verbatim
+   copy of `coeff_fpPolyToPolynomial`'s (`Basic.lean:58-66`), ten lines
+   reproduced after a `show` that makes the two goals definitionally the same.
+   `coeff_fpPolyToPolynomial` earns its place: the equivalence's `left_inv`,
+   `right_inv`, `map_mul'` and `map_add'` fields all use it, so it must exist
+   before `fpPolyEquiv` does, and its docstring says so. But
+   `coeff_toMathlibPolynomial` should then be `coeff_fpPolyToPolynomial f n`
+   rather than a second copy of the argument.
+
+3. `HexGFqMathlib/Subfield.lean:32` and `HexGFqMathlib/Primitivity.lean:31`
+   both say `open scoped HexPolyFpMathlib`. HexPolyFpMathlib declares nothing
+   `scoped` — no `scoped instance`, no notation, no macro — so both lines have
+   no effect. If the intent was to bring `commRing` into scope, that is
+   unnecessary: it is a global instance. Delete both lines, or, if a future
+   change does want the instance scoped, make it `scoped instance` and keep
+   them.
+
+None of these is a correctness problem; item 1 is the one with a behavioural
+consequence, a redundant rule in a `simp` set that downstream files inherit.
+
+Found in the Phase 2 scaffolding review of HexPolyFpMathlib.
+
+---
+
+## Current frontier
+
+Phase 2 is satisfied for HexPolyFpMathlib: the library is read, the token is
+committed, the SPEC Contents matches the implemented surface, and the three
+gaps are drafted for filing. The gaps are additive-surface and hygiene issues,
+not scaffolding violations; nothing in the tree needs to be deleted or
+rewritten before the token stands.
+
+## Next step
+
+A second agent continues on this branch to record phases 1 through 5 in
+`libraries.yml` with per-phase evidence. Two things it will want:
+
+- `libraries.yml[HexPolyFpMathlib].done_through` is currently `0`, with a
+  comment explaining that the extraction from HexBerlekampMathlib deliberately
+  did not inherit phase state.
+- Phase 4 for a correspondence-only mathlib layer requires the SPEC to declare
+  comparator absence with the `correspondence-only-layer` reason
+  (`PLAN/Phase4.md:218-222`). The SPEC currently says `proof-only-layer`. The
+  open PR #9367 makes exactly that edit, so recording Phase 4 on this branch
+  either waits on #9367 or duplicates its hunk; this session did not duplicate
+  it, to keep the two from conflicting.
+
+## Blockers
+
+None. Issues 1 to 3 are drafted rather than filed, per the session's
+instructions; they need a human or a follow-up session to file them.

--- a/progress/20260822T034500Z_poly-fp-mathlib-phases-1-5.md
+++ b/progress/20260822T034500Z_poly-fp-mathlib-phases-1-5.md
@@ -1,0 +1,131 @@
+# HexPolyFpMathlib phases 1 through 5 recorded
+
+## Accomplished
+
+Rebased `poly-fp-mathlib-phases-1-5` onto `origin/main` (picking up #9366's
+correspondence-only Phase 3/4 subsections and #9367's SPEC comparator
+rewording) with no conflicts, then recorded
+`libraries.yml[HexPolyFpMathlib].done_through` 0 -> 5 in six commits: the
+Phase 1 bump, the reviewer's token commit, then one commit per remaining phase,
+each carrying that phase's evidence in its message.
+
+### Granularity convention
+
+Not strictly one-phase-per-PR. Most bumps in history move one step
+(`b8ffdbf6e`, `cb7c8137b`, `2e95578a4`, `e4653d540`, `cf69e6d6e`), but a
+library catching up after a refactor or a late classification records several
+phases at once: `cf8890930` (HexMvPoly/HexMvPolyMathlib 0 -> 4), `3bfcafa20`
+(HexRCF 0 -> 3), `617acbffb` (HexRealRootsMathlib 1 -> 3), `5399b8e90`
+(HexResultant 1 -> 4 and HexResultantMathlib 1 -> 3), `346cca9a1`
+(HexMvPoly 4 -> 6). This library is exactly that shape: `15a68c4ac` extracted
+it from HexBerlekampMathlib and seeded it at 0. Splitting the commits keeps
+the per-phase evidence readable and leaves the PR split open.
+
+The Phase 1 bump precedes the token commit, because `PLAN/Phase2.md` gates the
+start of Phase 2 on `done_through >= 1`.
+
+### Per-phase evidence
+
+**Phase 1.** Deps HexPolyFp, HexPolyMathlib, HexModArithMathlib are all at
+`done_through: 7`, past the `>= 1` gate. `lake build HexPolyFpMathlib` green,
+1656 jobs, 67s. The SPEC-promised surface is all present in
+`HexPolyFpMathlib/Basic.lean` with nothing deferred. Data-level declarations,
+in full: `fpPolyToPolynomial` (`:43`, a `Finset.sum` of monomials),
+`polynomialToFpPoly` (`:48`, `DensePoly.ofList` over `List.range (natDegree +
+1)`), `fpPolyEquiv` (`:164`), `toMathlibPolynomial` (`:219`), and the
+`commRing` instance (`:385`), whose `sub` and `neg` fields carry the executable
+`DensePoly` operations. Each computes what its name says.
+
+**Phase 2.** `status/hex-poly-fp-mathlib.scaffolding-reviewed` is the
+attestation, committed by a reviewer agent other than the scaffolding author.
+Two corrections were made to it while recording the phase: its data-level
+enumeration was short by `toMathlibPolynomial` and `commRing`, and it described
+#9367 as open. The three gaps it identified are filed:
+https://github.com/kim-em/hex-dev/issues/9370,
+https://github.com/kim-em/hex-dev/issues/9371,
+https://github.com/kim-em/hex-dev/issues/9372. All three are additive surface
+or hygiene, so none blocks the token.
+
+**Phase 3**, under `PLAN/Phase3.md` §"Correspondence-only mathlib layers".
+`conformance/HexPolyFpMathlib/` does not exist and never has (`git log --all`
+on that path is empty); the `HexConformance` globs and
+`scripts/conformance_targets.py` do not name it. The layer carried no checks:
+`15a68c4ac` touched no path under `conformance/`, and HexBerlekampMathlib has
+no conformance module either.
+
+Per-operation coverage in the owners, and the two gaps the audit found:
+
+- The dense ring surface — add, sub, mul, derivative, `C`, `monomial`, `X` —
+  is hex-poly's, because `FpPoly p` is
+  `abbrev FpPoly (p : Nat) [ZMod64.Bounds p] := DensePoly (ZMod64 p)`
+  (`HexPolyFp/Field.lean:848`) and the transport lemmas are stated about
+  `Hex.DensePoly.*`. Covered in `conformance/HexPoly/Conformance.lean` at
+  `:167-169`, `:171-173`, `:213-220`, `:222-227`, `:229-235`, `:251-257`, with
+  accessors at `:183-185` and `:187-189`.
+- `dvd` is proved from a multiplication witness and `toMathlibPolynomial_mul`
+  (`Basic.lean:352-355`), so its executable content is multiplication —
+  including the oracle-backed FpPoly-level `mul` cases in
+  `conformance/HexPolyFp/EmitFixtures.lean` at p in {5, 11, 31}, checked
+  against python-flint `nmod_poly` by `scripts/oracle/polyfp_flint.py:137-147`.
+  Not gcd or divrem, which the operation never reaches.
+- `neg` and `linearPow` had no owner-side check anywhere. Both are now covered
+  by new `#guard`s in `conformance/HexPolyFp/Conformance.lean`, with the
+  module docstring's three lists extended to match the per-library module
+  contract in `SPEC/testing.md`. `lake build HexPolyFp.Conformance` green, 99
+  jobs, 0.6s; flipping one expected coefficient makes it fail.
+- The Frobenius, modular-composition and square-free surface was already
+  guarded at p = 5 in the same module, with oracle-backed `frobenius`,
+  `gcd`, `divrem` and (at p = 5 only) `squarefree` emissions alongside.
+
+**Phase 4**, under `PLAN/Phase4.md` §"Correspondence-only mathlib layers". Zero
+advertised operations in either track: no `Bench.lean`, no `Bench/`, no
+`lean_exe` bench entry, no `proof_probes` root, no elaborator or tactic. No
+`phase4` block, no headline report required.
+
+The SPEC's comparator declaration needed a fix. #9367 landed the right reason
+string, `correspondence-only-layer`, but named hex-poly-fp as the sole
+computational performance owner, which the code does not support: the dense
+ring surface belongs to hex-poly. The declaration now names both owners and
+maps the operation families to them, and says plainly that `linearPow` has no
+bench target in either — it is a structural recursion for kernel reduction
+whose only call sites are theorems, so a dedicated target would be a false
+attribution.
+
+**Phase 5.** Zero sorries: `grep -rn sorry HexPolyFpMathlib/
+HexPolyFpMathlib.lean` exits 1, as does the same grep for `sorryAx` and
+`axiom`. `lake build HexPolyFpMathlib HexBerlekampMathlib HexGF2Mathlib
+HexGFqMathlib` green, 2333 jobs, 311s (the host was heavily loaded; the
+absolute number is not a performance datum).
+
+### Checkers
+
+`python3 scripts/check_dag.py` exits 0. `python3 scripts/check_phase4.py`
+reports `Phase 4 checks passed`. `python3 scripts/status.py` moves
+HexPolyFpMathlib to Phase 6 and unblocks HexBerlekampMathlib's Phase 4 gate on
+this library.
+
+### libraries.yml comment
+
+Replaced the paragraph explaining why the counter sat at 0 with a shorter note:
+the extraction origin, the Phase 2 token, and the correspondence-only
+classification behind the absent conformance module, bench target and `phase4`
+block.
+
+## Current frontier
+
+HexPolyFpMathlib is at `done_through: 5`. HexBerlekampMathlib's Phase 4 gate on
+it is satisfied; it now waits only on HexBerlekamp reaching 4.
+
+## Next step
+
+Phase 6 (proof polishing) for HexPolyFpMathlib, or issues 9370 / 9371 / 9372,
+whose fixes are Phase-1-shaped additive surface and would be cheaper to land
+before a Phase 6 audit reads the same file.
+
+## Blockers
+
+None. One observation worth passing on rather than acting on: hex-poly's
+conformance module does not advertise `neg` in its covered-operations list,
+and hex-poly's own `#guard`s do not exercise it. The gap is closed here at
+`ZMod64 5`, which is the instantiation this layer transports, but the generic
+`DensePoly R` case remains unchecked in its own owner.

--- a/status/hex-poly-fp-mathlib.scaffolding-reviewed
+++ b/status/hex-poly-fp-mathlib.scaffolding-reviewed
@@ -1,0 +1,32 @@
+HexPolyFpMathlib Phase 2 scaffolding reviewed, by an agent other than the
+author of the scaffolding.
+
+Read in full against HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md:
+- HexPolyFpMathlib/Basic.lean
+- HexPolyFpMathlib.lean
+and the consumer surface in HexBerlekampMathlib/Irreducibility.lean,
+HexGF2Mathlib/Basic.lean, HexGFqMathlib/Subfield.lean and
+HexGFqMathlib/Primitivity.lean.
+
+Clean on the Phase 1 prohibitions: no `sorry`, no `axiom`, no `@[extern]`, no
+placeholder or wrong-shape or wrong-complexity body. The library is
+correspondence statements in a `noncomputable section`; its only data-level
+definitions are the two transport maps and the equivalence they assemble into,
+and each computes what its name says. `scripts/check_dag.py` passes and the
+declared deps match the imports.
+
+No SPEC-promised declaration is missing. The SPEC Contents was under-describing
+the implemented surface, and is corrected in the same commit; the central index
+line in SPEC/Libraries/README.md still advertises degree transport that the
+library does not have, which is corrected by the open PR #9367.
+
+Three gaps identified, with drafted follow-up issues recorded in
+progress/20260822T031132Z_poly-fp-mathlib-phase2-review.md:
+- the transport surface is a strict subset of the generic
+  HexPolyMathlib.PolynomialEquivalence surface that this library exists
+  because it cannot reuse, and two consumers re-derive missing members by hand;
+- degree and leading-coefficient transport is absent, and its
+  representation-level half is proved inside hex-berlekamp-mathlib, which the
+  SPEC's own ownership rule places here;
+- `coeff_toMathlibPolynomial_equiv` is a redundant `@[simp]` lemma with a
+  non-simp-normal right-hand side and no consumer.

--- a/status/hex-poly-fp-mathlib.scaffolding-reviewed
+++ b/status/hex-poly-fp-mathlib.scaffolding-reviewed
@@ -10,15 +10,19 @@ HexGFqMathlib/Primitivity.lean.
 
 Clean on the Phase 1 prohibitions: no `sorry`, no `axiom`, no `@[extern]`, no
 placeholder or wrong-shape or wrong-complexity body. The library is
-correspondence statements in a `noncomputable section`; its only data-level
-definitions are the two transport maps and the equivalence they assemble into,
-and each computes what its name says. `scripts/check_dag.py` passes and the
-declared deps match the imports.
+correspondence statements in a `noncomputable section`. Its data-level
+declarations are, in full: the two transport maps `fpPolyToPolynomial` and
+`polynomialToFpPoly`, the `fpPolyEquiv` they assemble into,
+`toMathlibPolynomial` (the forward map under the name statements use), and the
+`commRing` instance, which carries data — its `sub` and `neg` fields are pinned
+to the executable `DensePoly` operations rather than left at the
+minimal-axioms defaults. Each computes what its name says.
+`scripts/check_dag.py` passes and the declared deps match the imports.
 
 No SPEC-promised declaration is missing. The SPEC Contents was under-describing
 the implemented surface, and is corrected in the same commit; the central index
-line in SPEC/Libraries/README.md still advertises degree transport that the
-library does not have, which is corrected by the open PR #9367.
+line in SPEC/Libraries/README.md advertised degree transport that the library
+does not have, corrected by PR #9367.
 
 Three gaps identified, with drafted follow-up issues recorded in
 progress/20260822T031132Z_poly-fp-mathlib-phase2-review.md:


### PR DESCRIPTION
This PR advance `libraries.yml[HexPolyFpMathlib].done_through` from 0 to 5, one commit per phase, each carrying that phase's evidence. The library was extracted from HexBerlekampMathlib at `done_through: 0` and has since been taken through the phases in its own right.

Phase 1: every dependency is at 7, `lake build HexPolyFpMathlib` is green in 1656 jobs, the SPEC-promised surface is complete with nothing deferred, and all five data-level declarations compute what their names say. Phase 2: `status/hex-poly-fp-mathlib.scaffolding-reviewed` is the attestation, with the three gaps it identified filed as https://github.com/kim-em/hex-dev/issues/9370, https://github.com/kim-em/hex-dev/issues/9371 and https://github.com/kim-em/hex-dev/issues/9372, all additive surface or hygiene rather than scaffolding violations. The token's data-level enumeration was short by `toMathlibPolynomial` and `commRing`, and is corrected.

Phases 3 and 4 take the correspondence-only mathlib layer criteria, and the audit those criteria require turns up three things worth fixing rather than recording. There is no `conformance/HexPolyFpMathlib/Conformance.lean` and never has been, and the layer carried no checks to migrate. But `FpPoly p` is `DensePoly (ZMod64 p)`, so the dense ring surface this layer transports belongs to hex-poly, not hex-poly-fp: the SPEC's `correspondence-only-layer` declaration now names both owners and maps the operation families to them, where before it named hex-poly-fp alone. `toMathlibPolynomial_dvd` is attributed to multiplication, which is what it is proved from, rather than to division or gcd. And `neg` and `linearPow` had no owner-side conformance check anywhere, so this adds typical, edge and adversarial `#guard`s for both to `conformance/HexPolyFp/Conformance.lean` at `p = 5`, the instantiation the layer transports, with expected values derived from binomial expansions rather than from running the operation. `linearPow` has no bench target in either owner, and the SPEC says so plainly: it is a structural recursion for kernel reduction whose call sites are theorems and private proof-side helpers, so a dedicated target would be a false attribution.

Phase 5 is a recording rather than a proof effort: the library has been sorry-free since extraction, and it builds green alongside its three importers, HexBerlekampMathlib, HexGF2Mathlib and HexGFqMathlib.

The entry's comment, which explained why the counter sat at 0, is replaced by a short note on the extraction origin, the Phase 2 token, and the correspondence-only classification behind the absent conformance module, bench target and `phase4` block.

🤖 Prepared with Claude Code
