### PR TITLE
polish: HexResultant pair Phase-6 pass

### DIFF
--- a/HexResultant/BlockDeterminant.lean
+++ b/HexResultant/BlockDeterminant.lean
@@ -32,11 +32,13 @@ def castSquare {R : Type u} {n m : Nat} (h : n = m)
     (M : Square R n) : Square R m :=
   fun i j => M (Fin.cast h.symm i) (Fin.cast h.symm j)
 
+/-- Reindexing along a reflexive dimension equality changes nothing. -/
 @[simp, grind =]
 theorem castSquare_rfl {R : Type u} {n : Nat} (M : Square R n) :
     castSquare rfl M = M := by
   rfl
 
+/-- Entrywise value of a dimension reindexing. -/
 @[simp, grind =]
 theorem castSquare_apply {R : Type u} {n m : Nat} (h : n = m)
     (M : Square R n) (i j : Fin m) :
@@ -60,6 +62,7 @@ def swapAt {R : Type u} {n : Nat} (M : Square R n) (left : Nat)
     else if j.val = left + 1 then M i ⟨left, by omega⟩
     else M i j
 
+/-- Entrywise value of a numeric adjacent-column swap. -/
 @[simp, grind =]
 theorem swapAt_apply {R : Type u} {n : Nat} (M : Square R n)
     (left : Nat) (h : left + 1 < n) (i j : Fin n) :

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -33,12 +33,14 @@ def setCol {R : Type u} {n : Nat} (M : Square R n) (dst : Fin n)
     (v : Fin n → R) : Square R n :=
   fun i j => if j = dst then v i else M i j
 
+/-- Entrywise value of a column replacement. -/
 @[simp, grind =]
 theorem setCol_apply {R : Type u} {n : Nat} (M : Square R n)
     (dst : Fin n) (v : Fin n → R) (i j : Fin n) :
     setCol M dst v i j = if j = dst then v i else M i j := by
   rfl
 
+/-- Replacing a column by itself changes nothing. -/
 @[simp, grind =]
 theorem setCol_self {R : Type u} {n : Nat} (M : Square R n) (dst : Fin n) :
     setCol M dst (fun i => M i dst) = M := by
@@ -57,6 +59,7 @@ def swapAdjacent {R : Type u} {n : Nat} (M : Square R (n + 1))
     else if j = left.succ then M i left.castSucc
     else M i j
 
+/-- Entrywise value of an adjacent column swap. -/
 @[simp, grind =]
 theorem swapAdjacent_apply {R : Type u} {n : Nat}
     (M : Square R (n + 1)) (left : Fin n) (i j : Fin (n + 1)) :
@@ -66,12 +69,14 @@ theorem swapAdjacent_apply {R : Type u} {n : Nat}
       else M i j := by
   rfl
 
+/-- After an adjacent swap, the left column reads the old right column. -/
 @[simp, grind =]
 theorem swapAdjacent_left {R : Type u} {n : Nat}
     (M : Square R (n + 1)) (left : Fin n) (i : Fin (n + 1)) :
     swapAdjacent M left i left.castSucc = M i left.succ := by
   simp [swapAdjacent]
 
+/-- After an adjacent swap, the right column reads the old left column. -/
 @[simp, grind =]
 theorem swapAdjacent_right {R : Type u} {n : Nat}
     (M : Square R (n + 1)) (left : Fin n) (i : Fin (n + 1)) :
@@ -82,6 +87,7 @@ theorem swapAdjacent_right {R : Type u} {n : Nat}
     simp at hval
   simp [swapAdjacent, hne]
 
+/-- Columns away from the swapped pair are untouched. -/
 @[simp, grind =]
 theorem swapAdjacent_of_ne {R : Type u} {n : Nat}
     (M : Square R (n + 1)) (left : Fin n) (i j : Fin (n + 1))
@@ -89,6 +95,7 @@ theorem swapAdjacent_of_ne {R : Type u} {n : Nat}
     swapAdjacent M left i j = M i j := by
   simp [swapAdjacent, hl, hr]
 
+/-- Adjacent column swaps are involutive. -/
 @[simp, grind =]
 theorem swapAdjacent_swapAdjacent {R : Type u} {n : Nat}
     (M : Square R (n + 1)) (left : Fin n) :
@@ -106,12 +113,15 @@ theorem swapAdjacent_swapAdjacent {R : Type u} {n : Nat}
       simp [swapAdjacent, hne.symm]
     · simp [swapAdjacent, hl, hr]
 
+/-- Below the skipped position, the embedding preserves the numeric index. -/
 @[simp, grind =]
 theorem skipIndex_val_of_lt {n : Nat} (skip : Fin (n + 1)) (i : Fin n)
     (h : i.val < skip.val) :
     (skipIndex skip i).val = i.val := by
   simp [skipIndex, h]
 
+/-- From the skipped position on, the embedding shifts the numeric index up
+by one. -/
 @[simp, grind =]
 theorem skipIndex_val_of_not_lt {n : Nat} (skip : Fin (n + 1)) (i : Fin n)
     (h : ¬i.val < skip.val) :
@@ -160,6 +170,7 @@ def eraseIndex {n : Nat} (skip target : Fin (n + 1))
         omega
       omega⟩
 
+/-- The skipped-index embedding undoes index contraction. -/
 @[simp, grind =]
 theorem skipIndex_eraseIndex {n : Nat} (skip target : Fin (n + 1))
     (h : target ≠ skip) :
@@ -196,6 +207,8 @@ def eraseAdjacent {n : Nat} (removed : Fin (n + 2)) (left : Fin (n + 1))
         omega
       omega⟩
 
+/-- The contracted left column of an adjacent pair embeds back onto the
+original left column. -/
 @[simp, grind =]
 theorem skipIndex_eraseAdjacent_left {n : Nat} (removed : Fin (n + 2))
     (left : Fin (n + 1)) (hleft : removed ≠ left.castSucc)
@@ -218,6 +231,8 @@ theorem skipIndex_eraseAdjacent_left {n : Nat} (removed : Fin (n + 2))
       omega
     simp [eraseAdjacent, hlt, skipIndex, hkeep]
 
+/-- The contracted right column of an adjacent pair embeds back onto the
+original right column. -/
 @[simp, grind =]
 theorem skipIndex_eraseAdjacent_right {n : Nat} (removed : Fin (n + 2))
     (left : Fin (n + 1)) (hleft : removed ≠ left.castSucc)
@@ -813,11 +828,13 @@ def applySwaps {R : Type u} {n : Nat} (M : Square R (n + 1))
     (swaps : List (Fin n)) : Square R (n + 1) :=
   swaps.foldl swapAdjacent M
 
+/-- The empty swap sequence acts as the identity. -/
 @[simp, grind =]
 theorem applySwaps_nil {R : Type u} {n : Nat} (M : Square R (n + 1)) :
     applySwaps M [] = M := by
   rfl
 
+/-- A swap sequence acts head first. -/
 @[simp, grind =]
 theorem applySwaps_cons {R : Type u} {n : Nat} (M : Square R (n + 1))
     (left : Fin n) (swaps : List (Fin n)) :
@@ -847,6 +864,8 @@ theorem det_applySwaps {R : Type u} [Lean.Grind.CommRing R]
       rw [hsign]
       grind
 
+/-- Ordered form of arbitrary duplicate-column vanishing, by descending
+recursion on the column gap through one adjacent swap. -/
 private theorem det_eq_zero_of_col_eq_of_lt {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (M : Square R (n + 1))
     (a b : Fin (n + 1)) (hab : a.val < b.val)
@@ -926,6 +945,7 @@ def addCol {R : Type u} [Add R] [Mul R] {n : Nat}
     (M : Square R n) (src dst : Fin n) (c : R) : Square R n :=
   setCol M dst (fun i => M i dst + c * M i src)
 
+/-- Entrywise value of a scaled column addition. -/
 @[simp, grind =]
 theorem addCol_apply {R : Type u} [Add R] [Mul R] {n : Nat}
     (M : Square R n) (src dst : Fin n) (c : R) (i j : Fin n) :
@@ -951,18 +971,6 @@ theorem det_addCol {R : Type u} [Lean.Grind.CommRing R]
       rw [hdup, setCol_self]
       grind
 
-/-- Adding a scalar multiple of an adjacent column to its right neighbor
-preserves the local determinant. -/
-theorem det_setCol_add_adjacent {R : Type u} [Lean.Grind.CommRing R]
-    {n : Nat} (M : Square R (n + 1)) (left : Fin n) (c : R) :
-    det (setCol M left.succ
-      (fun i => M i left.succ + c * M i left.castSucc)) = det M := by
-  have hne : left.castSucc ≠ left.succ := by
-    intro h
-    have hval := congrArg Fin.val h
-    simp at hval
-  exact det_addCol M left.castSucc left.succ c hne
-
 end SubresultantMinor
 
 namespace DensePoly
@@ -972,6 +980,7 @@ section Scale
 
 variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
 
+/-- Integer-indexed coefficient lookup commutes with scalar multiplication. -/
 @[simp]
 theorem coeffInt_scale (c : R) (p : DensePoly R) (i : Int) :
     coeffInt (scale c p) i = c * coeffInt p i := by

--- a/HexResultant/Discriminant.lean
+++ b/HexResultant/Discriminant.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexResultant.Subresultant
-public meta import HexResultant.Subresultant
 public meta import HexPoly.Dense
 public meta import HexPoly.Euclid.DivGcd
 public meta import HexPoly.Operations
@@ -62,35 +61,12 @@ def disc [One R] [Add R] [Sub R] [Mul R] [Div R] [NatCast R]
       disc nonmonic = -8 &&
       disc cubic = -27
 
-/- A tiny executable characteristic-five field regression. This specifically
-guards the formal-degree correction: for `2X¹⁰ + 3X`, the derivative is the
-constant `3`, nine degrees below its formal derivative degree. -/
-private structure F5 where
-  val : Fin 5
-deriving DecidableEq
+/- The characteristic-five formal-degree regression (a `2X¹⁰ + 3X` fixture
+whose derivative degree drops by nine) lives in
+`conformance/HexResultant/Conformance.lean`. -/
 
-private instance : Zero F5 := ⟨⟨0⟩⟩
-private instance : One F5 := ⟨⟨1⟩⟩
-private instance (n : Nat) : OfNat F5 n :=
-  ⟨{ val := ⟨n % 5, Nat.mod_lt n (by decide)⟩ }⟩
-private instance : NatCast F5 :=
-  ⟨fun n => { val := ⟨n % 5, Nat.mod_lt n (by decide)⟩ }⟩
-private instance : Add F5 := ⟨fun a b => ⟨a.val + b.val⟩⟩
-private instance : Sub F5 := ⟨fun a b => ⟨a.val - b.val⟩⟩
-private instance : Mul F5 := ⟨fun a b => ⟨a.val * b.val⟩⟩
-private instance : Div F5 where
-  div a b :=
-    let inv : Fin 5 :=
-      match b.val.val with
-      | 1 => 1
-      | 2 => 3
-      | 3 => 2
-      | 4 => 4
-      | _ => 0
-    ⟨a.val * inv⟩
-
-#guard
-    let f : DensePoly F5 := ofList [0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 2]
-    disc f = 1
+/-- info: 'Hex.DensePoly.disc' depends on axioms: [propext, Quot.sound] -/
+#guard_msgs in
+#print axioms disc
 
 end Hex.DensePoly

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -264,6 +264,7 @@ lemmas as the lightweight `Lean.Grind` hierarchy.
 
 attribute [local instance] Lean.Grind.Semiring.natCast Lean.Grind.Ring.intCast
 
+/-- Dense-polynomial negation is involutive. -/
 theorem DensePoly.neg_neg_poly [Lean.Grind.CommRing R] [DecidableEq R]
     (p : DensePoly R) : -(-p) = p := by
   apply DensePoly.ext_coeff
@@ -283,6 +284,8 @@ def natPow [Lean.Grind.CommRing R] [DecidableEq R]
   | 0 => 1
   | n + 1 => natPow p n * p
 
+/-- Natural-number casts are constant polynomials, reusing the canonical zero
+and one. -/
 instance instNatCast [Lean.Grind.CommRing R] [DecidableEq R] :
     NatCast (DensePoly R) :=
   ⟨fun n =>
@@ -291,6 +294,7 @@ instance instNatCast [Lean.Grind.CommRing R] [DecidableEq R] :
     | 1 => One.one
     | n + 2 => C (Nat.cast (n + 2))⟩
 
+/-- Numerals are constant polynomials, reusing the canonical zero and one. -/
 instance instOfNat [Lean.Grind.CommRing R] [DecidableEq R] (n : Nat) :
     OfNat (DensePoly R) n :=
   ⟨match n with
@@ -298,14 +302,17 @@ instance instOfNat [Lean.Grind.CommRing R] [DecidableEq R] (n : Nat) :
     | 1 => One.one
     | n + 2 => C (OfNat.ofNat (n + 2))⟩
 
+/-- Natural scalar multiplication is multiplication by the cast constant. -/
 instance instNSMul [Lean.Grind.CommRing R] [DecidableEq R] :
     SMul Nat (DensePoly R) :=
   ⟨fun n p => (Nat.cast n : DensePoly R) * p⟩
 
+/-- Natural powers of dense polynomials via `natPow`. -/
 instance instNPow [Lean.Grind.CommRing R] [DecidableEq R] :
     HPow (DensePoly R) Nat (DensePoly R) :=
   ⟨natPow⟩
 
+/-- Integer casts are signed constant polynomials through the natural cast. -/
 instance instIntCast [Lean.Grind.CommRing R] [DecidableEq R] :
     IntCast (DensePoly R) :=
   ⟨fun i =>
@@ -313,6 +320,7 @@ instance instIntCast [Lean.Grind.CommRing R] [DecidableEq R] :
     | .ofNat n => (Nat.cast n : DensePoly R)
     | .negSucc n => -(Nat.cast (n + 1) : DensePoly R)⟩
 
+/-- Integer scalar multiplication is signed natural scalar multiplication. -/
 instance instZSMul [Lean.Grind.CommRing R] [DecidableEq R] :
     SMul Int (DensePoly R) :=
   ⟨fun i p =>
@@ -320,6 +328,7 @@ instance instZSMul [Lean.Grind.CommRing R] [DecidableEq R] :
     | .ofNat n => n • p
     | .negSucc n => -((n + 1) • p)⟩
 
+/-- A numeral polynomial stores its value in coefficient zero only. -/
 @[simp]
 theorem coeff_ofNat [Lean.Grind.CommRing R] [DecidableEq R]
     (n i : Nat) :
@@ -347,6 +356,7 @@ theorem coeff_ofNat [Lean.Grind.CommRing R] [DecidableEq R]
           · simp only [hi, if_true]
           · simpa only [hi, if_false] using (coeffZero_eq (R := R))
 
+/-- A cast-natural polynomial stores its value in coefficient zero only. -/
 @[simp]
 theorem coeff_natCast [Lean.Grind.CommRing R] [DecidableEq R]
     (n i : Nat) :

--- a/HexResultant/Fraction.lean
+++ b/HexResultant/Fraction.lean
@@ -16,6 +16,9 @@ The fraction field used internally by the Mathlib-free subresultant proof.
 The executable resultant never constructs these values.  They provide the
 classical quotient-field setting in which the Brown--Traub scale identities
 can be proved before exact quotients are pulled back to the coefficient ring.
+This module is retained as proof infrastructure: `SubresultantMinor` consumes
+`ofCoeff` for its fraction-embedding image certificates, and the manual embeds
+the quotient-pullback theorems (`div_pullback`, `divExp_exact`).
 -/
 
 namespace Hex
@@ -62,13 +65,17 @@ def Rel (a b : Fraction.Rep R) : Prop :=
   a.num * b.den = b.num * a.den
 
 omit [Div R] [ExactDivLaws R] in
+/-- Cross-multiplication is reflexive. -/
 theorem rel_refl (a : Fraction.Rep R) : Rel a a := by
   exact rfl
 
 omit [Div R] [ExactDivLaws R] in
+/-- Cross-multiplication is symmetric. -/
 theorem rel_symm {a b : Fraction.Rep R} (h : Rel a b) : Rel b a := by
   exact h.symm
 
+/-- Cross-multiplication is transitive; cancellation by the nonzero middle
+denominator is where `ExactDivLaws` enters. -/
 theorem rel_trans {a b c : Fraction.Rep R}
     (hab : Rel a b) (hbc : Rel b c) : Rel a c := by
   apply ExactDivLaws.mul_right_cancel b.den_ne
@@ -80,10 +87,13 @@ theorem rel_trans {a b c : Fraction.Rep R}
     _ = (c.num * b.den) * a.den := by rw [hbc]
     _ = c.num * a.den * b.den := by grind
 
+/-- Fraction representatives form a setoid under cross multiplication. -/
 instance : Setoid (Fraction.Rep R) where
   r := Rel
   iseqv := ⟨rel_refl, rel_symm, rel_trans⟩
 
+/-- Cross-multiplication equivalence is decidable when coefficient equality
+is. -/
 instance [DecidableEq R] (a b : Fraction.Rep R) : Decidable (Rel a b) :=
   by
     unfold Rel
@@ -103,6 +113,7 @@ def add (a b : Fraction.Rep R) : Fraction.Rep R :=
 def neg (a : Fraction.Rep R) : Fraction.Rep R :=
   ⟨-a.num, a.den, a.den_ne⟩
 
+/-- Representative products respect cross-multiplication equivalence. -/
 theorem mul_rel {a b c d : Fraction.Rep R}
     (hac : Rel a c) (hbd : Rel b d) : Rel (mul a b) (mul c d) := by
   unfold Rel at hac hbd
@@ -113,6 +124,7 @@ theorem mul_rel {a b c d : Fraction.Rep R}
     _ = (c.num * a.den) * (d.num * b.den) := by rw [hac, hbd]
     _ = c.num * d.num * (a.den * b.den) := by grind
 
+/-- Representative sums respect cross-multiplication equivalence. -/
 theorem add_rel {a b c d : Fraction.Rep R}
     (hac : Rel a c) (hbd : Rel b d) : Rel (add a b) (add c d) := by
   unfold Rel at hac hbd
@@ -126,6 +138,7 @@ theorem add_rel {a b c d : Fraction.Rep R}
     _ = (c.num * d.den + d.num * c.den) * (a.den * b.den) := by grind
 
 omit [Div R] [ExactDivLaws R] in
+/-- Representative negation respects cross-multiplication equivalence. -/
 theorem neg_rel {a b : Fraction.Rep R} (hab : Rel a b) :
     Rel (neg a) (neg b) := by
   unfold Rel at hab
@@ -196,11 +209,17 @@ protected def neg : Fraction R → Fraction R :=
     intro a b hab
     exact ofRep_eq (Fraction.Rep.neg_rel hab))
 
+/-- Zero is the embedded coefficient zero. -/
 instance : Zero (Fraction R) := ⟨ofCoeff 0⟩
+/-- One is the embedded coefficient one. -/
 instance : One (Fraction R) := ⟨ofCoeff 1⟩
+/-- Addition of fractions. -/
 instance : Add (Fraction R) := ⟨Fraction.add⟩
+/-- Multiplication of fractions. -/
 instance : Mul (Fraction R) := ⟨Fraction.mul⟩
+/-- Negation of fractions. -/
 instance : Neg (Fraction R) := ⟨Fraction.neg⟩
+/-- Subtraction of fractions, defined as addition of the negation. -/
 instance : Sub (Fraction R) := ⟨fun a b => a + -b⟩
 
 omit [NonzeroOne R] in
@@ -208,6 +227,7 @@ private theorem rep_eq (a b : Fraction.Rep R) (h : Fraction.Rep.Rel a b) :
     (ofRep a : Fraction R) = ofRep b :=
   Quotient.sound h
 
+/-- Zero is a right additive identity. -/
 theorem add_zero (a : Fraction R) : a + 0 = a := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -217,6 +237,7 @@ theorem add_zero (a : Fraction R) : a + 0 = a := by
         Lean.Grind.Semiring.mul_one]
 
 omit [NonzeroOne R] in
+/-- Fraction addition is commutative. -/
 theorem add_comm (a b : Fraction R) : a + b = b + a := by
   induction a, b using Quotient.inductionOn₂ with
   | _ a b =>
@@ -225,6 +246,7 @@ theorem add_comm (a b : Fraction R) : a + b = b + a := by
       grind
 
 omit [NonzeroOne R] in
+/-- Fraction addition is associative. -/
 theorem add_assoc (a b c : Fraction R) : a + b + c = a + (b + c) := by
   induction a, b, c using Quotient.inductionOn₃ with
   | _ a b c =>
@@ -233,6 +255,7 @@ theorem add_assoc (a b c : Fraction R) : a + b + c = a + (b + c) := by
       grind
 
 omit [NonzeroOne R] in
+/-- Fraction multiplication is associative. -/
 theorem mul_assoc (a b c : Fraction R) : a * b * c = a * (b * c) := by
   induction a, b, c using Quotient.inductionOn₃ with
   | _ a b c =>
@@ -240,6 +263,7 @@ theorem mul_assoc (a b c : Fraction R) : a * b * c = a * (b * c) := by
       unfold Fraction.Rep.Rel Fraction.Rep.mul
       grind
 
+/-- One is a right multiplicative identity. -/
 theorem mul_one (a : Fraction R) : a * 1 = a := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -247,6 +271,7 @@ theorem mul_one (a : Fraction R) : a * 1 = a := by
       unfold Fraction.Rep.Rel Fraction.Rep.mul
       simp only [Lean.Grind.Semiring.mul_one]
 
+/-- One is a left multiplicative identity. -/
 theorem one_mul (a : Fraction R) : 1 * a = a := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -255,6 +280,7 @@ theorem one_mul (a : Fraction R) : 1 * a = a := by
       simp only [Lean.Grind.Semiring.one_mul]
 
 omit [NonzeroOne R] in
+/-- Fraction multiplication distributes over addition on the left. -/
 theorem left_distrib (a b c : Fraction R) : a * (b + c) = a * b + a * c := by
   induction a, b, c using Quotient.inductionOn₃ with
   | _ a b c =>
@@ -263,6 +289,7 @@ theorem left_distrib (a b c : Fraction R) : a * (b + c) = a * b + a * c := by
       grind
 
 omit [NonzeroOne R] in
+/-- Fraction multiplication distributes over addition on the right. -/
 theorem right_distrib (a b c : Fraction R) : (a + b) * c = a * c + b * c := by
   induction a, b, c using Quotient.inductionOn₃ with
   | _ a b c =>
@@ -270,6 +297,7 @@ theorem right_distrib (a b c : Fraction R) : (a + b) * c = a * c + b * c := by
       unfold Fraction.Rep.Rel Fraction.Rep.mul Fraction.Rep.add
       grind
 
+/-- Zero is a left multiplicative absorber. -/
 theorem zero_mul (a : Fraction R) : 0 * a = 0 := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -277,6 +305,7 @@ theorem zero_mul (a : Fraction R) : 0 * a = 0 := by
       unfold Fraction.Rep.Rel Fraction.Rep.mul
       simp only [Lean.Grind.Semiring.zero_mul]
 
+/-- Zero is a right multiplicative absorber. -/
 theorem mul_zero (a : Fraction R) : a * 0 = 0 := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -284,6 +313,7 @@ theorem mul_zero (a : Fraction R) : a * 0 = 0 := by
       unfold Fraction.Rep.Rel Fraction.Rep.mul
       simp only [Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.zero_mul]
 
+/-- Every fraction cancels with its negation. -/
 theorem neg_add_cancel (a : Fraction R) : -a + a = 0 := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -292,6 +322,7 @@ theorem neg_add_cancel (a : Fraction R) : -a + a = 0 := by
       grind
 
 omit [NonzeroOne R] in
+/-- Fraction negation is involutive. -/
 theorem neg_neg (a : Fraction R) : -(-a) = a := by
   induction a using Quotient.inductionOn with
   | _ a =>
@@ -300,6 +331,7 @@ theorem neg_neg (a : Fraction R) : -(-a) = a := by
       rw [Lean.Grind.AddCommGroup.neg_neg]
 
 omit [NonzeroOne R] in
+/-- Fraction multiplication is commutative. -/
 theorem mul_comm (a b : Fraction R) : a * b = b * a := by
   induction a, b using Quotient.inductionOn₂ with
   | _ a b =>
@@ -308,6 +340,7 @@ theorem mul_comm (a b : Fraction R) : a * b = b * a := by
       grind
 
 omit [NonzeroOne R] in
+/-- Negation moves out of the left factor of a product. -/
 theorem neg_mul (a b : Fraction R) : (-a) * b = -(a * b) := by
   induction a, b using Quotient.inductionOn₂ with
   | _ a b =>
@@ -364,9 +397,12 @@ def natPow (a : Fraction R) : Nat → Fraction R
   | 0 => 1
   | n + 1 => natPow a n * a
 
+/-- Natural-number casts factor through the coefficient embedding. -/
 instance : NatCast (Fraction R) :=
   ⟨fun n => ofCoeff (Nat.cast n)⟩
 
+/-- Numerals factor through the coefficient embedding, reusing the canonical
+zero and one. -/
 instance (n : Nat) : OfNat (Fraction R) n :=
   ⟨match n with
     | 0 => Zero.zero
@@ -383,18 +419,23 @@ theorem ofNat_eq_ofCoeff (n : Nat) :
       | zero => rfl
       | succ n => rfl
 
+/-- Natural scalar multiplication is multiplication by the cast scalar. -/
 instance : SMul Nat (Fraction R) :=
   ⟨fun n a => (Nat.cast n : Fraction R) * a⟩
 
+/-- Natural powers of fractions via `natPow`. -/
 instance : HPow (Fraction R) Nat (Fraction R) :=
   ⟨natPow⟩
 
+/-- Integer casts factor through the coefficient embedding. -/
 instance : IntCast (Fraction R) :=
   ⟨fun i => ofCoeff (Int.cast i)⟩
 
+/-- Integer scalar multiplication is multiplication by the cast scalar. -/
 instance : SMul Int (Fraction R) :=
   ⟨fun i a => (Int.cast i : Fraction R) * a⟩
 
+/-- The quotient construction is a lightweight semiring. -/
 instance : Lean.Grind.Semiring (Fraction R) := by
   refine Lean.Grind.Semiring.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
   · exact add_zero
@@ -425,6 +466,7 @@ instance : Lean.Grind.Semiring (Fraction R) := by
   · intro _ _
     rfl
 
+/-- The quotient construction is a lightweight ring. -/
 instance : Lean.Grind.Ring (Fraction R) := by
   refine Lean.Grind.Ring.mk ?_ ?_ ?_ ?_ ?_ ?_
   · exact neg_add_cancel
@@ -450,6 +492,7 @@ instance : Lean.Grind.Ring (Fraction R) := by
       -ofCoeff (R := R) (Int.cast i)
     rw [Lean.Grind.Ring.intCast_neg, ofCoeff_neg]
 
+/-- The quotient construction is a lightweight commutative ring. -/
 instance : Lean.Grind.CommRing (Fraction R) := by
   refine Lean.Grind.CommRing.mk ?_
   exact mul_comm
@@ -500,14 +543,18 @@ protected def inv : Fraction R → Fraction R :=
     intro a b hab
     exact invRep_rel hab)
 
+/-- Total inversion of fractions, with zero sent to zero. -/
 instance : Inv (Fraction R) := ⟨Fraction.inv⟩
+/-- Division of fractions is multiplication by the total inverse. -/
 instance : Div (Fraction R) := ⟨fun a b => a * b⁻¹⟩
 
 omit [NonzeroOne R] [DecidableEq R] in
+/-- Products of embedded representatives multiply representatives. -/
 @[simp]
 theorem mul_ofRep (a b : Fraction.Rep R) :
     ofRep a * ofRep b = ofRep (Fraction.Rep.mul a b) := rfl
 
+/-- Inverting an embedded representative applies `invRep`. -/
 @[simp]
 theorem inv_ofRep (a : Fraction.Rep R) : (ofRep a)⁻¹ = invRep a := rfl
 
@@ -585,6 +632,7 @@ def intPow (a : Fraction R) : Int → Fraction R
   | .ofNat n => a ^ n
   | .negSucc n => (a ^ (n + 1))⁻¹
 
+/-- Integer powers of fractions via `intPow`. -/
 instance : HPow (Fraction R) Int (Fraction R) := ⟨intPow⟩
 
 /-- Division is multiplication by the fraction inverse. -/

--- a/HexResultant/FractionPoly.lean
+++ b/HexResultant/FractionPoly.lean
@@ -14,6 +14,11 @@ public section
 /-!
 Coefficient embedding from dense polynomials over an exact-division domain to
 dense polynomials over its fraction field.
+
+This module is retained as proof infrastructure: `SubresultantMinor` maps
+generalized Sylvester minors through `Fraction.map` for its image
+certificates, and the manual embeds the pseudo-division transport and
+scalar-quotient pullback theorems.
 -/
 
 namespace Hex

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -36,17 +36,11 @@ namespace Hex
 
 universe u
 
-/-- Law required of the coefficient quotient used by Brown's exact divisions.
-    It also implies cancellation by every nonzero right factor. -/
-class ExactDivLaws (R : Type u) [Zero R] [Mul R] [Div R] : Prop where
-  mul_div_cancel_right : ∀ a b : R, b ≠ 0 → (a * b) / b = a
+/- The `ExactDivLaws` law class and the total `exactDiv` wrapper
+   (`exactDiv a 0 = 0`, otherwise `a / b`) are declared below this library in
+   `HexBasic/ExactDiv.lean` and re-exported here through a public import. -/
 
 variable {R : Type u}
-
-/-- Total exact quotient wrapper. A zero denominator returns zero; on a
-    nonzero exact division this is the underlying lawful quotient. -/
-def exactDiv [Zero R] [DecidableEq R] [Div R] (a b : R) : R :=
-  if b = 0 then 0 else a / b
 
 /-- Natural powers by binary exponentiation, using only the executable `One`
     and `Mul` operations. -/
@@ -71,7 +65,19 @@ def det [Zero R] [One R] [Add R] [Sub R] [Mul R] :
 
 end SubresultantMinor
 
+/-- Executable result of a degree-ordered Brown PRS run. `chain` stores
+    Brown's nonzero `G₁, …, Gₖ`, excluding the generated terminal zero;
+    `scale` is the corrected terminal principal-subresultant scalar `hₖ`. -/
+structure PRSResult (R : Type u) [Zero R] [DecidableEq R] where
+  chain : Array (DensePoly R)
+  scale : R
+
 namespace DensePoly
+
+/-- The ring element `(-1)^n`, expressed using only `Zero`, `One`, and
+    `Sub`. -/
+def negOnePow [Zero R] [One R] [Sub R] (n : Nat) : R :=
+  if n % 2 = 0 then 1 else 0 - 1
 
 /-- Divide every coefficient by the same scalar through `exactDiv`. -/
 noncomputable def divScalar [Zero R] [DecidableEq R] [Div R]
@@ -116,16 +122,36 @@ def pseudoDivMod [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
    than `f`, then `pseudoDivMod f g = (0, f)`. Both have corresponding rewrite
    lemmas. -/
 
-/-- Brown's nonzero subresultant pseudo-remainder sequence. For two nonzero
-    inputs it orders them by decreasing degree, stores both ordered inputs,
-    and stops before the generated terminal zero. Zero inputs are omitted. -/
-def subresultantChain [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
-    [Mul R] [Div R] (f g : DensePoly R) : Array (DensePoly R) := ...
+/-- Brown's recurrence for two nonzero inputs already ordered by decreasing
+    dense degree, with an explicit proof-audit fuel parameter. -/
+def subresultantOrderedFuel [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) (fuel : Nat) : PRSResult R := ...
 
-/-- Resultant with Mathlib's default-formal-degree conventions. For ordered
-    nonzero inputs the Brown worker returns `(chain, hFinal)`; the value is
-    `hFinal` exactly when the last chain element is constant and zero
-    otherwise. Reversed inputs receive the standard degree-product sign. -/
+/-- The ordered Brown run at the sufficient public fuel budget
+    `g.size + 1`. -/
+def subresultantOrdered [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) : PRSResult R :=
+  subresultantOrderedFuel f g (g.size + 1)
+
+/-- Total Brown run. Zero inputs are omitted; two nonzero inputs are ordered
+    by decreasing dense degree before entering `subresultantOrdered`. -/
+def subresultantRun [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) : PRSResult R := ...
+
+/-- Brown's nonzero subresultant pseudo-remainder sequence: the chain stored
+    by `subresultantRun`. -/
+def subresultantChain [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) : Array (DensePoly R) :=
+  (subresultantRun f g).chain
+
+/-- The resultant of an ordered nonzero Brown run: the corrected terminal
+    scale when the last stored term is a nonzero constant, zero otherwise. -/
+def resultantOrdered [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) : R := ...
+
+/-- Resultant with Mathlib's default-formal-degree conventions. Zero inputs
+    are handled by the total conventions below; reversed nonzero inputs
+    receive the standard degree-product sign before `resultantOrdered`. -/
 def resultant [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
     [Div R] (f g : DensePoly R) : R := ...
 
@@ -421,32 +447,12 @@ quotient by `lc(f)`. This correction is essential in positive characteristic,
 where the derivative's actual degree can fall below `n - 1`; with it the
 quotient is exact over every stated exact-division domain.
 
-## Planned extended chain for gcd consumers
+## Downstream contracts
 
-`hex-poly-z-gcd` and `hex-mv-gcd` both need the transformation that produces
-each Brown entry, not only the entries themselves. The existing worker calls
-`pseudoDivMod` at `HexResultant/Subresultant.lean:616` and retains only the
-remainder, so this is a real extension rather than an accessor:
-
-```lean
-/-- `(uₖ, vₖ, Sₖ)` for every stored Brown entry, with
-`uₖ * f + vₖ * g = Sₖ`. -/
-def subresultantChainExt [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
-    [Mul R] [Div R] (f g : DensePoly R) :
-    Array (DensePoly R × DensePoly R × DensePoly R)
-```
-
-The extension uses the unchanged Brown remainder recurrence and accumulates
-the two transformation cofactors through every pseudo-scaling and exact
-scalar division. Its correctness theorem requires `Lean.Grind.CommRing R`
-and `ExactDivLaws R`, proves the displayed identity for every entry, and
-proves the cofactor numerators are divisible by each Brown scalar before the
-executable division. Projection of the third components equals
-`subresultantChain f g`, including input ordering and zero conventions.
-
-This API belongs here so the two gcd libraries share one recurrence and one
-proof. It is a prerequisite for their complete `splitBezout` fallback; it
-does not alter the current resultant or discriminant contracts.
+The extended chain `subresultantChainExt` (Bezout cofactors for every stored
+Brown entry) is a `hex-poly-z-gcd`/`hex-mv-gcd` prerequisite, sketched in
+[SPEC/future-work.md](../../SPEC/future-work.md); it does not alter the
+current resultant or discriminant contracts.
 
 ## File organisation
 

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -1491,6 +1491,10 @@ def resultant [One R] [Add R] [Sub R] [Mul R] [Div R]
     let ySubT : DensePoly (DensePoly Int) := ofList [0 - t, one]
     resultant ySqSubT ySubT = t * t - t
 
+/-- info: 'Hex.DensePoly.resultant' depends on axioms: [propext, Quot.sound] -/
+#guard_msgs in
+#print axioms resultant
+
 /-- Both zero inputs produce the empty nonzero chain. -/
 @[simp, grind =]
 theorem subresultantChain_zero_zero [One R] [Add R] [Sub R] [Mul R] [Div R] :

--- a/HexResultant/SubresultantMinor.lean
+++ b/HexResultant/SubresultantMinor.lean
@@ -58,6 +58,7 @@ def det {R : Type u} [Zero R] [One R] [Add R] [Sub R] [Mul R] :
         (fun acc j =>
           acc + sign j.val * M ⟨0, by omega⟩ j * det (deleteFirst M j)) 0
 
+/-- The empty local determinant is one. -/
 @[simp, grind =]
 theorem det_zero {R : Type u} [Zero R] [One R] [Add R] [Sub R] [Mul R]
     (M : Square R 0) : det M = 1 := by
@@ -208,6 +209,8 @@ def poly [One R] [Add R] [Sub R] [Mul R]
     (J : Nat) (f g : DensePoly R) : DensePoly R :=
   ofList ((List.range (J + 1)).map fun l => coeffMinor J l f g)
 
+/-- Coefficient `l` of the generalized subresultant is the corresponding
+scalar minor up to index `J`, and zero above. -/
 @[simp, grind =]
 theorem coeff_poly [One R] [Add R] [Sub R] [Mul R]
     (J : Nat) (f g : DensePoly R) (l : Nat) :
@@ -233,6 +236,8 @@ variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
   [Div R] [ExactDivLaws R]
   [Hex.Fraction.NonzeroOne R]
 
+/-- Integer-indexed coefficient lookup commutes with the fraction
+embedding. -/
 @[simp]
 theorem coeffInt_map (p : DensePoly R) (i : Int) :
     coeffInt (DensePoly.Fraction.map p) i =
@@ -243,6 +248,7 @@ theorem coeffInt_map (p : DensePoly R) (i : Int) :
     exact Hex.Fraction.ofCoeff_zero.symm
   · simp [h, DensePoly.Fraction.coeff_map]
 
+/-- The fraction embedding preserves the default formal degree. -/
 @[simp]
 theorem formalDegree_map (p : DensePoly R) :
     formalDegree (DensePoly.Fraction.map p) = formalDegree p := by

--- a/HexResultantMathlib/Basic.lean
+++ b/HexResultantMathlib/Basic.lean
@@ -7,8 +7,6 @@ Authors: Kim Morrison
 module
 
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
-public import Mathlib.FieldTheory.IsAlgClosed.Basic
-public import Mathlib.Data.Complex.Basic
 public import HexResultant
 public import HexPolyMathlib
 
@@ -28,6 +26,8 @@ universe u
 
 variable {R : Type u}
 
+/-- Horner evaluation of a coefficient list is the finite monomial sum over
+its positions. -/
 private theorem evalCoeffList_eq_sum_fin [CommSemiring R]
     (xs : List R) (x : R) :
     evalCoeffList xs x =

--- a/HexResultantMathlib/Chain.lean
+++ b/HexResultantMathlib/Chain.lean
@@ -90,4 +90,12 @@ theorem resultant_eq_zero_iff_common_root
     rw [hdf, hdg]
     exact Int.cast_eq_zero.mp hcast
 
+/-! Trust-surface regression check for the common-root characterization. -/
+
+/--
+info: 'Hex.DensePoly.resultant_eq_zero_iff_common_root' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms resultant_eq_zero_iff_common_root
+
 end Hex.DensePoly

--- a/HexResultantMathlib/Discriminant.lean
+++ b/HexResultantMathlib/Discriminant.lean
@@ -127,6 +127,10 @@ theorem toPolynomial_disc [CommRing R] [IsDomain R] [DecidableEq R]
           (n * (n - 1) / 2))
     rw [← mul_assoc, hsign, one_mul]
 
+/-- Mathlib's discriminant of a positive-degree product is the product of the
+factor discriminants times the squared cross-resultant. The proof runs both
+resultant multiplicativity laws through `resultant_deriv` and cancels the
+common sign and leading-coefficient factors. -/
 private theorem discr_mul [CommRing R] [IsDomain R]
     [IsAddTorsionFree R] (f g : Polynomial R)
     (hf : 0 < f.natDegree) (hg : 0 < g.natDegree) :
@@ -371,6 +375,12 @@ theorem disc_ne_zero_iff_separable [Field R] [IsAddTorsionFree R]
     exact (hzero.mp hdisc) hcoprime
 
 /-! Trust-surface regression checks for the headline discriminant contracts. -/
+
+/--
+info: 'Hex.DensePoly.toPolynomial_disc' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms toPolynomial_disc
 
 /--
 info: 'Hex.DensePoly.disc_mul' depends on axioms: [propext, Classical.choice, Quot.sound]

--- a/HexResultantMathlib/Roots.lean
+++ b/HexResultantMathlib/Roots.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexResultantMathlib.Sylvester
-public import Mathlib.Algebra.Polynomial.Splits
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
 
 public section
 

--- a/HexResultantMathlib/Sylvester.lean
+++ b/HexResultantMathlib/Sylvester.lean
@@ -90,6 +90,9 @@ private def sylvesterByVal [CommRing R] (f g : Polynomial R) (df dg : Nat) :
         f.coeff (i.val - jj)
       else 0
 
+/-- Mathlib's `Fin.addCases`-defined Sylvester matrix agrees with its
+value-indexed presentation, which rewrites cleanly against the numeric
+indexing of `coeffMatrixAt`. -/
 private theorem sylvester_eq_byVal [CommRing R] (f g : Polynomial R)
     (df dg : Nat) :
     Polynomial.sylvester f g df dg = sylvesterByVal f g df dg := by
@@ -339,6 +342,14 @@ theorem toPolynomial_resultant [CommRing R] [IsDomain R] [DecidableEq R]
       · rw [if_neg hfg]
         rw [resultantOrdered_eq_coeffMinor f g hf hg (by omega)]
         rw [Subresultant.coeffMinor_zero_eq_resultant, hdf, hdg]
+
+/-! Trust-surface regression check for the headline resultant correspondence. -/
+
+/--
+info: 'Hex.DensePoly.toPolynomial_resultant' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms toPolynomial_resultant
 
 end DensePoly
 end Hex

--- a/SPEC/Libraries/hex-mv-gcd.md
+++ b/SPEC/Libraries/hex-mv-gcd.md
@@ -428,9 +428,11 @@ transformation pair through the pseudo-scaling and the exact scalar
 division at every step, with proofs that each cofactor numerator is
 divisible by the Brown scalar it is divided by.
 
-The owning contract is now recorded under "Planned extended chain for gcd
-consumers" in [hex-resultant's SPEC](../../HexResultant/SPEC/hex-resultant.md);
-its signature is repeated here only to show the consumer boundary:
+The owning contract is now recorded under "Extended subresultant chain for
+gcd consumers" in [SPEC/future-work.md](../future-work.md), with a pointer
+from the Downstream contracts section of
+[hex-resultant's SPEC](../../HexResultant/SPEC/hex-resultant.md); its
+signature is repeated here only to show the consumer boundary:
 
 ```lean
 /-- The subresultant chain with the cofactors producing each entry:

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -116,6 +116,31 @@ asymptotic winners. The SPEC must keep the dependency direction from
 `hex-poly-fast` to both input libraries; `hex-truncated-series` should not
 acquire a dependency on `hex-poly` merely to support this consumer.
 
+### Extended subresultant chain for gcd consumers
+
+Amend `hex-resultant` with the transformation that produces each Brown entry,
+not only the entries themselves. `hex-poly-z-gcd` and `hex-mv-gcd` both need
+it for their complete `splitBezout` fallback; the existing worker retains only
+each pseudo-remainder, so this is a real extension rather than an accessor:
+
+```lean
+/-- `(uₖ, vₖ, Sₖ)` for every stored Brown entry, with
+`uₖ * f + vₖ * g = Sₖ`. -/
+def subresultantChainExt [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) :
+    Array (DensePoly R × DensePoly R × DensePoly R)
+```
+
+The extension uses the unchanged Brown remainder recurrence and accumulates
+the two transformation cofactors through every pseudo-scaling and exact
+scalar division. Its correctness theorem requires `Lean.Grind.CommRing R`
+and `ExactDivLaws R`, proves the displayed identity for every entry, and
+proves the cofactor numerators are divisible by each Brown scalar before the
+executable division. Projection of the third components equals
+`subresultantChain f g`, including input ordering and zero conventions. The
+API belongs in `hex-resultant` so the two gcd libraries share one recurrence
+and one proof; it does not alter the resultant or discriminant contracts.
+
 ### Positive-characteristic multivariate squarefree decomposition
 
 Amend `hex-mv-gcd` with squarefree decomposition over perfect fields of


### PR DESCRIPTION
This PR complete the Phase-6 polishing pass for HexResultant and HexResultantMathlib per PLAN/Phase6.md. Docstrings land on all ~74 previously undocumented public declarations across Fraction, DeterminantAlgebra, ExactDiv, SubresultantMinor, and BlockDeterminant plus the three companion helpers. The fraction infrastructure is kept with its consumers recorded in the module docstrings (SubresultantMinor image certificates; five manual-embedded theorems); the one true orphan (`det_setCol_add_adjacent`, a thin unreferenced wrapper) is deleted, while silent `simp`/`grind` fuel and SPEC-mandated conventions are kept with verification notes. The private `F5` test fixture leaves library source (identical coverage already lives in the conformance module), the duplicate Subresultant import is resolved to the one form the module system needs, and the unused `IsAlgClosed`/`Complex` imports leave the companion's root module with downstream builds verified. `#print axioms` guards pin `resultant`/`disc` at their actual `[propext, Quot.sound]` and the three companion headline theorems at `[propext, Classical.choice, Quot.sound]`. The SPEC's planned `subresultantChainExt` moves to SPEC/future-work.md as a hex-poly-z-gcd prerequisite with a pointer left in Downstream contracts, and the stale Contents block now matches the source surface. The `done_through: 6` bumps follow separately in the serialized queue once the remaining rungs land.

🤖 Prepared with Claude Code