### PR TITLE
chore: record NumberField cluster Phases 1-3, bump to 3/2/3/2

### DIFF
--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -144,8 +144,10 @@ Structural equality on factorization-lazy `AlgebraicRoot` is finer than equality
 of represented complex values. `AlgebraicPoly` owns the required semantic
 trimming without exporting an unjustified `DecidableEq`. That Boolean
 operation is `AlgebraicPoly.beq` (with its `BEq` instance): coefficientwise
-canonical equality over the trimmed data, faithful on canonical coefficients
-because `AlgebraicNumber` equality is canonical. `coeff n` is the canonical
+canonical equality over the trimmed data. Its faithfulness on canonical
+coefficients follows from the companion's `LawfulBEq AlgebraicNumber`
+plus trimming; packaging that as an `AlgebraicPoly.beq_iff` is Phase-6
+work (#9418). `coeff n` is the canonical
 coefficient (`0` beyond the degree) and `size` is the trimmed length backing
 `degree?`; all three are exercised by the module's compiled regressions.
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -614,22 +614,22 @@ libraries:
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
     mathlib: false
-    done_through: 0
+    done_through: 3
     status: active
   HexNumberFieldMathlib:
     deps: [HexNumberField, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRootsMathlib, HexPolyZMathlib]
     mathlib: true
-    done_through: 0
+    done_through: 2
     status: active
   HexNumberFieldTower:
     deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus]
     mathlib: false
-    done_through: 0
+    done_through: 3
     status: active
   HexNumberFieldTowerMathlib:
     deps: [HexNumberFieldTower, HexNumberFieldMathlib, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRowReduceMathlib]
     mathlib: true
-    done_through: 0
+    done_through: 2
     status: active
   HexRealRoots:
     deps: [HexPolyZ]

--- a/progress/20260822T100000Z_number-field-attestations.md
+++ b/progress/20260822T100000Z_number-field-attestations.md
@@ -1,0 +1,40 @@
+# NumberField cluster Phase 1-3 attestations
+
+## Accomplished
+
+- Distilled the two 2026-08-22 non-author Phase-2 confirmation reviews
+  (run after the #9393 SPEC reconciliation and #9403 correspondence
+  surface) into four substantive scaffolding-reviewed tokens: no
+  blocking gaps anywhere; zero banned markers across all 24+18
+  modules; every SPEC-declared item present unweakened; the panicWith
+  branches verified as genuinely eliminated; the companion's 23
+  build-enforced axiom guards and 24 rfl pinning regressions
+  confirmed; conformance and oracle paths verified CI-reachable with
+  the SPEC's adversarial cases present by name.
+- Filed the hygiene findings as Phase-6 issues #9418 (NumberField
+  pair) and #9419 (Tower pair), and softened the executable SPEC's
+  beq faithfulness sentence to point at the packaging work rather
+  than assert an undischarged claim.
+- Advanced the counters per the wave bump queue: HexNumberField and
+  HexNumberFieldTower 0 -> 3 (Phase 3's dep coupling is satisfied with
+  HexBerlekampZassenhaus at 4 on this branch), HexNumberFieldMathlib
+  and HexNumberFieldTowerMathlib 0 -> 2 (their Phase 3 waits on
+  HexBerlekampZassenhausMathlib reaching 3). Phase 1 was complete but
+  never recorded for all four; the tokens say so.
+- Recorded in each token that check_trust_surface.py does not yet
+  cover these unpublished libraries, so the direct sweeps and
+  build-enforced guards are the operative evidence.
+
+## Current frontier
+
+- The computational pair now needs its Phase-4 evidence (wave task
+  C16); the bridges wait on BZMathlib Phase 3 (wave task B8).
+
+## Next step
+
+- C16 Phase-4 evidence build for HexNumberField and
+  HexNumberFieldTower; B8 conformance decision for BZMathlib.
+
+## Blockers
+
+- This PR stacks on the BZ Phase-4 PR (#9417) for the dep coupling.

--- a/status/hex-number-field-mathlib.scaffolding-reviewed
+++ b/status/hex-number-field-mathlib.scaffolding-reviewed
@@ -1,0 +1,44 @@
+Phase-2 scaffolding review of HexNumberFieldMathlib, 2026-08-22,
+performed by a non-author reviewer agent against
+HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md at origin/main
+after the #9393 SPEC reconciliation (review basis 93ac1edbf).
+
+Audit lenses: SPEC-declaration coverage against the refreshed
+16-module table, statement-weakening comparison for every declared
+theorem, banned-marker sweep, trust-surface verification, instance
+coherence, module reachability, CI reachability.
+
+Results. The 16-module table matches the tree exactly and every module
+is reachable from the umbrella (traced edge by edge; the lean_lib has
+no globs, so an orphan would silently not build). Every SPEC-declared
+theorem exists unweakened: the semantic maps and injectivity, the
+equality/zero/approximation family (refineTo?_isSome carrying the
+SPEC's explicit nkThenPellet strategy), canonicalization and
+exactification, the full five-operation lazy soundness/completeness/
+correspondence families plus unconditional negation, the root API with
+the four finite-output obligations proved at both the
+algebraic-coefficient and fixed-field levels, and both an _isSome and
+a _sound for every option-valued Common-field declaration. Banned
+markers are zero. The trust surface is build-enforced: 23
+guard_msgs-pinned #print axioms checks, each exactly
+[propext, Classical.choice, Quot.sound], covering the headline
+results. Instance coherence is exemplary: the Field instance pins
+every data field, an OperationRegression section disables the
+standalone executable instances and re-derives all twelve operations
+by rfl plus the numeral normal form, the QAdjoin side carries eleven
+more rfl pins including the SPEC-required rational action, the
+noncomputable dictionary is scoped, and a canary example fails
+elaboration if Mathlib derivation ever displaces the executable
+operations (24 rfl pinning regressions in total).
+
+Trust-surface note: scripts/release/check_trust_surface.py does not
+yet cover this library (unpublished); the operative evidence is the
+direct sweep and the 23 build-enforced axiom guards above.
+
+Findings and dispositions. No blocking gap. Hygiene findings (the
+verbatim rename re-export refineTo?_isSome, Common.extendStep declared
+into the executable namespace from this layer, fromAdjoinRoot's single
+call site, two missing nsmul/zsmul rfl pins, SPEC-surface omissions
+for consumed proof infrastructure) are filed as issue #9418 for the
+Phase-6 pass. Phase 1 was complete but never recorded; the counter
+advances with this token per the wave bump queue.

--- a/status/hex-number-field-tower-mathlib.scaffolding-reviewed
+++ b/status/hex-number-field-tower-mathlib.scaffolding-reviewed
@@ -1,0 +1,44 @@
+Phase-2 scaffolding review of HexNumberFieldTowerMathlib, 2026-08-22,
+performed by a non-author reviewer agent against
+HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md at
+origin/main after #9393 and the #9403 correspondence surface (review
+basis 93ac1edbf).
+
+Audit lenses: SPEC-declaration coverage including the newly landed
+items; Sound-predicate strength comparison against the SPEC's claims;
+banned-marker sweep; instance-coherence audit over the scoped
+dictionary; DAG and file-organisation verification.
+
+Results. Every SPEC-declared item exists as the SPEC now words it:
+eval?/toComplex with injectivity, the map_add/map_mul/map_inv family,
+coordEquiv with all four LinearEquiv fields, toField and
+dim_eq_finrank via coordEquiv.finrank_eq, the scoped
+Lean.Grind.Field delegation to Field.toGrindField beside the field
+instance, and the embedAlgHom family under
+Extension.PreservesEmbedding with both the algebra-hom packaging and
+injectivity. All four Sound/isSome pairs plus flatten_toComplex are
+present and strong: Factorization.Sound includes scalar-bearing
+reconstruction, monicity, positive multiplicity, PolynomialIrreducible
+(proved equivalent to Mathlib Irreducible over the scoped field), and
+strict ordering; Extension.Sound carries the identity-extension
+biconditional; Splitting.Sound the zero-polynomial iff and GeneratedBy
+minimality; Flattening.Sound both round trips, both complex-value
+agreements, and the arithmetic laws including inverses. The Trager
+step rewrites with HexResultantMathlib's Stage-2 toPolynomial_resultant
+and the root-product formula at six sites, not the vanishing-only
+Stage 1 the SPEC calls insufficient. Exactly three instances exist in
+the library, all scoped in TowerField (Field, CharZero, Grind.Field);
+consumers opt in explicitly, and the qsmul slot resolves to the
+executable rational action with the coherence stated by rfl. Banned
+markers are zero; imports match the declared dependency line exactly;
+the 13-entry file table matches the tree with every module reachable.
+
+Trust-surface note: scripts/release/check_trust_surface.py does not
+yet cover this library (unpublished); the operative evidence is the
+direct zero-hit sweep and the axiom checks recorded with #9403.
+
+Findings and dispositions. No blocking gap. Hygiene findings (six
+unreferenced non-simp lemmas, the no-associates derivation note) are
+filed as issue #9419 for the Phase-6 pass. Phase 1 was complete but
+never recorded; the counter advances with this token per the wave
+bump queue.

--- a/status/hex-number-field-tower.scaffolding-reviewed
+++ b/status/hex-number-field-tower.scaffolding-reviewed
@@ -1,0 +1,47 @@
+Phase-2 scaffolding review of HexNumberFieldTower, 2026-08-22,
+performed by a non-author reviewer agent against
+HexNumberFieldTower/SPEC/hex-number-field-tower.md at origin/main
+after the #9393 SPEC reconciliation (review basis 93ac1edbf).
+
+Audit lenses: SPEC-declaration coverage over the sealed types,
+instances, and the four option-valued public operations; banned-marker
+sweep including the extern and scaffold-language greps; data-level
+placeholder audit over the raw layer; panicWith discharge
+verification; CI reachability; naming and instance checks.
+
+Results. Every SPEC-declared item exists with a matching signature:
+the sealed NumberTower and Elem (structure with private mk, the SPEC's
+opaque-as-boundary convention), all nine instances, Extension with its
+four fields, ofQAdjoin with all four hypotheses including the explicit
+HasOnlySimpleRoots, the Factorization/Roots/Splitting/Flattening
+records, and option-valued adjoin?/factor?/split?/flatten?. The raw
+layer is genuine throughout: mixed-radix convolve/reduce with
+descending monic reduction and proved width invariants, Yun-first
+factorRaw? with per-component tail recursion honouring the SPEC's
+mandatory no-whole-norm rule, and the exact
+choose(d*m,2)+1 Trager shift fuel. The two panicWith branches in
+RawArithmetic are genuinely eliminated, not annotated: the companion's
+xgcdLeft_size_one and the leading-coefficient nonvanishing argument
+let denote_invCoords rewrite past both branches
+(HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean). Banned markers
+are zero; there is no extern surface and no Mathlib import. The type
+system enforces the embedding invariant: Level.Certificate carries the
+irreducibility and fixed-embedding checks, and Internal.extend? is the
+only admitter of the private constructor. CI reachability holds
+through HEX_LIB_TARGETS, 47 in-library #guards (including the
+declaration-free Embed regression module with its adversarial
+negative-conjugate and non-unit-leading cases), the 27-guard
+conformance driver with the SPEC's intermediate-field adversarial
+case, and the cypari2 nfinit/nffactor oracle under
+HEX_REQUIRE_ORACLES.
+
+Trust-surface note: scripts/release/check_trust_surface.py does not
+yet cover this library (unpublished); the operative evidence is the
+direct zero-hit sweep above.
+
+Findings and dispositions. No blocking gap. Hygiene findings (the
+dead elemMajorant, Factor.yun?'s guard-only status, the SMul Rat
+instance missing from the SPEC list, the derived-not-stated
+no-associates clause) are filed as issue #9419 for the Phase-6 pass.
+Phase 1 was complete but never recorded; the counter advances with
+this token per the wave bump queue.

--- a/status/hex-number-field.scaffolding-reviewed
+++ b/status/hex-number-field.scaffolding-reviewed
@@ -1,0 +1,43 @@
+Phase-2 scaffolding review of HexNumberField, 2026-08-22, performed by
+a non-author reviewer agent against HexNumberField/SPEC/hex-number-field.md
+at origin/main after the #9393 SPEC reconciliation (review basis
+93ac1edbf).
+
+Audit lenses: SPEC-declaration coverage (including the new
+Common-field construction section and the specified beq/coeff/size
+surface), banned-marker sweep, data-level placeholder audit over every
+Option-returning def, native-numeric wrong-shape check, CI
+reachability, instance coherence, naming.
+
+Results. Every SPEC-declared declaration exists with a matching
+signature: the sealed AlgebraicNumber with all eight projections, the
+QAdjoin arithmetic and approx surfaces, the conversion and lazy
+layers, the disambiguation bound stack, both root APIs, and all
+seventeen Common-field declarations with the exact shift counts and
+trace formulas. Every guard-bit and precision constant was checked
+against the SPEC arithmetic (approxGuardBits, add/mul/inv guard bits,
+evalDisambiguationLimit, the sqrt-2-slack radius bound); every
+Option-returning def returns none only on genuine certification
+branches. Banned markers are zero across all modules; there is no
+extern surface and no native-numeric type. CI reachability holds four
+ways: HEX_LIB_TARGETS build, 37 in-module #guards, the 20-guard
+conformance driver in the HexConformance glob, and the
+cypari2/python-flint oracle path under HEX_REQUIRE_ORACLES with the
+SPEC's core cases all present by name. No deriving clause exists, so
+no structural equality leaks onto the sealed types; the checked
+instances carry their CheckedIrreducible hypotheses; the OfNat
+priority demotion is documented and companion-pinned.
+
+Trust-surface note: scripts/release/check_trust_surface.py walks only
+released repos and does not yet cover this library; the operative
+evidence is the direct zero-hit sweep above plus the companion's
+build-enforced axiom guards.
+
+Findings and dispositions. No blocking gap. Hygiene findings (the
+linear-time QAdjoin.natPow against repo precedent, the dead
+QAdjoin.mulMatrix, the extend?/extendShiftStep duplicated search and
+the companion-declared Common.extendStep it forces, the beq
+faithfulness packaging, minor SPEC-surface omissions for consumed
+public helpers) are filed as issue #9418 for the scheduled Phase-6
+pass. Phase 1 was complete but never recorded; the counter advances
+with this token per the wave bump queue.


### PR DESCRIPTION
This PR distill the two 2026-08-22 non-author Phase-2 confirmation reviews (run after the #9393 SPEC reconciliation and the #9403 correspondence surface) into four substantive scaffolding-reviewed tokens for the NumberField cluster and advance the counters per the wave bump queue. The reviews found no blocking gaps: zero banned markers across all modules, every SPEC-declared item present unweakened, the RawArithmetic `panicWith` branches verified as genuine eliminations through `denote_invCoords`, the companion's 23 build-enforced axiom guards and 24 rfl pinning regressions confirmed, and the conformance and oracle paths verified CI-reachable with the SPECs' adversarial cases present by name. Each token records that `check_trust_surface.py` does not yet cover these unpublished libraries, so the direct sweeps and build-enforced guards are the operative evidence. Hygiene findings file as #9418 and #9419 for the Phase-6 passes, and the executable SPEC's `beq` faithfulness sentence now points at the packaging work instead of asserting an undischarged claim. HexNumberField and HexNumberFieldTower advance 0 to 3 (Phase-3 dep coupling satisfied with BZ at 4 after #9417); the two companions advance 0 to 2 pending BZMathlib Phase 3. Phase 1 was complete but never recorded for all four.

🤖 Prepared with Claude Code