### PR TITLE
feat(bz): migrate hotPathCandidates onto the committed prime table

### DIFF
--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -1196,6 +1196,10 @@ theorem choosePrimeDataAdaptive?_form
   obtain ⟨_, hzero, heq⟩ := hform
   exact ⟨hzero, heq⟩
 
+-- The candidate lists are windows into the 1229-entry committed prime table,
+-- so incidental reductions that peer into them need headroom over the
+-- default 512 ceiling.
+set_option maxRecDepth 10000 in
 /--
 When `choosePrimeData? f` succeeds, the stored modular factor array is exactly
 the Berlekamp factor output for the monic modular image of the selected

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -15,12 +15,14 @@ public meta import HexHensel.QuadraticMultifactor
 public meta import HexMatrix.Basic
 public meta import HexPolyZ.Mignotte
 public meta import HexLLL
+public meta import HexPrimality.Table
 public import HexArith.Nat.Prime
 public import HexBerlekamp.Factor
 public import HexBerlekamp.Irreducibility
 public import HexHensel.Multifactor
 public import HexHensel.QuadraticMultifactor
 public import HexLLL
+public import HexPrimality.Table
 -- Kernel-reducible `Array`/`Vector` equality; see `HexBasic.ArrayDecEq`.
 -- Drop once leanprover/lean4#14270 lands and the toolchain is bumped past it.
 public import HexBasic.ArrayDecEq
@@ -523,13 +525,51 @@ structure SmallPrimeCandidate where
   /-- A proof that `p` is prime. -/
   prime : Nat.Prime p
 
-/-- Build a `SmallPrimeCandidate` from a trial-division primality witness and the
-small-modulus bound `p < 2^31` on `p`. -/
-private def smallPrimeCandidateOfTrial (p : Nat)
-    (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p < 2 ^ 31) :
-    SmallPrimeCandidate :=
-  let prime := Hex.Nat.isPrimeTrial_isPrime hprime
-  { p, bounds := { pPos := prime.pos, pLtR := hbound }, prime }
+/-- The window of committed table primes in `[lo, hi)`, as proof-carrying
+candidates: primality from `Hex.Nat.mem_primeTable_prime`, the
+`ZMod64.Bounds` instance from the window bound `hhi`. -/
+@[expose]
+def tableCandidates (lo hi : Nat) (hhi : hi ≤ 2 ^ 31) : List SmallPrimeCandidate :=
+  (Hex.Nat.primeTable.toList.filter
+      (fun q => decide (lo ≤ q) && decide (q < hi))).attach.map
+    fun ⟨q, hq⟩ =>
+      have hparts := List.mem_filter.mp hq
+      have hprime : Hex.Nat.Prime q :=
+        Hex.Nat.mem_primeTable_prime (Array.mem_def.mpr hparts.1)
+      have hlt : q < 2 ^ 31 := by
+        have hrange := hparts.2
+        rw [Bool.and_eq_true, decide_eq_true_iff, decide_eq_true_iff] at hrange
+        omega
+      { p := q, bounds := { pPos := hprime.pos, pLtR := hlt }, prime := hprime }
+
+private theorem mem_tableCandidates_range {lo hi : Nat} {hhi : hi ≤ 2 ^ 31}
+    {c : SmallPrimeCandidate} (hc : c ∈ tableCandidates lo hi hhi) :
+    lo ≤ c.p ∧ c.p < hi := by
+  unfold tableCandidates at hc
+  rw [List.mem_map] at hc
+  obtain ⟨⟨q, hq⟩, _, rfl⟩ := hc
+  have hrange := (List.mem_filter.mp hq).2
+  rw [Bool.and_eq_true, decide_eq_true_iff, decide_eq_true_iff] at hrange
+  exact hrange
+
+private theorem exists_mem_tableCandidates {lo hi : Nat} {hhi : hi ≤ 2 ^ 31}
+    {p : Nat} (hmem : p ∈ Hex.Nat.primeTable) (hlo : lo ≤ p) (hp : p < hi) :
+    ∃ c ∈ tableCandidates lo hi hhi, c.p = p := by
+  have hfilter : p ∈ Hex.Nat.primeTable.toList.filter
+      (fun q => decide (lo ≤ q) && decide (q < hi)) := by
+    rw [List.mem_filter]
+    refine ⟨Array.mem_def.mp hmem, ?_⟩
+    rw [Bool.and_eq_true, decide_eq_true_iff, decide_eq_true_iff]
+    exact ⟨hlo, hp⟩
+  exact ⟨_, List.mem_map_of_mem (List.mem_attach _ ⟨p, hfilter⟩), rfl⟩
+
+private theorem tableCandidates_map_p {lo hi : Nat} {hhi : hi ≤ 2 ^ 31} :
+    (tableCandidates lo hi hhi).map (fun c => c.p) =
+      Hex.Nat.primeTable.toList.filter
+        (fun q => decide (lo ≤ q) && decide (q < hi)) := by
+  unfold tableCandidates
+  rw [List.map_map]
+  exact List.attach_map_subtype_val _
 
 /-- A scored admissible small-prime candidate for default prime selection. -/
 structure PrimeCandidateScore where
@@ -538,106 +578,16 @@ structure PrimeCandidateScore where
   /-- Smaller scores are preferred; equal scores retain the earlier smaller prime. -/
   factorCount : Nat
 
-/-- The default list of small primes (`3` through `71`) used for Berlekamp-Zassenhaus trial division. -/
+/-- The default list of small primes (`3` through `71`) used for
+Berlekamp-Zassenhaus trial division: the committed table window `[3, 72)`. -/
 def smallPrimeCandidates : List SmallPrimeCandidate :=
-  [ smallPrimeCandidateOfTrial 3 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 5 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 7 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 11 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 13 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 17 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 19 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 23 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 29 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 31 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 37 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 41 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 43 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 47 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 53 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 59 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 61 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 67 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 71 (by decide) (by decide) ]
+  tableCandidates 3 72 (by decide)
 
-set_option maxRecDepth 10000 in
-/-- The extended list of larger small-prime candidates, tried when `smallPrimeCandidates` is exhausted. -/
+/-- The extended list of larger small-prime candidates (`73` through `499`),
+tried when `smallPrimeCandidates` is exhausted: the table window `[72, 501)`.
+(`500` itself is composite, so the window's closed upper edge is inert.) -/
 def extendedSmallPrimeCandidates : List SmallPrimeCandidate :=
-  [ smallPrimeCandidateOfTrial 73 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 79 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 83 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 89 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 97 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 101 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 103 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 107 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 109 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 113 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 127 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 131 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 137 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 139 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 149 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 151 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 157 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 163 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 167 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 173 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 179 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 181 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 191 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 193 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 197 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 199 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 211 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 223 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 227 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 229 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 233 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 239 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 241 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 251 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 257 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 263 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 269 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 271 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 277 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 281 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 283 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 293 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 307 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 311 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 313 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 317 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 331 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 337 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 347 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 349 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 353 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 359 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 367 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 373 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 379 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 383 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 389 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 397 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 401 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 409 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 419 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 421 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 431 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 433 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 439 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 443 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 449 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 457 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 461 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 463 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 467 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 479 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 487 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 491 (by decide) (by decide),
-    smallPrimeCandidateOfTrial 499 (by decide) (by decide) ]
+  tableCandidates 72 501 (by decide)
 
 /--
 The direct planner's prime candidate list: the deterministic small-prime prefix
@@ -656,49 +606,67 @@ def hotPathPrimorial : Nat :=
 #guard extendedSmallPrimeCandidates.length == 75
 #guard hotPathCandidates.length == 94
 
-set_option maxRecDepth 10000 in
+private theorem mem_smallPrimeCandidates_range {c : SmallPrimeCandidate}
+    (hc : c ∈ smallPrimeCandidates) : 3 ≤ c.p ∧ c.p < 72 :=
+  mem_tableCandidates_range hc
+
+private theorem mem_extendedSmallPrimeCandidates_range {c : SmallPrimeCandidate}
+    (hc : c ∈ extendedSmallPrimeCandidates) : 72 ≤ c.p ∧ c.p < 501 :=
+  mem_tableCandidates_range hc
+
 /-- The fixed hot-path list contains no repeated prime values. -/
 theorem hotPathPrimeValues_nodup :
     (hotPathCandidates.map fun c => c.p).Nodup := by
-  decide
+  have hsorted : (hotPathCandidates.map fun c => c.p).Pairwise (· < ·) := by
+    unfold hotPathCandidates smallPrimeCandidates extendedSmallPrimeCandidates
+    rw [List.map_append, tableCandidates_map_p, tableCandidates_map_p,
+      List.pairwise_append]
+    refine ⟨Hex.Nat.primeTable_sorted.filter _,
+      Hex.Nat.primeTable_sorted.filter _, ?_⟩
+    intro a ha b hb
+    have ha' := (List.mem_filter.mp ha).2
+    have hb' := (List.mem_filter.mp hb).2
+    rw [Bool.and_eq_true, decide_eq_true_iff, decide_eq_true_iff] at ha' hb'
+    omega
+  exact hsorted.imp Nat.ne_of_lt
 
 /--
 Soundness of the hot-path prime candidate list: every entry carries a
-prime in the closed range `[3, 500]`. The `Hex.Nat.Prime` conjunct is
-the structure field directly; the bounds follow by a decidable check
-over the 94 explicit primes in the list.
+prime in the closed range `[3, 500]`. The `Hex.Nat.Prime` conjunct is the
+structure field directly; the bounds come from the two table windows.
 -/
 theorem mem_hotPathCandidates_prime
     {c : SmallPrimeCandidate} (hc : c ∈ hotPathCandidates) :
     Hex.Nat.Prime c.p ∧ 3 ≤ c.p ∧ c.p ≤ 500 := by
-  have hmem : c.p ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) :=
-    List.mem_map_of_mem hc
-  have hbounds :
-      ∀ q ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p),
-        3 ≤ q ∧ q ≤ 500 := by
-    decide
-  exact ⟨c.prime, (hbounds c.p hmem).1, (hbounds c.p hmem).2⟩
+  refine ⟨c.prime, ?_⟩
+  unfold hotPathCandidates at hc
+  rcases List.mem_append.mp hc with h | h
+  · have := mem_smallPrimeCandidates_range h
+    omega
+  · have := mem_extendedSmallPrimeCandidates_range h
+    omega
 
-set_option maxRecDepth 4096 in
 /--
 Coverage of the hot-path prime candidate list: every prime `p` with
-`3 ≤ p ≤ 500` appears as the `.p` field of some candidate in
-`hotPathCandidates`.
+`3 ≤ p ≤ 500` appears as the `.p` field of some candidate, as a corollary
+of the committed table's completeness direction.
 -/
 theorem exists_mem_hotPathCandidates_of_prime
     {p : Nat} (hprime : Hex.Nat.Prime p) (hge : 3 ≤ p) (hle : p ≤ 500) :
     ∃ c ∈ hotPathCandidates, c.p = p := by
-  have htrial : Hex.Nat.isPrimeTrial p = true :=
-    Hex.Nat.isPrimeTrial_of_prime hprime
-  have key : ∀ q : Fin 501,
-      3 ≤ q.val → Hex.Nat.isPrimeTrial q.val = true →
-        q.val ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) := by
-    decide
-  have hmem :
-      p ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) :=
-    key ⟨p, Nat.lt_succ_of_le hle⟩ hge htrial
-  obtain ⟨c, hc, hcp⟩ := List.mem_map.mp hmem
-  exact ⟨c, hc, hcp⟩
+  have hmem : p ∈ Hex.Nat.primeTable :=
+    Hex.Nat.mem_primeTable_of_prime hprime
+      (Nat.lt_of_le_of_lt hle (by decide))
+  unfold hotPathCandidates
+  rcases Nat.lt_or_ge p 72 with h | h
+  · obtain ⟨c, hc, hcp⟩ :=
+      (exists_mem_tableCandidates hmem hge h :
+        ∃ c ∈ smallPrimeCandidates, c.p = p)
+    exact ⟨c, List.mem_append_left _ hc, hcp⟩
+  · obtain ⟨c, hc, hcp⟩ :=
+      (exists_mem_tableCandidates hmem h (by omega) :
+        ∃ c ∈ extendedSmallPrimeCandidates, c.p = p)
+    exact ⟨c, List.mem_append_right _ hc, hcp⟩
 
 /--
 Coerce an admissible nonzero modular image to its monic representative by

--- a/libraries.yml
+++ b/libraries.yml
@@ -375,7 +375,7 @@ libraries:
         - name: packed-generic-shared-bridge
           description: Shared binary representative family exercising both packed GF2q and generic GFq constructor/projection paths on the common p = 2 API surface.
   HexBerlekampZassenhaus:
-    deps: [HexBerlekamp, HexHensel, HexLLL]
+    deps: [HexBerlekamp, HexHensel, HexLLL, HexPrimality]
     mathlib: false
     done_through: 0
     status: active

--- a/progress/20260822T041656Z_primality-hotpath.md
+++ b/progress/20260822T041656Z_primality-hotpath.md
@@ -1,0 +1,36 @@
+# hex-primality: hotPathCandidates migrated onto the committed table
+
+## Accomplished
+
+- `HexBerlekampZassenhaus/PrimeSelection.lean`: the 94 hand-written
+  `smallPrimeCandidateOfTrial ... (by decide) (by decide)` entries are
+  replaced by `tableCandidates lo hi`, a proof-carrying window into
+  `Hex.Nat.primeTable` (primality from `mem_primeTable_prime`, bounds
+  from the window). `smallPrimeCandidates` is the window `[3, 72)`,
+  `extendedSmallPrimeCandidates` is `[72, 501)`, and
+  `hotPathCandidates` remains their append, so every consumer
+  (`ChoosePrimeData`, `Modular/PrimePlan`, bench, conformance) is
+  untouched.
+- `hotPathPrimeValues_nodup` now follows from `primeTable_sorted`;
+  `mem_hotPathCandidates_prime` from the window ranges plus the
+  structure field; `exists_mem_hotPathCandidates_of_prime` from
+  `mem_primeTable_of_prime`. The `Fin 501` decide and the
+  `maxRecDepth` overrides on those proofs are gone; the three length
+  `#guard`s (19/75/94) pin contents and order.
+- `libraries.yml`: `HexBerlekampZassenhaus` deps gain `HexPrimality`.
+- One downstream proof (`choosePrimeData?_factorsModP_berlekamp_form`)
+  needed a `maxRecDepth` bump because incidental reductions now walk
+  the 1229-entry table. Full tree build green; `check_dag.py` passes.
+
+## Current frontier
+
+This is the migration the SPEC calls the proof that the table is the
+right shape: the 94-entry list is now a view, with no loss.
+
+## Next step
+
+Order.lean (milestone 2a): the multiplicative-order development.
+
+## Blockers
+
+Stacked on the table PR.


### PR DESCRIPTION
This PR migrates hex-berlekamp-zassenhaus's prime candidate lists onto the committed table, per HexPrimality/SPEC/hex-primality.md §Initial segments: `smallPrimeCandidates` and `extendedSmallPrimeCandidates` become proof-carrying windows into `Hex.Nat.primeTable` (`tableCandidates`, with primality from `mem_primeTable_prime` and the `ZMod64.Bounds` instance from the window bound), and `hotPathCandidates` remains their append so every consumer is API-unchanged. `hotPathPrimeValues_nodup` now follows from `primeTable_sorted`, `mem_hotPathCandidates_prime` from the window ranges plus the structure field, and `exists_mem_hotPathCandidates_of_prime` from `mem_primeTable_of_prime`, deleting the `Fin 501` decide and its `maxRecDepth` overrides. The three length `#guard`s (19/75/94) pin the migrated contents and order. `libraries.yml` records the new `HexPrimality` dependency. One downstream proof needed a `maxRecDepth` bump because incidental reductions now walk the 1229-entry table.

Stacked on #9391.

🤖 Prepared with Claude Code