### PR TITLE
bench: add the number-field pair's Phase-4 ladders, PARI comparator, and declarations

### DIFF
--- a/Hex/BenchOracle/Pari.lean
+++ b/Hex/BenchOracle/Pari.lean
@@ -23,7 +23,7 @@ Environment overrides:
 
 namespace Hex.BenchOracle.Pari
 
-open Lean (Json)
+open Lean (Json JsonNumber)
 
 private abbrev PersistentComparator :=
   Hex.BenchOracle.Flint.PersistentComparator

--- a/Hex/BenchOracle/Pari.lean
+++ b/Hex/BenchOracle/Pari.lean
@@ -92,4 +92,68 @@ def runOp (family op : String) (fields : Array (String × Json)) : IO Json := do
   let reply ← sendRequestLine (Json.mkObj object.toList).compress
   resultOf family op reply
 
+/-- Encode an array of rationals as the driver's `[[num, den], ...]`
+JSON shape. `Rat` maintains `den > 0` and `gcd(num, den) = 1`, the
+normal form the protocol requires. -/
+def ratsToJson (qs : Array Rat) : Json :=
+  Json.arr <| qs.map fun q =>
+    Json.arr #[Json.num (JsonNumber.fromInt q.num),
+      Json.num (JsonNumber.fromInt (q.den : Int))]
+
+/-- Decode the driver's `[[num, den], ...]` shape back into an array of
+rationals. Raises `IO.userError` on shape mismatch. -/
+def jsonToRats (j : Json) : IO (Array Rat) := do
+  match j.getArr? with
+  | Except.error msg =>
+    throw (IO.userError
+      s!"pari_bench_driver: expected JSON array, got: {msg}; value: {j.compress}")
+  | Except.ok arr =>
+    let mut out : Array Rat := Array.mkEmpty arr.size
+    for elt in arr do
+      match elt.getArr? with
+      | Except.error msg =>
+        throw (IO.userError
+          s!"pari_bench_driver: rational not a pair: {msg}; element: {elt.compress}")
+      | Except.ok pair =>
+        if h : pair.size = 2 then
+          match pair[0].getInt?, pair[1].getInt? with
+          | Except.ok num, Except.ok den =>
+            if den ≤ 0 then
+              throw (IO.userError
+                s!"pari_bench_driver: nonpositive denominator: {elt.compress}")
+            out := out.push (mkRat num den.toNat)
+          | _, _ =>
+            throw (IO.userError
+              s!"pari_bench_driver: rational pair not integers: {elt.compress}")
+        else
+          throw (IO.userError
+            s!"pari_bench_driver: rational pair had {pair.size} fields: {elt.compress}")
+    return out
+
+/-- Decode a `[[a, b], ...]` JSON array of natural-number pairs (the
+`nf`/`factor_degrees` result shape). -/
+def jsonToNatPairs (j : Json) : IO (Array (Nat × Nat)) := do
+  match j.getArr? with
+  | Except.error msg =>
+    throw (IO.userError
+      s!"pari_bench_driver: expected JSON array, got: {msg}; value: {j.compress}")
+  | Except.ok arr =>
+    let mut out : Array (Nat × Nat) := Array.mkEmpty arr.size
+    for elt in arr do
+      match elt.getArr? with
+      | Except.error msg =>
+        throw (IO.userError
+          s!"pari_bench_driver: pair not an array: {msg}; element: {elt.compress}")
+      | Except.ok pair =>
+        if h : pair.size = 2 then
+          match pair[0].getNat?, pair[1].getNat? with
+          | Except.ok a, Except.ok b => out := out.push (a, b)
+          | _, _ =>
+            throw (IO.userError
+              s!"pari_bench_driver: pair entries not naturals: {elt.compress}")
+        else
+          throw (IO.userError
+            s!"pari_bench_driver: pair had {pair.size} fields: {elt.compress}")
+    return out
+
 end Hex.BenchOracle.Pari

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -521,6 +521,39 @@ oracle's independently computed decomposition with Lean's finite output.
 Phase 4 records separate timings for eliminant construction, isolation,
 disambiguation, and exactification so regressions are attributable.
 
+## External comparators
+
+**PARI/GP via cypari2** (https://pari.math.u-bordeaux.fr/, driven through
+the cypari2 binding, the same binding the conformance oracles use) —
+**informational**, scoped to the fixed-field arithmetic bench targets.
+PARI's t_POLMOD arithmetic (`Mod(a, m) * Mod(b, m)` and `Mod(a, m)^(-1)`)
+is the callable unit surface computing exactly `QAdjoin` multiplication and
+extended-gcd inversion in `ℚ[x]/(m)`. It is wired as a persistent-subprocess
+process call (`scripts/oracle/pari_bench_driver.py`,
+`Hex/BenchOracle/Pari.lean`) with per-rung fixed Lean/PARI registration
+pairs on identical deterministic inputs, joined on the identical reduced
+rational coefficient hash. PARI is a mature optimized C library, so the
+constant-factor gap is structural rather than algorithmic; the ratio is
+recorded for orientation and does not gate Phase 4.
+
+Absence declarations, all with reason
+**no-comparable-surface-in-named-comparator**:
+
+- *Factorization-lazy and canonical arithmetic* (`AlgebraicRoot.add?` and
+  friends, `AlgebraicNumber` arithmetic): PARI has no certified lazy
+  algebraic-number type; its floating `t_COMPLEX`/`algdep` workflow does not
+  expose "combine two isolated algebraic numbers into a certified isolated
+  result" as a callable unit.
+- *Exactification* (`AlgebraicRoot.exact?`): PARI exposes rational
+  polynomial factorization (already the BZ dependency's comparator surface)
+  but no unit function selecting and certifying the minimal polynomial of a
+  root given an isolating region.
+- *Root APIs* (`QAdjoin.roots?`, `AlgebraicPoly.roots?`): PARI's
+  `nfroots`/`nffactor` return only the roots lying inside the number field,
+  and `polroots` returns uncertified floating approximations; no PARI unit
+  surface produces the certified complete complex root multiset with
+  isolation data that these APIs return.
+
 ## References
 
 - Cohen, H. *A Course in Computational Algebraic Number Theory.* Springer,

--- a/HexNumberFieldTower/SPEC/hex-number-field-tower.md
+++ b/HexNumberFieldTower/SPEC/hex-number-field-tower.md
@@ -341,6 +341,39 @@ the measured reference-host ceiling under the repository benchmarking policy.
 Merge-facing conformance is restricted to tower dimension at most 8 and input
 degree at most 4 until those measurements exist.
 
+## External comparators
+
+**PARI/GP nffactor via cypari2** (https://pari.math.u-bordeaux.fr/, driven
+through the cypari2 binding, the same binding the conformance oracle uses) —
+**informational**, scoped to the `factor?` bench targets. `nffactor(nfinit f,
+t)` is the callable PARI unit surface for factoring a polynomial over a
+number field, the semantic task of `factor?` at one level. It is wired as a
+persistent-subprocess process call (`scripts/oracle/pari_bench_driver.py`,
+`Hex/BenchOracle/Pari.lean`) with per-rung fixed Lean/PARI registration
+pairs on shared deterministic Selmer trinomial inputs over `ℚ(√2)`, joined
+on the sorted factor degree/multiplicity multiset hash (factor coefficients
+live in each system's own field presentation and are not a shared
+observable; the degree/multiplicity multiset of a complete factorization
+is). PARI is a mature optimized C library running over `nfinit`'s absolute
+integral-basis presentation with maximal-order machinery, so the gap is
+structural; the ratio is recorded for orientation and does not gate Phase 4.
+
+Absence declarations, all with reason
+**no-comparable-surface-in-named-comparator**:
+
+- *Tower element arithmetic* (`Elem` add/sub/neg/mul/inv/div/smul): PARI's
+  number-field element operations (`nfelt*`) act on absolute integral-basis
+  coordinates after `nfinit`, not on relative mixed-radix tower coordinates
+  with a fixed embedding; nested `t_POLMOD` towers are not a supported
+  arithmetic surface for inversion. There is no callable PARI unit matching
+  arithmetic in this representation.
+- *Adjoining, splitting, flattening* (`adjoin?`, `split?`, `flatten?`):
+  PARI's `nfsplitting`, `polcompositum`, and `rnfequation` return abstract
+  defining polynomials up to isomorphism; they do not produce the
+  fixed-embedding root selection, coordinate maps, or validated tower level
+  that constitute these results, so they compute a different semantic task
+  than these units.
+
 ## File organisation
 
 ```text

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -5,6 +5,8 @@ Authors: Kim Morrison
 -/
 
 import HexNumberField
+import Hex.BenchOracle.Pari
+import Lean.Data.Json
 import LeanBench
 
 /-!
@@ -19,8 +21,41 @@ The fixed cases separate the costs requested by the library SPEC:
 * exactification through an irrelevant enclosing factor;
 * repeated-root extraction over `ℚ(√2)`.
 
-All fixtures and benchmark kernels are Mathlib-free. External PARI/FLINT
-comparison belongs to the conformance profile rather than the timed process.
+The parametric ladders carry the Phase-4 asymptotic evidence:
+
+* `runQAdjoinAddLadder` / `runQAdjoinMulLadder` / `runQAdjoinInvLadder`:
+  fixed-field arithmetic in `ℚ(2^{1/n})` at growing modulus degree `n`;
+* `runAddEliminantLadder`: Brown-resultant sum-eliminant construction at
+  growing first-operand degree;
+* `runLazyAddLadder`: end-to-end lazy `AlgebraicRoot.add?` at growing
+  degree product (capped at the SPEC's merge-facing ceiling `20`);
+* `runExactLadder`: exactification through an enclosing polynomial with an
+  irrelevant linear factor at growing degree;
+* `runQAdjoinRootsLadder` / `runAlgebraicRootsLadder`: the two root APIs on
+  non-degenerate inputs with a repeated factor (fixed field) and a
+  `√2`-dependent coefficient (canonical coefficients);
+* `runCommonPresentationLadder`: the public common-field construction
+  behind `AlgebraicPoly.roots?`, separated per the Attribution rule.
+
+Informational PARI comparator (`SPEC/benchmarking.md` §External comparators
+§Process call): PARI's `t_POLMOD` arithmetic (`Mod(a, m) * Mod(b, m)` and
+`Mod(a, m)^(-1)`) is the callable PARI surface matching `QAdjoin`
+multiplication and inversion. The `runQAdjoinMulPair*` / `runPariPolmodMul*`
+and `runQAdjoinInvPair*` / `runPariPolmodInv*` fixed rungs consume identical
+deterministic inputs and hash the identical reduced rational coefficient
+vector, so `compare` joins them on result hashes. The PARI side runs through
+the persistent-subprocess driver `scripts/oracle/pari_bench_driver.py`
+(one JSON request per line; the driver is started by a `warmupFirstIter`
+call outside the timed region and reused across the child's auto-tuned
+inner-repeat batch — see `Hex/BenchOracle/Pari.lean`). Both sides of every
+pair use `warmupFirstIter` so the lazily built rung fixture (root isolation
+and, for inversion, the irreducibility check) also stays outside the timed
+region, and share the same `minTotalSeconds` amortisation floor so per-rung
+ratios compare steady-state medians on the same basis. Lazy certified
+arithmetic, exactification, and the certified root-set APIs have no
+comparable PARI unit surface; see the SPEC's External comparators section.
+
+All fixtures and benchmark kernels are Mathlib-free.
 -/
 
 namespace Hex.NumberFieldBench
@@ -332,6 +367,547 @@ setup_fixed_benchmark runRoots where {
   repeats := 3, maxSecondsPerCall := 5.0,
   expectedHash := some 0x0927e3f02f6eee94
 }
+
+/-! # Parametric ladder fixtures -/
+
+/-- `X^m - 2`, Eisenstein-irreducible at `2` for every `m ≥ 1`. -/
+private def xPowSubTwo (m : Nat) : ZPoly :=
+  DensePoly.ofList ((-2 : Int) :: List.replicate (m - 1) 0 ++ [1])
+
+/-- Deterministic dense all-nonzero rational coefficients keyed by length
+and salt: alternating signs, growing numerators, denominator `i + 2`. -/
+private def denseRatCoeffs (len salt : Nat) : Array Rat :=
+  (Array.range len).map fun i =>
+    let sign : Int := if (i + salt) % 2 == 0 then 1 else -1
+    mkRat (sign * Int.ofNat (i + salt + 1)) (i + 2)
+
+/-- Deterministic refined isolation for a squarefree polynomial: run the
+bounded isolator at separation depth and take the first returned atom. -/
+private def refinedOf? (p : ZPoly) (h : HasOnlySimpleRoots p) :
+    Option (RefinedIsolation p) := do
+  let isolations ← isolate p h (separationDepth p : Int)
+  let iso ← isolations[0]?
+  iso.toRefined?
+
+/-- Deterministic factorization-lazy root of a primitive positive-leading
+squarefree polynomial (the first isolated root). -/
+private def mkLadderRoot? (p : ZPoly) : Option AlgebraicRoot :=
+  if hprim : ZPoly.content p = 1 then
+    if hlc : 0 < p.leadingCoeff then
+      if hdeg : 0 < p.degree?.getD 0 then
+        if hsf : HasOnlySimpleRoots p then
+          match refinedOf? p hsf with
+          | some rep =>
+            some { p := p, prim := hprim, pos_lc := hlc, pos_degree := hdeg
+                   squarefree := hsf, x := SimpleRoot.mk rep, rep := rep
+                   rep_mk := rfl }
+          | none => none
+        else none
+      else none
+    else none
+  else none
+
+/-- Prepared degree-`m` fixed-field arithmetic fixture: the field
+`ℚ(2^{1/m})` with two dense all-nonzero-coordinate elements. -/
+private structure FieldInput where
+  p : ZPoly
+  x : SimpleRoot p
+  a : QAdjoin p x
+  b : QAdjoin p x
+
+private instance : Hashable FieldInput where
+  hash input :=
+    mixHash (hash input.p.toArray)
+      (mixHash (fixedChecksum input.a) (fixedChecksum input.b))
+
+private instance : Inhabited FieldInput :=
+  ⟨{ p := sqrtTwoPoly, x := sqrtTwoRoot, a := fixedSqrtTwo, b := fixedSqrtTwo }⟩
+
+def prepFieldInput (n : Nat) : FieldInput :=
+  let m := max n 2
+  let p := xPowSubTwo m
+  if hsf : HasOnlySimpleRoots p then
+    match refinedOf? p hsf with
+    | some rep =>
+      let x := SimpleRoot.mk rep
+      { p := p, x := x
+        a := QAdjoin.reduce p x (DensePoly.ofCoeffs (denseRatCoeffs m 3))
+        b := QAdjoin.reduce p x (DensePoly.ofCoeffs (denseRatCoeffs m 7)) }
+    | none => panic! "prepFieldInput: isolation failed"
+  else panic! "prepFieldInput: squarefree check failed"
+
+/-- Prepared inversion fixture: `FieldInput` data plus the runtime-checked
+irreducibility instance, decided in prep so no factorization work leaks
+into the timed extended-gcd region. -/
+private structure InvInput where
+  p : ZPoly
+  x : SimpleRoot p
+  a : QAdjoin p x
+  checked : Option (PLift (ZPoly.CheckedIrreducible p))
+
+private instance : Hashable InvInput where
+  hash input := mixHash (hash input.p.toArray) (fixedChecksum input.a)
+
+private instance : Inhabited InvInput :=
+  ⟨{ p := sqrtTwoPoly, x := sqrtTwoRoot, a := fixedSqrtTwo, checked := none }⟩
+
+def prepInvInput (n : Nat) : InvInput :=
+  let m := max n 2
+  let p := xPowSubTwo m
+  if hirr : ZPoly.isIrreducible p = true then
+    if hdeg : 0 < p.degree?.getD 0 then
+      if hsf : HasOnlySimpleRoots p then
+        match refinedOf? p hsf with
+        | some rep =>
+          let x := SimpleRoot.mk rep
+          { p := p, x := x
+            a := QAdjoin.reduce p x (DensePoly.ofCoeffs (denseRatCoeffs m 5))
+            checked := some ⟨⟨hirr, hdeg⟩⟩ }
+        | none => panic! "prepInvInput: isolation failed"
+      else panic! "prepInvInput: squarefree check failed"
+    else panic! "prepInvInput: degree check failed"
+  else panic! "prepInvInput: irreducibility check failed"
+
+def runQAdjoinAddLadder (input : FieldInput) : UInt64 :=
+  fixedChecksum (input.a + input.b)
+
+def runQAdjoinMulLadder (input : FieldInput) : UInt64 :=
+  fixedChecksum (input.a * input.b)
+
+def runQAdjoinInvLadder (input : InvInput) : UInt64 :=
+  match input.checked with
+  | some ⟨inst⟩ =>
+    letI : ZPoly.CheckedIrreducible input.p := inst
+    fixedChecksum input.a⁻¹
+  | none => 0
+
+/- Cost model. `QAdjoin` addition adds the two reduced rational coefficient
+vectors coordinatewise: exactly `min` sizes rational additions plus a copy of
+the tail, `O(n)` operations for two dense degree-`(n-1)` operands over the
+degree-`n` modulus. Input numerators and denominators are bounded by the
+fixture schedule, so each rational operation is `O(1)` words and the declared
+wall model is linear. -/
+setup_benchmark runQAdjoinAddLadder n => n
+  with prep := prepFieldInput
+  where {
+    paramFloor := 4
+    paramCeiling := 32
+    paramSchedule := .custom #[4, 6, 8, 12, 16, 24, 32]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model. Dense schoolbook multiplication of two degree-`(n-1)` rational
+polynomials performs `O(n^2)` coefficient multiply/adds, and the subsequent
+reduction of the degree-`(2n-2)` product modulo the sparse monic degree-`n`
+relation `X^n - 2` retires `O(n)` excess coefficients at `O(1)` each. The
+quadratic convolution dominates; fixture coefficient heights are bounded, so
+the declared model is `n^2`. -/
+setup_benchmark runQAdjoinMulLadder n => n * n
+  with prep := prepFieldInput
+  where {
+    paramFloor := 4
+    paramCeiling := 32
+    paramSchedule := .custom #[4, 6, 8, 12, 16, 24, 32]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model. Inversion runs the polynomial extended gcd of the degree-`(n-1)`
+element against the degree-`n` modulus over `ℚ`: the Euclidean remainder
+sequence performs a quadratic number of rational coefficient operations (SPEC
+§Complexity: "extended gcd ... quadratic number of coefficient operations with
+coefficient-size growth"). Intermediate numerator/denominator growth across the
+chain is modelled with the same logarithmic limb-growth proxy the HexResultant
+Brown-chain registrations use, giving `n^2 * log n` rather than declaring every
+arbitrary-precision operation constant-cost. -/
+setup_benchmark runQAdjoinInvLadder n => n * n * (Nat.log2 (n + 2) + 1)
+  with prep := prepInvInput
+  where {
+    paramFloor := 3
+    paramCeiling := 12
+    paramSchedule := .custom #[3, 4, 6, 8, 12]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/-! # Lazy-arithmetic ladders -/
+
+/-- Prepared eliminant-construction pair: `X^m - 2` against the fixed
+quadratic `X^2 - 3` (no isolation is needed for construction alone). -/
+private structure EliminantInput where
+  p : ZPoly
+  q : ZPoly
+
+private instance : Hashable EliminantInput where
+  hash input := mixHash (hash input.p.toArray) (hash input.q.toArray)
+
+private instance : Inhabited EliminantInput := ⟨⟨sqrtTwoPoly, sqrtThreePoly⟩⟩
+
+def prepEliminantInput (n : Nat) : EliminantInput :=
+  ⟨xPowSubTwo (max n 2), sqrtThreePoly⟩
+
+def runAddEliminantLadder (input : EliminantInput) : UInt64 :=
+  polyChecksum (ZPoly.addEliminant input.p input.q)
+
+/-- Prepared lazy-addition pair: the first isolated root of `X^m - 2`
+against `√3`, degree product `2m` (merge-facing ceiling `20`). -/
+private structure LazyAddInput where
+  a : Option AlgebraicRoot
+  b : Option AlgebraicRoot
+
+private instance : Hashable LazyAddInput where
+  hash input :=
+    mixHash ((input.a.map rootChecksum).getD 0) ((input.b.map rootChecksum).getD 0)
+
+private instance : Inhabited LazyAddInput := ⟨⟨none, none⟩⟩
+
+def prepLazyAddInput (n : Nat) : LazyAddInput :=
+  ⟨mkLadderRoot? (xPowSubTwo (max n 2)), sqrtThree?⟩
+
+def runLazyAddLadder (input : LazyAddInput) : UInt64 :=
+  match input.a, input.b with
+  | some a, some b =>
+    match a.add? b with
+    | some c => rootChecksum c
+    | none => 1
+  | _, _ => 0
+
+/- Cost model. `addEliminant (X^n - 2) (X^2 - 3)` is the Brown resultant in
+`y` of a degree-`n` polynomial with constant coefficients against the monic
+`y`-quadratic `(t - y)^2 - 3` whose coefficients have `t`-degree at most 2.
+The first (monic) division performs `O(n)` elimination steps whose remainder
+coefficients grow to `t`-degree `O(n)`, `O(n^2)` integer coefficient
+operations in total; the short tail of the chain on `y`-degree `≤ 1`
+remainders with `t`-degree-`O(n)` coefficients adds the same order. Integer
+bit growth along the chain is modelled with the logarithmic limb-growth
+proxy used by the HexResultant registrations, so the declared wall model is
+`n^2 * log n`. -/
+setup_benchmark runAddEliminantLadder n => n * n * (Nat.log2 (n + 2) + 1)
+  with prep := prepEliminantInput
+  where {
+    paramFloor := 4
+    paramCeiling := 64
+    paramSchedule := .custom #[4, 8, 16, 32, 64]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model. Per SPEC §Complexity the lazy binary ceiling is the eliminant
+resultant cost plus the HexRoots isolation cost at the eliminant degree
+`d = deg(a.p) * deg(b.p) = 2n`, and isolation at separation depth dominates.
+State-of-practice real/complex isolation for a degree-`d` integer polynomial
+is `~O(d^3 + d^2 * tau)` bit operations with working precision `B`; here the
+separation-depth target and the resultant Hadamard coefficient bound give
+`tau, B = O(d log d)`, so the HexRoots heuristic `O(d^3 * B^2)` yields the
+declared `n^5 log^2 n` wall shape (constants in `d = 2n` drop out). The
+schedule stops at degree product 20, the SPEC's largest merge-facing lazy
+class. -/
+setup_benchmark runLazyAddLadder n => n ^ 5 * (Nat.log2 (n + 2)) ^ 2
+  with prep := prepLazyAddInput
+  where {
+    paramFloor := 2
+    paramCeiling := 10
+    paramSchedule := .custom #[2, 3, 4, 6, 8, 10]
+    maxSecondsPerCall := 60.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/-! # Exactification ladder -/
+
+/-- Prepared exactification fixture: the first isolated root of
+`(X^m - 2)(X + 3)`, so factor selection always faces at least two
+irreducible candidate factors. -/
+private structure ExactInput where
+  root : Option AlgebraicRoot
+
+private instance : Hashable ExactInput where
+  hash input := (input.root.map rootChecksum).getD 0
+
+private instance : Inhabited ExactInput := ⟨⟨none⟩⟩
+
+def prepExactInput (n : Nat) : ExactInput :=
+  ⟨mkLadderRoot? (xPowSubTwo (max n 2) * DensePoly.ofList [3, 1])⟩
+
+def runExactLadder (input : ExactInput) : UInt64 :=
+  match input.root with
+  | some root =>
+    match root.exact? with
+    | some a => polyChecksum a.p
+    | none => 1
+  | none => 0
+
+/- Cost model. Per SPEC §Complexity, exactification adds one
+Berlekamp-Zassenhaus factorization of the degree-`(n+1)` enclosing polynomial
+plus factor-root selection. The declared model is the classical BHKS
+polynomial bound in the enclosing degree, `n^9 + n^7 log^2 n` (the same shape
+the HexBerlekampZassenhaus registrations declare); the subsequent candidate
+re-isolation and canonicalization are lower order against it. -/
+setup_benchmark runExactLadder n => n ^ 9 + n ^ 7 * (Nat.log2 (n + 2)) ^ 2
+  with prep := prepExactInput
+  where {
+    paramFloor := 2
+    paramCeiling := 8
+    paramSchedule := .custom #[2, 3, 4, 6, 8]
+    maxSecondsPerCall := 30.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/-! # Root-API ladders -/
+
+/-- Prepared fixed-field roots fixture over `ℚ(√2)`: `f = g^2 * (X - 1)` with
+`g` dense of degree `m` and every coefficient `√2`-dependent, so Yun
+produces a genuine multiplicity-2 component and the norm eliminant has
+degree `2m`. -/
+private structure FieldRootsInput where
+  f : DensePoly (QAdjoin sqrtTwoPoly sqrtTwoRoot)
+  checked : Option (PLift (ZPoly.CheckedIrreducible sqrtTwoPoly))
+
+private instance : Hashable FieldRootsInput where
+  hash input :=
+    input.f.toArray.foldl
+      (fun checksum coefficient => mixHash checksum (fixedChecksum coefficient))
+      (hash input.f.size)
+
+private instance : Inhabited FieldRootsInput :=
+  ⟨⟨DensePoly.ofCoeffs #[], none⟩⟩
+
+def prepFieldRootsInput (n : Nat) : FieldRootsInput :=
+  let m := max n 1
+  let coeffs := (Array.range (m + 1)).map fun i =>
+    QAdjoin.reduce sqrtTwoPoly sqrtTwoRoot
+      (DensePoly.ofList
+        [mkRat (Int.ofNat (i + 2)) (i + 3),
+         mkRat (if i % 2 == 0 then 1 else -1) 2])
+  let g := DensePoly.ofCoeffs coeffs
+  let linear : DensePoly (QAdjoin sqrtTwoPoly sqrtTwoRoot) :=
+    DensePoly.ofList [-1, 1]
+  if hirr : ZPoly.isIrreducible sqrtTwoPoly = true then
+    ⟨g * g * linear, some ⟨⟨hirr, by decide⟩⟩⟩
+  else
+    panic! "prepFieldRootsInput: irreducibility check failed"
+
+def runQAdjoinRootsLadder (input : FieldRootsInput) : UInt64 :=
+  match input.checked with
+  | some ⟨inst⟩ =>
+    letI : ZPoly.CheckedIrreducible sqrtTwoPoly := inst
+    match QAdjoin.roots? input.f sqrtTwoRep rfl with
+    | some result => rootSetChecksum result
+    | none => 1
+  | none => 0
+
+/-- Prepared canonical-coefficient roots fixture: a dense degree-`m`
+`AlgebraicPoly` whose linear coefficient is `√2` and whose remaining
+coefficients are nonzero rationals, forcing a genuine common-field
+embedding into `ℚ(√2)` before the fixed-field root algorithm. -/
+private structure AlgPolyInput where
+  f : AlgebraicPoly
+
+private instance : Hashable AlgPolyInput where
+  hash input :=
+    input.f.coeffs.foldl
+      (fun checksum coefficient => mixHash checksum (polyChecksum coefficient.p))
+      (hash input.f.size)
+
+private instance : Inhabited AlgPolyInput := ⟨⟨AlgebraicPoly.ofArray #[]⟩⟩
+
+def prepAlgPolyInput (n : Nat) : AlgPolyInput :=
+  let m := max n 1
+  match sqrtTwo?.bind (·.exact?) with
+  | some sqrt2 =>
+    ⟨AlgebraicPoly.ofArray <| (Array.range (m + 1)).map fun i =>
+      if i == 1 then sqrt2
+      else AlgebraicNumber.ofRat (mkRat (Int.ofNat (i + 1)) (i + 2))⟩
+  | none => panic! "prepAlgPolyInput: √2 fixture failed"
+
+def runAlgebraicRootsLadder (input : AlgPolyInput) : UInt64 :=
+  match input.f.roots? with
+  | some result => rootSetChecksum result
+  | none => 1
+
+def runCommonPresentationLadder (input : AlgPolyInput) : UInt64 :=
+  match AlgebraicPoly.Common.presentation? input.f.coeffs with
+  | some presentation => polyChecksum presentation.generator.p
+  | none => 1
+
+/- Cost model. The public common-field construction behind
+`AlgebraicPoly.roots?`, separated per the Attribution rule: `primitive?`
+folds `extend?` over the `n + 1` coefficients, and with a single quadratic
+irrational among rationals every `extend?` tests a constant number of
+shifts (`choose(2, 2) + 1 = 2`) with bounded-degree canonical arithmetic,
+so the search is `O(n)` constant-size canonical operations; `powers?` is
+constant-size at the fixed quadratic generator, and `coordinates?` embeds
+each of the `n + 1` coefficients with a constant number of degree-2
+trace-pairing operations. The declared wall model is therefore linear in
+the coefficient count. -/
+setup_benchmark runCommonPresentationLadder n => n
+  with prep := prepAlgPolyInput
+  where {
+    paramFloor := 2
+    paramCeiling := 16
+    paramSchedule := .custom #[2, 4, 8, 16]
+    maxSecondsPerCall := 60.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/- Cost model. Per SPEC §Complexity the root API runs Yun decomposition
+(`O(n^2)` field operations, lower order here) and one norm eliminant per
+squarefree component, then isolates and disambiguates. For the degree-`n`
+squarefree component over the fixed quadratic field the norm eliminant has
+degree `d = 2n`, and its separation-depth isolation dominates exactly as in
+the lazy-addition derivation above (`O(d^3 * B^2)` with
+`tau, B = O(d log d)`), so the declared wall model is the same
+`n^5 log^2 n` shape. -/
+setup_benchmark runQAdjoinRootsLadder n => n ^ 5 * (Nat.log2 (n + 2)) ^ 2
+  with prep := prepFieldRootsInput
+  where {
+    paramFloor := 1
+    paramCeiling := 6
+    paramSchedule := .custom #[1, 2, 3, 4, 6]
+    maxSecondsPerCall := 60.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/- Cost model. `AlgebraicPoly.roots?` first embeds the coefficients into one
+primitive field — for this family the bounded primitive-element search
+stabilises on the fixed quadratic generator `√2` after `O(n)` cheap checked
+combinations — and then invokes the fixed-field algorithm, whose degree-`2n`
+norm-eliminant isolation dominates per the derivation on
+`runQAdjoinRootsLadder`. Declared model: the same `n^5 log^2 n` isolation
+shape. -/
+setup_benchmark runAlgebraicRootsLadder n => n ^ 5 * (Nat.log2 (n + 2)) ^ 2
+  with prep := prepAlgPolyInput
+  where {
+    paramFloor := 2
+    paramCeiling := 6
+    paramSchedule := .custom #[2, 3, 4, 6]
+    maxSecondsPerCall := 60.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/-! # PARI `t_POLMOD` comparator pairs
+
+Fixed per-rung Lean/PARI pairs for `QAdjoin` multiplication and inversion.
+Both sides consume the identical deterministic `prepFieldInput` /
+`prepInvInput` fixture and hash the identical reduced rational coefficient
+vector, so `compare` joins on result hashes. The rung fixtures are built
+lazily on the discarded `warmupFirstIter` call, keeping root isolation, the
+inversion irreducibility check, and the PARI driver startup out of the timed
+region on both sides. -/
+
+/-- Checksum matching `fixedChecksum` on a raw trimmed rational coefficient
+vector, used to compare PARI polmod results against `QAdjoin` results. -/
+private def ratCoeffsChecksum (coeffs : Array Rat) : UInt64 :=
+  coeffs.foldl (fun checksum q => mixHash checksum (ratChecksum q))
+    (hash coeffs.size)
+
+initialize mulPairRef4 : IO.Ref (Option FieldInput) ← IO.mkRef none
+initialize mulPairRef8 : IO.Ref (Option FieldInput) ← IO.mkRef none
+initialize mulPairRef16 : IO.Ref (Option FieldInput) ← IO.mkRef none
+initialize invPairRef4 : IO.Ref (Option InvInput) ← IO.mkRef none
+initialize invPairRef8 : IO.Ref (Option InvInput) ← IO.mkRef none
+initialize invPairRef12 : IO.Ref (Option InvInput) ← IO.mkRef none
+
+private def getMulPair (ref : IO.Ref (Option FieldInput)) (n : Nat) :
+    IO FieldInput := do
+  match ← ref.get with
+  | some input => pure input
+  | none =>
+    let input := prepFieldInput n
+    ref.set (some input)
+    pure input
+
+private def getInvPair (ref : IO.Ref (Option InvInput)) (n : Nat) :
+    IO InvInput := do
+  match ← ref.get with
+  | some input => pure input
+  | none =>
+    let input := prepInvInput n
+    ref.set (some input)
+    pure input
+
+private def pariPolmodMul (input : FieldInput) : IO UInt64 := do
+  let result ← Hex.BenchOracle.Pari.runOp "polmod" "mul"
+    #[("modulus", Hex.BenchOracle.Flint.intsToJson input.p.toArray.toList),
+      ("a", Hex.BenchOracle.Pari.ratsToJson input.a.coeffs.toArray),
+      ("b", Hex.BenchOracle.Pari.ratsToJson input.b.coeffs.toArray)]
+  return ratCoeffsChecksum (← Hex.BenchOracle.Pari.jsonToRats result)
+
+private def pariPolmodInv (input : InvInput) : IO UInt64 := do
+  let result ← Hex.BenchOracle.Pari.runOp "polmod" "inv"
+    #[("modulus", Hex.BenchOracle.Flint.intsToJson input.p.toArray.toList),
+      ("a", Hex.BenchOracle.Pari.ratsToJson input.a.coeffs.toArray)]
+  return ratCoeffsChecksum (← Hex.BenchOracle.Pari.jsonToRats result)
+
+def runQAdjoinMulPair4 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinMulLadder (← getMulPair mulPairRef4 4)
+def runPariPolmodMul4 : Unit → IO UInt64 := fun _ => do
+  pariPolmodMul (← getMulPair mulPairRef4 4)
+def runQAdjoinMulPair8 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinMulLadder (← getMulPair mulPairRef8 8)
+def runPariPolmodMul8 : Unit → IO UInt64 := fun _ => do
+  pariPolmodMul (← getMulPair mulPairRef8 8)
+def runQAdjoinMulPair16 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinMulLadder (← getMulPair mulPairRef16 16)
+def runPariPolmodMul16 : Unit → IO UInt64 := fun _ => do
+  pariPolmodMul (← getMulPair mulPairRef16 16)
+
+def runQAdjoinInvPair4 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinInvLadder (← getInvPair invPairRef4 4)
+def runPariPolmodInv4 : Unit → IO UInt64 := fun _ => do
+  pariPolmodInv (← getInvPair invPairRef4 4)
+def runQAdjoinInvPair8 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinInvLadder (← getInvPair invPairRef8 8)
+def runPariPolmodInv8 : Unit → IO UInt64 := fun _ => do
+  pariPolmodInv (← getInvPair invPairRef8 8)
+def runQAdjoinInvPair12 : Unit → IO UInt64 := fun _ => do
+  return runQAdjoinInvLadder (← getInvPair invPairRef12 12)
+def runPariPolmodInv12 : Unit → IO UInt64 := fun _ => do
+  pariPolmodInv (← getInvPair invPairRef12 12)
+
+/-- Timing shape shared by both sides of every PARI pair: the discarded
+`warmupFirstIter` call builds the lazily cached rung fixture (and, on the
+PARI side, spawns the persistent driver) outside the timed region, and the
+raised `minTotalSeconds` floor amortises steady-state work across the
+auto-tuned inner-repeat batch so per-rung ratios compare like with like. -/
+def pariCompareConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 30.0, warmupFirstIter := true,
+    minTotalSeconds := 0.2 }
+
+/- Fixed per-rung process-call comparator registrations for PARI t_POLMOD
+multiplication against `QAdjoin` multiplication (quadratic-cost surface; see
+the `runQAdjoinMulLadder` derivation). Identical inputs, identical reduced
+rational coefficient hash on both sides. -/
+setup_fixed_benchmark runQAdjoinMulPair4 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodMul4 where pariCompareConfig
+setup_fixed_benchmark runQAdjoinMulPair8 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodMul8 where pariCompareConfig
+setup_fixed_benchmark runQAdjoinMulPair16 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodMul16 where pariCompareConfig
+
+/- Fixed per-rung process-call comparator registrations for PARI t_POLMOD
+inversion against `QAdjoin` extended-gcd inversion (quadratic
+coefficient-operation surface; see the `runQAdjoinInvLadder` derivation). -/
+setup_fixed_benchmark runQAdjoinInvPair4 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodInv4 where pariCompareConfig
+setup_fixed_benchmark runQAdjoinInvPair8 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodInv8 where pariCompareConfig
+setup_fixed_benchmark runQAdjoinInvPair12 where pariCompareConfig
+setup_fixed_benchmark runPariPolmodInv12 where pariCompareConfig
 
 end Hex.NumberFieldBench
 

--- a/bench/HexNumberFieldTower/Bench.lean
+++ b/bench/HexNumberFieldTower/Bench.lean
@@ -5,6 +5,8 @@ Authors: Kim Morrison
 -/
 
 import HexNumberFieldTower
+import Hex.BenchOracle.Pari
+import Lean.Data.Json
 import LeanBench
 
 /-!
@@ -12,16 +14,44 @@ Benchmark registrations for `HexNumberFieldTower`.
 
 The fixed cases expose the Phase-4 components named by the library SPEC:
 
-* addition, multiplication, and recursive inversion in the dimension-four tower
+* addition, subtraction, negation, multiplication, recursive inversion,
+  division, and rational scalar action in the dimension-four tower
   `Q(sqrt(2), sqrt(3))`;
 * adjoining a fourth root of two to `Q(sqrt(2))`;
 * rational, one-level Trager-retry, and recursive two-level factorization;
 * splitting a quartic through two genuine extensions;
 * flattening a two-level tower to a primitive-element presentation.
 
-Every case stays within tower dimension four and input degree four; the
-isolated recovery adversary uses absolute degree six. The driver is
-Mathlib-free; external PARI comparison belongs to conformance, not timing.
+Every fixed case stays within tower dimension four and input degree four;
+the isolated recovery adversary uses absolute degree six.
+
+The parametric ladders carry the Phase-4 asymptotic evidence:
+
+* `runTowerAddLadder` / `runTowerMulLadder` / `runTowerInvLadder`:
+  coordinate arithmetic in the height-two tower `Q(sqrt(2), 3^{1/m})` at
+  growing dimension `D = 2m`;
+* `runTowerFactorLadder`: Trager factorization over `Q(sqrt(2))` of the
+  degree-`n` Selmer trinomial `X^n - X - 1`, whose rational coefficients
+  force the shift-zero norm to repeat, exercising the bounded shift search,
+  a genuine one-level norm retry, the recursive rational factorization of
+  the accepted degree-`2n` norm, and gcd recovery.
+
+Informational PARI comparator (`SPEC/benchmarking.md` §External comparators
+§Process call): `nffactor` is the callable PARI surface matching tower
+polynomial factorization at one level. The `runTowerFactorPair*` /
+`runPariNfFactor*` fixed rungs consume the same deterministic Selmer input
+over `Q(sqrt(2))` and hash the identical sorted factor
+degree/multiplicity multiset — the representation-free observable both
+implementations share — so `compare` joins on result hashes. The PARI side
+runs through the persistent-subprocess driver
+`scripts/oracle/pari_bench_driver.py` (one JSON request per line; started by
+a `warmupFirstIter` call outside the timed region and reused across the
+child's auto-tuned inner-repeat batch — see `Hex/BenchOracle/Pari.lean`).
+Both sides of every pair use `warmupFirstIter` and the same
+`minTotalSeconds` floor so per-rung ratios compare steady-state medians on
+the same basis. Tower element arithmetic, adjoining, splitting, and
+flattening have no comparable PARI unit surface; see the SPEC's External
+comparators section. The driver is Mathlib-free.
 -/
 
 namespace Hex.NumberTowerBench
@@ -650,6 +680,336 @@ setup_fixed_benchmark runFlatten where {
   expectedHash := some 0xcc1b7720bfe3fc24
 }
 
+
+/-! # Fixed registrations completing the arithmetic surface -/
+
+def runSub : Unit → IO UInt64 := fun _ => do
+  let tower ← getTwoLevel
+  let sqrtTwo := tower.extension.embed tower.base.gen
+  return elemChecksum (sqrtTwo - tower.extension.gen)
+
+def runNeg : Unit → IO UInt64 := fun _ => do
+  let tower ← getTwoLevel
+  let sqrtTwo := tower.extension.embed tower.base.gen
+  let value := sqrtTwo + tower.extension.gen
+  return elemChecksum (-value)
+
+def runDiv : Unit → IO UInt64 := fun _ => do
+  let tower ← getTwoLevel
+  let sqrtTwo := tower.extension.embed tower.base.gen
+  let value := sqrtTwo + tower.extension.gen
+  return elemChecksum (sqrtTwo / value)
+
+def runSMul : Unit → IO UInt64 := fun _ => do
+  let tower ← getTwoLevel
+  let sqrtTwo := tower.extension.embed tower.base.gen
+  let value := sqrtTwo + tower.extension.gen
+  return elemChecksum ((mkRat 3 7) • value)
+
+/- Coordinate subtraction, like addition, visits exactly `D` rational
+coordinates; this fixed `D = 4` case completes the linear-cost surface. -/
+setup_fixed_benchmark runSub where {
+  repeats := 5, maxSecondsPerCall := 2.0
+}
+
+/- Negation visits `D` coordinates with one rational negation each; the
+linear cost model matches addition. -/
+setup_fixed_benchmark runNeg where {
+  repeats := 5, maxSecondsPerCall := 2.0
+}
+
+/- Division composes recursive extended-gcd inversion with one `O(D^2)`
+multiplication/reduction; the inversion term dominates as in `runInv`. -/
+setup_fixed_benchmark runDiv where {
+  repeats := 5, maxSecondsPerCall := 2.0
+}
+
+/- Rational scalar action multiplies each of the `D` coordinates by one
+rational, a linear-cost surface like addition. -/
+setup_fixed_benchmark runSMul where {
+  repeats := 5, maxSecondsPerCall := 2.0
+}
+
+/-! # Parametric dimension ladders -/
+
+/-- `X^m - 3`, Eisenstein-irreducible at `3` for every `m ≥ 1`; its degree
+over `ℚ(√2)` is still `m` (the only quadratic subfield a pure cube/fourth/…
+root field of `3` can contain is `ℚ(√3)`), so adjoining its first root to
+`ℚ(√2)` yields a height-two tower of dimension `2m`. -/
+private def xPowSubThree (m : Nat) : ZPoly :=
+  DensePoly.ofList ((-3 : Int) :: List.replicate (m - 1) 0 ++ [1])
+
+/-- Deterministic refined isolation for a squarefree polynomial: run the
+bounded isolator at separation depth and take the first returned atom. -/
+private def refinedOf? (p : ZPoly) (h : HasOnlySimpleRoots p) :
+    Option (RefinedIsolation p) := do
+  let isolations ← isolate p h (separationDepth p : Int)
+  let iso ← isolations[0]?
+  iso.toRefined?
+
+/-- Deterministic factorization-lazy root of a primitive positive-leading
+squarefree polynomial (the first isolated root). -/
+private def mkLadderRoot? (p : ZPoly) : Option AlgebraicRoot :=
+  if hprim : ZPoly.content p = 1 then
+    if hlc : 0 < p.leadingCoeff then
+      if hdeg : 0 < p.degree?.getD 0 then
+        if hsf : HasOnlySimpleRoots p then
+          match refinedOf? p hsf with
+          | some rep =>
+            some { p := p, prim := hprim, pos_lc := hlc, pos_degree := hdeg
+                   squarefree := hsf, x := SimpleRoot.mk rep, rep := rep
+                   rep_mk := rfl }
+          | none => none
+        else none
+      else none
+    else none
+  else none
+
+/-- The height-two ladder tower `ℚ(√2, 3^{1/m})` (just `ℚ(√2)` at `m = 1`). -/
+private def ladderTower? (m : Nat) : Option NumberTower := do
+  let base ← sqrtTwo? ()
+  if m ≤ 1 then
+    pure base.tower
+  else do
+    let root ← mkLadderRoot? (xPowSubThree m)
+    let extension ← adjoin? base.tower root
+    pure extension.tower
+
+/-- Prepared dimension-`2m` coordinate-arithmetic fixture with two
+all-nonzero-coordinate elements. -/
+private structure ElemInput where
+  tower : NumberTower
+  a : Elem tower
+  b : Elem tower
+
+private instance : Hashable ElemInput where
+  hash input :=
+    mixHash (hash input.tower.dim)
+      (mixHash (elemChecksum input.a) (elemChecksum input.b))
+
+private instance : Inhabited ElemInput :=
+  ⟨⟨rat, ofRat rat 1, ofRat rat 2⟩⟩
+
+/-- Deterministic dense all-nonzero mixed-radix coordinates. -/
+private def ladderCoords (d salt : Nat) : Array Rat :=
+  (Array.range d).map fun i =>
+    let sign : Int := if (i + salt) % 2 == 0 then 1 else -1
+    mkRat (sign * Int.ofNat (i + salt + 2)) (i + 3)
+
+def prepElemInput (n : Nat) : ElemInput :=
+  let m := max n 1
+  match ladderTower? m with
+  | some tower =>
+    let d := tower.dim
+    { tower := tower
+      a := ofCoeffs tower (ladderCoords d 3)
+      b := ofCoeffs tower (ladderCoords d 7) }
+  | none => panic! "prepElemInput: tower fixture failed"
+
+def runTowerAddLadder (input : ElemInput) : UInt64 :=
+  elemChecksum (input.a + input.b)
+
+def runTowerMulLadder (input : ElemInput) : UInt64 :=
+  elemChecksum (input.a * input.b)
+
+def runTowerInvLadder (input : ElemInput) : UInt64 :=
+  elemChecksum input.a⁻¹
+
+/- Cost model. Coordinate addition adds the two mixed-radix coordinate
+vectors pointwise: exactly `D = 2n` rational additions for the
+dimension-`2n` ladder tower (SPEC §Complexity: "Coordinate addition costs
+O(D) rational operations"). Fixture coordinate heights are bounded, so each
+rational operation is `O(1)` words and the declared wall model is linear in
+the parameter. -/
+setup_benchmark runTowerAddLadder n => n
+  with prep := prepElemInput
+  where {
+    paramFloor := 1
+    paramCeiling := 6
+    paramSchedule := .custom #[1, 2, 3, 4, 6]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model. Schoolbook tower multiplication convolves the mixed-radix
+coordinates and reduces from the top generator downward, `O(D^2)` rational
+operations at dimension `D = 2n` (SPEC §Complexity: "Schoolbook
+multiplication and reduction cost O(D²)"). Bounded fixture heights make each
+rational operation `O(1)` words, so the declared wall model is quadratic. -/
+setup_benchmark runTowerMulLadder n => n * n
+  with prep := prepElemInput
+  where {
+    paramFloor := 1
+    paramCeiling := 6
+    paramSchedule := .custom #[1, 2, 3, 4, 6]
+    maxSecondsPerCall := 10.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model. Inversion runs the extended gcd in the top quotient
+`K[y]/(m_top)` with `deg m_top = n` over the fixed quadratic base `K`:
+`O(n^2)` coefficient operations in `K`, each `O(1)` base-field operations
+at the fixed base dimension, so `O(n^2) = O(D^2)` rational operations
+overall. Rational coefficient growth along the Euclidean chain is modelled
+with the same logarithmic limb-growth proxy the HexResultant Brown-chain
+registrations use, giving the declared `n^2 log n` wall model. -/
+setup_benchmark runTowerInvLadder n => n * n * (Nat.log2 (n + 2) + 1)
+  with prep := prepElemInput
+  where {
+    paramFloor := 1
+    paramCeiling := 6
+    paramSchedule := .custom #[1, 2, 3, 4, 6]
+    maxSecondsPerCall := 30.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/-! # Trager factorization ladder -/
+
+/-- Ascending rational coefficients of the Selmer trinomial `X^m - X - 1`
+(irreducible over `ℚ` for every `m ≥ 2`, and over `ℚ(√2)` because its
+Galois group `S_m` leaves `ℚ(root)` without quadratic subfields). Shared by
+the Lean fixture and the PARI comparator request so both sides factor the
+same input. -/
+private def selmerRatCoeffs (m : Nat) : Array Rat :=
+  (Array.range (m + 1)).map fun i =>
+    if i == 0 || i == 1 then (-1 : Rat) else if i == m then 1 else 0
+
+/-- The Selmer trinomial as a polynomial over a tower. -/
+private def selmerPoly (m : Nat) (T : NumberTower) : Poly T :=
+  DensePoly.ofCoeffs ((selmerRatCoeffs m).map (ofRat T))
+
+/-- Prepared Trager-ladder fixture: the degree-`m` Selmer trinomial over the
+fixed base `ℚ(√2)`. Rational coefficients make the shift-zero one-level
+norm the square `f^2`, so the bounded search always performs a genuine
+retry before accepting a squarefree norm. -/
+private structure FactorInput where
+  tower : NumberTower
+  f : Poly tower
+
+private instance : Hashable FactorInput where
+  hash input := mixHash (hash input.tower.dim) (polyChecksum input.f)
+
+private instance : Inhabited FactorInput :=
+  ⟨⟨rat, DensePoly.ofCoeffs #[]⟩⟩
+
+def prepFactorInput (n : Nat) : FactorInput :=
+  let m := max n 2
+  match sqrtTwo? () with
+  | some base => { tower := base.tower, f := selmerPoly m base.tower }
+  | none => panic! "prepFactorInput: base tower fixture failed"
+
+def runTowerFactorLadder (input : FactorInput) : UInt64 :=
+  match factor? input.tower input.f with
+  | some result => factorChecksum result
+  | none => 1
+
+/-- Worst-case textbook cost model for one Trager step over the quadratic
+base at input degree `n`: the SPEC's shift recurrence tries at most
+`choose(d * m, 2) + 1 = choose(2n, 2) + 1 = O(n^2)` one-level norms, each a
+Brown resultant against the fixed quadratic level relation costing `O(n^2)`
+coefficient operations, and then recursively factors one accepted norm of
+degree `2n` over `ℚ`, whose classical BHKS bound `(2n)^9 + (2n)^7 log^2 (2n)`
+dominates the total. -/
+def tragerLadderModel (n : Nat) : Nat :=
+  let bigN := 2 * n
+  (bigN * (bigN - 1) / 2 + 1) * (n * n)
+    + bigN ^ 9 + bigN ^ 7 * (Nat.log2 (bigN + 2)) ^ 2
+
+/- Cost model. Declared per the SPEC's Trager recurrence, worst case: at
+`K(α)/K` with `d = deg m_α = 2` and component degree `m = n`, at most
+`choose(2n, 2) + 1` one-level norms (each an `O(n^2)`-operation Brown
+resultant against the quadratic relation), plus the recursive rational
+factorization of the accepted degree-`2n` norm at its classical BHKS bound —
+the dominant term. `tragerLadderModel` writes out exactly this sum. The
+deterministic Selmer family realises the retry (repeated shift-zero norm),
+the accepted squarefree norm, the base factorization, and gcd recovery. -/
+setup_benchmark runTowerFactorLadder n => tragerLadderModel n
+  with prep := prepFactorInput
+  where {
+    paramFloor := 2
+    paramCeiling := 6
+    paramSchedule := .custom #[2, 3, 4, 6]
+    maxSecondsPerCall := 60.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    slopeTolerance := 0.35
+  }
+
+/-! # PARI `nffactor` comparator pairs -/
+
+/-- Sorted factor degree/multiplicity multiset checksum: the
+representation-free observable shared by the Lean and PARI factorizations. -/
+private def degreeMultChecksum (pairs : Array (Nat × Nat)) : UInt64 :=
+  let sorted := pairs.qsort fun a b => a.1 < b.1 || (a.1 == b.1 && a.2 < b.2)
+  sorted.foldl
+    (fun checksum pair => mixHash checksum (mixHash (hash pair.1) (hash pair.2)))
+    (hash pairs.size)
+
+private def towerFactorDegrees (input : FactorInput) : UInt64 :=
+  match factor? input.tower input.f with
+  | some result =>
+    degreeMultChecksum <| result.factors.map fun entry =>
+      (entry.1.degree?.getD 0, entry.2)
+  | none => 1
+
+private def pariNfFactorDegrees (m : Nat) : IO UInt64 := do
+  let result ← Hex.BenchOracle.Pari.runOp "nf" "factor_degrees"
+    #[("field", Hex.BenchOracle.Flint.intsToJson [-2, 0, 1]),
+      ("poly", Hex.BenchOracle.Pari.ratsToJson (selmerRatCoeffs m))]
+  return degreeMultChecksum (← Hex.BenchOracle.Pari.jsonToNatPairs result)
+
+initialize factorPairRef2 : IO.Ref (Option FactorInput) ← IO.mkRef none
+initialize factorPairRef3 : IO.Ref (Option FactorInput) ← IO.mkRef none
+initialize factorPairRef4 : IO.Ref (Option FactorInput) ← IO.mkRef none
+initialize factorPairRef6 : IO.Ref (Option FactorInput) ← IO.mkRef none
+
+private def getFactorPair (ref : IO.Ref (Option FactorInput)) (n : Nat) :
+    IO FactorInput := do
+  match ← ref.get with
+  | some input => pure input
+  | none =>
+    let input := prepFactorInput n
+    ref.set (some input)
+    pure input
+
+def runTowerFactorPair2 : Unit → IO UInt64 := fun _ => do
+  return towerFactorDegrees (← getFactorPair factorPairRef2 2)
+def runPariNfFactor2 : Unit → IO UInt64 := fun _ => pariNfFactorDegrees 2
+def runTowerFactorPair3 : Unit → IO UInt64 := fun _ => do
+  return towerFactorDegrees (← getFactorPair factorPairRef3 3)
+def runPariNfFactor3 : Unit → IO UInt64 := fun _ => pariNfFactorDegrees 3
+def runTowerFactorPair4 : Unit → IO UInt64 := fun _ => do
+  return towerFactorDegrees (← getFactorPair factorPairRef4 4)
+def runPariNfFactor4 : Unit → IO UInt64 := fun _ => pariNfFactorDegrees 4
+def runTowerFactorPair6 : Unit → IO UInt64 := fun _ => do
+  return towerFactorDegrees (← getFactorPair factorPairRef6 6)
+def runPariNfFactor6 : Unit → IO UInt64 := fun _ => pariNfFactorDegrees 6
+
+/-- Timing shape shared by both sides of every PARI pair: the discarded
+`warmupFirstIter` call builds the lazily cached rung fixture (and, on the
+PARI side, spawns the persistent driver) outside the timed region, and the
+raised `minTotalSeconds` floor amortises steady-state work across the
+auto-tuned inner-repeat batch so per-rung ratios compare like with like. -/
+def pariCompareConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 3, maxSecondsPerCall := 60.0, warmupFirstIter := true,
+    minTotalSeconds := 0.2 }
+
+/- Fixed per-rung process-call comparator registrations for PARI `nffactor`
+against `factor?` over `ℚ(√2)` (worst-case cost model per the
+`runTowerFactorLadder` derivation). Identical Selmer inputs, identical sorted
+degree/multiplicity multiset hash on both sides. -/
+setup_fixed_benchmark runTowerFactorPair2 where pariCompareConfig
+setup_fixed_benchmark runPariNfFactor2 where pariCompareConfig
+setup_fixed_benchmark runTowerFactorPair3 where pariCompareConfig
+setup_fixed_benchmark runPariNfFactor3 where pariCompareConfig
+setup_fixed_benchmark runTowerFactorPair4 where pariCompareConfig
+setup_fixed_benchmark runPariNfFactor4 where pariCompareConfig
+setup_fixed_benchmark runTowerFactorPair6 where pariCompareConfig
+setup_fixed_benchmark runPariNfFactor6 where pariCompareConfig
 
 end Hex.NumberTowerBench
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -937,6 +937,22 @@ libraries:
     mathlib: false
     done_through: 3
     status: active
+    phase4:
+      comparators:
+        - tool: "PARI/GP via cypari2"
+          class: informational
+          rationale: "PARI is a mature optimized C library; its t_POLMOD arithmetic (Mod(a, m) * Mod(b, m), Mod(a, m)^(-1)) is the callable unit surface matching QAdjoin multiplication and extended-gcd inversion, and the constant-factor gap against Hex's verified rational implementation is structural rather than algorithmic, so the ratio is recorded for orientation and does not gate Phase 4. Wired via the persistent-subprocess driver scripts/oracle/pari_bench_driver.py per SPEC/benchmarking.md §External comparators §Process call, paired per rung with the QAdjoin multiplication and inversion fixed registrations on identical inputs. Lazy certified arithmetic, exactification, and the certified root-set APIs have no comparable PARI unit surface; the per-library SPEC declares those absences."
+      input_families:
+        - name: qadjoin-arithmetic
+          description: Degree-n fixed-field arithmetic over the Eisenstein modulus X^n - 2 with dense all-nonzero rational elements, plus the SPEC's canonical degree-10 fixed cases and the minimal-relation search.
+        - name: lazy-arithmetic
+          description: Sum-eliminant construction and end-to-end lazy addition pairing the first root of X^n - 2 with sqrt(3), degree products up to the merge-facing ceiling 20, plus the fixed isolation and operation-ball selection components.
+        - name: exactification
+          description: Factorization-lazy roots of (X^n - 2)(X + 3), so canonicalization always selects among at least two irreducible candidate factors.
+        - name: fixed-field-roots
+          description: Fixed-field root extraction over Q(sqrt(2)) of g^2 * (X - 1) with dense sqrt(2)-dependent g, exercising Yun multiplicity separation and the degree-2n norm eliminant.
+        - name: algebraic-poly-roots
+          description: Canonical-coefficient root extraction and the separated common-field presentation for dense polynomials with one sqrt(2) coefficient among nonzero rationals.
   HexNumberFieldMathlib:
     deps: [HexNumberField, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRootsMathlib, HexPolyZMathlib]
     mathlib: true
@@ -947,6 +963,20 @@ libraries:
     mathlib: false
     done_through: 3
     status: active
+    phase4:
+      comparators:
+        - tool: "PARI/GP nffactor via cypari2"
+          class: informational
+          rationale: "PARI is a mature optimized C library whose nffactor runs over nfinit's absolute integral-basis presentation with maximal-order machinery, a structurally different pipeline from Hex's relative one-level Trager norms, so the ratio is recorded for orientation and does not gate Phase 4. Wired via the persistent-subprocess driver scripts/oracle/pari_bench_driver.py per SPEC/benchmarking.md §External comparators §Process call, paired per rung with the factor? fixed registrations on shared Selmer trinomial inputs over Q(sqrt(2)), joined on the sorted factor degree/multiplicity multiset hash. Tower element arithmetic, adjoining, splitting, and flattening have no comparable PARI unit surface; the per-library SPEC declares those absences."
+      input_families:
+        - name: tower-coordinate-arithmetic
+          description: Dimension-2m height-two towers Q(sqrt(2), 3^(1/m)) with dense all-nonzero mixed-radix elements for addition, subtraction, negation, multiplication, recursive inversion, division, and rational scalar action.
+        - name: trager-factorization
+          description: Selmer trinomials X^n - X - 1 over Q(sqrt(2)) whose rational coefficients force a genuine shift retry, plus the fixed rational, one-level retry, recursive two-level, and checked-replay cases.
+        - name: adjoin-extend
+          description: Fixed adjoining of a fourth root of two to Q(sqrt(2)), the identity re-adjoining case, and the one-level presentation constructor.
+        - name: split-flatten
+          description: Fixed quartic splitting, two-level flattening, candidate, certification, and coordinate-map components, and the degree-six recovery adversary.
   HexNumberFieldTowerMathlib:
     deps: [HexNumberFieldTower, HexNumberFieldMathlib, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRowReduceMathlib]
     mathlib: true

--- a/progress/2026-08-22T05-30-00Z.md
+++ b/progress/2026-08-22T05-30-00Z.md
@@ -1,0 +1,55 @@
+# Phase-4 evidence code for HexNumberField / HexNumberFieldTower
+
+## Accomplished
+
+- Added `scripts/oracle/pari_bench_driver.py` (persistent cypari2
+  subprocess, JSONL protocol, `polmod` mul/inv/overhead and `nf`
+  factor_degrees families) and `Hex/BenchOracle/Pari.lean` (reuses the
+  Flint `PersistentComparator`, `HEX_PARI_BENCH_DRIVER` /
+  `HEX_PARI_BENCH_PYTHON` config).
+- `bench/HexNumberField/Bench.lean`: nine parametric ladders with
+  adjacent textbook cost derivations (QAdjoin add/mul/inv over
+  `X^n - 2`, addEliminant, lazy add at degree products ≤ 20,
+  exactification over `(X^n - 2)(X + 3)`, the two root APIs, and the
+  separated common-field presentation), plus per-rung Lean/PARI
+  t_POLMOD pairs for QAdjoin mul (4/8/16) and inv (4/8/12) joined on
+  the reduced rational coefficient hash.
+- `bench/HexNumberFieldTower/Bench.lean`: fixed Sub/Neg/Div/SMul
+  registrations completing the arithmetic surface; dimension ladders
+  over `ℚ(√2, 3^{1/m})` for add/mul/inv; a Trager ladder on Selmer
+  trinomials `X^n - X - 1` over `ℚ(√2)` with the SPEC's
+  `choose(2n,2)+1` shift-recurrence worst-case model; per-rung
+  Lean/PARI `nffactor` pairs (2/3/4/6) joined on the sorted factor
+  degree/multiplicity multiset hash.
+- `libraries.yml`: `phase4` blocks (informational PARI comparators
+  with structural-gap rationales and real wire status; input families
+  matching the bench families) for both libraries.
+- SPEC `## External comparators` sections in both per-library SPECs
+  (PARI named and classified; no-comparable-surface declarations with
+  the `no-comparable-surface-in-named-comparator` reason).
+
+## Current frontier
+
+Both benches build; `list` and `verify` pass (numberfield verify ~7 s,
+tower ~41 s, PARI side via a cypari2 venv through
+`HEX_PARI_BENCH_PYTHON`). No timed measurements were run and
+`done_through` was not bumped; the measurement windows are serialized
+externally.
+
+## Next step
+
+External measurement runner: scientific `run --export` for every
+parametric registration, comparator-ratio runs for the fixed pairs,
+per-family profiles via `scripts/profile/run_profile.sh`, then the two
+headline reports and the `done_through` decision.
+
+## Blockers
+
+Feasibility probing found `QAdjoin.roots?` on a degree-2 component
+with an irrational coefficient (and `AlgebraicPoly.roots?` on the
+matching family) runs for minutes, dominated by exact dyadic
+refinement (GMP-heavy, `Dyadic.add`/Taylor passes in the profile);
+`Common.presentation?` itself is ~1 s and directly-constructed
+linear-component inputs are subsecond. The scientific rungs of the two
+root ladders will surface this as a Phase-4 finding; expect a
+bench-found rollback for that surface at measurement time.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1318,5 +1318,11 @@
     "baseline_blob": "8226e99030e7d5fa79f36b5652119b97ab8e0110",
     "current_blob": "10549d33f216b6879838e63f96725aec7633ddfc",
     "reason": "Combines the measured PolySmith registrations with current main's independent HexIntFactor, MV-GCD, and HexSmith build registrations; hexbz_factor_service, its build flags, and every factorization runtime dependency are unchanged."
+  },
+  {
+    "path": "Hex/BenchOracle/Pari.lean",
+    "baseline_blob": "8088a21c35f5bb60ea8cc0d9f5b5eb2d32a77265",
+    "current_blob": "67864822cc40d953e1324bc2f4224ab6d6f24e89",
+    "reason": "Extends the shared PARI bench driver helper with the number-field polmod/nffactor codec surface; it remains bench-oracle infrastructure never imported by the factorization service or any Hex library module."
   }
 ]

--- a/scripts/oracle/pari_bench_driver.py
+++ b/scripts/oracle/pari_bench_driver.py
@@ -209,6 +209,92 @@ def _sympy_snf(request: dict[str, Any]) -> list[dict[str, list[int]]]:
     return _smith(request["matrix"])
 
 
+def _rat(pair: Any):
+    """Build a PARI rational from a ``[num, den]`` pair."""
+    if not isinstance(pair, list) or len(pair) != 2:
+        raise ValueError(f"rational must be a [num, den] pair, got {pair!r}")
+    pari = _require_pari()
+    return pari(int(pair[0])) / pari(int(pair[1]))
+
+
+def _int_poly(coeffs: list[int], variable: str):
+    pari = _require_pari()
+    return pari.Polrev([int(c) for c in coeffs], variable)
+
+
+def _rat_poly(pairs: list[Any], variable: str):
+    pari = _require_pari()
+    return pari.Polrev([_rat(pair) for pair in pairs], variable)
+
+
+def _rat_coeffs(poly) -> list[list[int]]:
+    """Ascending ``[num, den]`` coefficient pairs of a PARI polynomial
+    (or scalar), trimmed of trailing zeros by PARI's normal form."""
+    pari = _require_pari()
+    return [
+        [int(pari.numerator(c)), int(pari.denominator(c))]
+        for c in pari.Vecrev(poly)
+    ]
+
+
+# ---------------------------------------------------------------------
+# `polmod` (arithmetic in Q[x]/(m))
+# ---------------------------------------------------------------------
+
+
+def _polmod_mul(req: dict[str, Any]) -> list[list[int]]:
+    pari = _require_pari()
+    modulus = _int_poly(req["modulus"], "x")
+    a = pari.Mod(_rat_poly(req["a"], "x"), modulus)
+    b = pari.Mod(_rat_poly(req["b"], "x"), modulus)
+    return _rat_coeffs(pari.lift(a * b))
+
+
+def _polmod_inv(req: dict[str, Any]) -> list[list[int]]:
+    pari = _require_pari()
+    modulus = _int_poly(req["modulus"], "x")
+    a = pari.Mod(_rat_poly(req["a"], "x"), modulus)
+    return _rat_coeffs(pari.lift(a ** (-1)))
+
+
+def _polmod_overhead(_req: dict[str, Any]) -> int:
+    return 0
+
+
+def _charpoly_berkowitz(request: dict[str, Any]) -> list[int]:
+    pari = _require_pari()
+    rows = [[int(value) for value in row] for row in request["rows"]]
+    n = len(rows)
+    if any(len(row) != n for row in rows):
+        raise ValueError("charpoly requires a square matrix")
+    matrix = pari.matrix(n, n, [value for row in rows for value in row])
+    polynomial = matrix.charpoly("x", 3)
+    coefficients = [int(value) for value in polynomial.list()]
+    if len(coefficients) != n + 1:
+        raise RuntimeError(
+            f"PARI charpoly returned {len(coefficients)} coefficients for n={n}"
+        )
+    return coefficients
+
+
+_FMPZ_MAT_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
+    "charpoly_berkowitz": _charpoly_berkowitz,
+}
+
+
+def _nf_factor_degrees(req: dict[str, Any]) -> list[list[int]]:
+    pari = _require_pari()
+    field = _int_poly(req["field"], "y")
+    poly = _rat_poly(req["poly"], "x")
+    factorization = pari.nffactor(pari.nfinit(field), poly)
+    rows = int(pari.matsize(factorization)[0])
+    pairs = sorted(
+        (int(pari.poldegree(factorization[i, 0])), int(factorization[i, 1]))
+        for i in range(rows)
+    )
+    return [[degree, multiplicity] for degree, multiplicity in pairs]
+
+
 def _dispatch(request: dict[str, Any]) -> Any:
     family = request.get("family")
     operation = request.get("op")
@@ -227,6 +313,16 @@ def _dispatch(request: dict[str, Any]) -> Any:
     if family == "polymatrix" and operation == "sympy_snf":
         return _sympy_snf(request)
     if family == "polymatrix" and operation == "overhead":
+        return 0
+    if family == "polmod" and operation == "mul":
+        return _polmod_mul(request)
+    if family == "polmod" and operation == "inv":
+        return _polmod_inv(request)
+    if family == "polmod" and operation == "overhead":
+        return _polmod_overhead(request)
+    if family == "nf" and operation == "factor_degrees":
+        return _nf_factor_degrees(request)
+    if family == "nf" and operation == "overhead":
         return 0
     raise ValueError(f"unknown PARI benchmark operation {family!r}/{operation!r}")
 


### PR DESCRIPTION
This PR add the Phase-4 evidence code for HexNumberField and HexNumberFieldTower: thirteen parametric `setup_benchmark` ladders with adjacent cost-model derivations covering every declared input family, the missing Tower `Sub`/`Neg`/`Div`/`SMul` fixed registrations so every SPEC-API operation is assigned to a track, a persistent PARI bench comparator driver (`scripts/oracle/pari_bench_driver.py` + `Hex/BenchOracle/Pari.lean`, reusing the Flint persistent-comparator plumbing) with warmed hash-joined Lean/PARI pairs for `t_POLMOD` arithmetic and `nffactor`, and the `phase4:` blocks plus `## External comparators` SPEC sections for both libraries. Surfaces PARI does not expose as callable API (certified lazy arithmetic, exactification, the certified root sets, mixed-radix coordinates, fixed-embedding adjoin/split/flatten) are declared `no-comparable-surface-in-named-comparator` with per-surface reasons.

Performance-rationale paragraph per PLAN/Phase4.md: the exactification ladder declares the BHKS-shaped `n^9 + n^7 log^2` bound rather than a smaller observed cost; the lazy-arithmetic and root ladders declare `n^5 log^2` degree-product envelopes (worst-case, not amortised); and the Tower's Trager ladder declares the SPEC's shift recurrence written out as `(choose(2n,2)+1) n^2 + (2n)^9 + (2n)^7 log^2 (2n)`, with the Selmer `X^n - X - 1` over `Q(sqrt 2)` family chosen so every rung exercises the shift retry, the accepted squarefree norm, the recursive rational factorization, and gcd recovery rather than a best case. No timed measurements land here; feasibility probing found the fixed-field root path pathological at rung 2 (minutes against the declared model), filed as #9423 and blocking that surface's scientific rungs; the measurement/report/bump PR follows once the external measurement queue drains and #9423 resolves.

🤖 Prepared with Claude Code