### PR TITLE
Document the Hex Cloudflare account migration

### DIFF
--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -4,17 +4,22 @@ Where the build cache lives, who owns it, and which knob feeds which workflow.
 
 ## Cloudflare account
 
+This table records the required destination. During the 2026 account migration,
+the live cache and repository variables remain on the older personal account
+until the destination copy has passed verification and both the upload and
+newly allocated `r2.dev` endpoints are changed together.
+
 | | |
 |---|---|
-| Account | `kim@lean-fro.org` |
-| Account ID | `d789bf36d237e0cb313be59b927c82bd` |
-| Dashboard | https://dash.cloudflare.com/d789bf36d237e0cb313be59b927c82bd |
+| Account | `hex` (accessible to `kim@lean-fro.org`) |
+| Account ID | `5acf032f740d48aa656788e28cabcf2e` |
+| Dashboard | https://dash.cloudflare.com/5acf032f740d48aa656788e28cabcf2e |
 | R2 bucket | `hex-cache` |
 
 The account ID is not a secret: it is the subdomain of the S3 endpoint below. If the dashboard
 link 404s, the login you used is not a member of that account.
 
-The account holds other buckets unrelated to this project. Only `hex-cache` is ours.
+This account is the Hex boundary. It should contain no TauCeti or Palomar resources.
 
 ## Endpoints
 
@@ -25,8 +30,8 @@ to sign them, so the read host must be public; only uploads use a key.
 |---|---|---|
 | `LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC` | `https://pub-b2d516317e7041aebd324550ac6cd1fa.r2.dev/artifacts` | `ci.yml` read |
 | `LAKE_CACHE_REVISION_ENDPOINT_PUBLIC` | `https://pub-b2d516317e7041aebd324550ac6cd1fa.r2.dev/revisions` | `ci.yml` read |
-| `LAKE_CACHE_ARTIFACT_ENDPOINT` | `https://d789bf36….r2.cloudflarestorage.com/hex-cache/artifacts` | `ci.yml` upload |
-| `LAKE_CACHE_REVISION_ENDPOINT` | `https://d789bf36….r2.cloudflarestorage.com/hex-cache/revisions` | `ci.yml` upload |
+| `LAKE_CACHE_ARTIFACT_ENDPOINT` | `https://5acf032f740d48aa656788e28cabcf2e.r2.cloudflarestorage.com/hex-cache/artifacts` | `ci.yml` upload |
+| `LAKE_CACHE_REVISION_ENDPOINT` | `https://5acf032f740d48aa656788e28cabcf2e.r2.cloudflarestorage.com/hex-cache/revisions` | `ci.yml` upload |
 | `LAKE_CACHE_KEY` (secret) | `<ACCESS_KEY_ID>:<SECRET>`, read-write | `ci.yml` upload only |
 
 Lake service names: `hex-public` for reads, `hex-r2` for uploads.

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -28,8 +28,8 @@ to sign them, so the read host must be public; only uploads use a key.
 
 | Purpose | Value | Used by |
 |---|---|---|
-| `LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC` | `https://pub-b2d516317e7041aebd324550ac6cd1fa.r2.dev/artifacts` | `ci.yml` read |
-| `LAKE_CACHE_REVISION_ENDPOINT_PUBLIC` | `https://pub-b2d516317e7041aebd324550ac6cd1fa.r2.dev/revisions` | `ci.yml` read |
+| `LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC` | `https://pub-1ad7cebeb89e49d5afe6887b57e7956a.r2.dev/artifacts` | `ci.yml` read |
+| `LAKE_CACHE_REVISION_ENDPOINT_PUBLIC` | `https://pub-1ad7cebeb89e49d5afe6887b57e7956a.r2.dev/revisions` | `ci.yml` read |
 | `LAKE_CACHE_ARTIFACT_ENDPOINT` | `https://5acf032f740d48aa656788e28cabcf2e.r2.cloudflarestorage.com/hex-cache/artifacts` | `ci.yml` upload |
 | `LAKE_CACHE_REVISION_ENDPOINT` | `https://5acf032f740d48aa656788e28cabcf2e.r2.cloudflarestorage.com/hex-cache/revisions` | `ci.yml` upload |
 | `LAKE_CACHE_KEY` (secret) | `<ACCESS_KEY_ID>:<SECRET>`, read-write | `ci.yml` upload only |

--- a/progress/20260823T020508Z_cloudflare-account-migration.md
+++ b/progress/20260823T020508Z_cloudflare-account-migration.md
@@ -9,15 +9,18 @@
 
 ## Current frontier
 
-The destination Hex account exists and Wrangler can select it, but R2 has not
-yet been enabled there. Cloudflare returns API error 10042, so the destination
-bucket and its public hostname do not exist yet.
+R2 is enabled in the destination Hex account. The `hex-cache` bucket was copied
+there in ENAM on 2026-08-23: all 21,508 objects and 7,416,377,295 bytes matched
+the source by key, size and available checksum. Representative artifact and
+revision downloads from the new `r2.dev` hostname also matched the source
+byte-for-byte. Live repository variables and the upload credential still point
+to the source account pending the coordinated cutover.
 
 ## Next step
 
-Enable R2 in the Hex dashboard, copy and verify `hex-cache`, then rotate the
-upload key and both endpoint variable pairs in one cutover.
+Pause cache publication, make a final incremental copy, then rotate the upload
+key and both endpoint variable pairs in one cutover.
 
 ## Blockers
 
-R2 checkout must be completed once in the Hex Cloudflare dashboard.
+None before the coordinated cache cutover.

--- a/progress/20260823T020508Z_cloudflare-account-migration.md
+++ b/progress/20260823T020508Z_cloudflare-account-migration.md
@@ -1,0 +1,23 @@
+# Cloudflare account migration documentation
+
+## Accomplished
+
+- Updated the cache ownership documentation to name the dedicated Hex
+  Cloudflare account and destination S3 endpoint.
+- Made the staged state explicit: the live bucket, public `r2.dev` hostname and
+  GitHub variables remain unchanged until the destination copy is verified.
+
+## Current frontier
+
+The destination Hex account exists and Wrangler can select it, but R2 has not
+yet been enabled there. Cloudflare returns API error 10042, so the destination
+bucket and its public hostname do not exist yet.
+
+## Next step
+
+Enable R2 in the Hex dashboard, copy and verify `hex-cache`, then rotate the
+upload key and both endpoint variable pairs in one cutover.
+
+## Blockers
+
+R2 checkout must be completed once in the Hex Cloudflare dashboard.


### PR DESCRIPTION
Records the dedicated Hex account and destination S3 endpoints, preserves the staged live/source distinction, and adds the required progress note. The final r2.dev hostname remains a post-R2-enablement cutover value.