### PR TITLE
doc: add the AES modulus and Kummer-Dedekind prime-splitting tutorials

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -37,6 +37,7 @@ import HexManual.Chapters.HexNumberField
 import HexManual.Chapters.HexNumberFieldTower
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
 import HexManual.Tutorials.AESField
+import HexManual.Tutorials.AESModulus
 import HexManual.Tutorials.Coppersmith
 
 open Verso.Genre Manual
@@ -124,6 +125,8 @@ end-to-end workflow, with every code snippet checked as part of this
 build.
 
 {include 2 HexManual.Tutorials.AESField}
+
+{include 2 HexManual.Tutorials.AESModulus}
 
 {include 2 HexManual.Tutorials.Coppersmith}
 

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -38,6 +38,7 @@ import HexManual.Chapters.HexNumberFieldTower
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
 import HexManual.Tutorials.AESField
 import HexManual.Tutorials.AESModulus
+import HexManual.Tutorials.PrimeSplitting
 import HexManual.Tutorials.Coppersmith
 
 open Verso.Genre Manual
@@ -127,6 +128,8 @@ build.
 {include 2 HexManual.Tutorials.AESField}
 
 {include 2 HexManual.Tutorials.AESModulus}
+
+{include 2 HexManual.Tutorials.PrimeSplitting}
 
 {include 2 HexManual.Tutorials.Coppersmith}
 

--- a/HexManual/Tutorials/AESModulus.lean
+++ b/HexManual/Tutorials/AESModulus.lean
@@ -1,0 +1,313 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexBerlekamp
+import HexGF2
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "Why the AES modulus works" =>
+%%%
+tag := "tutorial-aes-modulus"
+%%%
+
+# The story
+%%%
+tag := "tutorial-aes-modulus-story"
+%%%
+
+The {ref "tutorial-aes-field"}[AES byte arithmetic tutorial] builds the
+field `GF(2⁸)` as the quotient of `𝔽₂[x]` by the Rijndael modulus
+
+```
+x⁸ + x⁴ + x³ + x + 1
+```
+
+and leans on one theorem to do it: the modulus is irreducible over `𝔽₂`.
+Without that fact the quotient is only a ring, some nonzero bytes have no
+inverse, and the S-box construction collapses. That tutorial takes the
+theorem as given. This one earns it.
+
+The machinery is {ref "hex-berlekamp"}[`HexBerlekamp`]'s Rabin
+irreducibility test: an executable criterion, a replayable certificate,
+and a soundness theorem that turns a passing check into a proof. The plan
+is to run the test on the modulus, run it on a plausible-looking impostor
+that fails, inspect the certificate the test leaves behind, and finish
+with the kernel-checked irreducibility theorem the AES construction needs.
+
+# The modulus as a dense polynomial
+%%%
+tag := "tutorial-aes-modulus-poly"
+%%%
+
+`HexBerlekamp` works over {name}`Hex.FpPoly`, the dense polynomial type
+with `ZMod64 p` coefficients from {ref "hex-poly-fp"}[`HexPolyFp`]. For
+`p = 2` a coefficient is a bit, and the Rijndael modulus is nine of them,
+listed from the constant term up.
+
+```lean
+open Hex
+
+namespace AESModulusTutorial
+
+/-- The Rijndael modulus `x⁸ + x⁴ + x³ + x + 1` over
+`𝔽₂`, coefficients from the constant term up. -/
+def m : FpPoly 2 := #p[1, 1, 0, 1, 1, 0, 0, 0, 1]
+
+theorem m_monic : DensePoly.Monic m := by rfl
+
+-- Reading the coefficients as bits recovers the word
+-- 0x11B; its low byte 0x1B is exactly how the AES
+-- tutorial passes this modulus to the packed field
+-- type, with the leading x⁸ implicit.
+#guard (m.toArray.toList.map ZMod64.toNat).foldr
+    (fun b acc => acc * 2 + b) 0 == 0x11B
+
+end AESModulusTutorial
+```
+
+The monicity proof is by `rfl` because the leading coefficient is
+literally the bit `1`; every test and certificate below takes it as an
+argument, since Rabin's criterion is stated for monic polynomials.
+
+# What goes wrong without irreducibility
+%%%
+tag := "tutorial-aes-modulus-zero-divisors"
+%%%
+
+Before certifying the real modulus, it is worth seeing concretely what a
+bad one does. Take `x⁸ + 1`, which differs from the Rijndael modulus in
+three bits and looks just as plausible. Over `𝔽₂` it is `(x + 1)⁸`, about
+as far from irreducible as a degree-eight polynomial can be.
+
+```lean
+open Hex
+
+namespace AESModulusTutorial
+
+/-- The impostor `x⁸ + 1`, which over `𝔽₂` is
+`(x + 1)⁸`. -/
+def r : FpPoly 2 := #p[1, 0, 0, 0, 0, 0, 0, 0, 1]
+
+theorem r_monic : DensePoly.Monic r := by rfl
+
+def sq (f : FpPoly 2) : FpPoly 2 := f * f
+
+-- Squaring x + 1 three times really gives x⁸ + 1.
+#guard sq (sq (sq #p[1, 1])) == r
+
+/-- `(x + 1)⁴`, a nonzero residue modulo `x⁸ + 1`. -/
+def u : FpPoly 2 := #p[1, 0, 0, 0, 1]
+
+-- u has degree 4, so it is its own remainder: as a
+-- residue modulo x⁸ + 1 it is not zero.
+#guard FpPoly.modByMonic r u r_monic == u
+
+-- Yet u · u reduces to zero: u is a zero divisor.
+#guard (FpPoly.modByMonic r (u * u) r_monic).isZero
+
+end AESModulusTutorial
+```
+
+A quotient with zero divisors is not a field, and the failure is not
+abstract: `u` would be a byte with no multiplicative inverse, and the
+S-box's inversion stage would have nothing to send it to. Irreducibility
+of the modulus is exactly the condition that rules this out, for every
+nonzero residue at once.
+
+# Rabin's criterion
+%%%
+tag := "tutorial-aes-modulus-rabin"
+%%%
+
+The classical fact behind the test is that `X^(2^k) - X` is the product
+of all monic irreducible polynomials over `𝔽₂` whose degree divides `k`.
+Rabin's criterion reads that fact twice. A monic `f` of degree `n` is
+irreducible over `𝔽₂` exactly when
+
+* `f` divides `X^(2^n) - X`, so every irreducible factor of `f` has
+  degree dividing `n`; and
+* `gcd(f, X^(2^d) - X) = 1` for every maximal proper divisor `d` of `n`,
+  so no factor has degree strictly smaller than `n`.
+
+For `n = 8` the divisor lattice collapses pleasantly: the proper divisors
+of `8` are `1`, `2`, and `4`, and every one of them divides `4`, so a
+single gcd check at `d = 4` covers them all.
+
+```lean
+open Hex
+
+namespace AESModulusTutorial
+
+-- One maximal proper divisor, so one gcd leg.
+#guard Berlekamp.maximalProperDivisors 8 == [4]
+
+-- The Rijndael modulus passes both legs.
+#guard Berlekamp.rabinTest m m_monic
+#guard Berlekamp.rabinDividesTest m m_monic
+#guard Berlekamp.rabinWitnesses m m_monic == [(4, true)]
+
+-- The impostor fails both.
+#guard Berlekamp.rabinTest r r_monic == false
+#guard Berlekamp.rabinDividesTest r r_monic == false
+#guard Berlekamp.rabinWitnesses r r_monic
+    == [(4, false)]
+
+end AESModulusTutorial
+```
+
+The impostor's failures are instructive. `X^(2⁸) - X` is square-free, so
+the eightfold repeated factor `(x + 1)⁸` cannot divide it: the divides
+leg fails. And `x + 1` divides both `x⁸ + 1` and `X^(2⁴) - X`, so the gcd
+at `d = 4` is not a unit: the coprimality leg fails too. A polynomial
+that is merely *reducible* but square-free with a low-degree factor would
+pass the first leg and fail only the second; this one fails everything.
+
+# The certificate
+%%%
+tag := "tutorial-aes-modulus-certificate"
+%%%
+
+Running {name}`Hex.Berlekamp.rabinTest` costs repeated Frobenius steps
+and a gcd. That is cheap for a compiled program and expensive for a proof
+checker, so `HexBerlekamp` splits the work: an untrusted generator runs
+the test once in compiled code and writes down enough intermediate data
+that *checking* becomes easy. The data is a
+{name}`Hex.Berlekamp.IrreducibilityCertificate`: the chain of Frobenius
+powers `X^(2^k) mod f` for `k = 0, …, n`, plus one Bezout witness per
+maximal proper divisor, a pair `(left, right)` with
+`left · f + right · (X^(2^d) - X mod f) = 1`. The Bezout identity is the
+point: verifying that a gcd *is* `1` requires re-running the Euclidean
+algorithm, but verifying a Bezout combination is two multiplications and
+an addition, and it is just as conclusive.
+
+```lean
+open Hex
+
+namespace AESModulusTutorial
+
+/-- The Rabin certificate for the modulus, built by the
+compiled generator. -/
+def cert? : Option Berlekamp.IrreducibilityCertificate :=
+  Berlekamp.buildIrreducibilityCertificate? m m_monic
+
+#guard cert?.isSome
+
+-- Nine Frobenius powers: X^(2^k) mod m for k = 0..8.
+#guard (cert?.map fun c => c.powChain.size) == some 9
+
+-- One Bezout witness, for the single divisor 4.
+#guard (cert?.map fun c => c.bezout.size) == some 1
+
+-- The checker accepts the generated certificate.
+#guard (cert?.map fun c =>
+  Berlekamp.checkIrreducibilityCertificate m m_monic c)
+    == some true
+
+end AESModulusTutorial
+```
+
+{name}`Hex.Berlekamp.checkIrreducibilityCertificate` recomputes each pow
+chain entry by one Frobenius step from its predecessor, reads the divides
+leg off the last entry (which must reduce to `X mod f`), and replays each
+Bezout identity. The generator carries no soundness proof of its own and
+needs none: a wrong certificate makes the checker return `false`, never a
+false pass.
+
+# From a Boolean to a theorem
+%%%
+tag := "tutorial-aes-modulus-theorem"
+%%%
+
+Everything so far is a `#guard`: evaluated when this manual builds, by
+the same compiled code any caller would run, but checked by the
+evaluator rather than the kernel. The last step promotes the passing
+check to a kernel-checked theorem, using the `irreducibility` elaborator
+from {ref "hex-berlekamp"}[`HexBerlekamp`].
+
+```lean
+open Hex
+
+namespace AESModulusTutorial
+
+/-- Kernel-checked: the Rijndael modulus is irreducible
+over `𝔽₂`. -/
+theorem m_irreducible : FpPoly.Irreducible m :=
+  irreducibility m
+
+-- The tactic form closes the same goal.
+example : FpPoly.Irreducible m := by irreducibility
+
+end AESModulusTutorial
+```
+
+What happens under `irreducibility m` is the certifying pattern in
+miniature. At elaboration time the compiled generator produces the
+certificate from the previous section; the elaborator then emits a proof
+term applying the soundness theorem to the certificate *as reified
+literal data*. The kernel never runs the generator, the Frobenius
+exponentiation, or the extended Euclidean algorithm. What it checks is
+that the certificate check reduces to `true` on the literals, and the
+soundness theorem, proved once in the library as
+{name}`Hex.Berlekamp.checkIrreducibilityCertificate_imp_irreducible`
+(resting on {name}`Hex.Berlekamp.rabinTest_imp_irreducible`), turns that
+reduction into {name}`Hex.FpPoly.Irreducible`. The trusted surface is the
+small checker and its proof; the search that found the certificate is
+outside it. No `native_decide` is involved anywhere.
+
+{name}`Hex.FpPoly.Irreducible` itself says exactly what the zero-divisor
+section needed: `m` is nonzero, and any factorization `a * b = m` has a
+constant on one side. That is the hypothesis under which the quotient
+`𝔽₂[x] / (m)` has inverses for all nonzero residues.
+
+# Back to the AES field
+%%%
+tag := "tutorial-aes-modulus-aes"
+%%%
+
+The {ref "tutorial-aes-field"}[AES tutorial]'s field type is built on the
+committed theorem {name}`Hex.GF2Poly.aes_modulus_irreducible`, which
+lives in {ref "hex-gf2"}[`HexGF2`] and is stated for the *packed*
+polynomial type `GF2Poly`, where a polynomial over `𝔽₂` is machine words
+of bits rather than an array of `ZMod64 2` coefficients. That statement
+is proved by exactly the pipeline this page just walked through, on the
+packed representation: a committed certificate with the same shape (a
+Frobenius pow chain and one Bezout witness at `d = 4`) is replayed by
+{name}`Hex.GF2Poly.checkIrreducibilityCertificate` in the kernel, and
+{ref "hex-gf2-irreducible"}[the packed Rabin soundness theorem] lifts the
+passing check to irreducibility. Same criterion, same certificate
+discipline, two representations: the dense form here is where the
+general factorization machinery operates for any prime `p`, and the
+packed form is what the AES field type consumes at speed.
+
+So the debt is paid twice over. The byte arithmetic of the first
+tutorial rests on an irreducibility theorem, and that theorem is not a
+table lookup or a trusted comment: it is a replayed certificate, checked
+by the kernel, for a criterion whose soundness is itself a Lean theorem.
+
+# Cross-references
+%%%
+tag := "tutorial-aes-modulus-cross-references"
+%%%
+
+* {ref "tutorial-aes-field"}[AES byte arithmetic in GF(2⁸)] is the
+  downstream consumer: the field this page's theorem legitimizes.
+* {ref "hex-berlekamp"}[`HexBerlekamp`] documents the Rabin test, the
+  certificate checker, and the Berlekamp factorization this page did not
+  need.
+* {ref "hex-poly-fp"}[`HexPolyFp`] is the dense prime-field polynomial
+  layer the test runs on, including the quotient construction whose
+  field laws take irreducibility as a hypothesis.
+* {ref "hex-gf2-irreducible"}[Rabin irreducibility in `HexGF2`] is the
+  packed counterpart, where the committed AES certificate lives.
+* {ref "factor-tactics"}[The factor tactics] chapter documents the
+  `factor_poly` and `irreducibility` elaborators in full, including the
+  Mathlib-facing forms.

--- a/HexManual/Tutorials/PrimeSplitting.lean
+++ b/HexManual/Tutorials/PrimeSplitting.lean
@@ -1,0 +1,506 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexBerlekampZassenhaus
+import Mathlib.NumberTheory.KummerDedekind
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "Prime splitting via Kummer-Dedekind" =>
+%%%
+tag := "tutorial-prime-splitting"
+%%%
+
+# The story
+%%%
+tag := "tutorial-prime-splitting-story"
+%%%
+
+In the Gaussian integers `ℤ[i]`, the prime `5` stops being prime: it
+factors as `(2 + i)(2 - i)`. The prime `3` stays prime. The prime `2`
+does something stranger, becoming a unit times the *square* of `1 + i`.
+Every prime of `ℤ` meets one of these three fates in `ℤ[i]`, and which
+one is decided by a finite computation: factor `x² + 1` modulo
+`p`. Two distinct roots mod `5`, no roots mod `3`, a repeated root
+mod `2`.
+
+That is not a coincidence about `ℤ[i]`; it is the first case of the
+Kummer-Dedekind theorem, the standard dictionary between factoring a
+polynomial over `𝔽ₚ` and factoring the ideal `(p)` in the ring of
+integers of a number field. It is also exactly the computation the hex
+factorization pipeline automates. This page takes two concrete number
+fields, factors their defining polynomials modulo a handful of primes
+with {ref "hex-poly-fp"}[`HexPolyFp`] and
+{ref "hex-berlekamp"}[`HexBerlekamp`], and reads off the arithmetic of
+primes upstairs, with
+{ref "hex-berlekamp-zassenhaus"}[`HexBerlekampZassenhaus`] certifying
+the inputs and several of the answers. The dictionary itself is quoted
+number theory, stated carefully below but not re-proved here; the
+closing section is precise about that boundary.
+
+# Two number fields, certified
+%%%
+tag := "tutorial-prime-splitting-fields"
+%%%
+
+A number field is `K = ℚ(α)` for `α` a root of an irreducible integer
+polynomial. This page works with two of them: `ℚ(i)`, defined by
+`x² + 1`, and the cubic field `ℚ(∛2)`, defined by `x³ - 2`. Both
+polynomials are {name}`Hex.ZPoly` values, dense integer polynomials
+with coefficients listed from the constant term up.
+
+Irreducibility is the entry ticket: it is what makes `ℚ(x)/(f)` a
+*field* of degree `deg f` rather than a product of smaller pieces. The
+executable check is {name}`Hex.ZPoly.isIrreducible`, which runs the
+full Berlekamp-Zassenhaus factorizer {name}`Hex.ZPoly.factorize` and
+inspects the result; the `irreducibility` elaborator then produces the
+kernel-checked theorem, exactly as in
+{ref "tutorial-aes-modulus"}[the AES modulus tutorial] but over `ℤ`.
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+/-- `x² + 1`, the defining polynomial of `ℚ(i)`. -/
+def fGauss : ZPoly := #p[1, 0, 1]
+
+/-- `x³ - 2`, the defining polynomial of `ℚ(∛2)`. -/
+def fCubic : ZPoly := #p[-2, 0, 0, 1]
+
+-- Both pass the executable irreducibility check ...
+#guard ZPoly.isIrreducible fGauss
+#guard ZPoly.isIrreducible fCubic
+
+-- ... because each is its own entire factorization.
+#guard (ZPoly.factorize fGauss).factors
+    = #[(fGauss, 1)]
+#guard (ZPoly.factorize fGauss).scalar = 1
+#guard (ZPoly.factorize fCubic).factors
+    = #[(fCubic, 1)]
+
+/-- Kernel-certified: `x² + 1` is irreducible. -/
+theorem fGauss_irred : ZPoly.Irreducible fGauss :=
+  irreducibility fGauss
+
+/-- Kernel-certified: `x³ - 2` is irreducible. -/
+theorem fCubic_irred : ZPoly.Irreducible fCubic :=
+  irreducibility fCubic
+
+end PrimeSplittingTutorial
+```
+
+The certified theorems are worth a remark each. For `x³ - 2` the
+elaborator finds an Eisenstein-style witness at the prime `2`; for
+`x² + 1`, which is Eisenstein at no prime, it finds a prime `p` where
+the polynomial stays irreducible mod `p` and emits a single-prime
+modular certificate. Both proof terms are replayed by the kernel on
+literal data.
+
+# The correspondence
+%%%
+tag := "tutorial-prime-splitting-kd"
+%%%
+
+Fix a number field `K = ℚ(α)` with `α` an algebraic integer, `f` its
+monic minimal polynomial of degree `n`, and let `𝒪` be the ring of
+integers of `K`. In `𝒪` a prime `p` of `ℤ` need not stay prime, but
+unique factorization is restored at the level of ideals: the ideal
+`(p)` factors uniquely as
+
+```
+(p) = P₁^e₁ · P₂^e₂ ⋯ P_r^e_r
+```
+
+with distinct prime ideals `Pᵢ`. Each `Pᵢ` has a *residue degree*
+`fᵢ`, meaning its residue ring `𝒪/Pᵢ` is the finite field of `p^fᵢ`
+elements, and the exponent `eᵢ` is its *ramification index*. The
+invariants balance: `Σ eᵢ·fᵢ = n`, whatever `p` does.
+
+The Kummer-Dedekind theorem computes all of it from one polynomial
+factorization. Suppose `p` does not divide the conductor of `ℤ[α]`
+(the caveat gets its own section below; for this page's two fields the
+conductor is `1` and the hypothesis is vacuous). Factor the reduction
+of `f` into monic irreducibles over `𝔽ₚ`:
+
+```
+f ≡ g₁^e₁ · g₂^e₂ ⋯ g_r^e_r  (mod p)
+```
+
+Then the primes of `𝒪` above `p` are exactly `Pᵢ = (p, gᵢ(α))`, one
+per distinct factor, with residue degree `fᵢ = deg gᵢ` and
+ramification index the multiplicity `eᵢ`. The three fates of the
+opening section get their standard names from the shape of this data:
+`p` *splits completely* when `r = n` (all factors linear and
+distinct), is *inert* when `f` stays irreducible (`r = 1`, `e = 1`),
+and *ramifies* when some `eᵢ > 1`, which for `p` prime to the
+conductor happens exactly when `p` divides the discriminant of `f`.
+
+# The mod-p pipeline
+%%%
+tag := "tutorial-prime-splitting-pipeline"
+%%%
+
+The right-hand side of the dictionary is a computation hex already
+has, in three moves. {name}`Hex.ZPoly.modP` reduces the integer
+polynomial to an {name}`Hex.FpPoly`.
+{name}`Hex.FpPoly.squareFreeDecomposition` (Yun's algorithm) separates
+the multiplicities, which matters precisely at the ramified primes.
+{name}`Hex.Berlekamp.berlekampFactor` then splits each square-free
+part into irreducibles, as described in the
+{ref "hex-berlekamp"}[`HexBerlekamp` chapter]. Composing the three and
+keeping only the shape `(deg gᵢ, eᵢ)` gives the splitting type as a
+sorted list of (residue degree, ramification index) pairs.
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+/-- The shape of `f mod p`: one
+`(degree, multiplicity)` pair per distinct irreducible
+factor, sorted. Under Kummer-Dedekind, each pair is a
+prime above `p` with that residue degree and
+ramification index. -/
+def splittingType (p : Nat) [ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] (f : FpPoly p) :
+    List (Nat × Nat) :=
+  let dec := FpPoly.squareFreeDecomposition
+    ZMod64.PrimeModulus.prime f
+  let pairs := dec.factors.flatMap fun sf =>
+    if h : DensePoly.leadingCoeff sf.factor = 1 then
+      (Berlekamp.berlekampFactor sf.factor
+          (by exact h)).factors.map
+        fun g => (g.size - 1, sf.multiplicity)
+    else
+      [(sf.factor.size - 1, sf.multiplicity)]
+  pairs.mergeSort fun a b =>
+    decide (a.1 < b.1) ||
+      (a.1 == b.1 && decide (a.2 ≤ b.2))
+
+/-- Coefficients as naturals, for readable factors. -/
+def coeffNats {p : Nat} [ZMod64.Bounds p]
+    (f : FpPoly p) : List Nat :=
+  f.toArray.toList.map ZMod64.toNat
+
+-- The primes this page visits, with machine-word
+-- bounds and primality facts as instances.
+private instance pm2 : ZMod64.PrimeModulus 2 :=
+  ⟨by decide⟩
+private instance b3 : ZMod64.Bounds 3 :=
+  ⟨by decide, by decide⟩
+private instance pm3 : ZMod64.PrimeModulus 3 :=
+  ⟨by decide⟩
+private instance b5 : ZMod64.Bounds 5 :=
+  ⟨by decide, by decide⟩
+private instance pm5 : ZMod64.PrimeModulus 5 :=
+  ⟨by decide⟩
+private instance b7 : ZMod64.Bounds 7 :=
+  ⟨by decide, by decide⟩
+private instance pm7 : ZMod64.PrimeModulus 7 :=
+  ⟨by decide⟩
+private instance b13 : ZMod64.Bounds 13 :=
+  ⟨by decide, by decide⟩
+private instance pm13 : ZMod64.PrimeModulus 13 :=
+  ⟨by decide⟩
+private instance b31 : ZMod64.Bounds 31 :=
+  ⟨by decide, by decide⟩
+private instance pm31 : ZMod64.PrimeModulus 31 :=
+  ⟨by decide⟩
+
+end PrimeSplittingTutorial
+```
+
+The `if` branch is not dead code in general (Berlekamp's precondition
+is a monic input), but for the monic polynomials this page reduces it
+never fires: every square-free factor Yun returns is monic. Note what
+`splittingType` is: an honest computation, checked below by `#guard`
+against independently known number theory. The kernel-certified
+variant of the same factorizations appears in
+{ref "tutorial-prime-splitting-certified"}[a later section].
+
+# The Gaussian integers
+%%%
+tag := "tutorial-prime-splitting-gauss"
+%%%
+
+For `K = ℚ(i)` the ring of integers is `ℤ[i]` itself, the conductor is
+`1`, and the discriminant is `-4`, so Kummer-Dedekind applies at every
+prime and ramification can only happen at `2`.
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+-- p = 2: x² + 1 ≡ (x + 1)², ramified:
+-- (2) = (2, i + 1)² = (1 + i)².
+#guard splittingType 2 (ZPoly.modP 2 fGauss)
+    = [(1, 2)]
+
+-- p = 3: x² + 1 irreducible mod 3, inert: (3) stays
+-- prime with residue field of 9 elements.
+#guard splittingType 3 (ZPoly.modP 3 fGauss)
+    = [(2, 1)]
+
+-- p = 5 and p = 13: two distinct roots, split.
+#guard splittingType 5 (ZPoly.modP 5 fGauss)
+    = [(1, 1), (1, 1)]
+#guard splittingType 13 (ZPoly.modP 13 fGauss)
+    = [(1, 1), (1, 1)]
+
+-- Mod 13 the roots are 5 and 8: the factors are
+-- x - 5 and x - 8, stored as x + 8 and x + 5.
+def g13 : FpPoly 13 := #p[1, 0, 1]
+#guard ZPoly.modP 13 fGauss == g13
+theorem g13_monic : DensePoly.Monic g13 := by rfl
+
+#guard ((Berlekamp.berlekampFactor g13 g13_monic)
+  |>.factors.map coeffNats) == [[8, 1], [5, 1]]
+
+end PrimeSplittingTutorial
+```
+
+Reading the mod-13 factorization through the dictionary: the primes
+above `13` are `(13, i - 5)` and `(13, i - 8)`, each with residue
+degree one. And indeed `13 = (3 + 2i)(3 - 2i)` in `ℤ[i]`, with
+`i ≡ 5 (mod 3 + 2i)`: the ideal-theoretic answer collapses to honest
+element factorizations because `ℤ[i]` is a principal ideal domain.
+
+The split/inert dichotomy here is a theorem of Fermat in disguise:
+`x² + 1` has a root mod an odd `p` exactly when `p ≡ 1 (mod 4)`, so
+the primes that split in `ℤ[i]`, equivalently the primes that are sums
+of two squares, are exactly those congruent to `1` mod `4`. The
+`#guard`s above are four instances of that pattern, computed by
+Berlekamp factorization rather than quadratic reciprocity.
+
+# A cubic field
+%%%
+tag := "tutorial-prime-splitting-cubic"
+%%%
+
+The field `ℚ(∛2)` is more interesting: its Galois closure has group
+`S₃`, so primes have five possible fates rather than three, and which
+one occurs is no longer a congruence condition on `p` alone. The ring
+of integers is `ℤ[∛2]` (conductor `1` again), and the discriminant of
+`x³ - 2` is `-108 = -2²·3³`, so exactly `2` and `3` ramify.
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+-- p = 2: x³ - 2 ≡ x³, totally ramified:
+-- (2) = (2, ∛2)³ = (∛2)³.
+#guard splittingType 2 (ZPoly.modP 2 fCubic)
+    = [(1, 3)]
+
+-- p = 3: x³ - 2 ≡ (x + 1)³, totally ramified.
+#guard splittingType 3 (ZPoly.modP 3 fCubic)
+    = [(1, 3)]
+
+-- p = 5: one root (3³ = 27 ≡ 2) and an irreducible
+-- quadratic: a degree-1 and a degree-2 prime.
+#guard splittingType 5 (ZPoly.modP 5 fCubic)
+    = [(1, 1), (2, 1)]
+
+-- p = 7: no cube root of 2 mod 7, inert.
+#guard splittingType 7 (ZPoly.modP 7 fCubic)
+    = [(3, 1)]
+
+-- p = 31: totally split. 2 ≡ 4³ mod 31, and the
+-- roots are 4, 7, and 20.
+#guard splittingType 31 (ZPoly.modP 31 fCubic)
+    = [(1, 1), (1, 1), (1, 1)]
+
+def g31 : FpPoly 31 := #p[29, 0, 0, 1]
+#guard ZPoly.modP 31 fCubic == g31
+theorem g31_monic : DensePoly.Monic g31 := by rfl
+
+-- The factors x - 4, x - 7, x - 20, stored as
+-- x + 27, x + 24, x + 11.
+#guard ((Berlekamp.berlekampFactor g31 g31_monic)
+  |>.factors.map coeffNats)
+    == [[27, 1], [24, 1], [11, 1]]
+
+-- Whatever the shape, residue degrees weighted by
+-- ramification indices sum to the field degree.
+#guard ((splittingType 5 (ZPoly.modP 5 fCubic)).foldl
+  (fun s df => s + df.1 * df.2) 0) = 3
+
+end PrimeSplittingTutorial
+```
+
+The unramified shapes follow the cubic-residue arithmetic of `2`. For
+`p ≡ 2 (mod 3)` cubing is a bijection on `𝔽ₚ`, so `x³ - 2` has
+exactly one root and the shape is always a line times a conic, as at
+`p = 5`. For `p ≡ 1 (mod 3)` the cubes form an index-three subgroup:
+if `2` lands in it the polynomial splits completely, as at `p = 31`;
+if not there are no roots at all and `p` is inert, as at `p = 7`.
+
+There is a deeper pattern behind which shape occurs how often. The
+splitting type of an unramified `p` is the cycle type of its Frobenius
+element in the Galois group `S₃`, and the Chebotarev density theorem
+says each conjugacy class is hit with frequency proportional to its
+size: totally split with density `1/6`, the line-times-conic shape
+with density `1/2`, inert with density `1/3`. The five primes above
+are a small sample; the density statement is what the sample is drawn
+from.
+
+# Certified splittings
+%%%
+tag := "tutorial-prime-splitting-certified"
+%%%
+
+`splittingType` is compiled code checked by `#guard`. For a
+kernel-checked account of the same factorizations, the `factor_poly`
+and `irreducibility` elaborators from
+{ref "hex-berlekamp"}[`HexBerlekamp`] emit certificate-backed proof
+terms over `FpPoly p`, as described in
+{ref "factor-tactics"}[the factor tactics chapter].
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+/-- A certified factorization of `x² + 1` mod 13: the
+`factors_mul` and `factors_irred` fields are proofs,
+replayed by the kernel from Rabin certificates. -/
+noncomputable def fac13 := factor_poly g13
+
+example : fac13.factors = [#p[8, 1], #p[5, 1]] := by
+  rfl
+example : fac13.scalar = 1 := rfl
+
+def g7 : FpPoly 7 := #p[5, 0, 0, 1]
+#guard ZPoly.modP 7 fCubic == g7
+
+/-- Kernel-certified inertness: `x³ - 2` stays
+irreducible mod 7. -/
+theorem g7_irred : FpPoly.Irreducible g7 :=
+  irreducibility g7
+
+end PrimeSplittingTutorial
+```
+
+A {name}`Hex.FpPoly.Factored` value is not a list of factors that some
+compiled routine printed: its `factors_mul` field proves the product
+reconstructs `g13` and its `factors_irred` field proves each listed
+factor irreducible, so the mod-13 splitting data above `13` is backed
+by a kernel-checked factorization. Likewise `g7_irred` is precisely
+the "inert" claim for `7` in `ℚ(∛2)`, in certified form.
+
+# The conductor caveat
+%%%
+tag := "tutorial-prime-splitting-conductor"
+%%%
+
+Kummer-Dedekind's hypothesis was stated above and now has to be taken
+seriously: the dictionary reads factorizations of `f mod p` correctly
+only when `p` does not divide the conductor of `ℤ[α]` in `𝒪`, the
+largest ideal of `𝒪` contained in `ℤ[α]`. A prime dividing the
+conductor also divides the index `(𝒪 : ℤ[α])`, and the discriminants
+keep the books: `disc f = (𝒪 : ℤ[α])² · disc K`. When `ℤ[α]` is all
+of `𝒪`, as for `ℤ[i]` and `ℤ[∛2]`, the conductor is `1` and every
+prime is safe, which is why the sections above could proceed without
+comment.
+
+The caveat is not hypothetical, and Dedekind found the smallest
+counterexample: `K = ℚ(θ)` for `θ` a root of `x³ - x² - 2x - 8`. Here
+`disc f = -2012 = 2²·(-503)` while `disc K = -503`, so the index is
+`2`, and at `p = 2` the dictionary misreads:
+
+```lean
+open Hex
+
+namespace PrimeSplittingTutorial
+
+/-- Dedekind's cubic `x³ - x² - 2x - 8`. -/
+def fDedekind : ZPoly := #p[-8, -2, -1, 1]
+
+#guard ZPoly.isIrreducible fDedekind
+
+-- Mod 2 the polynomial is x²·(x + 1), which would
+-- read as one ramified prime and one unramified one.
+#guard splittingType 2 (ZPoly.modP 2 fDedekind)
+    = [(1, 1), (1, 2)]
+
+end PrimeSplittingTutorial
+```
+
+The computed factorization is perfectly correct *as a factorization
+mod 2*; what fails is the dictionary. The true splitting, computed
+with the full ring of integers, is that `2` splits completely: three
+distinct primes of residue degree one, no ramification at all
+(consistent with `2` not dividing `disc K = -503`). No better choice
+of `θ` fixes it, and the obstruction is charmingly finite: three
+distinct degree-one primes would require three distinct monic linear
+polynomials over `𝔽₂`, and there are only two. So *every* generator
+of this field has even index, `2` divides every conductor, and the
+polynomial dictionary is silent at `2` no matter which defining
+polynomial one factors. Primes like this are called common index
+divisors, and they are the precise reason the theorem carries its
+hypothesis.
+
+# What was computed, and what was proved
+%%%
+tag := "tutorial-prime-splitting-boundary"
+%%%
+
+Three grades of evidence appear on this page, and the point of the
+page is lost if they blur.
+
+The `#guard`s, including everything `splittingType` produced, are
+computations: evaluated when the manual builds, by the compiled
+factorization code a caller would run, and checked by the evaluator
+against expected values. They are tests, not theorems.
+
+The `irreducibility` and `factor_poly` results (`fGauss_irred`,
+`fCubic_irred`, `fac13`, `g7_irred`) are kernel-checked theorems about
+polynomials: the kernel replays a certificate check on literal data,
+and library soundness theorems convert the passing check into
+irreducibility and product statements. What is certified is the
+polynomial factorization, on both sides of the reduction mod `p`.
+
+The dictionary between those factorizations and ideals, the
+Kummer-Dedekind theorem itself, is imported number theory: this page
+states it and instantiates it in prose, and nothing here formalizes
+the ideal-theoretic side. That theorem does exist in formalized form,
+as Mathlib's
+{name}`KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk`,
+a bijection between the primes above `p` and the irreducible factors
+of the reduced minimal polynomial, conductor hypothesis and all.
+Connecting hex's executable factor lists to that statement, through
+the correspondence layers described in
+{ref "hex-berlekamp-zassenhaus"}[the `HexBerlekampZassenhaus` chapter],
+is exactly the kind of bridge the `*Mathlib` companion libraries
+exist for; this page stops at the polynomial boundary and says so.
+
+# Cross-references
+%%%
+tag := "tutorial-prime-splitting-cross-references"
+%%%
+
+* {ref "hex-berlekamp-zassenhaus"}[`HexBerlekampZassenhaus`] documents
+  {name}`Hex.ZPoly.factorize`, the integer factorizer whose
+  irreducibility checks anchor this page's number fields.
+* {ref "hex-berlekamp"}[`HexBerlekamp`] is the mod-`p` factorization
+  engine: Berlekamp's algorithm, Rabin's test, and the certificate
+  checkers behind `factor_poly` and `irreducibility`.
+* {ref "hex-poly-fp"}[`HexPolyFp`] provides the prime-field
+  polynomials, including the square-free decomposition that detects
+  ramification.
+* {ref "factor-tactics"}[The factor tactics] chapter documents the
+  elaborators used in the certified section, including their
+  Mathlib-facing forms.
+* {ref "tutorial-aes-modulus"}[Why the AES modulus works] is the same
+  certificate story at a single prime, told slowly.


### PR DESCRIPTION
This PR add the two tutorials the PLAN/Phase7.md anchor table declares but the tree lacked, unblocking the anchor libraries' Phase-7 bumps under `check_phase7.py`'s tutorial rules. "Why the AES modulus works" (anchored to hex-berlekamp) picks up the debt from the AES field tutorial: it exhibits the impostor `x^8+1 = (x+1)^8` with an explicit zero divisor in its quotient, walks both legs of Rabin's criterion for the real modulus and both failures for the impostor, inspects the irreducibility certificate (Frobenius pow chain, Bezout witness) and what the kernel replays, and lands the kernel-checked `FpPoly.Irreducible` theorem with no `native_decide`. "Prime splitting via Kummer-Dedekind" (anchored to hex-berlekamp-zassenhaus) certifies `x^2+1` and `x^3-2` irreducible, builds an executable `splittingType` through the mod-p Yun/Berlekamp pipeline, reads off split/inert/ramified behaviour for the Gaussian integers (the two-squares pattern) and the cubic field (with Chebotarev densities matching S3 cycle types), produces kernel-certified factorizations for representative primes, and closes with Dedekind's `x^3-x^2-2x-8` showing exactly where the conductor hypothesis bites. Every `#guard` value was validated through a built throwaway module before embedding; `lake build HexManual`, `check_phase7.py`, and `check_manual_split.py` are green.

🤖 Prepared with Claude Code