### PR TITLE
feat(interval): schedule repeated read occurrences

### DIFF
--- a/HexInterval/Runtime.lean
+++ b/HexInterval/Runtime.lean
@@ -189,8 +189,10 @@ structure OfferSnapshot (Fact Cause : Type) where
   serial : Nat
   remaining : Policy.EngineBudgetView
   /-- False only when every handler-approved runtime application can be
-  represented by Search's stricter distinct-port scheduler contract. A package
-  handler's intentional `offers = false` veto does not make this incomplete. -/
+  represented by Search's scheduler contract. Repeated ordered read
+  occurrences are representable; duplicate write or structural authority is
+  not. A package handler's intentional `offers = false` veto does not make
+  this incomplete. -/
   incomplete : Bool
   actions : Array Action
 
@@ -623,8 +625,7 @@ private def budgetView (limits : Limits) (state : State Fact Cause) :
     generation := remaining stateLimits.maxGeneration state.assembly.generation }
 
 private def schedulerCompatible (action : Action) : Bool :=
-  allDistinct action.inputs && allDistinct action.writes &&
-    allDistinct action.structuralInputs
+  allDistinct action.writes && allDistinct action.structuralInputs
 
 /-- Regenerate the complete deterministic executable offer snapshot from the
 exact assembly, branch, equality arena, and callback serial owned by this
@@ -632,9 +633,10 @@ runtime state. Handler applicability sees one authenticated whole-state
 context. Its Boolean is an intentional scheduling filter, not mutation
 authorization: it can suppress an offer without making the snapshot
 incomplete, while a separately supplied structurally current action is still
-decided only by `stepWithin`. Runtime-valid applications with duplicate
-resolved inputs, writes, or structural inputs cannot enter Search's stricter
-distinct-port scheduler; they are omitted and set the sealed incomplete bit.
+decided only by `stepWithin`. Repeated ordered reads can enter Search: every
+occurrence retains its exact node/version and later request reconstruction
+preserves the list. Runtime-valid applications with duplicate writes or
+structural inputs remain omitted and set the sealed incomplete bit.
 No mutable branch or assembly replacement is accepted from the caller, and no
 generated action bypasses the later exact `stepWithin` request reconstruction.
 Snapshot generation does not consume or reject the runtime `maxActions`

--- a/HexInterval/Runtime.lean
+++ b/HexInterval/Runtime.lean
@@ -635,8 +635,10 @@ authorization: it can suppress an offer without making the snapshot
 incomplete, while a separately supplied structurally current action is still
 decided only by `stepWithin`. Repeated ordered reads can enter Search: every
 occurrence retains its exact node/version and later request reconstruction
-preserves the list. Runtime-valid applications with duplicate writes or
-structural inputs remain omitted and set the sealed incomplete bit.
+preserves the list. Runtime-valid applications with duplicate writes remain
+omitted and set the sealed incomplete bit. The current sealed Executable
+compiler produces no structural matcher rows; the same omission applies to a
+future retained row with duplicate structural inputs.
 No mutable branch or assembly replacement is accepted from the caller, and no
 generated action bypasses the later exact `stepWithin` request reconstruction.
 Snapshot generation does not consume or reject the runtime `maxActions`

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3229,6 +3229,19 @@ generation report exact residuals, while matcher visits, retained suggestions,
 and queue entries report their full configured capacities because this runtime
 layer retains and consumes none of those three stores.
 
+Search read ports are ordered occurrences, not a set of node identities. Local
+registrations still require distinct declared slots, but distinct argument
+slots may resolve to the same node, as in `x + x`. Such occurrences retain the
+same exact current `SeenVersion` twice; authentication freshness-checks each
+occurrence and preserves the duplicate list through policy selection, request
+reconstruction, executable invocation, and runtime transition correlation.
+This does not weaken mutation or structural authority: resolved writes and
+structural inputs remain duplicate-free, and scoped binding reads remain
+duplicate-free under `ScopeBinding.check`. A runtime-owned snapshot containing
+only repeated reads is therefore complete. A handler-approved application with
+duplicate resolved writes or structural inputs is still omitted and sets the
+sticky incomplete bit.
+
 As with Search, sealing is an ordinary/public-import boundary. Deliberate
 `import all HexInterval.Executable` exposes its private constructors to trusted
 Lean source and is not part of the decoded runtime threat model. The repository
@@ -5656,11 +5669,14 @@ their declared cost inside a scheduler bound.
   binding, node, generation, and equality authority; and sealed before/after
   transitions retained by `Search.Result.Tree`. It also supplies sealed
   runtime-owned offer snapshots and an inseparable transition/sticky-cache
-  successor/snapshot value. Runtime-valid duplicate resolved input, write, or
-  structural-input ports remain executable through `Runtime.State.stepWithin`
-  but cannot satisfy Search's stricter scheduler contract, so snapshot
-  generation omits them and marks the snapshot incomplete. An intentional
-  package `handler.offers = false` veto is complete and does not set that bit.
+  successor/snapshot value. Repeated resolved read occurrences retain their
+  exact ordered node/version entries and are schedulable, including distinct
+  local slots that resolve to the same node. Runtime-valid duplicate resolved
+  writes or structural-input ports remain executable through
+  `Runtime.State.stepWithin` but cannot satisfy Search's authority contract, so
+  snapshot generation omits them and marks the snapshot incomplete. An
+  intentional package `handler.offers = false` veto is complete and does not
+  set that bit.
   All matcher-owned application rows must share one
   matcher epoch; mixed epochs are malformed and zero is the snapshot sentinel
   when no row carries an epoch. Offer generation checks `maxOffers` but does

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3205,29 +3205,28 @@ or authorize execution. Supported authority crosses complete `Session`
 authentication through `chooseWithin`, `prepareWithin`, or a checked session
 transition. The separate supported `Executable.Assembly` seals a checked
 program, exact package routes/caches, bindings, and concrete application rows,
-and its
-`invokeWithin` rechecks the selected identifier against the row's rule, anchor,
-kind, reads, writes, structural inputs, matcher epoch, effort, and creation
-generation before routing a callback. `Controller.Executable` now retains that
-assembly as a sticky handle, generates offers from its exact row order, and
-passes a replacement private cache onward only after Search, Driver, and
-quotation/schema checks accept the fact-only transition. Assembly separately
-retains the global
-generation cursor, so a node-only extension cannot lose its generation merely
-because it creates no concrete application. The supported `Runtime.State` owns that
-assembly together with the exact branch, equality arena, callback serial, and
-admitted-instance count. Its checked `stepWithin` is the Mathlib-free bridge
-from one exact application row to an atomic typed event batch. The supported
-`Runtime.Controller` owns that separate autonomous layer: a runtime-generated
+and its `invokeWithin` rechecks the selected identifier against the row's
+rule, anchor, kind, reads, writes, structural inputs, matcher epoch, effort,
+and creation generation before routing a callback. `Controller.Executable`
+now retains that assembly as a sticky handle, generates offers from its exact
+row order, and passes a replacement private cache onward only after Search,
+Driver, and quotation/schema checks accept the fact-only transition. The
+assembly separately retains the global generation cursor, so a node-only extension cannot lose its
+generation merely because it creates no concrete application. The supported
+`Runtime.State` owns that assembly together with the exact branch, equality
+arena, callback serial, and admitted-instance count. Its checked `stepWithin`
+is the Mathlib-free bridge from one exact application row to an atomic typed
+event batch. The supported `Runtime.Controller` owns that separate autonomous
+layer: a runtime-generated
 sealed offer snapshot carries the exact branch, application/binding tables,
 equality generations, callback serial, residual engine budgets, and an honest
-completeness bit into Search; one selected action
-returns an inseparable transition, sticky-cache successor, and regenerated
-offer snapshot before the same transition advances the retained tree. Assembly
-owns only the operation/node program: request
-program version and generation side tables remain controller-owned snapshot
-data and receive only the request-internal checks supplied by `ProgramView` and
-`RuleRequest`. Generic Search does not decrement a caller-supplied `remaining`
+completeness bit into Search; one selected action returns an inseparable
+transition, sticky-cache successor, and regenerated offer snapshot before the
+same transition advances the retained tree. The assembly owns only the
+operation/node program: request program version and generation
+side tables remain controller-owned snapshot data and receive only the
+request-internal checks supplied by `ProgramView` and `RuleRequest`. Generic
+Search does not decrement a caller-supplied `remaining`
 budget view. The runtime specialization instead replaces it from every sealed
 snapshot: actions, facts, nodes, applications, equalities, instances, and
 generation report exact residuals, while matcher visits, retained suggestions,
@@ -3249,10 +3248,16 @@ structural inputs remain duplicate-free. A runtime-owned snapshot containing
 only repeated reads is therefore complete. A handler-approved local
 application with duplicate resolved writes is omitted and sets the sticky
 incomplete bit, although direct Runtime execution still checks its exact row
-and events. The current sealed Executable compiler creates no structural
-matcher application rows; the structural-input distinctness check is retained
-for such rows when that compiler support is added, not presented as a
-currently constructible Runtime case.
+and events. Repeating a write node does not amplify the set-membership
+authority used by event admission, but Search intentionally keeps write and
+structural lists canonical and distinct instead of normalizing
+authority-bearing input. Consequently a contraction or backward rule on
+`f x x` whose distinct declared write slots resolve to the same node can remain
+directly executable yet unschedulable, with sticky snapshot incompleteness.
+This bridge does not broaden that contract. The current sealed Executable
+compiler creates no structural matcher application rows. The structural-input
+distinctness check is retained for such rows when that compiler support is
+added, not presented as a currently constructible Runtime case.
 
 As with Search, sealing is an ordinary/public-import boundary. Deliberate
 `import all HexInterval.Executable` exposes its private constructors to trusted
@@ -5569,10 +5574,10 @@ their declared cost inside a scheduler bound.
   callback request; scoped binding reads, writes, and structural inputs remain
   duplicate-free authority.
   A caller-owned logical measure bounds the initial policy state and every
-  callback successor against
-  independent byte/pair/work caps before retention; constructing and measuring
-  the arbitrary state remains non-preemptible. The choice cap is per sealed
-  `Controller.State` lineage: explicit `State.startWithin` starts a new handle
+  callback successor against independent byte/pair/work caps before retention;
+  constructing and measuring the arbitrary state remains non-preemptible. The
+  choice cap is per sealed `Controller.State` lineage: explicit
+  `State.startWithin` starts a new handle
   from a sealed current bundle and resets choices, the dismissal latch, and the
   search session's serial, steps, and diagnostic trace even when the retained
   head/scope is unchanged. Pure states can be reused to explore separately
@@ -5693,13 +5698,12 @@ their declared cost inside a scheduler bound.
   satisfy Search's authority contract, so snapshot generation omits them and
   marks the snapshot incomplete. The current sealed Executable compiler emits
   no structural matcher rows; Runtime retains the structural-input
-  distinctness gate for a later supported producer. An
-  intentional package `handler.offers = false` veto is complete and does not
-  set that bit.
-  All matcher-owned application rows must share one
-  matcher epoch; mixed epochs are malformed and zero is the snapshot sentinel
-  when no row carries an epoch. Offer generation checks `maxOffers` but does
-  not consume `maxActions`; `maxActions` is charged only by an actual runtime
+  distinctness gate for a later supported producer. An intentional package
+  `handler.offers = false` veto is complete and does not set that bit.
+  All matcher-owned application rows must share one matcher epoch; mixed epochs
+  are malformed, and zero is the snapshot sentinel when no row carries an
+  epoch. Offer generation checks `maxOffers` but does not consume `maxActions`;
+  `maxActions` is charged only by an actual runtime
   advance. Raw quotations remain inert data; theorem authority is supplied
   only by the separately checked `HexIntervalMathlib.RuntimeProof` proof
   adapter.
@@ -5833,8 +5837,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - malformed structural programs, including duplicate operation keys, wrong
   arity/domain, unknown operations, and self/forward SSA references;
 - malformed registration, scope, and request snapshots, including wrong
-  operation/rule versions, duplicate or out-of-range ports, misaligned side
-  tables, changed fact versions, and changed ordered write authority;
+  operation/rule versions, duplicate declared registration slots, duplicate
+  scoped reads/writes, duplicate action writes/structural inputs, out-of-range
+  ports, misaligned side tables, changed fact versions, and changed ordered
+  write authority, while accepting repeated local read occurrences resolved
+  from distinct declared slots;
 - malformed or over-budget state snapshots, including stale/cross-node update
   predecessors, wrong program versions, non-prefix extensions, exact generated
   version-zero seed restoration, dependency/watcher misalignment, stale dirty

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -3199,8 +3199,13 @@ independently checking the action's rule key and local rule id, anchor,
 operation, kind, reads, writes, and structural inputs. A callback must not use
 the compact application id as authority for a rule or anchor. Retaining and
 checking the exact application table is not part of the Search contract. The
-separate supported `Executable.Assembly` seals a checked program, exact
-package routes/caches, bindings, and concrete application rows, and its
+public `Search.actionCurrent` predicate is likewise only a diagnostic over
+explicit caller-supplied branch and side tables; it does not seal those tables
+or authorize execution. Supported authority crosses complete `Session`
+authentication through `chooseWithin`, `prepareWithin`, or a checked session
+transition. The separate supported `Executable.Assembly` seals a checked
+program, exact package routes/caches, bindings, and concrete application rows,
+and its
 `invokeWithin` rechecks the selected identifier against the row's rule, anchor,
 kind, reads, writes, structural inputs, matcher epoch, effort, and creation
 generation before routing a callback. `Controller.Executable` now retains that
@@ -3235,12 +3240,19 @@ slots may resolve to the same node, as in `x + x`. Such occurrences retain the
 same exact current `SeenVersion` twice; authentication freshness-checks each
 occurrence and preserves the duplicate list through policy selection, request
 reconstruction, executable invocation, and runtime transition correlation.
+The explicit Mathlib `Controller.Draft` generator follows the same rule for
+local registrations: it preserves duplicate read occurrences when deriving
+versions and Search authenticates the exact local slot projection. Scoped
+binding reads remain distinct authority under `ScopeBinding.check`.
 This does not weaken mutation or structural authority: resolved writes and
-structural inputs remain duplicate-free, and scoped binding reads remain
-duplicate-free under `ScopeBinding.check`. A runtime-owned snapshot containing
-only repeated reads is therefore complete. A handler-approved application with
-duplicate resolved writes or structural inputs is still omitted and sets the
-sticky incomplete bit.
+structural inputs remain duplicate-free. A runtime-owned snapshot containing
+only repeated reads is therefore complete. A handler-approved local
+application with duplicate resolved writes is omitted and sets the sticky
+incomplete bit, although direct Runtime execution still checks its exact row
+and events. The current sealed Executable compiler creates no structural
+matcher application rows; the structural-input distinctness check is retained
+for such rows when that compiler support is added, not presented as a
+currently constructible Runtime case.
 
 As with Search, sealing is an ordinary/public-import boundary. Deliberate
 `import all HexInterval.Executable` exposes its private constructors to trusted
@@ -5551,8 +5563,13 @@ their declared cost inside a scheduler bound.
   and proof registrations. It resource-first regenerates deterministic offers,
   derives age from sealed session chronology, revalidates exact
   `ApplicationId` routing, and iterates a replaceable policy over the sealed
-  session/tree bundle under a cumulative choice cap. A caller-owned logical
-  measure bounds the initial policy state and every callback successor against
+  session/tree bundle under a cumulative choice cap.
+  Local draft reads are ordered occurrences, so distinct local slots which
+  resolve to the same node retain duplicate exact versions through the
+  callback request; scoped binding reads, writes, and structural inputs remain
+  duplicate-free authority.
+  A caller-owned logical measure bounds the initial policy state and every
+  callback successor against
   independent byte/pair/work caps before retention; constructing and measuring
   the arbitrary state remains non-preemptible. The choice cap is per sealed
   `Controller.State` lineage: explicit `State.startWithin` starts a new handle
@@ -5672,9 +5689,11 @@ their declared cost inside a scheduler bound.
   successor/snapshot value. Repeated resolved read occurrences retain their
   exact ordered node/version entries and are schedulable, including distinct
   local slots that resolve to the same node. Runtime-valid duplicate resolved
-  writes or structural-input ports remain executable through
-  `Runtime.State.stepWithin` but cannot satisfy Search's authority contract, so
-  snapshot generation omits them and marks the snapshot incomplete. An
+  writes remain executable through `Runtime.State.stepWithin` but cannot
+  satisfy Search's authority contract, so snapshot generation omits them and
+  marks the snapshot incomplete. The current sealed Executable compiler emits
+  no structural matcher rows; Runtime retains the structural-input
+  distinctness gate for a later supported producer. An
   intentional package `handler.offers = false` veto is complete and does not
   set that bit.
   All matcher-owned application rows must share one

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -440,16 +440,20 @@ private def actionCurrentChecked (limits : State.Limits) (branch : State.Branch 
   if !bindingValid || !matcherValid then throw .invalidSession
 
 /-- Diagnostic structural/freshness predicate for one explicitly supplied
-action and its explicitly supplied tables. This is not an authorization
-boundary: the tables are ordinary caller values. Supported scheduling must
-authenticate a sealed `Session` through `chooseWithin`, `prepareWithin`, or a
-session transition, all of which additionally correlate the complete retained
-session. -/
+action and its explicitly supplied tables. It first validates the complete
+registration and binding tables against the branch program. This is not an
+authorization boundary: the tables are ordinary caller values. Supported
+scheduling must authenticate a sealed `Session` through `chooseWithin`,
+`prepareWithin`, or a session transition, all of which additionally correlate
+the complete retained session. -/
 opaque actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
     (rules : Array Registration) (bindings : Array ScopeBinding)
     (applicationGenerations equalityGenerations : Array Nat)
     (matcherEpoch serial : Nat) (action : Action) : Bool :=
   (do
+    if !Registration.check branch.program rules ||
+        !ScopeBinding.checkAll branch.program rules bindings then
+      throw Error.invalidSession
     preflightAction limits rules action
     actionCurrentChecked limits branch rules bindings applicationGenerations
       equalityGenerations matcherEpoch serial action).isOk

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -439,6 +439,12 @@ private def actionCurrentChecked (limits : State.Limits) (branch : State.Branch 
     | .network => action.matcherEpoch == some matcherEpoch && !action.structuralInputs.isEmpty
   if !bindingValid || !matcherValid then throw .invalidSession
 
+/-- Diagnostic structural/freshness predicate for one explicitly supplied
+action and its explicitly supplied tables. This is not an authorization
+boundary: the tables are ordinary caller values. Supported scheduling must
+authenticate a sealed `Session` through `chooseWithin`, `prepareWithin`, or a
+session transition, all of which additionally correlate the complete retained
+session. -/
 opaque actionCurrent (limits : State.Limits) (branch : State.Branch Fact Cause)
     (rules : Array Registration) (bindings : Array ScopeBinding)
     (applicationGenerations equalityGenerations : Array Nat)

--- a/HexInterval/Search.lean
+++ b/HexInterval/Search.lean
@@ -401,8 +401,12 @@ private def actionCurrentChecked (limits : State.Limits) (branch : State.Branch 
     throw .invalidSession
   let some instruction := branch.program.node? action.node | throw .invalidSession
   let some operation := branch.program.operation? instruction.op | throw .invalidSession
-  if operation.key != registration.head || !allDistinct action.inputs ||
-      !allDistinct action.writes || !allDistinct action.structuralInputs then
+  /- Read occurrences stay ordered and are checked independently below. A
+  local rule may watch distinct argument slots which resolve to the same node
+  (for example `x + x`); exact duplicate `SeenVersion`s are therefore valid.
+  Writes and structural dependencies remain duplicate-free authority. -/
+  if operation.key != registration.head || !allDistinct action.writes ||
+      !allDistinct action.structuralInputs then
     throw .invalidSession
   for seen in action.inputs do
     let some version := branch.versions[seen.node.index]? | throw .invalidSession

--- a/HexIntervalMathlib/Controller.lean
+++ b/HexIntervalMathlib/Controller.lean
@@ -325,8 +325,12 @@ private def generate [DecidableEq Fact] [DecidableEq Cause]
       throw (.resource (.state .matcherVisits))
     if envelope.state.maxEffort < draft.effort then
       throw (.resource (.state .effort))
-    if !allDistinct draft.inputs || !allDistinct draft.writes ||
-        !allDistinct draft.structuralInputs then
+    /- Draft reads are ordered occurrences. Distinct local registration slots
+    may resolve to one node, and `seenInputs?` preserves every occurrence for
+    exact Search authentication. Scoped reads and all write/structural
+    authority remain distinct. -/
+    if (registration.binding == .scoped && !allDistinct draft.inputs) ||
+        !allDistinct draft.writes || !allDistinct draft.structuralInputs then
       throw (.invalidApplication applicationId)
     if (branch.program.node? draft.node).isNone ||
         draft.writes.any (fun node => (branch.program.node? node).isNone) then

--- a/conformance/HexInterval/RuntimeConformance.lean
+++ b/conformance/HexInterval/RuntimeConformance.lean
@@ -814,6 +814,59 @@ def repeatAction : Action :=
       snapshot.remaining.applications == 0 && snapshot.remaining.acceptedFacts == 4
   | .error _ => false
 
+/- Distinct declared write slots can also resolve to the same node on `f x x`.
+Runtime execution keeps the exact duplicate list and remains sound because the
+single emitted fact update is independently checked. Search does not admit
+duplicate mutation authority, so offer generation omits the row and reports
+the loss through `incomplete`. -/
+def repeatWriteRuleKey : RuleKey := { name := "fixture.repeat.write" }
+
+def repeatWriteRegistration : Registration :=
+  { key := repeatWriteRuleKey, head := repeatKey, kind := .forward,
+    watches := [.result], writes := [.argument 0, .argument 1] }
+
+def repeatWriteBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  let exactWrites := request.writes ==
+    [({ index := 0 } : NodeId), ({ index := 0 } : NodeId)]
+  let value := if exactWrites then 11 else 12
+  { events := #[.fact
+      { action := request.action
+        update :=
+          { programVersion := 0, node := { index := 0 },
+            previous := { node := { index := 0 }, version := 0 },
+            fact := value, version := 1, cause := 104 }
+        proposed := value
+        quote := factQuote }] }
+
+def repeatWritePackage : Package Nat (Batch Nat Nat) :=
+  { Cache := Unit
+    cache := ()
+    operations := #[sourceOperation, repeatOperation]
+    handlers := #[handler repeatWriteRegistration .fact 3 33 repeatWriteBatch]
+    measure := runtimePackage.measure }
+
+def repeatWriteRuntime? : Option (Runtime.State Nat Nat) :=
+  match (Executable.buildWithin repeatExecutableLimits #[repeatWritePackage]
+      repeatProgram).toOption, repeatBranch? with
+  | some assembly, some branch =>
+      (Runtime.State.startWithin repeatLimits assembly branch).toOption
+  | _, _ => none
+
+def repeatWriteAction : Action :=
+  action 0 0 0 0 repeatWriteRuleKey 1 .forward 0
+    [{ node := { index := 1 }, version := 0 }] [{ index := 0 }, { index := 0 }]
+
+#guard repeatWriteRuntime?.any fun state =>
+  match state.offerSnapshotWithin repeatLimits 1 with
+  | .ok snapshot => snapshot.actions.isEmpty && snapshot.incomplete
+  | .error _ => false
+
+#guard repeatWriteRuntime?.any fun state =>
+  match state.stepWithin repeatLimits repeatWriteAction with
+  | .ok (applied, next) =>
+      applied.action == repeatWriteAction && next.branch.snapshot.facts == #[11, 20]
+  | .error _ => false
+
 def repeatStaleVersion : Action :=
   { repeatAction with inputs :=
       [{ node := { index := 0 }, version := 0 },
@@ -1187,6 +1240,17 @@ def repeatControllerState? : Option (Runtime.Controller.State Nat Nat Nat Nat) :
           | some ({ index := 0 }, source) => source.branch == state.runtime.branch
           | _ => false
     | _ => false
+
+-- Session authentication reaches `actionCurrentChecked` for every retained
+-- offer. Replacing only the second repeated occurrence by a stale version
+-- invalidates the session before policy selection.
+#guard repeatControllerState?.any fun state =>
+  let offers := state.session.offers.map fun offer =>
+    { offer with action := { offer.action with inputs := repeatStaleVersion.inputs } }
+  match Search.Session.refreshWithin repeatEnvelope Runtime.Controller.policyMeasure
+      state.session offers state.session.remaining state.session.incomplete with
+  | .error .invalidSession => true
+  | _ => false
 
 -- The policy echo cannot reuse the repeated-read offer at another callback
 -- serial; Search validates chronology before exposing the exact action.

--- a/conformance/HexInterval/RuntimeConformance.lean
+++ b/conformance/HexInterval/RuntimeConformance.lean
@@ -15,6 +15,10 @@ that fact at the second node. The complete chain runs at a root and in a fresh
 split child. A second split after root extension restarts over nonzero assembly
 generation, admits the next strict instance, and completes a fresh
 equality/fact/transport chain on the new local generation-one suffix.
+It also checks that a genuine binary repeated read such as `f x x` remains an
+ordered two-slot request across runtime offer generation, Search selection,
+and autonomous-controller advancement without admitting stale or spliced
+chronology.
 -/
 
 namespace Hex.Interval.RuntimeConformance
@@ -728,8 +732,8 @@ def repeatOperation : Operation :=
   { key := repeatKey, inputs := [real, real], output := real }
 
 /-- A genuine binary `f x x` node resolves two distinct argument slots to the
-same source node. Runtime accepts that exact application; Search deliberately
-requires distinct resolved scheduler ports. -/
+same source node. Runtime and Search preserve both ordered occurrences with
+their exact shared current version. -/
 def repeatProgram : Program :=
   { operations := #[sourceOperation, repeatOperation]
     nodes :=
@@ -740,14 +744,21 @@ def repeatRegistration : Registration :=
   { key := repeatRuleKey, head := repeatKey, kind := .forward,
     watches := [.argument 0, .argument 1], writes := [.result] }
 
+private def repeatInputExact (input : FactView Nat) : Bool :=
+  input.node == ({ index := 0 } : NodeId) && input.fact == 10 && input.version == 0
+
 def repeatBatch (request : RuleRequest Nat) : Batch Nat Nat :=
+  let exactInputs := match request.inputs with
+    | [left, right] => repeatInputExact left && repeatInputExact right
+    | _ => false
+  let value := if exactInputs then 31 else 32
   { events := #[.fact
       { action := request.action
         update :=
           { programVersion := 0, node := { index := 1 },
             previous := { node := { index := 1 }, version := 0 },
-            fact := 31, version := 1, cause := 103 }
-        proposed := 31
+            fact := value, version := 1, cause := 103 }
+        proposed := value
         quote := factQuote }] }
 
 def repeatPackage : Package Nat (Batch Nat Nat) :=
@@ -798,10 +809,30 @@ def repeatAction : Action :=
 
 #guard repeatRuntime?.any fun state =>
   match state.offerSnapshotWithin repeatLimits 1 with
-  | .ok snapshot => snapshot.actions.isEmpty && snapshot.incomplete &&
+  | .ok snapshot => snapshot.actions == #[repeatAction] && !snapshot.incomplete &&
       snapshot.remaining.actions == 8 && snapshot.remaining.nodes == 0 &&
       snapshot.remaining.applications == 0 && snapshot.remaining.acceptedFacts == 4
   | .error _ => false
+
+def repeatStaleVersion : Action :=
+  { repeatAction with inputs :=
+      [{ node := { index := 0 }, version := 0 },
+       { node := { index := 0 }, version := 1 }] }
+
+def repeatStaleSerial : Action := { repeatAction with serial := 1 }
+
+-- Every repeated read occurrence is checked: one stale version cannot hide
+-- behind the current occurrence for the same node.
+#guard repeatRuntime?.any fun state =>
+  match state.stepWithin repeatLimits repeatStaleVersion with
+  | .error .stale => true
+  | _ => false
+
+-- Callback chronology remains exact for the newly schedulable action.
+#guard repeatRuntime?.any fun state =>
+  match state.stepWithin repeatLimits repeatStaleSerial with
+  | .error .stale => true
+  | _ => false
 
 def splitAction : Action :=
   action 0 0 0 0 instantiateKey 0 .split 0
@@ -1142,12 +1173,32 @@ def repeatControllerState? : Option (Runtime.Controller.State Nat Nat Nat Nat) :
     runtime tree).toOption
 
 #guard repeatControllerState?.any fun state =>
-  state.session.offers.isEmpty && state.session.incomplete &&
+  state.session.offers.size == 1 && !state.session.incomplete &&
+    state.session.offers[0]?.any (fun offer => offer.action == repeatAction) &&
     state.session.remaining.actions == 8 && state.session.remaining.nodes == 0 &&
     match Runtime.Controller.runWithin repeatControllerLimits repeatEnvelope measure
-        plannedPolicy [] state with
-    | .ok (.stopped 0 state []) => state.session.incomplete && state.choices == 0
+        plannedPolicy [0] state with
+    | .ok (.stopped 1 state []) =>
+        state.choices == 1 && !state.session.incomplete && state.session.serial == 1 &&
+          state.session.offers.size == 1 && state.tree.transitions.size == 1 &&
+          state.runtime.branch.snapshot.facts == #[10, 31] &&
+          state.session.branch == state.runtime.branch &&
+          match Search.Result.current? state.tree with
+          | some ({ index := 0 }, source) => source.branch == state.runtime.branch
+          | _ => false
     | _ => false
+
+-- The policy echo cannot reuse the repeated-read offer at another callback
+-- serial; Search validates chronology before exposing the exact action.
+#guard repeatControllerState?.any fun state =>
+  match Search.chooseWithin repeatEnvelope Runtime.Controller.policyMeasure
+      plannedPolicy [0] state.session with
+  | .ok (.select decision _) =>
+      match Search.prepareWithin repeatEnvelope Runtime.Controller.policyMeasure
+          state.session { decision with serial := 1 } with
+      | .error (.policy .staleSerial) => true
+      | _ => false
+  | _ => false
 
 -- Dismissing the sole ordinary offer removes exactly one live item, charges
 -- one decision, and makes the offer view incomplete.
@@ -1271,6 +1322,21 @@ private def firstControllerStep? : Option FirstControllerStep := do
       Runtime.Controller.policyMeasure step.session step.decision step.advanced with
   | .error (.policy .staleSerial) => true
   | _ => false
+
+-- A sealed transition from another runtime lineage cannot be spliced behind
+-- a valid repeated-read decision, even though both use the same public
+-- application-id type.
+#guard match repeatControllerState?, firstControllerStep? with
+  | some repeated, some ordinary =>
+      match Search.chooseWithin repeatEnvelope Runtime.Controller.policyMeasure
+          plannedPolicy [0] repeated.session with
+      | .ok (.select decision _) =>
+          match Search.Session.advanceRuntimeWithin repeatEnvelope
+              Runtime.Controller.policyMeasure repeated.session decision ordinary.advanced with
+          | .error .invalidSession => true
+          | _ => false
+      | _ => false
+  | _, _ => false
 
 -- A runtime advanced away from the retained tree head cannot start a new
 -- controller lineage, even though both values remain individually sealed.

--- a/conformance/HexInterval/SearchConformance.lean
+++ b/conformance/HexInterval/SearchConformance.lean
@@ -123,6 +123,15 @@ private def startNetworkError (limits : State.Limits) : Option Search.Error := d
 #guard startScopedError stateLimits == none
 #guard startNetworkError stateLimits == none
 
+-- The public diagnostic checks the complete supplied rule/binding tables;
+-- an unrelated scoped binding cannot be ignored merely because this action is
+-- local and does not consult it during slot reconstruction.
+#guard match branch? with
+  | some branch =>
+      !Search.actionCurrent stateLimits branch #[localRule] #[binding]
+        #[0] #[0] 0 0 policyAction
+  | none => false
+
 #guard match branch? with
   | some branch =>
       searchError (.policy .offerLimit) <|
@@ -146,6 +155,12 @@ private def startNetworkError (limits : State.Limits) : Option Search.Error := d
 #guard startActionError
   { policyAction with writes := [contractNode 0, contractNode 1,
       contractNode 0, contractNode 1] } == some (.resource (.state .arity))
+
+-- Duplicate writes fit the port cap but violate Search's intentionally
+-- distinct write-authority contract during session authentication.
+#guard startActionError
+  { policyAction with writes := [contractNode 1, contractNode 1] } ==
+    some .invalidSession
 
 #guard startActionError
   { policyAction with structuralInputs := [

--- a/conformance/HexIntervalMathlib/ControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ControllerConformance.lean
@@ -569,7 +569,9 @@ private def malformedDraftRejected
           | .error (.invalidApplication ⟨0⟩) => true
           | _ => false
 
-def duplicateInputsRejected : Bool :=
+-- Scoped bindings remain sets of authority-bearing nodes, so a duplicate
+-- draft cannot be correlated with the separately validated binding table.
+def scopedDuplicateInputsRejected : Bool :=
   malformedDraftRejected (malformedDraftApplication [n1, n1] [n2] [])
 
 def duplicateWritesRejected : Bool :=
@@ -580,6 +582,103 @@ def duplicateStructuralRejected : Bool :=
     { envelope with state := { stateLimits with matcherBatchSize := 2 } }
   malformedDraftRejected
     (malformedDraftApplication [n1] [n2] [.node n1, .node n1]) structuralEnvelope
+
+/-! ## Local repeated-read occurrences -/
+
+def repeatOperationKey : OpKey := { name := "controller-repeat" }
+def repeatControllerRule : RuleKey := { name := "controller-repeat-forward", schema := 1 }
+
+def repeatOperation : Operation :=
+  { key := repeatOperationKey, inputs := [domain, domain], output := domain }
+
+def repeatProgram : Program :=
+  { operations := #[operation, repeatOperation]
+    nodes :=
+      #[sourceNode,
+        { domain, op := { index := 1 }, args := [n0, n0] }] }
+
+def repeatRegistration : Registration :=
+  { key := repeatControllerRule, head := repeatOperationKey, kind := .forward,
+    watches := [.argument 0, .argument 1], writes := [] }
+
+def repeatProofPackage : Proof.Package semantics (List Nat) :=
+  { registrations := #[repeatRegistration] }
+
+def repeatStateLimits : State.Limits :=
+  { stateLimits with
+    maxOperations := 2
+    maxNodes := 2
+    maxRules := 1
+    maxRegistryEntries := 1
+    maxApplications := 1
+    maxNodeDepth := 1 }
+
+def repeatProofRegistry? : Option (Proof.Registry semantics (List Nat)) :=
+  (Proof.Registry.buildWithin proofLimits repeatProgram #[repeatProofPackage]).toOption
+
+def repeatApplication : Controller.Application Fact Nat Nat :=
+  { offer := fun selectedScope branch =>
+      if selectedScope == scope && version? branch n1 == some 0 then
+        some
+          { key := 45
+            offerClass := .invoke
+            node := n1
+            effort := 0
+            inputs := [n0, n0] }
+      else none }
+
+def repeatRuntime : Driver.Package Fact Nat Controller.OfferId Nat (List Nat) :=
+  { rule := repeatControllerRule
+    invoke := fun request =>
+      if request.action.inputs == [seen n0 0, seen n0 0] then .stop 7 else .stop 8 }
+
+def repeatPackages : Array (Controller.Package Fact Nat Nat (List Nat)) :=
+  #[{ runtime := repeatRuntime, applications := #[repeatApplication] }]
+
+def repeatControllerRegistry? := do
+  let proof ← repeatProofRegistry?
+  (Controller.Registry.buildWithin repeatStateLimits controllerKey repeatProgram proof
+    repeatPackages).toOption
+
+def repeatRuntimeLimits : Runtime.Limits :=
+  { runtimeLimits with executable :=
+      { runtimeLimits.executable with state := repeatStateLimits } }
+
+def repeatResultLimits : Search.Result.Limits :=
+  { resultLimits with runtime := repeatRuntimeLimits }
+
+def repeatDriverLimits : Driver.Limits :=
+  { limits with result := repeatResultLimits }
+
+def repeatControllerLimits : Controller.Limits :=
+  { controllerLimits with maxChoices := 1, driver := repeatDriverLimits }
+
+def repeatEnvelope : Search.Envelope :=
+  { envelope with state := repeatStateLimits }
+
+def repeatControllerAccepted : Bool :=
+  match repeatControllerRegistry? with
+  | none => false
+  | some registry =>
+      match State.Branch.startWithin repeatStateLimits repeatProgram
+          #[Fact.yes, Fact.all] with
+      | .error _ => false
+      | .ok branch =>
+          match Driver.Bundle.startWithin repeatDriverLimits resultMeasure
+              recipeMeasure scope branch with
+          | .error _ => false
+          | .ok bundle =>
+              match Controller.State.startWithin repeatEnvelope
+                  (Controller.policyMeasure keyCost) registry bundle with
+              | .error _ => false
+              | .ok state =>
+                  state.session.offers[0]?.any (fun offer =>
+                    offer.action.inputs == [seen n0 0, seen n0 0]) &&
+                    match Controller.runWithin repeatControllerLimits repeatEnvelope keyCost
+                        unitCost resultMeasure recipeMeasure .depthFirst registry firstPolicy () state with
+                    | .ok (.stopped (.callbackFailure 7) stopped ()) =>
+                        stopped.choices == 1
+                    | _ => false
 
 def missingNodeRejected : Bool :=
   malformedDraftRejected
@@ -834,9 +933,10 @@ def sameKeyReplacementChecked : Bool :=
 #guard structuralBatchRejected
 #guard emptyNetworkRejected
 #guard networkStructuralAccepted
-#guard duplicateInputsRejected
+#guard scopedDuplicateInputsRejected
 #guard duplicateWritesRejected
 #guard duplicateStructuralRejected
+#guard repeatControllerAccepted
 #guard missingNodeRejected
 #guard wrongClassRejected
 #guard transplantRejected


### PR DESCRIPTION
## Summary

- preserve ordered repeated read occurrences such as `x + x` through Search and Runtime offer scheduling
- keep duplicate writes, structural inputs, and scoped binding reads fail-closed
- add runtime/controller conformance for exact multiplicity, mixed-version and serial staleness, and cross-lineage rejection

## Validation

- cold full `lake build` (9,833 jobs)
- incremental full `lake build` (9,826 jobs)
- exact rebased `lake build HexInterval HexInterval.RuntimeConformance`
- DAG/unit and trust-surface checks

An exact-head independent semantic review is running; this PR will not merge until it approves and CI is green.