### PR TITLE
polish: HexRootsMathlib Phase-6 pass

### DIFF
--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -372,13 +372,9 @@ theorem AlgebraicNumber.ofNormalized?_toComplex
     have haroot : arep.root = a.rep.root := by
       cases hp
       rfl
-    have hpne : p ≠ 0 := by
-      intro hp0
-      rw [hp0] at pos_degree
-      simp at pos_degree
     have hroot :=
-      (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq_of_simple
-        squarefree hpne arep rep).mp hinter
+      (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq
+        arep rep).mp hinter
     change a.rep.root = rep.root
     rw [← haroot]
     exact hroot

--- a/HexRootsMathlib/ArgumentTopology.lean
+++ b/HexRootsMathlib/ArgumentTopology.lean
@@ -73,23 +73,6 @@ theorem continuousOn_circleIntegral_div {X : Type*} [TopologicalSpace X]
       (fun q => ⟨q.1.2, mem_univ q.2⟩)
   · exact fun q => hzero q.1.1 q.1.2 q.2
 
-/-- The normalized fixed-circle integral inherits parametric continuity. -/
-theorem continuous_normalizedCircleIntegral {X : Type*} [TopologicalSpace X]
-    {f : X → ℂ → ℂ} (c : ℂ) (R : ℝ)
-    (hf : Continuous fun q : X × ℝ => f q.1 (circleMap c R q.2)) :
-    Continuous fun x => (2 * Real.pi * I)⁻¹ * ∮ z in C(c, R), f x z :=
-  continuous_const.mul (continuous_circleIntegral c R hf)
-
-/-- The normalized integral of a quotient varies continuously under the same
-nonvanishing hypothesis as the unnormalized integral. -/
-theorem continuous_normalizedCircleIntegral_div {X : Type*} [TopologicalSpace X]
-    {f g : X → ℂ → ℂ} (c : ℂ) (R : ℝ)
-    (hf : Continuous fun q : X × ℝ => f q.1 (circleMap c R q.2))
-    (hg : Continuous fun q : X × ℝ => g q.1 (circleMap c R q.2))
-    (hzero : ∀ q : X × ℝ, g q.1 (circleMap c R q.2) ≠ 0) :
-    Continuous fun x => (2 * Real.pi * I)⁻¹ * ∮ z in C(c, R), f x z / g x z :=
-  continuous_const.mul (continuous_circleIntegral_div c R hf hg hzero)
-
 /-- The normalized integral of a quotient varies continuously on a parameter
 set under a nonvanishing hypothesis restricted to that set. -/
 theorem continuousOn_normalizedCircleIntegral_div {X : Type*} [TopologicalSpace X]
@@ -100,32 +83,6 @@ theorem continuousOn_normalizedCircleIntegral_div {X : Type*} [TopologicalSpace 
     ContinuousOn (fun x =>
       (2 * Real.pi * I)⁻¹ * ∮ z in C(c, R), f x z / g x z) s :=
   continuous_const.continuousOn.mul (continuousOn_circleIntegral_div c R hf hg hzero)
-
-/-- Continuity of a real cast detects continuity of a natural-valued map. -/
-theorem continuous_nat_of_cast {X : Type*} [TopologicalSpace X] {f : X → ℕ}
-    (hf : Continuous fun x => (f x : ℝ)) : Continuous f := by
-  exact Nat.isClosedEmbedding_coe_real.isInducing.continuous_iff.mpr hf
-
-/-- Continuity of a complex cast detects continuity of a natural-valued map. -/
-theorem continuous_nat_of_complexCast {X : Type*} [TopologicalSpace X]
-    {f : X → ℕ} (hf : Continuous fun x => (f x : ℂ)) : Continuous f := by
-  apply continuous_nat_of_cast
-  have hre := Complex.continuous_re.comp hf
-  change Continuous (fun x => ((f x : ℂ).re)) at hre
-  simpa using hre
-
-/-- Continuity of a real cast detects continuity of an integer-valued map. -/
-theorem continuous_int_of_cast {X : Type*} [TopologicalSpace X] {f : X → ℤ}
-    (hf : Continuous fun x => (f x : ℝ)) : Continuous f := by
-  exact Int.isClosedEmbedding_coe_real.isInducing.continuous_iff.mpr hf
-
-/-- Continuity of a complex cast detects continuity of an integer-valued map. -/
-theorem continuous_int_of_complexCast {X : Type*} [TopologicalSpace X]
-    {f : X → ℤ} (hf : Continuous fun x => (f x : ℂ)) : Continuous f := by
-  apply continuous_int_of_cast
-  have hre := Complex.continuous_re.comp hf
-  change Continuous (fun x => ((f x : ℂ).re)) at hre
-  simpa using hre
 
 /-- Continuity on a set of a real cast detects continuity on that set of a
 natural-valued map. -/
@@ -164,13 +121,21 @@ theorem eq_endpoints_of_continuousOn {Y : Type*} [TopologicalSpace Y]
     (left_mem_Icc.mpr hab) (right_mem_Icc.mpr hab)
 
 /-- A natural-valued map has equal endpoint values when its complex cast is
-continuous on the intervening interval. -/
+continuous on the intervening interval.
+
+This packaged form is the module's stated terminus; the Rouché homotopy
+development applies the two halves (`continuousOn_nat_of_complexCast`,
+`eq_endpoints_of_continuousOn`) separately because it names the intermediate
+continuity statement `continuous_rootsInDisc`. -/
 theorem nat_eq_endpoints_of_complexCast {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℕ}
     (hf : ContinuousOn (fun x => (f x : ℂ)) (Icc a b)) : f a = f b :=
   eq_endpoints_of_continuousOn hab (continuousOn_nat_of_complexCast hf)
 
 /-- An integer-valued map has equal endpoint values when its complex cast is
-continuous on the intervening interval. -/
+continuous on the intervening interval.
+
+Integer-valued counterpart of `nat_eq_endpoints_of_complexCast`, kept as the
+module's general winding-number-valued terminus. -/
 theorem int_eq_endpoints_of_complexCast {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℤ}
     (hf : ContinuousOn (fun x => (f x : ℂ)) (Icc a b)) : f a = f b :=
   eq_endpoints_of_continuousOn hab (continuousOn_int_of_complexCast hf)

--- a/HexRootsMathlib/CircleIntegralLemmas.lean
+++ b/HexRootsMathlib/CircleIntegralLemmas.lean
@@ -25,16 +25,6 @@ namespace HexRootsMathlib
 
 noncomputable section
 
-/-- Difference of two reciprocal linear factors, with both poles excluded. -/
-theorem reciprocal_sub {z a b : ℂ} (hza : z ≠ a) (hzb : z ≠ b) :
-    (z - a)⁻¹ - (z - b)⁻¹ =
-      (a - b) / ((z - a) * (z - b)) := by
-  calc
-    (z - a)⁻¹ - (z - b)⁻¹ =
-        ((z - b) - (z - a)) / ((z - a) * (z - b)) :=
-      inv_sub_inv (sub_ne_zero.mpr hza) (sub_ne_zero.mpr hzb)
-    _ = (a - b) / ((z - a) * (z - b)) := by ring
-
 /-- The logarithmic derivative of a complex polynomial is the sum of its
 reciprocal linear factors, counted over the root multiset. -/
 theorem logDeriv_eq_sum (p : ℂ[X]) {z : ℂ} (hz : p.eval z ≠ 0) :

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -41,22 +41,6 @@ namespace Worklist
 
 end Worklist
 
-private theorem worklist_covers_iff_region {p : Hex.ZPoly}
-    {work : Array Hex.Component} :
-    Worklist.Covers p work ↔
-      ∀ z, (toPolyℂ p).IsRoot z → z ∈ Worklist.region work := by
-  constructor
-  · intro hcover z hzroot
-    obtain ⟨s, hs, hzs⟩ := hcover z hzroot
-    rw [Worklist.squares, Array.toList_flatMap, List.mem_flatMap] at hs
-    obtain ⟨c, hc, hsc⟩ := hs
-    exact ⟨c, hc, s, hsc, hzs⟩
-  · intro hregion z hzroot
-    obtain ⟨c, hc, s, hs, hzs⟩ := hregion z hzroot
-    refine ⟨s, ?_, hzs⟩
-    rw [Worklist.squares, Array.toList_flatMap, List.mem_flatMap]
-    exact ⟨c, hc, hs⟩
-
 @[simp] private theorem encSquare_singleton (s : Hex.DyadicSquare) :
     Hex.encSquare #[s] = s := by
   cases s with

--- a/HexRootsMathlib/Completeness/NKRecertification.lean
+++ b/HexRootsMathlib/Completeness/NKRecertification.lean
@@ -60,6 +60,8 @@ radius power replaced by one. -/
     (k : ℝ) * exactCoeffNorm (toPolyℂ p) k x
   else 0
 
+/-- The tail majorant is continuous wherever the derivative does not
+vanish. -/
 theorem continuousAt_tailMajorant {p : Hex.ZPoly}
     {x : NewtonKantorovich.ComplexSup}
     (hx : (toPolyℂ p).derivative.eval
@@ -85,6 +87,7 @@ theorem continuousAt_tailMajorant {p : Hex.ZPoly}
         simp [Finset.sum_insert hk]]
       exact hterm.add ih
 
+/-- The tail majorant is nonnegative. -/
 theorem tailMajorant_nonneg (p : Hex.ZPoly)
     (x : NewtonKantorovich.ComplexSup) : 0 ≤ tailMajorant p x := by
   unfold tailMajorant
@@ -329,6 +332,8 @@ theorem norm_approxInverse_le (p : Hex.ZPoly) (s : Hex.DyadicSquare)
     (norm_nonneg (NewtonKantorovich.ComplexSup.inverseAt (toPolyℂ p)
       (DyadicSquare.center s) v₀)) hθ1
 
+/-- The operator norm of the scaled executable Taylor-coefficient multiplier
+is the exact coefficient norm at the square's centre. -/
 theorem norm_exactCoeff (p : Hex.ZPoly) (s : Hex.DyadicSquare) (k : Nat) :
     ‖(NewtonKantorovich.ComplexSup.inverseAt (toPolyℂ p)
       (DyadicSquare.center s)).comp

--- a/HexRootsMathlib/Completeness/PelletConverse.lean
+++ b/HexRootsMathlib/Completeness/PelletConverse.lean
@@ -425,7 +425,11 @@ theorem pellet_one_of_roots {q : ℂ[X]} {a : ℂ} {s : Multiset ℂ} {d ρ : �
 /-- Translation form of `pellet_one_of_roots`. Here `z` is the designated
 root of `p`, `s` is the multiset of every other root (with multiplicity), and
 the conclusion is stated directly for the Taylor polynomial about an
-arbitrary centre `c`. -/
+arbitrary centre `c`.
+
+This is the clean-margin terminus of the Pellet converse; the executable
+completeness chain in `Completeness.PelletDyadic` uses the slack variant
+`pellet_one_comp_slack` instead, which absorbs the dyadic rounding gap. -/
 theorem pellet_one_comp_dominates {p : ℂ[X]} {c z : ℂ} {s : Multiset ℂ}
     {d ρ : ℝ} (hp : p ≠ 0) (hroots : p.roots = z ::ₘ s) (hd : 0 < d)
     (hρ : 0 ≤ ρ) (hremote : ∀ w ∈ s, d ≤ ‖w - c‖)

--- a/HexRootsMathlib/Completeness/PelletDyadic.lean
+++ b/HexRootsMathlib/Completeness/PelletDyadic.lean
@@ -25,24 +25,6 @@ namespace HexRootsMathlib
 
 noncomputable section
 
-private theorem sum_erase_range {M : Type*} [AddCommMonoid M]
-    (f : ℕ → M) (n k : ℕ) :
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-      ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-  classical
-  calc
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-        ∑ i ∈ (Finset.range n).filter (fun i => i ≠ k), f i := by
-      congr 1
-      ext i
-      simp [and_comm]
-    _ = ∑ i ∈ Finset.range n, if i ≠ k then f i else 0 := by
-      rw [Finset.sum_filter]
-    _ = ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-      apply Finset.sum_congr rfl
-      intro i hi
-      by_cases hik : i = k <;> simp [hik]
-
 /-- Converse to `pelletAt_bound`: a strict inequality between the exact real
 casts of the dyadic bounds makes the executable Boolean check succeed. -/
 theorem pelletAt_of_bound {cs : Array Hex.GaussDyadic} {k : ℕ}

--- a/HexRootsMathlib/Completeness/RootFreeConverse.lean
+++ b/HexRootsMathlib/Completeness/RootFreeConverse.lean
@@ -517,25 +517,6 @@ theorem exists_root_le_radius_of_not_rootFree {p : Hex.ZPoly}
   exact ⟨z, hz, root_near_of_simple hp hsize hzroot
     hsimple hprec hkeep hzc⟩
 
-/-- Convenient looser strict form of the sharp `65/32` survivor bound. -/
-theorem exists_root_lt_three_radius_of_not_rootFree {p : Hex.ZPoly}
-    {s : Hex.DyadicSquare} (hp : toPolyℂ p ≠ 0) (hsize : 1 < p.size)
-    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
-    (hprec : (Hex.separationDepth p : Int) ≤ s.prec)
-    (hkeep : Hex.rootFree p s ≠ true) :
-    ∃ z ∈ (toPolyℂ p).roots,
-      ‖z - DyadicSquare.center s‖ < 3 * Dyadic.toReal s.radiusHi := by
-  obtain ⟨z, hz, hnear⟩ :=
-    exists_root_le_radius_of_not_rootFree
-      hp hsize hsep hprec hkeep
-  refine ⟨z, hz, hnear.trans_lt ?_⟩
-  have hR : 0 < Dyadic.toReal s.radiusHi := by
-    rw [DyadicSquare.radiusHi_eq]
-    have : 0 < Dyadic.toReal Hex.sqrt2Hi := by
-      norm_num [Hex.sqrt2Hi, Dyadic.toReal_ofIntWithPrec]
-    exact mul_pos (by rw [DyadicSquare.halfWidth_eq]; positivity) this
-  nlinarith
-
 namespace DyadicSquare
 
 /-- Executable edge-or-corner adjacency is strictly less than four

--- a/HexRootsMathlib/Component.lean
+++ b/HexRootsMathlib/Component.lean
@@ -140,6 +140,7 @@ namespace Certified
   | .atom _ => 1
   | .cluster cl => cl.k
 
+/-- Every certificate claims at least one root. -/
 theorem count_pos {p : Hex.ZPoly} (r : Hex.Certified p) : 0 < count r := by
   cases r with
   | atom => simp [count]
@@ -169,6 +170,8 @@ theorem toComponent_wellFormed {p : Hex.ZPoly} (r : Hex.Certified p) :
     Component.WellFormed r.toComponent := by
   simp [Component.WellFormed, Hex.Component.prec]
 
+/-- Re-entry preserves candidate-count positivity; together with
+`toComponent_wellFormed` this is the loop kernel's re-entry contract. -/
 theorem toComponent_count_pos {p : Hex.ZPoly} (r : Hex.Certified p) :
     0 < r.toComponent.candidateK := by
   rw [toComponent_count]

--- a/HexRootsMathlib/Examples.lean
+++ b/HexRootsMathlib/Examples.lean
@@ -31,18 +31,22 @@ noncomputable section
 def pisot : ZPoly :=
   DensePoly.monomial 3 1 - DensePoly.monomial 1 1 - DensePoly.C 1
 
+/-- The complex interpretation of the Pisot cubic. -/
 theorem toPolyℂ_pisot : toPolyℂ pisot = X ^ 3 - X - 1 := by
   simp [pisot, toPolyℂ, monomial_one_right_eq_X_pow]
 
+/-- The rational interpretation of the Pisot cubic. -/
 theorem toPolyℚ_pisot : HexPolyZMathlib.toPolyℚ pisot = X ^ 3 - X - 1 := by
   simp [pisot, HexPolyZMathlib.toPolyℚ, monomial_one_right_eq_X_pow]
 
+/-- The Pisot cubic has degree three. -/
 theorem natDegree_pisot : (toPolyℂ pisot).natDegree = 3 := by
   rw [toPolyℂ_pisot,
     natDegree_sub_eq_left_of_natDegree_lt (by
       rw [natDegree_sub_eq_left_of_natDegree_lt] <;> norm_num),
     natDegree_sub_eq_left_of_natDegree_lt] <;> norm_num
 
+/-- The Pisot cubic is nonzero. -/
 theorem pisot_ne_zero : pisot ≠ 0 := by
   intro h
   have hcoeff := congrArg (fun p : ZPoly => p.coeff 3) h
@@ -69,51 +73,66 @@ theorem pisot_simple : HasOnlySimpleRoots pisot := by
     _ = C (23⁻¹ * 23) := by rw [map_mul]
     _ = 1 := by norm_num
 
+/-- Certified square around the lower complex root of `x³ - x - 1`. -/
 def pisotLowerSquare : DyadicSquare where
   re := .ofIntWithPrec (-91033924845) 37
   im := .ofIntWithPrec (-77279107697) 37
   prec := 33
 
+/-- Certified square around the upper complex root of `x³ - x - 1`. -/
 def pisotUpperSquare : DyadicSquare where
   re := .ofIntWithPrec (-91033924845) 37
   im := .ofIntWithPrec 4829944231 33
   prec := 33
 
+/-- Certified square around the real root of `x³ - x - 1` (the smallest
+Pisot number). -/
 def pisotRealSquare : DyadicSquare where
   re := .ofIntWithPrec 182067849689 37
   im := 0
   prec := 33
 
+/-- The lower square passes the executable Newton-Kantorovich test. -/
 theorem pisotLower_witness : nkWitness pisot pisotLowerSquare := by decide
 
+/-- The upper square passes the executable Newton-Kantorovich test. -/
 theorem pisotUpper_witness : nkWitness pisot pisotUpperSquare := by decide
 
+/-- The real-centred square passes the executable Newton-Kantorovich test. -/
 theorem pisotReal_witness : nkWitness pisot pisotRealSquare := by decide
 
+/-- The unique root of the Pisot cubic in the lower certified square. -/
 noncomputable def pisotLowerRoot : ℂ :=
   (NKData.existsUnique_root pisotLower_witness).exists.choose
 
+/-- The unique root of the Pisot cubic in the upper certified square. -/
 noncomputable def pisotUpperRoot : ℂ :=
   (NKData.existsUnique_root pisotUpper_witness).exists.choose
 
+/-- The unique root of the Pisot cubic in the real-centred certified
+square: the smallest Pisot number. -/
 noncomputable def pisotRealRoot : ℂ :=
   (NKData.existsUnique_root pisotReal_witness).exists.choose
 
+/-- The lower root satisfies the cubic and lies in its certified square. -/
 theorem pisotLowerRoot_spec :
     (toPolyℂ pisot).eval pisotLowerRoot = 0 ∧
       pisotLowerRoot ∈ DyadicSquare.closedSquare pisotLowerSquare :=
   (NKData.existsUnique_root pisotLower_witness).exists.choose_spec
 
+/-- The upper root satisfies the cubic and lies in its certified square. -/
 theorem pisotUpperRoot_spec :
     (toPolyℂ pisot).eval pisotUpperRoot = 0 ∧
       pisotUpperRoot ∈ DyadicSquare.closedSquare pisotUpperSquare :=
   (NKData.existsUnique_root pisotUpper_witness).exists.choose_spec
 
+/-- The real root satisfies the cubic and lies in its certified square. -/
 theorem pisotRealRoot_spec :
     (toPolyℂ pisot).eval pisotRealRoot = 0 ∧
       pisotRealRoot ∈ DyadicSquare.closedSquare pisotRealSquare :=
   (NKData.existsUnique_root pisotReal_witness).exists.choose_spec
 
+/-- Eight-decimal rational enclosures for the lower root's coordinates. -/
 theorem pisotLowerRoot_bounds :
     (-66235899 / 100000000 : ℝ) < pisotLowerRoot.re ∧
       pisotLowerRoot.re < (-66235897 / 100000000 : ℝ) ∧
@@ -131,6 +150,7 @@ theorem pisotLowerRoot_bounds :
   · linarith
   constructor <;> linarith
 
+/-- Eight-decimal rational enclosures for the upper root's coordinates. -/
 theorem pisotUpperRoot_bounds :
     (-66235899 / 100000000 : ℝ) < pisotUpperRoot.re ∧
       pisotUpperRoot.re < (-66235897 / 100000000 : ℝ) ∧
@@ -148,6 +168,7 @@ theorem pisotUpperRoot_bounds :
   · linarith
   constructor <;> linarith
 
+/-- Eight-decimal rational enclosure for the real root. -/
 theorem pisotRealRoot_bounds :
     (132471795 / 100000000 : ℝ) < pisotRealRoot.re ∧
       pisotRealRoot.re < (132471796 / 100000000 : ℝ) := by
@@ -181,6 +202,8 @@ theorem pisotRealRoot_im : pisotRealRoot.im = 0 := by
       ⟨hconjRoot, hconjMem⟩ pisotRealRoot_spec
   exact Complex.conj_eq_iff_im.mp hfixed
 
+/-- The lower complex root lies strictly inside the unit circle, as the
+Pisot property demands. -/
 theorem pisotLowerRoot_norm : ‖pisotLowerRoot‖ < 1 := by
   have hb := pisotLowerRoot_bounds
   have hre : |pisotLowerRoot.re| < (663 / 1000 : ℝ) := by
@@ -197,6 +220,8 @@ theorem pisotLowerRoot_norm : ‖pisotLowerRoot‖ < 1 := by
   rw [Complex.sq_norm, Complex.normSq_apply]
   nlinarith
 
+/-- The upper complex root lies strictly inside the unit circle, as the
+Pisot property demands. -/
 theorem pisotUpperRoot_norm : ‖pisotUpperRoot‖ < 1 := by
   have hb := pisotUpperRoot_bounds
   have hre : |pisotUpperRoot.re| < (663 / 1000 : ℝ) := by

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -108,9 +108,12 @@ namespace SquareBounds
   Dyadic.toReal b.ymin ≤ Dyadic.toReal (s.im - s.halfWidth) ∧
   Dyadic.toReal (s.im + s.halfWidth) ≤ Dyadic.toReal b.ymax
 
+/-- A square's own bounds contain it. -/
 theorem bounds_contains (s : Hex.DyadicSquare) : Contains s.bounds s := by
   simp [Contains, Hex.DyadicSquare.bounds]
 
+/-- Merging another square into a bounding box keeps everything it already
+contained. -/
 theorem contains_merge_left {b : Hex.SquareBounds} {s t : Hex.DyadicSquare}
     (h : Contains b s) : Contains (b.merge t) s := by
   rcases h with ⟨hxlo, hxhi, hylo, hyhi⟩
@@ -119,18 +122,22 @@ theorem contains_merge_left {b : Hex.SquareBounds} {s t : Hex.DyadicSquare}
   exact ⟨min_le_left _ _ |>.trans hxlo, hxhi.trans (le_max_left _ _),
     min_le_left _ _ |>.trans hylo, hyhi.trans (le_max_left _ _)⟩
 
+/-- A merged bounding box contains the newly merged square. -/
 theorem contains_merge_right (b : Hex.SquareBounds) (s : Hex.DyadicSquare) :
     Contains (b.merge s) s := by
   simp only [Contains, Hex.SquareBounds.merge, Hex.DyadicSquare.bounds,
     Dyadic.toReal_min, Dyadic.toReal_max]
   exact ⟨min_le_right _ _, le_max_right _ _, min_le_right _ _, le_max_right _ _⟩
 
+/-- Extending an optional bounding box keeps every previously contained
+square. -/
 theorem contains_extend_old {b : Option Hex.SquareBounds} {s t : Hex.DyadicSquare}
     (h : ∃ box, b = some box ∧ Contains box s) :
     ∃ box, Hex.SquareBounds.extend b t = some box ∧ Contains box s := by
   obtain ⟨box, rfl, hs⟩ := h
   exact ⟨box.merge t, rfl, contains_merge_left hs⟩
 
+/-- Extending an optional bounding box contains the newly added square. -/
 theorem contains_extend_new (b : Option Hex.SquareBounds) (s : Hex.DyadicSquare) :
     ∃ box, Hex.SquareBounds.extend b s = some box ∧ Contains box s := by
   cases b with
@@ -244,6 +251,9 @@ the Mathlib interpretations use the explicit `DyadicSquare.*` prefix.
     disc s = Metric.ball (center s) ((2 : ℝ) ^ (-s.prec) * √2) := by
   simp [disc]
 
+/-- The closed square is the sup-norm closed ball of half-width radius about
+the centre.  Characterising lemma recording what is otherwise a definitional
+equality, so consumers need not unfold `closedSquare`. -/
 theorem closedSquare_eq_supClosedBall (s : Hex.DyadicSquare) :
     closedSquare s = supClosedBall (center s) (halfWidth s) := rfl
 

--- a/HexRootsMathlib/Glue.lean
+++ b/HexRootsMathlib/Glue.lean
@@ -30,8 +30,10 @@ namespace Glue
 /-- Undirected executable edge adjacency. -/
 @[expose] def Linked (s t : Hex.DyadicSquare) : Prop := Edge s t ∨ Edge t s
 
+/-- Undirected adjacency is symmetric. -/
 theorem linked_symm {s t : Hex.DyadicSquare} : Linked s t → Linked t s := Or.symm
 
+/-- Executable adjacency is reflexive: a square is adjacent to itself. -/
 theorem edge_refl (s : Hex.DyadicSquare) : Edge s s := by
   rw [Edge, Hex.DyadicSquare.adjacent, if_pos rfl]
   have hpos : (0 : _root_.Dyadic) < .ofIntWithPrec 1 (s.prec - 2) := by
@@ -97,10 +99,12 @@ direction. Together with coverage and connectedness this is maximality. -/
   ∀ c ∈ components, ∀ d ∈ components, c ≠ d →
     ∀ s ∈ c, ∀ t ∈ d, ¬Edge s t ∧ ¬Edge t s
 
+/-- The executable `touches` test is adjacency to some member. -/
 theorem touches_iff {s : Hex.DyadicSquare} {component : List Hex.DyadicSquare} :
     s.touches component = true ↔ ∃ t ∈ component, Linked s t := by
   simp [Hex.DyadicSquare.touches, Linked, Edge]
 
+/-- A failed `touches` test is two-sided non-adjacency to every member. -/
 theorem not_touches_iff {s : Hex.DyadicSquare}
     {component : List Hex.DyadicSquare} :
     s.touches component = false ↔

--- a/HexRootsMathlib/Isolate.lean
+++ b/HexRootsMathlib/Isolate.lean
@@ -41,6 +41,7 @@ theorem root_spec {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) :
       ∀ w, (toPolyℂ p).eval w = 0 → w ∈ region iso → w = root iso :=
   (sound iso).choose_spec
 
+/-- The selected value is a root. -/
 theorem isRoot {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) :
     (toPolyℂ p).IsRoot (root iso) :=
   (root_spec iso).1
@@ -58,57 +59,6 @@ theorem root_refined {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p)
 
 end DyadicRootIsolation
 
-/-- An option-valued list map that succeeds preserves length and corresponding
-entries. -/
-private theorem list_mapM_some_get {α β : Type*} {f : α → Option β}
-    {xs : List α} {ys : List β} (hmap : xs.mapM f = some ys) :
-    xs.length = ys.length ∧
-      ∀ (i : Nat) (hi : i < xs.length) (hj : i < ys.length),
-        f xs[i] = some ys[i] := by
-  induction xs generalizing ys with
-  | nil =>
-      simp at hmap
-      subst ys
-      simp
-  | cons x xs ih =>
-      cases hfx : f x with
-      | none => simp [hfx] at hmap
-      | some y =>
-          cases htail : xs.mapM f with
-          | none => simp [hfx, htail] at hmap
-          | some ys' =>
-              have heq : some (y :: ys') = some ys := by
-                simpa [hfx, htail] using hmap
-              have hys : ys = y :: ys' := (Option.some.inj heq).symm
-              subst ys
-              obtain ⟨hlen, hget⟩ := ih htail
-              constructor
-              · simp [hlen]
-              · intro i hi hj
-                cases i with
-                | zero => simpa using hfx
-                | succ i =>
-                    simp only [List.getElem_cons_succ]
-                    exact hget i (by simpa using hi) (by simpa using hj)
-
-/-- An option-valued array map that succeeds preserves size and corresponding
-entries. -/
-theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
-    {xs : Array α} {ys : Array β} (hmap : xs.mapM f = some ys) :
-    xs.size = ys.size ∧
-      ∀ (i : Nat) (hi : i < xs.size) (hj : i < ys.size),
-        f xs[i] = some ys[i] := by
-  have hlist : xs.toList.mapM f = some ys.toList := by
-    calc
-      xs.toList.mapM f = Array.toList <$> xs.mapM f :=
-        Array.toList_mapM.symm
-      _ = some ys.toList := by rw [hmap]; rfl
-  obtain ⟨hlen, hget⟩ := list_mapM_some_get hlist
-  refine ⟨by simpa using hlen, ?_⟩
-  intro i hi hj
-  simpa only [← Array.getElem_toList] using hget i (by simpa using hi)
-    (by simpa using hj)
-
 private theorem list_mapM_isSome {α β : Type*} {f : α → Option β}
     {xs : List α} (h : ∀ x ∈ xs, (f x).isSome) :
     (xs.mapM f).isSome := by
@@ -125,7 +75,8 @@ private theorem list_mapM_isSome {α β : Type*} {f : α → Option β}
       exact ⟨y :: ys, by simp [hy, hys]⟩
 
 /-- An option-valued array map succeeds when its function succeeds on every
-input entry. -/
+input entry.  Public because `HexNumberFieldMathlib` uses it to discharge
+success of the embedding and refinement `mapM` pipelines. -/
 theorem array_mapM_isSome {α β : Type*} {f : α → Option β}
     {xs : Array α} (h : ∀ x ∈ xs.toList, (f x).isSome) :
     (xs.mapM f).isSome := by

--- a/HexRootsMathlib/Kantorovich.lean
+++ b/HexRootsMathlib/Kantorovich.lean
@@ -39,6 +39,8 @@ namespace NewtonKantorovich
 namespace ContractingWith
 
 omit [CompleteSpace α] in
+/-- A map that contracts on a forward-invariant set has at most one fixed
+point in that set. -/
 theorem eq_of_fixedPoints {s : Set α} (hsf : MapsTo f s s)
     (hf : ContractingWith K <| hsf.restrict f s s)
     {x y : α} (hxs : x ∈ s) (hys : y ∈ s) (hx : IsFixedPt f x) (hy : IsFixedPt f y) :
@@ -58,18 +60,21 @@ noncomputable def fixedPoint' {s : Set α} (hsc : IsClosed s) (hs' : s.Nonempty)
   _root_.ContractingWith.efixedPoint' f hsc.isComplete hsf hf
     (Exists.choose hs') (Exists.choose_spec hs') (edist_ne_top (Exists.choose hs') _)
 
+/-- The constructed fixed point lies in the invariant set. -/
 theorem fixedPoint'_mem {s : Set α} (hsc : IsClosed s) (hs' : s.Nonempty)
     (hsf : MapsTo f s s) (hf : ContractingWith K <| hsf.restrict f s s) :
     fixedPoint' f hsc hs' hsf hf ∈ s :=
   _root_.ContractingWith.efixedPoint_mem' hsc.isComplete hsf hf
     (Exists.choose_spec hs') (edist_ne_top (Exists.choose hs') _)
 
+/-- The constructed point is genuinely fixed by `f`. -/
 theorem fixedPoint'_isFixedPt {s : Set α} (hsc : IsClosed s) (hs' : s.Nonempty)
     (hsf : MapsTo f s s) (hf : ContractingWith K <| hsf.restrict f s s) :
     IsFixedPt f (fixedPoint' f hsc hs' hsf hf) :=
   _root_.ContractingWith.efixedPoint_isFixedPt' hsc.isComplete hsf hf
     (Exists.choose_spec hs') (edist_ne_top (Exists.choose hs') _)
 
+/-- Any fixed point of `f` in the invariant set is the constructed one. -/
 theorem fixedPoint'_unique {s : Set α} (hsc : IsClosed s) (hs' : s.Nonempty)
     (hsf : MapsTo f s s) (hf : ContractingWith K <| hsf.restrict f s s)
     {x : α} (hxs : x ∈ s) (hx : IsFixedPt f x) :

--- a/HexRootsMathlib/Loop.lean
+++ b/HexRootsMathlib/Loop.lean
@@ -438,7 +438,9 @@ theorem refineFastLoop_ready_disjoint {p : Hex.ZPoly} {target : Int}
             simpa [Hex.IsolationLoop.disjoint] using hemit.1.1.2⟩
         · exact ih hloop
 
-private theorem list_mapM_some_get { α β : Type* } {f : α → Option β}
+/-- An option-valued list map that succeeds preserves length and maps
+corresponding entries. -/
+private theorem list_mapM_some_get {α β : Type*} {f : α → Option β}
     {xs : List α} {ys : List β} (hmap : xs.mapM f = some ys) :
     xs.length = ys.length ∧
       ∀ (i : Nat) (hi : i < xs.length) (hj : i < ys.length),
@@ -469,7 +471,10 @@ private theorem list_mapM_some_get { α β : Type* } {f : α → Option β}
                     simp only [List.getElem_cons_succ]
                     exact hget i (by simpa using hi) (by simpa using hj)
 
-private theorem array_mapM_some_get { α β : Type* } {f : α → Option β}
+/-- An option-valued array map that succeeds preserves size and maps
+corresponding entries.  Shared plumbing for the isolation-loop soundness
+proofs here and in `NKDriver`, `Isolate`, and `HexNumberFieldMathlib`. -/
+theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
     {xs : Array α} {ys : Array β} (hmap : xs.mapM f = some ys) :
     xs.size = ys.size ∧
       ∀ (i : Nat) (hi : i < xs.size) (hj : i < ys.size),
@@ -781,6 +786,7 @@ theorem finishAllAtoms_covers {p : Hex.ZPoly} {target : Int}
                 · simp at hfinish
   · simp at hfinish
 
+/-- A successful atom-only finish emits only atom certificates. -/
 theorem finishAtoms_atoms {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
@@ -796,6 +802,8 @@ theorem finishAtoms_atoms {p : Hex.ZPoly} {target : Int}
       apply finishAllAtoms_atoms
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
+/-- A successful atom-only finish meets the target precision and emits
+pairwise-disjoint squares. -/
 theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
@@ -812,6 +820,8 @@ theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
       apply finishAllAtoms_ready_disjoint
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
+/-- With a preserving certifier, a successful atom-only finish covers every
+root covered by the input worklist. -/
 theorem finishAtoms_covers {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}

--- a/HexRootsMathlib/NKDriver.lean
+++ b/HexRootsMathlib/NKDriver.lean
@@ -23,59 +23,6 @@ namespace HexRootsMathlib
 
 noncomputable section
 
-/-- An option-valued list map that succeeds preserves length and maps
-corresponding entries. -/
-private theorem list_mapM_some_get {α β : Type*} {f : α → Option β}
-    {xs : List α} {ys : List β} (hmap : xs.mapM f = some ys) :
-    xs.length = ys.length ∧
-      ∀ (i : Nat) (hi : i < xs.length) (hj : i < ys.length),
-        f xs[i] = some ys[i] := by
-  induction xs generalizing ys with
-  | nil =>
-      simp at hmap
-      subst ys
-      simp
-  | cons x xs ih =>
-      cases hfx : f x with
-      | none => simp [hfx] at hmap
-      | some y =>
-          cases htail : xs.mapM f with
-          | none => simp [hfx, htail] at hmap
-          | some ys' =>
-              have heq : some (y :: ys') = some ys := by
-                simpa [hfx, htail] using hmap
-              have hys : ys = y :: ys' := by
-                exact (Option.some.inj heq).symm
-              subst ys
-              obtain ⟨hlen, hget⟩ := ih htail
-              constructor
-              · simp [hlen]
-              · intro i hi hj
-                cases i with
-                | zero => simpa using hfx
-                | succ i =>
-                    simp only [List.getElem_cons_succ]
-                    exact hget i (by simpa using hi) (by simpa using hj)
-
-/-- An option-valued array map that succeeds preserves size and maps
-corresponding entries. -/
-private theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
-    {xs : Array α} {ys : Array β} (hmap : xs.mapM f = some ys) :
-    xs.size = ys.size ∧
-      ∀ (i : Nat) (hi : i < xs.size) (hj : i < ys.size),
-        f xs[i] = some ys[i] := by
-  have hlist : xs.toList.mapM f = some ys.toList := by
-    calc
-      xs.toList.mapM f = Array.toList <$> xs.mapM f :=
-        Array.toList_mapM.symm
-      _ = some ys.toList := by rw [hmap]; rfl
-  obtain ⟨hlen, hget⟩ := list_mapM_some_get hlist
-  constructor
-  · simpa using hlen
-  · intro i hi hj
-    simpa only [← Array.getElem_toList] using hget i (by simpa using hi)
-      (by simpa using hj)
-
 /-- Every successful NK-only loop result is an NK atom. -/
 theorem isolateLoop_nk_atoms {p : Hex.ZPoly} {target : Int} {fuel : Nat}
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}

--- a/HexRootsMathlib/NKWitness.lean
+++ b/HexRootsMathlib/NKWitness.lean
@@ -194,6 +194,7 @@ theorem toComplex_residual (p : Hex.ZPoly) (s : Hex.DyadicSquare) (k : Nat) :
     NewtonKantorovich.ComplexSup →L[ℝ] NewtonKantorovich.ComplexSup :=
   NewtonKantorovich.ComplexSup.mul (inverseComplex p s)
 
+/-- Evaluation at the centre is the zeroth executable Taylor coefficient. -/
 theorem eval_center (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
     NewtonKantorovich.ComplexSup.eval (toPolyℂ p) (centerSup s) =
       NewtonKantorovich.ComplexSup.equiv
@@ -201,6 +202,8 @@ theorem eval_center (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
   rw [NewtonKantorovich.ComplexSup.eval, centerSup,
     ContinuousLinearEquiv.symm_apply_apply, coeff_zero]
 
+/-- Multiplying an executable Taylor coefficient by the approximate inverse
+gives the executable residual. -/
 theorem apply_residual (p : Hex.ZPoly) (s : Hex.DyadicSquare) (k : Nat) :
     NewtonKantorovich.ComplexSup.mul (inverseComplex p s)
         (NewtonKantorovich.ComplexSup.equiv
@@ -224,6 +227,8 @@ theorem norm_residual (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
     ← GaussDyadic.toReal_lo]
   rfl
 
+/-- The approximate inverse composed with the frozen centre derivative is
+multiplication by the first executable residual. -/
 theorem comp_deriv_center (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
     (approxInverse p s).comp
         (NewtonKantorovich.ComplexSup.evalDeriv (toPolyℂ p) (centerSup s)) =
@@ -256,12 +261,16 @@ theorem natDegree_lt_size (p : Hex.ZPoly) (hp : 0 < p.size) :
 @[expose] def shifted (p : Hex.ZPoly) (s : Hex.DyadicSquare) : Polynomial ℂ :=
   Polynomial.taylor (DyadicSquare.center s) (toPolyℂ p)
 
+/-- Coefficients of the recentred polynomial are the executable Taylor
+coefficients. -/
 theorem shifted_coeff (p : Hex.ZPoly) (s : Hex.DyadicSquare) (k : Nat) :
     (shifted p s).coeff k =
       GaussDyadic.toComplex ((coeffs p s).getD k (0, 0)) := by
   rw [shifted, Polynomial.taylor_apply, DyadicSquare.center_eq, coeffs]
   exact (taylor_coeff p s.center k).symm
 
+/-- The recentred derivative evaluates the original derivative at the
+translated point. -/
 theorem shifted_deriv (p : Hex.ZPoly) (s : Hex.DyadicSquare) (δ : ℂ) :
     (shifted p s).derivative.eval δ =
       (toPolyℂ p).derivative.eval (DyadicSquare.center s + δ) := by
@@ -373,6 +382,8 @@ theorem norm_term_le (d : Hex.GaussDyadic) (δ : ℂ) (k : Nat)
     NewtonKantorovich.ComplexSup.equiv (delta s x) = x - centerSup s := by
   simp [delta, centerSup, map_sub]
 
+/-- The complex displacement is at most `√2` times the sup-norm
+displacement from the centre. -/
 theorem norm_delta_le (s : Hex.DyadicSquare)
     (x : NewtonKantorovich.ComplexSup) :
     ‖delta s x‖ ≤ √2 * ‖x - centerSup s‖ := by
@@ -383,6 +394,8 @@ theorem norm_delta_le (s : Hex.DyadicSquare)
       rw [NewtonKantorovich.ComplexSup.norm_equiv]
     _ = _ := by rw [equiv_delta]
 
+/-- Inside the half-width sup ball, the complex displacement stays below
+the executable upper radius bound. -/
 theorem norm_delta_le_radiusHi (s : Hex.DyadicSquare)
     (x : NewtonKantorovich.ComplexSup)
     (hx : ‖x - centerSup s‖ ≤ DyadicSquare.halfWidth s) :
@@ -465,6 +478,7 @@ theorem deriv_lipschitz (p : Hex.ZPoly) (s : Hex.DyadicSquare)
   norm_num [pow_two]
   ring
 
+/-- The executable Lipschitz bound `z2` is nonnegative. -/
 theorem toReal_z2_nonneg (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
     0 ≤ Dyadic.toReal (z2 p s) := by
   rw [z2, Dyadic.toReal_mul, Dyadic.toReal_two, toReal_z2Sum]
@@ -489,14 +503,17 @@ theorem. -/
     rw [← norm_residual]
     positivity⟩
 
+/-- The executable derivative-defect bound `z1` as a nonnegative real. -/
 @[expose] def z1NN (p : Hex.ZPoly) (s : Hex.DyadicSquare) : NNReal :=
   ⟨Dyadic.toReal (z1 p s), by
     rw [← norm_defect]
     positivity⟩
 
+/-- The executable Lipschitz bound `z2` as a nonnegative real. -/
 @[expose] def z2NN (p : Hex.ZPoly) (s : Hex.DyadicSquare) : NNReal :=
   ⟨Dyadic.toReal (z2 p s), toReal_z2_nonneg p s⟩
 
+/-- The square's half-width as a nonnegative real. -/
 @[expose] def radiusNN (s : Hex.DyadicSquare) : NNReal :=
   ⟨DyadicSquare.halfWidth s, by
     rw [DyadicSquare.halfWidth_eq]
@@ -563,6 +580,8 @@ theorem existsUnique_root_sup {p : Hex.ZPoly} {s : Hex.DyadicSquare}
   · exact hyr.le
   · exact hzr
 
+/-- Closed-square membership is the sup-norm closed-ball inequality in the
+two-coordinate model. -/
 theorem mem_closedSquare_iff (s : Hex.DyadicSquare) (z : ℂ) :
     z ∈ DyadicSquare.closedSquare s ↔
       ‖NewtonKantorovich.ComplexSup.equiv z - centerSup s‖ ≤
@@ -572,6 +591,8 @@ theorem mem_closedSquare_iff (s : Hex.DyadicSquare) (z : ℂ) :
   rw [← NewtonKantorovich.ComplexSup.norm_equiv, map_sub]
   rfl
 
+/-- Open-square membership is the strict sup-norm ball inequality in the
+two-coordinate model. -/
 theorem mem_openSquare_iff (s : Hex.DyadicSquare) (z : ℂ) :
     z ∈ DyadicSquare.openSquare s ↔
       ‖NewtonKantorovich.ComplexSup.equiv z - centerSup s‖ <

--- a/HexRootsMathlib/Pellet.lean
+++ b/HexRootsMathlib/Pellet.lean
@@ -26,26 +26,6 @@ namespace HexRootsMathlib
 
 noncomputable section
 
-/-- Writing an omitted summand as an erased range or as an `if` gives the
-same finite sum. -/
-private theorem sum_erase_range {M : Type*} [AddCommMonoid M]
-    (f : ℕ → M) (n k : ℕ) :
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-      ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-  classical
-  calc
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-        ∑ i ∈ (Finset.range n).filter (fun i => i ≠ k), f i := by
-      congr 1
-      ext i
-      simp [and_comm]
-    _ = ∑ i ∈ Finset.range n, if i ≠ k then f i else 0 := by
-      rw [Finset.sum_filter]
-    _ = ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-      apply Finset.sum_congr rfl
-      intro i hi
-      by_cases hik : i = k <;> simp [hik]
-
 /-- The coefficient-dominance hypothesis is exactly the boundary inequality
 needed by Rouché's theorem. -/
 private theorem pellet_norm_sub_lt {p : ℂ[X]} {n k : ℕ} {r : ℝ}

--- a/HexRootsMathlib/RootFree.lean
+++ b/HexRootsMathlib/RootFree.lean
@@ -89,24 +89,6 @@ private theorem eval_ne_zero_of_dominates {q : Polynomial ℂ} {z : ℂ} {n : Na
         rw [norm_mul, norm_pow]
   exact (hcoeff.trans_lt hdom).false
 
-private theorem sum_erase_range {M : Type*} [AddCommMonoid M]
-    (f : ℕ → M) (n k : ℕ) :
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-      ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-  classical
-  calc
-    (∑ i ∈ (Finset.range n).erase k, f i) =
-        ∑ i ∈ (Finset.range n).filter (fun i => i ≠ k), f i := by
-      congr 1
-      ext i
-      simp [and_comm]
-    _ = ∑ i ∈ Finset.range n, if i ≠ k then f i else 0 := by
-      rw [Finset.sum_filter]
-    _ = ∑ i ∈ Finset.range n, if i = k then 0 else f i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      by_cases hik : i = k <;> simp [hik]
-
 /-- A successful root-exclusion test can only occur for a nonempty stored
 polynomial. -/
 theorem exactRootFree_size_pos {p : Hex.ZPoly} {s : Hex.DyadicSquare}

--- a/HexRootsMathlib/SimpleRoot.lean
+++ b/HexRootsMathlib/SimpleRoot.lean
@@ -44,6 +44,7 @@ theorem root_spec {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
         w ∈ DyadicRootIsolation.region i.1 → w = root i :=
   (DyadicRootIsolation.sound i.1).choose_spec
 
+/-- The selected value is a root. -/
 theorem isRoot {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
     (toPolyℂ p).IsRoot (root i) :=
   (root_spec i).1
@@ -200,14 +201,6 @@ theorem intersects_equivalence {p : Hex.ZPoly} :
     exact (intersects_iff_root_eq i k).mpr <|
       (intersects_iff_root_eq i j).mp hij |>.trans
         ((intersects_iff_root_eq j k).mp hjk)
-
-/-- Executable simple-root input supplies the separation hypothesis needed by
-the intersection semantics. -/
-theorem intersects_iff_root_eq_of_simple {p : Hex.ZPoly}
-    (_h : Hex.HasOnlySimpleRoots p) (_hp : p ≠ 0)
-    (i₁ i₂ : Hex.RefinedIsolation p) :
-    Hex.Intersects i₁ i₂ ↔ root i₁ = root i₂ :=
-  intersects_iff_root_eq i₁ i₂
 
 end RefinedIsolation
 

--- a/HexRootsMathlib/SoftPellet.lean
+++ b/HexRootsMathlib/SoftPellet.lean
@@ -763,7 +763,10 @@ theorem graeffe_enclosePoly {cs : Array Hex.CoeffBall} {q : ℂ[X]}
 
 /-! # Soundness of a soft coefficient comparison -/
 
-private theorem sum_erase_range {M : Type*} [AddCommMonoid M]
+/-- Writing an omitted summand as an erased range or as an `if` gives the
+same finite sum.  Shared by the Pellet-style dominance arguments downstream
+(`RootFree`, `Pellet`, `Completeness.PelletDyadic`). -/
+theorem sum_erase_range {M : Type*} [AddCommMonoid M]
     (f : ℕ → M) (n k : ℕ) :
     (∑ i ∈ (Finset.range n).erase k, f i) =
       ∑ i ∈ Finset.range n, if i = k then 0 else f i := by

--- a/progress/2026-08-22T05-14-41Z.md
+++ b/progress/2026-08-22T05-14-41Z.md
@@ -1,0 +1,51 @@
+# HexRootsMathlib Phase-6 polishing pass (#9384)
+
+## Accomplished
+
+- De-duplicated `sum_erase_range`: kept one public copy in
+  `HexRootsMathlib/SoftPellet.lean` (with docstring), deleted the verbatim
+  copies in `Pellet.lean`, `RootFree.lean`, and a fourth the review missed
+  in `Completeness/PelletDyadic.lean`.
+- De-duplicated `list_mapM_some_get` / `array_mapM_some_get`: hoisted to
+  `Loop.lean` (the upstream-most module `NKDriver` and `Isolate` both
+  transitively import), made the array form public with a docstring,
+  deleted the copies in `NKDriver.lean` and `Isolate.lean`.
+  `array_mapM_isSome` stays public in `Isolate.lean` with a docstring
+  justification (consumed by `HexNumberFieldMathlib`).
+- Deleted the vacuous alias `intersects_iff_root_eq_of_simple`
+  (`SimpleRoot.lean`); repointed its single call site
+  (`HexNumberFieldMathlib/Basic.lean`) at `intersects_iff_root_eq` and
+  dropped the now-unneeded local `hpne` derivation.
+- `ArgumentTopology.lean`: deleted the six redundant global-`Continuous`
+  wrappers (`continuous_normalizedCircleIntegral`,
+  `continuous_normalizedCircleIntegral_div`, `continuous_nat_of_cast`,
+  `continuous_nat_of_complexCast`, `continuous_int_of_cast`,
+  `continuous_int_of_complexCast`); kept the `ContinuousOn` chain the
+  Rouché development consumes and the two endpoint termini with justifying
+  docstrings.
+- Dead-declaration review: deleted `reciprocal_sub`
+  (`CircleIntegralLemmas.lean`), the private dead
+  `worklist_covers_iff_region` (`Completeness/DriverCompleteness.lean`),
+  and the self-described convenience wrapper
+  `exists_root_lt_three_radius_of_not_rootFree`
+  (`Completeness/RootFreeConverse.lean`). Kept the per-entry-point
+  mirrors, `@[simp]` automation lemmas, and slice termini among the
+  remaining candidates, adding docstrings where missing
+  (`closedSquare_eq_supClosedBall`, `toComponent_count_pos`,
+  `pellet_one_comp_dominates`).
+- Docstring sweep: added docstrings to all previously undocumented public
+  defs and substantive theorems (Examples, NKWitness, Kantorovich, Loop,
+  Geometry, Glue, Component, NKRecertification, Isolate, SimpleRoot).
+
+## Current frontier
+
+`lake build HexRootsMathlib HexNumberFieldMathlib HexReleaseTests` green;
+`scripts/check_dag.py` and `git diff --check` clean.
+
+## Next step
+
+Merge via PR; remaining #9384 non-code follow-ups (if any) tracked there.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR execute the Phase-6 polishing pass for HexRootsMathlib, closing the code items of #9384. The triplicated private helpers consolidate to single upstream copies (`sum_erase_range` in SoftPellet, where a fourth copy the review missed also fell; the `mapM` extraction lemmas in Loop, with the array form public and documented for its HexNumberFieldMathlib consumers). The vacuously-hypothesised alias `intersects_iff_root_eq_of_simple` is deleted with its one call site repointed at the unconditional theorem. ArgumentTopology loses its six global-`Continuous` wrappers and their two orphaned feeders (the Rouché development is inherently `ContinuousOn`) while keeping the consumed chain and both documented termini. The review's dead-declaration candidates were each repo-wide-grepped: three thin wrappers deleted, the rest kept as per-entry-point mirrors, automation partners, or documented slice termini, with docstrings added where the interface role was silent. ~55 docstrings land across the public surface, leaving only self-documenting `@[simp]` unfolding lemmas per the routine-plumbing exemption. Build green at 9336 jobs including HexNumberFieldMathlib and HexReleaseTests; the `done_through: 6` bump follows in the serialized queue.

Closes #9384

🤖 Prepared with Claude Code