### PR TITLE
bench(interval): compare authenticated decision policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Define the hex-dev cache + build target sets
         run: |
           echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexMvPoly HexModArith HexGF2 HexPolyZ HexRoots HexResultant HexInterval HexIntervalExperiment HexIntervalMathlib HexIntervalMathlibExperiment HexIntervalReplayProbe HexIntervalMathlibReplayProbe HexRealRootsMathlibReplayProbe HexRCFProofProbe HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexPolyFpMathlib HexFactorizationModules HexRealRootsMathlib HexGF2Mathlib HexGFqMathlib HexMvPolyMathlib HexMvPolyMathlibProofProbe HexRCF HexRCFTests HexRootsMathlib HexResultantMathlib HexNumberField HexNumberFieldMathlib HexNumberFieldTower HexNumberFieldTowerMathlib HexReleaseTests HexReleaseExamples" >> "$GITHUB_ENV"
-          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexmvpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_arith_floor hexlll_bench hexlll_gram_bench hexlll_external_reduction hexbz_factor_service" >> "$GITHUB_ENV"
+          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexmvpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexinterval_decision_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_arith_floor hexlll_bench hexlll_gram_bench hexlll_external_reduction hexbz_factor_service" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails
       # below only *run* things, never rebuild them -- which is what lets the
@@ -245,12 +245,15 @@ jobs:
             hexgramschmidt_bench hexlll_gram_bench \
             hexrealroots_bench hexrcf_bench hexroots_bench \
             hexresultant_bench hexnumberfield_bench \
-            hexnumberfieldtower_bench
-          # These interval scheduler spikes are exact logical-count canaries
-          # rather than lean-bench timing registrations. Build them above and
-          # exercise their fixtures directly here.
+            hexnumberfieldtower_bench hexinterval_decision_bench
+          # These two interval scheduler spikes are exact logical-count
+          # canaries rather than lean-bench timing registrations. Build them
+          # above and exercise their fixtures directly here.
           .lake/build/bin/hex_interval_scheduler_spike canary
           .lake/build/bin/hex_interval_policy_frontier_spike canary
+          # The decision target has fixed timing registrations above plus a
+          # separate canonical logical policy-comparison canary.
+          .lake/build/bin/hexinterval_decision_bench canary
           touch "$RUNNER_TEMP/bench.ok"
       - name: Conformance oracles + BZ gates
         id: conformance

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -6005,6 +6005,48 @@ the existing single CI job. This is deterministic representation evidence,
 not scientific timing; it neither uses a custom timing loop nor freezes the
 current touch-count aggregates as performance contracts.
 
+The supported decision benchmark is a narrower production-API experiment. It
+runs FIFO, static-rank, and adaptive callbacks through `Search.chooseWithin`,
+commits one exact fact update per selected addition through
+`Search.invokeWithin`, then regenerates the complete surviving offer set against
+the advanced serial and current input versions through checked
+`Search.Session.refreshWithin`. Static-rank orders a fixed age residue; adaptive
+first ranks the live predecessor-version feedback and then the bounded offer
+score. The canonical 128-node logical-count canary pins 126 accepted updates
+for every policy and observes zero live offers after completion.
+FIFO/static-rank/adaptive respectively record
+0/7,875/7,875 callback comparisons and rolling order hashes
+13,333,310,190,265,569,661 / 9,721,628,123,875,171,393 /
+558,125,824,506,216,197. Their final position-sensitive fact/version checksum
+is the shared 8,880,463,590,880,745,567. These are content-bearing conformance
+checks, not timing thresholds, and no policy is selected as a default.
+
+Timing is deliberately a separate shared-infrastructure leg. Six
+`setup_fixed_benchmark` registrations use initial offer counts 1,024, 2,048,
+4,096, 8,192, 16,384, and 32,768. Each call reads its count from a module-level
+`IO.Ref`, constructs the arithmetic program and checked branch/session,
+authenticates the initial offers, performs one FIFO `chooseWithin` /
+`invokeWithin` transition, regenerates and authenticates one complete refresh,
+walks the checked snapshot to form the report, and includes the harness's timed
+result hash. Complete-view duplicate-ID validation scans prior offers, so a
+quadratic component is expected, but these fixed points declare no automatic
+complexity verdict. On one five-repeat warm run, medians were 7.829, 12.038,
+42.102, 155.655, 599.540, and 2,343 ms; adjacent median ratios were 1.538,
+3.497, 3.697, 3.852, and 3.908, and the log-log least-squares slope was 1.712.
+Ranges were 3.902--8.131, 11.968--12.080, 41.606--48.953,
+154.152--162.673, 593.278--616.574, and 2,303--2,460 ms. Every rung has a
+five-second per-call cap, throws if construction or any transition fails, and
+pins its full `Report` hash through `expectedHash`. This is common end-to-end
+cost evidence and yields no comparative policy signal; policy comparison
+belongs to the logical-count leg.
+
+The end-to-end `Controller.Executable` route currently lives in the Mathlib
+companion, so importing it would violate the Mathlib-free computational-bench
+boundary. This is not an absence claim about direct APIs: Mathlib-free
+`Runtime.State.stepWithin` and `Search.Result.advanceRuntimeWithin` / `splitWithin` /
+`settleWithin` exist. Mixed typed-event and split/tree workloads are simply out
+of scope for this focused policy experiment.
+
 The declared models follow the complexity section above. Scientific runs also
 record accepted actions, endpoint heights, live leaves, retained derivations,
 and cache hits so a faster time cannot conceal a weaker search.

--- a/bench/HexInterval/DecisionBench.lean
+++ b/bench/HexInterval/DecisionBench.lean
@@ -1,0 +1,483 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Search
+import LeanBench
+
+/-!
+# Authenticated interval decision benchmark
+
+This experimental matrix exercises one supported scheduling surface which
+remains Mathlib-free: repeated `Search.chooseWithin` selection,
+`Search.invokeWithin` fact updates, and checked `Search.Session.refreshWithin`
+regeneration over one arithmetic DAG. FIFO, static-rank, and adaptive policies
+reach the same final fact state through different authenticated action orders;
+the logical-count leg selects no default.
+
+The end-to-end `Controller.Executable` fact adapter is intentionally absent.
+It currently imports the Mathlib proof driver, so importing it here would
+violate the repository's Mathlib-free computational-bench contract. Mixed
+typed-event and split/tree workloads are simply out of scope for this focused
+policy experiment: direct Mathlib-free `Runtime.State.stepWithin` and
+`Search.Result.advanceRuntimeWithin` / `splitWithin` / `settleWithin` APIs do
+exist. The benchmark does not make their absence a causal claim.
+
+The canonical `canary` input has 128 nodes and pins separate order-sensitive
+policy trace hashes, one shared final-state checksum, accepted updates, and
+callback comparisons. Fixed timing registrations instead measure one shared
+end-to-end authenticated choose/invoke/complete-refresh transition at each
+committed offer count. They include session construction and all checked
+authentication and yield no comparative policy signal. Every IO runner throws
+on failure and every fixed rung pins the hash of its full report.
+-/
+
+namespace Hex.Interval.DecisionBench
+
+inductive PolicyKind where
+  | fifo
+  | staticRank
+  | adaptive
+  deriving DecidableEq, Repr
+
+structure PolicyState where
+  decisions : Nat := 0
+  comparisons : Nat := 0
+  orderHash : UInt64 := 0
+  deriving DecidableEq, Repr
+
+structure Report where
+  nodes : Nat
+  offers : Nat
+  decisions : Nat
+  comparisons : Nat
+  updates : Nat
+  orderHash : UInt64
+  semantic : UInt64
+  deriving DecidableEq, Repr, Hashable
+
+private def domain : DomainId := { index := 0 }
+
+private def constantKey : OpKey := { name := "decision-bench.constant" }
+
+private def addKey : OpKey := { name := "decision-bench.add" }
+
+private def ruleKey : RuleKey := { name := "decision-bench.add-forward" }
+
+private def operations : Array Operation :=
+  #[{ key := constantKey, inputs := [], output := domain },
+    { key := addKey, inputs := [domain, domain], output := domain }]
+
+private def nodeId (index : Nat) : NodeId := { index }
+
+private def applicationId (index : Nat) : ApplicationId := { index }
+
+/-- A Fibonacci-shaped arithmetic DAG with two constants and `n - 2` additions. -/
+private def program (n : Nat) : Program :=
+  let nodes := (Array.range n).map fun index =>
+    if index < 2 then
+      { domain, op := { index := 0 }, args := [] }
+    else
+      { domain, op := { index := 1 }, args := [nodeId (index - 2), nodeId (index - 1)] }
+  { operations, nodes }
+
+private def rule : Registration :=
+  { key := ruleKey
+    head := addKey
+    kind := .forward
+    watches := [.argument 0, .argument 1]
+    writes := [.result] }
+
+private def stateLimits (n : Nat) : State.Limits :=
+  { maxOperations := 2
+    maxNodes := n
+    maxRules := 1
+    maxRegistryEntries := 0
+    maxReplayFormats := 0
+    maxArity := 2
+    maxApplications := n
+    maxQueueEntries := n
+    maxActions := n
+    maxAcceptedFacts := n
+    maxRetainedSuggestions := 0
+    maxEffort := 0
+    maxObservationValue := 0
+    maxDiagnosticValue := 0
+    maxOutcomeCandidates := 1
+    maxOutcomeSuggestions := 0
+    maxProposalItems := 0
+    maxInstances := 0
+    maxGeneration := 0
+    maxNodeDepth := n
+    maxEqualities := 0
+    splitEndpointLimit := { maxEndpointHeight := 0, maxAlignmentShift := 0 } }
+
+private def searchLimits (n : Nat) : Search.Limits :=
+  { maxSteps := n
+    maxSplits := 0
+    maxLeaves := 1
+    maxFrontier := 1
+    maxDepth := 0
+    maxScopes := 1
+    leafFuel := n }
+
+private def policyLimits (n : Nat) : Policy.Limits :=
+  { maxOffers := n
+    maxBytes := 64 * n
+    maxPairs := 4 * n
+    maxWork := 4 * n
+    maxScore := 128 }
+
+private def envelope (n : Nat) : Search.Envelope :=
+  { state := stateLimits n
+    policy := policyLimits n
+    trace := { maxEvents := 0, maxBytes := 0, maxWork := 0, maxCode := 0 }
+    search := searchLimits n }
+
+private def measure : Policy.Measure ApplicationId RuleKey :=
+  { id := fun _ => { pairs := 1, work := 1 }
+    key := fun key => { bytes := key.name.length + 1, pairs := 1, work := 1 } }
+
+private def scoreAt (index : Nat) : Int :=
+  Int.ofNat ((index * 17 + 11) % 101) - 50
+
+private def offer? (serial : Nat) (versions : Array Nat) (index : Nat) :
+    Option (Search.Offer ApplicationId RuleKey) := do
+  let output := index + 2
+  let leftVersion ← versions[output - 2]?
+  let rightVersion ← versions[output - 1]?
+  let action : Action :=
+    { serial
+      programVersion := 0
+      application := applicationId index
+      rule := { index := 0 }
+      key := ruleKey
+      node := nodeId output
+      kind := .forward
+      effort := 0
+      generation := 0
+      inputs :=
+        [{ node := nodeId (output - 2), version := leftVersion },
+          { node := nodeId (output - 1), version := rightVersion }]
+      writes := [nodeId output] }
+  pure
+    { view :=
+      { id := applicationId index
+        key := ruleKey
+        offerClass := .invoke
+        age := output % 3
+        score := scoreAt index }
+      action }
+
+private def offerCount (n : Nat) : Nat := n - 2
+
+private def budget (offers : Nat) : Policy.EngineBudgetView :=
+  { actions := offers
+    acceptedFacts := offers
+    applications := offers }
+
+private def offersFor (serial : Nat) (versions : Array Nat) (ids : Array Nat) :
+    Option (Array (Search.Offer ApplicationId RuleKey)) :=
+  ids.mapM (offer? serial versions)
+
+private def session? (n : Nat) : Option (Search.Session Nat Nat ApplicationId RuleKey) := do
+  let dag := program n
+  let branch ← (State.Branch.startWithin (stateLimits n) dag (Array.replicate n 0)).toOption
+  let offers ← offersFor 0 branch.versions (Array.range (offerCount n))
+  Search.Session.startWithin (envelope n) measure branch #[rule] #[]
+    (Array.replicate (offerCount n) 0) #[] 0 { index := 0 } offers
+    (budget offers.size) false
+    |>.toOption
+
+private def mix (acc : UInt64) (value : Nat) : UInt64 :=
+  acc * 0x9e3779b97f4a7c15 + UInt64.ofNat (value + 1)
+
+private def updateState (comparisons : Nat)
+    (offer : Policy.OfferView ApplicationId RuleKey) (state : PolicyState) : PolicyState :=
+  { decisions := state.decisions + 1
+    comparisons := state.comparisons + comparisons
+    orderHash := mix state.orderHash offer.id.index }
+
+private def first? (view : Policy.View Nat ApplicationId RuleKey) :=
+  view.offers[0]?
+
+private def staticBetter
+    (left right : Policy.OfferView ApplicationId RuleKey) : Bool :=
+  left.age < right.age || (left.age == right.age && left.id.index < right.id.index)
+
+private def readiness (view : Policy.View Nat ApplicationId RuleKey)
+    (offer : Policy.OfferView ApplicationId RuleKey) : Nat :=
+  let output := offer.id.index + 2
+  match view.facts.versions[output - 2]?, view.facts.versions[output - 1]? with
+  | some left, some right => left + right
+  | _, _ => 0
+
+private def adaptiveBetter
+    (view : Policy.View Nat ApplicationId RuleKey)
+    (left right : Policy.OfferView ApplicationId RuleKey) : Bool :=
+  let leftReady := readiness view left
+  let rightReady := readiness view right
+  rightReady < leftReady ||
+    (leftReady == rightReady &&
+      (right.score < left.score ||
+        (left.score == right.score && left.id.index < right.id.index)))
+
+private def best? (better : Policy.OfferView ApplicationId RuleKey →
+    Policy.OfferView ApplicationId RuleKey → Bool)
+    (view : Policy.View Nat ApplicationId RuleKey) :
+    Option (Policy.OfferView ApplicationId RuleKey) × Nat := Id.run do
+  let mut selected := none
+  let mut comparisons := 0
+  for index in [0:view.offers.size] do
+    let some current := view.offers[index]? | return (none, comparisons)
+    match selected with
+    | none => selected := some current
+    | some previous =>
+        comparisons := comparisons + 1
+        if better current previous then selected := some current
+  return (selected, comparisons)
+
+private def choose (kind : PolicyKind) (state : PolicyState)
+    (view : Policy.View Nat ApplicationId RuleKey) :
+    Policy.Step PolicyState ApplicationId RuleKey :=
+  let (selected, comparisons) := match kind with
+    | .fifo => (first? view, 0)
+    | .staticRank => best? staticBetter view
+    | .adaptive => best? (adaptiveBetter view) view
+  match selected with
+  | none => .stop state
+  | some selected =>
+      .select selected (updateState comparisons selected state)
+
+private def policy (kind : PolicyKind) :
+    Policy.Interface Nat PolicyState ApplicationId RuleKey :=
+  { choose := choose kind }
+
+private def callback (request : Search.Request Nat ApplicationId RuleKey) :=
+  match request.facts.version? request.action.node with
+  | none => Search.Reply.failure 0
+  | some version =>
+      Search.Reply.outcome
+        { scope := request.scope
+          serial := request.serial
+          programVersion := request.programVersion
+          offer := request.offer
+          action := request.action
+          updates :=
+            #[{ programVersion := request.programVersion
+                node := request.action.node
+                previous := { node := request.action.node, version }
+                fact := request.action.node.index + 1
+                version := version + 1
+                cause := request.offer.id.index }] }
+
+private def advance? (kind : PolicyKind) (n : Nat)
+    (session : Search.Session Nat Nat ApplicationId RuleKey) (state : PolicyState) :
+    Option (Search.Session Nat Nat ApplicationId RuleKey × PolicyState) := do
+  let choice ← (Search.chooseWithin (envelope n) measure (policy kind) state session).toOption
+  match choice with
+  | .select decision next =>
+      let remainingIds := (session.offers.filter fun current =>
+        current.view.id != decision.id).map (fun current => current.view.id.index)
+      if remainingIds.size + 1 != session.offers.size then none else pure ()
+      let applied ← (Search.invokeWithin (envelope n) measure callback session decision).toOption
+      let updated ← match applied with
+        | .applied updated => some updated
+        | .stopped _ _ => none
+      let remaining ← offersFor updated.serial updated.branch.versions remainingIds
+      let refreshed ← (Search.Session.refreshWithin (envelope n) measure updated remaining
+        (budget remaining.size) false).toOption
+      pure (refreshed, next)
+  | .dismiss _ _ | .stopped _ _ => none
+
+private def report?
+    (session : Search.Session Nat Nat ApplicationId RuleKey) (state : PolicyState) :
+    Option Report := do
+  let snapshot ← session.branch.checkedSnapshot?
+  let mut semantic : UInt64 := 0
+  for index in [0:snapshot.facts.size] do
+    let fact ← snapshot.facts[index]?
+    let version ← snapshot.versions[index]?
+    semantic := mix (mix semantic fact) version
+  pure
+    { nodes := session.branch.program.nodes.size
+      offers := session.offers.size
+      decisions := state.decisions
+      comparisons := state.comparisons
+      updates := session.branch.history.size
+      orderHash := state.orderHash
+      semantic }
+
+private def runFrom (kind : PolicyKind) (n : Nat)
+    (session : Search.Session Nat Nat ApplicationId RuleKey) : Option Report := do
+  let rec loop (fuel : Nat) (session : Search.Session Nat Nat ApplicationId RuleKey)
+      (state : PolicyState) :
+      Option (Search.Session Nat Nat ApplicationId RuleKey × PolicyState) := do
+    if session.offers.isEmpty then return (session, state)
+    match fuel with
+    | 0 => none
+    | fuel + 1 =>
+        let (refreshed, next) ← advance? kind n session state
+        loop fuel refreshed next
+  let (session, state) ← loop (offerCount n) session {}
+  report? session state
+
+def runReport (kind : PolicyKind) (n : Nat) : Option Report := do
+  let session ← session? n
+  runFrom kind n session
+
+private def runStepReport (offers : Nat) : Option Report := do
+  let n := offers + 2
+  let session ← session? n
+  if offers == 0 then
+    report? session {}
+  else
+    let (session, state) ← advance? .fifo n session {}
+    report? session state
+
+/-- One shared authenticated end-to-end transition, failing closed on error. -/
+def runAuthenticatedStep (offers : Nat) : IO Report :=
+  match runStepReport offers with
+  | some report => pure report
+  | none => throw <| IO.userError s!"authenticated decision step failed, offers={offers}"
+
+private def canonicalInput : Nat := 128
+
+private def expectedComparisons (n : Nat) : Nat :=
+  let count := offerCount n
+  count * (count - 1) / 2
+
+private def canonicalFifoHash : UInt64 := 13333310190265569661
+
+private def canonicalStaticHash : UInt64 := 9721628123875171393
+
+private def canonicalAdaptiveHash : UInt64 := 558125824506216197
+
+private def canonicalSemantic : UInt64 := 8880463590880745567
+
+private def canary (input : Option Nat := none) : IO UInt32 := do
+  let n := input.getD canonicalInput
+  if n < 2 then
+    IO.eprintln "decision benchmark requires at least two nodes"
+    return 1
+  let reports := [runReport .fifo n, runReport .staticRank n, runReport .adaptive n]
+  IO.println s!"nodes={n} supported=arithmetic-dag"
+  IO.println s!"fifo={repr reports[0]!}"
+  IO.println s!"static-rank={repr reports[1]!}"
+  IO.println s!"adaptive={repr reports[2]!}"
+  IO.println "mixed-typed-events=out-of-scope(direct Runtime.State.stepWithin exists)"
+  IO.println "split-tree=out-of-scope(direct Search.Result split/settle APIs exist)"
+  match reports with
+  | [some fifo, some staticRank, some adaptive] =>
+      if fifo.nodes == n && staticRank.nodes == n && adaptive.nodes == n &&
+          fifo.offers == 0 && staticRank.offers == 0 && adaptive.offers == 0 &&
+          fifo.decisions == offerCount n &&
+          fifo.comparisons == 0 && staticRank.comparisons == expectedComparisons n &&
+          adaptive.comparisons == expectedComparisons n &&
+          fifo.updates == offerCount n && staticRank.updates == offerCount n &&
+          adaptive.updates == offerCount n && fifo.semantic == staticRank.semantic &&
+          staticRank.semantic == adaptive.semantic &&
+          (n != 128 ||
+            (fifo.orderHash == canonicalFifoHash &&
+             staticRank.orderHash == canonicalStaticHash &&
+             adaptive.orderHash == canonicalAdaptiveHash &&
+             fifo.semantic == canonicalSemantic)) then
+        return 0
+      else
+        IO.eprintln "decision benchmark logical-count canary failed"
+        return 1
+  | _ =>
+      IO.eprintln "decision benchmark fixture failed to build"
+      return 1
+
+/-
+Fixed end-to-end cost attribution. Each rung includes runtime reads of the
+offer count, arithmetic-program and branch setup, initial offer construction,
+checked session authentication, one FIFO `chooseWithin` / `invokeWithin`
+transition, complete surviving-offer regeneration and refresh authentication,
+the checked snapshot walk used to build `Report`, and the fixed harness's
+timed result hashing. Complete-view duplicate-ID validation scans prior offers,
+so the measurements are expected to show a quadratic-dominated common cost.
+They are empirical fixed points, not an automatic complexity verdict or a
+policy comparison.
+-/
+initialize timingOffersRef : IO.Ref (Array Nat) ←
+  IO.mkRef #[1024, 2048, 4096, 8192, 16384, 32768]
+
+private def runFixed (index : Nat) : IO Report := do
+  let inputs ← timingOffersRef.get
+  match inputs[index]? with
+  | some offers => runAuthenticatedStep offers
+  | none => throw <| IO.userError s!"missing fixed decision input, index={index}"
+
+namespace Offers1024
+def run (_ : Unit) : IO Report := runFixed 0
+end Offers1024
+
+namespace Offers2048
+def run (_ : Unit) : IO Report := runFixed 1
+end Offers2048
+
+namespace Offers4096
+def run (_ : Unit) : IO Report := runFixed 2
+end Offers4096
+
+namespace Offers8192
+def run (_ : Unit) : IO Report := runFixed 3
+end Offers8192
+
+namespace Offers16384
+def run (_ : Unit) : IO Report := runFixed 4
+end Offers16384
+
+namespace Offers32768
+def run (_ : Unit) : IO Report := runFixed 5
+end Offers32768
+
+setup_fixed_benchmark Offers1024.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0xbbd09a2695e38e01
+}
+
+setup_fixed_benchmark Offers2048.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0x6e4e62b8e475bb32
+}
+
+setup_fixed_benchmark Offers4096.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0xcd7bca91050befed
+}
+
+setup_fixed_benchmark Offers8192.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0x5a04b99431d279fc
+}
+
+setup_fixed_benchmark Offers16384.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0xffdc8b53fcda1fd5
+}
+
+setup_fixed_benchmark Offers32768.run where {
+  repeats := 5
+  maxSecondsPerCall := 5.0
+  expectedHash := some 0x284aed8dace21e10
+}
+
+end Hex.Interval.DecisionBench
+
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | ["canary"] => Hex.Interval.DecisionBench.canary none
+  | ["canary", n] => match n.toNat? with
+    | some n => Hex.Interval.DecisionBench.canary (some n)
+    | none => pure 2
+  | _ => LeanBench.Cli.dispatch args

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -749,6 +749,10 @@ lean_exe hex_interval_policy_frontier_spike where
   srcDir := "bench"
   root := `HexInterval.IntervalPolicyFrontierSpike
 
+lean_exe hexinterval_decision_bench where
+  srcDir := "bench"
+  root := `HexInterval.DecisionBench
+
 lean_exe hexbz_factor_service where
   srcDir := "bench"
   root := `HexBench.FactorService

--- a/progress/20260822T062623Z_interval-decision-benchmark.md
+++ b/progress/20260822T062623Z_interval-decision-benchmark.md
@@ -1,0 +1,61 @@
+# Accomplished
+
+- Added a Mathlib-free logical comparison over one arithmetic DAG using only
+  supported `Search` APIs. FIFO, static-rank, and adaptive policies repeatedly
+  choose an authenticated offer, commit a real fact update through
+  `Search.invokeWithin`, and install a complete serial/version-aware offer set
+  through `Search.Session.refreshWithin`.
+- Made adaptive ordering genuinely depend on live predecessor versions. The
+  static-rank name now states that its age residue is fixed rather than learned.
+- Removed formula-derived duplicate and selected-position counters. The canary
+  retains only callback-instrumented comparisons, accepted history length,
+  selected-order hashes, and the final fact/version checksum.
+- Separated timing from policy comparison. Six `setup_fixed_benchmark`
+  registrations measure the shared authenticated program/branch/session setup,
+  choose/invoke/complete-refresh, report snapshot walk, and timed result-hash
+  path. Runtime counts come from a module-level `IO.Ref`; every rung throws on
+  failure and pins the exact full-report hash through `expectedHash`.
+- Measured fixed offer counts 1,024, 2,048, 4,096, 8,192, 16,384, and 32,768
+  with five repeats and a five-second per-call cap. Medians were 7.829, 12.038,
+  42.102, 155.655, 599.540, and 2,343 ms; ranges were 3.902--8.131,
+  11.968--12.080, 41.606--48.953, 154.152--162.673, 593.278--616.574, and
+  2,303--2,460 ms. Adjacent median ratios were 1.538, 3.497, 3.697, 3.852,
+  and 3.908; the empirical log-log least-squares slope was 1.712. These fixed
+  observations carry no framework complexity verdict. The earlier parametric
+  5x spawn-floor setup was below the normal 10x policy and has been removed.
+- At the canonical 128-node logical input, every policy accepts 126 updates and
+  zero live offers, and ends with semantic checksum 8,880,463,590,880,745,567.
+  FIFO/static-rank/adaptive respectively record 0/7,875/7,875 comparisons and
+  order hashes 13,333,310,190,265,569,661 /
+  9,721,628,123,875,171,393 / 558,125,824,506,216,197.
+- Kept the existing single CI job and canonical 128-node direct canary. The
+  canonical input is a plain definition; there is no mutable benchmark input.
+- Fixed full-report hashes at 1,024 / 2,048 / 4,096 / 8,192 / 16,384 / 32,768
+  offers are `0xbbd09a2695e38e01` / `0x6e4e62b8e475bb32` /
+  `0xcd7bca91050befed` / `0x5a04b99431d279fc` /
+  `0xffdc8b53fcda1fd5` / `0x284aed8dace21e10`.
+
+# Current frontier
+
+- The logical-count leg compares policy behavior. The timing leg measures only
+  shared authenticated end-to-end infrastructure and provides no comparative
+  policy-performance signal or default selection.
+- Mixed typed-event and split/tree workloads are out of scope for this focused
+  experiment. Direct Mathlib-free `Runtime.State.stepWithin` and `Search.Result`
+  runtime/split/settle APIs exist; only the `Controller.Executable` route used
+  by the separate fact adapter remains Mathlib-dependent.
+
+# Next step
+
+- Run the complete repository gates, amend and push the single benchmark commit,
+  then obtain the requested independent review before opening a pull request.
+- Extend the logical matrix only when a later experiment specifically scopes
+  typed-runtime or result-tree policy questions.
+
+# Blockers
+
+- No blocker remains for the scoped arithmetic-DAG logical comparison or the
+  shared authenticated timing registration.
+- The Mathlib-dependent executable route prevents this computational target
+  from measuring that adapter, but it does not block the existing direct
+  Mathlib-free runtime and result APIs.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -712,5 +712,11 @@
     "baseline_blob": "abbfb2327a8ee1c28a6fa20dcf5a285cd782284c",
     "current_blob": "dcb37c10309b6da8453022b47b27f680508177fe",
     "reason": "Adds the unrelated HexSparsePoly and interval experiment/conformance registrations already reviewed on main, then adds the proof-only HexIntervalMathlib typed-runtime quotation and recursive replay conformance module; none enters the factorization service target or changes its executable dependency graph."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "abbfb2327a8ee1c28a6fa20dcf5a285cd782284c",
+    "current_blob": "71093e603b8f4b6965534ffa140cf129522c6e0b",
+    "reason": "Additionally registers the Mathlib-free HexInterval authenticated decision benchmark on top of the reviewed typed-runtime proof conformance and executable-controller targets; this benchmark does not enter the factorization service target or change its executable dependency graph."
   }
 ]


### PR DESCRIPTION
## Summary

- add a Mathlib-free authenticated Search workload with real accepted, serial/version-aware updates
- compare FIFO, static-rank, and adaptive policy order via canonical logical counters and order-sensitive hashes
- register six SPEC-canonical fixed timing rungs from 1,024 through 32,768 offers with exact expected report hashes
- report end-to-end empirical scaling without an automatic framework verdict or policy default
- mark typed-event and split/tree benchmark cells accurately as out of scope, while naming the available direct Runtime/Search APIs

## Verification

- full `lake build` (9,826 jobs)
- all six fixed hashes via target `verify`; canonical n=128 canary; n<2 fail-closed case
- target CI verify cost ~5s / 360s cap
- Mathlib-free closure, DAG, Phase-4, conformance, freshness, and static checks
- independent exact-diff Claude review: APPROVE

## Result

The fixed medians over 1,024–32,768 offers were 7.829ms, 12.038ms, 42.102ms, 155.655ms, 599.540ms, and 2.343s (empirical log-log slope 1.712). This is recorded as experimental end-to-end evidence only; no default policy is selected.