### PR TITLE
doc: finish HexPolyFpMathlib Phases 6 and 7

### DIFF
--- a/HexBerlekampMathlib/Irreducibility.lean
+++ b/HexBerlekampMathlib/Irreducibility.lean
@@ -37,7 +37,7 @@ open Polynomial
 -- sites spelling these `HexBerlekampMathlib.foo` keep resolving.
 export HexPolyFpMathlib (fpPolyToPolynomial polynomialToFpPoly
   coeff_fpPolyToPolynomial fpPolyEquiv toMathlibPolynomial fpPolyEquiv_apply
-  fpPolyEquiv_symm_apply coeff_toMathlibPolynomial coeff_toMathlibPolynomial_equiv
+  fpPolyEquiv_symm_apply coeff_toMathlibPolynomial
   toMathlibPolynomial_monic toMathlibPolynomial_derivative toMathlibPolynomial_mul
   toMathlibPolynomial_add toMathlibPolynomial_sub toMathlibPolynomial_C
   toMathlibPolynomial_monomial_one toMathlibPolynomial_X toMathlibPolynomial_dvd

--- a/HexGFqMathlib/Primitivity.lean
+++ b/HexGFqMathlib/Primitivity.lean
@@ -28,7 +28,6 @@ extra ingredient is that reducing modulo the modulus is invisible after it.
 namespace HexGFqMathlib
 
 open Hex
-open scoped HexPolyFpMathlib
 
 variable {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 variable {f : Hex.FpPoly p} {hf : 0 < Hex.FpPoly.degree f}

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -29,7 +29,6 @@ monomial data.
 namespace HexGFqMathlib
 
 open Hex
-open scoped HexPolyFpMathlib
 
 variable {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -8,6 +8,8 @@ import VersoManual
 
 import HexPolyFp
 
+import HexPolyFpMathlib
+
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
 
@@ -270,6 +272,165 @@ reducible modulus (where a nonzero zero-divisor has no inverse).
 
 {docstring Hex.FpPoly.Quotient.inv_mul_cancel}
 
+# The Mathlib correspondence
+%%%
+tag := "hex-poly-fp-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. `HexPolyFpMathlib` is
+the companion that connects it to Mathlib, and this section is where
+that library is documented. It is the crossing point for the whole
+executable polynomial tower, not only for this chapter's library:
+below it a reader is in Hex's own {name}`Hex.DensePoly` over
+{name}`Hex.ZMod64`, and on the far side of it in Mathlib's
+`Polynomial (ZMod p)`.
+
+{docstring HexPolyFpMathlib.fpPolyEquiv}
+
+The equivalence asks only for {name}`Hex.ZMod64.Bounds`, not for
+primality. `FpPoly p` is a commutative ring for every admissible modulus,
+meaning every `p` with `0 < p` and `p < 2 ^ 31`, which is what that class
+requires; `Polynomial (ZMod p)` is one for any `p` at all; and nothing in
+the correspondence divides. So there is no reason to demand more of `p`
+than the representation itself does. Primality enters at exactly one
+declaration, and as an explicit hypothesis.
+
+{docstring HexPolyFpMathlib.primeModulus_of_fact}
+
+That is the door from Mathlib's `Fact (Nat.Prime p)` to the executable
+{name}`Hex.ZMod64.PrimeModulus` witness that the field-dependent
+operations require: coefficient inversion, the Bezout gcd, and modular
+division, and everything in
+{ref "hex-poly-fp-quotient"}[The quotient by a modulus] built on them. A
+caller who is already working in Mathlib supplies the `Fact` and gets the
+witness; a caller staying on the executable side never needs the `Fact`.
+
+## The forward map
+%%%
+tag := "hex-poly-fp-mathlib-forward"
+%%%
+
+Downstream statements are written against a named forward map rather
+than against the equivalence, so that a goal about an executable
+polynomial's Mathlib image carries no `RingEquiv` coercion.
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial}
+
+{docstring HexPolyFpMathlib.coeff_toMathlibPolynomial}
+
+The coefficient lemma is the normal form for the whole layer. Nearly
+every transport below is proved by taking coefficients on both sides and
+rewriting with it, and it is the `simp` rule a downstream proof reaches
+for first.
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_monic}
+
+Monicity is the hypothesis the executable Euclidean operations carry, so
+transporting it is what lets a Mathlib-side argument apply
+`Polynomial.Monic` lemmas to a polynomial that came out of
+{name}`Hex.FpPoly.modByMonic` or out of the square-free decomposition.
+
+## The transport family
+%%%
+tag := "hex-poly-fp-mathlib-transport"
+%%%
+
+The forward map is a ring equivalence, so each of the following follows
+from it. They are stated anyway: a caller reaching for one of them
+should not have to rediscover which `RingEquiv` lemma to compose, and
+the rewrite-friendly form is what the finite-field proofs actually use.
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_add}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_sub}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_mul}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_derivative}
+
+The derivative is the one that does not come free from the ring
+structure; it is proved coefficientwise. It is also the one the
+square-free correctness arguments need, since Yun's algorithm is stated
+in terms of the gcd of a polynomial with its derivative.
+
+The generators transport too, so a Mathlib-side computation can be
+rewritten all the way down to `X` and constants.
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_C}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_X}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_monomial_one}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_dvd}
+
+That last one is the forward direction only: it is proved from a
+multiplication witness and
+{name}`HexPolyFpMathlib.toMathlibPolynomial_mul`, with no division and no
+gcd. The equivalence can reflect such a witness backward just as well, so
+the two-sided `dvd_iff` is a gap in the current API rather than a
+property of the correspondence. It is tracked as
+[hex-dev issue 9370](https://github.com/kim-em/hex-dev/issues/9370),
+along with the rest of the inverse transport family. What genuinely does
+not belong here is a
+statement mentioning Berlekamp's basis size or Rabin's test, even when
+its conclusion is about
+{name}`HexPolyFpMathlib.toMathlibPolynomial`: that is a fact about a
+factoring algorithm rather than about the representation, and it lives in
+`HexBerlekampMathlib`.
+
+## Mathlib algebraic structure
+%%%
+tag := "hex-poly-fp-mathlib-instances"
+%%%
+
+A `RingEquiv` does not install a `CommRing`. Without one,
+`Hex.FpPoly p →+* R` is not a well-formed type, so the instance is a
+prerequisite for every ring homomorphism out of the executable
+polynomials rather than a convenience.
+
+{docstring HexPolyFpMathlib.commRing}
+
+The design point is worth restating, because the obvious alternative is
+the wrong one. Transporting a `CommRing` along
+{name}`HexPolyFpMathlib.fpPolyEquiv` would produce a correct instance
+whose operations are Mathlib's: `f * g` would mean "map both sides into
+`Polynomial (ZMod p)`, multiply there, map back", and none of the
+executable convolution would run. Building the instance from the laws
+`HexPolyFp` proves keeps the operations the executable ones, so
+multiplication under it is still the schoolbook loop.
+
+```lean
+open Hex in
+example {p : Nat} [ZMod64.Bounds p]
+    (f g : FpPoly p) :
+    f * g = DensePoly.mul f g := rfl
+```
+
+Mathlib's ring automation therefore applies directly to the fast
+representation:
+
+```lean
+open Hex in
+example {p : Nat} [ZMod64.Bounds p]
+    (f g : FpPoly p) :
+    (f + g) ^ 2 = f ^ 2 + 2 * (f * g) + g ^ 2 := by
+  ring
+```
+
+One executable operation needs to be identified with its Mathlib
+counterpart by hand, because `HexPolyFp` defines it by structural
+recursion for kernel reduction while the `CommRing` above supplies
+`npowRec`.
+
+{docstring HexPolyFpMathlib.linearPow_eq_pow}
+
+Finally, a naming note for readers of older code. The equivalence and
+its transports lived in `HexBerlekampMathlib` while Berlekamp factoring
+was their only consumer, and that library still re-exports the
+correspondence names, so a call site spelling one of them
+`HexBerlekampMathlib.toMathlibPolynomial` keeps resolving.
+
 # Cross-references
 %%%
 tag := "hex-poly-fp-cross-references"
@@ -297,3 +458,12 @@ Downstream, the finite-field libraries consume `HexPolyFp` directly:
 inverse laws documented above, each conditioned on irreducibility of the
 modulus, with the {name}`Hex.FpPoly.Irreducible` witness produced by a
 checkable Rabin certificate from `HexBerlekamp`.
+
+`HexPolyFp` is Mathlib-free. Its Mathlib correspondence is
+`HexPolyFpMathlib`, documented in
+{ref "hex-poly-fp-mathlib"}[The Mathlib correspondence] above, which
+identifies {name}`Hex.FpPoly` with `Polynomial (ZMod p)` and carries the
+`CommRing` instance that every ring homomorphism out of the executable
+polynomials needs. Nothing in this chapter depends on it: the modular
+exponentiation, the Frobenius maps, the square-free decomposition, and
+the quotient are all executable and Mathlib-free.

--- a/HexPolyFpMathlib/Basic.lean
+++ b/HexPolyFpMathlib/Basic.lean
@@ -31,11 +31,7 @@ those consumers do not depend on a factoring library to reach Mathlib.
 
 namespace HexPolyFpMathlib
 
-universe u
-
 noncomputable section
-
-open Polynomial
 
 variable {p : Nat} [Hex.ZMod64.Bounds p]
 
@@ -219,11 +215,17 @@ def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p) where
 def toMathlibPolynomial (f : Hex.FpPoly p) : Polynomial (ZMod p) :=
   fpPolyEquiv f
 
+/-- Applying the ring equivalence is the forward transport. The named forward
+map is the normal form: statements about an executable polynomial's Mathlib
+image read better without a `RingEquiv` coercion in the way. -/
 @[simp, grind =]
 theorem fpPolyEquiv_apply (f : Hex.FpPoly p) :
     fpPolyEquiv f = toMathlibPolynomial f := by
   rfl
 
+/-- Applying the inverse of the ring equivalence is `polynomialToFpPoly`, the
+partner of {name}`HexPolyFpMathlib.fpPolyEquiv_apply` for the backward
+direction. -/
 @[simp, grind =]
 theorem fpPolyEquiv_symm_apply (f : Polynomial (ZMod p)) :
     fpPolyEquiv.symm f = polynomialToFpPoly f := by
@@ -232,22 +234,8 @@ theorem fpPolyEquiv_symm_apply (f : Polynomial (ZMod p)) :
 /-- Coefficients are preserved by the equivalence with Mathlib polynomials. -/
 @[simp, grind =]
 theorem coeff_toMathlibPolynomial (f : Hex.FpPoly p) (n : Nat) :
-    (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) := by
-  show (fpPolyToPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n)
-  rw [fpPolyToPolynomial, Polynomial.finsetSum_coeff]
-  simp only [Polynomial.coeff_monomial]
-  rw [Finset.sum_ite_eq' (Finset.range f.size) n
-    (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]
-  by_cases hn : n ∈ Finset.range f.size
-  · rw [if_pos hn]
-  · rw [if_neg hn, Hex.DensePoly.coeff_eq_zero_of_size_le f
-      (Nat.le_of_not_lt (Finset.mem_range.not.mp hn))]
-    exact HexModArithMathlib.ZMod64.toZMod_zero.symm
-
-@[simp, grind =]
-theorem coeff_toMathlibPolynomial_equiv (f : Hex.FpPoly p) (n : Nat) :
-    (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.equiv (f.coeff n) := by
-  rw [coeff_toMathlibPolynomial, HexModArithMathlib.ZMod64.equiv_apply]
+    (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) :=
+  coeff_fpPolyToPolynomial f n
 
 /-- Monicity of executable finite-field polynomials transfers to Mathlib.
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -491,7 +491,7 @@ libraries:
     # PLAN/Phase4.md, so there is no conformance module, no bench target and no
     # phase4 block here, and the layer's performance owners are named in its
     # SPEC rather than measured locally.
-    done_through: 6
+    done_through: 7
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -491,7 +491,7 @@ libraries:
     # PLAN/Phase4.md, so there is no conformance module, no bench target and no
     # phase4 block here, and the layer's performance owners are named in its
     # SPEC rather than measured locally.
-    done_through: 5
+    done_through: 6
     status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]

--- a/progress/20260822T045500Z_poly-fp-mathlib-phase-6-7.md
+++ b/progress/20260822T045500Z_poly-fp-mathlib-phase-6-7.md
@@ -1,0 +1,102 @@
+# HexPolyFpMathlib Phase 6 and Phase 7
+
+## Accomplished
+
+**Phase 6 (proof polishing), `done_through` 5 → 6.**
+
+- Documented `fpPolyEquiv_apply` and `fpPolyEquiv_symm_apply`, the two public
+  theorems the library exported without a docstring. Every other public
+  declaration already had one.
+- Implemented the three cleanups filed as
+  https://github.com/kim-em/hex-dev/issues/9372, having first confirmed each
+  against the source:
+  - Dropped `coeff_toMathlibPolynomial_equiv`. Its left-hand side was
+    syntactically identical to `coeff_toMathlibPolynomial`'s and its
+    right-hand side was undone by `HexModArithMathlib.ZMod64.equiv_apply`,
+    which is itself `@[simp]`; `simpNF` flagged it. Its only occurrence
+    outside its own declaration was the re-export list in
+    `HexBerlekampMathlib/Irreducibility.lean`, which loses one name.
+  - `coeff_toMathlibPolynomial` now delegates to `coeff_fpPolyToPolynomial`
+    instead of repeating its ten-line proof behind a `show`. Both public
+    names stay: `coeff_fpPolyToPolynomial` has to exist before `fpPolyEquiv`
+    does, because all four of the equivalence's fields use it.
+  - Removed the no-op `open scoped HexPolyFpMathlib` from
+    `HexGFqMathlib/Subfield.lean` and `HexGFqMathlib/Primitivity.lean`.
+- Dropped the unused `universe u` and the `open Polynomial` the file never
+  relied on; every reference in it is already fully qualified.
+- Adjudicated the remaining zero-reference public declarations rather than
+  deleting them. `fpPolyToPolynomial` and `coeff_fpPolyToPolynomial` are the
+  pre-equivalence layer the `fpPolyEquiv` fields are proved from, and
+  `fpPolyEquiv_symm_apply` is the backward half of a complete `@[simp]`
+  apply/symm-apply pair.
+- The performance-regression exit criterion does not apply: the library's SPEC
+  declares it a `correspondence-only-layer` with no external comparator, and it
+  ships no bench or conformance target. No `sorry`, no `axiom`, no
+  `native_decide`. It exposes no irreducibility or field-construction claim of
+  its own; those live in `hex-berlekamp-mathlib` and `hex-gfq-*`.
+- Mathlib's `#lint` (14 default linters plus `docBlameThm`, run from a
+  throwaway `HexPolyFpMathlib/LintTests.lean` that was deleted before
+  committing) reported 4 errors in 21 declarations before and reports 0 in 20
+  after.
+
+**Phase 7 (user-facing documentation), `done_through` 6 → 7.**
+
+- Authored the `# The Mathlib correspondence` section (tag
+  `hex-poly-fp-mathlib`) in `HexManual/Chapters/HexPolyFp.lean`, which did not
+  exist. `scripts/check_phase7.py` requires the companion's Phase 7 deliverable
+  in its computational partner's chapter rather than in a chapter of its own.
+  The section pulls fifteen docstrings out of the library: the equivalence and
+  the `Bounds`-versus-primality boundary at the top, then subsections for the
+  named forward map with its coefficient and monicity lemmas, the transport
+  family, and the `CommRing` instance.
+- Two live code blocks make the `commRing` design point concrete: `f * g` is
+  `DensePoly.mul f g` by `rfl` under the instance, and `ring` closes a binomial
+  identity over `FpPoly p` directly. Transporting a `CommRing` along
+  `fpPolyEquiv` instead would give a correct instance whose multiplication is
+  Mathlib's, and no executable convolution would run.
+- Recorded the re-export: `HexBerlekampMathlib` still exports every name in the
+  section, so old call sites spelling them `HexBerlekampMathlib.foo` resolve.
+- Extended the chapter's cross-references with the executable/Mathlib boundary
+  in the direction the other chapters state it.
+- `HexPolyFpMathlib/README.md` already exists and conforms to
+  `SPEC/readme.md`; its quickstart names only `fpPolyEquiv`, which is
+  unaffected by the Phase 6 edits.
+
+## Adjudication: the open feature issues do not block the bumps
+
+A review of the branch argued that `done_through` 6 and 7 are premature while
+https://github.com/kim-em/hex-dev/issues/9370 (the inverse transport family,
+including the two-sided `dvd_iff`) and
+https://github.com/kim-em/hex-dev/issues/9371 (degree and `leadingCoeff`
+ownership) are open. Considered and declined; the bumps stand.
+
+The family precedent is that documented absent surface does not block Phase 7.
+`HexGF2Mathlib` is at 7 with no `Field` instance on `GF2n` and no
+`EuclideanDomain` instance, both recorded in its SPEC and its chapter section;
+`HexGFqMathlib` is at 7 with the primitivity glue absent. Phase 6's exit
+criteria are about the quality of the surface that exists, not about its
+extent: the linter is clean, docstring coverage meets the
+`SPEC/design-principles.md` rule, and the dead declarations are adjudicated.
+The Phase 2 scaffolding review that filed 9370 and 9371 classified both as
+additive work rather than as blocking gaps, and the issues are the tracked
+mechanism for them. The chapter's transport section now names 9370 at the
+point where a reader would notice the forward-only `dvd`, so the gap is
+documented where it bites rather than left to be rediscovered.
+
+## Current frontier
+
+`libraries.yml` records `HexPolyFpMathlib.done_through: 7`, so `status.py`
+lists it under "Fully done". `check_dag.py`, `check_phase7.py`,
+`check_phase4.py` and `release/check_manual_split.py` all pass. A full
+`lake build` (9818 jobs, 6m8s) is green, and `lake build HexManual` is green
+with the new section and emits no warnings from the chapter.
+
+## Next step
+
+`HexBerlekampMathlib` is the obvious follow-on: it is still at
+`done_through: 3`, it is the library that re-exports this one's names, and its
+`FactorTactics` chapter is already in the manual.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR bring `HexPolyFpMathlib` through proof polishing and user-facing documentation, from `done_through: 5` to `7`.

Phase 6 implements https://github.com/kim-em/hex-dev/issues/9372. `coeff_toMathlibPolynomial_equiv` is dropped: it was `@[simp, grind =]` with a left-hand side syntactically identical to `coeff_toMathlibPolynomial`'s and a right-hand side that `ZMod64.equiv_apply`, also `@[simp]`, rewrites straight back, so it added a second rule with the same trigger whose output the simp set immediately undid. Its only occurrence outside its own declaration was the re-export list in `HexBerlekampMathlib`, which loses one name. `coeff_toMathlibPolynomial` now delegates to `coeff_fpPolyToPolynomial` rather than repeating its proof behind a `show`, and the no-op `open scoped HexPolyFpMathlib` goes from `HexGFqMathlib/Subfield.lean` and `Primitivity.lean`. Alongside that, `fpPolyEquiv_apply` and `fpPolyEquiv_symm_apply` gain docstrings and the unused `universe u` and `open Polynomial` go. The remaining zero-reference declarations stay, adjudicated in the commit message. Mathlib's `#lint` with the default suite plus `docBlameThm` reported 4 errors in 21 declarations before and reports 0 in 20 after.

Phase 7 authors the `# The Mathlib correspondence` section in `HexManual/Chapters/HexPolyFp.lean`, the companion's Phase 7 deliverable, which did not exist. It pulls fifteen docstrings, states the boundary the library is careful about (the correspondence asks only for `ZMod64.Bounds p`, every `p` with `0 < p` and `p < 2 ^ 31`, and primality enters at the single explicit `primeModulus_of_fact`), and gives the `commRing` design point two live code blocks: `f * g` is `DensePoly.mul f g` by `rfl` under the instance, and `ring` closes a binomial identity over `FpPoly p` directly. The section names the forward-only `dvd` transport as a gap in the current API tracked by https://github.com/kim-em/hex-dev/issues/9370, since the equivalence could reflect a multiplication witness backward just as well. The open surface issues https://github.com/kim-em/hex-dev/issues/9370 and https://github.com/kim-em/hex-dev/issues/9371 stay open as additive work; the family precedent (HexGF2Mathlib and HexGFqMathlib, both at 7 with documented absent surface) is that Phase 6 polishes the surface that exists.

Closes https://github.com/kim-em/hex-dev/issues/9372

🤖 Prepared with Claude Code
