### PR TITLE
feat(interval): seal typed runtime terminals

### DIFF
--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -23,6 +23,7 @@ public import HexIntervalMathlib.Regularize
 public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
 public import HexIntervalMathlib.RuntimeProof
+public import HexIntervalMathlib.RuntimeTerminal
 public import HexIntervalMathlib.Rule
 public import HexIntervalMathlib.Frontend
 public import HexIntervalMathlib.Tactic
@@ -39,6 +40,10 @@ enclosures. It also supplies the function-agnostic semantics of supported
 programs and the chronological, package-owned proof-replay boundary.
 `HexIntervalMathlib.RuntimeProof` transactionally converts sealed typed runtime
 transition chains into those proof events without trusting raw quotations.
+`HexIntervalMathlib.RuntimeTerminal` binds target and refutation settlement to
+the same sealed runtime/search lineage, theorem registry, and immutable proof
+input; general split settlement remains blocked by the runtime/proof child
+equality-arena mismatch documented by that module.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
 `HexIntervalMathlib.Controller` supplies explicit stable application-table,

--- a/HexIntervalMathlib/RuntimeTerminal.lean
+++ b/HexIntervalMathlib/RuntimeTerminal.lean
@@ -46,6 +46,7 @@ inductive Error where
   | result (error : Search.Result.Error)
   | controller (error : Runtime.Controller.Error)
   | runtimeProof (error : RuntimeProof.Error)
+  | inheritedEqualities
   | mismatch
   deriving DecidableEq, Repr
 
@@ -79,8 +80,11 @@ structure Lineage (Fact : Type) (semantics : Proof.Semantics Fact)
   input : Proof.Input Fact
   tree : Search.Result.Tree Fact Cause Plan Proof.Key
 
-/-- A full transactional runtime quotation bound to its immutable proof input.
-The constructor is private, so replay cannot be redirected to another input. -/
+/-- A full transactional runtime quotation carrying the admitted proof input.
+Ordinary imports cannot fabricate the record directly. `replayWithin` performs
+the exact input equality check exposed in its result type, while the nested
+`RuntimeProof.Bundle` independently retains the exact theorem registry used by
+quotation. -/
 structure Checked (Fact : Type) (semantics : Proof.Semantics Fact)
     (Cause Plan : Type) where
   private mk ::
@@ -101,6 +105,12 @@ private def rootMatches [DecidableEq Fact]
         source.scope == input.scope && source.branch.baseProgram == input.program &&
         source.branch.initialFacts == input.facts
 
+/-- Public `Runtime.Controller.State.startWithin` and `runWithin` already
+preserve these equalities, and their private state constructor makes individual
+projection-splice counterexamples unconstructible under ordinary imports. This
+defensive repetition binds the visible controller projections at this separate
+theorem adapter edge; conformance tests the constructible whole-runtime and
+whole-input transplant paths instead of fabricating impossible field updates. -/
 private def liveMatches [DecidableEq Fact] [DecidableEq Cause]
     (controller : Runtime.Controller.State Fact Cause Plan Proof.Key) : Bool :=
   match Search.Result.current? controller.tree with
@@ -111,6 +121,32 @@ private def liveMatches [DecidableEq Fact] [DecidableEq Cause]
         controller.runtime.serial == controller.session.serial &&
         controller.runtime.assembly.program == source.branch.program &&
         controller.session.scope == source.scope
+
+private def hasEquality (applied : Runtime.Applied Fact Cause) : Bool :=
+  applied.events.any fun event => match event with
+    | .equality _ => true
+    | .fact _ | .transport _ | .instance _ => false
+
+/-- Whether an exact ancestor of `current` retained an equality event. The
+current node and sibling chronologies are deliberately excluded. A checked
+tree has one acyclic parent edge per non-root node, so `nodes.size` is a total
+structural bound for this walk. -/
+private def inheritsEquality
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key)
+    (current : Search.Result.Id) : Bool :=
+  let transitions := tree.transitions
+  let rec walk : Nat → Search.Result.Id → Bool
+    | 0, _ => false
+    | fuel + 1, child =>
+        match tree.nodes[child.index]? with
+        | none => false
+        | some node => match node.source.parent with
+          | none => false
+          | some parent =>
+              if transitions.any fun entry => entry.1 == parent && hasEquality entry.2 then
+                true
+              else walk fuel parent
+  walk tree.nodes.size current
 
 /-- Admit an already sealed live controller only when its root belongs to the
 exact registry/input pair and its current typed runtime remains aligned with
@@ -157,16 +193,20 @@ opaque Active.refuteWithin [DecidableEq Fact] [DecidableEq Cause]
     Except Error (Lineage Fact semantics Cause Plan) := do
   let _ := (← liftExcept Error.proof
     (Proof.bodyCheck limits.proof key .refute body)).down
+  if !active.controller.tree.check limits.result measure then
+    throw (Error.result .malformed)
   let some current := liftOption.{0, 1} (Search.Result.current? active.controller.tree)
     | throw Error.mismatch
   let source := current.down.2
+  if source.branch.versions[seen.node.index]? != some seen.version then
+    throw Error.mismatch
   let some fact := source.branch.factAt? seen | throw Error.mismatch
   let some schema := active.registry.proof.refuter? key
     | throw (Error.proof .missingSchema)
   let some certificate := schema.decode body | throw (Error.proof .malformedBody)
   let context : Proof.RefuteContext semantics :=
     { scope := source.scope, programVersion := source.branch.programVersion,
-      program := active.controller.runtime.assembly.program,
+      program := source.branch.program,
       node := seen.node, fact }
   let some _ := schema.prove context certificate | throw (Error.proof .malformedBody)
   let entry : Search.Result.Refute Proof.Key :=
@@ -177,15 +217,30 @@ opaque Active.refuteWithin [DecidableEq Fact] [DecidableEq Cause]
   pure { registry := active.registry, input := active.input, tree }
 
 /-- Restart the next retained child using a runtime already created from that
-child's exact version-zero branch. The controller constructor authenticates its
+child's exact version-zero branch. Before consulting the runtime, this rejects
+an ancestor equality chronology which `Proof.seedChild` would inherit but the
+runtime restart would reset. The controller constructor then authenticates the
 branch and reset serial against this token's tree; using the retained tree here
-prevents cross-lineage splicing. -/
+prevents cross-lineage splicing.
+
+Assembly generation is not a second inherited-proof identity: runtime restart
+authenticates its supplied assembly as the child's generation base, and full
+`RuntimeProof` quotation reconstructs the parent's post-chronology assembly and
+checks every child's exact before/after generation, bindings, and applications.
+A wrong same-program assembly can therefore produce no checked event bundle;
+with no child events, no proof evidence depends on that assembly metadata. -/
 opaque Lineage.resumeWithin [DecidableEq Fact] [DecidableEq Cause]
     (controllerLimits : Runtime.Controller.Limits) (envelope : Search.Envelope)
     (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
     (lineage : Lineage Fact semantics Cause Plan)
     (runtime : Runtime.State Fact Cause) :
     Except Error (Active Fact semantics Cause Plan) := do
+  if !lineage.tree.check controllerLimits.result measure then
+    throw (Error.result .malformed)
+  let some current := liftOption.{0, 1} (Search.Result.current? lineage.tree)
+    | throw Error.mismatch
+  if inheritsEquality lineage.tree current.down.1 then
+    throw Error.inheritedEqualities
   let controller ← Runtime.Controller.State.startWithin controllerLimits envelope measure
     runtime lineage.tree |>.mapError Error.controller
   if !rootMatches lineage.registry lineage.input lineage.tree || !liveMatches controller then

--- a/HexIntervalMathlib/RuntimeTerminal.lean
+++ b/HexIntervalMathlib/RuntimeTerminal.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.RuntimeController
+public import HexIntervalMathlib.RuntimeProof
+
+@[expose] public section
+
+/-!
+# Typed runtime terminals
+
+This module seals target and refutation settlement to the same typed runtime,
+retained search tree, theorem registry, and proof input later consumed by
+`RuntimeProof.replayTree`. A target must be the exact current target fact. A
+refutation must resolve its exact package-owned schema and certificate against
+the exact current fact before the inert search record is retained; recursive
+replay independently invokes the theorem schema again at the theorem boundary.
+
+The callback used by a refutation schema is arbitrary pure Lean code and is
+therefore non-preemptible. Structural body and retained-tree limits are checked
+before it runs. Complete runtime quotation limits are checked transactionally
+when `Lineage.quoteWithin` creates a checked bundle.
+
+There is deliberately no split adapter here. `Proof.seedChild` preserves the
+parent proof equality table and its compact identities, while
+`Runtime.State.startWithin` deliberately restarts every child with an empty
+runtime equality arena and identity zero. After a parent equality, the first
+child equality would consequently have runtime identity zero but proof identity
+`parent.equalities.count`. Until the Mathlib-free restart contract can import
+an authenticated equality arena (or proof replay changes its identity model),
+a general typed split adapter is not representable without weakening an exact
+correlation invariant.
+-/
+
+namespace Hex.Interval.RuntimeTerminal
+
+variable {Fact Cause Plan : Type} {semantics : Proof.Semantics Fact}
+
+inductive Error where
+  | proof (error : Proof.Error)
+  | result (error : Search.Result.Error)
+  | controller (error : Runtime.Controller.Error)
+  | runtimeProof (error : RuntimeProof.Error)
+  | mismatch
+  deriving DecidableEq, Repr
+
+private def liftOption.{u, v} {α : Type u} (value : Option α) :
+    Option (ULift.{v} α) :=
+  value.map ULift.up
+
+private def liftExcept.{u, v} {E : Type u} {A : Type v} (map : E → Error)
+    (value : Except E A) : Except Error (ULift.{1} A) :=
+  match value with
+  | .error error => .error (map error)
+  | .ok result => .ok ⟨result⟩
+
+/-- One exact live runtime/search lineage, theorem registry, and immutable
+proof input. Its private constructor prevents replacing any component after
+root and current-source alignment have been checked. -/
+structure Active (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type) where
+  private mk ::
+  registry : RuntimeProof.Registry Fact semantics Cause Plan
+  input : Proof.Input Fact
+  controller : Runtime.Controller.State Fact Cause Plan Proof.Key
+
+/-- A retained lineage after one exact target or refutation settlement. It may
+still have another split child pending. Resumption always starts a controller
+against this token's retained tree, so a sibling tree cannot be substituted. -/
+structure Lineage (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type) where
+  private mk ::
+  registry : RuntimeProof.Registry Fact semantics Cause Plan
+  input : Proof.Input Fact
+  tree : Search.Result.Tree Fact Cause Plan Proof.Key
+
+/-- A full transactional runtime quotation bound to its immutable proof input.
+The constructor is private, so replay cannot be redirected to another input. -/
+structure Checked (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type) where
+  private mk ::
+  input : Proof.Input Fact
+  bundle : RuntimeProof.Bundle Fact semantics Cause Plan
+
+private def rootMatches [DecidableEq Fact]
+    (registry : RuntimeProof.Registry Fact semantics Cause Plan)
+    (input : Proof.Input Fact)
+    (tree : Search.Result.Tree Fact Cause Plan Proof.Key) : Bool :=
+  match tree.nodes[0]? with
+  | none => false
+  | some root =>
+      let source := root.source
+      input.program.check && input.facts.size == input.program.nodes.size &&
+        input.target.node.index < input.program.nodes.size &&
+        registry.assembly.program == input.program &&
+        source.scope == input.scope && source.branch.baseProgram == input.program &&
+        source.branch.initialFacts == input.facts
+
+private def liveMatches [DecidableEq Fact] [DecidableEq Cause]
+    (controller : Runtime.Controller.State Fact Cause Plan Proof.Key) : Bool :=
+  match Search.Result.current? controller.tree with
+  | none => false
+  | some (_, source) =>
+      controller.runtime.branch == source.branch &&
+        controller.runtime.branch == controller.session.branch &&
+        controller.runtime.serial == controller.session.serial &&
+        controller.runtime.assembly.program == source.branch.program &&
+        controller.session.scope == source.scope
+
+/-- Admit an already sealed live controller only when its root belongs to the
+exact registry/input pair and its current typed runtime remains aligned with
+the retained pending source. `Runtime.Controller.State.startWithin` has already
+authenticated retained callback serial and offer state; the checks here bind
+that state to theorem replay. -/
+opaque Active.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (registry : RuntimeProof.Registry Fact semantics Cause Plan)
+    (input : Proof.Input Fact)
+    (controller : Runtime.Controller.State Fact Cause Plan Proof.Key) :
+    Except Error (Active Fact semantics Cause Plan) := do
+  if !rootMatches registry input controller.tree || !liveMatches controller then
+    throw .mismatch
+  pure { registry, input, controller }
+
+/-- Settle the exact current target fact. Neither node identity nor the current
+fact is inferred from a raw terminal record supplied by the caller. -/
+opaque Active.targetWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Search.Result.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (active : Active Fact semantics Cause Plan) (seen : SeenVersion) :
+    Except Error (Lineage Fact semantics Cause Plan) := do
+  let some current := liftOption.{0, 1} (Search.Result.current? active.controller.tree)
+    | throw Error.mismatch
+  let source := current.down.2
+  let some fact := source.branch.factAt? seen | throw Error.mismatch
+  if seen.node != active.input.target.node || fact != active.input.target.fact then
+    throw Error.mismatch
+  let entry : Search.Result.Target :=
+    { scope := source.scope, programVersion := source.branch.programVersion, seen }
+  let tree := (← liftExcept Error.result
+    (Search.Result.settleWithin limits measure active.controller.tree (.target entry))).down
+  pure { registry := active.registry, input := active.input, tree }
+
+/-- Retain one exact package-owned refutation. Decoding and the theorem callback
+run against the current runtime program and current fact before settlement;
+the evidence is intentionally not exported. Full recursive replay later proves
+the terminal again from the reconstructed chronology. -/
+opaque Active.refuteWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : RuntimeProof.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (active : Active Fact semantics Cause Plan) (seen : SeenVersion)
+    (key : Proof.Key) (body : List Nat) :
+    Except Error (Lineage Fact semantics Cause Plan) := do
+  let _ := (← liftExcept Error.proof
+    (Proof.bodyCheck limits.proof key .refute body)).down
+  let some current := liftOption.{0, 1} (Search.Result.current? active.controller.tree)
+    | throw Error.mismatch
+  let source := current.down.2
+  let some fact := source.branch.factAt? seen | throw Error.mismatch
+  let some schema := active.registry.proof.refuter? key
+    | throw (Error.proof .missingSchema)
+  let some certificate := schema.decode body | throw (Error.proof .malformedBody)
+  let context : Proof.RefuteContext semantics :=
+    { scope := source.scope, programVersion := source.branch.programVersion,
+      program := active.controller.runtime.assembly.program,
+      node := seen.node, fact }
+  let some _ := schema.prove context certificate | throw (Error.proof .malformedBody)
+  let entry : Search.Result.Refute Proof.Key :=
+    { scope := source.scope, programVersion := source.branch.programVersion,
+      seen, schema := key, body }
+  let tree := (← liftExcept Error.result
+    (Search.Result.settleWithin limits.result measure active.controller.tree (.refute entry))).down
+  pure { registry := active.registry, input := active.input, tree }
+
+/-- Restart the next retained child using a runtime already created from that
+child's exact version-zero branch. The controller constructor authenticates its
+branch and reset serial against this token's tree; using the retained tree here
+prevents cross-lineage splicing. -/
+opaque Lineage.resumeWithin [DecidableEq Fact] [DecidableEq Cause]
+    (controllerLimits : Runtime.Controller.Limits) (envelope : Search.Envelope)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (lineage : Lineage Fact semantics Cause Plan)
+    (runtime : Runtime.State Fact Cause) :
+    Except Error (Active Fact semantics Cause Plan) := do
+  let controller ← Runtime.Controller.State.startWithin controllerLimits envelope measure
+    runtime lineage.tree |>.mapError Error.controller
+  if !rootMatches lineage.registry lineage.input lineage.tree || !liveMatches controller then
+    throw .mismatch
+  pure { registry := lineage.registry, input := lineage.input, controller }
+
+/-- Transactionally quote the complete retained runtime tree. No partial
+terminal or event recipe escapes on a later failure. -/
+opaque Lineage.quoteWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : RuntimeProof.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (lineage : Lineage Fact semantics Cause Plan) :
+    Except Error (Checked Fact semantics Cause Plan) := do
+  let bundle ← RuntimeProof.quoteTreeWithin limits measure lineage.registry lineage.tree
+    |>.mapError Error.runtimeProof
+  pure { input := lineage.input, bundle }
+
+/-- Replay the exact checked quotation against the input sealed into it. -/
+def Checked.replay [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (limits : RuntimeProof.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (domain : Proof.Domain semantics) (laws : Proof.Laws semantics)
+    (checked : Checked Fact semantics Cause Plan) :
+    Except Error
+      (Proof.Evidence (semantics.Entails checked.input.program
+        (Proof.initialBase checked.input) checked.input.target)) :=
+  RuntimeProof.replayTree limits measure domain laws checked.input checked.bundle
+    |>.mapError Error.runtimeProof
+
+/-- Replay while exposing an expected input in the result type. The equality
+check is an exact anti-transplant guard, not a compatibility-key comparison. -/
+opaque Checked.replayWithin [DecidableEq Fact] [DecidableEq Cause] [DecidableEq Plan]
+    (limits : RuntimeProof.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (domain : Proof.Domain semantics) (laws : Proof.Laws semantics)
+    (input : Proof.Input Fact) (checked : Checked Fact semantics Cause Plan) :
+    Except Error
+      (Proof.Evidence (semantics.Entails input.program
+        (Proof.initialBase input) input.target)) := do
+  if h : input = checked.input then
+    h.symm ▸ checked.replay limits measure domain laws
+  else throw .mismatch
+
+end Hex.Interval.RuntimeTerminal

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -257,15 +257,19 @@ Target, refutation, and split remain the separately authenticated
 terminal schemas owned by `Proof.replayTree`; they are not synthesized from a
 runtime callback batch.
 `HexIntervalMathlib.RuntimeTerminal` supplies the sealed target/refutation
-edge. Its private tokens bind the live `Runtime.Controller.State`, retained
-tree, exact `RuntimeProof.Registry`, and immutable `Proof.Input`; sibling
-restart consumes the retained token's tree, and final quotation seals the input
-into the checked bundle. Target settlement resolves the exact current target
-fact. Refutation resolves and decodes the exact package schema and invokes it
-against the current runtime program/fact before retaining the inert terminal;
-recursive proof replay independently proves it again. Search/result and proof
-body resources are checked at settlement, while complete transition/event/
-structural/proof-tree resources remain transactional at bundle quotation.
+edge. Its ordinary-import-private constructors prevent direct token
+fabrication. `Active` and `Lineage` carry the live controller/retained tree,
+`RuntimeProof.Registry`, and admitted `Proof.Input`; `Checked` carries that
+input while its nested `RuntimeProof.Bundle` independently retains the exact
+registry used by quotation. `replayWithin` checks exact input equality rather
+than claiming that constructor privacy alone prevents redirection. Sibling
+restart consumes the retained token's tree. Target settlement resolves the
+exact current target fact. Refutation first revalidates the retained tree,
+requires the exact current version, then resolves and decodes the exact package
+schema and invokes it against the retained source program/fact; recursive proof
+replay independently proves it again. Search/result and proof body resources
+are checked at settlement, while complete transition/event/structural/proof-
+tree resources remain transactional at bundle quotation.
 
 A general split terminal adapter is intentionally absent. `Proof.seedChild`
 inherits the parent proof equality table and compact identities, whereas
@@ -275,6 +279,14 @@ runtime identity zero but proof identity `n`. Supporting only the empty-parent
 case under a general-looking API would weaken this invariant; the split edge
 therefore remains blocked until the Mathlib-free restart contract imports an
 authenticated equality arena or proof replay changes its identity model.
+`Lineage.resumeWithin` detects this condition along the current node's exact
+ancestor chain, excluding current-node and sibling events, and refuses before
+starting the supplied runtime. Assembly generation is not a parallel semantic
+identity gap: runtime restart authenticates the supplied generation base, and
+transactional `RuntimeProof` quotation reconstructs the parent's post-event
+assembly and checks each child's exact generation, bindings, applications, and
+program. A wrong same-program assembly cannot yield a checked child event; if
+there are no child events, no proof evidence depends on its assembly metadata.
 `Search` never decrements its `remaining` view; executable refresh preserves
 the controller-owned value stored in the sealed session. The adapter uses a
 fixed structural `policyMeasure` for application identifiers and rule keys,

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -256,6 +256,25 @@ rechecks the retained tree and proof limits once at its theorem boundary.
 Target, refutation, and split remain the separately authenticated
 terminal schemas owned by `Proof.replayTree`; they are not synthesized from a
 runtime callback batch.
+`HexIntervalMathlib.RuntimeTerminal` supplies the sealed target/refutation
+edge. Its private tokens bind the live `Runtime.Controller.State`, retained
+tree, exact `RuntimeProof.Registry`, and immutable `Proof.Input`; sibling
+restart consumes the retained token's tree, and final quotation seals the input
+into the checked bundle. Target settlement resolves the exact current target
+fact. Refutation resolves and decodes the exact package schema and invokes it
+against the current runtime program/fact before retaining the inert terminal;
+recursive proof replay independently proves it again. Search/result and proof
+body resources are checked at settlement, while complete transition/event/
+structural/proof-tree resources remain transactional at bundle quotation.
+
+A general split terminal adapter is intentionally absent. `Proof.seedChild`
+inherits the parent proof equality table and compact identities, whereas
+`Runtime.State.startWithin` restarts a child with an empty equality arena and
+identity zero. If the parent has `n > 0` equalities, the first child equality is
+runtime identity zero but proof identity `n`. Supporting only the empty-parent
+case under a general-looking API would weaken this invariant; the split edge
+therefore remains blocked until the Mathlib-free restart contract imports an
+authenticated equality arena or proof replay changes its identity model.
 `Search` never decrements its `remaining` view; executable refresh preserves
 the controller-owned value stored in the sealed session. The adapter uses a
 fixed structural `policyMeasure` for application identifiers and rule keys,
@@ -452,6 +471,10 @@ program and generation. It mutates every typed event role, executable/proof
 package ownership, schema, body, order, and child splice; checks exact one-under
 retained-transition, event, structural-cell, and proof-chronology resources;
 and guards the ordinary root/recursive axiom surfaces.
+`HexIntervalMathlib.RuntimeTerminalConformance` pins exact target settlement
+after the ordinary typed chronology at the root and in both restarted split
+children, exact package-owned refutation, cross-schema/current-fact/input and
+resource refusals, private constructors, and the ordinary replay axiom surface.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/conformance/HexIntervalMathlib/RuntimeTerminalConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeTerminalConformance.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.RuntimeTerminal
+import HexIntervalMathlib.RuntimeProofConformance
+
+/-!
+# Typed runtime-terminal conformance
+
+Target settlement is exercised after the ordinary instance/equality/fact/
+transport chronology both at the root and in two restarted split children.
+Refutation is exercised against an exact established empty interval and a
+package-owned theorem schema. The guards below, rather than the final fallback
+theorems, prove that the terminal adapter actually admitted and replayed each
+tree.
+-/
+
+namespace Hex.IntervalMathlib.RuntimeTerminalConformance
+
+open Hex.Interval
+open Hex.Interval.Executable
+open Hex.Interval.Runtime
+open Hex.Interval.RuntimeTerminal
+open Hex.Interval.Experiment.SineSign
+
+
+/-- error: Unknown constant `Hex.Interval.RuntimeTerminal.Active.mk` -/
+#guard_msgs in
+#check RuntimeTerminal.Active.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeTerminal.Lineage.mk` -/
+#guard_msgs in
+#check RuntimeTerminal.Lineage.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeTerminal.Checked.mk` -/
+#guard_msgs in
+#check RuntimeTerminal.Checked.mk
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 8, maxBytes := 1024, maxPairs := 64, maxWork := 64,
+    maxScore := 0 }
+
+def traceLimits : Trace.Limit :=
+  { maxEvents := 0, maxBytes := 0, maxWork := 0, maxCode := 8 }
+
+def envelope : Search.Envelope :=
+  { state := RuntimeProofConformance.stateLimits, policy := policyLimits, trace := traceLimits,
+    search := RuntimeProofConformance.searchLimits }
+
+def controllerLimits : Runtime.Controller.Limits :=
+  { maxChoices := 4, result := RuntimeProofConformance.resultLimits }
+
+def policy : Policy.Interface Range (List Nat) ApplicationId RuleKey :=
+  { choose := fun plan view => match plan with
+    | [] => .stop []
+    | wanted :: rest => match view.offers.find? fun offer => offer.id.index == wanted with
+      | none => .stop plan
+      | some offer => .select offer rest }
+
+private def liftOption.{u, v} {α : Type u} (value : Option α) : Option (ULift.{v} α) :=
+  value.map ULift.up
+
+private def runController
+    (state : Runtime.Controller.State Range Nat Nat Proof.Key) :
+    Option (Runtime.Controller.State Range Nat Nat Proof.Key) :=
+  match Runtime.Controller.runWithin controllerLimits envelope RuntimeProofConformance.measure policy
+      [0, 1, 3, 2] state with
+  | .ok (.stopped _ state []) => some state
+  | _ => none
+
+private def runtimeFor (branch : State.Branch Range Nat) :
+    Option (Runtime.State Range Nat) :=
+  match RuntimeProofConformance.assembly? with
+  | some assembly =>
+      (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits assembly branch).toOption
+  | none => none
+
+private def startRootController :
+    Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
+  let branch := (← liftOption.{0, 1} RuntimeProofConformance.branch?).down
+  let runtime ← runtimeFor branch
+  let tree := (← liftOption.{0, 1} ((Search.Result.startWithin
+    RuntimeProofConformance.resultLimits RuntimeProofConformance.measure
+    RuntimeProofConformance.scope branch).toOption)).down
+  let state ← (Runtime.Controller.State.startWithin controllerLimits envelope
+    RuntimeProofConformance.measure runtime tree).toOption
+  runController state
+
+def rootLineage? : Option
+    (RuntimeTerminal.Lineage Range RuntimeProofConformance.semantics Nat Nat) := do
+  let registry ← RuntimeProofConformance.registry?
+  let controller ← startRootController
+  let active ← (RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input controller).toOption
+  (RuntimeTerminal.Active.targetWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure active
+    { node := node 2, version := 1 }).toOption
+
+def rootChecked? : Option
+    (RuntimeTerminal.Checked Range RuntimeProofConformance.semantics Nat Nat) := do
+  let lineage ← rootLineage?
+  (lineage.quoteWithin RuntimeProofConformance.adapterLimits RuntimeProofConformance.measure).toOption
+
+def rootReplay? : Option
+    (Proof.Evidence (RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program
+      (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target)) := do
+  match rootChecked? with
+  | some checked =>
+      (checked.replayWithin RuntimeProofConformance.adapterLimits
+        RuntimeProofConformance.measure RuntimeProofConformance.domain
+        RuntimeProofConformance.laws RuntimeProofConformance.input).toOption
+  | none => none
+
+#guard rootReplay?.isSome
+
+#guard match RuntimeProofConformance.registry?, startRootController with
+  | some registry, some controller =>
+      (match RuntimeTerminal.Active.startWithin registry
+          { RuntimeProofConformance.input with facts := #[.unit, .empty, .all] }
+          controller with
+        | .error .mismatch => true
+        | _ => false) &&
+      (match RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input
+          controller with
+        | .ok active =>
+            match active.targetWithin RuntimeProofConformance.resultLimits
+                RuntimeProofConformance.measure { node := node 1, version := 0 } with
+            | .error .mismatch => true
+            | _ => false
+        | _ => false)
+  | _, _ => false
+
+-- Complete quotation resources remain fail-closed at the transactional edge.
+#guard match rootLineage? with
+  | some lineage =>
+      match lineage.quoteWithin
+          { RuntimeProofConformance.adapterLimits with maxEvents := 3 }
+          RuntimeProofConformance.measure with
+      | .error (.runtimeProof (.resource .events)) => true
+      | _ => false
+  | none => false
+
+private def pendingSplit? : Option
+    (Search.Result.Tree Range Nat Nat Proof.Key) := do
+  let branch ← RuntimeProofConformance.branch?
+  let root := (← liftOption
+    ((Search.Result.startWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure RuntimeProofConformance.scope branch).toOption)).down
+  (Search.Result.splitWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure .depthFirst root RuntimeProofConformance.splitRecipe
+    RuntimeProofConformance.leftSeed RuntimeProofConformance.rightSeed).toOption
+
+private def startCurrentController
+    (tree : Search.Result.Tree Range Nat Nat Proof.Key) :
+    Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
+  let (_, source) := (← liftOption.{0, 1} (Search.Result.current? tree)).down
+  let runtime ← runtimeFor source.branch
+  (Runtime.Controller.State.startWithin controllerLimits envelope RuntimeProofConformance.measure runtime tree).toOption
+
+private def settleFirstChild : Option
+    (RuntimeTerminal.Lineage Range RuntimeProofConformance.semantics Nat Nat) := do
+  let registry ← RuntimeProofConformance.registry?
+  let tree := (← liftOption.{0, 1} pendingSplit?).down
+  let controller ← startCurrentController tree >>= runController
+  let active ← (RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input controller).toOption
+  (active.targetWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure
+    { node := node 2, version := 1 }).toOption
+
+def splitChecked? : Option
+    (RuntimeTerminal.Checked Range RuntimeProofConformance.semantics Nat Nat) := do
+  let lineage ← settleFirstChild
+  let (_, source) := (← liftOption.{0, 1} (Search.Result.current? lineage.tree)).down
+  let runtime ← runtimeFor source.branch
+  -- The restart is bound to the first terminal's retained tree. Runtime starts
+  -- with serial/equality identity zero; this split occurs before parent events.
+  let resumed ← (lineage.resumeWithin controllerLimits envelope RuntimeProofConformance.measure runtime).toOption
+  let controller ← runController resumed.controller
+  let active ← (RuntimeTerminal.Active.startWithin resumed.registry resumed.input controller).toOption
+  let complete ← (active.targetWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure
+    { node := node 2, version := 1 }).toOption
+  (complete.quoteWithin RuntimeProofConformance.adapterLimits RuntimeProofConformance.measure).toOption
+
+def splitReplay? : Option
+    (Proof.Evidence (RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program
+      (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target)) := do
+  match splitChecked? with
+  | some checked =>
+      (checked.replayWithin RuntimeProofConformance.adapterLimits
+        RuntimeProofConformance.measure RuntimeProofConformance.domain
+        RuntimeProofConformance.laws RuntimeProofConformance.input).toOption
+  | none => none
+
+#guard splitReplay?.isSome
+
+/-! ## Exact refutation -/
+
+def refuteKey : Proof.Key :=
+  { rule := RuntimeProofConformance.splitKey, role := .refute, bodySchema := 1 }
+
+def refuteSchema : Proof.RefuteSchema RuntimeProofConformance.semantics :=
+  { key := refuteKey, Certificate := Unit, decode := RuntimeProofConformance.decode,
+    prove := fun context _ =>
+      if shape : context.program = baseProgram ∧ context.node = node 1 ∧
+          context.fact = .empty then
+        some
+          { proof := by
+              intro valuation model holds
+              have impossible := holds
+              simp [shape.1, shape.2.1, shape.2.2,
+                RuntimeProofConformance.semantics, Contains] at impossible }
+      else none }
+
+def refutePackage : Proof.Package RuntimeProofConformance.semantics Nat :=
+  { RuntimeProofConformance.proofPackage with refuters := #[refuteSchema] }
+
+def refuteProofLimits : Proof.Limits :=
+  { RuntimeProofConformance.proofLimits with maxSchemas := 5 }
+
+def refuteLimits : RuntimeProof.Limits :=
+  { RuntimeProofConformance.adapterLimits with proof := refuteProofLimits }
+
+def refuteRegistry? : Option
+    (RuntimeProof.Registry Range RuntimeProofConformance.semantics Nat Nat) := do
+  let assembly ← RuntimeProofConformance.assembly?
+  let proof ← (Proof.Registry.buildWithin refuteProofLimits baseProgram
+    #[refutePackage]).toOption
+  (RuntimeProof.Registry.buildWithin RuntimeProofConformance.executableLimits
+    { name := "sine-runtime-terminal", version := 1 } assembly proof).toOption
+
+def refuteInput : Proof.Input Range :=
+  { scope := RuntimeProofConformance.scope, program := baseProgram, facts := #[.unit, .empty, .all],
+    target := { node := node 2, fact := .nonpositive } }
+
+def refuteChecked? : Option
+    (RuntimeTerminal.Checked Range RuntimeProofConformance.semantics Nat Nat) := do
+  let registry ← refuteRegistry?
+  let branch := (← liftOption.{0, 1}
+    (RuntimeProofConformance.branchWith? refuteInput.facts)).down
+  let runtime ← runtimeFor branch
+  let tree := (← liftOption.{0, 1}
+    ((Search.Result.startWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure RuntimeProofConformance.scope branch).toOption)).down
+  let controller ← (Runtime.Controller.State.startWithin controllerLimits
+    envelope RuntimeProofConformance.measure runtime tree).toOption
+  let active ← (RuntimeTerminal.Active.startWithin registry refuteInput controller).toOption
+  let lineage ← (active.refuteWithin refuteLimits RuntimeProofConformance.measure
+    { node := node 1, version := 0 } refuteKey [1]).toOption
+  (lineage.quoteWithin refuteLimits RuntimeProofConformance.measure).toOption
+
+def refuteReplay? : Option
+    (Proof.Evidence (RuntimeProofConformance.semantics.Entails refuteInput.program
+      (Proof.initialBase refuteInput) refuteInput.target)) := do
+  match refuteChecked? with
+  | some checked =>
+      (checked.replayWithin refuteLimits RuntimeProofConformance.measure
+        RuntimeProofConformance.domain RuntimeProofConformance.laws refuteInput).toOption
+  | none => none
+
+#guard refuteReplay?.isSome
+
+#guard match rootChecked? with
+  | some checked =>
+      match checked.replayWithin RuntimeProofConformance.adapterLimits
+          RuntimeProofConformance.measure RuntimeProofConformance.domain
+          RuntimeProofConformance.laws refuteInput with
+      | .error .mismatch => true
+      | _ => false
+  | none => false
+
+-- Cross-schema and stale/current-fact substitutions fail before settlement.
+#guard match refuteRegistry?, RuntimeProofConformance.assembly?, RuntimeProofConformance.branchWith? refuteInput.facts with
+  | some registry, some assembly, some branch =>
+      match Runtime.State.startWithin RuntimeProofConformance.runtimeLimits assembly branch with
+      | .error _ => false
+      | .ok runtime =>
+          match Search.Result.startWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure RuntimeProofConformance.scope branch with
+          | .error _ => false
+          | .ok tree =>
+              match Runtime.Controller.State.startWithin controllerLimits envelope RuntimeProofConformance.measure
+                  runtime tree with
+              | .error _ => false
+              | .ok controller =>
+                  match RuntimeTerminal.Active.startWithin registry refuteInput controller with
+                  | .error _ => false
+                  | .ok active =>
+                      (match active.refuteWithin refuteLimits RuntimeProofConformance.measure
+                          { node := node 1, version := 0 }
+                          { refuteKey with bodySchema := 0 } [1] with
+                        | .error (.proof .missingSchema) => true
+                        | _ => false) &&
+                      (match active.refuteWithin refuteLimits RuntimeProofConformance.measure
+                          { node := node 1, version := 1 } refuteKey [1] with
+                        | .error .mismatch => true
+                        | _ => false) &&
+                      (match active.refuteWithin
+                          { refuteLimits with proof :=
+                            { refuteProofLimits with maxBodyCells := 0 } }
+                          RuntimeProofConformance.measure
+                          { node := node 1, version := 0 } refuteKey [1] with
+                        | .error (.proof .bodyLimit) => true
+                        | _ => false)
+  | _, _, _ => false
+
+#print axioms rootReplay?
+#print axioms splitReplay?
+#print axioms refuteReplay?
+
+end Hex.IntervalMathlib.RuntimeTerminalConformance

--- a/conformance/HexIntervalMathlib/RuntimeTerminalConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeTerminalConformance.lean
@@ -39,6 +39,30 @@ open Hex.Interval.Experiment.SineSign
 #guard_msgs in
 #check RuntimeTerminal.Checked.mk
 
+section PrivateConstruction
+
+variable (registry : RuntimeProof.Registry Range RuntimeProofConformance.semantics Nat Nat)
+  (input : Proof.Input Range)
+  (controller : Runtime.Controller.State Range Nat Nat Proof.Key)
+  (active : RuntimeTerminal.Active Range RuntimeProofConformance.semantics Nat Nat)
+
+/-- error: invalid {...} notation, constructor for `Active` is marked as private -/
+#guard_msgs in
+example : RuntimeTerminal.Active Range RuntimeProofConformance.semantics Nat Nat :=
+  { registry := registry, input := input, controller := controller }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeTerminal.Active` is marked as private -/
+#guard_msgs in
+example : RuntimeTerminal.Active Range RuntimeProofConformance.semantics Nat Nat :=
+  ⟨registry, input, controller⟩
+
+/-- error: invalid {...} notation, constructor for `Active` is marked as private -/
+#guard_msgs in
+example : RuntimeTerminal.Active Range RuntimeProofConformance.semantics Nat Nat :=
+  { active with input }
+
+end PrivateConstruction
+
 def policyLimits : Policy.Limits :=
   { maxOffers := 8, maxBytes := 1024, maxPairs := 64, maxWork := 64,
     maxScore := 0 }
@@ -63,13 +87,15 @@ def policy : Policy.Interface Range (List Nat) ApplicationId RuleKey :=
 private def liftOption.{u, v} {α : Type u} (value : Option α) : Option (ULift.{v} α) :=
   value.map ULift.up
 
-private def runController
+private def runPlan (plan : List Nat)
     (state : Runtime.Controller.State Range Nat Nat Proof.Key) :
     Option (Runtime.Controller.State Range Nat Nat Proof.Key) :=
   match Runtime.Controller.runWithin controllerLimits envelope RuntimeProofConformance.measure policy
-      [0, 1, 3, 2] state with
+      plan state with
   | .ok (.stopped _ state []) => some state
   | _ => none
+
+private def runController := runPlan [0, 1, 3, 2]
 
 private def runtimeFor (branch : State.Branch Range Nat) :
     Option (Runtime.State Range Nat) :=
@@ -78,7 +104,7 @@ private def runtimeFor (branch : State.Branch Range Nat) :
       (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits assembly branch).toOption
   | none => none
 
-private def startRootController :
+private def initialRootController :
     Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
   let branch := (← liftOption.{0, 1} RuntimeProofConformance.branch?).down
   let runtime ← runtimeFor branch
@@ -87,6 +113,11 @@ private def startRootController :
     RuntimeProofConformance.scope branch).toOption)).down
   let state ← (Runtime.Controller.State.startWithin controllerLimits envelope
     RuntimeProofConformance.measure runtime tree).toOption
+  pure state
+
+private def startRootController :
+    Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
+  let state ← initialRootController
   runController state
 
 def rootLineage? : Option
@@ -121,15 +152,51 @@ def rootReplay? : Option
           controller with
         | .error .mismatch => true
         | _ => false) &&
+      (match RuntimeTerminal.Active.startWithin registry
+          { RuntimeProofConformance.input with scope := { index := 1 } }
+          controller with
+        | .error .mismatch => true
+        | _ => false) &&
+      (match RuntimeTerminal.Active.startWithin registry
+          { scope := RuntimeProofConformance.scope, program := extendedProgram,
+            facts := #[.unit, .all, .all, .all, .all],
+            target := RuntimeProofConformance.input.target }
+          controller with
+        | .error .mismatch => true
+        | _ => false) &&
+      (match RuntimeTerminal.Active.startWithin registry
+          { RuntimeProofConformance.input with target :=
+            { node := node 3, fact := .nonpositive } }
+          controller with
+        | .error .mismatch => true
+        | _ => false) &&
       (match RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input
           controller with
         | .ok active =>
             match active.targetWithin RuntimeProofConformance.resultLimits
-                RuntimeProofConformance.measure { node := node 1, version := 0 } with
-            | .error .mismatch => true
-            | _ => false
+                  RuntimeProofConformance.measure { node := node 1, version := 0 } with
+              | .error .mismatch => true
+              | _ => false
         | _ => false)
   | _, _ => false
+
+def targetResourceError? : Option RuntimeTerminal.Error :=
+  match RuntimeProofConformance.registry?, startRootController with
+  | some registry, some controller =>
+      match RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input
+          controller with
+      | .ok active =>
+          match active.targetWithin
+              { RuntimeProofConformance.resultLimits with
+                search := { RuntimeProofConformance.searchLimits with
+                  maxSteps := active.controller.tree.accounting.steps } }
+              RuntimeProofConformance.measure { node := node 2, version := 1 } with
+          | .error error => some error
+          | .ok _ => none
+      | .error error => some error
+  | _, _ => none
+
+#guard targetResourceError? == some (.result (.search .steps))
 
 -- Complete quotation resources remain fail-closed at the transactional edge.
 #guard match rootLineage? with
@@ -191,6 +258,80 @@ def splitReplay? : Option
 
 #guard splitReplay?.isSome
 
+-- A runtime from the already-settled sibling or a different root lineage
+-- cannot resume the retained current child.
+#guard match settleFirstChild with
+  | some lineage =>
+      match pendingSplit? with
+      | some other =>
+        match Search.Result.current? other with
+        | some (_, left) =>
+          match runtimeFor left.branch with
+          | some leftRuntime =>
+              (match lineage.resumeWithin controllerLimits envelope
+                  RuntimeProofConformance.measure leftRuntime with
+                | .error (.controller .mismatch) => true
+                | _ => false) &&
+              (match startRootController with
+                | some root =>
+                    match lineage.resumeWithin controllerLimits envelope
+                        RuntimeProofConformance.measure root.runtime with
+                    | .error (.controller .mismatch) => true
+                    | _ => false
+                | none => false)
+          | none => false
+        | none => false
+      | none => false
+  | none => false
+
+/-! ## Inherited equality refusal -/
+
+def postEqualitySplitAction : Action :=
+  RuntimeProofConformance.action 2 1 0 4 RuntimeProofConformance.splitKey
+    (node 2) .split 1 [{ node := node 2, version := 0 }]
+
+def postEqualitySplitRecipe : Search.Result.Split Nat Proof.Key :=
+  { scope := RuntimeProofConformance.scope, programVersion := 1,
+    action := postEqualitySplitAction,
+    parent := { node := node 2, version := 0 }, plan := 1,
+    schema := RuntimeProofConformance.splitProofKey, body := [1] }
+
+def postEqualityLeft : Search.Result.Seed Range :=
+  { node := node 2, previous := postEqualitySplitRecipe.parent, fact := .nonpositive }
+
+def postEqualityRight : Search.Result.Seed Range :=
+  { node := node 2, previous := postEqualitySplitRecipe.parent, fact := .nonnegative }
+
+private def hazardousResume? : Option
+    (RuntimeTerminal.Lineage Range RuntimeProofConformance.semantics Nat Nat ×
+      Runtime.State Range Nat) := do
+  let registry ← RuntimeProofConformance.registry?
+  let parent ← initialRootController >>= runPlan [0, 1]
+  let tree := (← liftOption.{0, 1} ((Search.Result.splitWithin
+    RuntimeProofConformance.resultLimits RuntimeProofConformance.measure .depthFirst
+    parent.tree postEqualitySplitRecipe postEqualityLeft postEqualityRight).toOption)).down
+  let (_, left) := (← liftOption.{0, 1} (Search.Result.current? tree)).down
+  let leftRuntime ← (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits
+    parent.runtime.assembly left.branch).toOption
+  let leftController ← (Runtime.Controller.State.startWithin controllerLimits envelope
+    RuntimeProofConformance.measure leftRuntime tree).toOption
+  let active ← (RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input
+    leftController).toOption
+  let lineage ← (active.targetWithin RuntimeProofConformance.resultLimits
+    RuntimeProofConformance.measure { node := node 2, version := 0 }).toOption
+  let (_, right) := (← liftOption.{0, 1} (Search.Result.current? lineage.tree)).down
+  let rightRuntime ← (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits
+    parent.runtime.assembly right.branch).toOption
+  pure (lineage, rightRuntime)
+
+#guard match hazardousResume? with
+  | some (lineage, runtime) =>
+      match lineage.resumeWithin controllerLimits envelope
+          RuntimeProofConformance.measure runtime with
+      | .error .inheritedEqualities => true
+      | _ => false
+  | none => false
+
 /-! ## Exact refutation -/
 
 def refuteKey : Proof.Key :=
@@ -230,6 +371,12 @@ def refuteInput : Proof.Input Range :=
   { scope := RuntimeProofConformance.scope, program := baseProgram, facts := #[.unit, .empty, .all],
     target := { node := node 2, fact := .nonpositive } }
 
+private def ordinaryRefuteActive? : Option
+    (RuntimeTerminal.Active Range RuntimeProofConformance.semantics Nat Nat) := do
+  let registry ← refuteRegistry?
+  let controller ← startRootController
+  (RuntimeTerminal.Active.startWithin registry RuntimeProofConformance.input controller).toOption
+
 def refuteChecked? : Option
     (RuntimeTerminal.Checked Range RuntimeProofConformance.semantics Nat Nat) := do
   let registry ← refuteRegistry?
@@ -255,6 +402,31 @@ def refuteReplay? : Option
   | none => none
 
 #guard refuteReplay?.isSome
+
+-- Version zero at node two remains historically resolvable after transport,
+-- but is not the exact current version one and is rejected before decoding.
+#guard match ordinaryRefuteActive? with
+  | some active =>
+      (match active.refuteWithin refuteLimits RuntimeProofConformance.measure
+          { node := node 2, version := 0 } refuteKey [1] with
+        | .error .mismatch => true
+        | _ => false) &&
+      (match active.refuteWithin refuteLimits RuntimeProofConformance.measure
+          { node := node 1, version := 0 } refuteKey [0] with
+        | .error (.proof .malformedBody) => true
+        | _ => false) &&
+      (match active.refuteWithin refuteLimits RuntimeProofConformance.measure
+          { node := node 1, version := 0 } refuteKey [1] with
+        | .error (.proof .malformedBody) => true
+        | _ => false) &&
+      (match active.refuteWithin
+          { refuteLimits with result :=
+            { RuntimeProofConformance.resultLimits with maxBytes := 0 } }
+          RuntimeProofConformance.measure { node := node 1, version := 0 }
+          refuteKey [1] with
+        | .error (.result .malformed) => true
+        | _ => false)
+  | none => false
 
 #guard match rootChecked? with
   | some checked =>
@@ -299,8 +471,18 @@ def refuteReplay? : Option
                         | _ => false)
   | _, _, _ => false
 
+/-- info: 'Hex.IntervalMathlib.RuntimeTerminalConformance.rootReplay?' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms rootReplay?
+
+/-- info: 'Hex.IntervalMathlib.RuntimeTerminalConformance.splitReplay?' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms splitReplay?
+
+/-- info: 'Hex.IntervalMathlib.RuntimeTerminalConformance.refuteReplay?' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound] -/
+#guard_msgs in
 #print axioms refuteReplay?
 
 end Hex.IntervalMathlib.RuntimeTerminalConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -566,6 +566,7 @@ lean_lib HexConformance where
       `HexInterval.ExecutableConformance,
       `HexInterval.RuntimeConformance,
       `HexIntervalMathlib.RuntimeProofConformance,
+      `HexIntervalMathlib.RuntimeTerminalConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/2026-08-24T02-42-00Z.md
+++ b/progress/2026-08-24T02-42-00Z.md
@@ -1,0 +1,29 @@
+# Typed runtime terminal CI integration
+
+## Accomplished
+
+- Rebased the sealed runtime-terminal adapter onto the Lean 4.34 and current
+  sparse-poly release baseline.
+- Rebuilt `HexIntervalMathlib.RuntimeTerminalConformance` and
+  `HexIntervalMathlib` successfully across all 8,814 jobs.
+- Diagnosed the pre-Lean CI failure as the factor-sweep freshness checker
+  treating the new proof-only conformance glob as a factorization source
+  change.
+- Added the exact blob-to-blob proof-only exemption for that single
+  `lakefile.lean` transition; no path-wide exemption was introduced.
+
+## Current frontier
+
+The terminal implementation and conformance remain unchanged from the exact
+Claude-approved diff. The branch now also carries the narrow CI freshness
+classification required by its conformance registration.
+
+## Next step
+
+Run the freshness/DAG/trust checks, push the rebased head, obtain exact-head
+Claude approval including the exemption, and require fresh exact-head CI before
+merging PR #9436.
+
+## Blockers
+
+None.

--- a/progress/20260822T092630Z_runtime-terminal-adapter.md
+++ b/progress/20260822T092630Z_runtime-terminal-adapter.md
@@ -1,0 +1,34 @@
+# Typed runtime terminal adapter
+
+## Accomplished
+
+- Added the sealed `HexIntervalMathlib.RuntimeTerminal` target/refutation
+  boundary over exact `Runtime.Controller.State`, `RuntimeProof.Registry`, and
+  `Proof.Input` ownership.
+- Added exact target/current-fact and package-owned refuter schema/body/theorem
+  admission, retained-lineage child restart, transactional quotation, and
+  input-bound replay.
+- Added root and restarted split-child target canaries after the ordinary
+  instance/equality/fact/transport chronology, an exact empty-fact refutation
+  canary, mutation/resource guards, private-constructor guards, and axiom
+  reports.
+- Added umbrella/SPEC integration and an empty sealed `import all` allowlist.
+- Verified the focused module, umbrella, full `HexConformance`, DAG unit/static
+  gates, and forbidden-token scans.
+
+## Current frontier
+
+Target and refutation terminals now have a supported sealed typed adapter.
+
+## Next step
+
+Reconcile the child equality identity model before adding a general split
+terminal adapter.
+
+## Blockers
+
+`Proof.seedChild` inherits the parent semantic equality table and compact IDs,
+but `Runtime.State.startWithin` restarts each child with an empty equality arena
+and ID zero. A parent with any equality therefore makes the first child runtime
+ID disagree with proof replay's next ID. No sound general split adapter is
+representable under the current signatures.

--- a/progress/20260822T095825Z_runtime-terminal-review-repair.md
+++ b/progress/20260822T095825Z_runtime-terminal-review-repair.md
@@ -1,0 +1,34 @@
+# Runtime terminal review repair
+
+## Accomplished
+
+- Added an early dedicated refusal for restarted children whose exact ancestor
+  chain retained a runtime equality that proof replay would inherit while the
+  runtime equality arena resets.
+- Revalidated retained trees and exact current fact versions before refutation
+  schema decoding/callbacks, and used the retained source program in the
+  theorem context.
+- Added conformance for hazardous parent equality, safe pre-event split
+  restart, sibling/cross-lineage runtime refusal, genuine stale versions,
+  decoder/callback rejection, target resource refusal, input mismatch, private
+  construction forms, and exact guarded axiom reports.
+- Clarified checked-token, exact-registry, controller-recheck, and assembly
+  generation claims in the module and SPEC.
+- Verified focused conformance, the Mathlib umbrella, `HexConformance`, DAG
+  unit/static checks, trust-token scans, and whitespace checks.
+
+## Current frontier
+
+Target/refutation terminals and safe child restart are review-hardened.
+
+## Next step
+
+Reconcile the equality-arena restart contract before implementing general
+split terminal integration.
+
+## Blockers
+
+The underlying split limitation remains: proof children inherit parent
+equality identities while runtime children reset their equality arena. The
+adapter now refuses this condition at sibling restart instead of allowing a
+lineage that can only fail later during quotation/replay.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -868,5 +868,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "c973b09972fdea92dd362ebd997535fb9fe61a5b",
     "reason": "Registers only the HexModular conformance module and fixture emitter on top of the sparse-poly release registrations; no factorization runtime target, definition, build flag, or dependency changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "3508e63c162bdc9b9ca9d62662297a8c6501a504",
+    "reason": "Registers only the proof-side HexIntervalMathlib.RuntimeTerminalConformance glob; it does not enter hexbz_factor_service or change any factorization library, executable definition, or build flag."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -40,6 +40,7 @@ SEALED_IMPORT_ALL_ALLOWLIST: dict[str, frozenset[Path]] = {
     "HexIntervalMathlib.Controller": frozenset(),
     "HexIntervalMathlib.Proof": frozenset(),
     "HexIntervalMathlib.RuntimeProof": frozenset(),
+    "HexIntervalMathlib.RuntimeTerminal": frozenset(),
 }
 
 UMBRELLA_BUILD_TARGETS = {

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -37,6 +37,10 @@ class SealedImportAllTest(unittest.TestCase):
                     "HexIntervalMathlib.RuntimeProof"),
                 (Path("bench/HexIntervalMathlib/BypassRuntimeProof.lean"),
                     "HexIntervalMathlib.RuntimeProof"),
+                (Path("conformance/HexIntervalMathlib/BypassRuntimeTerminal.lean"),
+                    "HexIntervalMathlib.RuntimeTerminal"),
+                (Path("bench/HexIntervalMathlib/BypassRuntimeTerminal.lean"),
+                    "HexIntervalMathlib.RuntimeTerminal"),
             ]
             files = [path for path, _ in cases]
             for path, module in cases:
@@ -74,6 +78,12 @@ class SealedImportAllTest(unittest.TestCase):
                     "trusted-internals allowlist",
                     "bench/HexIntervalMathlib/BypassRuntimeProof.lean:1 uses "
                     "`import all HexIntervalMathlib.RuntimeProof` outside its exact "
+                    "trusted-internals allowlist",
+                    "conformance/HexIntervalMathlib/BypassRuntimeTerminal.lean:1 uses "
+                    "`import all HexIntervalMathlib.RuntimeTerminal` outside its exact "
+                    "trusted-internals allowlist",
+                    "bench/HexIntervalMathlib/BypassRuntimeTerminal.lean:1 uses "
+                    "`import all HexIntervalMathlib.RuntimeTerminal` outside its exact "
                     "trusted-internals allowlist",
                 ],
             )


### PR DESCRIPTION
## Summary

- bind target/refutation settlement to one sealed runtime controller lineage, theorem registry, and immutable proof input
- quote/replay transactionally through `RuntimeProof`, with exact current target/refuter admission and anti-transplant checks
- reject split-child resume early when ancestor equalities would hit the known runtime/proof compact-ID mismatch
- add root, two-child, refutation, mutation, resource, privacy, and axiom-surface conformance

## Deliberate boundary

General split after an ancestor equality is not representable today: `Proof.seedChild` inherits compact equality IDs while `Runtime.State.startWithin` resets the child arena at ID zero. `Lineage.resumeWithin` now detects the exact ancestor chronology and returns `inheritedEqualities`; split-before-parent-events remains supported.

## Validation

- full `lake build HexConformance` (9,630 jobs) before final rebase
- exact rebased `lake build HexIntervalMathlib.RuntimeTerminalConformance HexIntervalMathlib` (8,710 jobs)
- DAG/unit, trust, forbidden-token, import-all, and diff checks

An exact-head Claude semantic review is running; merge waits for its approval and exact CI.