### PR TITLE
chore: record HexResultantMathlib Phases 4-5, bump to 5

### DIFF
--- a/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
+++ b/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
@@ -321,6 +321,17 @@ HexResultantMathlib/
 The library is verified by building it. Executable conformance remains in
 `hex-resultant`.
 
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `correspondence-only-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
+resultant algorithm; it transports and characterises the executable
+subresultant chain implemented elsewhere. The computational performance
+owner is hex-resultant, where the chain, resultant, and discriminant
+bench targets and the FLINT comparator are measured.
+
 ## References
 
 - Collins, G. E. *Subresultants and reduced polynomial remainder sequences.*

--- a/libraries.yml
+++ b/libraries.yml
@@ -609,7 +609,7 @@ libraries:
   HexResultantMathlib:
     deps: [HexResultant, HexPolyMathlib]
     mathlib: true
-    done_through: 3
+    done_through: 5
     status: active
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]

--- a/progress/20260822T055000Z_resultant-mathlib-phase45.md
+++ b/progress/20260822T055000Z_resultant-mathlib-phase45.md
@@ -1,0 +1,30 @@
+# HexResultantMathlib Phases 4-5 and bump to 5
+
+## Accomplished
+
+- Added the External comparators absence declaration to the SPEC
+  (correspondence-only-layer; computational performance owner
+  hex-resultant), completing the Phase-4 declaration surface. The
+  headline-correctness-theorem designation (toPolynomial_resultant)
+  landed with #9378. check_phase4 exempts the library (mathlib, no
+  phase4 block, no report; HexLLLMathlib precedent) and Phase-4 dep
+  coupling is satisfied (HexResultant 5, HexPolyMathlib 7).
+- Phase 5 holds on the merits: the library is sorry-free and its full
+  correspondence surface is proved (see the 2026-08-21 wave audit and
+  status/hex-resultant-mathlib.scaffolding-reviewed).
+- Bumped done_through 3 -> 5 per the wave bump queue
+  (progress/20260822T034500Z_wave-dag-and-headline-audit.md).
+
+## Current frontier
+
+- The resultant pair now sits at 5/5. Remaining rungs are the Phase-6
+  hygiene passes (docstrings, dead-code decision on the fraction
+  detour, import trims) and Phase 7 (README, chapter heading rename).
+
+## Next step
+
+- B6: HexBerlekampZassenhaus headline report and bump.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR record HexResultantMathlib's Phase 4-5 completion and advance `done_through` from 3 to 5. Phase 4 adds the `correspondence-only-layer` external-comparator absence declaration to the SPEC (the headline-correctness-theorem designation, `toPolynomial_resultant`, landed with #9378); `check_phase4.py` exempts the library per the HexLLLMathlib precedent, and the dep coupling is satisfied with HexResultant at 5 and HexPolyMathlib at 7. Phase 5 holds on the merits: the library is sorry-free with its full declared correspondence surface proved and attested in the Phase-2 token.

🤖 Prepared with Claude Code