### PR TITLE
Remove per-turn progress log requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,18 +84,6 @@ meta-commentary about the history of our research process to any
 file. The git history tracks that. SPEC files and `PLAN/` contain
 the current state of the design, not a journal of how we got there.
 
-## Per-turn progress files
-
-Start of turn: read the most recent file in `progress/` (ISO-8601
-timestamps sort chronologically). If only `progress/0000-init.md`
-exists, the repo is freshly initialised — proceed with Phase 0.
-
-End of turn: write `progress/<UTC-timestamp>.md` with sections
-**Accomplished** / **Current frontier** / **Next step** / **Blockers**.
-Scope these to *your* session — what you touched, where you stopped,
-what you think comes next for your corner of the project.
-Commits made during the turn should mention the progress file.
-
 ## Lean
 
 Check diagnostics after every step; don't continue past errors. Build


### PR DESCRIPTION
## Summary

- remove the instruction to read the latest progress file at the start of every turn
- remove the instruction to create a progress file at the end of every turn
- keep Claude and Codex guidance aligned through the existing `.claude/CLAUDE.md` symlink

## Testing

- documentation-only change; `git diff --check` passes