### PR TITLE
chore: record HexRootsMathlib Phases 1-4, bump to 4

### DIFF
--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -252,7 +252,8 @@ The computational library never states this inequality directly: its
 witness compares dyadic bounds (`lo`, `hi`, and the rational `√2`
 bounds; see [hex-roots.md](../../HexRoots/SPEC/hex-roots.md)). The one-directional lemma
 "the dyadic-bound witness implies the exact Pellet inequality" lives
-in `HexRootsMathlib/Geometry.lean`, so the analytic development above
+in `HexRootsMathlib/Pellet.lean` (`pelletAt_dominates`, feeding
+`Pellet.sound`), so the analytic development above
 stays in the standard form (the form worth contributing to Mathlib)
 while the computational library stays decidable. The converse
 direction, that a sufficiently isolating disc makes the witness hold
@@ -278,8 +279,9 @@ developments above.
   `181/128 < √2 < 1449/1024` bounds, and the Mathlib geometry of a
   `DyadicSquare`: its complex centre, real half-width, closed sup-norm
   square, and open/closed circumscribed discs. Simp lemmas
-  `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`. The later Pellet
-  correspondence in this module proves "witness implies Pellet".
+  `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`. The
+  "witness implies Pellet" correspondence itself lives downstream in
+  `HexRootsMathlib/Pellet.lean`.
 - `HexRootsMathlib/Taylor.lean`: the shared exact-coefficient bridge
   ```lean
   theorem taylor_coeff (p : ZPoly) (z : GaussDyadic) (k : Nat) :
@@ -379,6 +381,27 @@ developments above.
   The refined-level wrapper preserves `RefinedIsolation.root` unconditionally
   by exposing the successful underlying raw refinement call; the packaged
   quotient equality remains available to Mathlib-free callers.
+- `HexRootsMathlib/IsolateTotal.lean`: the none-free consumption surface.
+  ```lean
+  noncomputable def isolate! (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+      (hp : p ≠ 0) (atomPrec : Int)
+      (strategy : Hex.AtomStrategy := .nkThenPellet) :
+      Array (Hex.DyadicRootIsolation p)
+  ```
+  Unlike `Hex.isolate`, this proof-facing wrapper cannot return `none`:
+  its hypotheses discharge the driver's completeness conditions and the
+  result is extracted from `isolate_exists`. It is characterized by
+  `isolate!_eq` (it is exactly the successful executable output), and
+  its behaviour is packaged by `isolate!_count` (one atom per root,
+  with multiplicity), `isolate!_roots` (the selected semantic roots are
+  exactly the root finset), `isolate!_prec` (every atom meets the
+  requested precision), and `isolate!_disjoint` (distinct atoms have
+  disjoint closed circumscribed discs).
+- `HexRootsMathlib/Examples.lean`: compiled regression examples for the
+  public surface (kernel-`decide` witness checks on committed dyadic
+  fixtures and `isolate!`-based root extraction). Deliberately excluded
+  from the umbrella and built through the release-tests target so CI
+  cannot silently lose it.
 
 ## Completeness development
 
@@ -448,7 +471,7 @@ and it is the analytically hardest part:
     adjacent to the component containing that root and hence glued into it.
     The preceding NK and Pellet converses then make every component pass
     `certify?` with `k = 1` under `.nk`, `.pellet`, and `.nkThenPellet`.
-    Mahler separation makes their stored discs pairwise disjoint. An
+    Mahler separation makes their stored discs pairwise disjoint.
     Under either Pellet-bearing strategy, an all-atom worklist may instead run
     the local one-atom refinement loop independently on each atom and emit
     before that depth when every refinement succeeds and the resulting discs
@@ -529,6 +552,8 @@ Correspondence theorems (depend on hex-roots data structures):
   HexRootsMathlib/Isolate.lean
   HexRootsMathlib/SimpleRoot.lean
   HexRootsMathlib/Refinement.lean
+  HexRootsMathlib/IsolateTotal.lean
+  HexRootsMathlib/Examples.lean  (release-tests target, not the umbrella)
 
 Completeness development:
   HexRootsMathlib/Completeness/PelletTail.lean
@@ -540,6 +565,7 @@ Completeness development:
   HexRootsMathlib/Completeness/NKDepth.lean
   HexRootsMathlib/Completeness/RootFreeConverse.lean
   HexRootsMathlib/Completeness/SurvivorComponent.lean
+  HexRootsMathlib/Completeness/RefinementCompleteness.lean
   HexRootsMathlib/Completeness/DriverCompleteness.lean
 ```
 

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -582,6 +582,33 @@ showing the approximate inverse is surjective and hence injective in equal
 dimensions. Polynomial and executable-witness specialization belongs in
 `KantorovichPoly.lean`, not in the generic module.
 
+## Headline correctness theorem
+
+`HexRootsMathlib.isolate_sound`: a successful run of the executable
+isolator on a nonzero polynomial with only simple roots returns atoms
+whose semantic roots enumerate the root finset of the polynomial
+exactly, every atom meeting the requested precision. This is the
+end-to-end post-condition of the public API. Totality under the same
+hypotheses is `isolate_isSome` (the completeness development's
+terminal theorem), packaged for consumers as the none-free `isolate!`
+wrapper with its characterisation family (`isolate!_eq`, `_count`,
+`_roots`, `_prec`, `_disjoint`); the general-multiplicity count
+identity is `isolateAll_count`. Those are independently justified
+public API, and the correspondence and completeness theorems above are
+load-bearing clauses of the headline proof, per the intermediate-lemma
+rule in PLAN/Conventions.md §Headline correctness theorem.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `correspondence-only-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
+root-isolation algorithm; it verifies the executable isolator
+implemented elsewhere. The computational performance owner is
+hex-roots, where the isolator's bench targets and the python-flint
+comparator are measured.
+
 ## References
 
 See [hex-roots.md](../../HexRoots/SPEC/hex-roots.md) for the BSSY, Pellet, Mahler, and

--- a/libraries.yml
+++ b/libraries.yml
@@ -547,7 +547,7 @@ libraries:
   HexRootsMathlib:
     deps: [HexRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 0
+    done_through: 2
     status: active
   HexResultant:
     deps: [HexPoly, HexBasic]

--- a/libraries.yml
+++ b/libraries.yml
@@ -547,7 +547,7 @@ libraries:
   HexRootsMathlib:
     deps: [HexRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 4
     status: active
   HexResultant:
     deps: [HexPoly, HexBasic]

--- a/progress/20260822T041500Z_roots-mathlib-phase2.md
+++ b/progress/20260822T041500Z_roots-mathlib-phase2.md
@@ -1,0 +1,38 @@
+# HexRootsMathlib Phase-2 review and bump to 2
+
+## Accomplished
+
+- Performed the Phase-2 scaffolding review of HexRootsMathlib against
+  its SPEC via a non-author reviewer agent: zero banned markers across
+  41 modules, all 38 SPEC-declared modules present, every SPEC-named
+  theorem present with matching statement, completeness constants
+  reproduced exactly, regression surface CI-reachable four ways.
+- Committed the substantive attestation
+  status/hex-roots-mathlib.scaffolding-reviewed.
+- Fixed the one-directional SPEC drift with the review: declared the
+  isolate! total consumption surface (IsolateTotal.lean) and
+  Examples.lean, added Completeness/RefinementCompleteness.lean to the
+  file table, moved the witness-implies-Pellet attribution from
+  Geometry.lean to Pellet.lean, repaired a dangling sentence.
+- Filed #9384 for the code-level hygiene items (triplicated private
+  helpers, the vacuously-hypothesised same-file alias with its
+  HexNumberFieldMathlib call site, ArgumentTopology pruning), scoped to
+  the wave's HexRootsMathlib Phase-6 pass.
+- Bumped done_through 0 -> 2 (Phase 1 was long since complete: full
+  scaffold, umbrella, local SPEC, deps HexRoots and HexPolyZMathlib
+  both >= 1; the counter had simply never been advanced).
+
+## Current frontier
+
+- Next rung per the wave bump queue
+  (progress/20260822T034500Z_wave-dag-and-headline-audit.md):
+  HexRootsMathlib 2 -> 4 via the Phase-3 exemption record and the
+  Phase-4 mathlib-bridge declaration.
+
+## Next step
+
+- Land the 2 -> 4 PR, then HexResultantMathlib 3 -> 5.
+
+## Blockers
+
+- None.

--- a/progress/20260822T053000Z_roots-mathlib-phase34.md
+++ b/progress/20260822T053000Z_roots-mathlib-phase34.md
@@ -1,0 +1,33 @@
+# HexRootsMathlib Phases 3-4 and bump to 4
+
+## Accomplished
+
+- Recorded the Phase-3 disposition: no conformance module by design
+  (SPEC/testing.md ceremonial-bridge ban), attested in
+  status/hex-roots-mathlib.conformance-reviewed with the executable
+  coverage pointers (conformance/HexRoots plus the CI-gated
+  Examples module).
+- Added the Phase-4 declarations to the SPEC: the headline correctness
+  theorem designation (isolate_sound, with isolate_isSome,
+  isolateAll_count, and the isolate! packaging as justified public
+  API) and the External comparators absence declaration
+  (correspondence-only-layer; computational performance owner
+  hex-roots).
+- Bumped done_through 2 -> 4. check_phase4 exempts the library
+  (mathlib, no phase4 block, no report; HexLLLMathlib precedent), and
+  Phase-4 dep coupling is satisfied (HexRoots 5, HexPolyZMathlib 6).
+
+## Current frontier
+
+- HexRootsMathlib is now at the wave's required level for the
+  NumberFieldMathlib Phase-3/4 edges. Its remaining rungs (5, 6, 7)
+  come with the Phase-6 hygiene pass (#9384) and the Phase-7
+  correspondence-heading work.
+
+## Next step
+
+- A4: HexResultantMathlib 3 -> 5.
+
+## Blockers
+
+- None.

--- a/status/hex-roots-mathlib.conformance-reviewed
+++ b/status/hex-roots-mathlib.conformance-reviewed
@@ -1,0 +1,14 @@
+HexRootsMathlib Phase 3 was reviewed on 2026-08-22. The library has no
+conformance module in-tree, and that absence is intentional, not an
+omission: SPEC/testing.md bans Conformance files in correspondence-only
+Hex*Mathlib bridges (the ceremonial-bridge ban), and this library
+exposes proof-only correspondence and completeness theorems with no
+runtime kernel of its own to conform to. The executable surface it
+verifies is exercised by the computational sibling's conformance module
+(conformance/HexRoots/, python-flint oracle wired in
+scripts/ci/run_oracles.sh) and by this library's own compiled
+regression module HexRootsMathlib/Examples.lean, which is CI-gated
+through the HexReleaseTests target and the release-manifest
+test_modules equality check. Precedent:
+status/hex-lll-mathlib.conformance-reviewed and the #3700/#3707
+history it records.

--- a/status/hex-roots-mathlib.scaffolding-reviewed
+++ b/status/hex-roots-mathlib.scaffolding-reviewed
@@ -1,0 +1,40 @@
+Phase-2 scaffolding review of HexRootsMathlib, 2026-08-22, performed by
+a non-author reviewer agent against HexRootsMathlib/SPEC/hex-roots-mathlib.md
+at origin/main (review basis 8049b20d5; token lands with the 0->2 bump).
+
+Audit lenses applied: placeholder-body audit over all 95 public
+def/abbrevs, banned-marker sweep (sorry, axiom, native_decide, TODO,
+FIXME, stub, placeholder, set_option escapes, commented-out
+declarations, @[extern]) over all 41 modules, wrong-shape/native-type
+audit, SPEC-vs-source signature comparison for every SPEC-named
+declaration, naming-convention pass, instance-coherence pass, and CI
+reachability of the regression surface.
+
+Results. Every banned-marker count is zero. All 38 SPEC-declared
+modules exist; every SPEC-named theorem exists with a matching
+statement, including exact reproduction of the completeness constants
+(PelletDyadic 2|a| + (2R+5|a|)((1+R/d)^m - 1) < r; PelletConverse
+|a| + (rho+3|a|)E < rho; NKConverse (1+4R/d)^m - 1 <= 1/32; PelletTail
+remote-tail bound). The noncomputable Classical.choice extractions
+(RefinedIsolation.root, isolate!) are correct proof-facing selections,
+each paired with a characterisation theorem; the SPEC promises no
+executability from this layer. Zero typeclass instances by documented
+design, so no coherence risk. The Examples regression surface is
+CI-reachable through four independent paths (default_target lib,
+HexReleaseTests, HEX_LIB_TARGETS, and the release-manifest test_modules
+equality check).
+
+Findings and dispositions. SPEC drift was one-directional (source
+ahead of SPEC) and is fixed with this review: the isolate! total
+consumption surface (IsolateTotal.lean) and Examples.lean are now
+declared, Completeness/RefinementCompleteness.lean is in the file
+table, the witness-implies-Pellet attribution moved from Geometry.lean
+to Pellet.lean (pelletAt_dominates), and a dangling sentence fragment
+in the DriverCompleteness clause is repaired. Code-level hygiene items
+(triplicated private helpers sum_erase_range and the mapM extraction
+lemmas; the vacuously-hypothesised same-file alias
+intersects_iff_root_eq_of_simple whose one call site is
+HexNumberFieldMathlib/Basic.lean:380; six unreferenced
+ArgumentTopology.lean declarations; dead-declaration candidates) are
+filed as issue #9384 for the scheduled Phase-6 pass. No data-level
+placeholder, no weakened SPEC theorem, and no blocking gap was found.


### PR DESCRIPTION
This PR record the Phase-2 scaffolding review of HexRootsMathlib and its Phase 3-4 dispositions, advancing `done_through` from 0 to 4. The non-author review against the SPEC found zero banned markers across all 41 modules, every SPEC-declared module and theorem present with matching statements (the completeness constants are reproduced exactly), no data-level placeholders, and a regression surface reachable from CI four independent ways; the attestation lands as `status/hex-roots-mathlib.scaffolding-reviewed`, with code-level hygiene findings filed as #9384 for the Phase-6 pass. The one-directional SPEC drift is fixed with the review: the `isolate!` total consumption surface and `Examples.lean` are declared, `Completeness/RefinementCompleteness.lean` joins the file table, and the witness-implies-Pellet attribution moves to `Pellet.lean`. Phase 3 is recorded as intentionally conformance-free per SPEC/testing.md's ceremonial-bridge ban (`status/hex-roots-mathlib.conformance-reviewed`), and Phase 4 adds the headline-correctness-theorem designation (`isolate_sound`) plus the `correspondence-only-layer` external-comparator declaration, with `check_phase4.py` exempting the library per the HexLLLMathlib precedent. Phase 1 was complete but never recorded; the bump follows the wave queue in progress/20260822T034500Z_wave-dag-and-headline-audit.md.

🤖 Prepared with Claude Code