### PR TITLE
feat(interval): replay sealed typed runtime proofs

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5613,7 +5613,7 @@ their declared cost inside a scheduler bound.
   compiler does not create global structural-matcher applications; offer
   generation remains a later layer. Fact-event correlation is supplied by
   `HexIntervalMathlib.Controller.Executable`; the separate supported
-  `HexIntervalMathlib.Runtime` companion correlates sealed typed fact,
+  `HexIntervalMathlib.RuntimeProof` companion correlates sealed typed fact,
   equality, transport, and instance transitions with theorem schemas.
 - `HexInterval/Runtime.lean`: supported sealed Mathlib-free ownership of one
   executable assembly, branch, and exact equality arena; atomic typed fact,
@@ -5621,7 +5621,7 @@ their declared cost inside a scheduler bound.
   binding, node, generation, and equality authority; and sealed before/after
   transitions retained by `Search.Result.Tree`. Raw quotations remain inert
   data; theorem authority is supplied only by the separately checked
-  `HexIntervalMathlib.Runtime` proof adapter.
+  `HexIntervalMathlib.RuntimeProof` proof adapter.
 - `HexInterval/Trace.lean`: supported exact fact/instance chronology and
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -5610,16 +5610,18 @@ their declared cost inside a scheduler bound.
   or theorem authority. Invocation rechecks complete application/request
   correspondence and commits
   a cache replacement only after result and quotation admission. The initial
-  compiler does not create global structural-matcher applications. Fact-event
-  correlation is supplied by `HexIntervalMathlib.Controller.Executable`; typed
-  equality/instance correlation and offer generation for typed batches remain
-  later layers.
+  compiler does not create global structural-matcher applications; offer
+  generation remains a later layer. Fact-event correlation is supplied by
+  `HexIntervalMathlib.Controller.Executable`; the separate supported
+  `HexIntervalMathlib.Runtime` companion correlates sealed typed fact,
+  equality, transport, and instance transitions with theorem schemas.
 - `HexInterval/Runtime.lean`: supported sealed Mathlib-free ownership of one
   executable assembly, branch, and exact equality arena; atomic typed fact,
   equality, transport, and append-only instance events; exact application,
   binding, node, generation, and equality authority; and sealed before/after
   transitions retained by `Search.Result.Tree`. Raw quotations remain inert
-  data pending a separately checked Mathlib proof adapter.
+  data; theorem authority is supplied only by the separately checked
+  `HexIntervalMathlib.Runtime` proof adapter.
 - `HexInterval/Trace.lean`: supported exact fact/instance chronology and
   bounded diagnostic-log contracts. Diagnostic bytes count retained `UInt8`
   payload cells after callback construction; they do not claim to preempt

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -22,6 +22,7 @@ public import HexIntervalMathlib.Controller
 public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
+public import HexIntervalMathlib.Runtime
 public import HexIntervalMathlib.Rule
 public import HexIntervalMathlib.Frontend
 public import HexIntervalMathlib.Tactic
@@ -36,6 +37,8 @@ natural power, outward regularization, and closed-left/strict-right
 transactional splitting, plus precision-indexed reciprocal and division
 enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
+`HexIntervalMathlib.Runtime` transactionally converts sealed typed runtime
+transition chains into those proof events without trusting raw quotations.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
 `HexIntervalMathlib.Controller` supplies explicit stable application-table,

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -22,7 +22,7 @@ public import HexIntervalMathlib.Controller
 public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
-public import HexIntervalMathlib.Runtime
+public import HexIntervalMathlib.RuntimeProof
 public import HexIntervalMathlib.Rule
 public import HexIntervalMathlib.Frontend
 public import HexIntervalMathlib.Tactic
@@ -37,7 +37,7 @@ natural power, outward regularization, and closed-left/strict-right
 transactional splitting, plus precision-indexed reciprocal and division
 enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
-`HexIntervalMathlib.Runtime` transactionally converts sealed typed runtime
+`HexIntervalMathlib.RuntimeProof` transactionally converts sealed typed runtime
 transition chains into those proof events without trusting raw quotations.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.

--- a/HexIntervalMathlib/Runtime.lean
+++ b/HexIntervalMathlib/Runtime.lean
@@ -1,0 +1,513 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.Proof
+
+@[expose] public section
+
+/-!
+# Typed runtime proof quotation
+
+This module is the supported companion boundary from sealed Mathlib-free
+`Runtime.Applied` transitions to the theorem-bearing `Proof.Event` language.
+Raw executable quotations remain inert: this adapter resolves their exact
+rule, role, and schema through both sealed registries, runs both the executable
+format validator and the theorem-schema decoder, and reconstructs every proof
+event from the authenticated typed runtime event.
+
+Instance events are wider than `Proof.InstanceStep`: before discarding the
+runtime-only fields, quotation checks the exact append-only program, binding,
+application-address, and generation suffixes. Transport has no raw quote; its
+proof event is derived only after independently checking the admitted equality
+descriptor, orientation, exact live source fact, and installed update.
+
+`quoteTreeWithin` performs a full transaction over the retained typed
+transition chains and seals the resulting per-node recipe. `replayTree`
+rechecks that quotation before entering the existing recursive proof fold.
+Target, refutation, and split records remain the separately checked terminal
+schemas already owned by `Proof.replayTree`.
+-/
+
+namespace Hex.Interval.RuntimeProof
+
+variable {Fact Cause Plan : Type}
+
+/-- Stable compatibility epoch for one executable/proof registry pair. It is
+not callback identity; all decoded results still cross both registries and the
+typed transition checks below. -/
+structure Key where
+  name : String
+  version : Nat
+  deriving DecidableEq, Repr
+
+abbrev Assembly (Fact Cause : Type) :=
+  Executable.Assembly Fact (Runtime.Batch Fact Cause)
+
+/-- Exact executable/theorem alignment. The private constructor prevents a
+caller from transplanting a proof registry after format coverage was checked. -/
+structure Registry (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type := List Nat) where
+  private mk ::
+  key : Key
+  assembly : Assembly Fact Cause
+  proof : Proof.Registry semantics Plan
+
+/-- Quotation limits in addition to the retained search/runtime and proof
+limits. `maxEvents` is a total-tree bound, while the runtime limit remains the
+per-callback batch bound. `maxStructuralCells` charges retained bindings,
+applications, equalities, and typed-event cells before recipe construction. -/
+structure Limits where
+  result : Search.Result.Limits
+  proof : Proof.Limits
+  tree : Proof.TreeLimits
+  maxTransitions : Nat
+  maxEvents : Nat
+  maxStructuralCells : Nat
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | transitions
+  | events
+  | structuralCells
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | invalidRegistry
+  | executable (error : Executable.Error)
+  | state (error : State.BranchError)
+  | proof (error : Proof.Error)
+  | missingFormat (key : Executable.ReplayKey)
+  | missingSchema (key : Proof.Key)
+  | invalidBody (key : Proof.Key)
+  | malformed
+  | mismatch
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+/-- Promote a small checked result into the universe used by registries and
+assemblies, whose package-owned certificate/cache types make them large. -/
+private def promote {E A : Type} (map : E → Error) :
+    Except E A → Except Error (ULift.{1, 0} A)
+  | .ok value => .ok ⟨value⟩
+  | .error error => .error (map error)
+
+private def sameRegistrations (left right : Array Registration) : Bool := Id.run do
+  if left.size != right.size then return false
+  for index in [0:left.size] do
+    let some a := left[index]? | return false
+    let some b := right[index]? | return false
+    if !a.same b then return false
+  return true
+
+private def proofRole : Executable.Role → Proof.Role
+  | .fact => .fact
+  | .equality => .equality
+  | .instance => .instance
+
+private def executableRole? : Proof.Role → Option Executable.Role
+  | .fact => some .fact
+  | .equality => some .equality
+  | .instance => some .instance
+  | .refute | .split => none
+
+private def proofKey (rule : RuleKey) (role : Executable.Role) (schema : Nat) : Proof.Key :=
+  { rule, role := proofRole role, bodySchema := schema }
+
+private def hasSchema (proof : Proof.Registry semantics Plan) (key : Proof.Key) : Bool :=
+  match key.role with
+  | .fact => (proof.fact? key).isSome
+  | .equality => (proof.equality? key).isSome
+  | .instance => (proof.instance? key).isSome
+  | .refute => (proof.refuter? key).isSome
+  | .split => (proof.split? key).isSome
+
+private def hasFormat (assembly : Assembly Fact Cause) (key : Proof.Key) : Bool :=
+  match executableRole? key.role,
+      Registration.find? assembly.registry.registrations key.rule with
+  | some role, some (ruleId, _) =>
+      match assembly.registry.formats? ruleId with
+      | some (rule, formats) =>
+          rule == key.rule && formats.any fun format =>
+            format.role == role && format.schema == key.bodySchema
+      | none => false
+  | _, _ => false
+
+private def formatCoverage (assembly : Assembly Fact Cause)
+    (proof : Proof.Registry semantics Plan) : Bool := Id.run do
+  for index in [0:assembly.registry.registrations.size] do
+    let some (rule, formats) := assembly.registry.formats? { index } | return false
+    for format in formats do
+      if !hasSchema proof (proofKey rule format.role format.schema) then return false
+  for schema in proof.facts do
+    if !hasFormat assembly schema.key then return false
+  for schema in proof.equalities do
+    if !hasFormat assembly schema.key then return false
+  for schema in proof.instances do
+    if !hasFormat assembly schema.key then return false
+  return true
+
+/-- Seal bidirectional coverage of every typed-runtime replay format and every
+fact/equality/instance proof schema. Refutation and split schemas are allowed
+as terminal-only registrations and deliberately require no executable format. -/
+opaque Registry.buildWithin (limits : Executable.Limits) (key : Key)
+    (assembly : Assembly Fact Cause) (proof : Proof.Registry semantics Plan) :
+    Except Error (Registry Fact semantics Cause Plan) := do
+  let _ ← promote Error.executable (assembly.preflightWithin limits)
+  if !assembly.program.check ||
+      !Registration.check assembly.program proof.registrations ||
+      !sameRegistrations assembly.registry.registrations proof.registrations ||
+      !formatCoverage assembly proof then
+    throw .invalidRegistry
+  pure { key, assembly, proof }
+
+private def inputsAvailable (branch : State.Branch Fact Cause)
+    (inputs : List SeenVersion) : Bool :=
+  inputs.all fun seen => (branch.factAt? seen).isSome
+
+private def current (branch : State.Branch Fact Cause) (seen : SeenVersion) : Bool :=
+  branch.versions[seen.node.index]? == some seen.version &&
+    (branch.factAt? seen).isSome
+
+private def expectedNodes (start count : Nat) : List NodeId :=
+  (List.range count).map fun offset => { index := start + offset }
+
+private def expectedApplications (start count : Nat) : List ApplicationId :=
+  (List.range count).map fun offset => { index := start + offset }
+
+private def suffix {α : Type} (before after : Array α) : List α :=
+  (List.range (after.size - before.size)).filterMap fun offset =>
+    after[before.size + offset]?
+
+private def equalityPrefix (before after : Array Runtime.Equality) : Bool := Id.run do
+  if after.size < before.size then return false
+  for index in [0:before.size] do
+    if before[index]? != after[index]? then return false
+  return true
+
+private def quoteOf : Runtime.Event Fact Cause → Option Executable.Quote
+  | .fact step => some step.quote
+  | .equality step => some step.quote
+  | .instance step => some step.quote
+  | .transport _ => none
+
+private def eventQuotes (events : Array (Runtime.Event Fact Cause)) :
+    Array Executable.Quote :=
+  events.toList.filterMap quoteOf |>.toArray
+
+private def decodeSchema (proof : Proof.Registry semantics Plan) (key : Proof.Key)
+    (body : List Nat) : Bool :=
+  match key.role with
+  | .fact => (proof.fact? key).any fun schema => (schema.decode body).isSome
+  | .equality => (proof.equality? key).any fun schema => (schema.decode body).isSome
+  | .instance => (proof.instance? key).any fun schema => (schema.decode body).isSome
+  | .refute => (proof.refuter? key).any fun schema => (schema.decode body).isSome
+  | .split => (proof.split? key).any fun schema => (schema.decode body).isSome
+
+private def checkQuote (limits : Proof.Limits)
+    (registry : Registry Fact semantics Cause Plan) (action : Action)
+    (expected : Executable.Role) (quote : Executable.Quote) :
+    Except Error Proof.Key := do
+  if quote.role != expected then throw .malformed
+  let some (rule, formats) := registry.assembly.registry.formats? action.rule
+    | throw .malformed
+  if rule != action.key then throw .malformed
+  let replayKey : Executable.ReplayKey :=
+    { rule, role := quote.role, schema := quote.schema }
+  let some format := formats.find? fun format =>
+      format.role == quote.role && format.schema == quote.schema
+    | throw (.missingFormat replayKey)
+  if !format.accepts quote then throw (.invalidBody (proofKey rule quote.role quote.schema))
+  let key := proofKey rule quote.role quote.schema
+  Proof.bodyCheck limits key (proofRole quote.role) quote.body |>.mapError Error.proof
+  if !hasSchema registry.proof key then throw (.missingSchema key)
+  if !decodeSchema registry.proof key quote.body then throw (.invalidBody key)
+  pure key
+
+private structure Cursor (Fact Cause : Type) where
+  branch : State.Branch Fact Cause
+  assembly : Assembly Fact Cause
+  equalities : Array Runtime.Equality
+  quotes : Array Executable.Quote
+  events : List (Proof.Event Fact)
+
+private def fromBranch {α : Type} : Except State.BranchError α → Except Error α
+  | .ok value => .ok value
+  | .error error => .error (.state error)
+
+private def pushFact [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause)
+    (cursor : Cursor Fact Cause) (step : Runtime.FactStep Fact Cause) :
+    Except Error (Cursor Fact Cause) := do
+  if step.action != applied.action ||
+      step.action.programVersion != cursor.branch.programVersion ||
+      step.update.programVersion != cursor.branch.programVersion ||
+      !step.action.writes.contains step.update.node then throw .malformed
+  let liftedKey ← promote id
+    (checkQuote limits.proof registry applied.action .fact step.quote)
+  let key := liftedKey.down
+  let _ ← promote Error.proof
+    (Proof.dependenciesCheck limits.proof applied.action.inputs)
+  let liftedNext ← promote id (fromBranch (State.Branch.pushWithin limits.result.state
+    cursor.branch step.update applied.after.contradictory))
+  let next := liftedNext.down
+  let event : Proof.Event Fact := .fact
+    { scope, programVersion := cursor.branch.programVersion, action := step.action,
+      node := step.update.node, previous := step.update.previous,
+      version := step.update.version, proposed := step.proposed,
+      installed := step.update.fact, assumptions := step.action.inputs,
+      schema := key, body := step.quote.body }
+  pure
+    { branch := next, assembly := cursor.assembly, equalities := cursor.equalities,
+      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+
+private def pushEquality [DecidableEq Fact]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause)
+    (cursor : Cursor Fact Cause) (step : Runtime.EqualityStep) :
+    Except Error (Cursor Fact Cause) := do
+  if step.action != applied.action ||
+      step.action.programVersion != cursor.branch.programVersion ||
+      step.equality.index != cursor.equalities.size || step.left == step.right ||
+      step.assumptions != step.action.inputs ||
+      !inputsAvailable cursor.branch step.assumptions ||
+      step.generation != step.action.generation then throw .malformed
+  let some left := cursor.branch.program.node? step.left | throw .malformed
+  let some right := cursor.branch.program.node? step.right | throw .malformed
+  if left.domain != right.domain then throw .malformed
+  let liftedKey ← promote id
+    (checkQuote limits.proof registry applied.action .equality step.quote)
+  let key := liftedKey.down
+  let _ ← promote Error.proof
+    (Proof.dependenciesCheck limits.proof step.assumptions)
+  let equality : Runtime.Equality :=
+    { left := step.left, right := step.right, generation := step.generation,
+      origin := step.action, assumptions := step.assumptions, quote := step.quote }
+  let event : Proof.Event Fact := .equality
+    { scope, programVersion := cursor.branch.programVersion, action := step.action,
+      equality := step.equality, left := step.left, right := step.right,
+      assumptions := step.assumptions, schema := key, body := step.quote.body }
+  pure
+    { branch := cursor.branch, assembly := cursor.assembly,
+      equalities := cursor.equalities.push equality,
+      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+
+private def pushTransport [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (scope : Policy.ScopeId)
+    (applied : Runtime.Applied Fact Cause) (cursor : Cursor Fact Cause)
+    (step : Runtime.TransportStep Fact Cause) : Except Error (Cursor Fact Cause) := do
+  if step.action != applied.action ||
+      step.action.programVersion != cursor.branch.programVersion ||
+      step.update.programVersion != cursor.branch.programVersion ||
+      !step.action.writes.contains step.update.node ||
+      !step.action.inputs.contains step.source || !current cursor.branch step.source ||
+      cursor.branch.factAt? step.source != some step.update.fact then throw .malformed
+  let some equality := cursor.equalities[step.equality.index]? | throw .malformed
+  let oriented :=
+    (step.update.node == equality.left && step.source.node == equality.right) ||
+      (step.update.node == equality.right && step.source.node == equality.left)
+  if !oriented then throw .malformed
+  let liftedNext ← promote id (fromBranch (State.Branch.pushWithin limits.result.state
+    cursor.branch step.update applied.after.contradictory))
+  let next := liftedNext.down
+  let event : Proof.Event Fact := .transport
+    { scope, programVersion := cursor.branch.programVersion, node := step.update.node,
+      previous := step.update.previous, version := step.update.version,
+      equality := step.equality, source := step.source, installed := step.update.fact }
+  pure
+    { branch := next, assembly := cursor.assembly, equalities := cursor.equalities,
+      quotes := cursor.quotes, events := cursor.events ++ [event] }
+
+private def pushInstance [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause)
+    (cursor : Cursor Fact Cause) (step : Runtime.InstanceStep Fact) :
+    Except Error (Cursor Fact Cause) := do
+  if step.action != applied.action || step.action.kind != .instantiate ||
+      step.action.programVersion != cursor.branch.programVersion ||
+      step.generation != cursor.assembly.generation + 1 ||
+      (step.newNodes.isEmpty && step.newBindings.isEmpty && step.newApplications.isEmpty) ||
+      !Executable.bindingsPrefix cursor.assembly.bindings step.bindings ||
+      step.newBindings != suffix cursor.assembly.bindings step.bindings ||
+      step.newNodes != expectedNodes cursor.branch.program.nodes.size
+        (step.after.nodes.size - cursor.branch.program.nodes.size) then throw .malformed
+  let nextAssembly ← cursor.assembly.extendAllWithin limits.result.runtime.executable
+    step.after step.bindings step.generation |>.mapError Error.executable
+  let freshApplications := nextAssembly.applications.size - cursor.assembly.applications.size
+  if step.newApplications != expectedApplications cursor.assembly.applications.size
+      freshApplications then throw .malformed
+  let liftedKey ← promote id
+    (checkQuote limits.proof registry applied.action .instance step.quote)
+  let key := liftedKey.down
+  let liftedNext ← promote id (fromBranch (State.Branch.extendWithin limits.result.state
+    cursor.branch step.after step.freshFacts (cursor.branch.programVersion + 1)))
+  let next := liftedNext.down
+  let event : Proof.Event Fact := .instance
+    { scope, beforeVersion := cursor.branch.programVersion,
+      afterVersion := next.programVersion, action := step.action,
+      after := step.after, newNodes := step.newNodes, schema := key,
+      body := step.quote.body }
+  pure
+    { branch := next, assembly := nextAssembly, equalities := cursor.equalities,
+      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+
+private def pushEvent [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause)
+    (cursor : Cursor Fact Cause) : Runtime.Event Fact Cause →
+      Except Error (Cursor Fact Cause)
+  | .fact step => pushFact limits registry scope applied cursor step
+  | .equality step => pushEquality limits registry scope applied cursor step
+  | .transport step => pushTransport limits scope applied cursor step
+  | .instance step => pushInstance limits registry scope applied cursor step
+
+private def quoteAppliedFrom [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (assembly : Assembly Fact Cause)
+    (applied : Runtime.Applied Fact Cause) :
+    Except Error (List (Proof.Event Fact) × Assembly Fact Cause) := do
+  if limits.result.runtime.maxEvents < applied.events.size ||
+      limits.maxEvents < applied.events.size then throw (.resource .events)
+  if applied.events.isEmpty || !applied.before.check || !applied.after.check ||
+      applied.serial != applied.action.serial ||
+      applied.before.baseProgram != applied.after.baseProgram ||
+      applied.before.initialFacts != applied.after.initialFacts ||
+      !Executable.bindingsPrefix applied.beforeBindings applied.afterBindings ||
+      !Executable.applicationsPrefix applied.beforeApplications applied.afterApplications ||
+      !equalityPrefix applied.beforeEqualities applied.afterEqualities ||
+      applied.beforeGeneration > applied.afterGeneration ||
+      applied.beforeGeneration + applied.after.programVersion !=
+        applied.afterGeneration + applied.before.programVersion ||
+      eventQuotes applied.events != applied.quotes ||
+      !State.programPrefix registry.assembly.program applied.before.baseProgram ||
+      assembly.program != applied.before.program ||
+      assembly.bindings != applied.beforeBindings ||
+      assembly.applications.size != applied.beforeApplications.size ||
+      !Executable.applicationsPrefix assembly.applications applied.beforeApplications ||
+      assembly.generation != applied.beforeGeneration ||
+      !Registration.check applied.before.program registry.proof.registrations ||
+      !Registration.check applied.after.program registry.proof.registrations then
+    throw .malformed
+  let mut cursor : Cursor Fact Cause :=
+    { branch := applied.before, assembly,
+      equalities := applied.beforeEqualities,
+      quotes := #[], events := [] }
+  for event in applied.events do
+    cursor ← pushEvent limits registry scope applied cursor event
+  if cursor.branch != applied.after || cursor.assembly.program != applied.after.program ||
+      cursor.assembly.bindings != applied.afterBindings ||
+      cursor.assembly.applications.size != applied.afterApplications.size ||
+      !Executable.applicationsPrefix cursor.assembly.applications applied.afterApplications ||
+      cursor.assembly.generation != applied.afterGeneration ||
+      cursor.equalities != applied.afterEqualities || cursor.quotes != applied.quotes then
+    throw .mismatch
+  pure (cursor.events, cursor.assembly)
+
+/-- Transactionally quote a sealed typed callback batch starting from the
+registry assembly. Full retained chains use `quoteTreeWithin`, which carries
+the reconstructed assembly across every later callback at the same node. -/
+opaque quoteAppliedWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause) :
+    Except Error (List (Proof.Event Fact)) :=
+  match quoteAppliedFrom limits registry scope registry.assembly applied with
+  | .ok (events, _) => .ok events
+  | .error error => .error error
+
+/-- Sealed exact retained tree and the recipe derived from all its typed
+runtime transition chains. -/
+structure Bundle (Fact Cause Plan : Type) where
+  private mk ::
+  key : Key
+  tree : Search.Result.Tree Fact Cause Plan Proof.Key
+  recipe : Proof.TreeRecipe Fact
+
+private def edgeOf (node : Search.Result.Node Fact Cause Plan Proof.Key) :
+    Proof.TreeEdge Fact :=
+  { parent := node.source.parent, side := node.source.side, seed := node.source.seed }
+
+private def structuralCells (transition : Runtime.Applied Fact Cause) : Nat :=
+  transition.events.size + transition.quotes.size +
+    transition.beforeBindings.size + transition.afterBindings.size +
+    transition.beforeApplications.size + transition.afterApplications.size +
+    transition.beforeEqualities.size + transition.afterEqualities.size
+
+private structure NodeCursor (Fact Cause : Type) where
+  events : List (Proof.Event Fact)
+  assembly : Assembly Fact Cause
+
+private def quoteTransitions [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key) :
+    List (Search.Result.Id × Runtime.Applied Fact Cause) →
+      Array (NodeCursor Fact Cause) → Except Error (Array (NodeCursor Fact Cause))
+  | [], cursors => pure cursors
+  | entry :: rest, cursors => do
+      let some node := tree.nodes[entry.1.index]? | throw .malformed
+      let some cursor := cursors[entry.1.index]? | throw .malformed
+      let (quoted, nextAssembly) ←
+        quoteAppliedFrom limits registry node.source.scope cursor.assembly entry.2
+      let next := cursors.set! entry.1.index
+        { events := cursor.events ++ quoted, assembly := nextAssembly }
+      quoteTransitions limits registry tree rest next
+
+private def quoteChronologies [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (transitions : Array (Search.Result.Id × Runtime.Applied Fact Cause)) :
+    Except Error (Array (List (Proof.Event Fact))) :=
+  let initial : Array (NodeCursor Fact Cause) :=
+    Array.replicate tree.nodes.size { events := [], assembly := registry.assembly }
+  match quoteTransitions limits registry tree transitions.toList initial with
+  | .error error => .error error
+  | .ok cursors => .ok (Array.map (fun cursor => cursor.events) cursors)
+
+/-- Quote the complete checked retained tree transactionally. No prefix recipe
+escapes if any later transition, schema, body, resource, or node-chain check
+fails. -/
+opaque quoteTreeWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (registry : Registry Fact semantics Cause Plan)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key) :
+    Except Error (Bundle Fact Cause Plan) := do
+  if !tree.check limits.result measure then throw .malformed
+  let transitions := tree.transitions
+  if limits.maxTransitions < transitions.size then throw (.resource .transitions)
+  let mut eventCount := 0
+  let mut cells := 0
+  for entry in transitions do
+    eventCount := eventCount + entry.2.events.size
+    cells := cells + structuralCells entry.2
+    if limits.maxEvents < eventCount then throw (.resource .events)
+    if limits.maxStructuralCells < cells then throw (.resource .structuralCells)
+  let mut edges : Array (Proof.TreeEdge Fact) := #[]
+  for node in tree.nodes do edges := edges.push (edgeOf node)
+  let events ← quoteChronologies limits registry tree transitions
+  for chronology in events do
+    if limits.proof.maxChronology < chronology.length then
+      throw (.proof .chronologyLimit)
+  let recipe : Proof.TreeRecipe Fact := { events, edges }
+  Proof.checkTreeLimits limits.tree tree recipe |>.mapError Error.proof
+  pure { key := registry.key, tree, recipe }
+
+/-- Recheck exact quotation and run the existing recursive proof fold. Raw
+quotes never become evidence; only independently decoded package schemas can
+construct the returned theorem. -/
+def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (registry : Registry Fact semantics Cause Plan) (domain : Proof.Domain semantics)
+    (laws : Proof.Laws semantics) (input : Proof.Input Fact)
+    (bundle : Bundle Fact Cause Plan) : Except Error
+      (Proof.Evidence (semantics.Entails input.program (Proof.initialBase input) input.target)) := do
+  if bundle.key != registry.key then throw .mismatch
+  let checked ← quoteTreeWithin limits measure registry bundle.tree
+  if checked.recipe != bundle.recipe then throw .mismatch
+  Proof.replayTree limits.result measure limits.proof limits.tree registry.proof
+    domain laws input bundle.tree bundle.recipe |>.mapError Error.proof
+
+end Hex.Interval.RuntimeProof

--- a/HexIntervalMathlib/RuntimeProof.lean
+++ b/HexIntervalMathlib/RuntimeProof.lean
@@ -24,13 +24,17 @@ Instance events are wider than `Proof.InstanceStep`: before discarding the
 runtime-only fields, quotation checks the exact append-only program, binding,
 application-address, and generation suffixes. Transport has no raw quote; its
 proof event is derived only after independently checking the admitted equality
-descriptor, orientation, exact live source fact, and installed update.
+descriptor, orientation, exact live source fact, and installed update. These
+are structural runtime authorizations, not semantic entailment authority:
+only equality-schema replay proves substitution.
 
 `quoteTreeWithin` performs a full transaction over the retained typed
-transition chains and seals the resulting per-node recipe. `replayTree`
-rechecks that quotation before entering the existing recursive proof fold.
-Target, refutation, and split records remain the separately checked terminal
-schemas already owned by `Proof.replayTree`.
+transition chains and seals the exact registry with the resulting per-node
+recipe. `replayTree` consumes that checked token without quoting again.
+The underlying proof fold deliberately rechecks the retained tree and proof
+limits once at its theorem boundary; arbitrary package decoders and theorem
+callbacks remain non-preemptible. Target, refutation, and split records remain
+the separately checked terminal schemas already owned by `Proof.replayTree`.
 -/
 
 namespace Hex.Interval.RuntimeProof
@@ -58,9 +62,11 @@ structure Registry (Fact : Type) (semantics : Proof.Semantics Fact)
   proof : Proof.Registry semantics Plan
 
 /-- Quotation limits in addition to the retained search/runtime and proof
-limits. `maxEvents` is a total-tree bound, while the runtime limit remains the
-per-callback batch bound. `maxStructuralCells` charges retained bindings,
-applications, equalities, and typed-event cells before recipe construction. -/
+limits. `maxEvents` is a total retained-tree admission bound, while the
+runtime limit remains the per-callback batch bound. Neither cap preempts
+callback execution or equality on arbitrary caller facts.
+`maxStructuralCells` charges retained bindings, applications,
+equalities, and typed-event cells before recipe construction. -/
 structure Limits where
   result : Search.Result.Limits
   proof : Proof.Limits
@@ -76,6 +82,16 @@ inductive Resource where
   | structuralCells
   deriving DecidableEq, Repr
 
+inductive Malformed where
+  | quote
+  | fact
+  | equality
+  | transport
+  | instance
+  | transition
+  | tree
+  deriving DecidableEq, Repr
+
 inductive Error where
   | invalidRegistry
   | executable (error : Executable.Error)
@@ -84,7 +100,7 @@ inductive Error where
   | missingFormat (key : Executable.ReplayKey)
   | missingSchema (key : Proof.Key)
   | invalidBody (key : Proof.Key)
-  | malformed
+  | malformed (location : Malformed)
   | mismatch
   | resource (resource : Resource)
   deriving DecidableEq, Repr
@@ -212,10 +228,10 @@ private def checkQuote (limits : Proof.Limits)
     (registry : Registry Fact semantics Cause Plan) (action : Action)
     (expected : Executable.Role) (quote : Executable.Quote) :
     Except Error Proof.Key := do
-  if quote.role != expected then throw .malformed
+  if quote.role != expected then throw (.malformed .quote)
   let some (rule, formats) := registry.assembly.registry.formats? action.rule
-    | throw .malformed
-  if rule != action.key then throw .malformed
+    | throw (.malformed .quote)
+  if rule != action.key then throw (.malformed .quote)
   let replayKey : Executable.ReplayKey :=
     { rule, role := quote.role, schema := quote.schema }
   let some format := formats.find? fun format =>
@@ -233,7 +249,7 @@ private structure Cursor (Fact Cause : Type) where
   assembly : Assembly Fact Cause
   equalities : Array Runtime.Equality
   quotes : Array Executable.Quote
-  events : List (Proof.Event Fact)
+  eventsRev : List (Proof.Event Fact)
 
 private def fromBranch {α : Type} : Except State.BranchError α → Except Error α
   | .ok value => .ok value
@@ -247,7 +263,7 @@ private def pushFact [DecidableEq Fact] [DecidableEq Cause]
   if step.action != applied.action ||
       step.action.programVersion != cursor.branch.programVersion ||
       step.update.programVersion != cursor.branch.programVersion ||
-      !step.action.writes.contains step.update.node then throw .malformed
+      !step.action.writes.contains step.update.node then throw (.malformed .fact)
   let liftedKey ← promote id
     (checkQuote limits.proof registry applied.action .fact step.quote)
   let key := liftedKey.down
@@ -264,7 +280,7 @@ private def pushFact [DecidableEq Fact] [DecidableEq Cause]
       schema := key, body := step.quote.body }
   pure
     { branch := next, assembly := cursor.assembly, equalities := cursor.equalities,
-      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+      quotes := cursor.quotes.push step.quote, eventsRev := event :: cursor.eventsRev }
 
 private def pushEquality [DecidableEq Fact]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
@@ -276,10 +292,10 @@ private def pushEquality [DecidableEq Fact]
       step.equality.index != cursor.equalities.size || step.left == step.right ||
       step.assumptions != step.action.inputs ||
       !inputsAvailable cursor.branch step.assumptions ||
-      step.generation != step.action.generation then throw .malformed
-  let some left := cursor.branch.program.node? step.left | throw .malformed
-  let some right := cursor.branch.program.node? step.right | throw .malformed
-  if left.domain != right.domain then throw .malformed
+      step.generation != step.action.generation then throw (.malformed .equality)
+  let some left := cursor.branch.program.node? step.left | throw (.malformed .equality)
+  let some right := cursor.branch.program.node? step.right | throw (.malformed .equality)
+  if left.domain != right.domain then throw (.malformed .equality)
   let liftedKey ← promote id
     (checkQuote limits.proof registry applied.action .equality step.quote)
   let key := liftedKey.down
@@ -295,7 +311,7 @@ private def pushEquality [DecidableEq Fact]
   pure
     { branch := cursor.branch, assembly := cursor.assembly,
       equalities := cursor.equalities.push equality,
-      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+      quotes := cursor.quotes.push step.quote, eventsRev := event :: cursor.eventsRev }
 
 private def pushTransport [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (scope : Policy.ScopeId)
@@ -306,12 +322,14 @@ private def pushTransport [DecidableEq Fact] [DecidableEq Cause]
       step.update.programVersion != cursor.branch.programVersion ||
       !step.action.writes.contains step.update.node ||
       !step.action.inputs.contains step.source || !current cursor.branch step.source ||
-      cursor.branch.factAt? step.source != some step.update.fact then throw .malformed
-  let some equality := cursor.equalities[step.equality.index]? | throw .malformed
+      cursor.branch.factAt? step.source != some step.update.fact then
+    throw (.malformed .transport)
+  let some equality := cursor.equalities[step.equality.index]?
+    | throw (.malformed .transport)
   let oriented :=
     (step.update.node == equality.left && step.source.node == equality.right) ||
       (step.update.node == equality.right && step.source.node == equality.left)
-  if !oriented then throw .malformed
+  if !oriented then throw (.malformed .transport)
   let liftedNext ← promote id (fromBranch (State.Branch.pushWithin limits.result.state
     cursor.branch step.update applied.after.contradictory))
   let next := liftedNext.down
@@ -321,7 +339,7 @@ private def pushTransport [DecidableEq Fact] [DecidableEq Cause]
       equality := step.equality, source := step.source, installed := step.update.fact }
   pure
     { branch := next, assembly := cursor.assembly, equalities := cursor.equalities,
-      quotes := cursor.quotes, events := cursor.events ++ [event] }
+      quotes := cursor.quotes, eventsRev := event :: cursor.eventsRev }
 
 private def pushInstance [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
@@ -335,12 +353,13 @@ private def pushInstance [DecidableEq Fact] [DecidableEq Cause]
       !Executable.bindingsPrefix cursor.assembly.bindings step.bindings ||
       step.newBindings != suffix cursor.assembly.bindings step.bindings ||
       step.newNodes != expectedNodes cursor.branch.program.nodes.size
-        (step.after.nodes.size - cursor.branch.program.nodes.size) then throw .malformed
+        (step.after.nodes.size - cursor.branch.program.nodes.size) then
+    throw (.malformed .instance)
   let nextAssembly ← cursor.assembly.extendAllWithin limits.result.runtime.executable
     step.after step.bindings step.generation |>.mapError Error.executable
   let freshApplications := nextAssembly.applications.size - cursor.assembly.applications.size
   if step.newApplications != expectedApplications cursor.assembly.applications.size
-      freshApplications then throw .malformed
+      freshApplications then throw (.malformed .instance)
   let liftedKey ← promote id
     (checkQuote limits.proof registry applied.action .instance step.quote)
   let key := liftedKey.down
@@ -354,7 +373,7 @@ private def pushInstance [DecidableEq Fact] [DecidableEq Cause]
       body := step.quote.body }
   pure
     { branch := next, assembly := nextAssembly, equalities := cursor.equalities,
-      quotes := cursor.quotes.push step.quote, events := cursor.events ++ [event] }
+      quotes := cursor.quotes.push step.quote, eventsRev := event :: cursor.eventsRev }
 
 private def pushEvent [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
@@ -366,9 +385,10 @@ private def pushEvent [DecidableEq Fact] [DecidableEq Cause]
   | .transport step => pushTransport limits scope applied cursor step
   | .instance step => pushInstance limits registry scope applied cursor step
 
-private def quoteAppliedFrom [DecidableEq Fact] [DecidableEq Cause]
+private def quoteAppliedRevFrom [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
     (scope : Policy.ScopeId) (assembly : Assembly Fact Cause)
+    (eventsRev : List (Proof.Event Fact))
     (applied : Runtime.Applied Fact Cause) :
     Except Error (List (Proof.Event Fact) × Assembly Fact Cause) := do
   if limits.result.runtime.maxEvents < applied.events.size ||
@@ -392,11 +412,11 @@ private def quoteAppliedFrom [DecidableEq Fact] [DecidableEq Cause]
       assembly.generation != applied.beforeGeneration ||
       !Registration.check applied.before.program registry.proof.registrations ||
       !Registration.check applied.after.program registry.proof.registrations then
-    throw .malformed
+    throw (.malformed .transition)
   let mut cursor : Cursor Fact Cause :=
     { branch := applied.before, assembly,
       equalities := applied.beforeEqualities,
-      quotes := #[], events := [] }
+      quotes := #[], eventsRev }
   for event in applied.events do
     cursor ← pushEvent limits registry scope applied cursor event
   if cursor.branch != applied.after || cursor.assembly.program != applied.after.program ||
@@ -406,24 +426,16 @@ private def quoteAppliedFrom [DecidableEq Fact] [DecidableEq Cause]
       cursor.assembly.generation != applied.afterGeneration ||
       cursor.equalities != applied.afterEqualities || cursor.quotes != applied.quotes then
     throw .mismatch
-  pure (cursor.events, cursor.assembly)
+  pure (cursor.eventsRev, cursor.assembly)
 
-/-- Transactionally quote a sealed typed callback batch starting from the
-registry assembly. Full retained chains use `quoteTreeWithin`, which carries
-the reconstructed assembly across every later callback at the same node. -/
-opaque quoteAppliedWithin [DecidableEq Fact] [DecidableEq Cause]
-    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
-    (scope : Policy.ScopeId) (applied : Runtime.Applied Fact Cause) :
-    Except Error (List (Proof.Event Fact)) :=
-  match quoteAppliedFrom limits registry scope registry.assembly applied with
-  | .ok (events, _) => .ok events
-  | .error error => .error error
-
-/-- Sealed exact retained tree and the recipe derived from all its typed
-runtime transition chains. -/
-structure Bundle (Fact Cause Plan : Type) where
+/-- Sealed exact registry, retained tree, and recipe derived from all its typed
+runtime transition chains. Retaining the registry inside this private-
+constructor token prevents replay under a different registry which merely
+reuses the same public compatibility key. -/
+structure Bundle (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type) where
   private mk ::
-  key : Key
+  registry : Registry Fact semantics Cause Plan
   tree : Search.Result.Tree Fact Cause Plan Proof.Key
   recipe : Proof.TreeRecipe Fact
 
@@ -437,45 +449,75 @@ private def structuralCells (transition : Runtime.Applied Fact Cause) : Nat :=
     transition.beforeApplications.size + transition.afterApplications.size +
     transition.beforeEqualities.size + transition.afterEqualities.size
 
-private structure NodeCursor (Fact Cause : Type) where
-  events : List (Proof.Event Fact)
-  assembly : Assembly Fact Cause
+private def groupSteps
+    (nodeCount : Nat)
+    (transitions : Array (Search.Result.Id × Runtime.Applied Fact Cause))
+    : Except Error (Array (List (Runtime.Applied Fact Cause))) := do
+  let mut reversed := Array.replicate nodeCount []
+  for entry in transitions do
+    let some steps := reversed[entry.1.index]? | throw (.malformed .tree)
+    reversed := reversed.set! entry.1.index (entry.2 :: steps)
+  pure (reversed.map List.reverse)
 
-private def quoteTransitions [DecidableEq Fact] [DecidableEq Cause]
+private def quoteSteps [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
-    (tree : Search.Result.Tree Fact Cause Plan Proof.Key) :
-    List (Search.Result.Id × Runtime.Applied Fact Cause) →
-      Array (NodeCursor Fact Cause) → Except Error (Array (NodeCursor Fact Cause))
-  | [], cursors => pure cursors
-  | entry :: rest, cursors => do
-      let some node := tree.nodes[entry.1.index]? | throw .malformed
-      let some cursor := cursors[entry.1.index]? | throw .malformed
-      let (quoted, nextAssembly) ←
-        quoteAppliedFrom limits registry node.source.scope cursor.assembly entry.2
-      let next := cursors.set! entry.1.index
-        { events := cursor.events ++ quoted, assembly := nextAssembly }
-      quoteTransitions limits registry tree rest next
+    (scope : Policy.ScopeId) :
+    List (Runtime.Applied Fact Cause) → List (Proof.Event Fact) →
+      Assembly Fact Cause →
+      Except Error (List (Proof.Event Fact) × Assembly Fact Cause)
+  | [], eventsRev, assembly => pure (eventsRev, assembly)
+  | transition :: rest, eventsRev, assembly => do
+      let (eventsRev, assembly) ←
+        quoteAppliedRevFrom limits registry scope assembly eventsRev transition
+      quoteSteps limits registry scope rest eventsRev assembly
+
+private structure TreeCursor (Fact Cause : Type) where
+  seeds : Array (Option (Assembly Fact Cause))
+  chronologies : Array (List (Proof.Event Fact))
+
+private def quoteNodes [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (registry : Registry Fact semantics Cause Plan)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (steps : Array (List (Runtime.Applied Fact Cause))) :
+    Nat → TreeCursor Fact Cause → Except Error (TreeCursor Fact Cause)
+  | index, cursor => do
+      if tree.nodes.size ≤ index then return cursor
+      let some node := tree.nodes[index]? | throw (.malformed .tree)
+      let some (some seed) := cursor.seeds[index]? | throw (.malformed .tree)
+      let some nodeSteps := steps[index]? | throw (.malformed .tree)
+      let (eventsRev, assembly) ←
+        quoteSteps limits registry node.source.scope nodeSteps [] seed
+      let chronologies := cursor.chronologies.set! index eventsRev.reverse
+      let seeds := match node with
+        | .split _ _ left right =>
+            (cursor.seeds.set! left.index (some assembly)).set! right.index (some assembly)
+        | .pending _ | .terminal _ _ => cursor.seeds
+      quoteNodes limits registry tree steps (index + 1) { seeds, chronologies }
 
 private def quoteChronologies [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (registry : Registry Fact semantics Cause Plan)
     (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
     (transitions : Array (Search.Result.Id × Runtime.Applied Fact Cause)) :
     Except Error (Array (List (Proof.Event Fact))) :=
-  let initial : Array (NodeCursor Fact Cause) :=
-    Array.replicate tree.nodes.size { events := [], assembly := registry.assembly }
-  match quoteTransitions limits registry tree transitions.toList initial with
+  match groupSteps tree.nodes.size transitions with
   | .error error => .error error
-  | .ok cursors => .ok (Array.map (fun cursor => cursor.events) cursors)
+  | .ok steps =>
+      let seeds := (Array.replicate tree.nodes.size none).set! 0 (some registry.assembly)
+      let initial : TreeCursor Fact Cause :=
+        { seeds, chronologies := Array.replicate tree.nodes.size [] }
+      -- Tree.check proves every child id is greater than its parent id and has
+      -- exactly one incoming edge. This index fold therefore sees the parent's
+      -- post-chronology assembly before it reaches either child.
+      match quoteNodes limits registry tree steps 0 initial with
+      | .error error => .error error
+      | .ok cursor => .ok cursor.chronologies
 
-/-- Quote the complete checked retained tree transactionally. No prefix recipe
-escapes if any later transition, schema, body, resource, or node-chain check
-fails. -/
-opaque quoteTreeWithin [DecidableEq Fact] [DecidableEq Cause]
+private def quoteRecipeWithin [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
     (registry : Registry Fact semantics Cause Plan)
     (tree : Search.Result.Tree Fact Cause Plan Proof.Key) :
-    Except Error (Bundle Fact Cause Plan) := do
-  if !tree.check limits.result measure then throw .malformed
+    Except Error (Proof.TreeRecipe Fact) := do
+  if !tree.check limits.result measure then throw (.malformed .tree)
   let transitions := tree.transitions
   if limits.maxTransitions < transitions.size then throw (.resource .transitions)
   let mut eventCount := 0
@@ -493,21 +535,32 @@ opaque quoteTreeWithin [DecidableEq Fact] [DecidableEq Cause]
       throw (.proof .chronologyLimit)
   let recipe : Proof.TreeRecipe Fact := { events, edges }
   Proof.checkTreeLimits limits.tree tree recipe |>.mapError Error.proof
-  pure { key := registry.key, tree, recipe }
+  pure recipe
 
-/-- Recheck exact quotation and run the existing recursive proof fold. Raw
-quotes never become evidence; only independently decoded package schemas can
-construct the returned theorem. -/
+/-- Quote the complete checked retained tree transactionally. No prefix recipe
+escapes if any later transition, schema, body, resource, or node-chain check
+fails. -/
+opaque quoteTreeWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (registry : Registry Fact semantics Cause Plan)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key) :
+    Except Error (Bundle Fact semantics Cause Plan) :=
+  match quoteRecipeWithin limits measure registry tree with
+  | .error error => .error error
+  | .ok recipe => .ok { registry, tree, recipe }
+
+/-- Consume one checked quotation without repeating it and run the recursive
+proof fold. The token retains the exact sealed registry, so replay neither
+accepts a registry substitute nor repeats executable-format/schema decoding.
+The proof fold still independently rechecks the retained tree and proof limits
+at its theorem boundary. Raw quotes never become evidence. -/
 def replayTree [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
     (limits : Limits) (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
-    (registry : Registry Fact semantics Cause Plan) (domain : Proof.Domain semantics)
-    (laws : Proof.Laws semantics) (input : Proof.Input Fact)
-    (bundle : Bundle Fact Cause Plan) : Except Error
+    (domain : Proof.Domain semantics) (laws : Proof.Laws semantics)
+    (input : Proof.Input Fact) (bundle : Bundle Fact semantics Cause Plan) :
+    Except Error
       (Proof.Evidence (semantics.Entails input.program (Proof.initialBase input) input.target)) := do
-  if bundle.key != registry.key then throw .mismatch
-  let checked ← quoteTreeWithin limits measure registry bundle.tree
-  if checked.recipe != bundle.recipe then throw .mismatch
-  Proof.replayTree limits.result measure limits.proof limits.tree registry.proof
+  Proof.replayTree limits.result measure limits.proof limits.tree bundle.registry.proof
     domain laws input bundle.tree bundle.recipe |>.mapError Error.proof
 
 end Hex.Interval.RuntimeProof

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -236,7 +236,7 @@ correlates an accepted request/update with an exact fact format and decoder;
 only later independent `Proof` replay invokes its theorem schema.
 The separate Mathlib-free typed runtime authenticates and retains the raw
 fact/equality/transport/instance event chronology without importing this proof
-module. `HexIntervalMathlib.Runtime` is the supported conversion edge: its
+module. `HexIntervalMathlib.RuntimeProof` is the supported conversion edge: its
 sealed registry checks bidirectional executable-format/proof-schema coverage,
 then reconstructs fact, equality, transport, and instance `Proof.Event`s from
 the sealed `Runtime.Applied` fields. It reruns append-only executable extension
@@ -245,9 +245,15 @@ generation suffix before narrowing an instance record to `Proof.InstanceStep`.
 Fact quotation preserves proposed/installed meet correlation; equality pins
 the exact endpoints, origin, assumptions, and schema; transport carries no
 quotation and replays only through the independently admitted equality and
-exact live source fact. Complete retained transition chains are quoted as one
-transaction into a sealed per-node recipe and rechecked before recursive proof
-replay. Target, refutation, and split remain the separately authenticated
+exact live source fact; these checks authorize structural substitution but the
+equality schema alone supplies semantic entailment. Complete retained
+transition chains are quoted as one transaction into a sealed token containing
+the exact registry and per-node recipe. Node-id order propagates each split
+parent's post-chronology executable assembly to both restarted children, so an
+instance before a split is retained exactly. Recursive replay consumes the
+token without repeating quotation; the underlying proof fold independently
+rechecks the retained tree and proof limits once at its theorem boundary.
+Target, refutation, and split remain the separately authenticated
 terminal schemas owned by `Proof.replayTree`; they are not synthesized from a
 runtime callback batch.
 `Search` never decrements its `remaining` view; executable refresh preserves
@@ -260,13 +266,12 @@ fixed-point `noChange` and malformed narrowing remain mismatches at this
 fact-only boundary. Its public `Run` currently contains only a resumable
 `stopped` result. Driver target, refutation, split, and unknown outcomes are
 rejected as mismatches until separate typed terminal correlation is added.
-The separate Mathlib-free typed runtime authenticates and retains raw
-fact/equality/transport/instance chronology without importing this proof
-module; conversion of those typed events to package-owned proof schemas remains
-a later edge.
 The assembly constructors are sealed under ordinary imports; deliberate
 `import all HexInterval.Executable` is a repository-guarded trusted-source
 escape hatch, not decoded runtime or proof authority.
+The typed-proof registry and bundle constructors are likewise sealed;
+`import all HexIntervalMathlib.RuntimeProof` is rejected outside an
+exact reviewed allowlist, currently empty.
 Automatic arbitrary-function theorem-package discovery and default registries
 remain experimental; supported typed-runtime replay requires an explicit
 sealed executable/proof registry pair.
@@ -441,10 +446,12 @@ nonvacuous ordinary theorem with a guarded axiom report, and transactional
 Meta-state restoration after a wrongly typed emitter.
 `HexIntervalMathlib.RuntimeProofConformance` pins the supported typed-runtime
 adapter with a real `sin (-x)` instance → equality → fact → transport theorem
-at the root and after both split children restart. It mutates every typed event
-role, executable/proof package ownership, schema, body, order, and child splice;
-checks exact one-under retained-transition, event, structural-cell, and proof-
-chronology resources; and guards the ordinary root/recursive axiom surfaces.
+at the root and after both split children restart. A second split canary extends
+the root first and proves both children restart from the inherited extended
+program and generation. It mutates every typed event role, executable/proof
+package ownership, schema, body, order, and child splice; checks exact one-under
+retained-transition, event, structural-cell, and proof-chronology resources;
+and guards the ordinary root/recursive axiom surfaces.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -234,6 +234,22 @@ callback packages and raw replay formats. Those raw quotations are not
 `Proof.Event`s and remain inert. The fact-only `Controller.Executable` adapter
 correlates an accepted request/update with an exact fact format and decoder;
 only later independent `Proof` replay invokes its theorem schema.
+The separate Mathlib-free typed runtime authenticates and retains the raw
+fact/equality/transport/instance event chronology without importing this proof
+module. `HexIntervalMathlib.Runtime` is the supported conversion edge: its
+sealed registry checks bidirectional executable-format/proof-schema coverage,
+then reconstructs fact, equality, transport, and instance `Proof.Event`s from
+the sealed `Runtime.Applied` fields. It reruns append-only executable extension
+to pin the exact program, registration, binding, concrete application, and
+generation suffix before narrowing an instance record to `Proof.InstanceStep`.
+Fact quotation preserves proposed/installed meet correlation; equality pins
+the exact endpoints, origin, assumptions, and schema; transport carries no
+quotation and replays only through the independently admitted equality and
+exact live source fact. Complete retained transition chains are quoted as one
+transaction into a sealed per-node recipe and rechecked before recursive proof
+replay. Target, refutation, and split remain the separately authenticated
+terminal schemas owned by `Proof.replayTree`; they are not synthesized from a
+runtime callback batch.
 `Search` never decrements its `remaining` view; executable refresh preserves
 the controller-owned value stored in the sealed session. The adapter uses a
 fixed structural `policyMeasure` for application identifiers and rule keys,
@@ -251,8 +267,9 @@ a later edge.
 The assembly constructors are sealed under ordinary imports; deliberate
 `import all HexInterval.Executable` is a repository-guarded trusted-source
 escape hatch, not decoded runtime or proof authority.
-Automatic arbitrary-function theorem-package discovery, equality/instance
-runtime recipes, and default registries remain experimental.
+Automatic arbitrary-function theorem-package discovery and default registries
+remain experimental; supported typed-runtime replay requires an explicit
+sealed executable/proof registry pair.
 The supported explicit fact-event controller can produce and replay
 search-selected recipes, while the tactic below remains a deliberately narrow
 direct forward client rather than that generic search bridge.
@@ -422,6 +439,12 @@ alignment and a live instance → fact → equality → transport chronology,
 including body/source/version/final-state mutations, refuter ownership, a
 nonvacuous ordinary theorem with a guarded axiom report, and transactional
 Meta-state restoration after a wrongly typed emitter.
+`HexIntervalMathlib.RuntimeProofConformance` pins the supported typed-runtime
+adapter with a real `sin (-x)` instance → equality → fact → transport theorem
+at the root and after both split children restart. It mutates every typed event
+role, executable/proof package ownership, schema, body, order, and child splice;
+checks exact one-under retained-transition, event, structural-cell, and proof-
+chronology resources; and guards the ordinary root/recursive axiom surfaces.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/conformance/HexIntervalMathlib/RuntimeProofConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeProofConformance.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexIntervalMathlib.Runtime
+import HexIntervalMathlib.RuntimeProof
 import HexIntervalMathlib.Experiment.SineSign
 
 /-!
@@ -23,6 +23,14 @@ open Hex.Interval.Executable
 open Hex.Interval.Runtime
 open Hex.Interval.RuntimeProof
 open Hex.Interval.Experiment.SineSign
+
+/-- error: Unknown constant `Hex.Interval.RuntimeProof.Registry.mk` -/
+#guard_msgs in
+#check RuntimeProof.Registry.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeProof.Bundle.mk` -/
+#guard_msgs in
+#check RuntimeProof.Bundle.mk
 
 def scope : Policy.ScopeId := { index := 0 }
 
@@ -92,7 +100,7 @@ def factBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
   { events := #[.fact
       { action := request.action,
         update :=
-          { programVersion := 1
+          { programVersion := request.action.programVersion
             node := node 4
             previous := { node := node 4, version := 0 }
             fact := .nonpositive
@@ -104,7 +112,7 @@ def transportBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
   { events := #[.transport
       { action := request.action,
         update :=
-          { programVersion := 1
+          { programVersion := request.action.programVersion
             node := node 2
             previous := { node := node 2, version := 0 }
             fact := .nonpositive
@@ -211,6 +219,17 @@ def transportAction : Action :=
   action 3 1 2 2 transportKey (node 2) .rewrite 1
     [{ node := node 4, version := 1 }] [node 2]
 
+def childEqualityAction : Action :=
+  action 0 0 1 1 equalityKey (node 2) .rewrite 1 []
+
+def childFactAction : Action :=
+  action 1 0 3 3 factKey (node 4) .forward 1
+    [{ node := node 0, version := 0 }] [node 4]
+
+def childTransportAction : Action :=
+  action 2 0 2 2 transportKey (node 2) .rewrite 1
+    [{ node := node 4, version := 1 }] [node 2]
+
 /-! ## Theorem registry -/
 
 def semantics : Proof.Semantics Range :=
@@ -265,6 +284,8 @@ theorem equalityProof : semantics.EntailsEq extendedProgram [] (node 2) (node 4)
   have original := model.2.1 (by rfl)
   have positive := model.2.2.1 (by rfl)
   have negative := model.2.2.2 (by rfl)
+  -- This is genuine substitution through the four model equations and
+  -- sin(-x), not ex-falso use of an inconsistent equality context.
   calc
     valuation (node 2) = Real.sin (valuation (node 1)) := original
     _ = Real.sin (-valuation (node 0)) := congrArg Real.sin negated
@@ -367,19 +388,20 @@ def factSchema : Proof.FactSchema semantics :=
 def splitSchema : Proof.SplitSchema semantics Nat :=
   { key := splitProofKey, Certificate := Unit, decode,
     prove := fun context _ =>
-      if shape : context.program = baseProgram ∧ context.parent.node = node 1 ∧
+      if shape : (context.program = baseProgram ∨ context.program = extendedProgram) ∧
+          context.parent.node = node 1 ∧
           context.left = { node := node 1, fact := .nonnegative } ∧
           context.right = { node := node 1, fact := .nonpositive } then
         some
           { proof := by
-              rcases shape with ⟨programEq, _, leftEq, rightEq⟩
+              rcases shape with ⟨_, _, leftEq, rightEq⟩
               intro valuation _ _
               change NodeId → ℝ at valuation
               rcases le_total 0 (valuation (node 1)) with left | right
               · left
-                simpa [programEq, leftEq, semantics, Contains] using left
+                simpa [leftEq, semantics, Contains] using left
               · right
-                simpa [programEq, rightEq, semantics, Contains] using right }
+                simpa [rightEq, semantics, Contains] using right }
       else none }
 
 def proofPackage : Proof.Package semantics Nat :=
@@ -498,43 +520,112 @@ def splitTree? : Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
           | .ok tree => (runCurrent tree assembly).bind fun tree => runCurrent tree assembly
   | _, _ => none
 
+def postInstanceSplitAction : Action :=
+  action 1 1 0 4 splitKey (node 1) .split 1
+    [{ node := node 1, version := 0 }]
+
+def postInstanceSplitRecipe : Search.Result.Split Nat Proof.Key :=
+  { scope, programVersion := 1, action := postInstanceSplitAction,
+    parent := { node := node 1, version := 0 }, plan := 1,
+    schema := splitProofKey, body := [1] }
+
+private def runExtendedCurrent (tree : Search.Result.Tree Range Nat Nat Proof.Key)
+    (assembly : RuntimeProof.Assembly Range Nat) :
+    Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match Search.Result.current? tree with
+  | none => none
+  | some (_, source) =>
+      match Runtime.State.startWithin runtimeLimits assembly source.branch with
+      | .error _ => none
+      | .ok runtime =>
+          match advance tree runtime
+              [childEqualityAction, childFactAction, childTransportAction] with
+          | none => none
+          | some (tree, _) =>
+              (Search.Result.settleWithin resultLimits measure tree (.target
+                { scope := source.scope, programVersion := 0,
+                  seen := { node := node 2, version := 1 } })).toOption
+
+/-- Root extension precedes the split; both children restart from the exact
+post-instance program and generation inherited from their parent. -/
+def postInstanceSplitTree? :
+    Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match branch?, assembly? with
+  | some branch, some assembly =>
+      match Search.Result.startWithin resultLimits measure scope branch,
+          Runtime.State.startWithin runtimeLimits assembly branch with
+      | .ok root, .ok runtime =>
+          match advance root runtime [instanceAction] with
+          | none => none
+          | some (root, runtime) =>
+              match Search.Result.splitWithin resultLimits measure .depthFirst root
+                  postInstanceSplitRecipe leftSeed rightSeed with
+              | .error _ => none
+              | .ok tree =>
+                  (runExtendedCurrent tree runtime.assembly).bind fun tree =>
+                    runExtendedCurrent tree runtime.assembly
+      | _, _ => none
+  | _, _ => none
+
 #guard rootTree?.any fun tree =>
   tree.check resultLimits measure && tree.transitions.size == 4 && tree.pending.isEmpty
 
 #guard splitTree?.any fun tree =>
   tree.check resultLimits measure && tree.transitions.size == 8 && tree.pending.isEmpty
 
-def rootBundle? : Option (RuntimeProof.Bundle Range Nat Nat) :=
+#guard postInstanceSplitTree?.any fun tree =>
+  tree.check resultLimits measure && tree.transitions.size == 7 && tree.pending.isEmpty
+
+def rootBundle? : Option (RuntimeProof.Bundle Range semantics Nat Nat) :=
   match registry?, rootTree? with
   | some registry, some tree =>
       (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
   | _, _ => none
 
-def splitBundle? : Option (RuntimeProof.Bundle Range Nat Nat) :=
+def splitBundle? : Option (RuntimeProof.Bundle Range semantics Nat Nat) :=
   match registry?, splitTree? with
+  | some registry, some tree =>
+      (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
+  | _, _ => none
+
+def postInstanceSplitBundle? :
+    Option (RuntimeProof.Bundle Range semantics Nat Nat) :=
+  match registry?, postInstanceSplitTree? with
   | some registry, some tree =>
       (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
   | _, _ => none
 
 def rootReplay? : Option (Proof.Evidence
     (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
-  match registry?, rootBundle? with
-  | some registry, some bundle =>
-      (RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle).toOption
-  | _, _ => none
+  match rootBundle? with
+  | some bundle =>
+      (RuntimeProof.replayTree adapterLimits measure domain laws input bundle).toOption
+  | none => none
 
 def splitReplay? : Option (Proof.Evidence
     (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
-  match registry?, splitBundle? with
-  | some registry, some bundle =>
-      (RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle).toOption
-  | _, _ => none
+  match splitBundle? with
+  | some bundle =>
+      (RuntimeProof.replayTree adapterLimits measure domain laws input bundle).toOption
+  | none => none
+
+def postInstanceSplitReplay? : Option (Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
+  match postInstanceSplitBundle? with
+  | some bundle =>
+      (RuntimeProof.replayTree adapterLimits measure domain laws input bundle).toOption
+  | none => none
 
 #guard rootBundle?.isSome
 #guard splitBundle?.isSome
+#guard postInstanceSplitBundle?.isSome
 #guard rootReplay?.isSome
 #guard splitReplay?.isSome
+#guard postInstanceSplitReplay?.isSome
 
+-- The fallback keeps these closed definitions total. The isSome guards above
+-- independently reduce quotation and replay, so the ordinary theorems do not
+-- serve as the canary that the adapter path actually ran.
 def fallback : Proof.Evidence
     (semantics.Entails input.program (Proof.initialBase input) input.target) :=
   { proof := by
@@ -772,7 +863,7 @@ private def packageReplayError
       match RuntimeProof.quoteTreeWithin adapterLimits measure registry tree with
       | .error _ => none
       | .ok bundle =>
-          match RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle with
+          match RuntimeProof.replayTree adapterLimits measure domain laws input bundle with
           | .error error => some error
           | .ok _ => none
   | _, _ => none

--- a/conformance/HexIntervalMathlib/RuntimeProofConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeProofConformance.lean
@@ -1,0 +1,842 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.Runtime
+import HexIntervalMathlib.Experiment.SineSign
+
+/-!
+# Typed runtime-to-proof conformance
+
+This canary runs the real `sin (-x)` vertical through the supported sealed
+runtime adapter.  Each root/child chronology is instance, equality, direct
+fact, and engine-owned transport.  The split children restart their runtime
+serial, equality arena, and executable extension from the same base assembly.
+-/
+
+namespace Hex.IntervalMathlib.RuntimeProofConformance
+
+open Hex.Interval
+open Hex.Interval.Executable
+open Hex.Interval.Runtime
+open Hex.Interval.RuntimeProof
+open Hex.Interval.Experiment.SineSign
+
+def scope : Policy.ScopeId := { index := 0 }
+
+def instanceRule : Registration :=
+  { key := oddnessRuleKey, head := sineKey, kind := .instantiate,
+    watches := [], writes := [] }
+
+def equalityKey : RuleKey := { name := "sine-sign.runtime.equality" }
+def transportKey : RuleKey := { name := "sine-sign.runtime.transport" }
+def factKey : RuleKey := { name := "sine-sign.runtime.fact" }
+def splitKey : RuleKey := { name := "sine-sign.runtime.split" }
+
+def equalityRule : Registration :=
+  { key := equalityKey, head := sineKey, kind := .rewrite,
+    watches := [], writes := [], binding := .scoped }
+
+def transportRule : Registration :=
+  { key := transportKey, head := sineKey, kind := .rewrite,
+    watches := [], writes := [], binding := .scoped }
+
+def factRule : Registration :=
+  { key := factKey, head := negationKey, kind := .forward,
+    watches := [], writes := [], binding := .scoped }
+
+def splitRule : Registration :=
+  { key := splitKey, head := negationKey, kind := .split,
+    watches := [], writes := [], binding := .scoped }
+
+def registrations : Array Registration :=
+  #[instanceRule, equalityRule, transportRule, factRule, splitRule]
+
+def equalityBinding : ScopeBinding :=
+  { rule := equalityKey, anchor := node 2, watches := [], writes := [] }
+
+def transportBinding : ScopeBinding :=
+  { rule := transportKey, anchor := node 2,
+    watches := [node 4], writes := [node 2] }
+
+def factBinding : ScopeBinding :=
+  { rule := factKey, anchor := node 4,
+    watches := [node 0], writes := [node 4] }
+
+def bindings : Array ScopeBinding :=
+  #[equalityBinding, transportBinding, factBinding]
+
+def instanceQuote : Quote := { role := .instance, schema := 1, body := [1] }
+def equalityQuote : Quote := { role := .equality, schema := 1, body := [1] }
+def factQuote : Quote :=
+  { role := .fact, schema := 1, body := [Range.nonpositive.code] }
+
+def instanceBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.instance
+      { action := request.action, after := extendedProgram,
+        freshFacts := #[.all, .all], bindings,
+        newNodes := [node 3, node 4],
+        newBindings := [equalityBinding, transportBinding, factBinding],
+        newApplications := [{ index := 1 }, { index := 2 }, { index := 3 }, { index := 4 }],
+        generation := 1, quote := instanceQuote }] }
+
+def equalityBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.equality
+      { action := request.action, equality := { index := 0 },
+        left := node 2, right := node 4, generation := 1,
+        assumptions := [], quote := equalityQuote }] }
+
+def factBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.fact
+      { action := request.action,
+        update :=
+          { programVersion := 1
+            node := node 4
+            previous := { node := node 4, version := 0 }
+            fact := .nonpositive
+            version := 1
+            cause := 40 },
+        proposed := .nonpositive, quote := factQuote }] }
+
+def transportBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.transport
+      { action := request.action,
+        update :=
+          { programVersion := 1
+            node := node 2
+            previous := { node := node 2, version := 0 }
+            fact := .nonpositive
+            version := 1
+            cause := 41 },
+        equality := { index := 0 }, source := { node := node 4, version := 1 } }] }
+
+def exactFormat (role : Executable.Role) (body : List Nat) : ReplayFormat :=
+  { role, schema := 1, validateBody := fun actual => actual == body }
+
+def handler (registration : Registration) (formats : Array ReplayFormat)
+    (accepts : Program → ScopeBinding → Bool)
+    (run : RuleRequest Range → Runtime.Batch Range Nat) :
+    Handler Range (Runtime.Batch Range Nat) Unit :=
+  { registration, formats, acceptsScope := accepts,
+    invoke := fun cache request =>
+      let result := run request
+      ({ result, quotes := result.events.toList.filterMap (fun
+          | .fact step => some step.quote
+          | .equality step => some step.quote
+          | .instance step => some step.quote
+          | .transport _ => none) |>.toArray }, cache) }
+
+def accepts (program : Program) (binding : ScopeBinding) : Bool :=
+  program == extendedProgram &&
+    (binding == equalityBinding || binding == transportBinding || binding == factBinding)
+
+def inertBatch (_ : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[] }
+
+def instanceHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler instanceRule #[exactFormat .instance [1]] (fun _ _ => false) instanceBatch
+
+def equalityHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler equalityRule #[exactFormat .equality [1]] accepts equalityBatch
+
+def transportHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler transportRule #[] accepts transportBatch
+
+def factHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler factRule #[exactFormat .fact [Range.nonpositive.code]] accepts factBatch
+
+def splitHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler splitRule #[] (fun _ _ => false) inertBatch
+
+def runtimePackage : Package Range (Runtime.Batch Range Nat) :=
+  { Cache := Unit, cache := (), operations := operations,
+    handlers :=
+      #[instanceHandler, equalityHandler, transportHandler, factHandler, splitHandler],
+    measure :=
+      { metadata := { bytes := 10, work := 10 },
+        application := fun _ => { bytes := 1, work := 1 },
+        cache := fun _ => {},
+        result := fun batch => { bytes := batch.events.size, work := batch.events.size } } }
+
+def stateLimits : State.Limits :=
+  { maxOperations := 3, maxNodes := 5, maxRules := 5,
+    maxRegistryEntries := 32, maxReplayFormats := 3, maxArity := 1,
+    maxScopeNodes := 1, maxApplications := 5, maxQueueEntries := 8,
+    maxActions := 4, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 2, maxRetainedSuggestions := 0, maxEffort := 0,
+    maxObservationValue := 8, maxDiagnosticValue := 8,
+    maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0, maxProposalItems := 1,
+    maxInstances := 1, maxGeneration := 1, maxNodeDepth := 2, maxEqualities := 1,
+    splitEndpointLimit := { maxEndpointHeight := 8, maxAlignmentShift := 8 } }
+
+def executableLimits : Executable.Limits :=
+  { state := stateLimits, maxPackages := 1,
+    maxMetadataBytes := 64, maxMetadataWork := 64,
+    maxCacheBytes := 0, maxCacheWork := 0,
+    maxResultBytes := 1, maxResultWork := 1,
+    maxQuotes := 1, maxQuoteCells := 1, maxAtom := 3, maxSchema := 1 }
+
+def runtimeLimits : Runtime.Limits :=
+  { executable := executableLimits, maxEvents := 1 }
+
+def assembly? : Option (RuntimeProof.Assembly Range Nat) :=
+  (Executable.buildWithin executableLimits #[runtimePackage] baseProgram).toOption
+
+def branchWith? (facts : Array Range) : Option (State.Branch Range Nat) :=
+  (State.Branch.startWithin stateLimits baseProgram facts).toOption
+
+def branch? : Option (State.Branch Range Nat) :=
+  branchWith? #[.unit, .all, .all]
+
+def action (serial programVersion application rule : Nat) (key : RuleKey)
+    (anchor : NodeId) (kind : ActionKind) (generation : Nat)
+    (inputs : List SeenVersion) (writes : List NodeId := []) : Action :=
+  { serial, programVersion, application := { index := application },
+    rule := { index := rule }, key, node := anchor, kind, effort := 0,
+    generation, inputs, writes }
+
+def instanceAction : Action :=
+  action 0 0 0 0 oddnessRuleKey (node 2) .instantiate 0 []
+
+def equalityAction : Action :=
+  action 1 1 1 1 equalityKey (node 2) .rewrite 1 []
+
+def factAction : Action :=
+  action 2 1 3 3 factKey (node 4) .forward 1
+    [{ node := node 0, version := 0 }] [node 4]
+
+def transportAction : Action :=
+  action 3 1 2 2 transportKey (node 2) .rewrite 1
+    [{ node := node 4, version := 1 }] [node 2]
+
+/-! ## Theorem registry -/
+
+def semantics : Proof.Semantics Range :=
+  { Value := ℝ, models := Models,
+    holds := fun _ valuation fact => Contains fact.fact (valuation fact.node),
+    holdsAgree := by
+      intro _ left right fact within _ _ agree
+      rw [agree fact.node within] }
+
+def domain : Proof.Domain semantics :=
+  { top := fun _ => .all,
+    topSound := by simp [semantics, Contains],
+    meet := fun program target previous proposed installed =>
+      if exact : installed = previous.meet proposed then
+        some
+          { proof := by
+              subst installed
+              intro valuation _
+              exact containsMeet previous proposed (valuation target) }
+      else none }
+
+theorem laws : Proof.Laws semantics :=
+  { holdsEq := by
+      intro _ valuation left right fact _ equal
+      change Contains fact (valuation left) ↔ Contains fact (valuation right)
+      rw [equal] }
+
+theorem factProof : semantics.Entails extendedProgram
+    [{ node := node 0, fact := .unit }] { node := node 4, fact := .nonpositive } := by
+  change ∀ valuation : NodeId → ℝ, Models extendedProgram valuation →
+    (∀ assumption, assumption ∈
+      ([{ node := node 0, fact := Range.unit }] : List (Proof.NodeFact Range)) →
+      Contains assumption.fact (valuation assumption.node)) →
+    Contains .nonpositive (valuation (node 4))
+  intro valuation model assumptions
+  have inputRange := assumptions { node := node 0, fact := .unit } (by simp)
+  have sineNonnegative : 0 ≤ valuation (node 3) := by
+    rw [model.2.2.1 (by rfl)]
+    exact Real.sin_nonneg_of_nonneg_of_le_pi inputRange.1
+      (inputRange.2.trans (by linarith [Real.one_le_pi_div_two]))
+  change valuation (node 4) ≤ 0
+  rw [model.2.2.2 (by rfl)]
+  exact neg_nonpos.mpr sineNonnegative
+
+theorem equalityProof : semantics.EntailsEq extendedProgram [] (node 2) (node 4) := by
+  change ∀ valuation : NodeId → ℝ, Models extendedProgram valuation →
+    (∀ assumption, assumption ∈ ([] : List (Proof.NodeFact Range)) →
+      Contains assumption.fact (valuation assumption.node)) →
+    valuation (node 2) = valuation (node 4)
+  intro valuation model _
+  have negated := model.1 (by rfl)
+  have original := model.2.1 (by rfl)
+  have positive := model.2.2.1 (by rfl)
+  have negative := model.2.2.2 (by rfl)
+  calc
+    valuation (node 2) = Real.sin (valuation (node 1)) := original
+    _ = Real.sin (-valuation (node 0)) := congrArg Real.sin negated
+    _ = -Real.sin (valuation (node 0)) := Real.sin_neg _
+    _ = -valuation (node 3) := congrArg Neg.neg positive.symm
+    _ = valuation (node 4) := negative.symm
+
+theorem stable : Proof.Stable semantics baseProgram extendedProgram :=
+  { appendOnly :=
+      { operationSize := programPrefix.operationSize,
+        nodeSize := programPrefix.nodeSize,
+        operationAt := programPrefix.operationAt,
+        nodeAt := programPrefix.nodeAt },
+    modelsBefore := by
+      intro valuation model
+      change Models extendedProgram valuation at model
+      change Models baseProgram valuation
+      refine ⟨?_, ?_, ?_, ?_⟩
+      · intro _; exact model.1 (by rfl)
+      · intro _; exact model.2.1 (by rfl)
+      · intro impossible
+        simp [baseProgram, Program.node?, node] at impossible
+      · intro impossible
+        simp [baseProgram, Program.node?, node] at impossible
+    holdsOld := by
+      intro oldValue newValue fact within _ _ agreement
+      change Contains fact.fact (oldValue fact.node) ↔ Contains fact.fact (newValue fact.node)
+      rw [agreement fact.node within] }
+
+def extension : Proof.Evidence (semantics.Extends baseProgram extendedProgram) :=
+  { proof := by
+      change ∀ valuation : NodeId → ℝ, Models baseProgram valuation →
+        ∃ extended : NodeId → ℝ, Models extendedProgram extended ∧
+          ∀ observed, observed.index < baseProgram.nodes.size →
+            valuation observed = extended observed
+      intro valuation model
+      refine ⟨extendValuation valuation, ?_, ?_⟩
+      · refine ⟨?_, ?_, ?_, ?_⟩
+        · intro _
+          have old := model.1 (by rfl)
+          simpa [extendValuation, node] using old
+        · intro _
+          have old := model.2.1 (by rfl)
+          simpa [extendValuation, node] using old
+        · intro _; simp [extendValuation, node]
+        · intro _; simp [extendValuation, node]
+      · intro observed within
+        have old : observed.index < 3 := by simpa [baseProgram] using within
+        have notThree : observed ≠ node 3 := by
+          intro equal; subst observed; simp [node] at old
+        have notFour : observed ≠ node 4 := by
+          intro equal; subst observed; simp [node] at old
+        simp [extendValuation, notThree, notFour] }
+
+def instanceProofKey : Proof.Key :=
+  { rule := oddnessRuleKey, role := .instance, bodySchema := 1 }
+def equalityProofKey : Proof.Key :=
+  { rule := equalityKey, role := .equality, bodySchema := 1 }
+def factProofKey : Proof.Key :=
+  { rule := factKey, role := .fact, bodySchema := 1 }
+def splitProofKey : Proof.Key :=
+  { rule := splitKey, role := .split, bodySchema := 1 }
+
+def decode (body : List Nat) : Option Unit :=
+  if body == [1] then some () else none
+
+def instanceSchema : Proof.InstanceSchema semantics :=
+  { key := instanceProofKey, Certificate := Unit, decode,
+    prove := fun context _ =>
+      if shape : context.before = baseProgram ∧ context.after = extendedProgram ∧
+          context.beforeVersion = 0 ∧ context.afterVersion = 1 ∧
+          context.newNodes = [node 3, node 4] then
+        some
+          { stable := by simpa [shape.1, shape.2.1] using stable
+            extension := by simpa [shape.1, shape.2.1] using extension }
+      else none }
+
+def equalitySchema : Proof.EqualitySchema semantics :=
+  { key := equalityProofKey, Certificate := Unit, decode,
+    prove := fun context _ =>
+      if shape : context.program = extendedProgram ∧ context.left = node 2 ∧
+          context.right = node 4 ∧ context.assumptions = [] then
+        some
+          { proof := by
+              simpa only [shape.1, shape.2.1, shape.2.2.1, shape.2.2.2] using
+                equalityProof }
+      else none }
+
+def factSchema : Proof.FactSchema semantics :=
+  { key := factProofKey, Certificate := Unit,
+    decode := fun body => if body == [Range.nonpositive.code] then some () else none,
+    prove := fun context _ =>
+      if shape : context.program = extendedProgram ∧
+          context.assumptions = [{ node := node 0, fact := .unit }] ∧
+          context.proposed = { node := node 4, fact := .nonpositive } then
+        some
+          { proof := by simpa [shape.1, shape.2.1, shape.2.2] using factProof }
+      else none }
+
+def splitSchema : Proof.SplitSchema semantics Nat :=
+  { key := splitProofKey, Certificate := Unit, decode,
+    prove := fun context _ =>
+      if shape : context.program = baseProgram ∧ context.parent.node = node 1 ∧
+          context.left = { node := node 1, fact := .nonnegative } ∧
+          context.right = { node := node 1, fact := .nonpositive } then
+        some
+          { proof := by
+              rcases shape with ⟨programEq, _, leftEq, rightEq⟩
+              intro valuation _ _
+              change NodeId → ℝ at valuation
+              rcases le_total 0 (valuation (node 1)) with left | right
+              · left
+                simpa [programEq, leftEq, semantics, Contains] using left
+              · right
+                simpa [programEq, rightEq, semantics, Contains] using right }
+      else none }
+
+def proofPackage : Proof.Package semantics Nat :=
+  { registrations, facts := #[factSchema], equalities := #[equalitySchema],
+    instances := #[instanceSchema], splits := #[splitSchema] }
+
+def proofLimits : Proof.Limits :=
+  { maxPackages := 1, maxSchemas := 4, maxBodyCells := 1,
+    maxDependencies := 1, maxChronology := 4 }
+
+def proofRegistry? : Option (Proof.Registry semantics Nat) :=
+  (Proof.Registry.buildWithin proofLimits baseProgram #[proofPackage]).toOption
+
+def adapterKey : RuntimeProof.Key := { name := "sine-runtime-proof", version := 1 }
+
+def registry? : Option (RuntimeProof.Registry Range semantics Nat Nat) := do
+  let assembly ← assembly?
+  let proof ← proofRegistry?
+  (RuntimeProof.Registry.buildWithin executableLimits adapterKey assembly proof).toOption
+
+#guard assembly?.isSome
+#guard proofRegistry?.isSome
+#guard registry?.isSome
+
+/-! ## Root and restarted split-child replay -/
+
+def searchLimits : Search.Limits :=
+  { maxSteps := 12, maxSplits := 1, maxLeaves := 2, maxFrontier := 2,
+    maxDepth := 1, maxScopes := 3, leafFuel := 12 }
+
+def resultLimits : Search.Result.Limits :=
+  { search := searchLimits, runtime := runtimeLimits, maxNodes := 3,
+    maxBodyCells := 8, maxBytes := 8192, maxWork := 8192, maxCode := 8 }
+
+def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
+
+def measure : Search.Result.Measure Range Nat Nat Proof.Key :=
+  { node := unitCost,
+    branch := fun branch =>
+      { bytes := branch.program.nodes.size + branch.history.size,
+        work := branch.program.nodes.size + branch.history.size },
+    fact := fun _ => unitCost, action := fun _ => unitCost,
+    plan := fun _ => unitCost, schema := fun _ => unitCost,
+    body := fun _ => unitCost, code := fun _ => unitCost }
+
+def adapterLimits : RuntimeProof.Limits :=
+  { result := resultLimits, proof := proofLimits,
+    tree := { maxNodes := 3, maxDepth := 1, maxBodyCells := 7, maxWork := 128 },
+    maxTransitions := 8, maxEvents := 8, maxStructuralCells := 138 }
+
+def input : Proof.Input Range :=
+  { scope, program := baseProgram, facts := #[.unit, .all, .all],
+    target := { node := node 2, fact := .nonpositive } }
+
+private def advance (tree : Search.Result.Tree Range Nat Nat Proof.Key)
+    (runtime : Runtime.State Range Nat) : List Action →
+    Option (Search.Result.Tree Range Nat Nat Proof.Key × Runtime.State Range Nat)
+  | [] => some (tree, runtime)
+  | next :: rest =>
+      match runtime.stepWithin runtimeLimits next with
+      | .error _ => none
+      | .ok (transition, runtime) =>
+          match Search.Result.advanceRuntimeWithin resultLimits measure tree transition with
+          | .error _ => none
+          | .ok tree => advance tree runtime rest
+
+private def runCurrent (tree : Search.Result.Tree Range Nat Nat Proof.Key)
+    (assembly : RuntimeProof.Assembly Range Nat) :
+    Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match Search.Result.current? tree with
+  | none => none
+  | some (_, source) =>
+      match Runtime.State.startWithin runtimeLimits assembly source.branch with
+      | .error _ => none
+      | .ok runtime =>
+          match advance tree runtime
+              [instanceAction, equalityAction, factAction, transportAction] with
+          | none => none
+          | some (tree, _) =>
+              (Search.Result.settleWithin resultLimits measure tree (.target
+                { scope := source.scope, programVersion := 1,
+                  seen := { node := node 2, version := 1 } })).toOption
+
+def rootTree? : Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match branch?, assembly? with
+  | some branch, some assembly =>
+      match Search.Result.startWithin resultLimits measure scope branch with
+      | .error _ => none
+      | .ok tree => runCurrent tree assembly
+  | _, _ => none
+
+def splitAction : Action :=
+  action 0 0 0 4 splitKey (node 1) .split 0
+    [{ node := node 1, version := 0 }]
+
+def splitRecipe : Search.Result.Split Nat Proof.Key :=
+  { scope, programVersion := 0, action := splitAction,
+    parent := { node := node 1, version := 0 }, plan := 1,
+    schema := splitProofKey, body := [1] }
+
+def leftSeed : Search.Result.Seed Range :=
+  { node := node 1, previous := splitRecipe.parent, fact := .nonnegative }
+
+def rightSeed : Search.Result.Seed Range :=
+  { node := node 1, previous := splitRecipe.parent, fact := .nonpositive }
+
+def splitTree? : Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match branch?, assembly? with
+  | some branch, some assembly =>
+      match Search.Result.startWithin resultLimits measure scope branch with
+      | .error _ => none
+      | .ok root =>
+          match Search.Result.splitWithin resultLimits measure .depthFirst root
+              splitRecipe leftSeed rightSeed with
+          | .error _ => none
+          | .ok tree => (runCurrent tree assembly).bind fun tree => runCurrent tree assembly
+  | _, _ => none
+
+#guard rootTree?.any fun tree =>
+  tree.check resultLimits measure && tree.transitions.size == 4 && tree.pending.isEmpty
+
+#guard splitTree?.any fun tree =>
+  tree.check resultLimits measure && tree.transitions.size == 8 && tree.pending.isEmpty
+
+def rootBundle? : Option (RuntimeProof.Bundle Range Nat Nat) :=
+  match registry?, rootTree? with
+  | some registry, some tree =>
+      (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
+  | _, _ => none
+
+def splitBundle? : Option (RuntimeProof.Bundle Range Nat Nat) :=
+  match registry?, splitTree? with
+  | some registry, some tree =>
+      (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
+  | _, _ => none
+
+def rootReplay? : Option (Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
+  match registry?, rootBundle? with
+  | some registry, some bundle =>
+      (RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle).toOption
+  | _, _ => none
+
+def splitReplay? : Option (Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target)) :=
+  match registry?, splitBundle? with
+  | some registry, some bundle =>
+      (RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle).toOption
+  | _, _ => none
+
+#guard rootBundle?.isSome
+#guard splitBundle?.isSome
+#guard rootReplay?.isSome
+#guard splitReplay?.isSome
+
+def fallback : Proof.Evidence
+    (semantics.Entails input.program (Proof.initialBase input) input.target) :=
+  { proof := by
+      change ∀ valuation : NodeId → ℝ, Models baseProgram valuation →
+        (∀ assumption, assumption ∈ Proof.initialBase input →
+          Contains assumption.fact (valuation assumption.node)) →
+        Contains .nonpositive (valuation (node 2))
+      intro valuation model assumptions
+      have inputRange := assumptions { node := node 0, fact := .unit } (by
+        have baseEq : Proof.initialBase input =
+            [{ node := node 0, fact := .unit }, { node := node 1, fact := .all },
+              { node := node 2, fact := .all }] := by rfl
+        rw [baseEq]
+        simp)
+      change valuation (node 2) ≤ 0
+      rw [model.2.1 (by rfl)]
+      rw [model.1 (by rfl), Real.sin_neg]
+      exact neg_nonpos.mpr (Real.sin_nonneg_of_nonneg_of_le_pi inputRange.1
+        (inputRange.2.trans (by linarith [Real.one_le_pi_div_two]))) }
+
+def rootEvidence := rootReplay?.getD fallback
+def splitEvidence := splitReplay?.getD fallback
+
+/-- Ordinary theorem obtained from the root typed-runtime chronology. -/
+theorem rootSinNeg {x : ℝ} (nonnegative : 0 ≤ x) (atMostOne : x ≤ 1) :
+    Real.sin (-x) ≤ 0 := by
+  have result := rootEvidence.proof (baseValuation x) (baseModels x) (by
+    intro assumption member
+    have baseEq : Proof.initialBase input =
+        [{ node := node 0, fact := .unit }, { node := node 1, fact := .all },
+          { node := node 2, fact := .all }] := by rfl
+    rw [baseEq] at member
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at member
+    rcases member with rfl | rfl | rfl
+    · exact ⟨nonnegative, atMostOne⟩
+    · trivial
+    · trivial)
+  exact result
+
+/-- The same ordinary theorem obtained after both split children restart and
+replay independent instance/equality/fact/transport chronologies. -/
+theorem splitSinNeg {x : ℝ} (nonnegative : 0 ≤ x) (atMostOne : x ≤ 1) :
+    Real.sin (-x) ≤ 0 := by
+  have result := splitEvidence.proof (baseValuation x) (baseModels x) (by
+    intro assumption member
+    have baseEq : Proof.initialBase input =
+        [{ node := node 0, fact := .unit }, { node := node 1, fact := .all },
+          { node := node 2, fact := .all }] := by rfl
+    rw [baseEq] at member
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at member
+    rcases member with rfl | rfl | rfl
+    · exact ⟨nonnegative, atMostOne⟩
+    · trivial
+    · trivial)
+  exact result
+
+/-! ## Exact rejection canaries -/
+
+private def quoteError (limits : RuntimeProof.Limits) : Option RuntimeProof.Error :=
+  match registry?, rootTree? with
+  | some registry, some tree =>
+      match RuntimeProof.quoteTreeWithin limits measure registry tree with
+      | .error error => some error
+      | .ok _ => none
+  | _, _ => none
+
+#guard quoteError { adapterLimits with maxTransitions := 3 } ==
+  some (.resource .transitions)
+#guard quoteError { adapterLimits with maxEvents := 3 } ==
+  some (.resource .events)
+#guard quoteError { adapterLimits with maxStructuralCells := 68 } ==
+  some (.resource .structuralCells)
+
+-- A one-under proof chronology cap is independent of the retained runtime cap.
+#guard quoteError { adapterLimits with proof := { proofLimits with maxChronology := 3 } } ==
+  some (.proof .chronologyLimit)
+
+def packageWith (instanceHandler equalityHandler transportHandler factHandler :
+    Handler Range (Runtime.Batch Range Nat) Unit) :
+    Package Range (Runtime.Batch Range Nat) :=
+  { runtimePackage with handlers :=
+      #[instanceHandler, equalityHandler, transportHandler, factHandler,
+        splitHandler] }
+
+def badInstanceBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.instance
+      { action := request.action, after := extendedProgram,
+        freshFacts := #[.all, .all], bindings,
+        newNodes := [node 3, node 4],
+        newBindings := [equalityBinding, transportBinding, factBinding],
+        newApplications := [{ index := 1 }, { index := 3 }, { index := 2 }, { index := 4 }],
+        generation := 1, quote := instanceQuote }] }
+
+def badEqualityBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.equality
+      { action := request.action, equality := { index := 0 },
+        left := node 2, right := node 2, generation := 1,
+        assumptions := [], quote := equalityQuote }] }
+
+def badTransportBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { events := #[.transport
+      { action := request.action,
+        update :=
+          { programVersion := 1
+            node := node 2
+            previous := { node := node 2, version := 0 }
+            fact := .nonpositive
+            version := 1
+            cause := 41 },
+        equality := { index := 0 }, source := { node := node 3, version := 0 } }] }
+
+def badInstanceHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler instanceRule #[exactFormat .instance [1]] (fun _ _ => false) badInstanceBatch
+
+def badEqualityHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler equalityRule #[exactFormat .equality [1]] accepts badEqualityBatch
+
+def badTransportHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler transportRule #[] accepts badTransportBatch
+
+private def runtimeWith? (package : Package Range (Runtime.Batch Range Nat)) :
+    Option (Runtime.State Range Nat) :=
+  match Executable.buildWithin executableLimits #[package] baseProgram, branch? with
+  | .ok assembly, some branch =>
+      (Runtime.State.startWithin runtimeLimits assembly branch).toOption
+  | _, _ => none
+
+private def instanceError (package : Package Range (Runtime.Batch Range Nat)) :
+    Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some runtime =>
+      match runtime.stepWithin runtimeLimits instanceAction with
+      | .error error => some error
+      | .ok _ => none
+
+private def equalityError (package : Package Range (Runtime.Batch Range Nat)) :
+    Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some runtime =>
+      match runtime.stepWithin runtimeLimits instanceAction with
+      | .error _ => none
+      | .ok (_, runtime) =>
+          match runtime.stepWithin runtimeLimits equalityAction with
+          | .error error => some error
+          | .ok _ => none
+
+private def transportError (package : Package Range (Runtime.Batch Range Nat)) :
+    Option Runtime.Error :=
+  match runtimeWith? package with
+  | none => none
+  | some runtime =>
+      match runtime.stepWithin runtimeLimits instanceAction with
+      | .error _ => none
+      | .ok (_, runtime) =>
+          match runtime.stepWithin runtimeLimits equalityAction with
+          | .error _ => none
+          | .ok (_, runtime) =>
+              match runtime.stepWithin runtimeLimits factAction with
+              | .error _ => none
+              | .ok (_, runtime) =>
+                  match runtime.stepWithin runtimeLimits transportAction with
+                  | .error error => some error
+                  | .ok _ => none
+
+#guard instanceError (packageWith badInstanceHandler equalityHandler
+    transportHandler factHandler) == some .malformed
+
+#guard equalityError (packageWith instanceHandler badEqualityHandler
+    transportHandler factHandler) == some .wrongEquality
+
+#guard transportError (packageWith instanceHandler equalityHandler
+    badTransportHandler factHandler) == some .unauthorized
+
+def proposedFactBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { factBatch request with events := (factBatch request).events.map fun
+      | .fact step => .fact { step with proposed := .all }
+      | event => event }
+
+def proposedFactHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler factRule #[exactFormat .fact [Range.nonpositive.code]] accepts proposedFactBatch
+
+def proposedPackage : Package Range (Runtime.Batch Range Nat) :=
+  packageWith instanceHandler equalityHandler transportHandler proposedFactHandler
+
+def looseFactQuote : Quote := { role := .fact, schema := 1, body := [0] }
+
+def looseFactBatch (request : RuleRequest Range) : Runtime.Batch Range Nat :=
+  { factBatch request with events := (factBatch request).events.map fun
+      | .fact step => .fact { step with quote := looseFactQuote }
+      | event => event }
+
+def looseFactHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler factRule
+    #[{ role := .fact, schema := 1, validateBody := fun body => body.length == 1 }]
+    accepts looseFactBatch
+
+def loosePackage : Package Range (Runtime.Batch Range Nat) :=
+  packageWith instanceHandler equalityHandler transportHandler looseFactHandler
+
+private def assemblyWith? (package : Package Range (Runtime.Batch Range Nat)) :
+    Option (RuntimeProof.Assembly Range Nat) :=
+  (Executable.buildWithin executableLimits #[package] baseProgram).toOption
+
+private def registryWith? (package : Package Range (Runtime.Batch Range Nat)) :
+    Option (RuntimeProof.Registry Range semantics Nat Nat) :=
+  match assemblyWith? package, proofRegistry? with
+  | some assembly, some proof =>
+      (RuntimeProof.Registry.buildWithin executableLimits adapterKey assembly proof).toOption
+  | _, _ => none
+
+private def treeWith? (package : Package Range (Runtime.Batch Range Nat)) :
+    Option (Search.Result.Tree Range Nat Nat Proof.Key) :=
+  match branch?, assemblyWith? package with
+  | some branch, some assembly =>
+      match Search.Result.startWithin resultLimits measure scope branch with
+      | .error _ => none
+      | .ok tree => runCurrent tree assembly
+  | _, _ => none
+
+private def packageQuoteError
+    (package : Package Range (Runtime.Batch Range Nat)) : Option RuntimeProof.Error :=
+  match registryWith? package, treeWith? package with
+  | some registry, some tree =>
+      match RuntimeProof.quoteTreeWithin adapterLimits measure registry tree with
+      | .error error => some error
+      | .ok _ => none
+  | _, _ => none
+
+private def packageReplayError
+    (package : Package Range (Runtime.Batch Range Nat)) : Option RuntimeProof.Error :=
+  match registryWith? package, treeWith? package with
+  | some registry, some tree =>
+      match RuntimeProof.quoteTreeWithin adapterLimits measure registry tree with
+      | .error _ => none
+      | .ok bundle =>
+          match RuntimeProof.replayTree adapterLimits measure registry domain laws input bundle with
+          | .error error => some error
+          | .ok _ => none
+  | _, _ => none
+
+#guard packageQuoteError loosePackage == some (.invalidBody factProofKey)
+#guard packageReplayError proposedPackage == some (.proof .malformedBody)
+
+-- The proof package cannot attach an equality schema to another package's rule.
+def foreignFactPackage : Proof.Package semantics Nat :=
+  { registrations := #[factRule], equalities := #[equalitySchema] }
+
+#guard match Proof.Registry.buildWithin proofLimits baseProgram #[foreignFactPackage] with
+  | .error (.foreignSchema 0 key) => key == equalityProofKey
+  | _ => false
+
+-- Numeric schema drift is rejected by bidirectional registry coverage.
+def schemaTwoFormat : ReplayFormat :=
+  { role := .fact, schema := 2, validateBody := fun body => body == [3] }
+
+def schemaTwoHandler : Handler Range (Runtime.Batch Range Nat) Unit :=
+  handler factRule #[schemaTwoFormat] accepts factBatch
+
+def schemaTwoPackage : Package Range (Runtime.Batch Range Nat) :=
+  { runtimePackage with handlers := runtimePackage.handlers.set! 3 schemaTwoHandler }
+
+def schemaTwoAssembly? : Option (RuntimeProof.Assembly Range Nat) :=
+  (Executable.buildWithin { executableLimits with maxSchema := 2 }
+    #[schemaTwoPackage] baseProgram).toOption
+
+#guard match schemaTwoAssembly?, proofRegistry? with
+  | some assembly, some proof =>
+      match RuntimeProof.Registry.buildWithin { executableLimits with maxSchema := 2 }
+          adapterKey assembly proof with
+      | .error .invalidRegistry => true
+      | _ => false
+  | _, _ => false
+
+-- Search/runtime sealing rejects chronology reuse and a transition splice
+-- across independently restarted split children before quotation can begin.
+#guard match branch?, rootTree?, splitTree? with
+  | some branch, some root, some split =>
+      match Search.Result.startWithin resultLimits measure scope branch,
+          root.transitions[0]?.map (·.2), split.transitions[4]?.map (·.2) with
+      | .ok fresh, some first, some foreign =>
+          match Search.Result.advanceRuntimeWithin resultLimits measure fresh first with
+          | .error _ => false
+          | .ok afterFirst =>
+              match Search.Result.advanceRuntimeWithin resultLimits measure afterFirst first,
+                  Search.Result.advanceRuntimeWithin resultLimits measure fresh foreign with
+              | .error .malformed, .error .malformed => true
+              | _, _ => false
+      | _, _, _ => false
+  | _, _, _ => false
+
+/--
+info: 'Hex.IntervalMathlib.RuntimeProofConformance.rootSinNeg' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms rootSinNeg
+
+/--
+info: 'Hex.IntervalMathlib.RuntimeProofConformance.splitSinNeg' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms splitSinNeg
+
+end Hex.IntervalMathlib.RuntimeProofConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -544,6 +544,7 @@ lean_lib HexConformance where
       `HexInterval.SearchConformance,
       `HexInterval.ExecutableConformance,
       `HexInterval.RuntimeConformance,
+      `HexIntervalMathlib.RuntimeProofConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/20260822T061218Z_typed-runtime-proof.md
+++ b/progress/20260822T061218Z_typed-runtime-proof.md
@@ -1,0 +1,37 @@
+# Typed runtime proof adapter
+
+## Accomplished
+
+- Integrated the exact reviewed typed-runtime and executable-controller
+  semantic commits, including the typed Runtime.Limits reconciliation in the
+  controller conformance driver.
+- Added the sealed HexIntervalMathlib.Runtime companion. It bidirectionally
+  aligns executable replay formats with proof schemas, transactionally quotes
+  fact/equality/transport/instance batches, validates exact append-only
+  instance suffixes, and recursively replays complete retained trees without
+  treating raw quotations as theorem authority.
+- Added a real-sine conformance theorem for an
+  instance/equality/fact/transport chronology at the root and in both
+  independently restarted split children. Mutation canaries cover every typed
+  event role, package/schema/body/order/splice failures, proposed/installed
+  fact correlation, and exact resource limits.
+- Recorded exact axiom reports for both ordinary theorem endpoints:
+  [propext, Classical.choice, Quot.sound].
+- Verified lake build HexConformance (9626 jobs), the focused runtime,
+  adapter, and executable-controller targets, DAG and DAG-unit checks,
+  copyright/file-size/trust-surface gates, the Mathlib-free bench check, and
+  whitespace checks.
+
+## Current frontier
+
+- The supported typed runtime-to-proof seam is implemented and locally green
+  on the reviewed integration stack.
+
+## Next step
+
+- Restack the local adapter commit on current main, review the resulting
+  single semantic diff, and run the upstream PR gates.
+
+## Blockers
+
+- None.

--- a/progress/20260822T065052Z_runtime-proof-repair.md
+++ b/progress/20260822T065052Z_runtime-proof-repair.md
@@ -1,0 +1,39 @@
+# Typed runtime proof adapter review repair
+
+## Accomplished
+
+- Renamed the supported companion to HexIntervalMathlib.RuntimeProof and
+  added it to the empty sealed-import-all allowlist with ownerless
+  conformance/bench unit cases and ordinary-import constructor guards.
+- Reworked tree quotation into an index-ordered node fold. Each split child is
+  seeded with its parent's post-chronology executable assembly, including the
+  exact extended program and generation after a parent instance transition.
+- Replaced quadratic chronology appends with reverse-list accumulation and
+  one linear transition-bucketing pass.
+- Bound each checked bundle to the exact sealed registry and removed replay's
+  second quotation/decoder pass. The theorem fold retains its independent
+  retained-tree and proof-limit check.
+- Removed the unused bare callback quotation API, split malformed diagnostics
+  by quote/event/transition/tree seam, and clarified admission/non-preemption
+  and structural-transport authority in module/SPEC documentation.
+- Added a conformance canary where the root instantiates before splitting and
+  both children restart from the inherited extended assembly, then replay
+  equality, fact, transport, and target closure. Added explicit ordinary-import
+  constructor failures and clarified the guarded fallback and equality proof.
+- Verified the focused target and lake build HexIntervalMathlib
+  HexConformance (9627 jobs), plus DAG/unit, copyright, line-count,
+  trust-surface, factor-freshness, Mathlib-free bench, and whitespace gates.
+
+## Current frontier
+
+- The reviewed proof-adapter blockers and relevant pre-release findings are
+  repaired on the isolated local stack.
+
+## Next step
+
+- Restack/review the repair commit and obtain the requested exact second
+  review before opening or updating the upstream PR.
+
+## Blockers
+
+- None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -694,5 +694,11 @@
     "baseline_blob": "c523b56fcf7249235b710bc86792042a57c4e26e",
     "current_blob": "dcb37c10309b6da8453022b47b27f680508177fe",
     "reason": "Additionally registers the proof-only HexIntervalMathlib typed-runtime quotation and recursive replay conformance module on top of the retained typed runtime and executable controller registrations; this theorem-side target does not enter the factorization service target or change its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "abbfb2327a8ee1c28a6fa20dcf5a285cd782284c",
+    "current_blob": "dcb37c10309b6da8453022b47b27f680508177fe",
+    "reason": "Adds the unrelated HexSparsePoly and interval experiment/conformance registrations already reviewed on main, then adds the proof-only HexIntervalMathlib typed-runtime quotation and recursive replay conformance module; none enters the factorization service target or changes its executable dependency graph."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -688,5 +688,11 @@
     "baseline_blob": "abbfb2327a8ee1c28a6fa20dcf5a285cd782284c",
     "current_blob": "c523b56fcf7249235b710bc86792042a57c4e26e",
     "reason": "Adds the unrelated HexSparsePoly lean_lib, two interval experiment/conformance globs, and the interval typed-runtime and executable-controller conformance globs; the hexbz_factor_service target, BZ library targets, and build flags are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "c523b56fcf7249235b710bc86792042a57c4e26e",
+    "current_blob": "dcb37c10309b6da8453022b47b27f680508177fe",
+    "reason": "Additionally registers the proof-only HexIntervalMathlib typed-runtime quotation and recursive replay conformance module on top of the retained typed runtime and executable controller registrations; this theorem-side target does not enter the factorization service target or change its executable dependency graph."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -38,6 +38,7 @@ SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexIntervalMathlib.Driver": frozenset(),
     "HexIntervalMathlib.Controller": frozenset(),
     "HexIntervalMathlib.Proof": frozenset(),
+    "HexIntervalMathlib.RuntimeProof": frozenset(),
 }
 
 UMBRELLA_BUILD_TARGETS = {

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -29,6 +29,10 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexIntervalMathlib.Proof"),
                 (Path("bench/HexIntervalMathlib/Bypass.lean"),
                     "HexIntervalMathlib.Proof"),
+                (Path("conformance/HexIntervalMathlib/BypassRuntimeProof.lean"),
+                    "HexIntervalMathlib.RuntimeProof"),
+                (Path("bench/HexIntervalMathlib/BypassRuntimeProof.lean"),
+                    "HexIntervalMathlib.RuntimeProof"),
             ]
             files = [path for path, _ in cases]
             for path, module in cases:
@@ -55,6 +59,12 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexIntervalMathlib.Proof` outside its exact trusted-internals allowlist",
                     "bench/HexIntervalMathlib/Bypass.lean:1 uses `import all "
                     "HexIntervalMathlib.Proof` outside its exact trusted-internals allowlist",
+                    "conformance/HexIntervalMathlib/BypassRuntimeProof.lean:1 uses "
+                    "`import all HexIntervalMathlib.RuntimeProof` outside its exact "
+                    "trusted-internals allowlist",
+                    "bench/HexIntervalMathlib/BypassRuntimeProof.lean:1 uses "
+                    "`import all HexIntervalMathlib.RuntimeProof` outside its exact "
+                    "trusted-internals allowlist",
                 ],
             )
 


### PR DESCRIPTION
## Summary

- quote sealed Mathlib-free typed runtime transitions into the theorem-backed proof replay vocabulary
- bind the executable registry, retained result tree, and proof recipe in an ordinary-import-sealed bundle
- preserve post-instance executable assemblies across split children and replay root/restarted-child lineages
- enforce exact cumulative event, transition, structural, and chronology limits with conformance canaries

## Verification

- full `lake build` (9,627 jobs) before mechanical restack
- post-restack `lake build HexIntervalMathlib.RuntimeProofConformance HexIntervalMathlib` (8,707 jobs)
- DAG, factor-freshness, trust-surface, and diff checks
- independent Claude semantic review: APPROVE; exact rebased-head confirmation pending before merge

## Known fail-closed frontier

Runtime split restarts currently begin with an empty equality arena, while proof split children inherit the parent proof equality count. A parent equality before split is therefore rejected rather than replayed; inheritable runtime equality arenas remain a later layer.