### PR TITLE
Remove redundant FactorTactic extension ABI versioning

### DIFF
--- a/HexBerlekamp/PolynomialTactic.lean
+++ b/HexBerlekamp/PolynomialTactic.lean
@@ -37,9 +37,8 @@ An extension module must `public meta import HexBerlekamp.PolynomialTactic`
 because the constructor of `Extension` is meta code, and must declare its
 extension as a `public meta def`. Its registration comment names
 `extensionNames`, and regression tests ensure that the declaration remains
-discoverable after renaming. The `version` field is checked against
-`Extension.abiVersion` before use, so an extension compiled against an
-incompatible interface fails with an explicit error.
+discoverable after renaming. The driver checks that every discovered
+declaration has type `Extension` before evaluating it.
 -/
 
 namespace Hex.FactorTactic
@@ -62,17 +61,12 @@ term hooks are the original syntax, the elaborated polynomial, its
 `whnfR`-normalized type, and the expected type of the surrounding
 elaboration. -/
 meta structure Extension where
-  /-- ABI guard, checked against `Extension.abiVersion` at trial time. -/
-  version : Nat
   /-- Handle a `factor_poly p` term elaboration. -/
   factorPoly? : Syntax → Expr → Expr → Option Expr → Term.TermElabM ExtensionResult
   /-- Handle an `irreducibility p` term elaboration. -/
   irreducibility? : Syntax → Expr → Expr → Option Expr → Term.TermElabM ExtensionResult
   /-- Handle goal-closing `irreducibility` on the given goal. -/
   goalIrred? : MVarId → Tactic.TacticM ExtensionResult
-
-/-- Interface version expected by the tactic driver. -/
-meta def Extension.abiVersion : Nat := 2
 
 /-- Well-known extension constants, checked in order. Downstream libraries
 declare a `public meta def` of type `Extension` under one of these names;
@@ -89,7 +83,7 @@ private meta unsafe def evalExtensionUnsafe (n : Name) : MetaM Extension :=
 private meta opaque evalExtensionCore (n : Name) : MetaM Extension
 
 /-- All extensions present in the current environment, in lookup order, with
-the declared type and ABI version checked before use. -/
+the declared type checked before use. -/
 meta def extensions : MetaM (List Extension) := do
   let env ← getEnv
   let mut found := []
@@ -99,10 +93,6 @@ meta def extensions : MetaM (List Extension) := do
         throwError "factor_poly/irreducibility: extension {n} has unexpected \
             type{indentExpr info.type}"
       let ext ← evalExtensionCore n
-      unless ext.version == Extension.abiVersion do
-        throwError "factor_poly/irreducibility: extension {n} has ABI version \
-            {ext.version}, but this driver expects {Extension.abiVersion}; \
-            rebuild the extension library against the current HexBerlekamp"
       found := found ++ [ext]
   return found
 

--- a/HexBerlekampMathlib/FactorTactic.lean
+++ b/HexBerlekampMathlib/FactorTactic.lean
@@ -378,7 +378,6 @@ open Lean Elab
 `Hex.FactorTactic.extensionNames`; the registration tests fail if a rename makes
 the extension undiscoverable. -/
 public meta def extension : Hex.FactorTactic.Extension where
-  version := Hex.FactorTactic.Extension.abiVersion
   factorPoly? := fun _stx eP ty _expectedType? =>
     withZModInput "factor_poly" ty fun q inst hpt qE =>
       @elabFactorZMod "factor_poly" q inst hpt qE eP

--- a/HexBerlekampZassenhaus/FactorTactic.lean
+++ b/HexBerlekampZassenhaus/FactorTactic.lean
@@ -318,7 +318,6 @@ open Lean Elab
 `Hex.FactorTactic.extensionNames`; the free and integration regression tests
 fail if a rename makes the extension undiscoverable. -/
 public meta def extension : Hex.FactorTactic.Extension where
-  version := Hex.FactorTactic.Extension.abiVersion
   factorPoly? := fun _stx pE ty _expectedType? => do
     match ← Hex.FactorTactic.classify ty with
     | .zpoly _ zeroE decE => factorPolyZPoly zeroE decE pE

--- a/HexBerlekampZassenhausMathlib/FactorTactic.lean
+++ b/HexBerlekampZassenhausMathlib/FactorTactic.lean
@@ -510,7 +510,6 @@ open Lean Elab
 the extension undiscoverable. Checked after the free `Hex.ZPoly`
 extension, so its `ZPoly` arms only see inputs the free layer declined. -/
 public meta def extension : Hex.FactorTactic.Extension where
-  version := Hex.FactorTactic.Extension.abiVersion
   factorPoly? := fun _stx eP ty _expectedType? => do
     match ← Hex.FactorTactic.classify ty with
     | .zpoly _ _ _ => factorZPolyStrong eP

--- a/progress/20260822T055750Z_issue-9420.md
+++ b/progress/20260822T055750Z_issue-9420.md
@@ -14,16 +14,23 @@
   successfully. The release tests exercise native `FpPoly`, free and strong
   `ZPoly`, and both Mathlib extension paths across term, tactic, goal, negative,
   and registration cases.
+- Opened PR #9421 after rebasing onto current `main`; an independent review
+  found no substantive concerns.
+- Diagnosed the first CI run's factor-sweep freshness failure and recorded
+  exact-blob runtime exemptions for the two meta-only tactic files, whose
+  changes cannot affect the benchmarked `Hex.ZPoly.factorize` entry.
+- Rebased onto the latest `main` after PR #9377 landed, retaining its newer
+  `lakefile.lean` freshness attestation alongside the two tactic exemptions.
 
 ## Current frontier
 
-- The implementation for issue #9420 is locally complete and verified on branch
-  `issue-9420`.
+- The implementation and CI freshness repair are rebased onto the latest
+  `main` on branch `issue-9420`.
 
 ## Next step
 
-- Open the PR, obtain the requested independent review while CI runs, address
-  any findings or CI failures, and enable squash auto-merge once green.
+- Reverify the rebased tree, push it, monitor the replacement Actions run, and
+  enable squash auto-merge once green.
 
 ## Blockers
 

--- a/progress/20260822T055750Z_issue-9420.md
+++ b/progress/20260822T055750Z_issue-9420.md
@@ -1,0 +1,30 @@
+# FactorTactic extension ABI-version cleanup
+
+## Accomplished
+
+- Removed the manual `version` field from `Hex.FactorTactic.Extension`, the
+  `Extension.abiVersion` constant, and the runtime version comparison and
+  diagnostic.
+- Removed the version assignment from the registered `Hex.ZPoly`,
+  `Polynomial (ZMod q)`, and `Polynomial ℤ` extensions.
+- Updated the interface documentation to describe the retained declaration-type
+  validation instead of an ABI-version guard.
+- Confirmed that no factor-tactic ABI-version identifier or prose remains.
+- Built the four changed modules, `HexReleaseTests`, and the full repository
+  successfully. The release tests exercise native `FpPoly`, free and strong
+  `ZPoly`, and both Mathlib extension paths across term, tactic, goal, negative,
+  and registration cases.
+
+## Current frontier
+
+- The implementation for issue #9420 is locally complete and verified on branch
+  `issue-9420`.
+
+## Next step
+
+- Open the PR, obtain the requested independent review while CI runs, address
+  any findings or CI failures, and enable squash auto-merge once green.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -690,6 +690,18 @@
     "reason": "Adds the unrelated HexSparsePoly lean_lib, two interval experiment/conformance globs, and the interval typed-runtime and executable-controller conformance globs; the hexbz_factor_service target, BZ library targets, and build flags are unchanged."
   },
   {
+    "path": "HexBerlekamp/PolynomialTactic.lean",
+    "baseline_blob": "d8232a738edfc3735c099eba5f362a4a30fcafcd",
+    "current_blob": "2d501f2ff596cfd0ddeeaacf08bbe407a4dc8c18",
+    "reason": "Removes the meta-only factor-tactic extension version field, constant, and discovery check and updates their documentation; the benchmarked Hex.ZPoly.factorize entry does not invoke tactic elaboration or extension discovery, so its executable behavior is unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/FactorTactic.lean",
+    "baseline_blob": "cdcfd422598d4c0ae7c6fa9f8f90a780cbcf57f1",
+    "current_blob": "fa093db4b7244a8c42005c479c9aa1ffcc40fa9f",
+    "reason": "Removes only the meta extension's version initializer; no executable factorization definition used by the benchmarked Hex.ZPoly.factorize entry changes."
+  },
+  {
     "path": "lakefile.lean",
     "baseline_blob": "c523b56fcf7249235b710bc86792042a57c4e26e",
     "current_blob": "dcb37c10309b6da8453022b47b27f680508177fe",


### PR DESCRIPTION
## Summary

- remove the redundant `Extension.version` field and `Extension.abiVersion` constant
- retain declaration-type validation and existing `ExtensionResult` dispatch
- remove version assignments from all three registered factor-tactic extensions and update interface documentation
- record exact-blob benchmark freshness exemptions for the two meta-only tactic files, which cannot affect the measured `Hex.ZPoly.factorize` entry

## Testing

- `lake build HexBerlekamp.PolynomialTactic`
- `lake build HexBerlekampZassenhaus.FactorTactic`
- `lake build HexBerlekampMathlib.FactorTactic`
- `lake build HexBerlekampZassenhausMathlib.FactorTactic`
- `lake build HexReleaseTests`
- `lake build`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `uv run --with matplotlib==3.11.1 python scripts/plots/hexbz-cactus.py --check`
- repository scan confirms no factor-tactic `abiVersion`, extension version assignment, or ABI-version prose remains

Closes #9420
