### PR TITLE
feat(sparse-poly): Phase-5 proof completion with the tree multiplication twin

### DIFF
--- a/HexSparsePoly/Arith.lean
+++ b/HexSparsePoly/Arith.lean
@@ -648,6 +648,141 @@ def mul [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R :=
 instance [Add R] [Mul R] : Mul (SparsePoly R) where
   mul := mul
 
+/-- Tree accumulator for `mulImpl`: fold every pairwise product into an
+`Std.ExtTreeMap` keyed on the exponent sum, replaying {name}`addCoeff`
+per key so the accumulated value is exactly the specification's
+input-order fold. A stored `0` encodes an exponent whose partial sum
+cancelled and is dropped at read-out. -/
+def mulTree [Add R] [Mul R] (s t : SparsePoly R) :
+    Std.ExtTreeMap Nat R compare :=
+  s.terms.foldl (init := ∅) fun acc a =>
+    t.terms.foldl (init := acc) fun acc b =>
+      acc.insert (a.1 + b.1)
+        (addCoeff (acc.getD (a.1 + b.1) 0) (a.2 * b.2))
+
+/-- One product list folded into the tree reads back as the per-key
+{name}`addCoeff` fold. -/
+private theorem getD_foldl_insert [Add R] (ps : List (Nat × R))
+    (acc : Std.ExtTreeMap Nat R compare) (f : Nat) :
+    (ps.foldl
+        (fun acc t => acc.insert t.1 (addCoeff (acc.getD t.1 0) t.2))
+        acc).getD f 0 =
+      (ps.filter (fun t => t.1 = f)).foldl
+        (fun a t => addCoeff a t.2) (acc.getD f 0) := by
+  induction ps generalizing acc with
+  | nil => rfl
+  | cons p ps ih =>
+      rw [List.foldl_cons, ih]
+      by_cases hpf : p.1 = f
+      · rw [List.filter_cons_of_pos (by simpa using hpf), List.foldl_cons,
+          Std.ExtTreeMap.getD_insert,
+          if_pos (Std.LawfulEqCmp.compare_eq_iff_eq.mpr hpf), hpf]
+      · rw [List.filter_cons_of_neg (by simpa using hpf),
+          Std.ExtTreeMap.getD_insert,
+          if_neg (fun h => hpf (Std.LawfulEqCmp.compare_eq_iff_eq.mp h))]
+
+/-- The tree reads back the whole pairwise-product fold. -/
+private theorem getD_mulTree [Add R] [Mul R] (s t : SparsePoly R)
+    (f : Nat) :
+    (mulTree s t).getD f 0 =
+      ((s.terms.toList.flatMap fun a =>
+          t.terms.toList.map fun b => (a.1 + b.1, a.2 * b.2)).filter
+        (fun u => u.1 = f)).foldl (fun a u => addCoeff a u.2) 0 := by
+  unfold mulTree
+  rw [← Array.foldl_toList]
+  have hnested : ∀ (l : List (Nat × R)) (acc : Std.ExtTreeMap Nat R compare),
+      l.foldl (fun acc a => t.terms.foldl
+        (fun acc b => acc.insert (a.1 + b.1)
+          (addCoeff (acc.getD (a.1 + b.1) 0) (a.2 * b.2))) acc) acc =
+      (l.flatMap fun a => t.terms.toList.map fun b =>
+        (a.1 + b.1, a.2 * b.2)).foldl
+        (fun acc u => acc.insert u.1 (addCoeff (acc.getD u.1 0) u.2)) acc := by
+    intro l acc
+    rw [List.foldl_flatMap]
+    induction l generalizing acc with
+    | nil => rfl
+    | cons a as ihl =>
+        rw [List.foldl_cons, List.foldl_cons, List.foldl_map,
+          ← Array.foldl_toList, ihl]
+  rw [hnested, getD_foldl_insert, Std.ExtTreeMap.getD_empty]
+
+/-- Runtime implementation of {name}`mul`, selected by the Phase-4
+sparse-multiplication bench family (see the SPEC's measured note): the
+`ExtTreeMap` accumulation, which beat sort-and-combine on both
+collision shapes and the Johnson heap merge everywhere (value-equal to
+{name}`mul` by `mul_eq_impl`, registered `@[csimp]`). -/
+def mulImpl [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R where
+  terms := ((mulTree s t).toList.filter (fun u => u.2 ≠ 0)).toArray
+  canonical := by
+    constructor
+    · rw [List.toList_toArray]
+      refine List.Pairwise.imp ?_
+        (List.Pairwise.filter _ Std.ExtTreeMap.ordered_keys_toList)
+      intro a b hab
+      exact Nat.compare_eq_lt.mp hab
+    · intro u hu
+      have := Array.mem_def.mp hu
+      rw [List.toList_toArray] at this
+      have := (List.mem_filter.mp this).2
+      simpa using this
+
+/-- The filtered ordered read-out has the tree's coefficients. -/
+private theorem coeffList_mulImpl [Add R] [Mul R] (s t : SparsePoly R)
+    (f : Nat) :
+    coeffList ((mulTree s t).toList.filter (fun u => u.2 ≠ 0)) f =
+      (mulTree s t).getD f 0 := by
+  cases hf : (mulTree s t)[f]? with
+  | none =>
+      rw [Std.ExtTreeMap.getD_eq_getD_getElem?, hf, Option.getD_none]
+      refine coeffList_eq_zero ?_
+      intro u hu huf
+      have hmem := (List.mem_filter.mp hu).1
+      have hsome : (mulTree s t)[u.1]? = some u.2 :=
+        Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some.mp hmem
+      rw [huf, hf] at hsome
+      cases hsome
+  | some v =>
+      rw [Std.ExtTreeMap.getD_eq_getD_getElem?, hf, Option.getD_some]
+      by_cases hv : v = 0
+      · subst hv
+        refine coeffList_eq_zero ?_
+        intro u hu huf
+        obtain ⟨hmem, hnz⟩ := List.mem_filter.mp hu
+        have hsome : (mulTree s t)[u.1]? = some u.2 :=
+          Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some.mp hmem
+        rw [huf, hf] at hsome
+        have h20 := Option.some.inj hsome
+        simp [← h20] at hnz
+      · have hval : coeffList ((mulTree s t).toList.filter
+            (fun u => u.2 ≠ 0)) (f, v).1 = (f, v).2 := by
+          refine coeffList_eq_of_mem ?_ ?_ rfl
+          · refine List.Pairwise.imp ?_
+              (List.Pairwise.filter _ Std.ExtTreeMap.ordered_keys_toList)
+            intro a b hab
+            exact Nat.compare_eq_lt.mp hab
+          · refine List.mem_filter.mpr ⟨?_, by simpa using hv⟩
+            exact Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some.mpr hf
+        exact hval
+
+/-- The specification and the tree accumulation compute the same
+polynomial, with no algebra assumed: the tree replays the
+{name}`addCoeff` steps per key in the specification's input order. -/
+theorem mul_eq_mulImpl [Add R] [Mul R] (s t : SparsePoly R) :
+    mul s t = mulImpl s t := by
+  apply ext_coeff
+  intro f
+  show (mul s t).coeff f = coeffList _ f
+  unfold mul mulImpl
+  rw [coeff_ofTerms_addCoeff, List.toList_toArray, List.toList_toArray,
+    coeffList_mulImpl, getD_mulTree]
+
+/-- Register the tree accumulation as the compiled implementation of
+{name}`mul`. -/
+@[csimp]
+theorem mul_eq_impl : @mul = @mulImpl := by
+  funext R _ _ _ _ s t
+  exact mul_eq_mulImpl s t
+
 /-- Raise to a power by binary powering over {name}`mul`. A caller
 wanting `f(x^k)` should use `substPow`, never `pow`: the cost
 difference is the whole reason this library exists. -/

--- a/HexSparsePoly/Dense.lean
+++ b/HexSparsePoly/Dense.lean
@@ -563,7 +563,7 @@ private theorem zero_add_zero : (Zero.zero : S) + Zero.zero = Zero.zero := by
   show (0 : S) + 0 = 0
   grind
 
-private theorem foldl_congr' {α β : Type _} {l : List α} {f g : β → α → β}
+theorem foldl_congr' {α β : Type _} {l : List α} {f g : β → α → β}
     {i j : β} (hij : i = j) (hfg : ∀ b : β, ∀ a ∈ l, f b a = g b a) :
     l.foldl f i = l.foldl g j := by
   subst hij
@@ -676,7 +676,7 @@ theorem mul_eq_foldl (s t : SparsePoly S) :
   rw [coeff_mul_foldl, coeff_foldl_add, coeff_zero]
 
 /-- The dense image of a fold of sums. -/
-private theorem toDense_foldl_add {α : Type _} (l : List α)
+theorem toDense_foldl_add {α : Type _} (l : List α)
     (g : α → SparsePoly S) (init : SparsePoly S) :
     (l.foldl (fun acc a => acc + g a) init).toDense =
       l.foldl (fun acc a => acc + (g a).toDense) init.toDense := by
@@ -845,6 +845,52 @@ private theorem pow_unfold (s : SparsePoly S) (n : Nat) (hn : ¬ n = 0) :
   show pow s n = _
   rw [pow, dif_neg hn]
   rfl
+
+/-- The conversion respects scalar multiplication. -/
+theorem toDense_scale (c : S) (s : SparsePoly S) :
+    (scale c s).toDense = DensePoly.scale c s.toDense := by
+  apply DensePoly.ext_coeff
+  intro f
+  rw [coeff_toDense, coeff_scale, DensePoly.coeff_scale_semiring,
+    coeff_toDense]
+
+/-- The conversion sends constants to constants. -/
+@[simp, grind =] theorem toDense_C (c : S) :
+    (C c).toDense = DensePoly.C c := by
+  apply DensePoly.ext_coeff
+  intro f
+  rw [coeff_toDense, coeff_C, DensePoly.coeff_C]
+  rfl
+
+/-- Scalar multiplication is multiplication by the constant. -/
+theorem scale_eq_C_mul (c : S) (s : SparsePoly S) :
+    scale c s = C c * s := by
+  apply toDense_inj
+  rw [toDense_scale, toDense_mul, toDense_C]
+  have hshift0 : DensePoly.shift 0 s.toDense = s.toDense := by
+    apply DensePoly.ext_coeff
+    intro f
+    rw [DensePoly.coeff_shift]
+    simp
+  have hmono : DensePoly.C c = DensePoly.scale c (DensePoly.C (1 : S)) := by
+    apply DensePoly.ext_coeff
+    intro f
+    rw [DensePoly.coeff_scale_semiring, DensePoly.coeff_C, DensePoly.coeff_C]
+    simp only [show (Zero.zero : S) = 0 from rfl]
+    grind
+  have hC1 : DensePoly.C (1 : S) = DensePoly.monomial 0 1 := by
+    apply DensePoly.ext_coeff
+    intro f
+    rw [DensePoly.coeff_C, DensePoly.coeff_monomial]
+  rw [hmono, hC1, ← DensePoly.scale_mul,
+    DensePoly.monomial_one_mul_poly_eq_shift, hshift0]
+
+/-- Sparse monomials multiply exponentwise, by transport. -/
+theorem monomial_mul_monomial (a b : Nat) (c d : S) :
+    monomial a c * monomial b d = monomial (a + b) (c * d) := by
+  apply toDense_inj
+  rw [toDense_mul, toDense_monomial, toDense_monomial, toDense_monomial]
+  exact DensePoly.monomial_mul_monomial a b c d
 
 /-- The power recurrence: with {name}`pow_zero` this characterises the
 binary powering completely, and together with {name}`coeff_mul` it is

--- a/HexSparsePoly/Euclid.lean
+++ b/HexSparsePoly/Euclid.lean
@@ -180,18 +180,121 @@ theorem divModMonic_spec (s t : SparsePoly S) (ht : t.Monic) :
     t.toDense ((monic_toDense t).mpr ht)]
   exact DensePoly.divMod_spec s.toDense t.toDense
 
-/-- Exact monic division returns exactly the cofactors. Proved in the
-implementation work loop: the reverse direction needs the dense
-uniqueness of monic division. -/
+/-- Divisibility forces a zero monic remainder: the dense mod of a
+multiple is zero, and the sparse remainder is its `ofDense` image. -/
+private theorem divModMonic_snd_eq_zero_of_dvd {s t : SparsePoly S}
+    (ht : t.Monic) (h : t ∣ s) : (divModMonic s t ht).2 = 0 := by
+  unfold divModMonic
+  simp only [Prod.map_snd]
+  rw [DensePoly.DivModLaws.divModMonic_eq_divMod_of_monic s.toDense
+    t.toDense ((monic_toDense t).mpr ht)]
+  have hm : (DensePoly.divMod s.toDense t.toDense).2 = 0 :=
+    DensePoly.mod_eq_zero_of_dvd s.toDense t.toDense (toDense_dvd h)
+  rw [hm, ofDense_zero]
+
+/-- Monic factors cancel at the dense level: a product with a monic
+polynomial vanishes only if the cofactor does. The trivial-ring case is
+split off; otherwise the product's leading coefficient is the
+cofactor's, which a nonzero cofactor keeps nonzero. -/
+private theorem dense_eq_zero_of_mul_monic {u g : DensePoly S}
+    (hg : g.Monic) (h : u * g = 0) : u = 0 := by
+  by_cases h10 : (1 : S) = 0
+  · apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_zero]
+    have h1 : u.coeff n * (1 : S) = u.coeff n := by grind
+    rw [← h1, h10]
+    grind
+  · by_cases hu : u.size = 0
+    · apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_zero]
+      exact DensePoly.coeff_eq_zero_of_size_le u (by omega)
+    · exfalso
+      have hupos : 0 < u.size := Nat.pos_of_ne_zero hu
+      have hgpos : 0 < g.size := by
+        rcases Nat.eq_zero_or_pos g.size with h0 | h0
+        · exfalso
+          apply h10
+          have hlz : g.leadingCoeff = 0 := by
+            have : g = 0 := by
+              apply DensePoly.ext_coeff
+              intro n
+              rw [DensePoly.coeff_zero]
+              exact DensePoly.coeff_eq_zero_of_size_le g (by omega)
+            rw [this, DensePoly.leadingCoeff_zero]
+          rw [← DensePoly.leadingCoeff_eq_one_of_monic hg, hlz]
+        · exact h0
+      have hlu : u.leadingCoeff ≠ (Zero.zero : S) := by
+        rw [DensePoly.leadingCoeff_eq_coeff_last u hupos]
+        exact DensePoly.coeff_last_ne_zero_of_pos_size u hupos
+      have hprod : u.leadingCoeff * g.leadingCoeff ≠ (Zero.zero : S) := by
+        rw [DensePoly.leadingCoeff_eq_one_of_monic hg]
+        grind
+      have hlm := DensePoly.leadingCoeff_mul u g hupos hgpos hprod
+      rw [h, DensePoly.leadingCoeff_zero,
+        DensePoly.leadingCoeff_eq_one_of_monic hg] at hlm
+      apply hlu
+      show u.leadingCoeff = (0 : S)
+      grind
+
+/-- Exact monic division returns exactly the cofactors: the forward
+direction is the division identity with a zero remainder, the reverse
+is dense monic cancellation applied to the two reconstructions. -/
 theorem divExactMonic?_eq_some {s t q : SparsePoly S} (ht : t.Monic) :
     divExactMonic? s t ht = some q ↔ s = q * t := by
-  sorry
+  show (if (divModMonic s t ht).2 = 0 then some (divModMonic s t ht).1
+    else none) = some q ↔ s = q * t
+  constructor
+  · intro h
+    by_cases hr : (divModMonic s t ht).2 = 0
+    · rw [if_pos hr, Option.some.injEq] at h
+      have hspec := divModMonic_spec s t ht
+      rw [hr, add_zero, h] at hspec
+      exact hspec.symm
+    · rw [if_neg hr] at h
+      cases h
+  · intro hs
+    have hdvd : t ∣ s := ⟨q, by rw [hs, mul_comm]⟩
+    have hr := divModMonic_snd_eq_zero_of_dvd ht hdvd
+    rw [if_pos hr, Option.some.injEq]
+    have hspec := divModMonic_spec s t ht
+    rw [hr, add_zero] at hspec
+    have hqt : (divModMonic s t ht).1 * t = q * t := by rw [hspec, hs]
+    apply toDense_inj
+    have hsub : ((divModMonic s t ht).1.toDense - q.toDense) * t.toDense
+        = 0 := by
+      rw [DensePoly.sub_mul_poly, ← toDense_mul, ← toDense_mul, hqt]
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
+      grind
+    have hz := dense_eq_zero_of_mul_monic ((monic_toDense t).mpr ht) hsub
+    apply DensePoly.ext_coeff
+    intro n
+    have hc := congrArg (fun p => DensePoly.coeff p n) hz
+    rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero] at hc
+    grind
 
 /-- Exact monic division succeeds exactly on multiples. A monic divisor
 is nonzero, so no `t ≠ 0` side condition is needed. -/
 theorem divExactMonic?_isSome {s t : SparsePoly S} (ht : t.Monic) :
     (divExactMonic? s t ht).isSome = true ↔ t ∣ s := by
-  sorry
+  show (if (divModMonic s t ht).2 = 0 then some (divModMonic s t ht).1
+    else none).isSome = true ↔ t ∣ s
+  constructor
+  · intro h
+    by_cases hr : (divModMonic s t ht).2 = 0
+    · have hspec := divModMonic_spec s t ht
+      rw [hr, add_zero] at hspec
+      refine ⟨(divModMonic s t ht).1, ?_⟩
+      rw [mul_comm]
+      exact hspec.symm
+    · rw [if_neg hr] at h
+      cases h
+  · intro hdvd
+    rw [if_pos (divModMonic_snd_eq_zero_of_dvd ht hdvd)]
+    rfl
 
 end Laws
 

--- a/HexSparsePoly/Eval.lean
+++ b/HexSparsePoly/Eval.lean
@@ -406,20 +406,25 @@ with the powers of `t` obtained by binary powering from the exponent
 gaps. The cost is the sum of the multiplication costs over this
 schedule, not a function of the output size. A caller wanting `f(x^k)`
 must use {name}`substPow`, never this. -/
-def compose [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R :=
-  (s.terms.foldl
-    (fun st term =>
-      let tp : Option (SparsePoly R) :=
-        if term.1 - st.2.1 = 0 then st.2.2
-        else
-          match st.2.2 with
-          | none => some (polyPow1 t (term.1 - st.2.1))
-          | some p => some (p * polyPow1 t (term.1 - st.2.1))
-      let contrib : SparsePoly R :=
-        match tp with
+def composeStep [Add R] [Mul R] (t : SparsePoly R)
+    (st : SparsePoly R × Nat × Option (SparsePoly R)) (term : Nat × R) :
+    SparsePoly R × Nat × Option (SparsePoly R) :=
+  match term.1 - st.2.1 with
+  | 0 =>
+      (st.1 + (match st.2.2 with
         | none => C term.2
-        | some p => scale term.2 p
-      (st.1 + contrib, (term.1, tp)))
+        | some p => scale term.2 p), term.1, st.2.2)
+  | g + 1 =>
+      match st.2.2 with
+      | none =>
+          (st.1 + scale term.2 (polyPow1 t (g + 1)), term.1,
+            some (polyPow1 t (g + 1)))
+      | some p =>
+          (st.1 + scale term.2 (p * polyPow1 t (g + 1)), term.1,
+            some (p * polyPow1 t (g + 1)))
+
+def compose [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R :=
+  (s.terms.foldl (composeStep t)
     ((0 : SparsePoly R), (0, (none : Option (SparsePoly R))))).1
 
 section Agreements
@@ -452,41 +457,563 @@ theorem derivative_mul {C : Type u} [Lean.Grind.CommRing C]
     toDense_mul, derivative_toDense, derivative_toDense]
   exact DensePoly.derivative_mul _ _
 
-/-- The fast path and the general path agree: what lets the cyclotomic
-adapter use {name}`substPow` and reason with {name}`compose`. Proved in
-the implementation work loop together with the `compose`
-characterisations. -/
-theorem substPow_eq_compose {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s : SparsePoly C) (k : Nat) :
-    s.substPow k = s.compose (monomial k 1) := by
-  sorry
+section ComposeAlgebra
 
-theorem eval_substPow {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s : SparsePoly C) (k : Nat) (x : C) :
-    (s.substPow k).eval x = s.eval (x ^ k) := by
-  sorry
+variable {K : Type u} [Lean.Grind.CommRing K] [DecidableEq K]
 
-theorem eval_compose {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s t : SparsePoly C) (x : C) :
-    (s.compose t).eval x = s.eval (t.eval x) := by
-  sorry
+/-- Powers at added exponents multiply, on the polynomials themselves. -/
+theorem poly_pow_add (p : SparsePoly K) (a b : Nat) :
+    p ^ (a + b) = p ^ a * p ^ b := by
+  induction b with
+  | zero => rw [Nat.add_zero, pow_zero, mul_one]
+  | succ b ih =>
+      rw [show a + (b + 1) = (a + b) + 1 from by omega, pow_succ, ih,
+        pow_succ, ← mul_assoc, mul_comm p (p ^ a), mul_assoc]
 
-theorem compose_toDense {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s t : SparsePoly C) :
+/-- Powers of the square are even powers, on the polynomials
+themselves. -/
+theorem poly_sq_pow (p : SparsePoly K) (n : Nat) :
+    (p * p) ^ n = p ^ (2 * n) := by
+  induction n with
+  | zero => rw [pow_zero, pow_zero]
+  | succ n ih =>
+      rw [pow_succ, ih, show 2 * (n + 1) = 2 * n + 1 + 1 from by omega,
+        pow_succ, pow_succ, mul_assoc]
+
+/-- The positive binary powering over `mul` computes the power. -/
+theorem polyPow1_eq (p : SparsePoly K) (g : Nat) (hg : 1 ≤ g) :
+    polyPow1 p g = p ^ g := by
+  induction p, g using polyPow1.induct with
+  | case1 p => omega
+  | case2 p =>
+      rw [polyPow1, pow_succ, pow_zero, mul_one]
+  | case3 p g hodd ih =>
+      rw [polyPow1, if_pos hodd, ih (by omega), poly_sq_pow]
+      show p ^ (2 * ((g + 2) / 2)) * p = p ^ (g + 2)
+      rw [mul_comm, ← pow_succ,
+        show 2 * ((g + 2) / 2) + 1 = g + 2 from by omega]
+  | case4 p g hodd ih =>
+      rw [polyPow1, if_neg hodd, ih (by omega), poly_sq_pow,
+        show 2 * ((g + 2) / 2) = g + 2 from by omega]
+
+/-- Evaluation is additive, by transport. -/
+theorem eval_add (s t : SparsePoly K) (x : K) :
+    (s + t).eval x = s.eval x + t.eval x := by
+  rw [eval_toDense, toDense_add, DensePoly.eval_add_semiring,
+    ← eval_toDense, ← eval_toDense]
+
+/-- Evaluation is multiplicative, by transport. -/
+theorem eval_mul (s t : SparsePoly K) (x : K) :
+    (s * t).eval x = s.eval x * t.eval x := by
+  rw [eval_toDense, toDense_mul, DensePoly.eval_mul_commring,
+    ← eval_toDense, ← eval_toDense]
+
+@[simp, grind =] theorem eval_monomial (e : Nat) (c : K) (x : K) :
+    (monomial e c).eval x = c * x ^ e := by
+  rw [eval_toDense, toDense_monomial, DensePoly.eval_monomial_semiring]
+
+@[simp, grind =] theorem eval_C (c : K) (x : K) : (C c).eval x = c := by
+  show (monomial 0 c).eval x = c
+  rw [eval_monomial]
+  grind
+
+@[simp, grind =] theorem eval_one (x : K) : (1 : SparsePoly K).eval x = 1 := by
+  show (SparsePoly.C 1).eval x = 1
+  rw [eval_C]
+
+@[simp, grind =] theorem eval_zero (x : K) :
+    (0 : SparsePoly K).eval x = 0 :=
+  rfl
+
+/-- Evaluation respects powers. -/
+theorem eval_pow (s : SparsePoly K) (n : Nat) (x : K) :
+    (s ^ n).eval x = s.eval x ^ n := by
+  induction n with
+  | zero =>
+      rw [pow_zero, eval_one]
+      grind
+  | succ n ih =>
+      rw [pow_succ, eval_mul, ih]
+      grind
+
+/-- The value the `compose` walk carries for `t^prev` (`none` encodes
+`t^0` so that no identity element is needed at the `[Add R] [Mul R]`
+signature). -/
+def tpVal : Option (SparsePoly K) → SparsePoly K
+  | none => 1
+  | some p => p
+
+/-- The stateful gap-powered walk of {name}`compose` computes the plain
+power-sum fold. -/
+private theorem compose_go (t : SparsePoly K) (l : List (Nat × K)) :
+    ∀ (acc : SparsePoly K) (prev : Nat) (tp : Option (SparsePoly K)),
+    l.Pairwise (fun a b => a.1 < b.1) → (∀ u ∈ l, prev ≤ u.1) →
+    (tp = none → prev = 0) → tpVal tp = t ^ prev →
+    (l.foldl (composeStep t) (acc, (prev, tp))).1 =
+      l.foldl (fun a u => a + SparsePoly.C u.2 * t ^ u.1) acc := by
+  induction l with
+  | nil =>
+      intro acc prev tp _ _ _ _
+      rfl
+  | cons u rest ih =>
+      intro acc prev tp hs hge hnone htpv
+      rw [List.pairwise_cons] at hs
+      rw [List.foldl_cons, List.foldl_cons]
+      have hple : prev ≤ u.1 := hge u (List.mem_cons_self ..)
+      have hnext : ∃ tp', composeStep t (acc, (prev, tp)) u =
+          (acc + SparsePoly.C u.2 * t ^ u.1, u.1, tp') ∧
+          (tp' = none → u.1 = 0) ∧ tpVal tp' = t ^ u.1 := by
+        unfold composeStep
+        cases hgap : u.1 - prev with
+        | zero =>
+            simp only [hgap]
+            have hpe : prev = u.1 := by omega
+            refine ⟨tp, ?_, ?_, ?_⟩
+            · cases tp with
+              | none =>
+                  have h0 : u.1 = 0 := by
+                    have := hnone rfl
+                    omega
+                  show (acc + SparsePoly.C u.2, u.1, none) = _
+                  rw [h0, pow_zero, mul_one]
+              | some p =>
+                  show (acc + scale u.2 p, u.1, some p) = _
+                  have hp : p = t ^ prev := htpv
+                  rw [scale_eq_C_mul, hp, hpe]
+            · intro h
+              subst h
+              have := hnone rfl
+              omega
+            · rw [htpv, hpe]
+        | succ g =>
+            have hg1 : g + 1 = u.1 - prev := hgap.symm
+            simp only [hgap]
+            cases tp with
+            | none =>
+                have h0 : prev = 0 := hnone rfl
+                refine ⟨some (polyPow1 t (g + 1)), ?_, by simp, ?_⟩
+                · show (acc + scale u.2 (polyPow1 t (g + 1)), u.1, _) = _
+                  rw [scale_eq_C_mul, polyPow1_eq t _ (by omega),
+                    show g + 1 = u.1 from by omega]
+                · show polyPow1 t (g + 1) = t ^ u.1
+                  rw [polyPow1_eq t _ (by omega),
+                    show g + 1 = u.1 from by omega]
+            | some p =>
+                have hp : p = t ^ prev := htpv
+                refine ⟨some (p * polyPow1 t (g + 1)), ?_, by simp, ?_⟩
+                · show (acc + scale u.2 (p * polyPow1 t (g + 1)), u.1, _)
+                      = _
+                  rw [scale_eq_C_mul, polyPow1_eq t _ (by omega), hp,
+                    ← poly_pow_add,
+                    show prev + (g + 1) = u.1 from by omega]
+                · show p * polyPow1 t (g + 1) = t ^ u.1
+                  rw [polyPow1_eq t _ (by omega), hp, ← poly_pow_add,
+                    show prev + (g + 1) = u.1 from by omega]
+      obtain ⟨tp', hstep, hn', hv'⟩ := hnext
+      rw [hstep]
+      exact ih _ _ _ hs.2
+        (fun v hv => Nat.le_of_lt (hs.1 v hv)) hn' hv'
+
+end ComposeAlgebra
+
+section Agreements
+
+variable {K : Type u} [Lean.Grind.CommRing K] [DecidableEq K]
+
+/-- {name}`compose` as the plain power-sum fold over the stored terms:
+the characterisation everything below transports through. -/
+theorem compose_eq_foldl (s t : SparsePoly K) :
+    s.compose t =
+      s.terms.toList.foldl
+        (fun a u => a + SparsePoly.C u.2 * t ^ u.1) 0 := by
+  show (s.terms.foldl (composeStep t) (0, 0, none)).1 = _
+  rw [← Array.foldl_toList]
+  exact compose_go t s.terms.toList 0 0 none s.pairwise_toList
+    (fun u _ => Nat.zero_le _) (fun _ => rfl)
+    (by show (1 : SparsePoly K) = t ^ 0; rw [pow_zero])
+
+private theorem dense_C_zero : (DensePoly.C (0 : K)) = 0 := by
+  apply DensePoly.ext_coeff
+  intro f
+  rw [DensePoly.coeff_C]
+  rw [show (0 : DensePoly K).coeff f = 0 from
+    DensePoly.coeff_eq_zero_of_size_le 0 (by simp)]
+  split <;> rfl
+
+private theorem q_mul_psf (q : DensePoly K) (cs : List K) :
+    ∀ base, q * DensePoly.composeCoeffPowerSumFrom cs base q =
+      DensePoly.composeCoeffPowerSumFrom cs (base + 1) q := by
+  induction cs with
+  | nil =>
+      intro base
+      show q * 0 = 0
+      rw [DensePoly.mul_comm_poly]
+      exact DensePoly.zero_mul q
+  | cons c cs ih =>
+      intro base
+      show q * (DensePoly.C c * DensePoly.composePower q base + _) =
+        DensePoly.C c * DensePoly.composePower q (base + 1) + _
+      rw [DensePoly.mul_add_right_poly, ih,
+        show DensePoly.composePower q (base + 1) =
+          q * DensePoly.composePower q base from rfl,
+        ← DensePoly.mul_assoc_poly, DensePoly.mul_comm_poly q (DensePoly.C c),
+        DensePoly.mul_assoc_poly]
+
+private theorem scl_eq_psf (q : DensePoly K) (cs : List K) :
+    DensePoly.composeScalarCoeffList cs q =
+      DensePoly.composeCoeffPowerSumFrom cs 0 q := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih =>
+      show DensePoly.C c + q * DensePoly.composeScalarCoeffList cs q = _
+      rw [ih, q_mul_psf]
+      show _ = DensePoly.C c * DensePoly.composePower q 0 + _
+      rw [show DensePoly.composePower q 0 = DensePoly.C 1 from rfl,
+        show DensePoly.C (1 : K) = (1 : DensePoly K) from rfl,
+        DensePoly.mul_one_right_poly]
+
+private theorem dense_foldl_add_init {α : Type _} (l : List α)
+    (g : α → DensePoly K) :
+    ∀ init, l.foldl (fun a u => a + g u) init =
+      init + l.foldl (fun a u => a + g u) 0 := by
+  induction l with
+  | nil =>
+      intro init
+      rw [List.foldl_nil, List.foldl_nil, DensePoly.add_zero_poly]
+  | cons u us ih =>
+      intro init
+      rw [List.foldl_cons, List.foldl_cons, ih, ih ((0 : DensePoly K) + g u),
+        DensePoly.zero_add, DensePoly.add_assoc_poly]
+
+private theorem psf_eq_terms_sum (q : DensePoly K) (cs : List K) :
+    ∀ base, DensePoly.composeCoeffPowerSumFrom cs base q =
+      (termsOfCoeffsList base cs).foldl
+        (fun a u => a + DensePoly.C u.2 * DensePoly.composePower q u.1)
+        0 := by
+  induction cs with
+  | nil => intro base; rfl
+  | cons c cs ih =>
+      intro base
+      show DensePoly.C c * DensePoly.composePower q base + _ = _
+      rw [ih (base + 1)]
+      by_cases hc : c = 0
+      · rw [show termsOfCoeffsList base (c :: cs) =
+            termsOfCoeffsList (base + 1) cs from by
+          rw [termsOfCoeffsList, if_pos hc]]
+        rw [hc, dense_C_zero, DensePoly.zero_mul, DensePoly.zero_add]
+      · rw [show termsOfCoeffsList base (c :: cs) =
+            (base, c) :: termsOfCoeffsList (base + 1) cs from by
+          rw [termsOfCoeffsList, if_neg hc]]
+        rw [List.foldl_cons]
+        conv => rhs; rw [dense_foldl_add_init, DensePoly.zero_add]
+
+/-- The dense image's stored coefficients walk back to exactly the
+sparse terms. -/
+private theorem termsOfCoeffsList_toDense (s : SparsePoly K) :
+    termsOfCoeffsList 0 s.toDense.toList = s.terms.toList := by
+  refine coeffList_ext (termsOfCoeffsList_canonical _ 0).1
+    s.pairwise_toList (termsOfCoeffsList_canonical _ 0).2
+    s.nonzero_toList ?_
+  intro e
+  have h := coeffList_termsOfCoeffsList s.toDense.toList 0 e
+  rw [Nat.zero_add] at h
+  rw [h]
+  have h2 : s.toDense.toList.getD e (Zero.zero : K) = s.toDense.coeff e :=
+    DensePoly.toList_getD_eq_coeff s.toDense e
+  rw [show s.toDense.toList.getD e (0 : K) =
+      s.toDense.toList.getD e (Zero.zero : K) from rfl, h2, coeff_toDense]
+  rfl
+
+/-- Powers transport to the dense iterated product. -/
+theorem toDense_composePower (t : SparsePoly K) (n : Nat) :
+    (t ^ n).toDense = DensePoly.composePower t.toDense n := by
+  induction n with
+  | zero =>
+      rw [pow_zero, toDense_one]
+      rfl
+  | succ n ih =>
+      rw [pow_succ, toDense_mul, ih]
+      rfl
+
+/-- The substitution transports: composing then converting is
+converting then composing. -/
+theorem compose_toDense (s t : SparsePoly K) :
     (s.compose t).toDense = s.toDense.compose t.toDense := by
-  sorry
+  have hstep : ∀ (acc : DensePoly K) (c : K),
+      acc * t.toDense + DensePoly.C c = DensePoly.C c + t.toDense * acc := by
+    intro acc c
+    rw [DensePoly.mul_comm_poly acc t.toDense, DensePoly.add_comm_poly]
+  rw [DensePoly.compose_eq_composeScalarCoeffList_of_step _ _ hstep,
+    scl_eq_psf, psf_eq_terms_sum, termsOfCoeffsList_toDense,
+    compose_eq_foldl, toDense_foldl_add]
+  rw [show (0 : SparsePoly K).toDense = 0 from toDense_zero]
+  refine foldl_congr' rfl fun b u _ => ?_
+  rw [toDense_mul, toDense_C, toDense_composePower]
 
-theorem substPow_toDense {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s : SparsePoly C) (k : Nat) :
+/-- Powers of a unit monomial are unit monomials. -/
+theorem monomial_one_pow (k : Nat) (e : Nat) :
+    (monomial k (1 : K)) ^ e = monomial (k * e) 1 := by
+  induction e with
+  | zero =>
+      rw [pow_zero, Nat.mul_zero]
+      rfl
+  | succ e ih =>
+      rw [pow_succ, ih, monomial_mul_monomial,
+        show k + k * e = k * (e + 1) from by
+          rw [Nat.mul_succ, Nat.add_comm],
+        show (1 : K) * 1 = 1 from by grind]
+
+/-- Constants scale unit monomials into monomials. -/
+theorem C_mul_monomial (c : K) (m : Nat) :
+    SparsePoly.C c * monomial m 1 = monomial m c := by
+  show monomial 0 c * monomial m 1 = monomial m c
+  rw [monomial_mul_monomial, Nat.zero_add,
+    show c * 1 = c from by grind]
+
+private theorem coeff_monomial_foldl (l : List (Nat × K)) (k : Nat)
+    (f : Nat) :
+    ∀ init : SparsePoly K,
+    (l.foldl (fun a u => a + monomial (k * u.1) u.2) init).coeff f =
+      l.foldl
+        (fun a u => a + (if f = k * u.1 then u.2 else 0))
+        (init.coeff f) := by
+  induction l with
+  | nil => intro init; rfl
+  | cons u us ih =>
+      intro init
+      rw [List.foldl_cons, List.foldl_cons, ih, coeff_add, coeff_monomial]
+
+private theorem foldl_add_ifs_zero {l : List (Nat × K)}
+    {g : Nat × K → K} (h : ∀ u ∈ l, g u = 0) :
+    ∀ x : K, l.foldl (fun a u => a + g u) x = x := by
+  induction l with
+  | nil => intro x; rfl
+  | cons u us ih =>
+      intro x
+      rw [List.foldl_cons, h u (List.mem_cons_self ..),
+        show x + (0 : K) = x from by grind]
+      exact ih (fun v hv => h v (List.mem_cons_of_mem _ hv)) x
+
+private theorem foldl_single_match {l : List (Nat × K)}
+    (hs : l.Pairwise (fun a b => a.1 < b.1)) {k : Nat} (hk : ¬ k = 0)
+    (e : Nat) :
+    l.foldl (fun a u => a + (if k * e = k * u.1 then u.2 else 0)) 0 =
+      coeffList l e := by
+  induction l with
+  | nil => rfl
+  | cons u us ih =>
+      rw [List.pairwise_cons] at hs
+      rw [List.foldl_cons]
+      by_cases hue : u.1 = e
+      · rw [if_pos (by rw [hue]),
+          show (0 : K) + u.2 = u.2 from by grind,
+          foldl_add_ifs_zero (fun v hv => by
+            rw [if_neg (fun h => by
+              have hev : e = v.1 := Nat.eq_of_mul_eq_mul_left
+                (by omega) h
+              have := hs.1 v hv
+              omega)])]
+        simp only [coeffList, if_pos hue]
+      · rw [if_neg (fun h => hue (Nat.eq_of_mul_eq_mul_left
+            (by omega) h).symm),
+          show (0 : K) + 0 = 0 from by grind, ih hs.2]
+        simp only [coeffList, if_neg (fun h : u.1 = e => hue h)]
+
+/-- The fast path and the general path agree: what lets the cyclotomic
+adapter use {name}`substPow` and reason with {name}`compose`. -/
+theorem substPow_eq_compose (s : SparsePoly K) (k : Nat) :
+    s.substPow k = s.compose (monomial k 1) := by
+  rw [compose_eq_foldl]
+  have hfold : s.terms.toList.foldl
+      (fun a u => a + SparsePoly.C u.2 * monomial k 1 ^ u.1) 0 =
+      s.terms.toList.foldl
+        (fun a u => a + monomial (k * u.1) u.2) 0 := by
+    refine foldl_congr' rfl fun b u _ => ?_
+    rw [monomial_one_pow, C_mul_monomial]
+  rw [hfold]
+  apply ext_coeff
+  intro f
+  rw [coeff_monomial_foldl, coeff_zero]
+  by_cases hk : k = 0
+  · subst hk
+    show (s.substPow 0).coeff f = _
+    unfold substPow
+    rw [dif_pos rfl, coeff_ofTerms_addCoeff]
+    have hz : ∀ c : K, (0 : K) + c = c := by grind
+    simp only [addCoeff_eq_add hz, Array.toList_map]
+    by_cases hf : f = 0
+    · subst hf
+      rw [show ((s.terms.toList.map fun t => ((0 : Nat), t.2)).filter
+          (fun t => t.1 = 0)) = s.terms.toList.map fun t => ((0 : Nat), t.2)
+        from List.filter_eq_self.mpr (fun a ha => by
+          obtain ⟨u, hu, rfl⟩ := List.mem_map.mp ha
+          simp)]
+      rw [List.foldl_map]
+      refine foldl_congr' rfl fun b u _ => ?_
+      rw [if_pos (by omega)]
+    · rw [show ((s.terms.toList.map fun t => ((0 : Nat), t.2)).filter
+          (fun t => t.1 = f)) = [] from List.filter_eq_nil_iff.mpr (fun a ha => by
+          obtain ⟨u, hu, rfl⟩ := List.mem_map.mp ha
+          simpa using fun h : (0 : Nat) = f => hf h.symm)]
+      rw [List.foldl_nil]
+      exact ((foldl_add_ifs_zero (fun u _ => by
+        rw [if_neg (by omega)])) 0).symm
+  · by_cases hmul : ∃ e, f = k * e
+    · obtain ⟨e, rfl⟩ := hmul
+      rw [coeff_substPow_mul s hk]
+      exact (foldl_single_match s.pairwise_toList hk e).symm
+    · rw [coeff_substPow_of_ne s hk (fun e h => hmul ⟨e, h⟩)]
+      exact ((foldl_add_ifs_zero (fun u _ => by
+        rw [if_neg (fun h => hmul ⟨u.1, h⟩)])) 0).symm
+
+private theorem eval_foldl_add {α : Type _} (l : List α)
+    (g : α → SparsePoly K) (x : K) :
+    ∀ init : SparsePoly K,
+    (l.foldl (fun a u => a + g u) init).eval x =
+      l.foldl (fun a u => a + (g u).eval x) (init.eval x) := by
+  induction l with
+  | nil => intro init; rfl
+  | cons u us ih =>
+      intro init
+      rw [List.foldl_cons, List.foldl_cons, ih, eval_add]
+
+/-- Substitution then evaluation is evaluation at the evaluation. -/
+theorem eval_compose (s t : SparsePoly K) (x : K) :
+    (s.compose t).eval x = s.eval (t.eval x) := by
+  rw [compose_eq_foldl, eval_foldl_add, eval_zero]
+  have hterm : ∀ (b : K) (u : Nat × K),
+      b + (SparsePoly.C u.2 * t ^ u.1).eval x =
+        b + u.2 * (t.eval x) ^ u.1 := by
+    intro b u
+    rw [eval_mul, eval_C, eval_pow]
+  rw [foldl_congr' rfl (fun b u _ => hterm b u)]
+  have hsub : ∀ (y : K) (l : List (Nat × K)),
+      l.foldr (fun u acc => u.2 * y ^ (u.1 - 0) + acc) 0 =
+        l.foldr (fun u acc => u.2 * y ^ u.1 + acc) 0 := by
+    intro y l
+    induction l with
+    | nil => rfl
+    | cons u us ih =>
+        rw [List.foldr_cons, List.foldr_cons, ih, Nat.sub_zero]
+  rw [show s.eval (t.eval x) =
+      evalShifted (t.eval x) s.terms.toList 0 from rfl,
+    evalShifted_eq s.pairwise_toList _ 0 (fun u _ => Nat.zero_le _),
+    hsub (t.eval x) s.terms.toList, foldl_add_eval_monomials]
+  grind
+
+/-- Evaluating the exponent substitution is evaluating at the power. -/
+theorem eval_substPow (s : SparsePoly K) (k : Nat) (x : K) :
+    (s.substPow k).eval x = s.eval (x ^ k) := by
+  rw [substPow_eq_compose, eval_compose, eval_monomial,
+    show (1 : K) * x ^ k = x ^ k from by grind]
+
+/-- The exponent substitution transports to dense composition with the
+unit monomial. -/
+theorem substPow_toDense (s : SparsePoly K) (k : Nat) :
     (s.substPow k).toDense = s.toDense.compose (DensePoly.monomial k 1) := by
-  sorry
+  rw [substPow_eq_compose, compose_toDense, toDense_monomial]
 
-/-- Coefficient law for {name}`substScale`: proved in the implementation
-work loop together with the `compose` characterisations. -/
-theorem coeff_substScale {C : Type u} [Lean.Grind.CommRing C]
-    [DecidableEq C] (s : SparsePoly C) (a : C) (e : Nat) :
+/-- The power of `a` the `substScale` walk carries (`none` encodes
+`a^0`). -/
+private def pwVal : Option K → K
+  | none => 1
+  | some p => p
+
+private theorem coeffList_substScaleGo (a : K) (l : List (Nat × K)) :
+    ∀ (prev : Nat) (pw : Option K),
+    l.Pairwise (fun x y => x.1 < y.1) → (∀ u ∈ l, prev ≤ u.1) →
+    (pw = none → prev = 0) → pwVal pw = a ^ prev →
+    ∀ f, coeffList (substScaleGo a prev pw l) f =
+      coeffList l f * a ^ f := by
+  induction l with
+  | nil =>
+      intro prev pw _ _ _ _ f
+      show (0 : K) = 0 * a ^ f
+      grind
+  | cons u rest ih =>
+      intro prev pw hs hge hnone hval f
+      rw [List.pairwise_cons] at hs
+      have hple : prev ≤ u.1 := hge u (List.mem_cons_self ..)
+      have hnext : ∃ pw', substScaleGo a prev pw (u :: rest) =
+          (if u.2 * pwVal pw' = 0 then substScaleGo a u.1 pw' rest
+           else (u.1, u.2 * pwVal pw') :: substScaleGo a u.1 pw' rest) ∧
+          (pw' = none → u.1 = 0) ∧ pwVal pw' = a ^ u.1 := by
+        rw [substScaleGo]
+        unfold substScaleStep
+        by_cases hgap : u.1 - prev = 0
+        · rw [if_pos hgap]
+          have hpe : prev = u.1 := by omega
+          refine ⟨pw, ?_, ?_, ?_⟩
+          · cases pw with
+            | none =>
+                show (if u.2 = 0 then _ else u :: _) = _
+                rw [show pwVal (none : Option K) = 1 from rfl]
+                by_cases hu2 : u.2 = 0
+                · rw [if_pos hu2, if_pos (by rw [hu2]; grind)]
+                · rw [if_neg hu2, if_neg (by
+                    intro h
+                    exact hu2 (by grind))]
+                  rw [show (u.1, u.2 * (1 : K)) =
+                    u from by rw [show u.2 * (1 : K) = u.2 from by grind]]
+            | some p =>
+                rfl
+          · intro h
+            rw [h] at hnone
+            have := hnone rfl
+            omega
+          · rw [hval, hpe]
+        · rw [if_neg hgap]
+          cases pw with
+          | none =>
+              have h0 : prev = 0 := hnone rfl
+              refine ⟨some (pow1 a (u.1 - prev)), rfl, by simp, ?_⟩
+              show pow1 a (u.1 - prev) = a ^ u.1
+              rw [pow1_eq a _ (by omega),
+                show u.1 - prev = u.1 from by omega]
+          | some p =>
+              have hp : p = a ^ prev := hval
+              refine ⟨some (p * pow1 a (u.1 - prev)), rfl, by simp, ?_⟩
+              show p * pow1 a (u.1 - prev) = a ^ u.1
+              rw [pow1_eq a _ (by omega), hp]
+              have : prev + (u.1 - prev) = u.1 := by omega
+              rw [← this]
+              grind
+      obtain ⟨pw', hstep, hn', hv'⟩ := hnext
+      rw [hstep]
+      have hrest := ih u.1 pw' hs.2
+        (fun v hv => Nat.le_of_lt (hs.1 v hv)) hn' hv'
+      have htail_zero : coeffList (substScaleGo a u.1 pw' rest) u.1 = 0 := by
+        rw [hrest u.1]
+        rw [coeffList_eq_zero (l := rest) (fun v hv hveq => by
+          have := hs.1 v hv
+          omega)]
+        grind
+      by_cases hzero : u.2 * pwVal pw' = 0
+      · rw [if_pos hzero]
+        by_cases hf : u.1 = f
+        · rw [← hf, htail_zero]
+          simp only [coeffList, if_true]
+          rw [← hv', ← hzero]
+        · rw [hrest f]
+          simp only [coeffList, if_neg hf]
+      · rw [if_neg hzero]
+        by_cases hf : u.1 = f
+        · simp only [coeffList, if_pos hf]
+          rw [← hf, hv']
+        · simp only [coeffList, if_neg hf]
+          exact hrest f
+
+/-- Coefficient law for {name}`substScale`: each coefficient is scaled
+by the power of the argument at its exponent. -/
+theorem coeff_substScale (s : SparsePoly K) (a : K) (e : Nat) :
     (s.substScale a).coeff e = s.coeff e * a ^ e := by
-  sorry
+  unfold substScale
+  rw [coeff_ofCanonicalList]
+  exact coeffList_substScaleGo a s.terms.toList 0 none
+    s.pairwise_toList (fun u _ => Nat.zero_le _) (fun _ => rfl)
+    (by show (1 : K) = a ^ 0; grind) e
+
+end Agreements
 
 end Agreements
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -135,7 +135,7 @@ libraries:
   HexSparsePoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:

--- a/progress/20260822T051045Z_sparse-poly-proofs.md
+++ b/progress/20260822T051045Z_sparse-poly-proofs.md
@@ -1,0 +1,41 @@
+# hex-sparse-poly: Phase 5 proof completion
+
+## Accomplished
+
+- The selected `ExtTreeMap`-accumulation multiplication twin is in the
+  library: `mulTree`/`mulImpl` in `Arith.lean` with the proved
+  `@[csimp] mul_eq_impl` value equality (via `getD_mulTree` and
+  `coeffList_mulImpl`), so compiled `*` now runs the Phase-4 winner
+  while the kernel-facing sort-and-combine specification is unchanged.
+- The compose agreement pack in `Eval.lean` is closed:
+  `compose_toDense`, `substPow_toDense`, `substPow_eq_compose`,
+  `eval_compose`, `eval_substPow`, and `coeff_substScale`, built on a
+  dense power-sum ladder (`psf_eq_terms_sum`,
+  `termsOfCoeffsList_toDense`, `toDense_composePower`) plus supporting
+  `Dense.lean` lemmas (`toDense_scale`, `toDense_C`,
+  `monomial_mul_monomial`, `pow_succ`).
+- The two `divExactMonic?` iff lemmas in `Euclid.lean` are proved:
+  `divExactMonic?_isSome` via the dense `mod_eq_zero_of_dvd` transport,
+  and `divExactMonic?_eq_some` via a new private dense monic
+  cancellation (`leadingCoeff_mul` on the difference, trivial-ring case
+  split off).
+- `grep sorry` over the library is empty; no `axiom`, no
+  `native_decide`. `lake build HexSparsePoly HexConformance
+  HexSparsePolyTests hexsparsepoly_bench` green; `check_dag.py` and
+  `libgraph.py` pass. `done_through: 5`.
+
+## Current frontier
+
+Phase 5 complete. `scripts/status.py` now shows HexSparsePoly at
+Phase 6 (polish) and HexSparsePolyMathlib unblocked.
+
+## Next step
+
+Milestone 6: activate HexSparsePolyMathlib (`Equiv.lean` with
+`denseEquiv`, `equiv`, `coeff_equiv`, and the `equiv_support`
+headline), then Phase 6 polish for both libraries (there is a known
+backlog of unusedSimpArgs / unusedSectionVars linter warnings).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR complete Phase 5 for hex-sparse-poly: land the `ExtTreeMap`-accumulation multiplication twin selected by the Phase-4 measurement as the `@[csimp]` implementation of `*`, with its proved value equality against the kernel-facing sort-and-combine specification; close the compose agreement pack (`compose_toDense`, `substPow_toDense`, `substPow_eq_compose`, `eval_compose`, `eval_substPow`, `coeff_substScale`); and prove the two `divExactMonic?` iff lemmas, the reverse direction through a dense monic cancellation built on `leadingCoeff_mul` with the trivial-ring case split off. The library is now sorry-free and `done_through: 5`.

🤖 Prepared with Claude Code