### PR TITLE
doc: rename companion-contract sections to the Phase-7 heading

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -201,7 +201,7 @@ finite root array carrying positive multiplicities.
 
 {docstring Hex.AlgebraicPoly.roots?}
 
-# Companion contracts
+# The Mathlib correspondence
 %%%
 tag := "hex-number-field-correspondence"
 %%%

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -148,7 +148,7 @@ valid tower.
 
 {docstring Hex.NumberTower.flatten?}
 
-# Companion contracts
+# The Mathlib correspondence
 %%%
 tag := "hex-number-field-tower-correspondence"
 %%%

--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -278,7 +278,7 @@ private def g : DensePoly Int := DensePoly.ofList [-3, 1]
 end HexResultantChapter
 ```
 
-# Companion contracts
+# The Mathlib correspondence
 %%%
 tag := "hex-resultant-correspondence"
 %%%

--- a/progress/20260822T070000Z_correspondence-headings.md
+++ b/progress/20260822T070000Z_correspondence-headings.md
@@ -1,0 +1,25 @@
+# Correspondence headings for the check_phase7 contract
+
+## Accomplished
+
+- Renamed the "# Companion contracts" section to
+  "# The Mathlib correspondence" in the HexResultant, HexNumberField,
+  and HexNumberFieldTower manual chapters. scripts/check_phase7.py
+  requires that literal heading in a companion's partner chapter at
+  done_through 7; the content was already right, only the heading
+  string differed. Section tags are unchanged.
+
+## Current frontier
+
+- The four ladder chapters (HexRoots, HexPolyFp, HexBerlekamp,
+  HexBerlekampZassenhaus) still lack the section entirely; adding it
+  there needs authored content and lands with the ladder Phase-7 work
+  (wave task B9).
+
+## Next step
+
+- B9 chapter sections; Phase-7 bump PRs cite this heading contract.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR rename the `# Companion contracts` section to `# The Mathlib correspondence` in the HexResultant, HexNumberField, and HexNumberFieldTower manual chapters. `scripts/check_phase7.py` requires that literal heading in a companion's partner chapter once the companion records `done_through: 7`; the content was already correct, only the heading string differed, and the section tags are unchanged. The four ladder chapters that lack the section entirely get authored content with the ladder Phase-7 work.

🤖 Prepared with Claude Code