### PR TITLE
feat(basic): add Hex.Rand, the splitmix64 generator for Las Vegas search

### DIFF
--- a/progress/20260822T042502Z_hexbasic-rand.md
+++ b/progress/20260822T042502Z_hexbasic-rand.md
@@ -1,0 +1,30 @@
+# hex-basic: Hex.Rand (cross-SPEC, from hex-finite-field §Randomness)
+
+## Accomplished
+
+- `HexBasic/Rand.lean`: splitmix64 `Rand` with `next`, `RandError`
+  (`zeroBound` / `exhausted attempts rand` carrying the advanced
+  state), `Rand.nat` by rejection sampling over enough 64-bit words
+  (rejecting the incomplete top interval, no modulo bias), and
+  `Rand.ofSeed`. One theorem, `Rand.nat_lt` (range correctness), per
+  the SPEC's executable-contract posture: no uniformity claim is made
+  or transferable from a 64-bit-state generator.
+- `#guard` block: the canonical splitmix64 seed-0 known-answer vector,
+  seed-42 replay chain, and each result shape of `Rand.nat` including
+  a two-word bound.
+
+## Current frontier
+
+This implements the API specified in
+SPEC/Libraries/hex-finite-field.md §Randomness, sited in hex-basic
+per that SPEC (consumers in several subtrees). hex-primality's
+milestone 3 (certificate search) consumes it next.
+
+## Next step
+
+hex-primality Cert.lean: the Pocklington certificate, checker, and
+soundness.
+
+## Blockers
+
+None; independent of the primality stack.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -766,5 +766,11 @@
     "baseline_blob": "1063ee045056aabe060a319d7dbe48460e6fdd75",
     "current_blob": "635c202971d2276a498505da9842deac1c833c9f",
     "reason": "Updates diagnostic-service projections from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; every measured operation and branch is unchanged."
+  },
+  {
+    "path": "HexBasic/Rand.lean",
+    "baseline_blob": null,
+    "current_blob": "aa8588a6a6a6db3e4393346d885e1f81ccd2aaff",
+    "reason": "Adds the standalone SplitMix64 and unbiased bounded-sampling API for future randomized consumers. Existing factorization code does not reference its declarations, so the measured factorization service runtime is unchanged."
   }
 ]


### PR DESCRIPTION
This PR adds `HexBasic/Rand.lean`, implementing the API specified in SPEC/Libraries/hex-finite-field.md §Randomness at the site that SPEC chooses (hex-basic, because the generator has no dependencies and consumers in several subtrees: hex-finite-field's Cantor-Zassenhaus stage, hex-mv-gcd's Zippel evaluation points, and hex-primality's certificate search, which is what makes it a prerequisite now). `Rand` is a splitmix64 state with `next`; `RandError` distinguishes `zeroBound` from `exhausted`, the latter carrying the attempt count and the advanced state so callers resume rather than replay a failed stream; `Rand.nat` draws below a bound by rejection sampling over `⌈bits/64⌉` words, rejecting the incomplete top interval rather than folding it in with a biased modulo; `Rand.ofSeed` builds the initial state. The one theorem is `Rand.nat_lt` (range correctness), matching the SPEC's executable-contract posture: no uniformity or independence claim is made, since none transfers from a 64-bit-state generator. Known-answer guards pin the canonical splitmix64 seed-0 output, a seed-42 replay chain, and every result shape of `Rand.nat`.

🤖 Prepared with Claude Code