### PR TITLE
polish: HexRCF Phase-6 pass

### DIFF
--- a/HexRCF/LintTests.lean
+++ b/HexRCF/LintTests.lean
@@ -16,6 +16,26 @@ import Mathlib.Tactic.Linter.TacticDocumentation
 This file intentionally uses legacy file syntax rather than `module`. Imported
 docstring metadata is not available to the linter through module imports, which
 would make every imported declaration appear undocumented.
+
+Beyond Batteries' default linter set (which already includes `docBlame` for
+defs, structures, and other non-theorem declarations), this run enables
+theorem docstring coverage via `docBlameThm'` below, so the
+docstring-coverage bar of `SPEC/design-principles.md` is build-enforced
+rather than manual. `docBlame` is listed explicitly to record that the bar
+depends on it.
 -/
 
-#lint- in HexRCF
+open Batteries.Tactic.Lint in
+/-- `docBlameThm`, minus the compiler-generated `ofNat_ctorIdx` theorems of
+enum inductives. Batteries' `Environment.isAutoDecl` filter predates that
+generated name (it recognises `ofNat`, `toCtorIdx`, and `ctorIdx`, but not
+`ofNat_ctorIdx`), so plain `docBlameThm` reports those theorems as
+undocumented; `@[nolint]` cannot repair this from here because it only applies
+in the defining module. -/
+@[env_linter disabled] def docBlameThm' : Linter :=
+  { docBlameThm with
+    test := fun declName => do
+      if declName.components.getLast? == some `ofNat_ctorIdx then return none
+      docBlameThm.test declName }
+
+#lint- docBlame docBlameThm' in HexRCF

--- a/progress/2026-08-22T07-02-01Z.md
+++ b/progress/2026-08-22T07-02-01Z.md
@@ -1,0 +1,72 @@
+# HexRCF Phase-6 polishing pass
+
+## Accomplished
+
+- **Phase-2 token backfill.** Wrote `status/hex-rcf.scaffolding-reviewed`
+  (explicitly marked as a backfill at done_through 5): all 172 backticked
+  SPEC identifiers resolve (HexRCF-owned surface in the 24 implementation
+  modules, dependency-owned names in HexRealRoots/HexRealRootsMathlib, the
+  rest tactic/tooling/negative mentions); banned-marker sweep found 0
+  sorry/axiom/native_decide/admit and 0 TODO/FIXME/placeholder/stub/dummy
+  across `HexRCF/`, `bench/HexRCF/`, `conformance/HexRCF/`; fixture audit
+  found 30 concrete sentence/result pairs in
+  `conformance-fixtures/HexRCF/rcf.jsonl`; CI reachability confirmed
+  (HexRCF/HexRCFTests/HexRCFProofProbe in ci.yml HEX_LIB_TARGETS,
+  `HexRCF.Conformance` in the HexConformance globs, oracle tuple at
+  `scripts/ci/run_oracles.sh:55`).
+- **Linter upgrade.** `HexRCF/LintTests.lean` now runs theorem docstring
+  coverage in addition to Batteries' defaults. `docBlameThm` cannot be used
+  directly: the compiler-generated `ofNat_ctorIdx` theorems of the three
+  enum inductives (`Hex.RCF.Cmp`, `Hex.RCF.Separation.RootCmp`,
+  `Hex.RCF.Sign`) postdate Batteries' `Environment.isAutoDecl` name list,
+  and `@[nolint]` cannot be attached from outside the defining module. The
+  file defines `docBlameThm'` (docBlameThm minus `ofNat_ctorIdx`) and runs
+  `#lint- docBlame docBlameThm' in HexRCF`, which is green.
+- **Docstring coverage.** With the upgraded linter enforced, coverage is
+  complete: 0 missing docstrings on defs (docBlame was already
+  default-enforced) and 0 on theorems beyond the three generated
+  false positives above. Manual sweep agreed (apparent gaps in
+  Carrier/CommonRoot/Language were grep artifacts of prose lines starting
+  with the word "theorem").
+- **Dead-declaration sweep.** Boundary-aware repo-wide reference analysis
+  over all 326 declarations in the 24 impl modules: 13 declarations are
+  never referenced by name outside their definition. All were kept as
+  interface roles, none deleted: `@[simp]` enumeration lemma
+  (`CellsCheck.size_all`), characterising/spec lemmas of public defs
+  (`sign?_spec`, `evalCell_eq_true_iff`, `dedupPolys_nodup`, `rank_lt`,
+  `carrier_ne_zero`), totality lemma (`Separation.classify_exists`),
+  failure-channel characterisations of the strict option folds
+  (`allArray_none`/`anyArray_none`/`allWhereArray_none`/`anyWhereArray_none`),
+  builder contract (`check_buildSturmReplay`), and the `@[tactic]` entry
+  point (`evalRCFTac`). Each already carries a role-stating docstring. No
+  unreferenced private helpers exist.
+- **Perf regression rung.** `lake exe hexrcf_bench list` (21 targets) and
+  `verify`: all 15 Lean-side benchmarks pass; the 6 `runFlintDecision*`
+  comparator targets fail only because python-flint is not installed here
+  (scheduled-only informational comparators per libraries.yml; not a
+  regression). No timed sweeps run (measurement windows are serialized
+  externally). This pass changes no compiled or proof-path code, so the
+  committed chungus2 baselines in `reports/bench-results/hex-rcf-*` and
+  the passed budgets recorded in `reports/hex-rcf-performance.md` remain
+  the regression evidence; a fresh timed comparison, if wanted for the
+  done_through bump, goes to the external measurement queue.
+- Verified: `lake build HexRCF HexRCFTests HexConformance` green,
+  `scripts/check_dag.py`, `scripts/check_phase4.py`, `git diff --check`.
+
+## Current frontier
+
+HexRCF has now cleared the Phase-6 code items reachable from this
+session: enforced docstring coverage, no dead declarations, clean
+upgraded lint, backfilled scaffolding token.
+
+## Next step
+
+A fresh timed bench comparison on the serialized measurement queue if
+the Phase-6 sign-off wants one; then the `done_through: 6` bump in
+libraries.yml (deliberately not touched by this pass) and the publish PR
+that moves SPEC/Libraries/hex-rcf.md.
+
+## Blockers
+
+None. (Local environment lacks python-flint, so the informational FLINT
+comparator benches cannot be exercised here; CI installs it.)

--- a/status/hex-rcf.scaffolding-reviewed
+++ b/status/hex-rcf.scaffolding-reviewed
@@ -1,0 +1,30 @@
+Backfill: this token was authored during the Phase-6 polishing pass with
+the library already at done_through 5, applying the Phase-2 scaffolding
+lens retroactively; no Phase-2-era gap remained to fix.
+SPEC-declaration coverage against SPEC/Libraries/hex-rcf.md: all 172
+backticked identifiers resolve. The HexRCF-owned surface (Sentence,
+Formula, Cmp, Atom, the toProp family, SturmReplay.check, CarrierCert /
+IsolationCert / CommonRootCert / SignMatrixCert and their checkers,
+classify?, separate?, Cells.all/rank/rootModel, Certificate.replay? with
+its emptyIoc/constants/noRoots/cells branches, check_sound, decide,
+decide_sound, buildCarrier?, buildCommonRoot(s)?, build?, replay_build,
+reifySentence, and the rcf tactic) exists across the 24 implementation
+modules; dependency-owned names (Sturm.sturmVar, sturm_line,
+sturm_half_open, SturmChainCert, ZPoly.sturmChain, isolate?_isSome,
+RealRootIsolation.refine1With, refineTo, the ChainCorrespond lemma set)
+resolve in HexRealRoots / HexRealRootsMathlib; the remainder are Mathlib
+tactic names (polyrith, nlinarith), file or lake-target names, and the
+explicit negative mention "No executable gcdZ API is assumed".
+Banned-marker sweep: 0 occurrences of sorry / axiom / native_decide /
+admit and 0 of TODO / FIXME / placeholder / stub / dummy across
+HexRCF/, bench/HexRCF/, and conformance/HexRCF/.
+Data-level placeholder audit: conformance-fixtures/HexRCF/rcf.jsonl
+carries 30 paired rcf_sentence/result records with concrete coefficient
+payloads spanning both quantifiers, Ioc bounds, and true/false verdicts;
+the failure channel is builder-refusal, not a stubbed value.
+CI reachability: HexRCF, HexRCFTests, and HexRCFProofProbe are in
+ci.yml's HEX_LIB_TARGETS build list; HexRCF.Conformance is in the
+HexConformance globs (lakefile.lean); and the oracle path is wired as
+the run_oracles.sh tuple
+HexRCF|hexrcf_emit_fixtures|scripts/oracle/rcf_flint.py|conformance-fixtures/HexRCF/rcf.jsonl
+with both oracle scripts present.


### PR DESCRIPTION
This PR complete the Phase-6 pass for HexRCF and backfill its Phase-2 attestation. The backfilled `status/hex-rcf.scaffolding-reviewed` records the full lens pass: all 172 SPEC-backticked identifiers resolve, zero banned markers across the implementation, bench, and conformance trees, 30 concrete oracle fixture pairs, and CI reachability through `HEX_LIB_TARGETS`, the conformance glob, and the run_oracles tuple. Docstring coverage was already complete; the pass upgrades `LintTests.lean` to also run `docBlame` and a `docBlameThm'` variant build-enforced over the HexRCF prefix (the variant skips the compiler-generated `ofNat_ctorIdx` enum theorems that Batteries' auto-decl list misses and that `@[nolint]` cannot reach cross-module, with both facts documented in place). The dead-declaration sweep found 13 zero-reference declarations, all kept as documented interface roles (simp fuel, characterising lemmas, failure-channel totality lemmas, the tactic entry point); nothing warranted deletion. The perf-regression rung stands on the committed chungus2 baselines and passed budget bounds in `reports/hex-rcf-performance.md`, since this pass changes no compiled or proof-path code; the `done_through: 6` bump follows in the serialized queue.

🤖 Prepared with Claude Code