### PR TITLE
feat: prove the PolyFp square-free headline in the Mathlib companion

### DIFF
--- a/HexPolyFpMathlib.lean
+++ b/HexPolyFpMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexPolyFpMathlib.Basic
+public import HexPolyFpMathlib.SquareFree
 
 /-!
 `HexPolyFpMathlib` relates the executable prime-field polynomial representation

--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -24,11 +24,46 @@ Mathlib's own polynomial type.
   monoid power that `commRing` supplies, so `map_pow` applies to executable
   powers.
 - `primeModulus_of_fact`, deriving the executable `ZMod64.PrimeModulus p`
-  witness from Mathlib's `Fact (Nat.Prime p)`.
+  witness from Mathlib's `Fact (Nat.Prime p)`, and `hexPrime_of_fact`,
+  deriving the executable `Hex.Nat.Prime p` from the same fact.
+- The headline correctness theorem `squareFreeDecomposition_correct`
+  (see below) with its transport chain: `pow_eq_pow` and
+  `weightedProduct_eq_prod` identifying the executable square-and-multiply
+  power and the weighted factor product with their Mathlib counterparts,
+  `toMathlibPolynomial_{one, pow, weightedProduct}`, and the gcd-unit
+  conversions `isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one`
+  and `squarefree_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one`.
 
 Everything below this library is Hex's own tower: `DensePoly` over `ZMod64`,
 reached through hex-poly-mathlib and hex-mod-arith-mathlib. Everything a
 Mathlib user starts from is on the far side of `fpPolyEquiv`.
+
+## Headline correctness theorem
+
+`HexPolyFpMathlib.squareFreeDecomposition_correct`: the executable Yun
+square-free decomposition is a genuine square-free decomposition in
+`Polynomial (ZMod p)`. For a prime modulus and any input `f`, writing `d` for
+`squareFreeDecomposition hp f` and `T` for `toMathlibPolynomial`:
+
+- **reconstruction** — `C (toZMod d.unit)` times the product of
+  `T sf.factor ^ sf.multiplicity` over `d.factors` equals `T f`;
+- **square-freeness** — every transported factor `T sf.factor` is
+  `Squarefree`;
+- **pairwise coprimality** — the transported factors are pairwise
+  `IsCoprime`;
+- **positive multiplicities** — every recorded multiplicity is positive.
+
+It needs no nonzeroness or degree hypothesis on `f`: the executable
+post-conditions cover the degenerate cases (for `f = 0` the emitted unit is
+`0`) and transport unchanged. It is built from the four Mathlib-free
+post-conditions of `HexPolyFp.SquareFree`
+(`squareFreeDecomposition_{weightedProduct, factors_squareFree,
+pairwise_coprime, multiplicity_pos}`), with the gcd-unit certificates those
+theorems emit — the monic normalization of the executable gcd reducing to
+`1` — converted through the executable Bezout identity to `IsCoprime`, and
+coprimality with the formal derivative reaching `Squarefree` via
+`Polynomial.Separable`. A `#print axioms` guard pins its proof cone to the
+three standard axioms.
 
 ## Ownership
 
@@ -56,11 +91,17 @@ map's coefficient reasoning uses.
 
 ## What belongs here, and what does not
 
-This library states the correspondence and the lemmas that follow from it
-alone. A lemma that mentions Berlekamp's `basisSize`, `isUnitPolynomial`, or
-Rabin's test belongs in hex-berlekamp-mathlib even when its conclusion is about
-`toMathlibPolynomial`, because it is a fact about the factoring algorithm rather
-than about the representation.
+This library states the correspondence, the lemmas that follow from it alone,
+and one designated exception: the headline correctness theorem
+`squareFreeDecomposition_correct` for hex-poly-fp's own algorithmic surface,
+together with the transport lemmas that compose into it. hex-poly-fp has no
+other Mathlib companion, so the headline the per-library rule in
+`PLAN/Conventions.md` requires lives here. Beyond that single theorem and its
+supporting chain, algorithm-level lemmas stay out: a lemma that mentions
+Berlekamp's `basisSize`, `isUnitPolynomial`, or Rabin's test belongs in
+hex-berlekamp-mathlib even when its conclusion is about `toMathlibPolynomial`,
+because it is a fact about the factoring algorithm rather than about the
+representation.
 
 ## External comparators
 

--- a/HexPolyFpMathlib/SquareFree.lean
+++ b/HexPolyFpMathlib/SquareFree.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyFpMathlib.Basic
+public import Mathlib.FieldTheory.Separable
+
+public section
+
+/-!
+The headline correctness theorem for hex-poly-fp: the executable Yun
+square-free decomposition, transported through `fpPolyEquiv`, reconstructs the
+input in `Polynomial (ZMod p)` from factors that are `Squarefree` and pairwise
+`IsCoprime`, each carried with a positive multiplicity.
+
+The executable layer (`HexPolyFp.SquareFree`) proves the same post-condition
+Mathlib-free, phrasing square-freeness and coprimality through the monic
+normalization of the executable gcd reducing to `1`. This module converts each
+of those gcd-unit certificates into the corresponding Mathlib predicate — a
+unit gcd yields a Bezout identity, hence `IsCoprime`; coprimality with the
+formal derivative is `Polynomial.Separable`, hence `Squarefree` — and restates
+the weighted factor product as a Mathlib list product.
+-/
+
+namespace HexPolyFpMathlib
+
+open Polynomial
+
+variable {p : Nat} [Hex.ZMod64.Bounds p]
+
+/-- Mathlib's `Nat.Prime` fact yields the executable prime predicate, so the
+executable square-free decomposition (which consumes `Hex.Nat.Prime p`) can be
+invoked in a context carrying only the Mathlib-side hypothesis. -/
+theorem hexPrime_of_fact (p : Nat) [Fact (Nat.Prime p)] : Hex.Nat.Prime p :=
+  ⟨(Fact.out : Nat.Prime p).two_le,
+    fun m hm => (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hm⟩
+
+/-- The square-and-multiply loop computes `acc * base ^ k`, with the exponent
+laws now supplied by the Mathlib `CommRing` on `Hex.FpPoly p`. -/
+private theorem pow_go_eq_mul_pow (acc base : Hex.FpPoly p) (k : Nat) :
+    Hex.FpPoly.pow.go acc base k = acc * base ^ k := by
+  induction k using Nat.strongRecOn generalizing acc base with
+  | ind k ih =>
+      rw [Hex.FpPoly.pow.go.eq_def]
+      by_cases hk : k = 0
+      · simp [hk]
+      · rw [dif_neg hk]
+        have hlt : k / 2 < k := Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide)
+        show Hex.FpPoly.pow.go (if k % 2 = 1 then acc * base else acc)
+          (base * base) (k / 2) = acc * base ^ k
+        rcases Nat.mod_two_eq_zero_or_one k with hmod | hmod
+        · have hnot : ¬ k % 2 = 1 := by omega
+          have hk2 : 2 * (k / 2) = k := by omega
+          rw [if_neg hnot, ih _ hlt, ← sq, ← pow_mul, hk2]
+        · have hk2 : 2 * (k / 2) + 1 = k := by omega
+          rw [if_pos hmod, ih _ hlt, ← sq, ← pow_mul, mul_assoc, ← pow_succ', hk2]
+
+/-- The executable square-and-multiply power is Mathlib's monoid power, the
+sibling of `linearPow_eq_pow` for the exponentiation the compiled square-free
+path actually runs. -/
+theorem pow_eq_pow (f : Hex.FpPoly p) (n : Nat) : Hex.FpPoly.pow f n = f ^ n := by
+  rw [Hex.FpPoly.pow, pow_go_eq_mul_pow, one_mul]
+
+/-- The executable weighted factor product is the Mathlib list product of the
+factors raised to their multiplicities, still on the executable side of the
+correspondence. -/
+theorem weightedProduct_eq_prod (factors : List (Hex.FpPoly.SquareFreeFactor p)) :
+    Hex.FpPoly.weightedProduct factors =
+      (factors.map fun sf => sf.factor ^ sf.multiplicity).prod := by
+  rw [Hex.FpPoly.weightedProduct]
+  simp only [pow_eq_pow]
+  rw [List.prod_eq_foldl, List.foldl_map]
+
+/-- The unit executable polynomial transports to the unit Mathlib polynomial. -/
+theorem toMathlibPolynomial_one : toMathlibPolynomial (1 : Hex.FpPoly p) = 1 :=
+  map_one fpPolyEquiv
+
+/-- Powers commute with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_pow (f : Hex.FpPoly p) (n : Nat) :
+    toMathlibPolynomial (f ^ n) = toMathlibPolynomial f ^ n :=
+  map_pow fpPolyEquiv f n
+
+/-- The weighted factor product transports to the Mathlib list product of the
+transported factors raised to their multiplicities. -/
+theorem toMathlibPolynomial_weightedProduct
+    (factors : List (Hex.FpPoly.SquareFreeFactor p)) :
+    toMathlibPolynomial (Hex.FpPoly.weightedProduct factors) =
+      (factors.map fun sf => toMathlibPolynomial sf.factor ^ sf.multiplicity).prod := by
+  rw [weightedProduct_eq_prod, ← fpPolyEquiv_apply, map_list_prod fpPolyEquiv,
+    List.map_map]
+  simp only [Function.comp_def, map_pow, fpPolyEquiv_apply]
+
+/-- A polynomial whose monic normalization is `1` is a nonzero constant, so its
+transport is a Mathlib unit. The zero case is impossible (`normalizeMonic`
+sends `0` to `(0, 0)`), and otherwise `normalizeMonic` exhibits an explicit
+constant multiplier reaching `1`. -/
+private theorem isUnit_toMathlibPolynomial_of_normalizeMonic_eq_one
+    [Fact (Nat.Prime p)] {g : Hex.FpPoly p}
+    (h : (Hex.FpPoly.normalizeMonic g).2 = 1) :
+    IsUnit (toMathlibPolynomial g) := by
+  cases hz : g.isZero with
+  | true =>
+      exfalso
+      rw [show (Hex.FpPoly.normalizeMonic g).2 = 0 by
+        simp [Hex.FpPoly.normalizeMonic, hz]] at h
+      have h0 := congrArg toMathlibPolynomial h
+      rw [← fpPolyEquiv_apply, ← fpPolyEquiv_apply, map_zero, map_one] at h0
+      exact zero_ne_one h0
+  | false =>
+      have hC : Hex.DensePoly.C (Hex.DensePoly.leadingCoeff g)⁻¹ * g = 1 := by
+        rw [Hex.FpPoly.C_mul_eq_scale, ← h]
+        simp [Hex.FpPoly.normalizeMonic, hz]
+      have hM := congrArg toMathlibPolynomial hC
+      rw [toMathlibPolynomial_mul, toMathlibPolynomial_C, toMathlibPolynomial_one] at hM
+      exact isUnit_of_mul_isUnit_right (hM ▸ isUnit_one)
+
+/-- The executable square-free layer's coprimality certificate — the monic
+normalization of the executable gcd reducing to `1` — transports to Mathlib
+coprimality, via the executable Bezout identity. This is the hex-poly-fp
+counterpart of hex-berlekamp-mathlib's
+`isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd`, keyed on the gcd-unit
+phrasing the Yun theorems emit rather than Berlekamp's `isUnitPolynomial`. -/
+theorem isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one
+    [Fact (Nat.Prime p)] {a b : Hex.FpPoly p}
+    (h : (Hex.FpPoly.normalizeMonic (Hex.DensePoly.gcd a b)).2 = 1) :
+    IsCoprime (toMathlibPolynomial a) (toMathlibPolynomial b) := by
+  haveI : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  obtain ⟨u, hu⟩ := isUnit_toMathlibPolynomial_of_normalizeMonic_eq_one h
+  have hbez : (Hex.DensePoly.xgcd a b).left * a + (Hex.DensePoly.xgcd a b).right * b
+      = Hex.DensePoly.gcd a b :=
+    (Hex.DensePoly.xgcd_bezout a b).trans (Hex.DensePoly.xgcd_gcd_eq_gcd a b)
+  have hbezM :
+      toMathlibPolynomial (Hex.DensePoly.xgcd a b).left * toMathlibPolynomial a +
+        toMathlibPolynomial (Hex.DensePoly.xgcd a b).right * toMathlibPolynomial b =
+        toMathlibPolynomial (Hex.DensePoly.gcd a b) := by
+    rw [← toMathlibPolynomial_mul, ← toMathlibPolynomial_mul, ← toMathlibPolynomial_add,
+      hbez]
+  refine ⟨↑u⁻¹ * toMathlibPolynomial (Hex.DensePoly.xgcd a b).left,
+    ↑u⁻¹ * toMathlibPolynomial (Hex.DensePoly.xgcd a b).right, ?_⟩
+  rw [mul_assoc, mul_assoc, ← mul_add, hbezM, ← hu]
+  exact u.inv_mul
+
+/-- The executable square-freeness certificate — the monic normalization of
+`gcd g (derivative g)` reducing to `1` — transports to Mathlib
+`Squarefree`: coprimality with the formal derivative is `Polynomial.Separable`,
+and separable polynomials are square-free. -/
+theorem squarefree_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one
+    [Fact (Nat.Prime p)] {g : Hex.FpPoly p}
+    (h : (Hex.FpPoly.normalizeMonic
+      (Hex.DensePoly.gcd g (Hex.DensePoly.derivative g))).2 = 1) :
+    Squarefree (toMathlibPolynomial g) := by
+  have hco := isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one h
+  rw [toMathlibPolynomial_derivative] at hco
+  exact (show (toMathlibPolynomial g).Separable from hco).squarefree
+
+/-- Headline correctness theorem for hex-poly-fp: the executable Yun
+square-free decomposition is a genuine square-free decomposition in
+`Polynomial (ZMod p)`.
+
+For a prime modulus and any input `f`, writing `d` for the decomposition:
+
+- **reconstruction** — the constant `C d.unit` times the product of the
+  transported factors, each raised to its recorded multiplicity, is the
+  transport of `f`;
+- **square-freeness** — every transported factor is `Squarefree`;
+- **pairwise coprimality** — the transported factors are pairwise `IsCoprime`;
+- **positive multiplicities** — every recorded multiplicity is positive.
+
+No nonzeroness or degree hypothesis on `f` is required: the executable
+theorems cover the degenerate cases (for `f = 0` the emitted unit is `0`),
+and the statement transports them unchanged. Built from the Mathlib-free
+post-conditions `squareFreeDecomposition_weightedProduct`,
+`squareFreeDecomposition_factors_squareFree`,
+`squareFreeDecomposition_pairwise_coprime`, and
+`squareFreeDecomposition_multiplicity_pos`, with the gcd-unit certificates
+converted through the executable Bezout identity. -/
+theorem squareFreeDecomposition_correct
+    [Fact (Nat.Prime p)] (hp : Hex.Nat.Prime p) (f : Hex.FpPoly p) :
+    let d := Hex.FpPoly.squareFreeDecomposition hp f
+    Polynomial.C (HexModArithMathlib.ZMod64.toZMod d.unit) *
+        (d.factors.map fun sf => toMathlibPolynomial sf.factor ^ sf.multiplicity).prod =
+      toMathlibPolynomial f ∧
+    (∀ sf ∈ d.factors, Squarefree (toMathlibPolynomial sf.factor)) ∧
+    d.factors.Pairwise (fun a b =>
+      IsCoprime (toMathlibPolynomial a.factor) (toMathlibPolynomial b.factor)) ∧
+    (∀ sf ∈ d.factors, 0 < sf.multiplicity) := by
+  intro d
+  refine ⟨?_, ?_, ?_, Hex.FpPoly.squareFreeDecomposition_multiplicity_pos hp f⟩
+  · have hrec : Hex.DensePoly.C
+        (Hex.FpPoly.squareFreeDecomposition hp f).unit *
+        Hex.FpPoly.weightedProduct (Hex.FpPoly.squareFreeDecomposition hp f).factors = f :=
+      Hex.FpPoly.squareFreeDecomposition_weightedProduct hp f
+    have hM := congrArg toMathlibPolynomial hrec
+    rw [toMathlibPolynomial_mul, toMathlibPolynomial_C,
+      toMathlibPolynomial_weightedProduct] at hM
+    exact hM
+  · intro sf hsf
+    exact squarefree_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one
+      (Hex.FpPoly.squareFreeDecomposition_factors_squareFree hp f sf hsf)
+  · have hpair : (Hex.FpPoly.squareFreeDecomposition hp f).factors.Pairwise
+        (fun a b =>
+          (Hex.FpPoly.normalizeMonic (Hex.DensePoly.gcd a.factor b.factor)).2 = 1) :=
+      Hex.FpPoly.squareFreeDecomposition_pairwise_coprime hp f
+    exact hpair.imp fun hab =>
+      isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one hab
+
+/-! # Axiom hygiene
+
+The headline theorem's proof cone must stay on the three standard axioms:
+no `sorry`, no `native_decide`. -/
+
+/--
+info: 'HexPolyFpMathlib.squareFreeDecomposition_correct' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms squareFreeDecomposition_correct
+
+end HexPolyFpMathlib


### PR DESCRIPTION
This PR close the one real headline-theorem hole the 2026-08-22 wave audit found: HexPolyFp sits at `done_through: 7` while its companion carried only representation-correspondence lemmas. The new `HexPolyFpMathlib.squareFreeDecomposition_correct` states the end-to-end post-condition in `Polynomial (ZMod p)`: the unit-scaled product of the returned factors at their multiplicities reconstructs the input, every factor is `Squarefree`, the factors are pairwise `IsCoprime`, and every multiplicity is positive, with no nonzeroness hypothesis (the executable theorems cover the degenerate cases and transport unchanged). Square-freeness routes the executable gcd-unit certificates through Bezout to `IsCoprime` and `Polynomial.Separable.squarefree`; the square-and-multiply invariant is re-derived against Mathlib's power since the executable algebra lemmas are private. A build-enforced `#guard_msgs in #print axioms` pins the axioms to `[propext, Classical.choice, Quot.sound]`. The companion SPEC gains the `## Headline correctness theorem` designation in the house shape, with its scope paragraph reworded to admit the single designated headline while keeping the general correspondence-only boundary (pre-authorized wave SPEC edit).

🤖 Prepared with Claude Code