### PR TITLE
spec: specify the common-field surface and reconcile number-field file maps

### DIFF
--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -210,7 +210,7 @@ example : LawfulBEq (QAdjoin sqrtTwoPoly sqrtTwoRoot) := inferInstance
 
 -- Construct the checked instance through the executable decision so this
 -- regression reaches the shipped inverse and division implementations without
--- adding a proof axiom or a test-only `sorry`.
+-- adding anything to the trust surface.
 #guard
     if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
       letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -105,8 +105,12 @@ inductive RootSet where
 opaque AlgebraicPoly
 def AlgebraicPoly.ofArray (coeffs : Array AlgebraicNumber) : AlgebraicPoly
 def AlgebraicPoly.coeffs (f : AlgebraicPoly) : Array AlgebraicNumber
+def AlgebraicPoly.coeff (f : AlgebraicPoly) (n : Nat) : AlgebraicNumber
+def AlgebraicPoly.size (f : AlgebraicPoly) : Nat
 def AlgebraicPoly.degree? (f : AlgebraicPoly) : Option Nat
 def AlgebraicPoly.isZero (f : AlgebraicPoly) : Bool
+def AlgebraicPoly.beq (f g : AlgebraicPoly) : Bool
+instance : BEq AlgebraicPoly
 
 end Hex
 ```
@@ -138,7 +142,12 @@ normalization is semantic, while canonical algebraic-number equality is exposed
 here as a Boolean operation whose correctness is proved only in the companion.
 Structural equality on factorization-lazy `AlgebraicRoot` is finer than equality
 of represented complex values. `AlgebraicPoly` owns the required semantic
-trimming without exporting an unjustified `DecidableEq`.
+trimming without exporting an unjustified `DecidableEq`. That Boolean
+operation is `AlgebraicPoly.beq` (with its `BEq` instance): coefficientwise
+canonical equality over the trimmed data, faithful on canonical coefficients
+because `AlgebraicNumber` equality is canonical. `coeff n` is the canonical
+coefficient (`0` beyond the degree) and `size` is the trimmed length backing
+`degree?`; all three are exercised by the module's compiled regressions.
 
 ## Equality and zero
 
@@ -360,9 +369,10 @@ For `QAdjoin.roots?`:
 5. Return the surviving `AlgebraicRoot` values with the Yun multiplicity.
 
 `AlgebraicPoly.roots?` first embeds all nonzero coefficients into one computed
-primitive `QAdjoin`, then invokes the fixed-field algorithm. This internal
-common-field construction is deterministic and bounded but is not used for
-binary arithmetic.
+primitive `QAdjoin`, then invokes the fixed-field algorithm. This common-field
+construction is deterministic and bounded, is not used for binary arithmetic,
+and is a public surface in its own right (the tower library builds on it); its
+contract is the next section.
 
 For a candidate evaluation, construct its integer eliminant `q`, remove its
 maximal `X` power, and take the primitive part. If the evaluation is nonzero,
@@ -382,6 +392,72 @@ centre norm. The displayed search endpoint still has sufficient slack.
 The displayed endpoint proves that the bounded search succeeds. The same
 construction, with the eliminant for each generator/factor evaluation, is used
 by tower adjoining. No API performs unbounded refinement.
+
+## Common-field construction
+
+The `Hex.AlgebraicPoly.Common` namespace is the public bounded
+primitive-element machinery behind `AlgebraicPoly.roots?`, consumed directly
+by hex-number-field-tower (raw evaluation, flattening recovery) and its
+Mathlib companion. Everything is option-valued and checked: a `none` records
+a failed certification, never a wrong value.
+
+```lean
+structure Presentation where
+  generator : AlgebraicNumber
+  coefficients : Array (QAdjoin generator.p generator.x)
+
+def signedShift : Nat → Int
+def rational? (q : Rat) : Option AlgebraicNumber
+def add? (a b : AlgebraicNumber) : Option AlgebraicNumber
+def mul? (a b : AlgebraicNumber) : Option AlgebraicNumber
+def scale? (c : Int) (a : AlgebraicNumber) : Option AlgebraicNumber
+def shift? (theta alpha : AlgebraicNumber) (c : Int) : Option AlgebraicNumber
+def degree (a : AlgebraicNumber) : Nat
+
+structure ShiftCandidate where
+  shift : Int
+  value : AlgebraicNumber
+
+def extendShiftStep (theta alpha : AlgebraicNumber) :
+    Option ShiftCandidate → Nat → Option (Option ShiftCandidate)
+def extendShift? (theta alpha : AlgebraicNumber) : Option ShiftCandidate
+def extend? (theta alpha : AlgebraicNumber) : Option AlgebraicNumber
+def primitive? (coefficients : Array AlgebraicNumber) : Option AlgebraicNumber
+def powers? (gamma : AlgebraicNumber) (last : Nat) :
+    Option (Array AlgebraicNumber)
+def trace? (ambient : Nat) (a : AlgebraicNumber) : Option Rat
+def coordinates? (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber) : Option (QAdjoin gamma.p gamma.x)
+def presentation? (coefficients : Array AlgebraicNumber) :
+    Option Presentation
+```
+
+`signedShift` is the deterministic shift order `0, 1, -1, 2, -2, ...`.
+`rational?`, `add?`, `mul?`, `scale?`, and `shift?` are the checked canonical
+constructions the search composes: `shift? theta alpha c` is the
+primitive-element candidate `theta + c * alpha`, with `c = 0` returning
+`theta` unchanged.
+
+`extend? theta alpha` is the bounded primitive-element search: it tests
+`choose(degree theta * degree alpha, 2) + 1` signed shifts and keeps a
+maximum-degree candidate, which generates the compositum even when the two
+fields overlap. `extendShift?` is the same search retaining the producing
+shift (the form the tower's flattening recovery needs), and
+`extendShiftStep` is its single fold step, exposed so consumers can interleave
+the search with their own early exits. `primitive?` folds `extend?` over the
+nonzero entries of a coefficient array.
+
+`powers? gamma last` returns the checked canonical powers
+`1, gamma, ..., gamma^last`. `trace? ambient a` is the field trace of `a`
+from a known ambient degree: with `m = degree a` it requires `m ∣ ambient`
+and returns `(ambient / m)` times the conjugate sum
+`-coeff (m-1) / leadingCoeff`. `coordinates? gamma a powers` recovers the
+power-basis coordinate of `a` through the nondegenerate trace pairing (Gram
+matrix of power traces against the traces of `a * gamma^k`), then validates
+the recovered coordinate by canonical algebraic equality before returning it.
+`presentation?` composes the above: find a primitive generator, take its
+powers up to `2 * degree - 2`, embed every coefficient, and return the
+validated fixed-field `Presentation`.
 
 ## Totalization
 

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -269,14 +269,27 @@ staged resultant theorems specified by `hex-resultant-mathlib`.
 
 ```text
 HexNumberFieldMathlib/
-  Basic.lean          : semantic maps and canonical forms
-  AdjoinRoot.lean     : fixed-field correspondence
-  Approx.lean         : ball semantics
-  Exact.lean          : canonicalization and exactification
-  Lazy.lean           : arithmetic soundness and completeness
-  AlgebraicPoly.lean  : semantic coefficient polynomials
-  Roots.lean          : root completeness and multiplicity
+  Basic.lean                 : semantic maps and canonical forms
+  AdjoinRoot.lean            : fixed-field correspondence
+  Approx.lean                : ball semantics
+  Exact.lean                 : canonicalization and exactification
+  Lazy.lean                  : arithmetic soundness and completeness
+  Field.lean                 : the Field instances pinned to executable data
+  AlgebraicPoly.lean         : semantic coefficient polynomials
+  Roots.lean                 : root completeness and multiplicity
+  AlgebraicRoots.lean        : finite-output root-set obligations
+  ComponentRoots.lean        : per-component root soundness
+  RootDisambiguation.lean    : candidate rejection soundness
+  Yun.lean                   : Yun multiplicity correspondence
+  Primitive.lean             : bounded primitive-element search soundness
+  Presentation.lean          : checked common-field arithmetic totality
+  PresentationSemantics.lean : assembly of total primitive presentations
+  Coordinates.lean           : trace-pairing coordinate recovery
 ```
+
+The last four verify the `Hex.AlgebraicPoly.Common` surface (see the
+hex-number-field SPEC §Common-field construction), which the tower
+libraries consume.
 
 The library is verified by building it. Executable conformance belongs to
 `hex-number-field`.

--- a/HexNumberFieldTower/SPEC/hex-number-field-tower.md
+++ b/HexNumberFieldTower/SPEC/hex-number-field-tower.md
@@ -12,6 +12,11 @@ chosen as its generator.
 
 ## Representation
 
+`opaque` below marks the public abstraction boundary, not the implementing
+keyword, per the hex-number-field SPEC's representation convention; the
+implementation seals `NumberTower` and `Elem` with `structure ... private
+mk ::` so that `Internal.extend?` remains the only level admitter.
+
 ```lean
 namespace Hex
 
@@ -340,14 +345,22 @@ degree at most 4 until those measurements exist.
 
 ```text
 HexNumberFieldTower/
-  Basic.lean       : private level data, NumberTower, Elem, coordinates
-  Arithmetic.lean  : field operations
-  Embed.lean       : Extension and smart constructors
-  Norm.lean        : recursive resultants
-  Factor.lean      : Yun and Trager factorization
-  Split.lean       : root adjoining and splitting fields
-  Flatten.lean     : primitive-element conversion
+  Data.lean           : raw number-tower level data
+  RawArithmetic.lean  : runtime-indexed mixed-radix tower arithmetic
+  RawEvaluation.lean  : fixed-embedding evaluation for raw coordinates
+  Basic.lean          : NumberTower, Elem, Extension, smart constructors
+  Arithmetic.lean     : field operations
+  Embed.lean          : compiled extension regressions (#guard fixtures)
+  Norm.lean           : recursive resultants
+  FactorRaw.lean      : raw tower polynomial factorization
+  Factor.lean         : Yun and Trager factorization, checked replay
+  Split.lean          : root adjoining and splitting fields
+  Flatten.lean        : primitive-element conversion
 ```
+
+`Extension` and `ofQAdjoin` live in `Basic.lean` beside the sealed types
+whose invariants they establish; `Embed.lean` retains the compiled
+extension regressions exercising them.
 
 ## References
 

--- a/progress/20260822T060000Z_number-field-spec-prep.md
+++ b/progress/20260822T060000Z_number-field-spec-prep.md
@@ -1,0 +1,40 @@
+# NumberField cluster SPEC preparation
+
+## Accomplished
+
+- Specified the `Hex.AlgebraicPoly.Common` public surface in the
+  hex-number-field SPEC (new §Common-field construction: the bounded
+  primitive-element search, checked canonical arithmetic, trace
+  pairing, coordinate recovery, and presentation assembly the tower
+  libraries consume), replacing the stale "internal" wording.
+- Reconciled both stale file-organisation tables: the
+  hex-number-field-mathlib SPEC now lists all 16 modules (noting the
+  four that verify the Common surface), and the tower SPEC lists all
+  11 (Data/RawArithmetic/RawEvaluation/FactorRaw declared, Embed.lean
+  recorded as the compiled extension-regression module, with
+  Extension/ofQAdjoin homed in Basic.lean).
+- Recorded the tower's sealed-type convention as a pointer to the
+  hex-number-field SPEC's existing opaque-as-boundary paragraph.
+- Resolved the audit's dead-code question by specifying rather than
+  deleting: `AlgebraicPoly.coeff`, `size`, `beq`, and the `BEq`
+  instance are exercised by the module's compiled regressions and are
+  now in the SPEC's core-types block, tied to the existing
+  Boolean-equality doctrine.
+- Reworded the QAdjoin regression comment so casual trust-surface
+  greps stay quiet (the mechanical check strips comments and already
+  passed).
+
+## Current frontier
+
+- The cluster's SPECs now match the source, clearing the way for the
+  Phase 1/2 attestations once the BZ edge lands (wave task C14).
+
+## Next step
+
+- C12: the three missing TowerMathlib SPEC declarations
+  (dim/finrank via toField, the Grind.Field package, the public
+  Extension.embed homomorphism statement).
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR specify the `Hex.AlgebraicPoly.Common` namespace in the hex-number-field SPEC and reconcile the number-field cluster's SPECs with the source, per the wave plan's C11/C13 items (Kim-authorized SPEC edits, 2026-08-21). The common-field construction (bounded primitive-element search, checked canonical arithmetic, field-trace pairing, coordinate recovery, and presentation assembly) is consumed directly by the tower libraries but was described as internal; it now has a full contract section. Both stale file-organisation tables are refreshed (the companion SPEC listed 7 of 16 modules, the tower SPEC 7 of 11), `Embed.lean` is recorded as the compiled extension-regression module with `Extension`/`ofQAdjoin` homed in `Basic.lean`, and the tower's sealed-type wording now points at the existing opaque-as-boundary convention. The 2026-08-21 audit's dead-code question resolves by specifying rather than deleting: `AlgebraicPoly.coeff`/`size`/`beq`/`BEq` are exercised by compiled regressions and join the core-types block under the SPEC's existing Boolean-equality doctrine. One regression comment is reworded so casual trust-surface greps stay quiet; `lake build HexNumberField` and the DAG/phase checkers pass.

🤖 Prepared with Claude Code