### PR TITLE
feat: implement multivariate factorization stack

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -14,6 +14,7 @@ public import HexBasic.Fold
 public import HexBasic.List
 public import HexBasic.ModuleBoundaryTests
 public import HexBasic.OfFn
+public import HexBasic.Rand
 public import HexBasic.Vector.Modify
 
 public section

--- a/HexBasic/Rand.lean
+++ b/HexBasic/Rand.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public section
+
+/-!
+Deterministic, seedable randomness for Las Vegas search, per the
+hex-finite-field SPEC's "Randomness" section (which sites `Hex.Rand` here in
+hex-basic: it has no dependencies and consumers in several subtrees).
+
+The generator is splitmix64. Its contract is executable and testable — range
+correctness (`Rand.nat_lt`), deterministic replay, explicit state
+advancement, rejection sampling with no modulo reduction of an incomplete
+interval, and bounded termination — and deliberately not a mathematical
+uniformity or independence claim: a 64-bit-state generator has at most `2^64`
+streams and cannot induce a uniform draw on an arbitrary larger bound.
+Probability analyses in consumer SPECs are carried out against an ideal
+sampler and never transferred to this concrete generator.
+
+The discipline for consumers: every randomised function takes `Rand` as an
+explicit argument and returns the advanced state (no monad, no `IO`, no
+global generator); randomness affects how long a search runs, never what it
+returns; fuel is explicit, and exhaustion is a documented outcome carrying
+the advanced state, never a wrong answer or an unbounded loop.
+-/
+
+namespace Hex
+
+/-- A splitmix64 state. Deterministic, seedable, and reproducible across runs
+and platforms; this is a source of arbitrary values for Las Vegas search, not
+a cryptographic generator, and nothing in the tree may treat it as one. -/
+structure Rand where
+  /-- The 64-bit generator state. -/
+  state : UInt64
+deriving Repr, DecidableEq
+
+/-- Advance the splitmix64 state and produce one 64-bit output. -/
+def Rand.next (r : Rand) : UInt64 × Rand :=
+  let s := r.state + 0x9E3779B97F4A7C15
+  let z := s
+  let z := (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9
+  let z := (z ^^^ (z >>> 27)) * 0x94D049BB133111EB
+  (z ^^^ (z >>> 31), ⟨s⟩)
+
+/-- Why a bounded draw failed. -/
+inductive RandError where
+  /-- The requested bound was `0`, so no value below it exists. -/
+  | zeroBound
+  /-- Rejection sampling ran out of fuel; the attempt count and the advanced
+  state are returned so the caller can resume rather than replay a failed
+  stream. -/
+  | exhausted (attempts : Nat) (rand : Rand)
+deriving Repr
+
+/-- Concatenate `w` fresh 64-bit words into one natural number below
+`2 ^ (64 * w)`. -/
+def Rand.words (r : Rand) : Nat → Nat × Rand
+  | 0 => (0, r)
+  | w + 1 =>
+      let (x, r') := r.next
+      let (rest, r'') := Rand.words r' w
+      (rest <<< 64 ||| x.toNat, r'')
+
+private def Rand.natGo (bound limit w : Nat) :
+    Nat → Nat → Rand → Except RandError (Nat × Rand)
+  | 0, attempts, r => .error (.exhausted attempts r)
+  | fuel + 1, attempts, r =>
+      let (c, r') := Rand.words r w
+      if c < limit then .ok (c % bound, r')
+      else Rand.natGo bound limit w fuel (attempts + 1) r'
+
+/-- Draw a natural number below `bound` by rejection sampling: form a
+candidate from enough 64-bit words and reject the incomplete top interval
+(rather than folding it in with `next % bound`, which would add modulo
+bias). `fuel` bounds the rejection retries, including the initial candidate;
+`bound = 0` returns `zeroBound`. -/
+def Rand.nat (r : Rand) (bound fuel : Nat) : Except RandError (Nat × Rand) :=
+  if bound = 0 then .error .zeroBound
+  else
+    let w := bound.log2 / 64 + 1
+    let t := 1 <<< (64 * w)
+    Rand.natGo bound (t - t % bound) w fuel 0 r
+
+/-- Construct the initial state from a seed. -/
+def Rand.ofSeed (seed : Nat) : Rand := ⟨UInt64.ofNat seed⟩
+
+private theorem Rand.natGo_lt {bound limit w : Nat} (hb : 0 < bound) :
+    ∀ (fuel attempts : Nat) (r : Rand) {v : Nat} {r' : Rand},
+      Rand.natGo bound limit w fuel attempts r = .ok (v, r') → v < bound := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro attempts r v r' h
+      simp [Rand.natGo] at h
+  | succ fuel ih =>
+      intro attempts r v r' h
+      unfold Rand.natGo at h
+      by_cases hc : (Rand.words r w).1 < limit
+      · simp only [hc, if_pos] at h
+        cases h
+        exact Nat.mod_lt _ hb
+      · simp only [hc, if_neg, not_false_iff] at h
+        exact ih (attempts + 1) (Rand.words r w).2 h
+
+/-- Range correctness: a successful bounded draw is below the bound. -/
+theorem Rand.nat_lt {r : Rand} {bound fuel v : Nat} {r' : Rand}
+    (h : Rand.nat r bound fuel = .ok (v, r')) : v < bound := by
+  unfold Rand.nat at h
+  by_cases hb : bound = 0
+  · rw [if_pos hb] at h
+    cases h
+  · rw [if_neg hb] at h
+    exact Rand.natGo_lt (Nat.pos_of_ne_zero hb) fuel 0 r h
+
+/-! Regression coverage: the canonical splitmix64 known-answer values (the
+seed-`0` first output is the reference vector from the original
+implementation), deterministic replay, and bounded-draw behaviour on every
+result shape. -/
+
+#guard (Rand.ofSeed 0).next.1 = 0xe220a8397b1dcdaf
+#guard (Rand.ofSeed 42).next.1 = 0xbdd732262feb6e95
+#guard (Rand.ofSeed 42).next.2.next.1 = 0x28efe333b266f103
+#guard (Rand.ofSeed 42).next.2.next.2.next.1 = 0x47526757130f9f52
+#guard (Rand.ofSeed 7).next.1 = (Rand.ofSeed 7).next.1   -- replay
+#guard (match (Rand.ofSeed 1).nat 10 8 with
+        | .ok (v, _) => v < 10
+        | .error _ => false)
+#guard (match (Rand.ofSeed 1).nat 0 8 with
+        | .error .zeroBound => true
+        | _ => false)
+#guard (match (Rand.ofSeed 1).nat 5 0 with
+        | .error (.exhausted 0 _) => true
+        | _ => false)
+-- A bound above one word draws two words and still lands in range.
+#guard (match (Rand.ofSeed 3).nat (2 ^ 80) 8 with
+        | .ok (v, _) => v < 2 ^ 80
+        | .error _ => false)
+
+end Hex

--- a/HexBerlekampZassenhaus/FactorizationData.lean
+++ b/HexBerlekampZassenhaus/FactorizationData.lean
@@ -14,6 +14,7 @@ public meta import HexHensel.Multifactor
 public meta import HexHensel.QuadraticMultifactor
 public meta import HexMatrix.Basic
 public meta import HexPolyZ.Mignotte
+public meta import HexPolyZ.ExactDivision
 public meta import HexLLL
 public import HexArith.Nat.Prime
 public import HexBerlekamp.Factor
@@ -21,6 +22,7 @@ public import HexBerlekamp.Irreducibility
 public import HexHensel.Multifactor
 public import HexHensel.QuadraticMultifactor
 public import HexLLL
+public import HexPolyZ.ExactDivision
 -- Kernel-reducible `Array`/`Vector` equality; see `HexBasic.ArrayDecEq`.
 -- Drop once leanprover/lean4#14270 lands and the toolchain is bumped past it.
 public import HexBasic.ArrayDecEq
@@ -535,11 +537,7 @@ def exactQuotient? (target candidate : ZPoly) : Option ZPoly :=
   if candidate.isZero || candidate = 1 then
     none
   else
-    let qr := DensePoly.divMod target candidate
-    if qr.2 = 0 && qr.1 * candidate == target then
-      some qr.1
-    else
-      none
+    ZPoly.divExact? target candidate
 
 /-- Successful exact-division extracts a multiplication witness:
 `exactQuotient? target candidate = some quotient` implies
@@ -552,17 +550,7 @@ theorem exactQuotient?_product
   unfold exactQuotient? at hquot
   split at hquot
   · contradiction
-  · rename_i hnontrivial
-    generalize hqr : DensePoly.divMod target candidate = qr at hquot
-    cases qr with
-    | mk q r =>
-        simp only at hquot
-        split at hquot
-        · rename_i hcheck
-          cases hquot
-          exact (by
-            simpa [Bool.and_eq_true, beq_iff_eq] using hcheck : r = 0 ∧ quotient * candidate = target).2
-        · contradiction
+  · exact ZPoly.divExact?_product hquot
 
 /--
 Greedy peel of `candidate^?` out of `target` via repeated exact division.

--- a/HexBerlekampZassenhaus/FactorizationResult.lean
+++ b/HexBerlekampZassenhaus/FactorizationResult.lean
@@ -1690,8 +1690,8 @@ theorem exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one, hdivMod_eq]
-  simp [hmul]
+  rw [if_neg hcandidate_ne_one]
+  exact (ZPoly.divExact?_eq hcandidate_ne).2 hmul.symm
 
 /--
 Non-monic packaging companion for `exactQuotient?_product`.
@@ -1707,7 +1707,7 @@ quotient.
 theorem exactQuotient?_eq_some_of_divMod_eq_of_shouldRecord
     {target candidate quotient : ZPoly}
     (hrecord : shouldRecordPolynomialFactor candidate = true)
-    (hdivMod : DensePoly.divMod target candidate = (quotient, 0))
+    (_hdivMod : DensePoly.divMod target candidate = (quotient, 0))
     (hmul : quotient * candidate = target) :
     exactQuotient? target candidate = some quotient := by
   have hrecord_props :
@@ -1740,7 +1740,7 @@ theorem exactQuotient?_eq_some_of_divMod_eq_of_shouldRecord
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one, hdivMod]
-  simp [hmul]
+  rw [if_neg hcandidate_ne_one]
+  exact (ZPoly.divExact?_eq hcandidate_ne).2 hmul.symm
 
 end Hex

--- a/HexModArith.lean
+++ b/HexModArith.lean
@@ -8,6 +8,7 @@ module
 
 public import HexModArith.Residue
 public import HexModArith.HotLoop
+public import HexModArith.Modulus
 public import HexModArith.Prime
 public import HexModArith.Ring
 public import HexModArith.WordMod

--- a/HexModArith/Modulus.lean
+++ b/HexModArith/Modulus.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArith.Prime
+
+public section
+
+/-!
+Bundled word-sized moduli and the runtime prime supply for `hex-mod-arith`.
+
+The structures in this module carry the dependent `ZMod64.Bounds` evidence
+needed to instantiate modular arithmetic at a modulus selected at runtime.
+-/
+namespace Hex
+
+namespace ZMod64
+
+/-- A usable word-sized modulus together with the evidence required by
+`ZMod64`. -/
+structure Modulus where
+  /-- The natural-number modulus. -/
+  m : Nat
+  /-- Positivity and word-size bounds for the modulus. -/
+  [bounds : Bounds m]
+
+/-- A usable word-sized modulus known to be prime. This is the data-carrying
+counterpart of the `PrimeModulus` typeclass. -/
+structure Prime extends Modulus where
+  /-- Project-local primality evidence for the bundled modulus. -/
+  prime : Hex.Nat.Prime m
+
+/-- Scan downward through candidates, appending at most `remaining` primes to
+`out`. The candidate decreases on every iteration, including rejected
+composites, so the scan is fuelled by the finite interval below `candidate`. -/
+private def primesBelow.go (remaining candidate : Nat)
+    (hbound : candidate < 2 ^ 31) (out : Array Prime) :
+    Array Prime :=
+  if remaining = 0 || candidate < 2 then
+    out
+  else if hprime : Hex.Nat.isPrimeTrial candidate = true then
+    have prime : Hex.Nat.Prime candidate := Hex.Nat.isPrimeTrial_isPrime hprime
+    let bounds : Bounds candidate := { pPos := prime.pos, pLtR := hbound }
+    let entry : Prime := { m := candidate, bounds, prime }
+    primesBelow.go (remaining - 1) (candidate - 1) (by omega) (out.push entry)
+  else
+    primesBelow.go remaining (candidate - 1) (by omega) out
+termination_by candidate
+decreasing_by all_goals simp_all; omega
+
+/-- Return at most the requested number of successive primes below `2^31`, in
+descending order starting at `start`. Runtime trial division produces the
+primality evidence stored in every result; candidates above the `ZMod64` bound
+are skipped by clamping the start of the scan. -/
+def primesBelow (start : Nat) : Nat → Array Prime
+  | count =>
+      primesBelow.go count (min start (2 ^ 31 - 1)) (by omega) #[]
+
+#guard (primesBelow 11 4).map (fun p => p.m) == #[11, 7, 5, 3]
+
+end ZMod64
+
+end Hex

--- a/HexModular.lean
+++ b/HexModular.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.Crt
+public import HexModular.Euclid
+public import HexModular.KernelTests
+public import HexModular.Loop
+public import HexModular.Recon
+public import HexModular.SymMod
+
+public section
+
+/-!
+`HexModular` provides symmetric integer representatives, incremental scalar
+and vector CRT, bounded and heuristic rational reconstruction, and a fuelled
+multi-modular loop. The library is Mathlib-free.
+-/

--- a/HexModular/Crt.lean
+++ b/HexModular/Crt.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.SymMod
+
+public section
+
+/-!
+Incremental scalar and vector Chinese remaindering for `hex-modular`.
+-/
+namespace Hex
+
+namespace Modular
+
+/-- A residue accumulated from coprime moduli. `value` is the symmetric
+representative of their common solution modulo `modulus`. -/
+structure Crt where
+  /-- Product of the moduli already folded into the state. -/
+  modulus : Nat
+  /-- Symmetric representative of the accumulated residue. -/
+  value : Int
+  /-- The accumulated modulus is positive. -/
+  pos : 0 < modulus
+  /-- The representative lies in the symmetric interval. -/
+  le : 2 * value.natAbs ≤ modulus
+
+namespace Crt
+
+/-- The empty scalar CRT accumulation, modulo one. -/
+@[expose]
+def init : Crt :=
+  { modulus := 1, value := 0, pos := by decide, le := by decide }
+
+/-- Fold the residue `r` modulo `m` into a scalar CRT accumulation using one
+Garner mixed-radix step. Moduli zero and one and moduli not coprime to the
+accumulated modulus are rejected. -/
+@[expose]
+def push (c : Crt) (r : Int) (m : Nat) : Option Crt :=
+  if hm : 1 < m then
+    let eg := Hex.pureIntExtGcd (Int.ofNat (c.modulus % m)) (Int.ofNat m)
+    if hg : eg.1 = 1 then
+      let inverse := eg.2.1
+      let delta := symMod ((r - c.value) * inverse) m
+      let modulus := c.modulus * m
+      let value := symMod (c.value + Int.ofNat c.modulus * delta) modulus
+      some
+        { modulus
+          value
+          pos := Nat.mul_pos c.pos (by omega)
+          le := symMod_le (Nat.mul_pos c.pos (by omega)) }
+    else
+      none
+  else
+    none
+
+/-- GMP-backed compiled implementation of `Crt.push`. -/
+def pushImpl (c : Crt) (r : Int) (m : Nat) : Option Crt :=
+  if hm : 1 < m then
+    let eg := HexArith.Int.extGcd (Int.ofNat (c.modulus % m)) (Int.ofNat m)
+    if hg : eg.1 = 1 then
+      let inverse := eg.2.1
+      let delta := symMod ((r - c.value) * inverse) m
+      let modulus := c.modulus * m
+      let value := symMod (c.value + Int.ofNat c.modulus * delta) modulus
+      some
+        { modulus
+          value
+          pos := Nat.mul_pos c.pos (by omega)
+          le := symMod_le (Nat.mul_pos c.pos (by omega)) }
+    else
+      none
+  else
+    none
+
+/-- The compiled CRT step agrees with its kernel-reducible reference. -/
+theorem push_eq_impl : @push = @pushImpl := by
+  funext c r m
+  simp only [push, pushImpl, HexArith.Int.extGcd]
+  rfl
+
+@[csimp] theorem push_csimp : @push = @pushImpl := push_eq_impl
+
+/-- A successful scalar push multiplies the accumulated modulus by the new
+one. -/
+theorem push_modulus {c c' : Crt} {r : Int} {m : Nat}
+    (h : c.push r m = some c') :
+    c'.modulus = c.modulus * m := by
+  unfold push at h
+  split at h
+  · simp only at h
+    split at h
+    · cases h
+      rfl
+    · contradiction
+  · contradiction
+
+/-- A successful scalar push records the requested new residue. -/
+theorem push_congr_new {c c' : Crt} {r : Int} {m : Nat}
+    (h : c.push r m = some c') :
+    c'.value % (m : Int) = r % (m : Int) := by
+  sorry
+
+/-- A successful scalar push preserves the accumulated value modulo every
+divisor of the old accumulated modulus. -/
+theorem push_congr_old {c c' : Crt} {r : Int} {m d : Nat}
+    (hd : d ∣ c.modulus) (h : c.push r m = some c') :
+    c'.value % (d : Int) = c.value % (d : Int) := by
+  sorry
+
+/-- A successful scalar push preserves the symmetric-size invariant. -/
+theorem push_le {c c' : Crt} {r : Int} {m : Nat}
+    (_h : c.push r m = some c') :
+    2 * c'.value.natAbs ≤ c'.modulus := by
+  exact c'.le
+
+end Crt
+
+/-- Several accumulated residues sharing one positive product modulus. -/
+structure CrtVec (k : Nat) where
+  /-- Product of the moduli already folded into the state. -/
+  modulus : Nat
+  /-- Symmetric representatives of the accumulated residues. -/
+  value : Vector Int k
+  /-- The accumulated modulus is positive. -/
+  pos : 0 < modulus
+  /-- Every representative lies in the symmetric interval. -/
+  le : ∀ i : Fin k, 2 * value[i].natAbs ≤ modulus
+
+namespace CrtVec
+
+/-- The empty vector CRT accumulation, modulo one. -/
+@[expose]
+def init (k : Nat) : CrtVec k :=
+  { modulus := 1
+    value := Vector.replicate k 0
+    pos := by decide
+    le := by intro i; simp }
+
+/-- Fold `k` residues sharing modulus `m` into a vector CRT accumulation. The
+extended GCD and modular inverse are computed once and reused for every
+coordinate. -/
+def push (c : CrtVec k) (r : Vector Int k) (m : Nat) : Option (CrtVec k) :=
+  if hm : 1 < m then
+    let eg := Hex.pureIntExtGcd (Int.ofNat (c.modulus % m)) (Int.ofNat m)
+    if hg : eg.1 = 1 then
+      let inverse := eg.2.1
+      let modulus := c.modulus * m
+      let value := Vector.zipWith
+        (fun old new =>
+          let delta := symMod ((new - old) * inverse) m
+          symMod (old + Int.ofNat c.modulus * delta) modulus)
+        c.value r
+      some
+        { modulus
+          value
+          pos := Nat.mul_pos c.pos (by omega)
+          le := by
+            intro i
+            have hle := symMod_le (a :=
+              c.value[i] + Int.ofNat c.modulus *
+                symMod ((r[i] - c.value[i]) * inverse) m)
+              (m := modulus) (Nat.mul_pos c.pos (by omega))
+            grind }
+    else
+      none
+  else
+    none
+
+/-- GMP-backed compiled implementation of `CrtVec.push`. -/
+def pushImpl (c : CrtVec k) (r : Vector Int k) (m : Nat) : Option (CrtVec k) :=
+  if hm : 1 < m then
+    let eg := HexArith.Int.extGcd (Int.ofNat (c.modulus % m)) (Int.ofNat m)
+    if hg : eg.1 = 1 then
+      let inverse := eg.2.1
+      let modulus := c.modulus * m
+      let value := Vector.zipWith
+        (fun old new =>
+          let delta := symMod ((new - old) * inverse) m
+          symMod (old + Int.ofNat c.modulus * delta) modulus)
+        c.value r
+      some
+        { modulus
+          value
+          pos := Nat.mul_pos c.pos (by omega)
+          le := by
+            intro i
+            have hle := symMod_le (a :=
+              c.value[i] + Int.ofNat c.modulus *
+                symMod ((r[i] - c.value[i]) * inverse) m)
+              (m := modulus) (Nat.mul_pos c.pos (by omega))
+            grind }
+    else
+      none
+  else
+    none
+
+/-- The compiled vector CRT step agrees with its kernel-reducible reference. -/
+theorem push_eq_impl : @push = @pushImpl := by
+  funext k c r m
+  simp only [push, pushImpl, HexArith.Int.extGcd]
+  rfl
+
+@[csimp] theorem push_csimp : @push = @pushImpl := push_eq_impl
+
+/-- A successful vector push multiplies the accumulated modulus by the new
+one. -/
+theorem push_modulus {c c' : CrtVec k} {r : Vector Int k} {m : Nat}
+    (h : c.push r m = some c') :
+    c'.modulus = c.modulus * m := by
+  unfold push at h
+  split at h
+  · simp only at h
+    split at h
+    · cases h
+      rfl
+    · contradiction
+  · contradiction
+
+/-- A successful vector push records every requested new residue. -/
+theorem push_congr_new {c c' : CrtVec k} {r : Vector Int k} {m : Nat}
+    (h : c.push r m = some c') :
+    ∀ i : Fin k, c'.value[i] % (m : Int) = r[i] % (m : Int) := by
+  sorry
+
+/-- A successful vector push preserves every old accumulated residue modulo
+every divisor of the old modulus. -/
+theorem push_congr_old {c c' : CrtVec k} {r : Vector Int k} {m d : Nat}
+    (hd : d ∣ c.modulus) (h : c.push r m = some c') :
+    ∀ i : Fin k, c'.value[i] % (d : Int) = c.value[i] % (d : Int) := by
+  sorry
+
+/-- A successful vector push preserves every symmetric-size invariant. -/
+theorem push_le {c c' : CrtVec k} {r : Vector Int k} {m : Nat}
+    (_h : c.push r m = some c') :
+    ∀ i : Fin k, 2 * c'.value[i].natAbs ≤ c'.modulus := by
+  exact c'.le
+
+end CrtVec
+
+/-- Two integers strictly smaller than half the accumulated modulus and
+congruent modulo that modulus are equal. -/
+theorem crt_unique {c : Crt} {x y : Int}
+    (h : 2 * x.natAbs < c.modulus)
+    (h' : 2 * y.natAbs < c.modulus)
+    (hx : x % (c.modulus : Int) = y % (c.modulus : Int)) :
+    x = y := by
+  have hxs : symMod y c.modulus = x := symMod_unique h hx
+  have hys : symMod y c.modulus = y := symMod_unique h' rfl
+  exact hxs.symm.trans hys
+
+end Modular
+
+end Hex

--- a/HexModular/Euclid.lean
+++ b/HexModular/Euclid.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexArith
+
+public section
+
+/-!
+Truncated extended-Euclidean rows for rational reconstruction.
+-/
+namespace Hex
+
+namespace Modular
+
+/-- One row of the extended Euclidean remainder sequence on `(m, a)`. The
+omitted coefficient of `m` is never inspected by reconstruction consumers. -/
+structure Row where
+  /-- The current Euclidean remainder. -/
+  r : Int
+  /-- The coefficient of the second input `a`. -/
+  t : Int
+  deriving DecidableEq
+
+/-- Continue the nonnegative Euclidean recurrence until the current remainder
+is at most `P`, or until the zero remainder is reached. -/
+private def euclidUntil.go (P : Int) (oldR r : Nat) (oldT t : Int) : Row :=
+  if (r : Int) ≤ P then
+    { r := Int.ofNat r, t }
+  else if _hr : r = 0 then
+    { r := 0, t }
+  else
+    let q := oldR / r
+    euclidUntil.go P r (oldR % r) t (oldT - Int.ofNat q * t)
+termination_by r
+decreasing_by exact Nat.mod_lt _ (Nat.pos_of_ne_zero _hr)
+
+/-- Return the first row of the extended Euclidean remainder sequence on
+`(m, a)` whose remainder is at most `P`. The modulus is interpreted up to
+sign, and `a` is reduced before entering the recurrence. -/
+def euclidUntil (m a P : Int) : Row :=
+  let modulus := m.natAbs
+  if _hm : modulus = 0 then
+    { r := 0, t := 0 }
+  else
+    let residue := (a % (Int.ofNat modulus)).natAbs
+    euclidUntil.go P modulus residue 0 1
+
+#guard euclidUntil 1 0 1 == { r := 0, t := 1 }
+#guard euclidUntil 101 51 2 == { r := 1, t := 2 }
+
+end Modular
+
+end Hex

--- a/HexModular/KernelTests.lean
+++ b/HexModular/KernelTests.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.Crt
+public import HexModular.Loop
+public import HexModular.Recon
+
+public section
+
+/-!
+Small kernel-reduction canaries for the executable certificate closure.  The
+search routines are exercised only on tiny values; certificate replay itself
+reduces through `symMod`, `Crt.push`, and `ratReconCheck`.
+-/
+
+namespace Hex.Modular.KernelTests
+
+/-- The outer-reduction regression from the SPEC. -/
+@[expose] def outerReduction : Option (Nat × Int) := do
+  let first ← Crt.init.push 1 3
+  let second ← first.push 0 2
+  pure (second.modulus, second.value)
+
+example : outerReduction = some (6, -2) := by
+  decide +kernel
+
+/-- Degenerate and non-coprime moduli are rejected. -/
+example : (Crt.init.push 1 0).isNone = true := by
+  decide +kernel
+
+example : (Crt.init.push 1 1).isNone = true := by
+  decide +kernel
+
+@[expose] def nonCoprimeRejected : Bool :=
+  match Crt.init.push 1 3 with
+  | none => false
+  | some state => (state.push 2 6).isNone
+
+example : nonCoprimeRejected = true := by
+  decide +kernel
+
+/-- `2/3` represents residue `68` modulo `101`. -/
+example : ratReconCheck 68 101 8 8 (Rat.divInt 2 3) = true := by
+  decide +kernel
+
+/-- A wrong numerator is rejected even when it lies inside the bounds. -/
+example : ratReconCheck 68 101 8 8 (Rat.divInt 1 3) = false := by
+  decide +kernel
+
+end Hex.Modular.KernelTests

--- a/HexModular/Loop.lean
+++ b/HexModular/Loop.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.Crt
+
+public section
+
+/-!
+Fuelled multi-modular reconstruction loops.
+-/
+namespace Hex
+
+namespace Modular
+
+/-- Consume the remaining supply entries, skipping rejected images and
+non-coprime moduli and testing `accept` only after a successful CRT push. -/
+private def crtLoop.go (image : Nat → Option (Vector Int k))
+    (accept : CrtVec k → Option α) (supply : Array Nat)
+    (fuel index : Nat) (state : CrtVec k) : Option α :=
+  if hf : fuel = 0 then
+    none
+  else if hi : index < supply.size then
+    let modulus := supply[index]
+    match image modulus with
+    | none => crtLoop.go image accept supply (fuel - 1) (index + 1) state
+    | some residues =>
+        match state.push residues modulus with
+        | none => crtLoop.go image accept supply (fuel - 1) (index + 1) state
+        | some next =>
+            match accept next with
+            | some result => some result
+            | none => crtLoop.go image accept supply (fuel - 1) (index + 1) next
+  else
+    none
+termination_by fuel
+decreasing_by all_goals omega
+
+/-- Fold moduli into a vector CRT state until the caller-supplied exact check
+accepts a reconstruction. A rejected image never enters the state, and the
+fuel bounds the number of supply entries inspected. -/
+def crtLoop (image : Nat → Option (Vector Int k))
+    (accept : CrtVec k → Option α) (supply : Array Nat) (fuel : Nat) :
+    Option α :=
+  crtLoop.go image accept supply fuel 0 (CrtVec.init k)
+
+/-- Every successful loop result was returned by `accept` on some accumulated
+CRT state; the loop itself never manufactures a caller result. -/
+theorem crtLoop_of_some {image : Nat → Option (Vector Int k)}
+    {accept : CrtVec k → Option α} {supply : Array Nat} {fuel : Nat} {x : α}
+    (h : crtLoop image accept supply fuel = some x) :
+    ∃ state, accept state = some x := by
+  have go : ∀ (remaining index : Nat) (state : CrtVec k),
+      crtLoop.go image accept supply remaining index state = some x →
+        ∃ state, accept state = some x := by
+    intro remaining
+    induction remaining with
+    | zero =>
+        intro index state h
+        simp [crtLoop.go] at h
+    | succ remaining ih =>
+        intro index state h
+        unfold crtLoop.go at h
+        simp only [Nat.succ_ne_zero, ↓reduceDIte] at h
+        split at h
+        · split at h
+          · exact ih _ _ h
+          · split at h
+            · exact ih _ _ h
+            · split at h
+              · rename_i result next hnext
+                cases h
+                exact ⟨_, by assumption⟩
+              · exact ih _ _ h
+        · contradiction
+  exact go fuel 0 (CrtVec.init k) h
+
+end Modular
+
+end Hex

--- a/HexModular/Recon.lean
+++ b/HexModular/Recon.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.Crt
+public import HexModular.Euclid
+
+public section
+
+/-!
+Bounded, vector, and maximal-quotient rational reconstruction.
+-/
+namespace Hex
+
+namespace Modular
+
+/-- Check that `x` represents `a` modulo `m` and satisfies the requested
+numerator and denominator bounds. This is split from the Euclidean search so
+certificate replay need not unfold that search. -/
+@[expose]
+def ratReconCheck (a : Int) (m : Nat) (P Q : Int) (x : Rat) : Bool :=
+  decide (0 < m) &&
+    decide ((Int.ofNat x.den * a - x.num) % (m : Int) = 0) &&
+    decide ((x.num.natAbs : Int) ≤ P) &&
+    decide ((0 : Int) < x.den) &&
+    decide ((x.den : Int) ≤ Q)
+
+/-- Reconstruct `a mod m` as a rational with numerator absolute value at most
+`P` and positive denominator at most `Q`. The truncated Euclidean candidate is
+normalized and all output conditions are checked before it is returned. -/
+def ratRecon? (a : Int) (m : Nat) (P Q : Int) : Option Rat :=
+  if m = 0 then
+    none
+  else
+    let row := euclidUntil (Int.ofNat m) a P
+    if row.t = 0 then
+      none
+    else
+      let candidate := Rat.divInt row.r row.t
+      if ratReconCheck a m P Q candidate then some candidate else none
+
+/-- Symmetric rational reconstruction with
+`P = Q = ⌊√((m-1)/2)⌋`, which guarantees `2 P Q < m`. -/
+def ratReconWide? (a : Int) (m : Nat) : Option Rat :=
+  let bound := Nat.sqrt ((m - 1) / 2)
+  ratRecon? a m (Int.ofNat bound) (Int.ofNat bound)
+
+/-- Every rational returned by bounded reconstruction satisfies the requested
+modular congruence. -/
+theorem ratRecon?_congr {a : Int} {m : Nat} {P Q : Int} {x : Rat}
+    (h : ratRecon? a m P Q = some x) :
+    (Int.ofNat x.den * a - x.num) % (m : Int) = 0 := by
+  unfold ratRecon? at h
+  split at h <;> try contradiction
+  dsimp only at h
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  next candidate hcheck =>
+    cases h
+    simp only [ratReconCheck, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+    rcases hcheck with ⟨⟨⟨⟨_, hcongr⟩, _⟩, _⟩, _⟩
+    exact hcongr
+
+/-- Every rational returned by bounded reconstruction satisfies the requested
+numerator and denominator bounds. -/
+theorem ratRecon?_bounds {a : Int} {m : Nat} {P Q : Int} {x : Rat}
+    (h : ratRecon? a m P Q = some x) :
+    (x.num.natAbs : Int) ≤ P ∧ 0 < x.den ∧ (x.den : Int) ≤ Q := by
+  unfold ratRecon? at h
+  split at h <;> try contradiction
+  dsimp only at h
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  next candidate hcheck =>
+    cases h
+    simp only [ratReconCheck, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+    rcases hcheck with ⟨⟨⟨⟨_, _⟩, hnum⟩, hdenpos⟩, hdenBound⟩
+    exact ⟨hnum, by simpa using hdenpos, hdenBound⟩
+
+/-- The reduced denominator of a successful reconstruction is coprime to the
+modulus. -/
+theorem ratRecon?_den_coprime {a : Int} {m : Nat} {P Q : Int} {x : Rat}
+    (h : ratRecon? a m P Q = some x) :
+    Nat.gcd x.den m = 1 := by
+  sorry
+
+/-- Rational reconstruction is unique whenever twice the product of the two
+bounds is strictly smaller than the modulus. -/
+theorem ratRecon_unique {a P Q : Int} {m : Nat} {y₁ y₂ : Rat}
+    (hm : 2 * P * Q < (m : Int))
+    (h₁ : (Int.ofNat y₁.den * a - y₁.num) % (m : Int) = 0)
+    (h₂ : (Int.ofNat y₂.den * a - y₂.num) % (m : Int) = 0)
+    (b₁ : (y₁.num.natAbs : Int) ≤ P ∧ (y₁.den : Int) ≤ Q)
+    (b₂ : (y₂.num.natAbs : Int) ≤ P ∧ (y₂.den : Int) ≤ Q) :
+    y₁ = y₂ := by
+  sorry
+
+/-- Under the uniqueness bound, bounded reconstruction finds every rational
+that satisfies the congruence and bounds. -/
+theorem ratRecon?_complete {a P Q : Int} {m : Nat} {y : Rat}
+    (hm : 2 * P * Q < (m : Int))
+    (hy : (Int.ofNat y.den * a - y.num) % (m : Int) = 0)
+    (hb : (y.num.natAbs : Int) ≤ P ∧ (y.den : Int) ≤ Q) :
+    ratRecon? a m P Q = some y := by
+  sorry
+
+/-- Check a vector reconstruction with common denominator. -/
+private def ratReconVecCheck (a y : Vector Int k) (m : Nat) (P Q d : Int) : Bool :=
+  decide (0 < m) && decide (0 < d) && decide (d ≤ Q) &&
+    (Vector.zipWith
+      (fun ai yi =>
+        decide ((d * ai - yi) % (m : Int) = 0) &&
+          decide ((yi.natAbs : Int) ≤ P))
+      a y).toArray.all (fun ok => ok)
+
+/-- Process the remaining coordinates of a common-denominator reconstruction.
+The index increases until it reaches the statically known vector length. -/
+private def ratReconVec.go (a : Vector Int k) (m : Nat) (P Q : Int)
+    (i : Nat) (hi : i ≤ k) (nums : Vector Int k) (d : Nat) :
+    Option (Vector Int k × Nat) :=
+  if hik : i = k then
+    some (nums, d)
+  else
+    have hlt : i < k := by omega
+    let residue := a[i]
+    let fast := symMod (Int.ofNat d * residue) m
+    if (fast.natAbs : Int) ≤ P then
+      ratReconVec.go a m P Q (i + 1) (by omega) (nums.set i fast) d
+    else do
+      let entry ← ratRecon? residue m P Q
+      let newD := Nat.lcm d entry.den
+      let oldScale := Int.ofNat (newD / d)
+      let entryScale := Int.ofNat (newD / entry.den)
+      let nums :=
+        (nums.map fun value => value * oldScale).set i (entry.num * entryScale)
+      ratReconVec.go a m P Q (i + 1) (by omega) nums newD
+termination_by k - i
+decreasing_by all_goals exact Nat.sub_lt_sub_left hlt (Nat.lt_succ_self i)
+
+/-- Reconstruct `k` residues as rationals with a common denominator. The first
+entry seeds the denominator. Later entries first try one symmetric
+multiplication at that denominator, falling back to their own Euclidean run
+only when necessary. Denominators are combined with `lcm`, and the final
+numerator vector and denominator are reduced by their common gcd. -/
+def ratReconVec? (a : Vector Int k) (m : Nat) (P Q : Int) :
+    Option (Vector Int k × Int) :=
+  if hk : k = 0 then
+    let y := Vector.replicate k (0 : Int)
+    if ratReconVecCheck a y m P Q 1 then
+      some (y, 1)
+    else
+      none
+  else
+    do
+      have hkpos : 0 < k := by omega
+      let first ← ratRecon? a[0] m P Q
+      let nums := (Vector.replicate k (0 : Int)).set 0 first.num
+      let (nums, d) ← ratReconVec.go a m P Q 1 (by omega) nums first.den
+      let common := nums.foldl (fun g value => Nat.gcd g value.natAbs) d
+      let reducedNums := nums.map fun value => value / Int.ofNat common
+      let reducedDen := d / common
+      let denInt := Int.ofNat reducedDen
+      if ratReconVecCheck a reducedNums m P Q denInt then
+        some (reducedNums, denInt)
+      else
+        none
+
+/-- A successful common-denominator vector reconstruction has a positive
+bounded denominator, and every coordinate satisfies its congruence and
+numerator bound. -/
+theorem ratReconVec?_spec {a : Vector Int k} {m : Nat} {P Q d : Int}
+    {y : Vector Int k}
+    (h : ratReconVec? a m P Q = some (y, d)) :
+    0 < d ∧ d ≤ Q ∧
+      ∀ i : Fin k,
+        (d * a[i] - y[i]) % (m : Int) = 0 ∧ (y[i].natAbs : Int) ≤ P := by
+  sorry
+
+/-- Track the row immediately preceding the largest quotient in an extended
+Euclidean run. -/
+private def maxQuotRow.go (oldR r : Nat) (oldT t : Int)
+    (bestQuot : Nat) (best : Option Row) : Option Row :=
+  if _hr : r = 0 then
+    best
+  else
+    let quotient := oldR / r
+    let (bestQuot, best) :=
+      if bestQuot < quotient then
+        (quotient, some { r := Int.ofNat r, t })
+      else
+        (bestQuot, best)
+    maxQuotRow.go r (oldR % r) t (oldT - Int.ofNat quotient * t)
+      bestQuot best
+termination_by r
+decreasing_by exact Nat.mod_lt _ (Nat.pos_of_ne_zero _hr)
+
+/-- Produce the maximal-quotient rational-reconstruction candidate. This is a
+heuristic: only the modular congruence is checked and promised. -/
+def ratReconMaxQuot? (a : Int) (m : Nat) : Option Rat :=
+  if _hm : m = 0 then
+    none
+  else
+    let residue := (a % (m : Int)).natAbs
+    if residue = 0 then
+      some 0
+    else
+      match maxQuotRow.go m residue 0 1 0 none with
+      | none => none
+      | some row =>
+          if row.t = 0 then
+            none
+          else
+            let candidate := Rat.divInt row.r row.t
+            if (Int.ofNat candidate.den * a - candidate.num) % (m : Int) = 0 then
+              some candidate
+            else
+              none
+
+/-- A maximal-quotient candidate always satisfies the modular congruence; no
+claim is made that it is the intended rational. -/
+theorem ratReconMaxQuot?_congr {a : Int} {m : Nat} {x : Rat}
+    (h : ratReconMaxQuot? a m = some x) :
+    (Int.ofNat x.den * a - x.num) % (m : Int) = 0 := by
+  unfold ratReconMaxQuot? at h
+  split at h <;> try contradiction
+  dsimp only at h
+  split at h
+  · cases h
+    have hr : a % (m : Int) = 0 := Int.natAbs_eq_zero.mp (by assumption)
+    simpa [hr]
+  · split at h <;> try contradiction
+    split at h <;> try contradiction
+    try dsimp only at h
+    split at h <;> try contradiction
+    next candidate hcheck =>
+      cases h
+      exact hcheck
+
+end Modular
+
+end Hex

--- a/HexModular/SPEC/hex-modular.md
+++ b/HexModular/SPEC/hex-modular.md
@@ -8,10 +8,10 @@ algorithms elsewhere in the tree draw on. Mathlib-free. The companion
 them usable from a Mathlib goal.
 
 This SPEC is the first of three expanding the "Modular techniques" entry
-in [future-work](../future-work.md). The other two are
-[hex-modular-matrix](hex-modular-matrix.md), which holds the
+in [future-work](../../SPEC/future-work.md). The other two are
+[hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md), which holds the
 multi-modular determinant, certified rank, and Dixon lifting, and
-[hex-poly-z-gcd](hex-poly-z-gcd.md), which holds the modular gcd for
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md), which holds the modular gcd for
 `ℤ[x]`. This library is what all three of them share.
 
 Two claims in that entry need correcting, and both are corrected below.
@@ -27,11 +27,11 @@ than a check, derivable from `gcd(p, q) = 1` and the congruence. See
 ## Why this library exists
 
 **Three consumers, none of which should depend on the others.**
-[hex-modular-matrix](hex-modular-matrix.md) reconstructs an integer
+[hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md) reconstructs an integer
 determinant from residues and a rational solution vector from a `p`-adic
-expansion. [hex-poly-z-gcd](hex-poly-z-gcd.md) reconstructs an integer
+expansion. [hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) reconstructs an integer
 polynomial coefficient vector from residues.
-[hex-mv-gcd](hex-mv-gcd.md) does the same one arity up. A matrix library
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) does the same one arity up. A matrix library
 and a polynomial library have no business depending on each other, so
 what they share belongs underneath both.
 
@@ -87,12 +87,12 @@ denominator; the modulus supply and its runtime primality test; and the
 loop combinator that adds moduli until a caller-supplied check accepts.
 
 Not in scope: `p`-adic lifting (that is Dixon's, and it lives with its
-consumer in [hex-modular-matrix](hex-modular-matrix.md)); the
+consumer in [hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md)); the
 coefficient bounds that tell a consumer how large a modulus it needs
 (a Hadamard bound is a matrix fact and a Mignotte bound is a polynomial
 fact, so each belongs with its own type); prime *choice* heuristics,
 which are per-consumer; and a first-class `Zp` type, which is its own
-entry in [future-work](../future-work.md) and would consume this library
+entry in [future-work](../../SPEC/future-work.md) and would consume this library
 rather than replace it.
 
 ## Symmetric representatives
@@ -300,7 +300,7 @@ theorem ratRecon?_den_coprime : ratRecon? a m P Q = some x →
     Nat.gcd x.den m = 1
 ```
 
-[future-work](../future-work.md) lists it among the conditions the
+[future-work](../../SPEC/future-work.md) lists it among the conditions the
 algorithm establishes, which reads as though it were a fourth thing to
 test. It is a consequence of the other three, and stating it as a theorem
 rather than a check keeps one modular inverse out of the inner loop.
@@ -433,7 +433,7 @@ The soundness theorem is the congruence and nothing else, which is
 honest, and it is enough for a consumer whose check is exact (trial
 division for a gcd, one matrix-vector product for a linear solve). It is
 **not** enough for the multi-modular determinant, which has no cheap
-check, and [hex-modular-matrix](hex-modular-matrix.md) says so in the one
+check, and [hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md) says so in the one
 place it matters. Monagan, "Maximal quotient rational reconstruction: an
 almost optimal algorithm for rational reconstruction" (ISSAC 2004), is
 the reference, and the failure probability analysis there is the reason
@@ -443,7 +443,7 @@ this is offered as a candidate producer rather than as a decision.
 
 ### Primality is not what the checkers need
 
-[future-work](../future-work.md) says the checker's obligations include
+[future-work](../../SPEC/future-work.md) says the checker's obligations include
 "primality and distinctness of the moduli". Neither half is right, and
 getting this wrong would put a large avoidable cost inside the kernel.
 
@@ -466,7 +466,7 @@ possible.
 
 **Where primality genuinely appears** is in statements that mention
 `F_p` as a field: the rank of an image, and the coprimality witness in
-[hex-poly-z-gcd](hex-poly-z-gcd.md), which needs `F_p[x]` to be a domain.
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md), which needs `F_p[x]` to be a domain.
 Those consumers carry a `Hex.Nat.Prime p` argument, and the rest do not.
 
 ### Kernel-replayed primality is priced by the size of the prime
@@ -486,7 +486,7 @@ for the import alone:
 
 The consequence is a design rule, not a footnote: **a certificate whose
 checker needs a prime should name the smallest usable one.** The
-coprimality witness in [hex-poly-z-gcd](hex-poly-z-gcd.md) may use any
+coprimality witness in [hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) may use any
 prime at which two degrees survive, so it uses a small one and the
 kernel replay is free. A multi-modular determinant wants primes as large
 as `ZMod64.Bounds` allows, and it can have them precisely because its
@@ -497,7 +497,7 @@ under a millisecond of compiled code, which is negligible beside one
 `O(n³)` image, so moduli are found by running it rather than by consulting
 a table.
 
-**The "Better primality" item in [future-work](../future-work.md) changes
+**The "Better primality" item in [future-work](../../SPEC/future-work.md) changes
 both halves of this, and neither change is on this library's critical
 path.** Its Miller-Rabin
 compositeness test replaces trial division in `primesBelow`, turning tens
@@ -562,10 +562,10 @@ the modulus exceeds twice the bound never stops.
 
 Nothing in this library can fix that, and it is recorded here because it
 is the shared cause of three separate obligations elsewhere:
-[hex-modular-matrix](hex-modular-matrix.md)'s determinant needs a
+[hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md)'s determinant needs a
 fallback that does not use moduli at all, its rank certificate needs a
 lower-bound witness that is not restricted to small moduli, and
-[hex-poly-z-gcd](hex-poly-z-gcd.md)'s coprimality certificate needs a
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md)'s coprimality certificate needs a
 constructor that names no prime. Each of those SPECs carries the
 counterexample for its own case.
 
@@ -673,7 +673,7 @@ test over a fixed small certificate so that a change making `symMod` or
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). A Lean driver at
 `conformance/HexModular/EmitFixtures.lean` exposed as
 `lean_exe hexmodular_emit_fixtures`, a committed snapshot at
 `conformance-fixtures/HexModular/modular.jsonl`, and an oracle driver at
@@ -727,7 +727,7 @@ Cases that must be present:
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexModular/Bench.lean`. Native and kernel: the kernel suite
 measures `symMod` and `Crt.push` reduction, since those are the two
 operations a downstream certificate replay pays for.
@@ -777,7 +777,7 @@ Mathlib has `ZMod.chineseRemainder` for coprime moduli, so the
 correspondence for a two-modulus push is a transport. The `k`-modulus
 statement is an induction over the fold, and the reason to state it at all
 is that a Mathlib-facing consumer (the determinant correspondence in
-[hex-modular-matrix-mathlib](hex-modular-matrix.md)) wants to argue in
+[hex-modular-matrix-mathlib](../../SPEC/Libraries/hex-modular-matrix.md)) wants to argue in
 `ZMod` and land in `ℤ`.
 
 Rational reconstruction has no Mathlib counterpart to correspond with, so
@@ -815,13 +815,13 @@ hex-mod-arith type, its proof uses `ZMod64` lemmas and
 `HexPolyFp.Degree`. As it stands, any library wanting to do linear
 algebra over `F_p` must depend on hex-poly-fp for one instance about a
 type it already has, which is what
-[hex-modular-matrix](hex-modular-matrix.md) would otherwise have to do.
+[hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md) would otherwise have to do.
 
 **`floorSqrt` and `ceilSqrt` should move to hex-arith.** They are
 Newton-iteration integer square roots defined in `HexPolyZ/Mignotte.lean`
 under the `Hex.ZPoly` namespace, where the Mignotte bound needed them.
 `ratReconWide?` needs `⌊√((m-1)/2)⌋` and the Hadamard bound in
-[hex-modular-matrix](hex-modular-matrix.md) needs `ceilSqrt` per column.
+[hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md) needs `ceilSqrt` per column.
 An integer square root under a polynomial namespace is a naming error as
 well as a placement one.
 
@@ -878,8 +878,8 @@ hex-mod-arith, per "The supply", and `crtLoop` takes bare `Nat` moduli.
   HexModular:
     deps: [HexArith]
     mathlib: false
-    done_through: 0
-    status: planned
+    done_through: 1
+    status: active
   HexModularMathlib:
     deps: [HexModular, HexModArithMathlib]   # ZMod correspondence only
     mathlib: true
@@ -887,9 +887,8 @@ hex-mod-arith, per "The supply", and `crtLoop` takes bare `Nat` moduli.
     status: planned
 ```
 
-`status: planned` rather than `draft`: the SPEC is complete, every
-dependency is `active` at `done_through: 7`, and nothing here waits on
-another SPEC.
+The Mathlib-free core is active through Phase 1.  The companion remains
+planned until its correspondence and decidability layer is implemented.
 
 ## Open questions
 
@@ -913,12 +912,12 @@ another SPEC.
 - **When to switch the modulus supply to a better primality test.** The
   switch to Miller-Rabin is a strict improvement, and it introduces a
   dependency on whichever library ends up owning the "Better primality"
-  item in [future-work](../future-work.md). The question is only
+  item in [future-work](../../SPEC/future-work.md). The question is only
   ordering, and the answer should be "as soon as that library has a
   compositeness test", at which point it joins the `deps` list above.
 - **Whether a first-class `Zp` type subsumes the Dixon lifting loop.**
-  [future-work](../future-work.md) proposes `Zp` and `Qp` at fixed
+  [future-work](../../SPEC/future-work.md) proposes `Zp` and `Qp` at fixed
   precision, with Dixon named as a consumer. If that lands, the precision
   contract it specifies is the natural home for the lifting loop that
-  [hex-modular-matrix](hex-modular-matrix.md) currently writes out. The
+  [hex-modular-matrix](../../SPEC/Libraries/hex-modular-matrix.md) currently writes out. The
   reconstruction and the CRT stay here either way.

--- a/HexModular/SymMod.lean
+++ b/HexModular/SymMod.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexArith
+
+public section
+
+/-!
+Symmetric integer representatives for `hex-modular`.
+-/
+namespace Hex
+
+namespace Modular
+
+/-- The representative of `a` modulo `m` in the interval `(-m/2, m/2]`.
+For the degenerate modulus zero, this returns `a`, matching `Int.emod`'s
+zero-modulus convention. -/
+@[expose]
+def symMod (a : Int) (m : Nat) : Int :=
+  if m = 0 then
+    a
+  else
+    let r := a % (m : Int)
+    if (m : Int) < 2 * r then r - m else r
+
+#guard symMod 3 6 == 3
+#guard symMod (-3) 6 == 3
+#guard symMod 4 6 == -2
+
+/-- Symmetric reduction preserves the ordinary nonnegative residue at every
+positive modulus. -/
+theorem symMod_emod {a : Int} {m : Nat} (h : 0 < m) :
+    (symMod a m) % (m : Int) = a % (m : Int) := by
+  unfold symMod
+  rw [if_neg (Nat.ne_of_gt h)]
+  simp only
+  split
+  · rw [Int.sub_emod, Int.emod_self, Int.sub_zero]
+    simp only [Int.emod_emod]
+  · exact Int.emod_emod _ _
+
+/-- A symmetric representative has absolute value at most half its positive
+modulus, with the positive representative selected at an even tie. -/
+theorem symMod_le {a : Int} {m : Nat} (h : 0 < m) :
+    2 * (symMod a m).natAbs ≤ m := by
+  have hm : (0 : Int) < (m : Int) := by omega
+  have hr0 : (0 : Int) ≤ a % (m : Int) :=
+    Int.emod_nonneg _ (by omega)
+  have hrm : a % (m : Int) < (m : Int) :=
+    Int.emod_lt_of_pos _ hm
+  unfold symMod
+  rw [if_neg (Nat.ne_of_gt h)]
+  simp only
+  split
+  · rename_i hlarge
+    apply Int.ofNat_le.mp
+    rw [Int.natCast_mul, Int.ofNat_natAbs_of_nonpos (by omega)]
+    omega
+  · rename_i hsmall
+    apply Int.ofNat_le.mp
+    rw [Int.natCast_mul, Int.ofNat_natAbs_of_nonneg hr0]
+    omega
+
+/-- A strictly-half-bounded integer congruent to `a` is the unique symmetric
+representative. The strict bound excludes the two representatives at an even
+tie. -/
+theorem symMod_unique {a x : Int} {m : Nat}
+    (h : 2 * x.natAbs < m)
+    (hx : x % (m : Int) = a % (m : Int)) :
+    symMod a m = x := by
+  have hm : 0 < m := by omega
+  let s := symMod a m
+  have hs : 2 * s.natAbs ≤ m := symMod_le hm
+  have hsum : s.natAbs + x.natAbs < m := by omega
+  have hdiff : (s - x).natAbs < m :=
+    Nat.lt_of_le_of_lt (Int.natAbs_sub_le s x) hsum
+  have hsx : s % (m : Int) = x % (m : Int) := by
+    exact (symMod_emod hm).trans hx.symm
+  have hdvd : (m : Int) ∣ s - x :=
+    Int.dvd_of_emod_eq_zero
+      (Int.emod_eq_emod_iff_emod_sub_eq_zero.mp hsx)
+  have hzero : s - x = 0 := by
+    apply Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hdvd
+    simpa using hdiff
+  dsimp only [s] at hzero ⊢
+  omega
+
+end Modular
+
+end Hex

--- a/HexMvFactor.lean
+++ b/HexMvFactor.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Decomp
+public import HexMvFactor.Kronecker
+public import HexMvFactor.Irred
+public import HexMvFactor.Leading
+public import HexMvFactor.Point
+public import HexMvFactor.Input
+public import HexMvFactor.Eez
+public import HexMvFactor.Factor
+public import HexMvFactor.KernelTests
+public import HexMvFactor.KroneckerTests
+public import HexMvFactor.LeadingTests
+public import HexMvFactor.PointTests
+public import HexMvFactor.InputTests
+public import HexMvFactor.EezTests
+public import HexMvFactor.FactorTests
+public import HexMvFactor.CompleteTests
+
+public section
+
+/-!
+Checked multivariate factorization over the integers.
+
+The umbrella exposes checked decompositions, irreducibility certificates,
+the complete Kronecker route, and the bounded EEZ factorization pipeline.
+-/

--- a/HexMvFactor/CompleteTests.lean
+++ b/HexMvFactor/CompleteTests.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Factor
+public import HexMvFactor.Factor
+
+public section
+
+namespace Hex.MvFactor.CompleteTests
+
+open Hex
+open Hex.MvPoly
+open Hex.MvFactor
+
+private abbrev P0 := MvPoly 0 Int Mono.lex
+private abbrev P1 := MvPoly 1 Int Mono.lex
+private abbrev P2 := MvPoly 2 Int Mono.lex
+private abbrev P32 := MvPoly 32 Int Mono.lex
+private abbrev P4096 := MvPoly 4096 Int Mono.lex
+
+private def ux : P1 := X 0
+private def x : P2 := X 0
+private def y : P2 := X 1
+
+private def quadratic : P2 := x ^ 2 + y ^ 2 + 1
+private def hardPoint : P2 := x ^ 4 + y ^ 3
+private def highMono : Mono 32 := Hex.Vector.ofFn' fun _ => 2
+private def highSparse : P32 := MvPoly.monomial highMono 1 + 1
+private def hugeMono : Mono 4096 := Hex.Vector.ofFn' fun _ => 1
+private def hugeSparse : P4096 := MvPoly.monomial hugeMono 1 + 1
+
+private def withKronecker : Config :=
+  { Config.default with kronecker := true }
+
+private def noImage : Config :=
+  { withKronecker with pointFuel := 0 }
+
+/- The obligation-free route precedes both image search and Kronecker. -/
+#guard
+  match irredCert? withKronecker (x + y + 1) with
+  | .ok (cert, _) =>
+      cert.noKronecker && (obligations (x + y + 1) cert).isEmpty &&
+        checkIrred (x + y + 1) cert
+  | _ => false
+
+/- A successful image is retained even when the complete fallback is enabled. -/
+#guard
+  match irredCert? withKronecker quadratic with
+  | .ok (cert, _) =>
+      cert.noKronecker && !(obligations quadratic cert).isEmpty &&
+        checkIrred quadratic cert
+  | _ => false
+
+/- BZ stores positive-leading factors and moves the sign to its scalar;
+   the image obligation deliberately retains the primitive part's sign. -/
+#guard
+  match irredCert? Config.default (-quadratic) with
+  | .ok (cert, _) =>
+      cert.noKronecker && !(obligations (-quadratic) cert).isEmpty &&
+        checkIrred (-quadratic) cert
+  | _ => false
+
+/- With image search disabled, the actual Kronecker factorization and sweep
+   produce the certificate. -/
+#guard
+  match irredCert? noImage quadratic with
+  | .ok (cert@(.kronecker _ _), _) => checkIrred quadratic cert
+  | _ => false
+
+private def disabled : Config :=
+  { Config.default with pointFuel := 0, kronecker := false }
+
+#guard
+  match irredCert? disabled quadratic with
+  | .error (.irreducible factor) => factor == quadratic
+  | _ => false
+
+private def noKronBudget : Config :=
+  { noImage with kroneckerDeg := 0 }
+
+#guard
+  match irredCert? noKronBudget quadratic with
+  | .error (.irreducible factor) => factor == quadratic
+  | _ => false
+
+/- The sparse degree guard must reject before attempting to allocate the
+   `3^32`-position dense image represented by this two-term polynomial. -/
+private def noHugeImage : Config :=
+  { Config.default with
+    pointFuel := 0
+    kronecker := true
+    kroneckerDeg := 0 }
+
+#guard
+  let degrees := kronDegrees highSparse
+  match kronDegree? (fun i => degrees[i]) highSparse with
+  | some degree => 1_000_000 < degree
+  | none => false
+
+#guard (kronCert? noHugeImage highSparse).isNone
+
+#guard
+  match irredCert? noHugeImage highSparse with
+  | .error (.irreducible factor) => factor == highSparse
+  | _ => false
+
+/- Many degree-one variables make exact weights grow as `2^i`.  A zero
+   budget keeps the entire precheck in the saturated values zero and one. -/
+#guard
+  let degrees := kronDegrees hugeSparse
+  kronDegreeUpTo? 0 (fun i => degrees[i]) hugeSparse == some 1
+
+#guard (kronCert? noHugeImage hugeSparse).isNone
+
+/- Zero has a checked decomposition but deliberately no complete answer. -/
+#guard
+  match completeWith Config.default (0 : P2) with
+  | .error stoppedAnswer =>
+      (match stoppedAnswer.reason with | .zero => true | _ => false) &&
+        checkDecomp 0 stoppedAnswer.found.raw
+  | .ok _ => false
+
+/- Constants, including arity zero, have no polynomial obligations. -/
+#guard
+  match complete? (C 12 : P0) with
+  | .ok answer =>
+      answer.raw.certs.isEmpty && checkComplete (C 12 : P0) answer.raw
+  | .error _ => false
+
+/- Monomial variables receive degree-one certificates with their
+   multiplicities preserved. -/
+#guard
+  let subject : P2 := C 6 * x ^ 2 * y
+  match complete? subject with
+  | .ok answer =>
+      answer.raw.decomp.factors.length == 2 &&
+        answer.raw.certs.length == 2 && NoKronecker answer.raw &&
+        checkComplete subject answer.raw
+  | .error _ => false
+
+/- Repeated factors stay merged and are certified once. -/
+#guard
+  let subject : P1 := (ux + 1) ^ 3 * (ux ^ 2 + 1)
+  match complete? subject with
+  | .ok answer =>
+      answer.raw.decomp.factors.length == 2 &&
+        answer.raw.decomp.factors.any (fun entry => entry.multiplicity == 3) &&
+        checkComplete subject answer.raw
+  | .error _ => false
+
+/- At seed one the factorizer first sees the irreducible `x^4 + 1` image.
+   Its advanced state makes certificate scouting stop at the reducible
+   `x^4 - 1` image, so this exercises `completeWith`'s real fallback. -/
+private def completeUsesKron (seed : Nat) : Bool :=
+  let cfg : Config :=
+    { Config.default with
+      rand := Rand.ofSeed seed
+      pointFuel := 3
+      pointScouts := 1
+      pointShell := 1
+      kronecker := true }
+  match completeWith cfg hardPoint with
+  | .ok (answer, _) => !NoKronecker answer.raw
+  | .error _ => false
+
+#guard completeUsesKron 1
+
+end Hex.MvFactor.CompleteTests

--- a/HexMvFactor/Decomp.lean
+++ b/HexMvFactor/Decomp.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Squarefree
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Checked product decompositions for multivariate integer polynomials.
+
+This layer deliberately says nothing about irreducibility.  Its checker
+replays the product identity and the canonical-form side conditions which
+make multiplicities meaningful.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- One nonconstant entry in a product decomposition. -/
+structure Factor (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  factor : MvPoly n Int cmp
+  multiplicity : Nat
+
+/-- An integer scalar and a list of polynomial powers. -/
+structure Decomp (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  content : Int
+  factors : List (Factor n cmp)
+
+namespace Decomp
+
+variable {n : Nat} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+/-- Reconstruct the polynomial represented by a decomposition. -/
+@[reducible] def product (D : Decomp n cmp) : MvPoly n Int cmp :=
+  D.factors.foldl
+    (fun acc entry => acc * entry.factor ^ entry.multiplicity)
+    (C D.content)
+
+end Decomp
+
+variable {n : Nat} {cmp : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp]
+
+/-- The local canonical-form conditions for one decomposition entry. -/
+@[reducible] def checkFactor (entry : Factor n cmp) : Bool :=
+  decide (0 < entry.multiplicity) &&
+    decide (entry.factor.vars ≠ []) &&
+    (polyNormalize entry.factor == entry.factor) &&
+    decide (MvPoly.content entry.factor = 1)
+
+/-- Boolean pairwise distinctness, kept structural for kernel replay. -/
+@[reducible] def distinctFactors : List (Factor n cmp) → Bool
+  | [] => true
+  | entry :: entries =>
+      entries.all (fun other => decide (entry.factor ≠ other.factor)) &&
+        distinctFactors entries
+
+/-- Replay all five decomposition conditions from the SPEC. -/
+@[reducible] def checkDecomp (f : MvPoly n Int cmp)
+    (D : Decomp n cmp) : Bool :=
+  (D.product == f) &&
+    D.factors.all checkFactor &&
+    distinctFactors D.factors
+
+/-- The semantic product and nonconstant-positive-multiplicity payload of a
+checked decomposition.  Normalization and distinctness are checker-side
+canonicity conditions rather than part of this minimal witness. -/
+def IsDecompOf (f : MvPoly n Int cmp) (D : Decomp n cmp) : Prop :=
+  D.product = f ∧
+    ∀ entry ∈ D.factors,
+      0 < entry.multiplicity ∧ ¬ MvPoly.IsConst entry.factor
+
+/-- Accepted decomposition data tied to the subject checked by its caller. -/
+structure CheckedDecomp (f : MvPoly n Int cmp) where
+  raw : Decomp n cmp
+  valid : checkDecomp f raw = true
+
+/-- Executable replay implies the semantic decomposition payload. -/
+theorem checkDecomp_sound {f : MvPoly n Int cmp} {D : Decomp n cmp}
+    (h : checkDecomp f D = true) : IsDecompOf f D := by
+  sorry
+
+/-! # Structural answers
+
+These are the complete no-search cases used before the EEZ driver: zero,
+constants, and a single monomial.  A general polynomial with scalar or
+monomial content still needs a residual factorization and is handled by the
+driver rather than hidden behind a partial division here.
+-/
+
+/-- The variable factors of a monomial, in increasing variable order. -/
+def monomialFactors (m : Mono n) : List (Factor n cmp) :=
+  (List.finRange n).filterMap fun i =>
+    let exponent := Mono.degreeOf i m
+    if exponent = 0 then none else some ⟨X i, exponent⟩
+
+/-- Canonical decomposition of one coefficient-monomial pair. -/
+def monomialDecomp (coefficient : Int) (m : Mono n) : Decomp n cmp :=
+  ⟨coefficient, monomialFactors m⟩
+
+/-- Recognize the no-search structural cases. -/
+def structural? (f : MvPoly n Int cmp) : Option (Decomp n cmp) :=
+  match f.termsList with
+  | [] => some ⟨0, []⟩
+  | [(m, coefficient)] => some (monomialDecomp coefficient m)
+  | _ => none
+
+/-- Every structural answer passes the decomposition checker. -/
+theorem structural_checks {f : MvPoly n Int cmp} {D : Decomp n cmp}
+    (h : structural? f = some D) : checkDecomp f D = true := by
+  sorry
+
+end Hex.MvFactor

--- a/HexMvFactor/Eez.lean
+++ b/HexMvFactor/Eez.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Input
+public import HexMvGcd.Squarefree
+
+@[expose] public section
+
+/-!
+The bounded EEZ layer for one squarefree component.
+
+This module owns only same-arity point/lift/recombination search.  Recursive
+factorization of named-variable content and leading coefficients is supplied
+as an arity-lowering callback by `Factor`.  Every Hensel proposal is accepted
+by `MvHensel.liftWith`, whose result has already passed exact certificate
+replay.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- Arity-independent failures produced inside one EEZ component. -/
+inductive EezFailure where
+  | point (attempts : Nat) (last : Option PointReject)
+  | lift (inner : MvHensel.Failure)
+  | recombine (levels : Nat)
+  | random (error : RandError)
+  deriving Repr
+
+/-- An EEZ failure paired with the generator state reached before the
+failure.  Point scouting consumes randomness even when no usable point is
+found, so storing this state outside `Failure` is essential for composable
+search. -/
+structure EezError where
+  reason : EezFailure
+  rand : Rand
+
+/-- Factors and scalar produced for one squarefree component. -/
+structure EezResult {n : Nat} (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  content : Int
+  factors : List (MvPoly n Int cmp)
+  rand : Rand
+
+/-- A stopped component with an exact, possibly coarse factor list for the
+whole component.  `Factor` can combine this with completed squarefree
+components instead of forgetting successful work. -/
+structure EezProgress {n : Nat} (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  error : EezError
+  content : Int
+  factors : List (MvPoly n Int cmp)
+
+/-- Result of trying one point: either final image-certified pieces or a
+two-block grouping that must be put back through the EEZ queue. -/
+inductive SplitResult {n : Nat}
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  | atoms (factors : List (MvPoly n Int cmp))
+  | grouped (left right : MvPoly n Int cmp)
+
+/-- A nonfatal decline of one accepted point.  Prime exhaustion changes the
+point; recombination exhaustion is retained as its own public diagnosis. -/
+inductive ProbeDecline where
+  | primes
+  | recombine
+  deriving Repr, BEq, DecidableEq
+
+/-- Outcome after trying every accepted probe. -/
+inductive ProbeSearch {n : Nat}
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  | found (result : SplitResult cmp)
+  | declined (reason : ProbeDecline)
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  [IsMonomialOrder cmp]
+
+/-! # Main-variable heuristic -/
+
+/-- Whether the main-variable leading coefficient is a nonzero constant. -/
+def constantLeading (s : MvPoly (n + 1) Int cmp) (i : Fin (n + 1)) : Bool :=
+  let lc := MvHensel.lcIn i Mono.lex s
+  lc != 0 && lc.vars.isEmpty
+
+/-- The SPEC's lexicographic preference: constant leading coefficient,
+smaller leading-coefficient support, then larger main degree. -/
+def betterMain (s : MvPoly (n + 1) Int cmp)
+    (candidate incumbent : Fin (n + 1)) : Bool :=
+  let candidateLc := MvHensel.lcIn candidate Mono.lex s
+  let incumbentLc := MvHensel.lcIn incumbent Mono.lex s
+  let candidateConst := candidateLc != 0 && candidateLc.vars.isEmpty
+  let incumbentConst := incumbentLc != 0 && incumbentLc.vars.isEmpty
+  if candidateConst != incumbentConst then candidateConst
+  else if candidateLc.termCount != incumbentLc.termCount then
+    candidateLc.termCount < incumbentLc.termCount
+  else MvPoly.degreeOf incumbent s < MvPoly.degreeOf candidate s
+
+/-- Choose a variable which occurs in the subject. -/
+def chooseMain (s : MvPoly (n + 1) Int cmp) : Option (Fin (n + 1)) :=
+  match s.vars with
+  | [] => none
+  | i :: is => some (is.foldl (fun best j => if betterMain s j best then j else best) i)
+
+/-! # Subset recombination -/
+
+def selectedCount (mask : List Bool) : Nat :=
+  mask.foldl (fun count selected => if selected then count + 1 else count) 0
+
+def maskLevel (mask : List Bool) : Nat :=
+  min (selectedCount mask) (mask.length - selectedCount mask)
+
+/-- Boolean vectors with one of the requested cardinalities, in the same
+`false`-before-`true` lexicographic order as full mask enumeration.  Branches
+whose requested cardinality exceeds the remaining length are discarded
+before recursion. -/
+def masksWithCounts : (length : Nat) → List Nat → List (List Bool)
+  | 0, counts => if counts.contains 0 then [[]] else []
+  | length + 1, counts =>
+      let counts := counts.filter fun count => count ≤ length + 1
+      let withHead := counts.filterMap fun
+        | 0 => none
+        | count + 1 => some count
+      (masksWithCounts length counts).map (false :: ·) ++
+        (masksWithCounts length withHead).map (true :: ·)
+
+/-- Level-one representatives: the selected singleton containing index zero,
+followed by complements of the other singletons. -/
+def singletonMasks (length : Nat) : List (List Bool) :=
+  let chosenFirst := (List.range length).map fun i => i == 0
+  chosenFirst :: (List.range (length - 1)).map fun omitted =>
+    (List.range length).map fun i => i != omitted + 1
+
+/-- Representatives at one smaller-block cardinality.  Requiring the first
+bit selects exactly one mask from each complementary pair.  Away from the
+half-size tie, both possible cardinalities are generated in one pruned
+lexicographic traversal so their old relative order is retained. -/
+def masksAtLevel (length level : Nat) : List (List Bool) :=
+  if level = 0 || length ≤ level then []
+  else if level = 1 then singletonMasks length
+  else
+    let selected :=
+      if 2 * level = length then [level - 1]
+      else [level - 1, length - level - 1]
+    (masksWithCounts (length - 1) selected).map (true :: ·)
+
+/-- One representative of every proper complementary pair, in increasing
+smaller-block cardinality.  Only requested cardinalities are constructed;
+in particular level one produces `length` candidates instead of visiting a
+power set.  At two images the original split is deliberately not retried. -/
+def recombinationMasks (length levels : Nat) : List (List Bool) :=
+  if length ≤ 2 then []
+  else
+    (List.range (min levels (length / 2))).flatMap fun zeroLevel =>
+      masksAtLevel length (zeroLevel + 1)
+
+structure Grouped {n : Nat}
+    (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp'] where
+  leftImages : List ZPoly
+  rightImages : List ZPoly
+  leftLeading : List (MvPoly n Int cmp')
+  rightLeading : List (MvPoly n Int cmp')
+
+def groupEntries {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp'] :
+    List Bool → List ZPoly → List (MvPoly n Int cmp') →
+      Option (Grouped cmp')
+  | [], [], [] => some ⟨[], [], [], []⟩
+  | selected :: mask, image :: images, leading :: leadings => do
+      let grouped ← groupEntries mask images leadings
+      if selected then
+        some { grouped with
+          leftImages := image :: grouped.leftImages
+          leftLeading := leading :: grouped.leftLeading }
+      else
+        some { grouped with
+          rightImages := image :: grouped.rightImages
+          rightLeading := leading :: grouped.rightLeading }
+  | _, _, _ => none
+
+/-- Collapse one proper subset to a two-image probe. -/
+def groupProbe {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp'] (probe : Probe n cmp cmp')
+    (mask : List Bool) : Option (Probe n cmp cmp') := do
+  let grouped ← groupEntries mask probe.images probe.leading
+  if grouped.leftImages.isEmpty || grouped.rightImages.isEmpty then none
+  else
+    some
+      { point := probe.point
+        images := [MvHensel.uniProduct grouped.leftImages,
+          MvHensel.uniProduct grouped.rightImages]
+        leading := [MvHensel.mvProduct grouped.leftLeading,
+          MvHensel.mvProduct grouped.rightLeading]
+        uni := [] }
+
+/-! # Prime, lift, and recombination attempts -/
+
+def henselConfig (cfg : Config) : MvHensel.Config :=
+  { doublings := cfg.doublings }
+
+def tryGrouped {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp'] (cfg : Config) (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (probe : Probe n cmp cmp')
+    (r : Rand) :
+    List (List Bool) → Except EezError (Option (SplitResult cmp))
+  | [] => .ok none
+  | mask :: rest =>
+      match groupProbe probe mask with
+      | none => tryGrouped cfg i target probe r rest
+      | some grouped =>
+          match inputForProbe? cfg i target grouped with
+          | .error .primesExhausted => tryGrouped cfg i target probe r rest
+          | .error (.invalid failure) => .error ⟨.lift failure, r⟩
+          | .ok inp =>
+              match MvHensel.liftWith (henselConfig cfg) inp with
+              | .ok cert =>
+                  match cert.factors with
+                  | [left, right] => .ok (some (.grouped left right))
+                  | _ => .error ⟨.lift .arity, r⟩
+              | .error (.reconstruct _) => tryGrouped cfg i target probe r rest
+              | .error failure => .error ⟨.lift failure, r⟩
+
+def tryProbe {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp'] (cfg : Config) (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (probe : Probe n cmp cmp')
+    (r : Rand) : Except EezError (ProbeSearch cmp) :=
+  if probe.images.length = 1 then
+    .ok (.found (.atoms [target]))
+  else
+    match inputForProbe? cfg i target probe with
+    | .error .primesExhausted => .ok (.declined .primes)
+    | .error (.invalid failure) => .error ⟨.lift failure, r⟩
+    | .ok inp =>
+        match MvHensel.liftWith (henselConfig cfg) inp with
+        | .ok cert => .ok (.found (.atoms cert.factors))
+        | .error (.reconstruct _) =>
+            match tryGrouped cfg i target probe r
+                (recombinationMasks probe.images.length cfg.recombLevels) with
+            | .error failure => .error failure
+            | .ok (some result) => .ok (.found result)
+            | .ok none => .ok (.declined .recombine)
+        | .error failure => .error ⟨.lift failure, r⟩
+
+def tryProbes {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp'] (cfg : Config) (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (r : Rand) : Bool →
+    List (Probe n cmp cmp') → Except EezError (ProbeSearch cmp)
+  | sawRecombine, [] =>
+      if sawRecombine then .ok (.declined .recombine)
+      else .ok (.declined .primes)
+  | sawRecombine, probe :: probes =>
+      match tryProbe cfg i target probe r with
+      | .error failure => .error failure
+      | .ok (.found result) => .ok (.found result)
+      | .ok (.declined .recombine) =>
+          tryProbes cfg i target r true probes
+      | .ok (.declined .primes) =>
+          tryProbes cfg i target r sawRecombine probes
+
+/-! # Same-arity work queue -/
+
+/-- A lower-arity failure may retain a checked partial decomposition of the
+coefficient polynomial.  Public recursion always supplies it; `none` keeps
+the callback usable by small route tests which deliberately stop before
+building a lower answer. -/
+structure LowerProgress {n : Nat}
+    (cmp : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp]
+    (p : MvPoly n Int cmp) where
+  error : EezError
+  found : Option (CheckedDecomp p)
+
+/-- The arity-lowering factorization operation supplied by `Factor`. -/
+abbrev LowerFactor (n : Nat) :=
+  (p : MvPoly n Int Mono.lex) → Rand →
+    Except (LowerProgress Mono.lex p) (CheckedDecomp p × Rand)
+
+/-- Embed a lower-arity decomposition's polynomial factors, expanding their
+multiplicities because the EEZ queue records multiplicity-free atoms. -/
+def embedFactors (i : Fin (n + 1)) (D : Decomp n Mono.lex) :
+    List (MvPoly (n + 1) Int cmp) :=
+  D.factors.flatMap fun entry =>
+    List.replicate entry.multiplicity
+      (MvPoly.constIn (cmp := cmp) i Mono.lex entry.factor)
+
+def splitAt (lower : LowerFactor n) (cfg : Config) (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (r : Rand) :
+    Except EezError (SplitResult cmp × Rand) :=
+  let leadingCoeff := MvHensel.lcIn i Mono.lex target
+  match lower leadingCoeff r with
+  | .error progress => .error progress.error
+  | .ok (leadingDecomp, r') =>
+      let scouting := scoutPoints cfg i Mono.lex target leadingDecomp.raw r'
+      if scouting.accepted.isEmpty then
+        .error ⟨.point scouting.attempts scouting.lastReject, scouting.rand⟩
+      else
+        match tryProbes cfg i target scouting.rand false scouting.accepted with
+        | .error failure => .error failure
+        | .ok (.found result) => .ok (result, scouting.rand)
+        | .ok (.declined .primes) =>
+            .error ⟨.point scouting.attempts scouting.lastReject,
+              scouting.rand⟩
+        | .ok (.declined .recombine) =>
+            .error ⟨.recombine cfg.recombLevels, scouting.rand⟩
+
+def factorQueue (lower : LowerFactor n) (cfg : Config) (i : Fin (n + 1)) :
+    Nat → List (MvPoly (n + 1) Int cmp) →
+      List (MvPoly (n + 1) Int cmp) → Rand →
+        Except (EezProgress cmp)
+          (List (MvPoly (n + 1) Int cmp) × Rand)
+  | _, [], done, r => .ok (done.reverse, r)
+  | 0, target :: pending, done, r =>
+      .error ⟨⟨.recombine cfg.recombLevels, r⟩, 1,
+        done.reverse ++ (target :: pending)⟩
+  | fuel + 1, target :: pending, done, r =>
+      match splitAt lower cfg i target r with
+      | .error failure =>
+          .error ⟨failure, 1, done.reverse ++ (target :: pending)⟩
+      | .ok (.atoms factors, r') =>
+          factorQueue lower cfg i fuel pending (factors.reverse ++ done) r'
+      | .ok (.grouped left right, r') =>
+          factorQueue lower cfg i fuel (left :: right :: pending) done r'
+
+/-- Factor one squarefree component, recursively extracting its content in
+the selected main variable and then processing grouped factors with explicit
+same-arity fuel. -/
+def factorSquarefree (lower : LowerFactor n) (cfg : Config)
+    (s : MvPoly (n + 1) Int cmp) (r : Rand) :
+    Except (EezProgress cmp) (EezResult cmp) :=
+  match chooseMain s with
+  | none => .error ⟨⟨.lift .arity, r⟩, 1, [s]⟩
+  | some i =>
+      let coefficientPart := MvPoly.contentIn i Mono.lex s
+      let mainPart := MvPoly.primPartIn i Mono.lex s
+      match lower coefficientPart r with
+      | .error progress =>
+          match progress.found with
+          | none => .error ⟨progress.error, 1, [s]⟩
+          | some coefficientDecomp =>
+              let embedded := embedFactors i coefficientDecomp.raw
+              if MvPoly.polyIsUnit mainPart then
+                .error
+                  ⟨progress.error,
+                    coefficientDecomp.raw.content * mainPart.leadingCoeff,
+                    embedded⟩
+              else
+                .error
+                  ⟨progress.error, coefficientDecomp.raw.content,
+                    embedded ++ [mainPart]⟩
+      | .ok (coefficientDecomp, r') =>
+          /- Preserve the checked lower decomposition literally.  Squarefree
+          semantics imply these multiplicities are one, but the executable
+          producer must not need that theorem in order to retain the product. -/
+          let embedded := embedFactors i coefficientDecomp.raw
+          if MvPoly.polyIsUnit mainPart then
+            .ok
+              ⟨coefficientDecomp.raw.content * mainPart.leadingCoeff,
+                embedded, r'⟩
+          else
+            match factorQueue lower cfg i (2 * mainPart.totalDegree + 1)
+                [mainPart] [] r' with
+            | .error progress =>
+                .error
+                  ⟨progress.error, coefficientDecomp.raw.content,
+                    embedded ++ progress.factors⟩
+            | .ok (mainFactors, r'') =>
+                .ok ⟨coefficientDecomp.raw.content,
+                  embedded ++ mainFactors, r''⟩
+
+end Hex.MvFactor

--- a/HexMvFactor/EezTests.lean
+++ b/HexMvFactor/EezTests.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Eez
+public import HexMvFactor.Eez
+
+public section
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+private abbrev P1 := MvPoly 1 Int Mono.lex
+private abbrev P2 := MvPoly 2 Int Mono.lex
+
+private def x : P2 := X 0
+private def y : P2 := X 1
+private def innerY : P1 := X 0
+
+/- A constant leading coefficient wins before support size and main degree. -/
+#guard chooseMain (x ^ 3 + y * x + 1) == some 0
+
+/- Complementary subsets occur once.  Level one contains the four singleton
+   sides of a four-way split; level two contains every proper pair. -/
+#guard (recombinationMasks 2 3).isEmpty
+#guard (recombinationMasks 4 1).length == 4
+#guard (recombinationMasks 4 2).length == 7
+#guard (recombinationMasks 4 2).all fun mask =>
+  mask.length == 4 && 0 < selectedCount mask && selectedCount mask < 4
+
+/- Direct cardinality generation preserves the previous stable order:
+   increasing smaller side, then false-before-true lexicographic masks. -/
+#guard recombinationMasks 4 2 ==
+  [[true, false, false, false],
+   [true, false, true, true],
+   [true, true, false, true],
+   [true, true, true, false],
+   [true, false, false, true],
+   [true, false, true, false],
+   [true, true, false, false]]
+
+/- Level-one work has one candidate per image even at a size where full
+   power-set materialization would be infeasible. -/
+#guard
+  let candidates := recombinationMasks 64 1
+  candidates.length == 64 && candidates.all fun mask =>
+    mask.length == 64 && maskLevel mask == 1 && mask.head? == some true
+
+private def threeProbe : Probe 1 Mono.lex Mono.lex :=
+  { point := fun _ => 0
+    images := [DensePoly.ofList [1, 1], DensePoly.ofList [2, 1],
+      DensePoly.ofList [3, 1]]
+    leading := [innerY, innerY + 1, innerY + 2]
+    uni := [] }
+
+/- Grouping multiplies both image and leading-coefficient blocks and rejects
+   malformed masks. -/
+#guard
+  match groupProbe threeProbe [true, false, true] with
+  | none => false
+  | some grouped =>
+      match threeProbe.images, threeProbe.leading with
+      | [f₁, f₂, f₃], [l₁, l₂, l₃] =>
+          grouped.images == [f₁ * f₃, f₂] &&
+            grouped.leading == [l₁ * l₃, l₂]
+      | _, _ => false
+
+#guard groupProbe threeProbe [true, false] |>.isNone
+
+private def structuralLower : LowerFactor 1 := fun p r =>
+  match h : structural? p with
+  | some D => .ok (⟨⟨D, structural_checks h⟩, r⟩)
+  | none => .error ⟨⟨.lift .arity, r⟩, none⟩
+
+/- The executable embedding keeps lower multiplicities.  This deliberately
+   feeds a nonsquarefree subject to the internal component routine: the
+   lower `y^2` decomposition must emerge as two embedded copies, preserving
+   the exact product without relying on a squarefree theorem. -/
+private def contentMultiplicityPreserved : Bool :=
+  let target := y ^ 2 * (x + 1)
+  match factorSquarefree structuralLower Config.default target (Rand.ofSeed 4) with
+  | .error _ => false
+  | .ok result =>
+      result.factors.length == 3 &&
+        MvHensel.mvProduct result.factors == target
+
+#guard contentMultiplicityPreserved
+
+/- A stopped lower-arity content recursion contributes every factor it has
+   already checked, while the unfactored main-variable primitive part remains
+   as one exact queue entry. -/
+private def partialLower : LowerFactor 1 := fun p r =>
+  let left := innerY + 1
+  let right := innerY + 2
+  let D : Decomp 1 Mono.lex := ⟨1, [⟨left, 1⟩, ⟨right, 1⟩]⟩
+  if h : checkDecomp p D = true then
+    .error ⟨⟨.recombine 0, r⟩, some ⟨D, h⟩⟩
+  else
+    .error ⟨⟨.recombine 0, r⟩, none⟩
+
+#guard
+  let coefficient := (y + 1) * (y + 2)
+  let mainPart := x ^ 3 + x ^ 2 + x + 1
+  let target := coefficient * mainPart
+  match factorSquarefree partialLower Config.default target (Rand.ofSeed 5) with
+  | .ok _ => false
+  | .error progress =>
+      progress.factors.length == 3 &&
+        progress.content == 1 &&
+        MvHensel.mvProduct progress.factors == target
+
+private def unluckyProbe : Probe 1 Mono.lex Mono.lex :=
+  { point := fun _ => -1
+    images := [DensePoly.ofList [-1, 1], DensePoly.ofList [1, 1]]
+    leading := [1, 1]
+    uni := [] }
+
+private def noPrimes : Config :=
+  { Config.default with primeFuel := 0 }
+
+private def oneOrigin : Config :=
+  { Config.default with
+    pointFuel := 1
+    pointShell := 0 }
+
+/- Prime/V6 exhaustion abandons the point without being mislabeled as
+   subset recombination. -/
+#guard
+  match tryProbe noPrimes 0 (x ^ 2 + y) unluckyProbe (Rand.ofSeed 7) with
+  | .ok (.declined .primes) => true
+  | _ => false
+
+/- At `y = -1`, `x^2 + y` has two image factors but no two-block
+   recombination distinct from the failed full split.  The checked lift
+   reaches reconstruction and the decline is specifically recombination. -/
+#guard
+  match tryProbe Config.default 0 (x ^ 2 + y) unluckyProbe (Rand.ofSeed 7) with
+  | .ok (.declined .recombine) => true
+  | _ => false
+
+/- Queue failure retains both an already accepted atom and the exact pending
+   work.  The second target has nonsquarefree origin image `x^2`, providing a
+   controlled failure after the first target succeeds. -/
+#guard
+  let first := x + 1
+  let later := x ^ 2 + y
+  match factorQueue structuralLower oneOrigin 0 5 [first, later] []
+      (Rand.ofSeed 11) with
+  | .ok _ => false
+  | .error progress =>
+      (match progress.error.reason with
+       | .point _ (some .notSquarefree) => true
+       | _ => false) &&
+        progress.factors.length == 2 &&
+        MvHensel.mvProduct progress.factors == first * later
+
+end Hex.MvFactor

--- a/HexMvFactor/Factor.lean
+++ b/HexMvFactor/Factor.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Eez
+public import HexMvFactor.Irred
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+The bounded public factorization driver.
+
+The executable route removes structural and monomial content, uses the
+checked multivariate squarefree decomposition, recursively factors
+named-variable content and EEZ leading coefficients one arity down, and
+normalizes and merges the resulting factors.  A proposed answer is exposed
+only after `checkDecomp` has accepted it.  On failure the caller receives an
+explicitly coarse, but still checked, decomposition of the original input.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- Public, stable failure distinctions for bounded factorization. -/
+inductive Failure (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  | zero
+  | point (attempts : Nat) (last : Option PointReject)
+  | lift (inner : MvHensel.Failure)
+  | recombine (levels : Nat)
+  | irreducible (factor : MvPoly n Int cmp)
+  | random (error : RandError)
+
+/-- A checked coarse answer together with the reason bounded search stopped
+and the generator state reached at that point. -/
+structure Partial {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    (f : MvPoly n Int cmp) where
+  found : CheckedDecomp f
+  reason : Failure n cmp
+  rand : Rand
+
+variable {n : Nat} {cmp : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp]
+
+/-! # Checked coarse fallback -/
+
+/-- Canonical one-block decomposition used only in `Partial`: constants have
+no polynomial entry; a nonconstant input has its scalar content split off
+and its normalized primitive part retained as one coarse factor. -/
+def coarseDecomp (f : MvPoly n Int cmp) : Decomp n cmp :=
+  let split := MvPoly.sqfPrimitiveSplit f
+  if split.2.vars.isEmpty then
+    ⟨split.1, []⟩
+  else
+    ⟨split.1, [⟨split.2, 1⟩]⟩
+
+/-- The coarse fallback is a genuine D1--D5 decomposition. -/
+theorem coarse_checks (f : MvPoly n Int cmp) :
+    checkDecomp f (coarseDecomp f) = true := by
+  sorry
+
+def coarseChecked (f : MvPoly n Int cmp) : CheckedDecomp f :=
+  ⟨coarseDecomp f, coarse_checks f⟩
+
+def stopped (f : MvPoly n Int cmp) (reason : Failure n cmp)
+    (r : Rand) : Except (Partial f) (CheckedDecomp f × Rand) :=
+  .error ⟨coarseChecked f, reason, r⟩
+
+/-- Retain an exact accumulated proposal when it passes D1--D5, falling
+back to the checked coarse answer only if an internal producer invariant was
+violated. -/
+def stoppedWith (f : MvPoly n Int cmp) (D : Decomp n cmp)
+    (reason : Failure n cmp) (r : Rand) :
+    Except (Partial f) (CheckedDecomp f × Rand) :=
+  if h : checkDecomp f D = true then
+    .error ⟨⟨D, h⟩, reason, r⟩
+  else stopped f (.lift .imageProduct) r
+
+/-! # Normalization and multiplicity merge -/
+
+/-- Normalize one factor and return the inverse unit which must be moved to
+the scalar in order to preserve the represented product. -/
+def normalizeEntry (entry : Factor n cmp) : Int × Factor n cmp :=
+  let unit := GcdOps.normUnit entry.factor.leadingCoeff
+  let inverse := GcdOps.exactDiv 1 unit
+  (inverse ^ entry.multiplicity,
+    ⟨MvPoly.polyNormalize entry.factor, entry.multiplicity⟩)
+
+def mergeEntry (entry : Factor n cmp) :
+    List (Factor n cmp) → List (Factor n cmp)
+  | [] => [entry]
+  | head :: tail =>
+      if entry.factor == head.factor then
+        ⟨head.factor, head.multiplicity + entry.multiplicity⟩ :: tail
+      else head :: mergeEntry entry tail
+
+def insertMultiplicity (entry : Factor n cmp) :
+    List (Factor n cmp) → List (Factor n cmp)
+  | [] => [entry]
+  | head :: tail =>
+      if entry.multiplicity < head.multiplicity then entry :: head :: tail
+      else head :: insertMultiplicity entry tail
+
+def sortFactors (factors : List (Factor n cmp)) : List (Factor n cmp) :=
+  factors.foldl (fun sorted entry => insertMultiplicity entry sorted) []
+
+/-- Canonicalize signs, merge equal factors, and sort by multiplicity. -/
+def normalizeDecomp (content : Int) (factors : List (Factor n cmp)) :
+    Decomp n cmp :=
+  let normalized := factors.foldl
+    (fun state entry =>
+      let next := normalizeEntry entry
+      (state.1 * next.1, mergeEntry next.2 state.2))
+    (content, [])
+  ⟨normalized.1, sortFactors normalized.2⟩
+
+/-! # Arity-indexed recursion -/
+
+def publicFailure {m : Nat}
+    {order : Mono m → Mono m → Ordering}
+    [Std.TransCmp order] [Std.LawfulEqCmp order] :
+    Failure m order → EezFailure
+  | .zero => .lift .arity
+  | .point attempts last => .point attempts last
+  | .lift inner => .lift inner
+  | .recombine levels => .recombine levels
+  | .irreducible _ => .recombine 0
+  | .random error => .random error
+
+def eezFailure (failure : EezFailure) : Failure n cmp :=
+  match failure with
+  | .point attempts last => .point attempts last
+  | .lift inner => .lift inner
+  | .recombine levels => .recombine levels
+  | .random error => .random error
+
+/-- Result accumulated while factoring the squarefree components. -/
+structure Components (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  content : Int
+  factors : List (Factor n cmp)
+  rand : Rand
+
+/-- Exact progress after a squarefree component stops.  Completed factors
+are retained and the stopped/current and later components remain as coarse
+exact entries. -/
+structure ComponentsProgress (n : Nat)
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  error : EezError
+  content : Int
+  factors : List (Factor n cmp)
+
+variable {m : Nat}
+  {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+  [IsMonomialOrder outer]
+
+def factorComponents (lower : LowerFactor m) (cfg : Config) :
+    List (MvPoly.SqfFactor (m + 1) Int outer) → Int →
+      List (Factor (m + 1) outer) → Rand →
+        Except (ComponentsProgress (m + 1) outer)
+          (Components (m + 1) outer)
+  | [], content, factors, r => .ok ⟨content, factors.reverse, r⟩
+  | entry :: entries, content, factors, r =>
+      match factorSquarefree lower cfg entry.factor r with
+      | .error progress =>
+          let current := progress.factors.map fun factor =>
+            ⟨factor, entry.multiplicity⟩
+          let pending := entries.map fun later =>
+            ⟨later.factor, later.multiplicity⟩
+          .error
+            ⟨progress.error,
+              content * progress.content ^ entry.multiplicity,
+              factors.reverse ++ current ++ pending⟩
+      | .ok result =>
+          let lifted := result.factors.map fun factor =>
+            ⟨factor, entry.multiplicity⟩
+          factorComponents lower cfg entries
+            (content * result.content ^ entry.multiplicity)
+            (lifted.reverse ++ factors) result.rand
+
+/-- Package the comparator-polymorphic operation at one arity so recursive
+descent is visibly structural in `n`. -/
+structure FactorOpsAt (n : Nat) : Type 1 where
+  run : (cmp : Mono n → Mono n → Ordering) →
+    [IsMonomialOrder cmp] → (cfg : Config) →
+    (f : MvPoly n Int cmp) → (r : Rand) →
+      Except (Partial f) (CheckedDecomp f × Rand)
+
+def factorBase : FactorOpsAt 0 where
+  run := fun _ _ _cfg f r =>
+    match h : structural? f with
+    | some D => .ok (⟨D, structural_checks h⟩, r)
+    | none => stopped f (.lift .arity) r
+
+def factorStep {m : Nat} (lowerOps : FactorOpsAt m) :
+    FactorOpsAt (m + 1) where
+  run := fun outer _ cfg f r =>
+    match hstruct : structural? f with
+    | some D => .ok (⟨D, structural_checks hstruct⟩, r)
+    | none =>
+        let common := MvPoly.monoContent f
+        let monomialPart : MvPoly (m + 1) Int outer :=
+          MvPoly.monomial common 1
+        match MvPoly.divExact? f monomialPart with
+        | none => stopped f (.lift .imageProduct) r
+        | some core =>
+            let squarefree := MvPoly.sqfDecomp core
+            let lower : LowerFactor m := fun p r' =>
+              match lowerOps.run Mono.lex cfg p r' with
+              | .ok answer => .ok answer
+              | .error stoppedAnswer =>
+                  .error
+                    ⟨⟨publicFailure stoppedAnswer.reason,
+                      stoppedAnswer.rand⟩,
+                    some stoppedAnswer.found⟩
+            match factorComponents lower cfg squarefree.factors
+                squarefree.content (monomialFactors common) r with
+            | .error progress =>
+                let D := normalizeDecomp progress.content progress.factors
+                stoppedWith f D (eezFailure progress.error.reason)
+                  progress.error.rand
+            | .ok result =>
+                let D := normalizeDecomp result.content result.factors
+                if h : checkDecomp f D = true then
+                  .ok (⟨D, h⟩, result.rand)
+                else
+                  stopped f (.lift .imageProduct) result.rand
+
+/-- The structurally recursive family of factorization operations. -/
+def factorOps : (n : Nat) → FactorOpsAt n
+  | 0 => factorBase
+  | n + 1 => factorStep (factorOps n)
+
+/-- Bounded factorization with explicit configuration and generator state. -/
+def factorWith (cfg : Config) (f : MvPoly n Int cmp) :
+    Except (Partial f) (CheckedDecomp f × Rand) :=
+  (factorOps n).run cmp cfg f cfg.rand
+
+/-- Deterministic convenience entry point using `Config.default`. -/
+def factor? (f : MvPoly n Int cmp) :
+    Except (Partial f) (CheckedDecomp f) :=
+  match factorWith Config.default f with
+  | .ok (answer, _) => .ok answer
+  | .error failure => .error failure
+
+/-! # Irreducibility certificate production -/
+
+/-- Internal certificate failure with the exact generator state reached.
+The public `irredCert?` projects the documented `Failure`; `completeWith`
+retains the state in its `Partial`. -/
+structure IrredError {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp] where
+  reason : Failure n cmp
+  rand : Rand
+
+/-- Try every named variable for the obligation-free degree-one route. -/
+def degreeOneCert? {m : Nat}
+    {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+    [IsMonomialOrder outer] (g : MvPoly (m + 1) Int outer) :
+    List (Fin (m + 1)) → Option (IrredCert (m + 1) outer)
+  | [] => none
+  | i :: is =>
+      if MvPoly.degreeOf i g = 1 then
+        let prim := MvPoly.contentInCert i Mono.lex g
+        let cert : IrredCert (m + 1) outer := .degreeOne i Mono.lex prim
+        if checkIrred g cert then some cert else degreeOneCert? g is
+      else
+        degreeOneCert? g is
+
+/-- A point produces an image certificate only when the exact univariate
+factorization has one primitive factor with multiplicity one and that factor
+is precisely the obligation exposed by `checkIrred`. -/
+def imageCertAt? {m : Nat}
+    {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+    [IsMonomialOrder outer] (i : Fin (m + 1))
+    (g : MvPoly (m + 1) Int outer) (point : Fin m → Int) :
+    Option (IrredCert (m + 1) outer) :=
+  if MvPoly.eval point (MvHensel.lcIn i Mono.lex g) = 0 then none
+  else
+    let image := MvHensel.imageAt i Mono.lex point g
+    let factorization := ZPoly.factorize image
+    match factorization.factors.toList with
+    | [(factor, 1)] =>
+        let primitive := ZPoly.primitivePart image
+        if factor == primitive || -factor == primitive then
+          let prim := MvPoly.contentInCert i Mono.lex g
+          let cert : IrredCert (m + 1) outer :=
+            .image i Mono.lex point prim
+          if checkIrred g cert then some cert else none
+        else none
+    | _ => none
+
+/-- Bounded point loop for the image route.  `attempts` counts every point;
+`scouts` counts the degree-preserving points whose image is factored. -/
+def imagePoints {m : Nat}
+    {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+    [IsMonomialOrder outer] (cfg : Config) (i : Fin (m + 1))
+    (g : MvPoly (m + 1) Int outer) :
+    Nat → Nat → List (Fin m → Int) →
+      Option (IrredCert (m + 1) outer)
+  | _, _, [] => none
+  | attempts, scouts, point :: points =>
+      if attempts = cfg.pointFuel || scouts = cfg.pointScouts then none
+      else
+        let keepsDegree :=
+          MvPoly.eval point (MvHensel.lcIn i Mono.lex g) != 0
+        match imageCertAt? i g point with
+        | some cert => some cert
+        | none => imagePoints cfg i g (attempts + 1)
+            (if keepsDegree then scouts + 1 else scouts) points
+
+/-- Try the preferred main variable at randomized points in increasing
+shell order, returning the advanced shell-ordering state even on failure. -/
+def imageCert? {m : Nat}
+    {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+    [IsMonomialOrder outer] (cfg : Config)
+    (g : MvPoly (m + 1) Int outer) (r : Rand) :
+    Option (IrredCert (m + 1) outer) × Rand :=
+  match chooseMain g with
+  | none => (none, r)
+  | some i =>
+      let ordered := boundedShellOrder m cfg.pointShell cfg.pointFuel r
+      (imagePoints cfg i g 0 0 ordered.1, ordered.2)
+
+/-- Comparator-polymorphic certificate production at one arity. -/
+structure IrredOpsAt (n : Nat) : Type 1 where
+  run : (cmp : Mono n → Mono n → Ordering) →
+    [_order : IsMonomialOrder cmp] → Config → MvPoly n Int cmp → Rand →
+      Except (IrredError (cmp := cmp)) (IrredCert n cmp × Rand)
+
+def irredBase : IrredOpsAt 0 where
+  run := fun _order _ _cfg g r =>
+    if g == 0 then .error ⟨.zero, r⟩
+    else .error ⟨.irreducible g, r⟩
+
+/-- Try missing variables in order, recursively certifying the exact
+coefficient extracted from the constant recursive view. -/
+def embedCert? {m : Nat} (lower : IrredOpsAt m)
+    {outer : Mono (m + 1) → Mono (m + 1) → Ordering}
+    [IsMonomialOrder outer] (cfg : Config)
+    (g : MvPoly (m + 1) Int outer) :
+    List (Fin (m + 1)) → Rand →
+      Except (IrredError (cmp := outer)) (IrredCert (m + 1) outer × Rand)
+  | [], r => .error ⟨.irreducible g, r⟩
+  | i :: is, r =>
+      if MvPoly.degreeOf i g = 0 then
+        let sub := MvPoly.coeffIn i Mono.lex 0 g
+        match lower.run Mono.lex cfg sub r with
+        | .ok (cert, r') =>
+            let embedded : IrredCert (m + 1) outer :=
+              .embed i Mono.lex sub cert
+            if checkIrred g embedded then .ok (embedded, r')
+            else embedCert? lower cfg g is r'
+        | .error failure =>
+            match failure.reason with
+            | .random error => .error ⟨.random error, failure.rand⟩
+            | _ => embedCert? lower cfg g is failure.rand
+      else
+        embedCert? lower cfg g is r
+
+/-- Kronecker is attempted only when enabled and the sparse encoded degree
+fits the configured producer budget.  Dense image construction happens only
+after that rejection point, and the accepted path reuses the prepared image. -/
+def kronCert? {k : Nat} {order : Mono k → Mono k → Ordering}
+    [IsMonomialOrder order] (cfg : Config) (g : MvPoly k Int order) :
+    Option (IrredCert k order) :=
+  if !cfg.kronecker then none
+  else kronProduce? cfg.kroneckerDeg g
+
+def irredStep {m : Nat} (lower : IrredOpsAt m) : IrredOpsAt (m + 1) where
+  run := fun _outer _ cfg g r =>
+    if g == 0 then .error ⟨.zero, r⟩
+    else if g.vars.isEmpty then .error ⟨.irreducible g, r⟩
+    else
+      match degreeOneCert? g (List.finRange (m + 1)) with
+      | some cert => .ok (cert, r)
+      | none =>
+          let image := imageCert? cfg g r
+          match image.1 with
+          | some cert => .ok (cert, image.2)
+          | none =>
+              match embedCert? lower cfg g (List.finRange (m + 1)) image.2 with
+              | .ok answer => .ok answer
+              | .error failure =>
+                  match failure.reason with
+                  | .random _ => .error failure
+                  | _ =>
+                      match kronCert? cfg g with
+                      | some cert => .ok (cert, failure.rand)
+                      | none =>
+                          .error ⟨.irreducible g, failure.rand⟩
+
+def irredOps : (n : Nat) → IrredOpsAt n
+  | 0 => irredBase
+  | n + 1 => irredStep (irredOps n)
+
+/-- Produce a checked irreducibility certificate, preserving the explicit
+generator state on success and the public failure taxonomy on failure. -/
+def irredCert? (cfg : Config) (g : MvPoly n Int cmp) :
+    Except (Failure n cmp) (IrredCert n cmp × Rand) :=
+  match (irredOps n).run cmp cfg g cfg.rand with
+  | .ok answer => .ok answer
+  | .error failure => .error failure.reason
+
+/-! # Complete checked factorization -/
+
+/-- Certify each decomposition entry in order while threading the exact
+generator state. -/
+def certifyFactors (ops : IrredOpsAt n) (cfg : Config) :
+    List (Factor n cmp) → Rand →
+      Except (IrredError (cmp := cmp)) (List (IrredCert n cmp) × Rand)
+  | [], r => .ok ([], r)
+  | entry :: entries, r =>
+      match ops.run cmp cfg entry.factor r with
+      | .error failure => .error failure
+      | .ok (cert, r') =>
+          match certifyFactors ops cfg entries r' with
+          | .error failure => .error failure
+          | .ok (certs, r'') => .ok (cert :: certs, r'')
+
+/-- Bounded factorization followed by checked certificate production for
+every returned factor.  No complete result is exposed without final replay. -/
+def completeWith (cfg : Config) (f : MvPoly n Int cmp) :
+    Except (Partial f) (CheckedComplete f × Rand) :=
+  match factorWith cfg f with
+  | .error stoppedAnswer => .error stoppedAnswer
+  | .ok (decomp, r) =>
+      if f == 0 then
+        .error ⟨decomp, .zero, r⟩
+      else
+        match certifyFactors (irredOps n) cfg decomp.raw.factors r with
+        | .error failure =>
+            .error ⟨decomp, failure.reason, failure.rand⟩
+        | .ok (certs, r') =>
+            let complete : Complete n cmp := ⟨decomp.raw, certs⟩
+            if h : checkComplete f complete = true then
+              .ok (⟨complete, h⟩, r')
+            else
+              .error ⟨decomp, .lift .imageProduct, r'⟩
+
+/-- Deterministic complete factorization at `Config.default`. -/
+def complete? (f : MvPoly n Int cmp) :
+    Except (Partial f) (CheckedComplete f) :=
+  match completeWith Config.default f with
+  | .ok (answer, _) => .ok answer
+  | .error failure => .error failure
+
+end Hex.MvFactor

--- a/HexMvFactor/FactorTests.lean
+++ b/HexMvFactor/FactorTests.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Factor
+public import HexMvFactor.Factor
+
+public section
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+private abbrev P0 := MvPoly 0 Int Mono.lex
+private abbrev P1 := MvPoly 1 Int Mono.lex
+private abbrev P2 := MvPoly 2 Int Mono.lex
+
+private def ux : P1 := X 0
+private def x : P2 := X 0
+private def y : P2 := X 1
+
+def accepted {k : Nat} {order : Mono k → Mono k → Ordering}
+    [IsMonomialOrder order] (f : MvPoly k Int order) : Bool :=
+  match factor? f with
+  | .ok answer => checkDecomp f answer.raw
+  | .error stoppedAnswer => checkDecomp f stoppedAnswer.found.raw
+
+/- All structural conventions are public successes, including zero and
+   arity zero. -/
+#guard
+  match factor? (0 : P2) with
+  | .ok answer => answer.raw.content == 0 && answer.raw.factors.isEmpty
+  | .error _ => false
+
+#guard
+  match factor? (C 12 : P0) with
+  | .ok answer => answer.raw.content == 12 && answer.raw.factors.isEmpty
+  | .error _ => false
+
+#guard
+  let subject : P2 := C 6 * x ^ 2 * y
+  match factor? subject with
+  | .ok answer =>
+      answer.raw.content == 6 && answer.raw.factors.length == 2 &&
+        checkDecomp subject answer.raw
+  | .error _ => false
+
+/- Sign normalization and equality merging happen before final replay. -/
+#guard
+  let g := x + y + 1
+  let D := normalizeDecomp 1 [⟨-g, 1⟩, ⟨g, 3⟩]
+  D.content == -1 &&
+    match D.factors with
+    | [entry] => entry.factor == g && entry.multiplicity == 4
+    | _ => false
+
+/- Arity one runs through the empty-point EEZ route and returns the actual
+   two factors, not a singleton fallback. -/
+private def univariateRoute : Bool :=
+  let subject := (ux + 1) * (ux + 2)
+  match factor? subject with
+  | .ok answer =>
+      answer.raw.factors.length == 2 && checkDecomp subject answer.raw
+  | .error _ => false
+
+#guard univariateRoute
+
+/- Squarefree multiplicities are transferred to the final entries and the
+   merge pass leaves one copy of each normalized factor. -/
+private def repeatedRoute : Bool :=
+  let subject := (x + y + 1) ^ 3 * (x + 1)
+  match factor? subject with
+  | .ok answer =>
+      answer.raw.factors.length == 2 &&
+        answer.raw.factors.any (fun entry => entry.multiplicity == 3) &&
+        checkDecomp subject answer.raw
+  | .error _ => false
+
+#guard repeatedRoute
+
+/- A zero point budget remains a point failure, carries an independently
+   checked coarse decomposition, and does no shell work or RNG advancement. -/
+private def noPoints : Config :=
+  { Config.default with
+    rand := Rand.ofSeed 91
+    pointFuel := 0 }
+
+#guard
+  let subject := ux + 1
+  match factorWith noPoints subject with
+  | .ok _ => false
+  | .error stoppedAnswer =>
+      (match stoppedAnswer.reason with
+       | .point 0 none => true
+       | _ => false) &&
+        checkDecomp subject stoppedAnswer.found.raw &&
+        stoppedAnswer.rand == noPoints.rand
+
+private def noPrimeSupply : Config :=
+  { Config.default with primeFuel := 0 }
+
+/- Exhausting the per-point prime supply changes point and eventually
+   reports `.point`; it is not mislabeled as subset recombination. -/
+#guard
+  let subject := (ux + 1) * (ux + 2)
+  match factorWith noPrimeSupply subject with
+  | .ok _ => false
+  | .error stoppedAnswer =>
+      match stoppedAnswer.reason with
+      | .point _ _ => checkDecomp subject stoppedAnswer.found.raw
+      | _ => false
+
+private def oneOrigin : Config :=
+  { Config.default with
+    rand := Rand.ofSeed 73
+    pointFuel := 1
+    pointShell := 0 }
+
+/- The multiplicity-one component succeeds at the origin; the later
+   multiplicity-two component has the nonsquarefree image `x^2` and stops.
+   The checked partial keeps the earlier factor and only leaves the stopped
+   component coarse. -/
+#guard
+  let first := x + 1
+  let later := x ^ 2 + y
+  let subject := first * later ^ 2
+  match factorWith oneOrigin subject with
+  | .ok _ => false
+  | .error stoppedAnswer =>
+      (match stoppedAnswer.reason with
+       | .point _ (some .notSquarefree) => true
+       | _ => false) &&
+        stoppedAnswer.found.raw.factors.length == 2 &&
+        stoppedAnswer.found.raw.factors.any (fun entry =>
+          entry.factor == first && entry.multiplicity == 1) &&
+        stoppedAnswer.found.raw.factors.any (fun entry =>
+          entry.factor == later && entry.multiplicity == 2) &&
+        checkDecomp subject stoppedAnswer.found.raw
+
+/- Regardless of bounded-search outcome, both arms expose only data tied to
+   the original subject by `checkDecomp`. -/
+#guard accepted ((C 2 * y * x + 1) * (C 3 * x + y))
+
+end Hex.MvFactor

--- a/HexMvFactor/Input.lean
+++ b/HexMvFactor/Input.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArith.Modulus
+public import HexMvFactor.Point
+public import HexMvHensel.Lift
+
+@[expose] public section
+
+/-!
+Construction of validated multivariate-Hensel inputs.
+
+Prime divisibility is rejected before the polynomial witness computation.
+`witnessOf?` supplies V6, and the completed value is replayed through
+`MvHensel.valid` before it leaves this module.  The starting exponent is a
+cheap shifted-coefficient heuristic; successful lifting remains certified by
+the exact Hensel checker and never trusts this estimate.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-- Distinguish the cheap V5 rejection from failure to produce V6. -/
+inductive InputReject where
+  | primeDividesLeading
+  | notCoprime
+  | invalid (failure : MvHensel.Failure)
+  deriving Repr, BEq, DecidableEq
+
+/-- Terminal result of the bounded prime loop. -/
+inductive InputSearchReject where
+  | invalid (failure : MvHensel.Failure)
+  | primesExhausted
+  deriving Repr, BEq, DecidableEq
+
+/-- Sum of absolute coefficients, used only as a starting-size heuristic. -/
+def coeffOneNorm (p : MvPoly (n + 1) Int cmp) : Nat :=
+  p.termsList.foldl (fun total term => total + term.2.natAbs) 0
+
+/-- Twice the shifted one-norm, floored at one. -/
+def shiftedEstimate (i : Fin (n + 1)) (point : Fin n → Int)
+    (target : MvPoly (n + 1) Int cmp) : Nat :=
+  max 1 (2 * coeffOneNorm (MvHensel.shift i point target))
+
+/-- A positive exponent whose power is above twice the heuristic estimate for
+every bundled prime (`p ≥ 2`).  Using the base-two logarithm is conservative
+for larger primes and avoids a value-sized linear loop. -/
+def startingExponent (estimate : Nat) : Nat :=
+  (2 * estimate).log2 + 1
+
+/-- Exponents tried after reconstruction failures. -/
+def exponentSchedule (initial doublings : Nat) : List Nat :=
+  (List.range (doublings + 1)).map fun k => initial * 2 ^ k
+
+/-- V5's allocation-free prime rejection. -/
+def primeAvoidsLeading (prime : ZMod64.Prime) (images : List ZPoly) : Bool :=
+  images.all fun F => F.leadingCoeff % (prime.m : Int) != 0
+
+/-- Build and independently validate an input at one chosen prime and
+exponent. -/
+def inputAtPrime (i : Fin (n + 1)) (target : MvPoly (n + 1) Int cmp)
+    (probe : Probe n cmp cmp') (prime : ZMod64.Prime) (exponent : Nat) :
+    Except InputReject (MvHensel.Input n cmp cmp') :=
+  if !primeAvoidsLeading prime probe.images then
+    .error .primeDividesLeading
+  else
+    let setup : MvHensel.Setup n :=
+      { main := i, point := probe.point, prime, exponent }
+    match MvHensel.witnessOf? setup probe.images with
+    | none => .error .notCoprime
+    | some witness =>
+        let inp : MvHensel.Input n cmp cmp' :=
+          { setup
+            target
+            images := probe.images
+            leading := probe.leading
+            witness }
+        match MvHensel.failure? inp with
+        | none => .ok inp
+        | some failure => .error (.invalid failure)
+
+/-- Try the supplied primes in order and retain the first fully valid input. -/
+def inputFromPrimes (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (probe : Probe n cmp cmp')
+    (exponent : Nat) : List ZMod64.Prime →
+      Except InputSearchReject (MvHensel.Input n cmp cmp')
+  | [] => .error .primesExhausted
+  | prime :: primes =>
+      match inputAtPrime i target probe prime exponent with
+      | .ok inp => .ok inp
+      | .error .primeDividesLeading =>
+          inputFromPrimes i target probe exponent primes
+      | .error .notCoprime =>
+          inputFromPrimes i target probe exponent primes
+      | .error (.invalid failure) => .error (.invalid failure)
+
+/-- Small-prime-first bundled supply used by the EEZ route. -/
+def factorPrimes (fuel : Nat) : List ZMod64.Prime :=
+  (ZMod64.primesBelow 257 257).toList.reverse.take fuel
+
+/-- Construct the first valid Hensel input for an accepted probe. -/
+def inputForProbe? (cfg : Config) (i : Fin (n + 1))
+    (target : MvPoly (n + 1) Int cmp) (probe : Probe n cmp cmp') :
+    Except InputSearchReject (MvHensel.Input n cmp cmp') :=
+  let estimate := shiftedEstimate i probe.point target
+  inputFromPrimes i target probe (startingExponent estimate)
+    (factorPrimes cfg.primeFuel)
+
+end Hex.MvFactor

--- a/HexMvFactor/InputTests.lean
+++ b/HexMvFactor/InputTests.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Input
+public import HexMvFactor.Input
+
+public section
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+private def x : MvPoly 2 Int Mono.lex := X 0
+private def y : MvPoly 2 Int Mono.lex := X 1
+private def innerY : MvPoly 1 Int Mono.lex := X 0
+private def atFive : Fin 1 → Int := fun _ => 5
+
+private def target : MvPoly 2 Int Mono.lex :=
+  (C 2 * y * x + 1) * (C 3 * x + y)
+
+private def image₁ : ZPoly := DensePoly.ofList [1, 10]
+private def image₂ : ZPoly := DensePoly.ofList [5, 3]
+
+private def accepted : Probe 1 Mono.lex Mono.lex :=
+  { point := atFive
+    images := [image₁, image₂]
+    leading := [C 2 * innerY, C 3]
+    uni := [image₁, image₂] }
+
+/- Prime 2 is rejected by V5 before witness production. -/
+#guard
+  match (ZMod64.primesBelow 2 1)[0]? with
+  | none => false
+  | some prime =>
+      match inputAtPrime 0 target accepted prime 2 with
+      | .error .primeDividesLeading => true
+      | _ => false
+
+/- At prime 7 the images remain coprime, `witnessOf?` supplies V6, and the
+   completed route passes the actual Hensel V1--V6 checker. -/
+#guard
+  match (ZMod64.primesBelow 7 1)[0]? with
+  | none => false
+  | some prime =>
+      match inputAtPrime 0 target accepted prime 2 with
+      | .ok inp => MvHensel.valid inp
+      | .error _ => false
+
+/- Malformed accepted-probe data is a caller error, not a reason to consume
+   the rest of the prime budget. -/
+private def malformed : Probe 1 Mono.lex Mono.lex :=
+  { accepted with leading := [] }
+
+#guard
+  match (ZMod64.primesBelow 7 1)[0]? with
+  | none => false
+  | some prime =>
+      match inputFromPrimes 0 target malformed 2 [prime] with
+      | .error (.invalid .arity) => true
+      | _ => false
+
+#guard exponentSchedule 3 3 == [3, 6, 12, 24]
+#guard startingExponent 20 = 6
+#guard (factorPrimes 5).map (fun prime => prime.m) == [2, 3, 5, 7, 11]
+
+end Hex.MvFactor

--- a/HexMvFactor/Irred.lean
+++ b/HexMvFactor/Irred.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Kronecker
+public import HexMvHensel.Complete
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Irreducibility certificate replay independent of the factor search.
+
+The four constructors reduce multivariate irreducibility either to a
+primitive degree-one argument, to an explicitly reported univariate
+obligation, or to a certificate one arity lower.  The Kronecker constructor
+checks a carried univariate factorization and exhaustively refutes every
+proper exponent-vector product by exact division.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- Replay a primitive-content certificate against the coefficients in one
+named-variable view. -/
+@[reducible] def checkPrimitive {n : Nat}
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (g : MvPoly (n + 1) Int cmp)
+    (prim : ContentCert n Int cmp') : Bool :=
+  checkContent (toUnivariate i cmp' g).toArray.toList prim &&
+    decide (prim.value = 1)
+
+/-- Replay an irreducibility certificate.  Successful `image` certificates
+leave the primitive univariate image as an explicit obligation. -/
+@[reducible] def checkIrred : {n : Nat} →
+    {cmp : Mono n → Mono n → Ordering} →
+    [IsMonomialOrder cmp] → MvPoly n Int cmp → IrredCert n cmp → Bool
+  | _, _, _, g,
+      @IrredCert.degreeOne _ _ _ _ i cmp' order prim =>
+      letI : IsMonomialOrder cmp' := order
+      decide (MvPoly.degreeOf i g = 1) &&
+        checkPrimitive i cmp' g prim
+  | _, _, _, g,
+      @IrredCert.image _ _ _ _ i cmp' order point prim =>
+      letI : IsMonomialOrder cmp' := order
+      decide (0 < MvPoly.degreeOf i g) &&
+        decide (MvPoly.eval point (MvHensel.lcIn i cmp' g) ≠ 0) &&
+        checkPrimitive i cmp' g prim
+  | _, _, _, g,
+      @IrredCert.embed _ _ _ _ i cmp' order sub cert =>
+      letI : IsMonomialOrder cmp' := order
+      (g == constIn i cmp' sub) && checkIrred sub cert
+  | _, _, _, g, @IrredCert.kronecker _ _ _ _ scalar uni =>
+      checkKronecker g scalar uni
+
+/-- The univariate facts still trusted by a successful certificate replay. -/
+@[reducible] def obligations {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (g : MvPoly n Int cmp) (cert : IrredCert n cmp) : List ZPoly :=
+  match cert with
+  | @IrredCert.degreeOne _ _ _ _ _ _ _ _ => []
+  | @IrredCert.image _ _ _ _ i cmp' order point _ =>
+      letI : IsMonomialOrder cmp' := order
+      [ZPoly.primitivePart (MvHensel.imageAt i cmp' point g)]
+  | @IrredCert.embed _ _ _ _ _ _ order sub cert =>
+      @obligations _ _ order sub cert
+  | @IrredCert.kronecker _ _ _ _ _ uni => uni.map Prod.fst
+
+/-- Checked certificate replay, together with its declared univariate
+obligations, implies Mathlib-free irreducibility. -/
+theorem checkIrred_sound {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {g : MvPoly n Int cmp} {cert : IrredCert n cmp}
+    (h : checkIrred g cert = true)
+    (ho : ∀ F ∈ obligations g cert, MvHensel.Irred F) :
+    MvHensel.Irred g := by
+  sorry
+
+/-! # Reducibility witnesses -/
+
+/-- Replay a factorization and reject a unit on either side. -/
+@[reducible] def checkSplit {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (g : MvPoly n Int cmp) (split : Split n cmp) : Bool :=
+  checkSplitCore g split
+
+/-- Semantic payload of a checked split. -/
+def IsSplitOf {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (g : MvPoly n Int cmp) (split : Split n cmp) : Prop :=
+  split.left * split.right = g ∧
+    ¬ (∃ u, split.left * u = 1) ∧
+    ¬ (∃ u, split.right * u = 1)
+
+/-- Cheap split replay directly refutes irreducibility. -/
+theorem checkSplit_sound {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {g : MvPoly n Int cmp} {split : Split n cmp}
+    (h : checkSplit g split = true) : ¬ MvHensel.Irred g := by
+  sorry
+
+/-! # Complete decompositions -/
+
+@[reducible] def checkCerts {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp] :
+    List (Factor n cmp) → List (IrredCert n cmp) → Bool
+  | [], [] => true
+  | entry :: entries, cert :: certs =>
+      checkIrred entry.factor cert && checkCerts entries certs
+  | _, _ => false
+
+/-- Reject zero, replay the decomposition, and pair every factor with exactly
+one irreducibility certificate. -/
+@[reducible] def checkComplete {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f : MvPoly n Int cmp) (complete : Complete n cmp) : Bool :=
+  decide (f ≠ 0) &&
+    checkDecomp f complete.decomp &&
+    decide (complete.certs.length = complete.decomp.factors.length) &&
+    checkCerts complete.decomp.factors complete.certs
+
+/-- Detect the expensive constructor through embedded certificates as well as
+at the outermost arity. -/
+@[reducible] def IrredCert.noKronecker : {n : Nat} →
+    {cmp : Mono n → Mono n → Ordering} →
+    [IsMonomialOrder cmp] → IrredCert n cmp → Bool
+  | _, _, _, @IrredCert.degreeOne _ _ _ _ _ _ _ _ => true
+  | _, _, _, @IrredCert.image _ _ _ _ _ _ _ _ _ => true
+  | _, _, _, @IrredCert.embed lowerN _ _ _ _ lowerCmp lowerOrder _ cert =>
+      @IrredCert.noKronecker lowerN lowerCmp lowerOrder cert
+  | _, _, _, @IrredCert.kronecker _ _ _ _ _ _ => false
+
+/-- True exactly when all certificates use only the cheap replay routes. -/
+@[reducible] def NoKronecker {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (complete : Complete n cmp) : Bool :=
+  complete.certs.all IrredCert.noKronecker
+
+/-- A product decomposition into normalized, pairwise nonassociated
+irreducible factors, up to the retained integer content. -/
+def IsFactorizationOf {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f : MvPoly n Int cmp) (D : Decomp n cmp) : Prop :=
+  f ≠ 0 ∧
+    IsDecompOf f D ∧
+    (∀ entry ∈ D.factors, MvHensel.Irred entry.factor) ∧
+    D.factors.Pairwise fun left right =>
+      ∀ u : Int, u * u = 1 → left.factor ≠ right.factor * C u
+
+/-- Accepted complete data tied to its checked subject. -/
+structure CheckedComplete {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f : MvPoly n Int cmp) where
+  raw : Complete n cmp
+  valid : checkComplete f raw = true
+
+/-- Complete checker replay plus the declared univariate obligations gives a
+factorization into irreducibles. -/
+theorem checkComplete_sound {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {f : MvPoly n Int cmp} {complete : Complete n cmp}
+    (h : checkComplete f complete = true)
+    (ho : ∀ pair ∈ complete.decomp.factors.zip complete.certs,
+      ∀ F ∈ obligations pair.1.factor pair.2, MvHensel.Irred F) :
+    IsFactorizationOf f complete.decomp := by
+  sorry
+
+/-! # Kronecker decision contracts -/
+
+/-- On its intended primitive, nonconstant domain, an irreducible verdict
+replays and reduces the conclusion to the carried univariate obligations. -/
+theorem kronDecide_irreducible {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {g : MvPoly n Int cmp} {cert : IrredCert n cmp}
+    (hprim : MvPoly.content g = 1) (hnonconst : ¬ MvPoly.IsConst g)
+    (h : kronDecide g = .irreducible cert)
+    (ho : ∀ F ∈ obligations g cert, MvHensel.Irred F) :
+    MvHensel.Irred g := by
+  sorry
+
+/-- Reducible verdicts retain the exact divisor found by the sweep. -/
+theorem kronDecide_reducible {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {g : MvPoly n Int cmp} {split : Split n cmp}
+    (h : kronDecide g = .reducible split) : checkSplit g split = true := by
+  exact kronDecide_split h
+
+end Hex.MvFactor

--- a/HexMvFactor/IrredData.lean
+++ b/HexMvFactor/IrredData.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Decomp
+
+@[expose] public section
+
+/-! Data shared by irreducibility replay and the Kronecker producer. -/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- A checkable irreducibility witness, modulo the univariate obligations
+reported by `obligations`. -/
+inductive IrredCert :
+    (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+    [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type 1
+  | degreeOne {n : Nat}
+      {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+      [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+      (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+      [order : IsMonomialOrder cmp']
+      (prim : ContentCert n Int cmp') :
+      @IrredCert (n + 1) cmp outerTrans outerEq
+  | image {n : Nat}
+      {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+      [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+      (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+      [order : IsMonomialOrder cmp'] (point : Fin n → Int)
+      (prim : ContentCert n Int cmp') :
+      @IrredCert (n + 1) cmp outerTrans outerEq
+  | embed {n : Nat}
+      {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+      [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+      (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+      [order : IsMonomialOrder cmp'] (sub : MvPoly n Int cmp')
+      (cert : IrredCert n cmp') :
+      @IrredCert (n + 1) cmp outerTrans outerEq
+  | kronecker {n : Nat} {cmp : Mono n → Mono n → Ordering}
+      [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+      (scalar : Int) (uni : List (ZPoly × Nat)) :
+      @IrredCert n cmp outerTrans outerEq
+
+/-- A proposed nontrivial factorization into two factors. -/
+structure Split (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  left : MvPoly n Int cmp
+  right : MvPoly n Int cmp
+
+/-- A decomposition paired positionally with irreducibility certificates. -/
+structure Complete (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  decomp : Decomp n cmp
+  certs : List (IrredCert n cmp)
+
+/-- The total outcome of the Kronecker sweep. -/
+inductive Verdict (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] : Type 1
+  | irreducible (cert : IrredCert n cmp)
+  | reducible (split : Split n cmp)
+
+end Hex.MvFactor

--- a/HexMvFactor/KernelTests.lean
+++ b/HexMvFactor/KernelTests.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Irred
+public meta import HexMvPoly.Ring
+public import HexMvFactor.Irred
+
+public section
+
+/-! Small kernel-reduced replays for the milestone 1–2 checkers. -/
+
+namespace Hex.MvFactor.KernelTests
+
+open Hex
+open Hex.MvPoly
+open Hex.MvFactor
+
+private abbrev P0 := MvPoly 0 Int Mono.lex
+private abbrev P1 := MvPoly 1 Int Mono.lex
+private abbrev P2 := MvPoly 2 Int Mono.lex
+
+private def x : P2 := X 0
+private def y : P2 := X 1
+
+private def good : Decomp 2 Mono.lex :=
+  ⟨1, [⟨x + y, 2⟩, ⟨x + 1, 1⟩]⟩
+
+#guard checkDecomp ((x + y) ^ 2 * (x + 1)) good
+
+private def zeroMultiplicity : Decomp 2 Mono.lex :=
+  ⟨1, [⟨x + y, 0⟩]⟩
+
+example : checkDecomp 1 zeroMultiplicity = false := by
+  decide +kernel
+
+private def constantFactor : Decomp 2 Mono.lex :=
+  ⟨1, [⟨1, 1⟩]⟩
+
+#guard !checkDecomp 1 constantFactor
+
+private def nonprimitive : Decomp 2 Mono.lex :=
+  ⟨1, [⟨C 2 * x, 1⟩]⟩
+
+#guard !checkDecomp (C 2 * x) nonprimitive
+
+private def duplicate : Decomp 2 Mono.lex :=
+  ⟨1, [⟨x + 1, 1⟩, ⟨x + 1, 2⟩]⟩
+
+#guard !checkDecomp ((x + 1) ^ 3) duplicate
+
+#guard
+  match structural? (0 : P2) with
+  | some D => D.content == 0 && D.factors.isEmpty && checkDecomp 0 D
+  | none => false
+
+#guard
+  let f : P2 := C 6 * x ^ 2 * y
+  match structural? f with
+  | some D =>
+      match D.factors with
+      | [left, right] =>
+          D.content == 6 && left.factor == x && left.multiplicity == 2 &&
+            right.factor == y && right.multiplicity == 1 && checkDecomp f D
+      | _ => false
+  | _ => false
+
+private def split : Split 2 Mono.lex :=
+  ⟨x + 1, y + 2⟩
+
+example : checkSplit ((x + 1) * (y + 2)) split = true := by
+  decide +kernel
+
+example : checkSplit (x + 1) (⟨1, x + 1⟩ : Split 2 Mono.lex) = false := by
+  decide +kernel
+
+private def zeroStep : GcdCert 0 Int Mono.lex :=
+  .mk 0 1 1 .unit
+
+private def oneStep : GcdCert 0 Int Mono.lex :=
+  .mk 1 0 1 .unit
+
+private def primitiveX : ContentCert 0 Int Mono.lex :=
+  .ofSteps 1 [zeroStep, oneStep]
+
+private def x1 : P1 := X 0
+
+private def degreeOneCert : IrredCert 1 Mono.lex :=
+  .degreeOne 0 Mono.lex primitiveX
+
+#guard checkIrred x1 degreeOneCert
+
+example : obligations x1 degreeOneCert = [] := by
+  decide +kernel
+
+private def noPoint : Fin 0 → Int := fun i => nomatch i
+
+private def imageCert : IrredCert 1 Mono.lex :=
+  .image 0 Mono.lex noPoint primitiveX
+
+#guard checkIrred x1 imageCert
+
+#guard obligations x1 imageCert == [DensePoly.ofList [0, 1]]
+
+private def embedded : P2 := constIn (cmp := Mono.lex) 1 Mono.lex x1
+
+private def embedCert : IrredCert 2 Mono.lex :=
+  .embed 1 Mono.lex x1 degreeOneCert
+
+#guard checkIrred embedded embedCert
+
+private def completeX : Complete 1 Mono.lex :=
+  ⟨⟨1, [⟨x1, 1⟩]⟩, [degreeOneCert]⟩
+
+#guard checkComplete x1 completeX
+
+example : NoKronecker completeX = true := by
+  decide +kernel
+
+example :
+    checkComplete (0 : P1) (⟨⟨0, []⟩, []⟩ : Complete 1 Mono.lex) = false := by
+  decide +kernel
+
+example :
+    checkComplete (C 12 : P1)
+      (⟨⟨12, []⟩, []⟩ : Complete 1 Mono.lex) = true := by
+  decide +kernel
+
+end Hex.MvFactor.KernelTests

--- a/HexMvFactor/Kronecker.lean
+++ b/HexMvFactor/Kronecker.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.IrredData
+public import HexBerlekampZassenhaus.Factorization
+public import HexPolyZ.ExactDivision
+public import Batteries.Data.Vector.Basic
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Mixed-radix Kronecker substitution and the unconditional divisor sweep.
+
+This is variable packing, not the coefficient-packing multiplication in
+`HexPolyZ.Kronecker`.  Every inverse result is checked by applying `kron`
+again, and every reducible verdict retains a split accepted by the cheap split
+checker core.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+variable {n : Nat} {cmp : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp]
+
+/-- Coordinate degrees tabulated once from the sparse representation. -/
+def kronDegrees (p : MvPoly n Int cmp) : Vector Nat n :=
+  Hex.Vector.ofFn' fun i => MvPoly.degreeOf i p
+
+/-- All mixed-radix weights, computed in one left-to-right pass. -/
+def radixWeights (degrees : Fin n → Nat) : Vector Nat n :=
+  let bases := Hex.Vector.ofFn' fun i => degrees i + 1
+  (bases.scanl (fun weight base => weight * base) 1).pop.cast (by omega)
+
+/-- Product of the earlier mixed-radix bases. -/
+def radixWeight (degrees : Fin n → Nat) (j : Fin n) : Nat :=
+  (radixWeights degrees)[j]
+
+/-- Number of exponent vectors in the degree box. -/
+def radixSize (degrees : Fin n → Nat) : Nat :=
+  (List.finRange n).foldl (fun size i => size * (degrees i + 1)) 1
+
+/-- Mixed-radix encoding using already tabulated weights. -/
+def kronExponentWith (weights : Vector Nat n) (m : Mono n) : Nat :=
+  (List.finRange n).foldl
+    (fun exponent i => exponent + Mono.degreeOf i m * weights[i]) 0
+
+/-- Mixed-radix encoding of one exponent vector. -/
+def kronExponent (degrees : Fin n → Nat) (m : Mono n) : Nat :=
+  kronExponentWith (radixWeights degrees) m
+
+/-- Substitute with already tabulated mixed-radix weights. -/
+def kronWith (weights : Vector Nat n) (p : MvPoly n Int cmp) : ZPoly :=
+  p.foldTerms
+    (fun image monomial coefficient =>
+      image + DensePoly.monomial (kronExponentWith weights monomial) coefficient)
+    0
+
+/-- Substitute `x_j = z^(radixWeight degrees j)`. -/
+def kron (degrees : Fin n → Nat) (p : MvPoly n Int cmp) : ZPoly :=
+  kronWith (radixWeights degrees) p
+
+/-- Maximum encoded exponent, read directly from the sparse support without
+constructing a dense univariate image. -/
+def kronDegreeWith (weights : Vector Nat n)
+    (p : MvPoly n Int cmp) : Option Nat :=
+  p.foldTerms
+    (fun degree monomial _ =>
+      let encoded := kronExponentWith weights monomial
+      some <| match degree with
+        | none => encoded
+        | some current => max current encoded)
+    none
+
+/-- Sparse encoded degree with weights prepared from the degree box. -/
+def kronDegree? (degrees : Fin n → Nat)
+    (p : MvPoly n Int cmp) : Option Nat :=
+  kronDegreeWith (radixWeights degrees) p
+
+/-! # Budget-saturated sparse degree -/
+
+/-- Add natural numbers, returning `cap + 1` as soon as the result exceeds
+the producer cap. -/
+def kronCapAdd (cap a b : Nat) : Nat :=
+  if cap < a || cap - a < b then cap + 1 else a + b
+
+/-- Multiply natural numbers, returning `cap + 1` as soon as the result
+exceeds the producer cap.  The comparison happens before multiplication. -/
+def kronCapMul (cap a b : Nat) : Nat :=
+  if a = 0 || b = 0 then 0
+  else if cap / a < b then cap + 1 else a * b
+
+/-- Encoded exponent saturated at `cap + 1`.  The current weight is carried
+through one fold, so rejection neither recomputes nor stores exact powers. -/
+def kronExponentUpTo (cap : Nat) (degrees : Fin n → Nat)
+    (monomial : Mono n) : Nat :=
+  ((List.finRange n).foldl
+    (fun state i =>
+      (kronCapAdd cap state.1
+          (kronCapMul cap (Mono.degreeOf i monomial) state.2),
+        kronCapMul cap state.2 (degrees i + 1)))
+    (0, 1)).1
+
+/-- Sparse encoded degree saturated at `cap + 1`.  In particular, a tiny
+budget never constructs the exact exponentially growing weight table. -/
+def kronDegreeUpTo? (cap : Nat) (degrees : Fin n → Nat)
+    (p : MvPoly n Int cmp) : Option Nat :=
+  p.foldTerms
+    (fun degree monomial _ =>
+      let encoded := kronExponentUpTo cap degrees monomial
+      some <| match degree with
+        | none => encoded
+        | some current => max current encoded)
+    none
+
+/-- Decode an exponent using already tabulated weights and box size. -/
+def decodeExponentWith? (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size exponent : Nat) : Option (Mono n) :=
+  if exponent < size then
+    some <| Hex.Vector.ofFn' fun i =>
+      exponent / weights[i] % (degrees i + 1)
+  else
+    none
+
+/-- Decode an exponent inside the mixed-radix box. -/
+def decodeExponent? (degrees : Fin n → Nat) (exponent : Nat) : Option (Mono n) :=
+  decodeExponentWith? degrees (radixWeights degrees) (radixSize degrees) exponent
+
+/-- Decode the dense coefficients, rejecting any supported exponent outside
+the mixed-radix box. -/
+def unKronAux (degrees : Fin n → Nat) (weights : Vector Nat n) (size : Nat) :
+    Nat → List Int → List (Mono n × Int) → Option (MvPoly n Int cmp)
+  | _, [], terms => some (MvPoly.ofTerms terms.reverse)
+  | exponent, coefficient :: coefficients, terms =>
+      if coefficient = 0 then
+        unKronAux degrees weights size (exponent + 1) coefficients terms
+      else
+        match decodeExponentWith? degrees weights size exponent with
+        | none => none
+        | some monomial =>
+            unKronAux degrees weights size (exponent + 1) coefficients
+              ((monomial, coefficient) :: terms)
+
+/-- Partial inverse with mixed-radix prework supplied by the caller. -/
+def unKronWith? (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (P : ZPoly) : Option (MvPoly n Int cmp) :=
+  match unKronAux (cmp := cmp) degrees weights size 0 P.toArray.toList [] with
+  | none => none
+  | some p => if kronWith weights p == P then some p else none
+
+/-- Partial inverse to `kron`, with an exact re-encoding check before any
+decoded polynomial is exposed. -/
+def unKron? (degrees : Fin n → Nat) (P : ZPoly) : Option (MvPoly n Int cmp) :=
+  let weights := radixWeights degrees
+  unKronWith? degrees weights (radixSize degrees) P
+
+/-- Structural polynomial power used by certificate replay. -/
+def zPow (P : ZPoly) : Nat → ZPoly
+  | 0 => 1
+  | exponent + 1 => zPow P exponent * P
+
+/-- Product represented by the univariate part of a Kronecker certificate. -/
+def uniProduct (scalar : Int) (uni : List (ZPoly × Nat)) : ZPoly :=
+  uni.foldl (fun product entry => product * zPow entry.1 entry.2)
+    (DensePoly.C scalar)
+
+/-- Product selected by one exponent vector.  Length mismatch is rejected. -/
+def candidateProduct? : List (ZPoly × Nat) → List Nat → Option ZPoly
+  | [], [] => some 1
+  | entry :: entries, exponent :: exponents =>
+      (candidateProduct? entries exponents).map fun product =>
+        zPow entry.1 exponent * product
+  | _, _ => none
+
+/-- All exponent vectors bounded componentwise by the stored multiplicities. -/
+def exponentVectors : List (ZPoly × Nat) → List (List Nat)
+  | [] => [[]]
+  | entry :: entries =>
+      (List.range (entry.2 + 1)).flatMap fun exponent =>
+        (exponentVectors entries).map fun exponents => exponent :: exponents
+
+/-- Remove the two exponent vectors representing the trivial unit and whole
+products. -/
+def properExponentVectors (uni : List (ZPoly × Nat)) : List (List Nat) :=
+  let full := uni.map Prod.snd
+  (exponentVectors uni).filter fun exponents =>
+    decide (exponents ≠ List.replicate uni.length 0) && decide (exponents ≠ full)
+
+/-- Positive multiplicity and primitive positive degree for one stored
+univariate factor. -/
+def checkUniFactor (entry : ZPoly × Nat) : Bool :=
+  decide (0 < entry.2) &&
+    decide (ZPoly.content entry.1 = 1) &&
+    match entry.1.degree? with
+    | none => false
+    | some degree => decide (0 < degree)
+
+/-- Pairwise exact distinctness of the stored univariate factors. -/
+def distinctUni : List (ZPoly × Nat) → Bool
+  | [] => true
+  | entry :: entries =>
+      entries.all (fun other => decide (entry.1 ≠ other.1)) && distinctUni entries
+
+/-- One candidate is refuted when it does not decode, decodes to a constant,
+or fails checked exact division.  Mixed-radix prework is shared by the whole
+candidate sweep. -/
+def candidateRejected (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (g : MvPoly n Int cmp) (uni : List (ZPoly × Nat))
+    (exponents : List Nat) : Bool :=
+  match candidateProduct? uni exponents with
+  | none => false
+  | some candidate =>
+      match unKronWith? (cmp := cmp) degrees weights size candidate with
+      | none => true
+      | some divisor =>
+          if divisor.vars.isEmpty then true
+          else (MvPoly.divExact? g divisor).isNone
+
+/-- Replay against a prepared degree box and its exact Kronecker image. -/
+def checkKroneckerWith (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (g : MvPoly n Int cmp) (image : ZPoly) (scalar : Int)
+    (uni : List (ZPoly × Nat)) : Bool :=
+  decide (MvPoly.content g = 1) &&
+    decide (g.vars ≠ []) &&
+    (uniProduct scalar uni == image) &&
+    uni.all checkUniFactor &&
+    distinctUni uni &&
+    (properExponentVectors uni).all
+      (candidateRejected degrees weights size g uni)
+
+/-- Replay the complete Kronecker certificate without refactoring its
+univariate image. -/
+def checkKronecker (g : MvPoly n Int cmp) (scalar : Int)
+    (uni : List (ZPoly × Nat)) : Bool :=
+  let degreeData := kronDegrees g
+  let degrees : Fin n → Nat := fun i => degreeData[i]
+  let weights := radixWeights degrees
+  checkKroneckerWith degrees weights (radixSize degrees) g
+    (kronWith weights g) scalar uni
+
+/-- Cheap replay core shared by `checkSplit` and the producer. -/
+def checkSplitCore (g : MvPoly n Int cmp) (split : Split n cmp) : Bool :=
+  (split.left * split.right == g) &&
+    !polyIsUnit split.left && !polyIsUnit split.right
+
+/-- Inspect candidates in order and retain the first accepted nontrivial
+divisor and its exact quotient. -/
+def findSplitAux (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (g : MvPoly n Int cmp) (uni : List (ZPoly × Nat)) :
+    List (List Nat) → Option (Split n cmp)
+  | [] => none
+  | exponents :: rest =>
+      match candidateProduct? uni exponents with
+      | none => findSplitAux degrees weights size g uni rest
+      | some candidate =>
+          match unKronWith? (cmp := cmp) degrees weights size candidate with
+          | none => findSplitAux degrees weights size g uni rest
+          | some divisor =>
+              if divisor.vars.isEmpty then
+                findSplitAux degrees weights size g uni rest
+              else
+                match MvPoly.divExact? g divisor with
+                | none => findSplitAux degrees weights size g uni rest
+                | some quotient =>
+                    let split : Split n cmp := ⟨divisor, quotient⟩
+                    if checkSplitCore g split then some split
+                    else findSplitAux degrees weights size g uni rest
+
+/-- Search with mixed-radix prework supplied by the caller. -/
+def findSplitWith (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (g : MvPoly n Int cmp)
+    (uni : List (ZPoly × Nat)) : Option (Split n cmp) :=
+  findSplitAux degrees weights size g uni (properExponentVectors uni)
+
+/-- Search all proper exponent vectors for a genuine multivariate divisor. -/
+def findSplit (degrees : Fin n → Nat) (g : MvPoly n Int cmp)
+    (uni : List (ZPoly × Nat)) : Option (Split n cmp) :=
+  let weights := radixWeights degrees
+  findSplitWith degrees weights (radixSize degrees) g uni
+
+/-- Kronecker decision with a prepared degree box and its exact image. -/
+def kronDecideWith (degrees : Fin n → Nat) (weights : Vector Nat n)
+    (size : Nat) (g : MvPoly n Int cmp) (image : ZPoly) : Verdict n cmp :=
+  let factorization := ZPoly.factorize image
+  let uni := factorization.factors.toList
+  match findSplitWith degrees weights size g uni with
+  | some split => .reducible split
+  | none => .irreducible (.kronecker factorization.scalar uni)
+
+/-- Produce a Kronecker certificate only when the sparse encoded degree fits
+`maxDegree`.  Rejection uses saturated arithmetic; acceptance constructs the
+dense image once and shares it between factorization and producer replay. -/
+def kronProduce? (maxDegree : Nat) (g : MvPoly n Int cmp) :
+    Option (IrredCert n cmp) :=
+  let degreeData := kronDegrees g
+  let degrees : Fin n → Nat := fun i => degreeData[i]
+  match kronDegreeUpTo? maxDegree degrees g with
+  | none => none
+  | some degree =>
+      if maxDegree < degree then none
+      else
+        let weights := radixWeights degrees
+        let size := radixSize degrees
+        let image := kronWith weights g
+        match kronDecideWith degrees weights size g image with
+        | .reducible _ => none
+        | .irreducible cert@(.kronecker scalar uni) =>
+            if checkKroneckerWith degrees weights size g image scalar uni then
+              some cert
+            else none
+        | .irreducible _ => none
+
+/-- Total Kronecker decision procedure on the intended primitive,
+nonconstant domain.  Outside that domain it still terminates, while the
+soundness theorem below deliberately requires the missing hypotheses. -/
+def kronDecide (g : MvPoly n Int cmp) : Verdict n cmp :=
+  let degreeData := kronDegrees g
+  let degrees : Fin n → Nat := fun i => degreeData[i]
+  let weights := radixWeights degrees
+  kronDecideWith degrees weights (radixSize degrees) g (kronWith weights g)
+
+/-- The producer's irreducible branch replays on its intended domain. -/
+theorem kronDecide_checks {g : MvPoly n Int cmp} {cert : IrredCert n cmp}
+    (hprim : MvPoly.content g = 1) (hnonconst : ¬ MvPoly.IsConst g)
+    (h : kronDecide g = .irreducible cert) :
+    ∃ scalar uni,
+      cert = .kronecker scalar uni ∧ checkKronecker g scalar uni = true := by
+  sorry
+
+/-- Every reducible outcome has already passed cheap split replay. -/
+theorem kronDecide_split {g : MvPoly n Int cmp} {split : Split n cmp}
+    (h : kronDecide g = .reducible split) : checkSplitCore g split = true := by
+  sorry
+
+end Hex.MvFactor

--- a/HexMvFactor/KroneckerTests.lean
+++ b/HexMvFactor/KroneckerTests.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Irred
+public meta import HexMvPoly.Ring
+public import HexMvFactor.Irred
+
+public section
+
+/-! Executable checks for mixed-radix substitution and the complete route. -/
+
+namespace Hex.MvFactor.KroneckerTests
+
+open Hex
+open Hex.MvPoly
+open Hex.MvFactor
+
+private abbrev P2 := MvPoly 2 Int Mono.lex
+
+private def x : P2 := X 0
+private def y : P2 := X 1
+
+private def degrees : Fin 2 → Nat := fun _ => 1
+
+example : radixWeight degrees 0 = 1 := by
+  decide +kernel
+
+example : radixWeight degrees 1 = 2 := by
+  decide +kernel
+
+example : radixWeights degrees = #v[1, 2] := by
+  decide +kernel
+
+example : radixSize degrees = 4 := by
+  decide +kernel
+
+private def packed : P2 := C 3 + C 2 * x + y + x * y
+
+#guard kron degrees packed == DensePoly.ofList [3, 2, 1, 1]
+
+#guard kronDegree? degrees packed == some 3
+
+#guard kronDegreeUpTo? 2 degrees packed == some 3
+
+#guard kronDegreeUpTo? 3 degrees packed == some 3
+
+#guard unKron? (cmp := Mono.lex) degrees (kron degrees packed) == some packed
+
+#guard
+  (unKron? (cmp := Mono.lex) degrees (DensePoly.monomial 4 1)).isNone
+
+private def px : ZPoly := DensePoly.ofList [0, 1]
+private def px1 : ZPoly := DensePoly.ofList [1, 1]
+private def xyImage : List (ZPoly × Nat) := [(px, 1), (px1, 1)]
+
+#guard properExponentVectors xyImage == [[0, 1], [1, 0]]
+
+private def irreducible : P2 := x + y
+private def irreducibleCert : IrredCert 2 Mono.lex :=
+  .kronecker 1 xyImage
+
+#guard checkIrred irreducible irreducibleCert
+
+#guard obligations irreducible irreducibleCert == [px, px1]
+
+private def completeIrreducible : Complete 2 Mono.lex :=
+  ⟨⟨1, [⟨irreducible, 1⟩]⟩, [irreducibleCert]⟩
+
+example : NoKronecker completeIrreducible = false := by
+  decide +kernel
+
+#guard
+  match kronDecide irreducible with
+  | .irreducible cert => checkIrred irreducible cert
+  | .reducible _ => false
+
+private def reducible : P2 := (x + 1) * (y + 1)
+
+#guard
+  match kronDecide reducible with
+  | .irreducible _ => false
+  | .reducible split => checkSplit reducible split
+
+#guard !checkIrred irreducible (.kronecker 1 [(px1, 1)])
+
+#guard !checkIrred irreducible (.kronecker 1 [(px, 1), (px1, 1), (px + 1, 0)])
+
+end Hex.MvFactor.KroneckerTests

--- a/HexMvFactor/Leading.lean
+++ b/HexMvFactor/Leading.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvFactor.Decomp
+public import HexMvHensel.Cert
+
+@[expose] public section
+
+/-!
+Wang's leading-coefficient assignment.
+
+The implementation deliberately works with the evaluated integer values of
+the recursively decomposed leading coefficient.  It neither factors those
+integers nor guesses a placement: the non-divisor pass isolates a value for
+each polynomial part, repeated exact division assigns its multiplicity, and
+the forced integer multipliers are allocated before the residual scalar.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+variable {n : Nat} {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp']
+
+/-! # Integer non-divisors -/
+
+/-- Remove every factor shared with `r`.  Each nonterminal division is exact
+and strictly decreases `q`; no factorization of either integer is involved. -/
+def stripCommon (q r : Nat) : Nat :=
+  if _hq : q ≤ 1 then q
+  else
+    let g := Nat.gcd q r
+    if _hg : g ≤ 1 then q else stripCommon (q / g) r
+termination_by q
+decreasing_by
+  exact Nat.div_lt_self (by omega) (by omega)
+
+/-- Strip the factors already visible in all earlier values. -/
+def stripPrevious (q : Nat) : List Nat → Nat
+  | [] => q
+  | r :: rs => stripPrevious (stripCommon q r) rs
+
+/-- Wang's non-divisor pass.  The scalar is the first earlier value; each
+accepted residual is then included when separating later polynomial parts. -/
+def nonDivisors (scalar : Int) : List Int → Option (List Nat) :=
+  let rec go (previous : List Nat) : List Int → Option (List Nat)
+    | [] => some []
+    | d :: ds => do
+        let q := stripPrevious d.natAbs previous
+        if q ≤ 1 then none
+        else
+          let tail ← go (q :: previous) ds
+          some (q :: tail)
+  go [scalar.natAbs]
+
+/-- Count at most `fuel` exact divisions by a nontrivial natural divisor. -/
+def divisorMultiplicity (d : Nat) : Nat → Nat → Nat
+  | 0, _ => 0
+  | fuel + 1, value =>
+      if d ≤ 1 || value % d != 0 then 0
+      else 1 + divisorMultiplicity d fuel (value / d)
+
+/-! # Polynomial-part assignment -/
+
+/-- Evaluated values of the non-scalar entries of a decomposition. -/
+def leadingValues (a : Fin n → Int) (D : Decomp n cmp') : List Int :=
+  D.factors.map fun entry => MvPoly.eval a entry.factor
+
+def countsFor (scalar : Int) (d multiplicity : Nat) :
+    List ZPoly → List Nat
+  | [] => []
+  | h :: hs =>
+      divisorMultiplicity d multiplicity
+          (h.leadingCoeff * scalar).natAbs ::
+        countsFor scalar d multiplicity hs
+
+def multiplyAssigned (omega : MvPoly n Int cmp') :
+    List (MvPoly n Int cmp') → List Nat →
+      Option (List (MvPoly n Int cmp'))
+  | [], [] => some []
+  | p :: ps, e :: es => do
+      let tail ← multiplyAssigned omega ps es
+      some (p * omega ^ e :: tail)
+  | _, _ => none
+
+def assignPolynomialParts (scalar : Int) :
+    List (Factor n cmp') → List Nat → List ZPoly →
+      List (MvPoly n Int cmp') → Option (List (MvPoly n Int cmp'))
+  | [], [], _, assigned => some assigned
+  | entry :: entries, d :: ds, uni, assigned => do
+      let counts := countsFor scalar d entry.multiplicity uni
+      if counts.sum != entry.multiplicity then none
+      else
+        let assigned ← multiplyAssigned entry.factor assigned counts
+        assignPolynomialParts scalar entries ds uni assigned
+  | _, _, _, _ => none
+
+/-! # Forced scalar allocation and rescaling -/
+
+/-- Forced integer multipliers at the actual evaluation point. -/
+def needsAt (a : Fin n → Int) :
+    List (MvPoly n Int cmp') → List ZPoly → Option (List Nat)
+  | [], [] => some []
+  | p :: ps, h :: hs => do
+      let lead := h.leadingCoeff.natAbs
+      if lead = 0 then none
+      else
+        let need := lead / Nat.gcd lead (MvPoly.eval a p).natAbs
+        let tail ← needsAt a ps hs
+        some (need :: tail)
+  | _, _ => none
+
+def scalarMultipliers (scalar : Int) : List Nat → Option (List Int)
+  | [] => none
+  | need :: needs =>
+      let forced := (need :: needs).prod
+      if forced = 0 || scalar.natAbs % forced != 0 then none
+      else
+        let residual := scalar.natAbs / forced
+        let firstMagnitude := need * residual
+        let first : Int :=
+          if scalar < 0 then -(Int.ofNat firstMagnitude)
+          else Int.ofNat firstMagnitude
+        some (first :: needs.map Int.ofNat)
+
+def attachScalars : List (MvPoly n Int cmp') → List Int →
+    Option (List (MvPoly n Int cmp'))
+  | [], [] => some []
+  | p :: ps, c :: cs => do
+      let tail ← attachScalars ps cs
+      some (p * C c :: tail)
+  | _, _ => none
+
+def rescaleImages (a : Fin n → Int) :
+    List (MvPoly n Int cmp') → List ZPoly → Option (List ZPoly)
+  | [], [] => some []
+  | L :: Ls, h :: hs => do
+      let lead := h.leadingCoeff
+      if lead = 0 then none
+      else
+        let value := MvPoly.eval a L
+        let gamma := value / lead
+        if gamma * lead != value then none
+        else
+          let tail ← rescaleImages a Ls hs
+          some (DensePoly.scaleImpl gamma h :: tail)
+  | _, _ => none
+
+def leadingImagesAgree (a : Fin n → Int) :
+    List (MvPoly n Int cmp') → List ZPoly → Bool
+  | [], [] => true
+  | L :: Ls, F :: Fs =>
+      MvPoly.eval a L == F.leadingCoeff && leadingImagesAgree a Ls Fs
+  | _, _ => false
+
+/-- Assign the recursively decomposed leading coefficient to primitive
+univariate factors and rescale those factors so V3 and V4 can hold together.
+Every integer division is checked before its quotient affects the result. -/
+def distributeCore? (a : Fin n → Int) (lc : Decomp n cmp')
+    (uni : List ZPoly) (scalar : Int) :
+    Option (List (MvPoly n Int cmp') × List ZPoly) := do
+  if uni.isEmpty || scalar = 0 then none else pure ()
+  let values := leadingValues a lc
+  -- The stripped residuals witness separability only.  Multiplicities must
+  -- be counted by dividing by the full evaluated value `Ω_m(a)`, not by
+  -- that residual (and not by one of its prime divisors).
+  let _ ← nonDivisors lc.content values
+  let parts ← assignPolynomialParts lc.content lc.factors
+    (values.map Int.natAbs) uni
+    (List.replicate uni.length 1)
+  let needs ← needsAt a parts uni
+  let multipliers ← scalarMultipliers lc.content needs
+  let leading ← attachScalars parts multipliers
+  let images ← rescaleImages a leading uni
+  if MvHensel.mvProduct leading != lc.product then none
+  else if !leadingImagesAgree a leading images then none
+  else if MvHensel.uniProduct images !=
+      DensePoly.scaleImpl scalar (MvHensel.uniProduct uni) then none
+  else some (leading, images)
+
+/-- Public SPEC-shaped wrapper.  The main-variable index records the ambient
+arity for callers even though all work here is already in the `n` remaining
+variables. -/
+def distribute? (_i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (lc : Decomp n cmp')
+    (uni : List ZPoly) (scalar : Int) :
+    Option (List (MvPoly n Int cmp') × List ZPoly) :=
+  distributeCore? a lc uni scalar
+
+end Hex.MvFactor

--- a/HexMvFactor/LeadingTests.lean
+++ b/HexMvFactor/LeadingTests.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Leading
+public import HexMvFactor.Leading
+
+public section
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+private def y : MvPoly 1 Int Mono.lex := X 0
+private def atFive : Fin 1 → Int := fun _ => 5
+private def h₁ : ZPoly := DensePoly.ofList [1, 10]
+private def h₂ : ZPoly := DensePoly.ofList [5, 3]
+
+/- The integer content is forced across both leading coefficients:
+   `(2y, 3)`, not `(6y, 1)`. -/
+private def splitContent : Decomp 1 Mono.lex :=
+  { content := 6
+    factors := [⟨y, 1⟩] }
+
+#guard
+  match distribute? 0 Mono.lex atFive splitContent [h₁, h₂] 1 with
+  | some (leading, images) =>
+      leading == [C 2 * y, C 3] && images == [h₁, h₂]
+  | none => false
+
+/- The separated residual of `Ω(5) = 6` against scalar `2` is `3`, but
+   multiplicity counting must still divide by the full value `6`.  Only one
+   full division is available, so an asserted multiplicity two is rejected. -/
+private def sharedScalar : Decomp 1 Mono.lex :=
+  { content := 2
+    factors := [⟨y + 1, 2⟩] }
+
+private def sharedImage : ZPoly := DensePoly.ofList [1, 9]
+
+#guard nonDivisors 2 [6] == some [3]
+#guard distribute? 0 Mono.lex atFive sharedScalar [sharedImage] 8 |>.isNone
+
+/- A value without a factor distinct from all earlier values is rejected by
+   the non-divisor condition. -/
+#guard nonDivisors 6 [12] |>.isNone
+
+end Hex.MvFactor

--- a/HexMvFactor/Point.lean
+++ b/HexMvFactor/Point.lean
@@ -1,0 +1,345 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBasic.Rand
+public import HexBerlekampZassenhaus.Factorization
+public import HexMvFactor.Leading
+public import HexPolyZGcd.SquareFree
+
+@[expose] public section
+
+/-!
+Evaluation-point probing and shell enumeration for Wang's EEZ driver.
+
+Degree loss is rejected before factorization, relative rational
+squarefreeness is tested on the primitive image, and the complete leading
+coefficient assignment is retained in an accepted probe.  Shells are visited
+in increasing infinity norm; a fresh splitmix word gives every point in one
+shell a deterministic random ordering key.
+-/
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+/-- Search budgets shared by the point layer and the downstream EEZ driver. -/
+structure Config where
+  rand : Rand
+  pointFuel : Nat
+  pointScouts : Nat
+  pointShell : Nat
+  primeFuel : Nat
+  doublings : Nat
+  recombLevels : Nat
+  kronecker : Bool
+  kroneckerDeg : Nat
+  deriving Repr, DecidableEq
+
+namespace Config
+
+/-- Reproducible default search policy from the factorization SPEC. -/
+def default : Config :=
+  { rand := Rand.ofSeed 0
+    pointFuel := 256
+    pointScouts := 4
+    pointShell := 8
+    primeFuel := 16
+    doublings := 6
+    recombLevels := 3
+    kronecker := false
+    kroneckerDeg := 4096 }
+
+end Config
+
+/-- The first condition which rejected a candidate evaluation point. -/
+inductive PointReject where
+  | degreeDrop
+  | notSquarefree
+  | leadingSplit
+  deriving Repr, BEq, DecidableEq
+
+/-- Data computed once at an accepted point and consumed unchanged by input
+construction and recombination.  Here `n` is the number of non-main
+variables; the target itself has arity `n + 1`. -/
+structure Probe (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp'] where
+  point : Fin n → Int
+  images : List ZPoly
+  leading : List (MvPoly n Int cmp')
+  uni : List ZPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+def primitiveFactors : List (ZPoly × Nat) → Option (List ZPoly)
+  | [] => some []
+  | (h, multiplicity) :: hs => do
+      if multiplicity != 1 then none else pure ()
+      match h.degree? with
+      | none => none
+      | some 0 => none
+      | some (_ + 1) =>
+          let tail ← primitiveFactors hs
+          some (h :: tail)
+
+/-- Executable relative squarefreeness test through the checked integer-gcd
+route.  Taking the primitive part is essential: nonunit image content is
+irrelevant to multiplicities of the polynomial part. -/
+def squareFreeImage (image : ZPoly) : Bool :=
+  let primitive := ZPoly.primitivePart image
+  let derivative := DensePoly.derivative primitive
+  (ZPoly.gcd primitive derivative).size ≤ 1
+
+/-- Probe one caller-supplied point.  Factorization is deterministic, so the
+random state is returned unchanged; only shell ordering advances it. -/
+def probe (_cfg : Config) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (s : MvPoly (n + 1) Int cmp)
+    (lc : Decomp n cmp') (r : Rand) :
+    Except PointReject (Probe n cmp cmp' × Rand) :=
+  let leadingCoeff := MvHensel.lcIn i cmp' s
+  if MvPoly.eval a leadingCoeff = 0 then
+    .error .degreeDrop
+  else
+    let image := MvHensel.imageAt i cmp' a s
+    if !squareFreeImage image then
+      .error .notSquarefree
+    else
+      let factorization := ZPoly.factorize image
+      match primitiveFactors factorization.factors.toList with
+      | none => .error .notSquarefree
+      | some uni =>
+          match distribute? i cmp' a lc uni factorization.scalar with
+          | none => .error .leadingSplit
+          | some (leading, images) =>
+              if MvHensel.uniProduct images != image ||
+                  MvHensel.mvProduct leading != leadingCoeff then
+                .error .leadingSplit
+              else
+                .ok (⟨a, images, leading, uni⟩, r)
+
+/-! # Increasing-shell enumeration -/
+
+/-- Integer coordinates from `-radius` through `radius`. -/
+def shellCoordinates (radius : Nat) : List Int :=
+  (List.range (2 * radius + 1)).map fun k =>
+    Int.ofNat k - Int.ofNat radius
+
+/-- Every point in the closed infinity-norm cube of the given radius. -/
+def cubePoints : (dimension radius : Nat) → List (Fin dimension → Int)
+  | 0, _ => [fun i => Fin.elim0 i]
+  | dimension + 1, radius =>
+      (shellCoordinates radius).flatMap fun head =>
+        (cubePoints dimension radius).map fun tail =>
+          fun i => Fin.cases head tail i
+
+/-- Infinity norm of an integer point. -/
+def pointNorm (a : Fin n → Int) : Nat :=
+  (List.finRange n).foldl (fun bound i => max bound (a i).natAbs) 0
+
+/-- Points on the shell of exact infinity norm `radius`. -/
+def shellPoints (dimension radius : Nat) : List (Fin dimension → Int) :=
+  (cubePoints dimension radius).filter fun a => pointNorm a = radius
+
+def insertKey {alpha : Type} (entry : UInt64 × alpha) :
+    List (UInt64 × alpha) → List (UInt64 × alpha)
+  | [] => [entry]
+  | x :: xs =>
+      if entry.1 < x.1 then entry :: x :: xs
+      else x :: insertKey entry xs
+
+def keyPoints {alpha : Type} :
+    List alpha → Rand → List (UInt64 × alpha) × Rand
+  | [], r => ([], r)
+  | x :: xs, r =>
+      let (key, r') := r.next
+      let (tail, r'') := keyPoints xs r'
+      (insertKey (key, x) tail, r'')
+
+/-- Randomized order within one shell, with explicit state advancement. -/
+def orderShell (points : List (Fin n → Int)) (r : Rand) :
+    List (Fin n → Int) × Rand :=
+  let keyed := keyPoints points r
+  (keyed.1.map Prod.snd, keyed.2)
+
+/-- Concatenate randomly ordered shells from radius zero through `maxShell`.
+The shell order itself remains deterministic and size-preferring. -/
+def shellOrder (dimension : Nat) : Nat → Rand →
+    List (Fin dimension → Int) × Rand
+  | 0, r => orderShell (shellPoints dimension 0) r
+  | maxShell + 1, r =>
+      let prior := shellOrder dimension maxShell r
+      let current := orderShell (shellPoints dimension (maxShell + 1)) prior.2
+      (prior.1 ++ current.1, current.2)
+
+/-! # Fuel-bounded shell enumeration
+
+The materialized helpers above remain useful for small route tests.  Search
+uses the bounded rank/unrank route below: it never constructs more points
+than the caller can try and its counters saturate at that budget, so a large
+arity cannot turn a small point fuel into a dense cube allocation.
+-/
+
+def capAdd (cap a b : Nat) : Nat :=
+  min cap (a + b)
+
+def capMul (cap a b : Nat) : Nat :=
+  if a = 0 || b = 0 then 0
+  else if cap / a < b then cap else min cap (a * b)
+
+def cubeCountBound : Nat → Nat → Nat → Nat
+  | 0, _, cap => min cap 1
+  | dimension + 1, radius, cap =>
+      capMul cap (2 * radius + 1)
+        (cubeCountBound dimension radius cap)
+
+/-- Number of exact-shell points, saturated at `cap`. -/
+def shellCountBound : Nat → Nat → Nat → Nat
+  | 0, 0, cap => min cap 1
+  | 0, _ + 1, _ => 0
+  | _dimension + 1, 0, cap => min cap 1
+  | dimension + 1, radius + 1, cap =>
+      let boundary := capMul cap 2
+        (cubeCountBound dimension (radius + 1) cap)
+      let interior := capMul cap (2 * radius + 1)
+        (shellCountBound dimension (radius + 1) cap)
+      capAdd cap boundary interior
+
+/-- Unrank a point of the closed cube.  Counts are saturated at `rank + 1`:
+that is enough to decide every branch while avoiding arity-sized powers. -/
+def cubePointAt : (dimension radius rank : Nat) → Fin dimension → Int
+  | 0, _, _ => fun i => Fin.elim0 i
+  | dimension + 1, radius, rank =>
+      let tailCount := cubeCountBound dimension radius (rank + 1)
+      let headIndex := if tailCount = 0 then 0 else rank / tailCount
+      let tailRank := if tailCount = 0 then 0 else rank % tailCount
+      fun i => Fin.cases
+        (Int.ofNat headIndex - Int.ofNat radius)
+        (cubePointAt dimension radius tailRank) i
+
+/-- Unrank the budget-visible prefix of an exact infinity-norm shell. -/
+def shellPointAt : (dimension radius rank : Nat) → Fin dimension → Int
+  | 0, _, _ => fun i => Fin.elim0 i
+  | _dimension + 1, 0, _ => fun i => Fin.cases 0 (fun _ => 0) i
+  | dimension + 1, radius + 1, rank =>
+      let actualRadius := radius + 1
+      let cap := rank + 1
+      let cubeTail := cubeCountBound dimension actualRadius cap
+      if rank < cubeTail then
+        fun i => Fin.cases (-Int.ofNat actualRadius)
+          (cubePointAt dimension actualRadius rank) i
+      else
+        let afterLeft := rank - cubeTail
+        let shellTail := shellCountBound dimension actualRadius
+          (afterLeft + 1)
+        let interiorCount := capMul (afterLeft + 1) (2 * radius + 1)
+          shellTail
+        if afterLeft < interiorCount && shellTail != 0 then
+          let headIndex := afterLeft / shellTail
+          let tailRank := afterLeft % shellTail
+          fun i => Fin.cases
+            (Int.ofNat (headIndex + 1) - Int.ofNat actualRadius)
+            (shellPointAt dimension actualRadius tailRank) i
+        else
+          let tailRank := afterLeft - interiorCount
+          fun i => Fin.cases (Int.ofNat actualRadius)
+            (cubePointAt dimension actualRadius tailRank) i
+
+def rotatedRanks (count : Nat) (word : UInt64) : List Nat :=
+  if count = 0 then []
+  else
+    let offset := word.toNat % count
+    let backwards := word.toNat % 2 = 1
+    (List.range count).map fun k =>
+      if backwards then (offset + count - k % count) % count
+      else (offset + k) % count
+
+/-- At most `fuel` points from increasing shells through `maxShell`.
+Small shells are visited completely; a shell larger than the remaining
+budget contributes a randomized, duplicate-free prefix.  One random word is
+consumed per nonempty visited shell and zero fuel is the identity on `Rand`. -/
+def boundedShellOrder (dimension maxShell fuel : Nat) (r : Rand) :
+    List (Fin dimension → Int) × Rand :=
+  let rec go : Nat → Nat → Nat → List (Fin dimension → Int) →
+      Rand → List (Fin dimension → Int) × Rand
+    | 0, _, _, acc, r => (acc.reverse, r)
+    | shells + 1, radius, remaining, acc, r =>
+      if remaining = 0 then (acc.reverse, r)
+      else
+      let count := shellCountBound dimension radius remaining
+      if count = 0 then go shells (radius + 1) remaining acc r
+      else
+        let next := r.next
+        let points := (rotatedRanks count next.1).map fun rank =>
+          shellPointAt dimension radius rank
+        go shells (radius + 1) (remaining - count)
+          (points.reverse ++ acc) next.2
+  go (maxShell + 1) 0 fuel [] r
+
+/-- Result of a bounded scouting pass, including rejection diagnostics and
+the generator state after shell randomization. -/
+structure PointSearchResult (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp'] where
+  best : Option (Probe n cmp cmp')
+  /-- All admissible probes, ordered by increasing image-factor count. -/
+  accepted : List (Probe n cmp cmp')
+  attempts : Nat
+  lastReject : Option PointReject
+  rand : Rand
+
+def insertProbe (candidate : Probe n cmp cmp') :
+    List (Probe n cmp cmp') → List (Probe n cmp cmp')
+  | [] => [candidate]
+  | probe :: probes =>
+      if candidate.images.length < probe.images.length then
+        candidate :: probe :: probes
+      else probe :: insertProbe candidate probes
+
+def scoutPoints (cfg : Config) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (s : MvPoly (n + 1) Int cmp) (lc : Decomp n cmp') (r : Rand) :
+    PointSearchResult n cmp cmp' :=
+  let ordered := boundedShellOrder n cfg.pointShell cfg.pointFuel r
+  let rec go (fuel scouts attempts : Nat) (last : Option PointReject)
+      (best : Option (Probe n cmp cmp'))
+      (accepted : List (Probe n cmp cmp')) :
+      List (Fin n → Int) → PointSearchResult n cmp cmp'
+    | [] => ⟨best, accepted, attempts, last, ordered.2⟩
+    | a :: points =>
+        if fuel = 0 || scouts = cfg.pointScouts then
+          ⟨best, accepted, attempts, last, ordered.2⟩
+        else
+          match probe cfg i cmp' a s lc ordered.2 with
+          | .error reject =>
+              go (fuel - 1) scouts (attempts + 1) (some reject) best
+                accepted points
+          | .ok (candidate, _) =>
+              let best := match best with
+                | none => some candidate
+                | some incumbent =>
+                    if candidate.images.length < incumbent.images.length then
+                      some candidate
+                    else some incumbent
+              let accepted := insertProbe candidate accepted
+              if candidate.images.length = 1 then
+                ⟨some candidate, accepted, attempts + 1, last, ordered.2⟩
+              else
+                go (fuel - 1) (scouts + 1) (attempts + 1) last best
+                  accepted points
+  go cfg.pointFuel 0 0 none none [] ordered.1
+
+end Hex.MvFactor

--- a/HexMvFactor/PointTests.lean
+++ b/HexMvFactor/PointTests.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvFactor.Point
+public import HexMvFactor.Point
+
+public section
+
+namespace Hex.MvFactor
+
+open Hex
+open Hex.MvPoly
+
+private def x : MvPoly 2 Int Mono.lex := X 0
+private def y : MvPoly 2 Int Mono.lex := X 1
+private def innerY : MvPoly 1 Int Mono.lex := X 0
+private def zeroPoint : Fin 1 → Int := fun _ => 0
+private def atFive : Fin 1 → Int := fun _ => 5
+
+private def coordinates {n : Nat} (a : Fin n → Int) : List Int :=
+  (List.finRange n).map a
+
+private def samePointSet {n : Nat} (as bs : List (Fin n → Int)) : Bool :=
+  as.length == bs.length &&
+    as.all fun a => bs.any fun b => coordinates a == coordinates b
+
+private def variableLeading : Decomp 1 Mono.lex :=
+  { content := 1, factors := [⟨innerY, 1⟩] }
+
+private def constantLeading : Decomp 1 Mono.lex :=
+  { content := 1, factors := [] }
+
+private def splitLeading : Decomp 1 Mono.lex :=
+  { content := 6, factors := [⟨innerY, 1⟩] }
+
+/- V2 is checked before either squarefreeness or univariate factorization. -/
+#guard
+  match probe Config.default 0 Mono.lex zeroPoint (y * x + 1)
+      variableLeading (Rand.ofSeed 0) with
+  | .error .degreeDrop => true
+  | _ => false
+
+/- Relative squarefreeness rejects the repeated image `(x+1)^2`. -/
+#guard
+  match probe Config.default 0 Mono.lex zeroPoint ((x + 1) ^ 2)
+      constantLeading (Rand.ofSeed 0) with
+  | .error .notSquarefree => true
+  | _ => false
+
+/- The complete point route factors the squarefree image, distributes `6y`,
+   and returns the rescaled image product without recomputation. -/
+#guard
+  let target := (C 2 * y * x + 1) * (C 3 * x + y)
+  match probe Config.default 0 Mono.lex atFive target splitLeading
+      (Rand.ofSeed 9) with
+  | .ok (accepted, _) =>
+      accepted.images.length = 2 &&
+        MvHensel.uniProduct accepted.images ==
+          MvHensel.imageAt 0 Mono.lex atFive target &&
+        MvHensel.mvProduct accepted.leading ==
+          MvHensel.lcIn 0 Mono.lex target
+  | .error _ => false
+
+/- Shell zero is the origin and the one-dimensional radius-one shell has
+   exactly the two endpoints. -/
+#guard (shellPoints 1 0).length = 1
+#guard (shellPoints 1 1).length = 2
+#guard (shellPoints 2 1).length = 8
+
+/- Full budget-visible small shells agree with the materialized reference.
+   Comparing coordinate sets and lengths catches both omissions and
+   duplicate ranks while allowing the intended within-shell permutation. -/
+#guard
+  let actual := (boundedShellOrder 1 2 5 (Rand.ofSeed 23)).1
+  samePointSet (actual.filter fun a => pointNorm a == 2) (shellPoints 1 2)
+
+#guard
+  let actual := (boundedShellOrder 2 1 9 (Rand.ofSeed 29)).1
+  samePointSet (actual.filter fun a => pointNorm a == 1) (shellPoints 2 1)
+
+#guard
+  let actual := (boundedShellOrder 2 2 25 (Rand.ofSeed 37)).1
+  samePointSet (actual.filter fun a => pointNorm a == 2) (shellPoints 2 2)
+
+/- Ordering consumes one generator word per point and remains replayable. -/
+#guard
+  (orderShell (shellPoints 1 1) (Rand.ofSeed 17)).2 =
+    (orderShell (shellPoints 1 1) (Rand.ofSeed 17)).2
+
+/- The production enumerator is capped before constructing any cube. -/
+#guard
+  let seed := Rand.ofSeed 31
+  let ordered := boundedShellOrder 512 8 0 seed
+  ordered.1.isEmpty && ordered.2 == seed
+
+#guard
+  let ordered := boundedShellOrder 128 8 3 (Rand.ofSeed 31)
+  ordered.1.length == 3
+
+/- Zero fuel reaches neither shell construction nor random advancement in
+   the actual scouting API. -/
+#guard
+  let cfg := { Config.default with pointFuel := 0 }
+  let seed := Rand.ofSeed 44
+  let result := scoutPoints cfg 0 Mono.lex (x + 1) constantLeading seed
+  result.attempts == 0 && result.accepted.isEmpty && result.rand == seed
+
+end Hex.MvFactor

--- a/HexMvFactor/SPEC/hex-mv-factor.md
+++ b/HexMvFactor/SPEC/hex-mv-factor.md
@@ -10,10 +10,10 @@ checker leaves open, proves uniqueness against Mathlib's unique
 factorization, and supplies `Decidable (Irreducible p)`.
 
 This SPEC expands the "Multivariate factorization" entry in
-[future-work](../future-work.md). It consumes the lifting contract
-accepted in [hex-mv-hensel](hex-mv-hensel.md), the content, exact
+[future-work](../../SPEC/future-work.md). It consumes the lifting contract
+accepted in [hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md), the content, exact
 division, and squarefree decomposition accepted in
-[hex-mv-gcd](hex-mv-gcd.md), the representation fixed by
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md), the representation fixed by
 [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md), and univariate
 integer factorization from
 [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md).
@@ -72,7 +72,7 @@ factorization of the content.
 Also not in scope: coefficient rings other than `Int`, absolute
 factorization (factoring over `ℚ̄` or a number field), factorization
 over `F_q[x₁, …, x_v]`, and sparse Hensel lifting (see
-[hex-mv-hensel §Future extension: sparse Hensel lifting](hex-mv-hensel.md)).
+[hex-mv-hensel §Future extension: sparse Hensel lifting](../../HexMvHensel/SPEC/hex-mv-hensel.md)).
 
 **Why `Int` and not a general coefficient domain.** The four
 ingredients this library composes are all integer-specific. Univariate
@@ -157,7 +157,7 @@ distinctness makes the multiplicities unambiguous. Without D5, the same
 polynomial could appear twice and `multiplicity` would mean nothing.
 
 **Normalization depends on the monomial order, and over `ℤ` as well.**
-This is the same trap [hex-mv-gcd](hex-mv-gcd.md) records for `gcd`:
+This is the same trap [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) records for `gcd`:
 negation flips every coefficient at once, but *which* monomial is
 leading changes with `cmp`, so `x - y` normalizes to `x - y` under an
 order with `x` leading and to `y - x` under an order with `y` leading.
@@ -178,7 +178,7 @@ structure Complete (n : Nat) (cmp : Mono n → Mono n → Ordering) where
 def checkComplete (f : MvPoly n Int cmp) (K : Complete n cmp) : Bool
 
 /-- Mathlib-free irreducibility, reused from
-[hex-mv-hensel](hex-mv-hensel.md) rather than restated: no
+[hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md) rather than restated: no
 factorization into two nonunits. The companion identifies it with
 Mathlib's `Irreducible`. -/
 -- Hex.MvHensel.Irred
@@ -218,7 +218,7 @@ reader from adding a redundant sixth condition to `checkDecomp`.
 **Why the content is not factored.** `Factorization` in
 [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md)
 carries a signed integer `scalar` and does not split it into constant
-prime polynomials, `sqfDecomp` in [hex-mv-gcd](hex-mv-gcd.md) carries a
+prime polynomials, `sqfDecomp` in [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) carries a
 `content : R` and does not factor it, and SymPy's `factor_list` does
 the same. This library follows that convention: `C p` for prime `p` is
 genuinely irreducible in `ℤ[x₁, …, x_v]`, so the ring-theoretic
@@ -232,7 +232,7 @@ up to the integer content", and never drops the qualifier.
 
 ## What a checked decomposition does not prove
 
-[hex-mv-hensel §What a checked lift does not prove](hex-mv-hensel.md)
+[hex-mv-hensel §What a checked lift does not prove](../../HexMvHensel/SPEC/hex-mv-hensel.md)
 makes this point about one lift; it is worth making again about the
 whole pipeline, because the pipeline has more places to lose it.
 
@@ -261,7 +261,7 @@ of univariate irreducibility obligations that the checker cannot
 discharge Mathlib-free. -/
 inductive IrredCert :
     (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
-    [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type
+    [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type 1
   | degreeOne (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering)
       [IsMonomialOrder cmp'] (prim : ContentCert n Int cmp') :
       IrredCert (n+1) cmp
@@ -292,6 +292,11 @@ theorem checkComplete_sound
     IsFactorizationOf f K.decomp
 ```
 
+`IrredCert` lives in `Type 1` because its `degreeOne` and `image`
+constructors store `ContentCert n Int cmp'`, whose coefficient type is an
+index and therefore already places that certificate in `Type 1`.  This is a
+universe requirement only; it does not change the stored evidence or checker.
+
 **The obligations are the honest part of this design.** Irreducibility
 of a univariate integer polynomial is not something the Mathlib-free
 tree decides: `ZPoly.factorize` is total and returns factors it calls
@@ -303,7 +308,7 @@ and names them. The companion discharges the list, either from the
 factorizer's own theorem or from
 `Decidable (Irreducible f)` for `Polynomial ℤ`, and only then is the
 conclusion unconditional. This is [design
-principle 2](../design-principles.md) applied to a hypothesis about
+principle 2](../../SPEC/design-principles.md) applied to a hypothesis about
 irreducibility rather than about analysis, and it has the same shape as
 hex-mv-hensel stating `BoundsFactors` and letting its companion
 discharge it.
@@ -375,7 +380,7 @@ irreducible primitive `g`, Gauss's lemma makes `g` irreducible in
 the integer points at which that irreducibility fails to specialize
 form a thin set. So a small random point usually gives an irreducible
 image and a certificate with one univariate obligation. Nothing is
-proved from that, in exactly the way [hex-mv-gcd](hex-mv-gcd.md) proves
+proved from that, in exactly the way [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) proves
 nothing from the success rate of its heuristic gcd: it is why the cheap
 route is worth trying first, and the fuel makes the producer partial
 regardless.
@@ -461,7 +466,7 @@ at dense-size degree, and the enumeration is `∏_k (e_k + 1)` exact
 divisions. Neither has a useful bound in terms of the input, and both
 are astronomically worse than the `image` route on inputs where the
 `image` route fires. It is specified for the same reason
-[hex-mv-gcd](hex-mv-gcd.md)'s extended-subresultant route and
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md)'s extended-subresultant route and
 [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md)'s
 `factorTrial` are: it is unconditional, it needs no bound anybody has to
 prove, and it is what makes the companion's `Decidable` instance total.
@@ -508,6 +513,8 @@ it finds one, and returns it. -/
 def kronDecide (g : MvPoly n Int cmp) : Verdict n cmp
 
 theorem kronDecide_irreducible
+    (hprim : MvPoly.content g = 1)
+    (hnonconst : ¬ MvPoly.IsConst g)
     (h : kronDecide g = .irreducible c)
     (ho : ∀ F ∈ obligations g c, MvHensel.Irred F) :
     MvHensel.Irred g
@@ -569,7 +576,7 @@ with its prerequisite named.
 Everything below is untrusted. It produces `Decomp` and `IrredCert`
 values, and `checkDecomp` and `checkIrred` decide whether they are
 accepted, in the sense of [design
-principle 4](../design-principles.md).
+principle 4](../../SPEC/design-principles.md).
 
 **Termination.** The pipeline enters itself twice, at step 2 on
 `contentIn i cmp' s` and at step 4 on `lcIn i cmp' s`, and both are at
@@ -577,7 +584,7 @@ arity `n` when the caller was at arity `n + 1`, so the recursion is
 structural on the arity and bottoms out at the constants. Everything
 else in a single call is bounded by the configured fuel. The arity drop
 is free rather than an invariant to maintain, for the reason
-[hex-mv-gcd](hex-mv-gcd.md) gives about its own certificate: the types
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) gives about its own certificate: the types
 of `contentIn` and `lcIn` say so.
 
 ### 0. Structural reductions, always applied
@@ -597,7 +604,7 @@ In order, each of which shrinks the problem without any search:
   factors gets a `degreeOne` certificate, so the monomial part of the
   answer is complete with no obligations at all.
 - **Integer content.** Divide out `content f` from
-  [hex-mv-gcd](hex-mv-gcd.md), which is the producer-free scalar fold,
+  [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md), which is the producer-free scalar fold,
   and put it in `Decomp.content` together with the sign that
   `polyNormalize` extracts.
 
@@ -606,7 +613,7 @@ variable.
 
 ### 1. Squarefree decomposition
 
-Call `sqfDecomp` from [hex-mv-gcd](hex-mv-gcd.md). It returns
+Call `sqfDecomp` from [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md). It returns
 `⟨c, [(s_k, k)]⟩` with the `s_k` squarefree, primitive, nonconstant,
 pairwise coprime, and of distinct multiplicities; `c` is `±1` here,
 because step 0 already removed the content, and it multiplies into
@@ -634,7 +641,7 @@ pipeline, and wrap each factor found there in `embed`.
 The content and the primitive part are coprime: a common divisor would
 have its square dividing `s`, contradicting squarefreeness. So the two
 factor lists concatenate without a merge step, which is the same
-argument [hex-mv-gcd](hex-mv-gcd.md) makes for Yun's content recursion.
+argument [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes for Yun's content recursion.
 
 Steps 3 to 7 work on `primPartIn i cmp' s`, and `s` denotes it from
 here on, so `contentIn i cmp' s = 1` throughout them. That primitivity
@@ -673,7 +680,12 @@ inductive PointReject
 /-- What an accepted point yields. The point loop returns this, so the
 univariate factorization and the assignment are computed once and not
 recomputed by the caller. -/
-structure Probe (n : Nat) (cmp) (cmp') where
+/- Here `n` is the number of non-main variables, so the target has arity
+`n + 1`.  Indexing `Probe` by the target arity would not determine the
+`Fin n` point or the inner comparator at arity zero. -/
+structure Probe (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    (cmp' : Mono n → Mono n → Ordering) where
   point   : Fin n → Int
   images  : List ZPoly                 -- rescaled, so V3 and V4 hold
   leading : List (MvPoly n Int cmp')
@@ -689,7 +701,7 @@ A candidate `a : Fin n → Int` is admissible when:
    [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md)'s relative predicate
    and already carries a `Decidable` instance; the underlying test is
    the gcd of the *primitive part* with its derivative, through
-   [hex-poly-z-gcd](hex-poly-z-gcd.md).
+   [hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md).
 
    The relative predicate is the right one and the ring-theoretic one
    would be wrong here. Evaluation routinely gives the image a nonunit
@@ -697,7 +709,7 @@ A candidate `a : Fin n → Int` is admissible when:
    while its polynomial part is and its factorization is
    multiplicity-free. Testing `F` itself would reject good points for a
    property the algorithm does not need. This is the same convention
-   [hex-mv-gcd](hex-mv-gcd.md) fixes under "What squarefree means
+   [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) fixes under "What squarefree means
    here".
 3. **A usable leading-coefficient distribution exists**, in the sense
    of the next section.
@@ -1010,7 +1022,7 @@ points with few image factors, and it is why `cfg.recombLevels`
 defaults to a small number rather than to `r`.
 
 **Bad, unlucky, and fatal.** The vocabulary matches
-[hex-mv-gcd](hex-mv-gcd.md)'s for Brown's algorithm, and the analogy is
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md)'s for Brown's algorithm, and the analogy is
 exact. A *bad* point is one the admissibility tests reject, before any
 work. An *unlucky* point is one whose image splits too finely, and it
 is detected only by a failed lift and repaired by recombination. A
@@ -1086,7 +1098,7 @@ anything.
 **Every failure carries the decomposition found so far.** `Partial`
 holds a `CheckedDecomp`, so a caller that runs out of budget keeps the
 coarser answer instead of nothing, and can resume with a larger budget.
-This is the structure [future-work](../future-work.md) anticipates for
+This is the structure [future-work](../../SPEC/future-work.md) anticipates for
 the number-field consumers under `PartialFactorization`, and it is the
 reason the public entry point returns `Except (Partial f) _` rather
 than `Option`: the distinctions in the middle column are what a caller
@@ -1095,7 +1107,7 @@ them.
 
 There is no total `factor : MvPoly n Int cmp → Decomp n cmp`. A finite
 fuel does not make a partial search total, and [design
-principle 8](../design-principles.md) does not admit "the default is
+principle 8](../../SPEC/design-principles.md) does not admit "the default is
 generous" as a classification. The one total form in the library is
 `checkDecomp`, which is a decision procedure rather than a search.
 
@@ -1197,7 +1209,9 @@ structure Complete (n : Nat) (cmp)
 inductive IrredCert (n : Nat) (cmp)
 inductive Failure (n : Nat) (cmp)
 inductive PointReject
-structure Probe (n : Nat) (cmp) (cmp')
+structure Probe (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    (cmp' : Mono n → Mono n → Ordering)
 structure Partial (f : MvPoly n Int cmp)
 
 structure CheckedDecomp (f : MvPoly n Int cmp)
@@ -1266,7 +1280,7 @@ def irredCert?   (cfg : Config) (g : MvPoly n Int cmp) :
 -- Pieces the conformance drivers exercise directly
 def probe (cfg : Config) (i : Fin (n+1)) (cmp') (a : Fin n → Int)
     (s : MvPoly (n+1) Int cmp) (lc : Decomp n cmp') (r : Rand) :
-    Except PointReject (Probe (n+1) cmp cmp' × Rand)
+    Except PointReject (Probe n cmp cmp' × Rand)
 def distribute?  (i : Fin (n+1)) (cmp') (a : Fin n → Int)
     (lc : Decomp n cmp') (uni : List ZPoly) (scalar : Int) :
     Option (List (MvPoly n Int cmp') × List ZPoly)
@@ -1327,7 +1341,7 @@ the same subject need not correspond at all.
 ## Complexity
 
 These are **probe counts** in the sense
-[hex-mv-gcd](hex-mv-gcd.md) and [hex-mv-hensel](hex-mv-hensel.md) use:
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) and [hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md) use:
 they count evaluations, univariate factorizations, lifts, and
 divisions, and they omit the cost of each probe. Multiplying through
 would need a cost model for arithmetic modulo `q` at `l` words, which
@@ -1405,13 +1419,13 @@ claim it is one artefact.
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). A Lean driver at
 `conformance/HexMvFactor/EmitFixtures.lean` exposed as
 `lean_exe hexmvfactor_emit_fixtures`, a committed snapshot at
 `conformance-fixtures/HexMvFactor/mvfactor.jsonl`, and an oracle driver
 at `scripts/oracle/mvfactor_sympy.py`. One tuple appended to `ORACLES`
 in `scripts/ci/run_oracles.sh`, not a new job, per
-[SPEC/CI.md](../CI.md):
+[SPEC/CI.md](../../SPEC/CI.md):
 
 ```
 "HexMvFactor|hexmvfactor_emit_fixtures|scripts/oracle/mvfactor_sympy.py|conformance-fixtures/HexMvFactor/mvfactor.jsonl"
@@ -1429,7 +1443,7 @@ fixture kind defines, so one parser serves them, hex-mv-gcd's three
 kinds, and hex-mv-hensel's two.
 
 **The oracle suite alone cannot catch the bugs this library is most
-likely to have**, for the reason [hex-mv-gcd](hex-mv-gcd.md) gives
+likely to have**, for the reason [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) gives
 about its own routes. Every answer goes through `checkDecomp`, and a
 rejected candidate falls through to another point or another grouping,
 so an end-to-end fixture passes even when the non-divisor
@@ -1543,7 +1557,7 @@ SymPy's normalisation conventions.
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexMvFactor/Bench.lean`. Native only for throughput. A separate
 `bench/HexMvFactor/Kernel.lean` suite replays valid and
 one-field-corrupted data through `by decide +kernel`: a decomposition
@@ -1585,7 +1599,7 @@ Families, chosen to isolate the costs the complexity table separates:
 **dense EEZ** bench target, with the goal that this library solve every
 rung the comparator solves under the declared cap and stay within a
 stated constant of it there. That is the required ratio
-[hex-mv-hensel](hex-mv-hensel.md) defers to this library, on the one
+[hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md) defers to this library, on the one
 family where the two implementations are doing the same work. On every
 other family FLINT is `informational`: its sparse Hensel lifting and
 Zippel interpolation have no counterpart here while hex-mv-hensel
@@ -1755,13 +1769,14 @@ semantic operation: `checkDecomp`, `checkIrred`, `factor?`,
 ```
 HexMvFactor/
   Decomp.lean     -- Factor, Decomp, checkDecomp, soundness, structural reductions
-  Irred.lean      -- IrredCert, checkIrred, obligations, Split, soundness of each constructor
-  Point.lean      -- probe, Probe, PointReject, the shell enumeration
+  IrredData.lean  -- IrredCert, Split, Complete, and Verdict shared data
+  Irred.lean      -- checkIrred, obligations, checkSplit, Complete replay, soundness
+  Point.lean      -- Config, probe, Probe, PointReject, the shell enumeration
   Leading.lean    -- lc factorization, distribute?, the rescaling to V3 and V4
   Input.lean      -- building MvHensel.Input, prime selection, the modulus schedule
   Eez.lean        -- the per-squarefree driver, retries, recombination, normalization
   Kronecker.lean  -- kron, unKron?, kronDecide, the complete route
-  Factor.lean     -- Config, the top-level recursion, the public API
+  Factor.lean     -- the top-level recursion and public API
 HexMvFactor.lean
 HexMvFactorMathlib/
   Correspondence.lean -- transport of checkDecomp and checkIrred
@@ -1776,8 +1791,8 @@ HexMvFactorMathlib.lean
   HexMvFactor:
     deps: [HexBasic, HexMvPoly, HexMvGcd, HexMvHensel, HexPoly, HexPolyZ, HexPolyZGcd, HexBerlekampZassenhaus, HexPolyFp, HexModArith, HexModular, HexArith]
     mathlib: false
-    done_through: 0
-    status: planned
+    done_through: 1
+    status: active
     phase4:
       comparators:
         - tool: "FLINT fmpz_mpoly_factor (dense EEZ bench target)"
@@ -1805,15 +1820,10 @@ supply and the symmetric representatives, and `HexArith` through the
 integer gcd behind the non-divisor test. `HexPoly` comes in
 through `DensePoly`.
 
-`HexMvPoly`, `HexMvPolyMathlib`, `HexPoly`, `HexPolyZ`, `HexPolyFp`,
-`HexModArith`, `HexArith`, `HexBerlekampZassenhaus`, and
-`HexBerlekampZassenhausMathlib` are active. `HexMvGcd`, `HexMvHensel`,
-`HexModular`, and `HexPolyZGcd` are planned and not yet registered in
-`libraries.yml`; their entries must be added and implemented before the
-block above can be applied. The new entries are `planned` rather than
-`draft` because this SPEC fixes their required API and milestones,
-which is the same position [hex-mv-gcd](hex-mv-gcd.md) and
-[hex-mv-hensel](hex-mv-hensel.md) record for themselves.
+The computational dependency chain through `HexModular`, `HexPolyZGcd`,
+`HexMvGcd`, and `HexMvHensel` is active and registered in `libraries.yml`.
+The Mathlib companion remains planned: it starts only after the
+Mathlib-facing bridge libraries in its dependency list are available.
 
 `HexIntFactor` is deliberately absent; "The two claims" gives the
 reason and "Open questions" records the flag that would add it.
@@ -1870,8 +1880,8 @@ untouched.
   three lines. If a third one appears, the flag is cheaper than the
   repetition.
 - **Which sparse route merits an amendment.** Shared with
-  [hex-mv-gcd](hex-mv-gcd.md) and
-  [hex-mv-hensel](hex-mv-hensel.md), whose open questions of the same
+  [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) and
+  [hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md), whose open questions of the same
   name should be decided together. The dense diophantine recursion is
   the dominant cost of this library on sparse inputs, and the
   "sparse targets" family measures it in the meantime.

--- a/HexMvGcd.lean
+++ b/HexMvGcd.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Coeff
+public import HexMvGcd.Divide
+public import HexMvGcd.View
+public import HexMvGcd.Normalize
+public import HexMvGcd.Instances
+public import HexMvGcd.Gauss
+public import HexMvGcd.KernelTests
+public import HexMvGcd.Cert
+public import HexMvGcd.Content
+public import HexMvGcd.Prs
+public import HexMvGcd.Fast
+public import HexMvGcd.Heu
+public import HexMvGcd.Brown
+public import HexMvGcd.Gcd
+public import HexMvGcd.Squarefree
+public import HexMvGcd.Kernel
+public import HexMvGcd.Eval
+
+public section
+
+/-!
+Checked multivariate exact division, gcd, and squarefree decomposition.
+-/

--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -1,0 +1,767 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular
+public import HexMvGcd.Heu
+public import HexPolyZGcd.Gcd
+
+@[expose] public section
+
+/-!
+The state machines used by Brown's dense route.
+
+The point layer and the prime layer deliberately expose their decisions.  A
+bad image must not mutate reconstruction state, a larger image degree is
+unlucky, and a smaller image degree discards all accumulated interpolation or
+CRT data.  Keeping those decisions executable and separate from candidate
+checking makes the three failure modes directly testable.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+/-- Brown's response to one evaluation point. -/
+inductive BrownPointAction where
+  /-- An input leading coefficient or the correction scalar vanished. -/
+  | bad
+  /-- The image gcd degree was larger than the current minimum. -/
+  | unlucky
+  /-- A smaller degree invalidated all previously accumulated images. -/
+  | restart
+  /-- The image has the current minimal degree and may be interpolated. -/
+  | accept
+deriving BEq, DecidableEq, Repr
+
+/-- Degree state for one dense interpolation layer. -/
+structure BrownPointState where
+  bestDegree? : Option Nat := none
+  accepted : Nat := 0
+deriving BEq, DecidableEq, Repr
+
+/-- Classify one point before it can affect interpolation state. -/
+def BrownPointState.offer (state : BrownPointState)
+    (inputDegreesSurvive gammaNonzero : Bool) (imageDegree : Nat) :
+    BrownPointAction × BrownPointState :=
+  if !inputDegreesSurvive || !gammaNonzero then
+    (.bad, state)
+  else
+    match state.bestDegree? with
+    | none =>
+        (.accept, { bestDegree? := some imageDegree, accepted := 1 })
+    | some degree =>
+        if imageDegree > degree then
+          (.unlucky, state)
+        else if imageDegree < degree then
+          (.restart, { bestDegree? := some imageDegree, accepted := 1 })
+        else
+          (.accept, { state with accepted := state.accepted + 1 })
+
+/-- Brown's response to one modular image. -/
+inductive BrownPrimeAction where
+  /-- Reduction destroyed an input degree or normalization datum. -/
+  | bad
+  /-- The modular gcd degree was larger than the running minimum. -/
+  | unlucky
+  /-- A smaller degree invalidated all previous CRT data. -/
+  | restart
+  /-- The image may be accumulated, but its support is not stable yet. -/
+  | accumulate
+  /-- The image degree and support agree with the preceding image. -/
+  | stable
+deriving BEq, DecidableEq, Repr
+
+/-- Prime-layer state.  `support` is stored in canonical monomial order, so
+plain list equality is the exact support-stability test required before CRT
+reconstruction is trusted. -/
+structure BrownPrimeState (n : Nat) where
+  bestDegree? : Option Nat := none
+  support : List (Mono n) := []
+  stableRounds : Nat := 0
+deriving BEq, DecidableEq, Repr
+
+/-- Classify a modular image before it can mutate a CRT accumulator. -/
+def BrownPrimeState.offer {n : Nat} (state : BrownPrimeState n)
+    (inputDegreesSurvive normalizationNonzero : Bool)
+    (imageDegree : Nat) (imageSupport : List (Mono n)) :
+    BrownPrimeAction × BrownPrimeState n :=
+  if !inputDegreesSurvive || !normalizationNonzero then
+    (.bad, state)
+  else
+    match state.bestDegree? with
+    | none =>
+        (.accumulate,
+          { bestDegree? := some imageDegree
+            support := imageSupport
+            stableRounds := 0 })
+    | some degree =>
+        if imageDegree > degree then
+          (.unlucky, state)
+        else if imageDegree < degree then
+          (.restart,
+            { bestDegree? := some imageDegree
+              support := imageSupport
+              stableRounds := 0 })
+        else if imageSupport == state.support then
+          (.stable, { state with stableRounds := state.stableRounds + 1 })
+        else
+          -- Equal degree with a different support starts a new stabilization
+          -- epoch.  Existing CRT coordinates cannot be paired with it.
+          (.restart,
+            { bestDegree? := some imageDegree
+              support := imageSupport
+              stableRounds := 0 })
+
+/-- Scale a nonzero univariate image gcd so that its leading coefficient is
+the evaluated Brown correction `gamma`.  Returning `none` for either zero is
+the zero-divisor/bad-point branch; callers must not interpolate that image. -/
+def brownCorrectImage? {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    (gamma : R) (image : DensePoly R) : Option (DensePoly R) :=
+  if gamma == 0 || image.isZero then
+    none
+  else
+    let leading := image.leadingCoeff
+    if leading == 0 then none
+    else some (DensePoly.scaleImpl (gamma * leading⁻¹) image)
+
+/-- The scalar Lagrange basis which is one at `point` and zero at every
+member of `others`.  Duplicate points are rejected instead of relying on an
+inverse of zero. -/
+def brownBasis? {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    (point : R) (others : List R) : Option (DensePoly R) := do
+  let (numerator, denominator) ← others.foldlM
+    (fun (state : DensePoly R × R) other =>
+      if point == other then none
+      else some
+        (state.1 * DensePoly.ofList [-other, 1],
+          state.2 * (point - other)))
+    (1, 1)
+  if denominator == 0 then none
+  else some (DensePoly.scaleImpl denominator⁻¹ numerator)
+
+/-- Embed a scalar dense polynomial into a dense polynomial whose
+coefficients are multivariate constants. -/
+def brownLiftBasis {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (basis : DensePoly R) : DensePoly (MvPoly n R cmp) :=
+  DensePoly.ofList <|
+    (List.range basis.size).map fun degree => C (basis.coeff degree)
+
+/-- Dense Lagrange interpolation of polynomial-valued samples.  The result
+is a univariate polynomial in the evaluated variable whose coefficients are
+polynomials in all remaining variables. -/
+def brownInterpolate? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    (samples : List (R × MvPoly n R cmp)) :
+    Option (DensePoly (MvPoly n R cmp)) :=
+  let rec go (seen : List R) (remaining : List (R × MvPoly n R cmp))
+      (result : DensePoly (MvPoly n R cmp)) :
+      Option (DensePoly (MvPoly n R cmp)) := do
+    match remaining with
+    | [] => some result
+    | (point, value) :: rest =>
+        let others := seen.reverse ++ rest.map Prod.fst
+        let basis ← brownBasis? point others
+        let term := brownLiftBasis (n := n) (cmp := cmp) basis * DensePoly.C value
+        go (point :: seen) rest (result + term)
+  go [] samples 0
+
+/-- Evaluate the last variable and remove it.  `Mono.lex` is used for the
+remaining variables only as a storage order; reconstruction may target any
+monomial order. -/
+def brownEvalLast {n : Nat} {R : Type u}
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (point : R) (p : MvPoly (n + 1) R cmp) : MvPoly n R Mono.lex :=
+  DensePoly.evalImpl (toUnivariate (Fin.last n) Mono.lex p) (C point)
+
+/-- Leading coefficient when variable zero is the fixed Brown main
+variable. -/
+def brownMainLeadingCoeff {n : Nat} {R : Type u}
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (p : MvPoly (n + 1) R cmp) : MvPoly n R Mono.lex :=
+  (toUnivariate 0 Mono.lex p).leadingCoeff
+
+/-- Turn an untrusted Brown polynomial into a complete certificate.  Trial
+division and a deterministic cofactor gcd build the witness, and the public
+checker remains the only acceptance condition. -/
+def brownCheckedCandidate? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (f h candidate : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+  checkedCandidate? f h candidate
+
+/-! # Recursive point layer -/
+
+/-- Candidate operation at a fixed arity over a field-like coefficient
+kernel.  Inverses need not be trusted: every completed candidate is checked
+by `brownCheckedCandidate?`. -/
+structure BrownOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+  candidate? : (cmp : Mono n → Mono n → Ordering) →
+    [IsMonomialOrder cmp] → Nat → List R →
+    MvPoly n R cmp → MvPoly n R cmp → Option (MvPoly n R cmp)
+
+/-- Exact base image at arity zero. -/
+def brownBaseOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : BrownOpsAt R 0 where
+  candidate? := fun _ _ _ _ f h => some (rawPrsCert f h).gcd
+
+/-- Exact univariate image.  This is the leaf reached after evaluating all
+outer variables and is intentionally the existing checked PRS kernel rather
+than a second polynomial Euclidean implementation. -/
+def brownUnaryOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : BrownOpsAt R 1 where
+  candidate? := fun _ _ _ _ f h => some (rawPrsCert f h).gcd
+
+/-- Exact bad-point predicate used by the interpolation loop and by
+route-level tests. -/
+def brownPointBad {n : Nat} {R : Type u}
+    {cmp : Mono (n + 2) → Mono (n + 2) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (point : R) (gamma : MvPoly (n + 1) R Mono.lex)
+    (f h : MvPoly (n + 2) R cmp) : Bool :=
+  let fImage := brownEvalLast point f
+  let hImage := brownEvalLast point h
+  degreeOf (0 : Fin (n + 1)) fImage != degreeOf (0 : Fin (n + 2)) f ||
+    degreeOf (0 : Fin (n + 1)) hImage != degreeOf (0 : Fin (n + 2)) h ||
+    brownEvalLast point gamma == 0
+
+/-- One recursive dense-interpolation layer.  Variable zero remains the main
+variable; the last variable is evaluated and reconstructed. -/
+def brownStepOps {n : Nat} {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (lower : BrownOpsAt R (n + 1)) : BrownOpsAt R (n + 2) where
+  candidate? := fun cmp _ pointFuel points f h =>
+    if f == 0 || h == 0 || polyIsUnit f || polyIsUnit h then
+      some (rawPrsCert f h).gcd
+    else
+      let main : Fin (n + 2) := ⟨0, by omega⟩
+      let outer : Fin (n + 2) := Fin.last (n + 1)
+      let fView := toUnivariate main Mono.lex f
+      let hView := toUnivariate main Mono.lex h
+      let fContent := contentCertWith (fun a b => rawPrsCert a b)
+        fView.toArray.toList
+      let hContent := contentCertWith (fun a b => rawPrsCert a b)
+        hView.toArray.toList
+      let common := rawPrsCert fContent.value hContent.value
+      let fPrimitive := quotient f (constIn main Mono.lex fContent.value)
+      let hPrimitive := quotient h (constIn main Mono.lex hContent.value)
+      let gamma :=
+        (rawPrsCert (brownMainLeadingCoeff fPrimitive)
+          (brownMainLeadingCoeff hPrimitive)).gcd
+      let sampleTarget :=
+        max (degreeOf outer fPrimitive) (degreeOf outer hPrimitive) + 1
+      let rec loop (remaining : List R) (fuel : Nat)
+          (state : BrownPointState)
+          (samples : List (R × MvPoly (n + 1) R Mono.lex)) :
+          Option (MvPoly (n + 2) R cmp) := do
+        if fuel = 0 then none else pure PUnit.unit
+        match remaining with
+        | [] => none
+        | point :: rest =>
+            let fImage := brownEvalLast point fPrimitive
+            let hImage := brownEvalLast point hPrimitive
+            let gammaAt := brownEvalLast point gamma
+            if brownPointBad point gamma fPrimitive hPrimitive then
+              loop rest (fuel - 1) state samples
+            else
+              match lower.candidate? Mono.lex (fuel - 1) rest fImage hImage with
+              | none => loop rest (fuel - 1) state samples
+              | some rawImage =>
+                  let imageLeading := brownMainLeadingCoeff rawImage
+                  match divExact? gammaAt imageLeading with
+                  | none => loop rest (fuel - 1) state samples
+                  | some scale =>
+                      let corrected := constIn (0 : Fin (n + 1)) Mono.lex scale * rawImage
+                      if brownMainLeadingCoeff corrected != gammaAt then
+                        loop rest (fuel - 1) state samples
+                      else
+                        let imageDegree := degreeOf (0 : Fin (n + 1)) corrected
+                        let offered := state.offer true true imageDegree
+                        match offered.1 with
+                        | .bad | .unlucky =>
+                            loop rest (fuel - 1) offered.2 samples
+                        | .restart =>
+                            if sampleTarget ≤ 1 then
+                              let interpolation ← brownInterpolate? [(point, corrected)]
+                              let reconstructed :=
+                                ofUnivariate (cmp := cmp) outer Mono.lex interpolation
+                              let reconstructedView := toUnivariate main Mono.lex reconstructed
+                              let reconstructedContent := contentCertWith
+                                (fun a b => rawPrsCert a b)
+                                reconstructedView.toArray.toList
+                              let primitive := quotient reconstructed
+                                (constIn main Mono.lex reconstructedContent.value)
+                              some (constIn main Mono.lex common.gcd * primitive)
+                            else
+                              loop rest (fuel - 1) offered.2 [(point, corrected)]
+                        | .accept =>
+                            let nextSamples := (point, corrected) :: samples
+                            if sampleTarget ≤ offered.2.accepted then
+                              let interpolation ← brownInterpolate? nextSamples
+                              let reconstructed :=
+                                ofUnivariate (cmp := cmp) outer Mono.lex interpolation
+                              let reconstructedView := toUnivariate main Mono.lex reconstructed
+                              let reconstructedContent := contentCertWith
+                                (fun a b => rawPrsCert a b)
+                                reconstructedView.toArray.toList
+                              let primitive := quotient reconstructed
+                                (constIn main Mono.lex reconstructedContent.value)
+                              some (constIn main Mono.lex common.gcd * primitive)
+                            else
+                              loop rest (fuel - 1) offered.2 nextSamples
+      loop points pointFuel {} []
+
+/-- Construct all recursive point layers by arity. -/
+def brownOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    (n : Nat) → BrownOpsAt R n
+  | 0 => brownBaseOps
+  | 1 => brownUnaryOps
+  | n + 2 => brownStepOps (brownOps (n + 1))
+
+/-- Main variable of smallest positive input degree.  Ties keep the first
+variable, making the choice deterministic. -/
+def brownMainIndex {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (f h : MvPoly n R cmp) : Option (Fin n) :=
+  (List.finRange n).foldl (fun best i =>
+    let degree := max (degreeOf i f) (degreeOf i h)
+    if degree = 0 then best
+    else
+      match best with
+      | none => some i
+      | some j =>
+          if degree < max (degreeOf j f) (degreeOf j h) then some i
+          else best) none
+
+/-- Involutive variable permutation which moves `main` to coordinate zero. -/
+def brownSwapToZero {n : Nat} (main : Fin n) : Fin n → Fin n :=
+  let zero : Fin n := ⟨0, Nat.zero_lt_of_lt main.isLt⟩
+  fun i => if i = zero then main else if i = main then zero else i
+
+/-- Run the recursive point layers after moving the cheapest main variable
+to coordinate zero, then undo the same involution on the candidate. -/
+def brownCandidate? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (pointFuel : Nat) (points : List R)
+    (f h : MvPoly n R cmp) : Option (MvPoly n R cmp) :=
+  match brownMainIndex f h with
+  | none => (brownOps (R := R) n).candidate? cmp pointFuel points f h
+  | some main =>
+      let swap := brownSwapToZero main
+      let f' := rename cmp swap f
+      let h' := rename cmp swap h
+      match (brownOps (R := R) n).candidate? cmp pointFuel points f' h' with
+      | none => none
+      | some candidate => some (rename cmp swap candidate)
+
+/-- Run the recursive finite-field point layer and certify its result. -/
+def brownFieldCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (pointFuel : Nat) (points : List R)
+    (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+  match brownCandidate? pointFuel points f h with
+  | none => none
+  | some candidate => brownCheckedCandidate? f h candidate
+
+/-! # Integer prime/CRT layer -/
+
+/-- A nondependent modular image, ready for prime classification and CRT. -/
+structure BrownModImage (n : Nat) where
+  modulus : Nat
+  degree : Nat
+  support : List (Mono n)
+  residues : List Int
+deriving BEq, Repr
+
+/-- Reduce an integer problem at one bundled prime and run every recursive
+point layer there.  Destroyed input degrees are rejected before returning an
+image. -/
+def intBrownImage? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (pointFuel : Nat) (f h : MvPoly n Int cmp)
+    (prime : ZMod64.Prime) : Option (BrownModImage n) :=
+  letI : ZMod64.Bounds prime.m := prime.bounds
+  letI : ZMod64.PrimeModulus prime.m :=
+    ZMod64.primeModulusOfPrime prime.prime
+  let fImage := mapCoeffs (ZMod64.intCast prime.m) f
+  let hImage := mapCoeffs (ZMod64.intCast prime.m) h
+  let gamma : Int := Int.ofNat (Int.gcd f.leadingCoeff h.leadingCoeff)
+  let gammaImage := ZMod64.intCast prime.m gamma
+  if fImage.degrees != f.degrees || hImage.degrees != h.degrees ||
+      gammaImage == 0 then
+    none
+  else
+    let points : List (ZMod64 prime.m) :=
+      (List.range (min pointFuel prime.m)).map
+        (fun point => ZMod64.ofNat prime.m point)
+    match brownCandidate? pointFuel points fImage hImage with
+    | none => none
+    | some candidate =>
+        if candidate == 0 || candidate.leadingCoeff == 0 then none
+        else
+          let corrected :=
+            C (gammaImage * candidate.leadingCoeff⁻¹) * candidate
+          match brownCheckedCandidate? fImage hImage corrected with
+          | none => none
+          | some _ =>
+            -- Keep the gamma-scaled candidate, not the field-normalized
+            -- certificate gcd: monic normalization is correct for checking
+            -- but would destroy the cross-prime normalization needed by CRT.
+            some
+              { modulus := prime.m
+                degree := corrected.totalDegree
+                support := corrected.monomials
+                residues := corrected.termsList.map
+                  (fun term => Int.ofNat term.2.toNat) }
+
+/-- Coefficientwise CRT state at one stabilized support. -/
+structure BrownCrtState (n : Nat) where
+  prime : BrownPrimeState n
+  coeffs : List Modular.Crt
+
+/-- Start a fresh CRT epoch from one image. -/
+def BrownCrtState.start {n : Nat} (state : BrownPrimeState n)
+    (image : BrownModImage n) : Option (BrownCrtState n) :=
+  match image.residues.mapM
+      (fun residue => Modular.Crt.init.push residue image.modulus) with
+  | none => none
+  | some coeffs => some { prime := state, coeffs }
+
+/-- Atomically push corresponding CRT coordinates. -/
+def brownPushCrt : List Modular.Crt → List Int → Nat →
+    Option (List Modular.Crt)
+  | [], [], _ => some []
+  | old :: olds, residue :: residues, modulus =>
+      match old.push residue modulus,
+          brownPushCrt olds residues modulus with
+      | some next, some rest => some (next :: rest)
+      | _, _ => none
+  | _, _, _ => none
+
+/-- Fold an equal-support image into the current CRT epoch. -/
+def BrownCrtState.push {n : Nat} (state : BrownCrtState n)
+    (nextPrime : BrownPrimeState n) (image : BrownModImage n) :
+    Option (BrownCrtState n) :=
+  match brownPushCrt state.coeffs image.residues image.modulus with
+  | none => none
+  | some coeffs => some { prime := nextPrime, coeffs }
+
+/-- Symmetric integer candidate from the current stable support, with scalar
+content restored after primitive normalization. -/
+def BrownCrtState.candidate {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (state : BrownCrtState n) (f h : MvPoly n Int cmp) :
+    MvPoly n Int cmp :=
+  let raw := ofTerms <|
+    state.prime.support.zip (state.coeffs.map fun coeff => coeff.value)
+  let commonContent := GcdOps.gcd (content f) (content h)
+  polyNormalize (C commonContent * primPart raw)
+
+/-- Fuel-bounded integer prime layer.  A candidate is offered only after an
+equal-degree support has appeared twice and the second image has actually
+been pushed through CRT. -/
+def intBrownLoop {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (pointFuel : Nat) (f h : MvPoly n Int cmp) :
+    List ZMod64.Prime → Nat → Option (BrownCrtState n) →
+      Option (GcdCert n Int cmp)
+  | _, 0, _ => none
+  | [], _, _ => none
+  | prime :: primes, fuel + 1, state =>
+      match intBrownImage? pointFuel f h prime with
+      | none => intBrownLoop pointFuel f h primes fuel state
+      | some image =>
+          let oldPrime := state.map (fun s => s.prime) |>.getD {}
+          let offered := oldPrime.offer true true image.degree image.support
+          match offered.1 with
+          | .bad | .unlucky =>
+              intBrownLoop pointFuel f h primes fuel state
+          | .accumulate | .restart =>
+              match BrownCrtState.start offered.2 image with
+              | none => intBrownLoop pointFuel f h primes fuel state
+              | some next => intBrownLoop pointFuel f h primes fuel (some next)
+          | .stable =>
+              match state with
+              | none =>
+                  -- `stable` cannot arise from the empty default state.
+                  intBrownLoop pointFuel f h primes fuel none
+              | some old =>
+                  match old.push offered.2 image with
+                  | none => intBrownLoop pointFuel f h primes fuel state
+                  | some next =>
+                      match brownCheckedCandidate? f h (next.candidate f h) with
+                      | some cert => some cert
+                      | none =>
+                          intBrownLoop pointFuel f h primes fuel (some next)
+
+/-- Full integer Brown route for arity at least two. -/
+def intBrownModularCert? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Int cmp) :
+    Option (GcdCert n Int cmp) :=
+  let supply := smallPrimeSupply 257 cfg.brownPrimeFuel
+  intBrownLoop cfg.brownPointFuel f h supply cfg.brownPrimeFuel none
+
+/-! # Concrete route-3 dispatch
+
+The released univariate integer Brown implementation is reused verbatim at
+arity one.  Higher arities use the point/prime machinery above; a fuel or
+stabilization failure is a benign decline which leaves the mandatory checked
+PRS route in control. -/
+
+/-- Convert an arity-one integer polynomial to the released dense integer
+kernel without changing coefficients. -/
+def brownToZPoly {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f : MvPoly 1 Int cmp) : ZPoly :=
+  let view := toUnivariate (0 : Fin 1) Mono.lex f
+  DensePoly.ofList <|
+    (List.range view.size).map fun degree => coeff Mono.zero (view.coeff degree)
+
+/-- Re-embed a released dense integer polynomial at arity one. -/
+def brownOfZPoly {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f : ZPoly) : MvPoly 1 Int cmp :=
+  ofUnivariate (cmp := cmp) (0 : Fin 1) Mono.lex <|
+    DensePoly.ofList <|
+      (List.range f.size).map fun degree => C (f.coeff degree)
+
+/-- Default arity-one integer certificate delegated to `HexPolyZGcd`.  The
+dense kernel supplies the gcd and cofactors; the multivariate checker receives
+a freshly constructed arity-one coprimality witness over those exact
+cofactors. -/
+def intArityOneRaw {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) : GcdCert 1 Int cmp :=
+  let z := ZPoly.gcdCert (brownToZPoly f) (brownToZPoly h)
+  let g := brownOfZPoly z.gcd
+  let cofL := brownOfZPoly z.cofL
+  let cofR := brownOfZPoly z.cofR
+  let lower := prsOps (R := Int) 0
+  .mk g cofL cofR (succCoprime lower cmp cofL cofR)
+
+theorem intArityOneRaw_checks {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) :
+    checkGcd f h (intArityOneRaw f h) = true := by
+  sorry
+
+def intArityOneCert {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) : GcdCert 1 Int cmp :=
+  intArityOneRaw f h
+
+/-- Arity-indexed integer Brown producer.  The arity-one branch calls the
+actual `HexPolyZGcd` Brown route and then builds a fresh multivariate
+certificate; higher arities run dense point interpolation and prime CRT. -/
+def intBrownCert? {n : Nat} (cmp : Mono n → Mono n → Ordering)
+    [order : IsMonomialOrder cmp] (cfg : GcdConfig)
+    (f h : MvPoly n Int cmp) : Option (GcdCert n Int cmp) :=
+  match n, cmp, order, f, h with
+  | 0, _, _, _, _ => none
+  | 1, _, _, f, h =>
+      if cfg.brownPrimeFuel = 0 || cfg.brownPointFuel = 0 then none
+      else
+        match ZPoly.brownCert? (brownToZPoly f) (brownToZPoly h) with
+        | none => none
+        | some cert => brownCheckedCandidate? f h (brownOfZPoly cert.gcd)
+  | _ + 2, _, _, f, h => intBrownModularCert? cfg f h
+
+/-- Generic routes 0--3 for integer coefficients above the delegated
+arity-one case. -/
+def intConcreteProposalGeneric {n : Nat}
+    (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
+  let fast := intFastProposal cfg f h
+  match fast.cert? with
+  | some _ => fast
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, fast.rand⟩
+      | some reduced =>
+          match intHeuristicCert? cfg reduced.left reduced.right with
+          | some cert =>
+              ⟨restoreStructural? f h reduced cert, fast.rand⟩
+          | none =>
+              let cert? := intBrownCert? cmp cfg reduced.left reduced.right
+              ⟨cert?.bind (restoreStructural? f h reduced), fast.rand⟩
+
+/-- Concrete integer producer.  Arity one delegates immediately to the
+released dense integer kernel; other arities use the multivariate routes. -/
+def intConcreteProposal {n : Nat}
+    (cmp : Mono n → Mono n → Ordering) [order : IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
+  match n, cmp, order, f, h with
+  | 0, cmp, _, f, h => intConcreteProposalGeneric cmp cfg f h
+  | 1, _, _, f, h => ⟨some (intArityOneCert f h), cfg.rand⟩
+  | _ + 2, cmp, _, f, h => intConcreteProposalGeneric cmp cfg f h
+
+/-- Dense Brown route over rationals.  Rational points are unbounded, so the
+caller-provided point fuel is the only point-supply limit. -/
+def ratBrownCert? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Rat cmp) :
+    Option (GcdCert n Rat cmp) :=
+  let points := (List.range cfg.brownPointFuel).map fun (point : Nat) =>
+    ((Int.ofNat point : Int) : Rat)
+  brownFieldCert? cfg.brownPointFuel points f h
+
+/-! # Rational integer lifting -/
+
+/-- Least common denominator of the stored rational coefficients. -/
+def ratMvDen {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n Rat cmp) : Nat :=
+  p.termsList.foldl (fun den term => Nat.lcm den term.2.den) 1
+
+/-- Clear rational coefficients against a supplied common denominator. -/
+def ratMvClear {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp] (den : Nat)
+    (p : MvPoly n Rat cmp) : MvPoly n Int cmp :=
+  ofTerms <| p.termsList.map fun term =>
+    (term.1, term.2.num * Int.ofNat (den / term.2.den))
+
+/-- Primitive integer model together with the rational scalar which embeds
+it back to the original polynomial. -/
+structure RatPrimitiveModel (n : Nat)
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  scale : Rat
+  poly : MvPoly n Int cmp
+
+/-- Clear all denominators and remove integer scalar content. -/
+def ratPrimitiveModel {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (p : MvPoly n Rat cmp) : RatPrimitiveModel n cmp :=
+  let den := ratMvDen p
+  let cleared := ratMvClear den p
+  let rawModel := primPart cleared
+  let unitInv := GcdOps.exactDiv 1 (GcdOps.normUnit rawModel.leadingCoeff)
+  let model := polyNormalize rawModel
+  let scale : Rat :=
+    (((content cleared * unitInv : Int) : Rat) / (den : Rat))
+  ⟨scale, model⟩
+
+/-- Build the required rational cofactor witness from primitive integer
+models.  The integer PRS is run only on those models; both the nested integer
+certificate and the final rational transport are executable checker gates. -/
+def ratLiftCoprime? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n Rat cmp) : Option (CoprimeCert n Rat cmp) :=
+  let left := ratPrimitiveModel f
+  let right := ratPrimitiveModel h
+  if left.scale == 0 || right.scale == 0 then none
+  else
+    let intCert := rawPrsCert left.poly right.poly
+    let cert := CoprimeCert.ratLift left.scale right.scale
+      left.poly right.poly intCert.coprime
+    if checkCoprime f h cert then some cert else none
+
+/-- Offer a rational gcd candidate using exact divisions and a `ratLift`
+cofactor certificate. -/
+def ratCheckedCandidate? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h candidate : MvPoly n Rat cmp) : Option (GcdCert n Rat cmp) :=
+  if candidate == 0 then none
+  else
+    let normalized := polyNormalize candidate
+    match divExact? f normalized, divExact? h normalized with
+    | some cofL, some cofR =>
+        match ratLiftCoprime? cofL cofR with
+        | none => none
+        | some coprime =>
+            let cert := GcdCert.mk normalized cofL cofR coprime
+            if checkGcd f h cert then some cert else none
+    | _, _ => none
+
+/-- Rational gcd through primitive integer models.  Scaling either input by a
+nonzero rational unit does not change the monic gcd; candidate acceptance and
+cofactor transport are both checked concretely. -/
+def ratIntegerLiftCert? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n Rat cmp) : Option (GcdCert n Rat cmp) :=
+  let left := ratPrimitiveModel f
+  let right := ratPrimitiveModel h
+  if left.scale == 0 || right.scale == 0 then none
+  else
+    let intCert := rawPrsCert left.poly right.poly
+    ratCheckedCandidate? f h (intModelToRat intCert.gcd)
+
+/-- Routes 0--3 for rational coefficients. -/
+def ratConcreteProposal {n : Nat}
+    (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Rat cmp) : GcdProposal n Rat cmp :=
+  match structuralCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, cfg.rand⟩
+      | some reduced =>
+          match ratIntegerLiftCert? reduced.left reduced.right with
+          | some cert => ⟨restoreStructural? f h reduced cert, cfg.rand⟩
+          | none =>
+              let cert? := ratBrownCert? cfg reduced.left reduced.right
+              ⟨cert?.bind (restoreStructural? f h reduced), cfg.rand⟩
+
+/-- Dense Brown route over an already-prime coefficient field. -/
+def primeFieldBrownCert? {n p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p]
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n (@ZMod64 p hp) cmp) :
+    Option (GcdCert n (@ZMod64 p hp) cmp) :=
+  let points := (List.range (min cfg.brownPointFuel p)).map fun point =>
+    ZMod64.ofNat p point
+  brownFieldCert? cfg.brownPointFuel points f h
+
+/-- Routes 0--3 over a bundled prime field. -/
+def primeConcreteProposal {n p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p]
+    (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n (@ZMod64 p hp) cmp) :
+    GcdProposal n (@ZMod64 p hp) cmp :=
+  let earlier := primeFastProposal cmp cfg f h
+  match earlier.cert? with
+  | some _ => earlier
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, earlier.rand⟩
+      | some reduced =>
+          let cert? := primeFieldBrownCert? cfg reduced.left reduced.right
+          ⟨cert?.bind (restoreStructural? f h reduced), earlier.rand⟩
+
+instance intProducer : GcdProducer Int where
+  propose := fun cmp _ cfg f h => intConcreteProposal cmp cfg f h
+
+instance ratProducer : GcdProducer Rat where
+  propose := fun cmp _ cfg f h => ratConcreteProposal cmp cfg f h
+
+instance primeProducer {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] : GcdProducer (@ZMod64 p hp) where
+  propose := fun cmp _ cfg f h => primeConcreteProposal cmp cfg f h
+
+end Hex.MvPoly

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -1,0 +1,602 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArith.Modulus
+public import HexMvGcd.Instances
+public import HexPolyFp
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Checked recursive certificates for multivariate gcd and content.
+
+The three datatypes are mutually inductive because positive-arity coprimality
+certificates contain checked coefficient-content folds, whose steps are gcd
+certificates one arity lower.  Every cycle therefore decreases the arity.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+/-- Coefficientwise image followed by evaluation of all remaining variables,
+leaving one dense univariate polynomial over the bundled prime field. -/
+def imageAt {n : Nat} {R : Type u}
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (P : ZMod64.Prime)
+    (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
+    (a : Fin n → @ZMod64 P.m P.bounds)
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (f : MvPoly (n + 1) R cmp) :
+    @FpPoly P.m P.bounds :=
+  letI : ZMod64.Bounds P.m := P.bounds
+  letI : ZMod64.PrimeModulus P.m := ZMod64.primeModulusOfPrime P.prime
+  let q := toUnivariate i cmp' f
+  DensePoly.ofList <| (List.range q.size).map fun k =>
+    MvPoly.eval a (MvPoly.mapCoeffs φ.toField (q.coeff k))
+
+/-- Computational core of `imageAt`, separated from the law-bearing
+`CoeffHom` so dependent certificate elimination does not have to identify
+the constructor's stored operation dictionaries with the checker's ones. -/
+def imageAtRaw {n : Nat} {R : Type u}
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (P : ZMod64.Prime)
+    (φ : R → @ZMod64 P.m P.bounds)
+    (a : Fin n → @ZMod64 P.m P.bounds)
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (f : MvPoly (n + 1) R cmp) :
+    @FpPoly P.m P.bounds :=
+  letI : ZMod64.Bounds P.m := P.bounds
+  letI : ZMod64.PrimeModulus P.m := ZMod64.primeModulusOfPrime P.prime
+  let q := toUnivariate i cmp' f
+  DensePoly.ofList <| (List.range q.size).map fun k =>
+    MvPoly.eval a (MvPoly.mapCoeffs φ (q.coeff k))
+
+/-- A law-bearing coefficient embedding used by the internal
+universe-polymorphic form of rational lifting.  The public smart constructor
+fixes this to the canonical embedding from `Int` into `Rat`. -/
+structure CoeffEmbedding (S R : Type u)
+    where
+  toFun : S → R
+
+mutual
+  /-- Recursive evidence that two multivariate polynomials have no common
+  nonunit divisor.  The result sort is `Type (u + 1)`: because the
+  coefficient type `R : Type u` is itself an index, Lean's universe checker
+  rejects `Type u` before considering any constructor fields. -/
+  inductive CoprimeCert :
+      (n : Nat) → (R : Type u) → [Zero R] →
+      (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
+    | unit {n : Nat} {R : Type u} [Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
+        CoprimeCert n R cmp
+    | base {R : Type u} [Zero R]
+        {cmp : Mono 0 → Mono 0 → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (u v : R) : CoprimeCert 0 R cmp
+    /-- Internal universe-polymorphic form of rational lifting.  The public
+    `CoprimeCert.ratLift` smart constructor fixes the embedded coefficient
+    type to `Int` and the target type to `Rat`. -/
+    | ratLiftCore {n : Nat} {R S : Type u}
+        [zeroR : Zero R] [One R] [Add R] [Mul R]
+        [Lean.Grind.CommRing S]
+        [DecidableEq S] [BEq S] [LawfulBEq S] [Dvd S] [GcdOps S]
+        {cmp : Mono n → Mono n → Ordering}
+        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+        (embed : CoeffEmbedding S R)
+        (mapZero : embed.toFun 0 = 0)
+        (mapOne : embed.toFun 1 = 1)
+        (mapAdd : ∀ a b, embed.toFun (a + b) =
+          embed.toFun a + embed.toFun b)
+        (mapMul : ∀ a b, embed.toFun (a * b) =
+          embed.toFun a * embed.toFun b)
+        (injective : ∀ {a b}, embed.toFun a = embed.toFun b → a = b)
+        /- The two replayed scale factors and explicit inverse candidates.
+        The checker validates both inverse equations; this keeps the
+        universe-polymorphic core sound even though its target is not fixed
+        to the rational field. -/
+        (scaleL scaleR invL invR : R)
+        (left right : MvPoly n S cmp)
+        (cert : CoprimeCert n S cmp) :
+        @CoprimeCert n R zeroR cmp outerTrans outerEq
+    | split {n : Nat} {R : Type u} [zeroR : Zero R]
+        [One R] [Add R] [Mul R]
+        {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+        [order : IsMonomialOrder cmp']
+        (P : ZMod64.Prime)
+        (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
+        (a : Fin n → @ZMod64 P.m P.bounds)
+        (α β : @FpPoly P.m P.bounds)
+        (left right : @ContentCert n R zeroR cmp'
+          order.toTransCmp order.toLawfulEqCmp)
+        (rest : @CoprimeCert n R zeroR cmp'
+          order.toTransCmp order.toLawfulEqCmp) :
+        @CoprimeCert (n + 1) R zeroR cmp outerTrans outerEq
+    | splitBezout {n : Nat} {R : Type u}
+        [zeroR : Zero R] [One R] [Add R] [Mul R]
+        {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+        [order : IsMonomialOrder cmp']
+        (u v : @MvPoly (n + 1) R zeroR cmp outerTrans outerEq)
+        (r : @MvPoly n R zeroR cmp' order.toTransCmp order.toLawfulEqCmp)
+        (left right : @ContentCert n R zeroR cmp'
+          order.toTransCmp order.toLawfulEqCmp)
+        (rest : @CoprimeCert n R zeroR cmp'
+          order.toTransCmp order.toLawfulEqCmp) :
+        @CoprimeCert (n + 1) R zeroR cmp outerTrans outerEq
+  /-- A gcd candidate, exact cofactors, and recursive coprimality evidence. -/
+  inductive GcdCert :
+      (n : Nat) → (R : Type u) → [Zero R] →
+      (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
+    | mk {n : Nat} {R : Type u} [Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (gcd cofL cofR : MvPoly n R cmp)
+        (coprime : CoprimeCert n R cmp) : GcdCert n R cmp
+
+  /-- A checked left fold of gcd over a coefficient list. -/
+  inductive ContentCert :
+      (n : Nat) → (R : Type u) → [Zero R] →
+      (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
+    | mk {n : Nat} {R : Type u} [Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (value : MvPoly n R cmp)
+        (steps : GcdCerts n R cmp) : ContentCert n R cmp
+
+  /-- Strictly-positive list used inside the mutual certificate block.
+  `List (GcdCert ...)` is a nested inductive occurrence, which Lean rejects
+  when the certificate indices contain local comparator instances. -/
+  inductive GcdCerts :
+      (n : Nat) → (R : Type u) → [Zero R] →
+      (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
+    | nil {n : Nat} {R : Type u} [Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] : GcdCerts n R cmp
+    | cons {n : Nat} {R : Type u} [Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (head : GcdCert n R cmp) (tail : GcdCerts n R cmp) :
+        GcdCerts n R cmp
+end
+
+namespace CoprimeCert
+
+def intEmbeddingRat : CoeffEmbedding Int Rat where
+  toFun := fun z => (z : Rat)
+
+/-- Rational coprimality transported from primitive integer models.  This is
+the public, index-specialized constructor; the law-bearing generic embedding
+is an implementation detail needed to preserve universe polymorphism. -/
+def ratLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (scaleL scaleR : Rat) (left right : MvPoly n Int cmp)
+    (cert : CoprimeCert n Int cmp) : CoprimeCert n Rat cmp :=
+  .ratLiftCore intEmbeddingRat (by rfl) (by rfl)
+    (by intro a b; exact Rat.intCast_add a b)
+    (by intro a b; exact Rat.intCast_mul a b)
+    (by intro a b h; exact Rat.intCast_inj.mp h)
+    scaleL scaleR scaleL⁻¹ scaleR⁻¹ left right cert
+
+end CoprimeCert
+
+/-- Flat rational-lift data retained as a convenient standalone replay view.
+The checked certificate sum itself exposes `CoprimeCert.ratLift`; new
+producers use that constructor. -/
+structure RatLiftCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  scaleL : Rat
+  scaleR : Rat
+  left : MvPoly n Int cmp
+  right : MvPoly n Int cmp
+  cert : CoprimeCert n Int cmp
+
+namespace GcdCerts
+
+variable {n : Nat} {R : Type u} [Zero R]
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def toList : GcdCerts n R cmp → List (GcdCert n R cmp)
+  | .nil => []
+  | .cons head tail => head :: toList tail
+
+@[reducible] def ofList : List (GcdCert n R cmp) → GcdCerts n R cmp
+  | [] => .nil
+  | head :: tail => .cons head (ofList tail)
+
+end GcdCerts
+
+namespace GcdCert
+
+variable {n : Nat} {R : Type u} [Zero R]
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def gcd : GcdCert n R cmp → MvPoly n R cmp
+  | .mk gcd _ _ _ => gcd
+
+@[reducible] def cofL : GcdCert n R cmp → MvPoly n R cmp
+  | .mk _ cofL _ _ => cofL
+
+@[reducible] def cofR : GcdCert n R cmp → MvPoly n R cmp
+  | .mk _ _ cofR _ => cofR
+
+@[reducible] def coprime : GcdCert n R cmp → CoprimeCert n R cmp
+  | .mk _ _ _ coprime => coprime
+
+end GcdCert
+
+namespace ContentCert
+
+variable {n : Nat} {R : Type u} [Zero R]
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def value : ContentCert n R cmp → MvPoly n R cmp
+  | .mk value _ => value
+
+@[reducible] def steps : ContentCert n R cmp → List (GcdCert n R cmp)
+  | .mk _ steps => steps.toList
+
+/-- Public list-based constructor; the strictly-positive internal list is an
+implementation detail of Lean's mutual-inductive positivity checker. -/
+@[reducible] def ofSteps (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp)) :
+    ContentCert n R cmp :=
+  .mk value (GcdCerts.ofList steps)
+
+end ContentCert
+
+/-- Coefficientwise cast from the integer model used by `ratLift`. -/
+def intModelToRat {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n Int cmp) : MvPoly n Rat cmp :=
+  mapCoeffs (fun z : Int => (z : Rat)) p
+
+/-- The three replay operations at one arity.  Packaging them by arity avoids
+Lean's well-founded mutual-recursion compiler: recursive certificate calls
+always move to the already-built lower-arity package, while content folds are
+ordinary structural recursion on their two lists. -/
+structure CheckOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+  coprime : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    MvPoly n R cmp → MvPoly n R cmp → CoprimeCert n R cmp → Bool
+  gcd : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool
+  content : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    List (MvPoly n R cmp) → ContentCert n R cmp → Bool
+
+@[reducible] def checkGcdUsing {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (coprime : MvPoly n R cmp → MvPoly n R cmp →
+      CoprimeCert n R cmp → Bool)
+    (f h : MvPoly n R cmp) (cert : GcdCert n R cmp) : Bool :=
+  (cert.gcd * cert.cofL == f) &&
+    (cert.gcd * cert.cofR == h) &&
+    (polyNormalize cert.gcd == cert.gcd) &&
+    coprime cert.cofL cert.cofR cert.coprime
+
+@[reducible] def checkContentUsing {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (gcd : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
+    (coeffs : List (MvPoly n R cmp)) (cert : ContentCert n R cmp) : Bool :=
+  let rec go (acc : MvPoly n R cmp) :
+      List (MvPoly n R cmp) → List (GcdCert n R cmp) → Bool
+    | [], [] => acc == cert.value
+    | q :: qs, step :: steps => gcd acc q step && go step.gcd qs steps
+    | _, _ => false
+  go 0 coeffs cert.steps
+
+/-! The rational-lift branch contains an embedded coefficient certificate at
+the same arity.  Its replay therefore uses this independent structural
+package, which rejects nested lifts, instead of recursing through the main
+coefficient-polymorphic package.  This keeps both definitions structurally
+recursive. -/
+
+@[reducible] def baseCheckNoLift {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
+    [Dvd S] [GcdOps S]
+    {cmp : Mono 0 → Mono 0 → Ordering}
+    [IsMonomialOrder cmp]
+    (f h : MvPoly 0 S cmp) (cert : CoprimeCert 0 S cmp) : Bool :=
+  match cert with
+  | .unit => polyIsUnit f || polyIsUnit h
+  | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
+  | _ => false
+
+@[reducible] def succCheckNoLift {n : Nat} {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
+    [Dvd S] [GcdOps S]
+    (lower : CheckOpsAt S n)
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    (f h : MvPoly (n + 1) S cmp)
+    (cert : CoprimeCert (n + 1) S cmp) : Bool := by
+  cases cert with
+  | unit => exact polyIsUnit f || polyIsUnit h
+  | ratLiftCore => exact false
+  | split i cmp' P φ a α β left right rest =>
+      letI : ZMod64.Bounds P.m := P.bounds
+      letI : ZMod64.PrimeModulus P.m :=
+        ZMod64.primeModulusOfPrime P.prime
+      let fImage := imageAtRaw P φ.toField a i cmp' f
+      let hImage := imageAtRaw P φ.toField a i cmp' h
+      let fView := toUnivariate i cmp' f
+      let hView := toUnivariate i cmp' h
+      exact decide (fImage.degree? = fView.degree?) &&
+        decide (hImage.degree? = hView.degree?) &&
+        (α * fImage + β * hImage == 1) &&
+        lower.content cmp' fView.toArray.toList left &&
+        lower.content cmp' hView.toArray.toList right &&
+        lower.coprime cmp' left.value right.value rest
+  | splitBezout i cmp' u v r left right rest =>
+      let fView := toUnivariate i cmp' f
+      let hView := toUnivariate i cmp' h
+      exact decide (r ≠ 0) &&
+        (u * f + v * h == constIn i cmp' r) &&
+        lower.content cmp' fView.toArray.toList left &&
+        lower.content cmp' hView.toArray.toList right &&
+        lower.coprime cmp' left.value right.value rest
+
+@[reducible] def noLiftOps {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
+    [Dvd S] [GcdOps S] : (n : Nat) → CheckOpsAt S n
+  | 0 =>
+      { coprime := fun cmp _ => baseCheckNoLift (cmp := cmp)
+        gcd := fun cmp _ => checkGcdUsing (baseCheckNoLift (cmp := cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (baseCheckNoLift (cmp := cmp))) }
+  | n + 1 =>
+      let lower := noLiftOps n
+      { coprime := fun cmp _ => succCheckNoLift lower (cmp := cmp)
+        gcd := fun cmp _ => checkGcdUsing (succCheckNoLift lower (cmp := cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (succCheckNoLift lower (cmp := cmp))) }
+
+/-- Replay the payload of the equality-packed rational-lift constructor. -/
+@[reducible] def checkRatLiftCoreUsing {n : Nat} {R S : Type u}
+    [zeroR : Zero R]
+    [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
+    [Dvd S] [GcdOps S]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h : MvPoly n R cmp) (embed : CoeffEmbedding S R)
+    (scaleL scaleR invL invR : R) (left right : MvPoly n S cmp)
+    (cert : CoprimeCert n S cmp) : Bool :=
+  decide (scaleL ≠ 0) && decide (scaleR ≠ 0) &&
+    (scaleL * invL == 1) && (scaleR * invR == 1) &&
+    (f == C scaleL * mapCoeffs embed.toFun left) &&
+    (h == C scaleR * mapCoeffs embed.toFun right) &&
+    decide (scalarContent left = 1) &&
+    decide (scalarContent right = 1) &&
+    (noLiftOps n).coprime cmp left right cert
+
+@[reducible] def baseCheckCoprime {R : Type u}
+    {cmp : Mono 0 → Mono 0 → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h : MvPoly 0 R cmp) (cert : CoprimeCert 0 R cmp) : Bool :=
+  match cert with
+  | .unit => polyIsUnit f || polyIsUnit h
+  | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
+  | @CoprimeCert.ratLiftCore _ _ S _ _ _ _ _ringModel _decModel
+      _beqModel _lawfulModel _dvdModel _gcdModel _ _ _ embed _ _ _ _ _
+      scaleL scaleR invL invR left right cert =>
+      checkRatLiftCoreUsing (S := S) f h embed scaleL scaleR invL invR
+        left right cert
+
+@[reducible] def succCheckCoprime {n : Nat} {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R]
+    (lower : CheckOpsAt R n)
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    (f h : MvPoly (n + 1) R cmp)
+    (cert : CoprimeCert (n + 1) R cmp) : Bool := by
+  cases cert with
+  | unit => exact polyIsUnit f || polyIsUnit h
+  | @ratLiftCore _ _ S _ _ _ _ ringModel decModel beqModel
+      lawfulModel dvdModel gcdModel _ _ _ embed _ _ _ _ _
+      scaleL scaleR invL invR left right cert =>
+      exact checkRatLiftCoreUsing (S := S) f h embed
+        scaleL scaleR invL invR left right cert
+  | split i cmp' P φ a α β left right rest =>
+      letI : ZMod64.Bounds P.m := P.bounds
+      letI : ZMod64.PrimeModulus P.m :=
+        ZMod64.primeModulusOfPrime P.prime
+      let fImage := imageAtRaw P φ.toField a i cmp' f
+      let hImage := imageAtRaw P φ.toField a i cmp' h
+      let fView := toUnivariate i cmp' f
+      let hView := toUnivariate i cmp' h
+      exact decide (fImage.degree? = fView.degree?) &&
+        decide (hImage.degree? = hView.degree?) &&
+        (α * fImage + β * hImage == 1) &&
+        lower.content cmp' fView.toArray.toList left &&
+        lower.content cmp' hView.toArray.toList right &&
+        lower.coprime cmp' left.value right.value rest
+  | splitBezout i cmp' u v r left right rest =>
+      let fView := toUnivariate i cmp' f
+      let hView := toUnivariate i cmp' h
+      exact decide (r ≠ 0) &&
+        (u * f + v * h == constIn i cmp' r) &&
+        lower.content cmp' fView.toArray.toList left &&
+        lower.content cmp' hView.toArray.toList right &&
+        lower.coprime cmp' left.value right.value rest
+
+@[reducible] def checkOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] : (n : Nat) → CheckOpsAt R n
+  | 0 =>
+      { coprime := fun cmp _ => baseCheckCoprime (cmp := cmp)
+        gcd := fun cmp _ => checkGcdUsing (baseCheckCoprime (cmp := cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (baseCheckCoprime (cmp := cmp))) }
+  | n + 1 =>
+      let lower := checkOps n
+      { coprime := fun cmp _ => succCheckCoprime lower (cmp := cmp)
+        gcd := fun cmp _ => checkGcdUsing (succCheckCoprime lower (cmp := cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (succCheckCoprime lower (cmp := cmp))) }
+
+/-- Replay recursive coprimality evidence. -/
+@[reducible] def checkCoprime {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h : MvPoly n R cmp) (cert : CoprimeCert n R cmp) : Bool :=
+  (checkOps (R := R) n).coprime cmp f h cert
+
+/-- Replay a gcd candidate and its coprimality evidence. -/
+@[reducible] def checkGcd {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h : MvPoly n R cmp) (cert : GcdCert n R cmp) : Bool :=
+  (checkOps (R := R) n).gcd cmp f h cert
+
+/-- Replay a coefficient gcd fold, starting from zero and requiring exactly
+one checked gcd step per coefficient. -/
+@[reducible] def checkContent {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (coeffs : List (MvPoly n R cmp)) (cert : ContentCert n R cmp) : Bool :=
+  (checkOps (R := R) n).content cmp coeffs cert
+
+/-- Replay rational scaling and primitive integer-model coprimality. -/
+@[reducible] def checkRatLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    (f h : MvPoly n Rat cmp) (lift : RatLiftCert n cmp) : Bool :=
+  decide (lift.scaleL ≠ 0) && decide (lift.scaleR ≠ 0) &&
+    (f == C lift.scaleL * intModelToRat lift.left) &&
+    (h == C lift.scaleR * intModelToRat lift.right) &&
+    decide (scalarContent lift.left = 1) &&
+    decide (scalarContent lift.right = 1) &&
+    checkCoprime lift.left lift.right lift.cert
+
+/-- The semantic property witnessed by a coprimality certificate. -/
+def CoprimeCofactors {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (f h : MvPoly n R cmp) : Prop :=
+  ∀ d, d ∣ f → d ∣ h → ∃ u, d * u = 1
+
+/-- The standalone rational-lift replay transports integer-model
+coprimality. -/
+theorem checkRatLift_sound {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    {f h : MvPoly n Rat cmp} {lift : RatLiftCert n cmp}
+    (hc : checkRatLift f h lift = true) : CoprimeCofactors f h := by
+  sorry
+
+/-- Direct semantic payload of a checked gcd certificate. -/
+def CheckedGcdResult {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h g cofL cofR : MvPoly n R cmp) : Prop :=
+  f = g * cofL ∧ h = g * cofR ∧ polyNormalize g = g ∧
+    CoprimeCofactors cofL cofR
+
+/-- A checked result plus greatest-common-divisor maximality. -/
+def IsGcdCertResult {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f h g cofL cofR : MvPoly n R cmp) : Prop :=
+  CheckedGcdResult f h g cofL cofR ∧
+    ∀ d, d ∣ f → d ∣ h → d ∣ g
+
+/-- Simultaneous checker soundness: recursive coprimality replay. -/
+theorem checkCoprime_sound {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+    {f h : MvPoly n R cmp} {cert : CoprimeCert n R cmp}
+    (hc : checkCoprime f h cert = true) : CoprimeCofactors f h := by
+  sorry
+
+/-- Simultaneous checker soundness: a content fold is both a common divisor
+and greatest among common divisors. -/
+theorem checkContent_sound {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+    {coeffs : List (MvPoly n R cmp)} {cert : ContentCert n R cmp}
+    (hc : checkContent coeffs cert = true) :
+    (∀ q ∈ coeffs, cert.value ∣ q) ∧
+      ∀ d, (∀ q ∈ coeffs, d ∣ q) → d ∣ cert.value := by
+  sorry
+
+/-- Simultaneous checker soundness: exact cofactors, normalization, and
+coprimality. -/
+theorem checkGcd_sound {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+    {f h : MvPoly n R cmp} {cert : GcdCert n R cmp}
+    (hc : checkGcd f h cert = true) :
+    CheckedGcdResult f h cert.gcd cert.cofL cert.cofR := by
+  sorry
+
+/-- Separate gcd-domain cancellation turns checked coprime cofactors into
+maximality. -/
+theorem CheckedGcdResult.greatest {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    [CoprimeCancelLaws (MvPoly n R cmp)]
+    {f h g cofL cofR : MvPoly n R cmp}
+    (hc : CheckedGcdResult f h g cofL cofR) :
+    ∀ d, d ∣ f → d ∣ h → d ∣ g := by
+  sorry
+
+/-- Full semantic payload of an accepted certificate. -/
+theorem checkGcd_greatest {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+    [CoprimeCancelLaws (MvPoly n R cmp)]
+    {f h : MvPoly n R cmp} {cert : GcdCert n R cmp}
+    (hc : checkGcd f h cert = true) :
+    IsGcdCertResult f h cert.gcd cert.cofL cert.cofR := by
+  exact ⟨checkGcd_sound hc, (checkGcd_sound hc).greatest⟩
+
+end Hex.MvPoly

--- a/HexMvGcd/Coeff.lean
+++ b/HexMvGcd/Coeff.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArith.Ring
+public import HexMvPoly.Ring
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+The coefficient-side operations and laws used by multivariate gcd algorithms.
+
+The executable structures are deliberately weaker than their law packages.
+In particular, `GcdOps.exactDiv` may return a stable junk value when its right
+argument does not exactly divide its left argument; every computational caller
+must validate a proposed quotient by multiplying it back.
+-/
+
+namespace Hex
+
+universe u
+
+/-- Executable gcd-domain operations. `exactDiv` has a law only on known exact
+division by a nonzero element. -/
+class GcdOps (R : Type u) where
+  gcd : R → R → R
+  exactDiv : R → R → R
+  isUnit : R → Bool
+  normUnit : R → R
+
+/-- The canonical associate selected by `GcdOps`. -/
+def normalize {R : Type u} [Mul R] [GcdOps R] (a : R) : R :=
+  a * GcdOps.normUnit a
+
+/-- Executable extended gcd in a coefficient ring where pairs admit Bézout
+coefficients. -/
+class BezoutOps (R : Type u) extends GcdOps R where
+  xgcd : R → R → R × R
+
+/-- Algebraic laws for `GcdOps`, separated from the executable operations so
+certificate checkers do not carry proof data at runtime. -/
+class LawfulGcdOps (R : Type u) [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] : Prop where
+  dvd_iff : ∀ a b : R, a ∣ b ↔ ∃ c, b = a * c
+  one_ne_zero : (1 : R) ≠ 0
+  no_zero_div : ∀ a b : R, a * b = 0 → a = 0 ∨ b = 0
+  gcd_dvd_left : ∀ a b : R, GcdOps.gcd a b ∣ a
+  gcd_dvd_right : ∀ a b : R, GcdOps.gcd a b ∣ b
+  dvd_gcd : ∀ a b d : R, d ∣ a → d ∣ b → d ∣ GcdOps.gcd a b
+  gcd_normalized : ∀ a b : R,
+    normalize (GcdOps.gcd a b) = GcdOps.gcd a b
+  exactDiv_cancel : ∀ a b : R,
+    b ≠ 0 → GcdOps.exactDiv (a * b) b = a
+  isUnit_iff : ∀ a : R, GcdOps.isUnit a = true ↔ ∃ b, a * b = 1
+  normUnit_unit : ∀ a : R, ∃ b, GcdOps.normUnit a * b = 1
+  normalize_mul : ∀ a b : R, normalize (a * b) = normalize a * normalize b
+  normalize_idem : ∀ a : R, normalize (normalize a) = normalize a
+  normalize_unit : ∀ a : R, GcdOps.isUnit a = true → normalize a = 1
+
+/-- Correctness of executable extended gcd. -/
+class LawfulBezoutOps (R : Type u) [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R] [Dvd R] [BezoutOps R] [LawfulGcdOps R] : Prop where
+  xgcd_bezout : ∀ a b : R,
+    let uv := BezoutOps.xgcd a b
+    uv.1 * a + uv.2 * b = normalize (GcdOps.gcd a b)
+
+/-- Proof-only existence and maximality of gcds. This class intentionally does
+not select an executable gcd operation. -/
+class GcdDomainLaws (S : Type u) [Lean.Grind.CommRing S] [Dvd S] : Prop where
+  dvd_iff : ∀ a b : S, a ∣ b ↔ ∃ c, b = a * c
+  one_ne_zero : (1 : S) ≠ 0
+  no_zero_div : ∀ a b : S, a * b = 0 → a = 0 ∨ b = 0
+  gcd_exists : ∀ a b : S, ∃ g : S,
+    g ∣ a ∧ g ∣ b ∧ ∀ d, d ∣ a → d ∣ b → d ∣ g
+
+/-- Euclid cancellation in the form used by gcd-certificate maximality. -/
+class CoprimeCancelLaws (S : Type u) [Lean.Grind.CommRing S] [Dvd S] : Prop where
+  cancel_coprime : ∀ g a b d : S,
+    (∀ e, e ∣ a → e ∣ b → ∃ u, e * u = 1) →
+    d ∣ g * a → d ∣ g * b → d ∣ g
+
+/-- A total coefficient homomorphism into a bounded prime field. The map is
+certificate data rather than a typeclass because several maps may be useful
+for one coefficient ring. -/
+structure CoeffHom (R : Type u) (p : Nat) [Zero R] [One R] [Add R]
+    [Mul R] [ZMod64.Bounds p] where
+  toField : R → ZMod64 p
+  map_zero : toField 0 = 0
+  map_one : toField 1 = 1
+  map_add : ∀ a b, toField (a + b) = toField a + toField b
+  map_mul : ∀ a b, toField (a * b) = toField a * toField b
+
+end Hex

--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Cert
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Producer-independent content and primitive-part operations.
+
+The recursive coefficient fold is parameterised by a concrete lower-arity
+certificate producer. `Prs.lean` supplies that producer structurally, while
+the checker remains independent of candidate production.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+  [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [GcdOps R]
+
+/-- Componentwise minimum of the monomials in the support, with zero for the
+zero polynomial. -/
+def monoContent (p : MvPoly n R cmp) : Mono n :=
+  match p.support with
+  | [] => Mono.zero
+  | m :: ms => ms.foldl Mono.gcd m
+
+/-- Producer-free scalar content. -/
+def content (p : MvPoly n R cmp) : R :=
+  scalarContent p
+
+/-- Divide every stored coefficient by scalar content, with primitive part
+zero for the zero polynomial. -/
+def primPart (p : MvPoly n R cmp) : MvPoly n R cmp :=
+  let c := content p
+  if c = 0 then 0 else mapCoeffs (fun a => GcdOps.exactDiv a c) p
+
+/-- Fold a concrete lower-arity gcd-certificate producer over coefficients.
+The returned certificate stores every step that the checker replays. -/
+def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (coeffs : List (MvPoly n R cmp)) : ContentCert n R cmp :=
+  let pair := coeffs.foldl
+    (fun state q =>
+      let step := produce state.1 q
+      (step.gcd, state.2 ++ [step]))
+    (0, [])
+  .ofSteps pair.1 pair.2
+
+/-- A producer-built fold has exactly one step per coefficient. -/
+theorem contentCertWith_length {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (coeffs : List (MvPoly n R cmp)) :
+    (contentCertWith produce coeffs).steps.length = coeffs.length := by
+  sorry
+
+/-- A producer-built fold checks when every supplied gcd certificate checks. -/
+theorem contentCertWith_checks {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (hproduce : ∀ f h, checkGcd f h (produce f h) = true)
+    (coeffs : List (MvPoly n R cmp)) :
+    checkContent coeffs (contentCertWith produce coeffs) = true := by
+  sorry
+
+/-- Scalar content and primitive part reconstruct the input. -/
+theorem content_mul_primPart [LawfulGcdOps R] (p : MvPoly n R cmp) :
+    C (content p) * primPart p = p := by
+  sorry
+
+@[simp] theorem content_zero : content (0 : MvPoly n R cmp) = 0 := by
+  rfl
+
+@[simp] theorem primPart_zero : primPart (0 : MvPoly n R cmp) = 0 := by
+  simp [primPart, content]
+
+theorem content_primPart [LawfulGcdOps R] {p : MvPoly n R cmp} (hp : p ≠ 0) :
+    content (primPart p) = 1 := by
+  sorry
+
+theorem content_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
+    content (p * q) = content p * content q := by
+  sorry
+
+theorem primPart_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
+    primPart (p * q) = primPart p * primPart q := by
+  sorry
+
+end Hex.MvPoly

--- a/HexMvGcd/Divide.lean
+++ b/HexMvGcd/Divide.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBasic.ExactDiv
+public import HexMvGcd.Coeff
+public import HexMvPoly.Query
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Checked single-divisor reduction for distributed multivariate polynomials.
+
+The loops use the well-founded monomial order, not an arbitrary fuel bound.
+Every coefficient quotient is checked by multiplying it back before it can
+affect the quotient polynomial.
+
+The SPEC originally omitted `LawfulGcdOps R` from quotient completeness and
+decidable divisibility. That assumption is necessary: a bare `GcdOps` may set
+`exactDiv` to a junk operation. The executable functions and forward soundness
+remain available under bare `GcdOps`; completeness and instances that consume
+it require the law package.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+section Dvd
+
+variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+
+/-- Polynomial divisibility, with the quotient on the left to agree with the
+library's multiplication-facing exact-division convention. -/
+instance instDvd : Dvd (MvPoly n R cmp) where
+  dvd g f := ∃ q, f = q * g
+
+end Dvd
+
+section Divide
+
+variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+
+/-- The leading-monomial relation lifted with `none` as its least element.
+This makes zero smaller than every nonzero running dividend. -/
+def leadRel (a b : MvPoly n R cmp) : Prop :=
+  Option.lt (fun x y => cmp x y = .lt) a.leadingMono b.leadingMono
+
+omit [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] in
+theorem leadRel_wf :
+    WellFounded (leadRel (n := n) (R := R) (cmp := cmp)) := by
+  apply InvImage.wf (fun p : MvPoly n R cmp => p.leadingMono)
+  exact Option.wellFounded_lt IsMonomialOrder.wf
+
+local instance instDivideWf : WellFoundedRelation (MvPoly n R cmp) where
+  rel := leadRel
+  wf := leadRel_wf
+
+/-- Move the leading term of `r` into the accumulated remainder. -/
+def moveLeading (r s : MvPoly n R cmp) (m : Mono n) (c : R) :
+    MvPoly n R cmp × MvPoly n R cmp :=
+  let t := monomial m c
+  (r - t, s + t)
+
+/-- The well-founded division-with-remainder loop. -/
+def divModAux (g q r s : MvPoly n R cmp) :
+    MvPoly n R cmp × MvPoly n R cmp :=
+  match r.leadingTerm with
+  | none => (q, s)
+  | some (mr, cr) =>
+      match g.leadingTerm with
+      | none => (q, s + r)
+      | some (mg, cg) =>
+          match Mono.div mg mr with
+          | none =>
+              let next := moveLeading r s mr cr
+              divModAux g q next.1 next.2
+          | some mq =>
+              let cq := GcdOps.exactDiv cr cg
+              if cq * cg = cr then
+                let t := monomial mq cq
+                divModAux g (q + t) (r - t * g) s
+              else
+                let next := moveLeading r s mr cr
+                divModAux g q next.1 next.2
+termination_by r
+decreasing_by
+  all_goals sorry
+
+/-- Division with remainder against one divisor. The zero-divisor branch is
+fixed as `(0, f)`. -/
+def divMod (f g : MvPoly n R cmp) : MvPoly n R cmp × MvPoly n R cmp :=
+  if g = 0 then (0, f) else divModAux g 0 f 0
+
+/-- Necessary per-variable degree conditions for exact divisibility. -/
+def degreeFilter (f g : MvPoly n R cmp) : Bool :=
+  (List.finRange n).all fun i => decide (degreeOf i g ≤ degreeOf i f)
+
+/-- Monomial content, with `none` reserved for the zero polynomial. -/
+def monoContent? (f : MvPoly n R cmp) : Option (Mono n) :=
+  match f.monomials with
+  | [] => none
+  | m :: ms => some (ms.foldl Mono.gcd m)
+
+/-- Necessary monomial-content divisibility. -/
+def monoFilter (f g : MvPoly n R cmp) : Bool :=
+  match monoContent? f, monoContent? g with
+  | none, _ => true
+  | some _, none => false
+  | some mf, some mg => Mono.dvd mg mf
+
+/-- Necessary leading-coefficient divisibility, checked rather than trusted. -/
+def coeffFilter (f g : MvPoly n R cmp) : Bool :=
+  match f.leadingTerm, g.leadingTerm with
+  | none, _ => true
+  | some _, none => false
+  | some (_, cf), some (_, cg) =>
+      GcdOps.exactDiv cf cg * cg == cf
+
+/-- Cheap allocation-free rejection tests ahead of exact trial division. -/
+def passesFilter (f g : MvPoly n R cmp) : Bool :=
+  degreeFilter f g && monoFilter f g && coeffFilter f g
+
+/-- The fail-fast exact-division loop. Unlike `divModAux`, a term that cannot
+be cancelled immediately rejects the candidate. -/
+def divExactAux (g q r : MvPoly n R cmp) : Option (MvPoly n R cmp) :=
+  match r.leadingTerm with
+  | none => some q
+  | some (mr, cr) =>
+      match g.leadingTerm with
+      | none => none
+      | some (mg, cg) =>
+          match Mono.div mg mr with
+          | none => none
+          | some mq =>
+              let cq := GcdOps.exactDiv cr cg
+              if cq * cg = cr then
+                let t := monomial mq cq
+                divExactAux g (q + t) (r - t * g)
+              else
+                none
+termination_by r
+decreasing_by
+  all_goals sorry
+
+/-- Exact quotient, rejecting a zero divisor and every failed necessary test
+before entering the reduction loop. -/
+def divExact? (f g : MvPoly n R cmp) : Option (MvPoly n R cmp) :=
+  if g = 0 then
+    none
+  else if f = 0 then
+    some 0
+  else if passesFilter f g then
+    divExactAux g 0 f
+  else
+    none
+
+/-- No term of `r` is cancellable by the leading term of `g`. -/
+def ReducedBy (r g : MvPoly n R cmp) : Prop :=
+  ∀ m c, (m, c) ∈ r.termsList →
+    match g.leadingTerm with
+    | none => True
+    | some (mg, cg) =>
+        match Mono.div mg m with
+        | none => True
+        | some _ => GcdOps.exactDiv c cg * cg ≠ c
+
+/-- Division with remainder reconstructs its dividend. -/
+theorem divMod_spec (f g : MvPoly n R cmp) :
+    f = (divMod f g).1 * g + (divMod f g).2 := by
+  sorry
+
+/-- The returned remainder has no term reducible by the divisor's leading
+term. -/
+theorem divMod_reduced {f g : MvPoly n R cmp} (hg : g ≠ 0) :
+    ReducedBy (divMod f g).2 g := by
+  sorry
+
+/-- Exact division rejects a zero right argument. -/
+@[simp] theorem divExact?_zero_right (f : MvPoly n R cmp) :
+    divExact? f 0 = none := by
+  simp [divExact?]
+
+/-- Every quotient returned by the checked loop reconstructs the dividend.
+This direction needs no laws for `GcdOps` because each scalar quotient was
+validated by multiplication. -/
+theorem eq_mul_of_divExact?_eq_some {f g q : MvPoly n R cmp}
+    (h : divExact? f g = some q) : f = q * g := by
+  sorry
+
+/-- Under lawful coefficient division, the checked exact quotient is complete
+as well as sound. -/
+theorem divExact?_eq [LawfulGcdOps R] {f g q : MvPoly n R cmp}
+    (hg : g ≠ 0) : divExact? f g = some q ↔ f = q * g := by
+  sorry
+
+/-- A known nonzero divisor makes the exact-division loop succeed. -/
+theorem divExact?_isSome_of_dvd [LawfulGcdOps R] {f g : MvPoly n R cmp}
+    (hg : g ≠ 0) : g ∣ f → (divExact? f g).isSome := by
+  sorry
+
+/-- Decidable polynomial divisibility. The zero divisor is decided by equality;
+the nonzero branch uses checked exact division. -/
+instance instDecidableDvd [LawfulGcdOps R] (g f : MvPoly n R cmp) :
+    Decidable (g ∣ f) :=
+  if hg : g = 0 then
+    if hf : f = 0 then
+      isTrue (by
+        subst g
+        subst f
+        exact ⟨0, by rw [Lean.Grind.Semiring.zero_mul]⟩)
+    else
+      isFalse (by
+        rintro ⟨q, hq⟩
+        rw [hg, Lean.Grind.Semiring.mul_zero] at hq
+        exact hf hq)
+  else
+    match hq : divExact? f g with
+    | some q =>
+        isTrue ⟨q, (divExact?_eq hg).mp hq⟩
+    | none =>
+        isFalse fun hd => by
+          have hs := divExact?_isSome_of_dvd hg hd
+          simp [hq] at hs
+
+/-- Total exact division. Its zero and inexact branches use the stable junk
+value zero. -/
+instance instDiv : Div (MvPoly n R cmp) where
+  div f g := (divExact? f g).getD 0
+
+/-- Total multivariate division cancels every known nonzero exact right
+factor. -/
+instance instExactDivLaws [LawfulGcdOps R] : ExactDivLaws (MvPoly n R cmp) where
+  mul_div_cancel_right := by
+    intro a b hb
+    change (divExact? (a * b) b).getD 0 = a
+    have hq : divExact? (a * b) b = some a :=
+      (divExact?_eq hb).mpr rfl
+    simp [hq]
+
+end Divide
+
+end Hex.MvPoly

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -1,0 +1,274 @@
+module
+public meta import HexMvGcd.Gcd
+public meta import HexMvGcd.Prs
+public meta import HexMvGcd.Squarefree
+public meta import HexMvPoly.Ring
+public import HexMvGcd.Gcd
+public import HexMvGcd.Squarefree
+public section
+namespace Hex.MvPoly
+private abbrev P0 := MvPoly 0 Int Mono.lex
+private abbrev P1 := MvPoly 1 Int Mono.lex
+private abbrev P2 := MvPoly 2 Int Mono.lex
+private abbrev Q2 := MvPoly 2 Rat Mono.lex
+private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
+  (ZMod64.primesBelow p 1)[0]?
+#guard (smallPrimeSupply 47 5).map (fun P => P.m) == [2, 3, 5, 7, 11]
+@[instance_reducible] private def rejectingProducer : GcdProducer Int where
+  propose := fun _ _ _ f h =>
+    ⟨some (.mk 1 f h .unit), Rand.ofSeed 99⟩
+#guard checkGcd (0 : P0) 0 (rawPrsCert 0 0)
+#guard
+  let f : P0 := C 12
+  let h : P0 := C 18
+  checkGcd f h (rawPrsCert f h)
+#guard
+  let x : P1 := X 0
+  let f := C 12 * x
+  let h := C 18 * x
+  checkGcd f h (rawPrsCert f h)
+#guard
+  let x : P1 := X 0
+  let common := x + 1
+  let f := common * (x + 2)
+  let h := common * (x + 3)
+  checkGcd f h (rawPrsCert f h)
+#guard
+  let x : P1 := X 0
+  let common := x + 1
+  let f := common * (x + 2)
+  let h := common * (x + 3)
+  checkGcd f h (intArityOneRaw f h)
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let common := x + y + 1
+  let f := common * (x + 2)
+  let h := common * (y + 3)
+  checkGcd f h (rawPrsCert f h)
+#guard (fastProposal GcdConfig.default (0 : P1) 0).cert?.isSome
+#guard
+  let x : P1 := X 0
+  (intTryCoprimeCert? 8 (Rand.ofSeed 0) (x + 1) (x + 2)).1.isSome
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let f := x + y + 1
+  let h := x * y + x + 2
+  let run := intTryCoprimeCert? 8 (Rand.ofSeed 17) f h
+  match run.1 with
+  | some cert => checkGcd f h cert && cert.gcd == 1
+  | none => false
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let f := C 6 * x * y * (x + 1)
+  let h := C 9 * x * y * (y + 1)
+  let run := intFastProposal GcdConfig.default f h
+  match run.cert? with
+  | some cert => checkGcd f h cert && cert.gcd == C 3 * x * y
+  | none => false
+#guard
+  let x : P1 := X 0
+  let common := x + 1
+  (intTryCoprimeCert? 8 (Rand.ofSeed 0)
+    (common * (x + 2)) (common * (x + 3))).1.isNone
+#guard
+  let x : P1 := X 0
+  let common := x + 1
+  let f := common * (x + 2)
+  let h := common * (x + 3)
+  let cfg : GcdConfig :=
+    { GcdConfig.default with brownPrimeFuel := 0, brownPointFuel := 0 }
+  let cfg : GcdConfig := { cfg with heuristicBitBudget := 0 }
+  let proposal := GcdProducer.propose Mono.lex cfg f h
+  match proposal.cert? with
+  | some cert => cert.gcd == common && checkGcd f h cert
+  | none => false
+#guard
+  let x : P1 := X 0
+  (intHeuristicCert? { GcdConfig.default with heuristicBitBudget := 0 }
+    (x + 1) (x + 2)).isNone
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let common := x + y + 1
+  let f := common * (x + 2)
+  let h := common * (y + 3)
+  (checkedCandidate? f h (intHeuristicCandidateAt f h 101)).isSome
+#guard
+  let x : P1 := X 0
+  let f := x
+  let h := x + 5
+  (checkedCandidate? f h (intHeuristicCandidateAt f h 5)).isNone
+#guard
+  letI : GcdProducer Int := rejectingProducer
+  let x : P1 := X 0
+  let common := x + 1
+  let f := common * (x + 2)
+  let h := common * (x + 3)
+  let run := gcdCertWith GcdConfig.default f h
+  checkGcd f h run.cert && run.rand == Rand.ofSeed 99
+#guard
+  let state : BrownPointState :=
+    { bestDegree? := some 2, accepted := 3 }
+  let offered := state.offer false true 1
+  offered.1 == .bad && offered.2 == state
+#guard
+  let state : BrownPointState :=
+    { bestDegree? := some 2, accepted := 3 }
+  let larger := state.offer true true 4
+  let smaller := state.offer true true 1
+  larger.1 == .unlucky && larger.2 == state &&
+    smaller.1 == .restart &&
+    smaller.2 == { bestDegree? := some 1, accepted := 1 }
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  brownMainIndex (x ^ 5 + y) (x ^ 4 + y) == some (1 : Fin 2)
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let gamma : MvPoly 1 Rat Mono.lex := X 0
+  brownPointBad 0 gamma (y * x + 1) (y * x + 2)
+#guard
+  let x : Mono 1 := Mono.unit 0
+  let state : BrownPrimeState 1 :=
+    { bestDegree? := some 1, support := [Mono.zero, x], stableRounds := 0 }
+  let same := state.offer true true 1 [Mono.zero, x]
+  let changed := state.offer true true 1 [x]
+  same.1 == .stable && same.2.stableRounds == 1 &&
+    changed.1 == .restart && changed.2.stableRounds == 0
+#guard
+  match brownCorrectImage? (2 : Rat) (DensePoly.ofList [1, 1]) with
+  | some image => image == DensePoly.ofList [2, 2]
+  | none => false
+#guard
+  let samples : List (Rat × MvPoly 0 Rat Mono.lex) :=
+    [(0, C 2), (1, C 5)]
+  match brownInterpolate? samples with
+  | some interpolation =>
+      interpolation == DensePoly.ofList [C 2, C 3]
+  | none => false
+#guard
+  let x : P1 := X 0
+  let common := C 2 * x + 1
+  let f := common * (x + 1)
+  let h := common * (x + 2)
+  match intBrownCert? Mono.lex GcdConfig.default f h with
+  | some cert => checkGcd f h cert
+  | none => false
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let common := x + y + 1
+  let f := common * (x + 2)
+  let h := common * (y + 3)
+  match brownFieldCert? 12 [0, 1, 2, 3] f h with
+  | some cert => checkGcd f h cert && cert.gcd == common
+  | none => false
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let left := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
+  let right := C ((1 : Rat) / 5) * x * y + x + 2
+  match ratLiftCoprime? left right with
+  | some cert => checkCoprime left right cert
+  | none => false
+#guard
+  let x : Q2 := X 0
+  let p := -(C ((1 : Rat) / 2) * x + 1)
+  let model := ratPrimitiveModel p
+  C model.scale * intModelToRat model.poly == p
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let common := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
+  let f := common * (x + C ((1 : Rat) / 5))
+  let h := common * (y + C ((1 : Rat) / 7))
+  match ratIntegerLiftCert? f h with
+  | some cert => checkGcd f h cert
+  | none => false
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let common := x + y + 1
+  let f := common * (x + 2)
+  let h := common * (y + 3)
+  let cfg : GcdConfig :=
+    { GcdConfig.default with brownPrimeFuel := 8, brownPointFuel := 8 }
+  match intBrownModularCert? cfg f h with
+  | some cert => checkGcd f h cert && cert.gcd == common
+  | none => false
+#guard
+  let x : P2 := X 0
+  let f := C 2 * x + 1
+  let h := C 2 * x + 3
+  match brownPrimeAt? 2 with
+  | some prime => (intBrownImage? 4 f h prime).isNone
+  | none => false
+#guard
+  let x : P2 := X 0
+  let f := x
+  let h := x + 2
+  match brownPrimeAt? 2, brownPrimeAt? 3 with
+  | some p2, some p3 =>
+      match intBrownImage? 4 f h p2, intBrownImage? 4 f h p3 with
+      | some image2, some image3 =>
+          let first := ({} : BrownPrimeState 2).offer
+            true true image2.degree image2.support
+          let second := first.2.offer
+            true true image3.degree image3.support
+          first.1 == .accumulate && second.1 == .restart
+      | _, _ => false
+  | _, _ => false
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let common := C 2 * x + y + 1
+  let f := common * (x + 1)
+  let h := common * (y + 2)
+  match brownPrimeAt? 5 with
+  | some prime =>
+      match intBrownImage? 8 f h prime with
+      | none => false
+      | some image =>
+          letI : ZMod64.Bounds prime.m := prime.bounds
+          letI : ZMod64.PrimeModulus prime.m :=
+            ZMod64.primeModulusOfPrime prime.prime
+          let expected := mapCoeffs (ZMod64.intCast prime.m) common
+          image.support == expected.monomials &&
+            image.residues == expected.termsList.map
+              (fun term => Int.ofNat term.2.toNat)
+  | none => false
+#guard
+  let d := sqfDecomp (C 6 : P1)
+  d.content == 6 && d.factors.isEmpty
+#guard
+  let d := sqfDecomp (C (-6) : P1)
+  d.content == -6 && d.factors.isEmpty
+#guard
+  let x : P1 := X 0
+  !isSquarefree ((x + 1) ^ 2)
+#guard
+  let x : P1 := X 0
+  isSquarefree ((x + 1) * (x + 2))
+#guard
+  let x : P1 := X 0
+  let p := (x + 1) ^ 2 * (x + 2) ^ 3
+  radical p == (x + 1) * (x + 2)
+#guard
+  let x : P1 := X 0
+  let p := (C 6 : P1) * (x + 1) ^ 2 * (x + 2) ^ 3
+  let d := sqfDecomp p
+  d.factors.foldl
+    (fun acc f => acc * f.factor ^ f.multiplicity) (C d.content) == p
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let p := (x + 1) * (y + 1) ^ 2
+  let d := sqfDecomp p
+  d.factors.map (fun f => f.multiplicity) == [1, 2] &&
+    d.factors.foldl
+      (fun acc f => acc * f.factor ^ f.multiplicity) (C d.content) == p
+end Hex.MvPoly

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
 module
 public meta import HexMvGcd.Gcd
 public meta import HexMvGcd.Prs

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -1,0 +1,361 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBasic.Rand
+public import HexMvGcd.Prs
+
+@[expose] public section
+
+/-! Checked proposal plumbing and routes 0--1. -/
+
+namespace Hex.MvPoly
+
+universe u
+
+structure GcdConfig where
+  rand : Rand
+  heuristicBitBudget : Nat
+  brownPrimeFuel : Nat
+  brownPointFuel : Nat
+
+def GcdConfig.default : GcdConfig where
+  rand := Rand.ofSeed 0
+  heuristicBitBudget := 1048576
+  brownPrimeFuel := 64
+  brownPointFuel := 4096
+
+/-- The genuinely small-prime-first prefix below a fixed bounded window.
+The whole window is enumerated before reversing; asking the downward scanner
+for only `fuel` entries would instead select the largest primes in it. -/
+def smallPrimeSupply (bound fuel : Nat) : List ZMod64.Prime :=
+  (ZMod64.primesBelow bound bound).toList.reverse.take fuel
+
+structure GcdRun (n : Nat) (R : Type u) [Zero R]
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  cert : GcdCert n R cmp
+  rand : Rand
+
+/-- Untrusted fast-backend output. -/
+structure GcdProposal (n : Nat) (R : Type u) [Zero R]
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  cert? : Option (GcdCert n R cmp)
+  rand : Rand
+
+class GcdProducer (R : Type u) [Zero R] where
+  propose : {n : Nat} → (cmp : Mono n → Mono n → Ordering) →
+    [IsMonomialOrder cmp] → GcdConfig →
+    MvPoly n R cmp → MvPoly n R cmp → GcdProposal n R cmp
+
+/-- Abstract rings have no coefficient-specific speculative route. -/
+@[instance_reducible] def noFastProducer {R : Type u} [Zero R] : GcdProducer R where
+  propose := fun _ _ cfg _ _ => ⟨none, cfg.rand⟩
+
+instance (priority := 10) instNoFastProducer {R : Type u} [Zero R] :
+    GcdProducer R := noFastProducer
+
+/-- Route 0: zero and unit cases, all represented by genuine replayable
+certificates. -/
+def structuralCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+  if f == 0 && h == 0 then some (.mk 0 1 1 .unit)
+  else if f == 0 then
+    let g := polyNormalize h
+    some (.mk g 0 (quotient h g) .unit)
+  else if h == 0 then
+    let g := polyNormalize f
+    some (.mk g (quotient f g) 0 .unit)
+  else if polyIsUnit f || polyIsUnit h then
+    some (.mk 1 f h .unit)
+  else none
+
+/-- The common monomial/coefficient factor removed before every nondegenerate
+route, together with the two exact reduced inputs. -/
+structure StructuralReduction (n : Nat) (R : Type u) [Zero R]
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  factor : MvPoly n R cmp
+  left : MvPoly n R cmp
+  right : MvPoly n R cmp
+
+/-- Route 0's linear common-monomial and scalar-content reduction.  Exact
+division is matched explicitly, so an invariant failure declines rather than
+manufacturing a reduced input. -/
+def structuralReduction? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R]
+    (f h : MvPoly n R cmp) : Option (StructuralReduction n R cmp) := do
+  let commonMono := Mono.gcd (monoContent f) (monoContent h)
+  let commonCoeff := GcdOps.gcd (content f) (content h)
+  let factor := monomial commonMono commonCoeff
+  let left ← divExact? f factor
+  let right ← divExact? h factor
+  some ⟨factor, left, right⟩
+
+/-- Re-embed a certificate for structurally reduced inputs.  The common
+factor and the reduced gcd are both normalized, and the final checker is the
+only acceptance gate for the reassociated product identities. -/
+def restoreStructural? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R]
+    (f h : MvPoly n R cmp) (reduced : StructuralReduction n R cmp)
+    (cert : GcdCert n R cmp) : Option (GcdCert n R cmp) :=
+  let restored := GcdCert.mk (reduced.factor * cert.gcd)
+    cert.cofL cert.cofR cert.coprime
+  if checkGcd f h restored then some restored else none
+
+/-- Offer an arbitrary nonzero polynomial candidate to the full multivariate
+checker.  Exact division builds cofactors and route 4 supplies their
+coprimality witness; no producer may bypass this function's final replay. -/
+def checkedCandidate? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (f h candidate : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+  if candidate == 0 then none
+  else
+    let normalized := polyNormalize candidate
+    let cofL := quotient f normalized
+    let cofR := quotient h normalized
+    let cofactorCert := rawPrsCert cofL cofR
+    let cert := GcdCert.mk normalized cofL cofR cofactorCert.coprime
+    if checkGcd f h cert then some cert else none
+
+/-! # Integer modular coprimality -/
+
+/-- Canonical reduction homomorphism carried in an image certificate. -/
+def intCoeffHom (prime : ZMod64.Prime) :
+    @CoeffHom Int prime.m _ _ _ _ prime.bounds := by
+  letI : ZMod64.Bounds prime.m := prime.bounds
+  exact
+    { toField := ZMod64.intCast prime.m
+      map_zero := by exact Lean.Grind.Ring.intCast_zero
+      map_one := by exact Lean.Grind.Ring.intCast_one
+      map_add := by intro a b; exact Lean.Grind.Ring.intCast_add a b
+      map_mul := by intro a b; exact Lean.Grind.Ring.intCast_mul a b }
+
+/-- A one-prime coprimality attempt at fixed arity, returning the advanced
+random state even when the image is inconclusive.  The coefficient
+homomorphism is explicit certificate data, so the same recursion serves
+integers and polynomial coefficients evaluated into their ground field. -/
+structure CoprimeOpsAt (R : Type u) [Zero R] [One R] [Add R] [Mul R]
+    (n : Nat) where
+  tryAt : (cmp : Mono n → Mono n → Ordering) →
+    [IsMonomialOrder cmp] → (P : ZMod64.Prime) →
+    @CoeffHom R P.m _ _ _ _ P.bounds → Rand →
+    MvPoly n R cmp → MvPoly n R cmp →
+    Option (CoprimeCert n R cmp) × Rand
+
+/-- Arity-zero modular-coprimality leaf. -/
+def coprimeBase {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : CoprimeOpsAt R 0 where
+  tryAt := fun cmp _ _ _ rand f h =>
+    let cert := baseCoprime cmp f h
+    (if checkCoprime f h cert then some cert else none, rand)
+
+/-- One recursive modular image and coefficient-content descent. -/
+def coprimeStep {n : Nat} {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (lower : CoprimeOpsAt R n) : CoprimeOpsAt R (n + 1) where
+  tryAt := fun cmp _ prime φ rand f h =>
+    letI : ZMod64.Bounds prime.m := prime.bounds
+    letI : ZMod64.PrimeModulus prime.m :=
+      ZMod64.primeModulusOfPrime prime.prime
+    let next := rand.next
+    let points : Fin n → ZMod64 prime.m := fun j =>
+      ZMod64.ofNat prime.m (next.1.toNat + j.val)
+    let main : Fin (n + 1) := ⟨0, by omega⟩
+    let fView := toUnivariate main Mono.lex f
+    let hView := toUnivariate main Mono.lex h
+    let fImage := imageAtRaw prime φ.toField points main Mono.lex f
+    let hImage := imageAtRaw prime φ.toField points main Mono.lex h
+    if fImage.degree? != fView.degree? || hImage.degree? != hView.degree? then
+      (none, next.2)
+    else
+      let xg := DensePoly.xgcd fImage hImage
+      if xg.gcd.size != 1 then
+        (none, next.2)
+      else
+        let scalar := xg.gcd.coeff 0
+        if scalar == 0 then
+          (none, next.2)
+        else
+          let alpha := DensePoly.scaleImpl scalar⁻¹ xg.left
+          let beta := DensePoly.scaleImpl scalar⁻¹ xg.right
+          let left := contentCertWith (fun a b => rawPrsCert a b)
+            fView.toArray.toList
+          let right := contentCertWith (fun a b => rawPrsCert a b)
+            hView.toArray.toList
+          let restRun := lower.tryAt Mono.lex prime φ next.2
+            left.value right.value
+          match restRun.1 with
+          | none => (none, restRun.2)
+          | some rest =>
+              let cert := CoprimeCert.split main Mono.lex prime φ points
+                alpha beta left right rest
+              (if checkCoprime f h cert then some cert else none, restRun.2)
+
+/-- Construct the per-variable modular coprimality route. -/
+def coprimeOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    (n : Nat) → CoprimeOpsAt R n
+  | 0 => coprimeBase
+  | n + 1 => coprimeStep (coprimeOps n)
+
+/-- Route 1 at one selected prime and coefficient homomorphism.  A failed
+image is inconclusive, while a returned gcd certificate has passed the full
+recursive checker. -/
+def tryCoprimeCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (P : ZMod64.Prime) (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
+    (rand : Rand) (f h : MvPoly n R cmp) :
+    Option (GcdCert n R cmp) × Rand :=
+  let run := (coprimeOps (R := R) n).tryAt cmp P φ rand f h
+  match run.1 with
+  | none => (none, run.2)
+  | some coprime =>
+      let cert := GcdCert.mk 1 f h coprime
+      (if checkGcd f h cert then some cert else none, run.2)
+
+/-- Search a finite prime supply, threading fresh points through every failed
+attempt. -/
+def intCoprimeLoop {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n Int cmp) :
+    List ZMod64.Prime → Nat → Rand →
+      Option (GcdCert n Int cmp) × Rand
+  | _, 0, rand => (none, rand)
+  | [], _, rand => (none, rand)
+  | prime :: primes, fuel + 1, rand =>
+      let run := tryCoprimeCert? prime (intCoeffHom prime) rand f h
+      match run.1 with
+      | some cert => (some cert, run.2)
+      | none => intCoprimeLoop f h primes fuel run.2
+
+/-- Route 1 over integers: one image gcd per variable, with all image degree,
+Bezout, content, and recursive certificates replayed by `checkGcd`. -/
+def intTryCoprimeCert? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (primeFuel : Nat) (rand : Rand) (f h : MvPoly n Int cmp) :
+    Option (GcdCert n Int cmp) × Rand :=
+  let supply := smallPrimeSupply 47 primeFuel
+  intCoprimeLoop f h supply primeFuel rand
+
+/-- Integer routes 0--1. -/
+def intFastProposal {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
+  match structuralCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, cfg.rand⟩
+      | some reduced =>
+          let run := intTryCoprimeCert? cfg.brownPrimeFuel cfg.rand
+            reduced.left reduced.right
+          ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+
+/-! # Concrete finite-field coefficient homomorphisms -/
+
+/-- Identity coefficient homomorphism for a polynomial already over the
+selected bundled prime field. -/
+def primeCoeffHom {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    @CoeffHom (@ZMod64 p hp) p _ _ _ _ hp :=
+  { toField := fun x => x
+    map_zero := rfl
+    map_one := rfl
+    map_add := by intros; rfl
+    map_mul := by intros; rfl }
+
+/-- Evaluation of a univariate prime-field polynomial at a chosen field
+point, packaged with the homomorphism laws required by `CoprimeCert.split`. -/
+def fpCoeffHom {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] (point : @ZMod64 p hp) :
+    @CoeffHom (@FpPoly p hp) p _ _ _ _ hp :=
+  { toField := fun f => DensePoly.evalImpl f point
+    map_zero := by
+      simpa only [← DensePoly.eval_eq_evalImpl] using FpPoly.eval_zero point
+    map_one := by
+      simpa only [← DensePoly.eval_eq_evalImpl] using FpPoly.eval_one point
+    map_add := by
+      intro f h
+      simpa only [← DensePoly.eval_eq_evalImpl] using FpPoly.eval_add f h point
+    map_mul := by
+      intro f h
+      simpa only [← DensePoly.eval_eq_evalImpl] using FpPoly.eval_mul f h point }
+
+/-- Routes 0--1 over a fixed bounded prime field. -/
+def primeFastProposal {n p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p]
+    (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n (@ZMod64 p hp) cmp) :
+    GcdProposal n (@ZMod64 p hp) cmp :=
+  match structuralCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, cfg.rand⟩
+      | some reduced =>
+          let P : ZMod64.Prime :=
+            { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
+          let run := tryCoprimeCert? P primeCoeffHom cfg.rand
+            reduced.left reduced.right
+          ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+
+/-- Routes 0--1 for `FpPoly` coefficients.  One random field point defines
+the total evaluation homomorphism carried by the certificate; subsequent
+draws are used for the multivariate image points. -/
+def fpFastProposal {n p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p]
+    (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n (@FpPoly p hp) cmp) :
+    GcdProposal n (@FpPoly p hp) cmp :=
+  match structuralCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨none, cfg.rand⟩
+      | some reduced =>
+          let P : ZMod64.Prime :=
+            { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
+          let draw := cfg.rand.next
+          let point := ZMod64.ofNat p draw.1.toNat
+          let run := tryCoprimeCert? P (fpCoeffHom point) draw.2
+            reduced.left reduced.right
+          ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+
+/-- Coefficient-generic structural proposal.  Route 1 needs an explicit
+total `CoeffHom`, so concrete coefficient backends add it after this common
+route-0 pass. -/
+def fastProposal {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (cfg : GcdConfig) (f h : MvPoly n R cmp) : GcdProposal n R cmp :=
+  match structuralCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
+  | none => ⟨none, cfg.rand⟩
+
+end Hex.MvPoly

--- a/HexMvGcd/Gauss.lean
+++ b/HexMvGcd/Gauss.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Instances
+public import HexResultant.Fraction
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Proof-only Gauss and common-factor algebra.
+
+This file deliberately defines no executable multivariate gcd, content
+producer, checker, or candidate route. Its finite coefficient gcd is an
+existential object selected only inside proofs; the fraction embedding and
+primitive descent isolate the algebra needed to lift gcd-domain laws through
+polynomial arities.
+-/
+
+namespace Hex
+
+universe u
+
+section Domain
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+  [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R]
+
+/-- The executable gcd laws supply the proof-only gcd-domain package. -/
+theorem gcdDomainOfLawful [LawfulGcdOps R] : GcdDomainLaws R where
+  dvd_iff := LawfulGcdOps.dvd_iff
+  one_ne_zero := LawfulGcdOps.one_ne_zero
+  no_zero_div := LawfulGcdOps.no_zero_div
+  gcd_exists a b :=
+    ⟨GcdOps.gcd a b, LawfulGcdOps.gcd_dvd_left a b,
+      LawfulGcdOps.gcd_dvd_right a b,
+      fun d hda hdb => LawfulGcdOps.dvd_gcd a b d hda hdb⟩
+
+/-- Low-priority bridge from executable lawful gcd operations to the
+producer-free algebraic package. -/
+instance (priority := 100) instGcdDomainLawsOfLawful [LawfulGcdOps R] :
+    GcdDomainLaws R :=
+  gcdDomainOfLawful
+
+end Domain
+
+section Cancel
+
+variable {R : Type u} [Lean.Grind.CommRing R] [Dvd R]
+  [GcdDomainLaws R]
+
+/-- Ordinary gcd-domain arithmetic gives Euclid cancellation in the exact
+form consumed by certificate maximality. -/
+theorem coprimeCancelOfGcdDomain : CoprimeCancelLaws R := by
+  sorry
+
+instance (priority := 100) instCoprimeCancelLawsOfGcdDomain :
+    CoprimeCancelLaws R :=
+  coprimeCancelOfGcdDomain
+
+end Cancel
+
+section CoeffFold
+
+variable {R : Type u} [Lean.Grind.CommRing R] [Dvd R]
+
+/-- Proof object for a greatest common divisor of every member of a finite
+coefficient list. It is not executable certificate data. -/
+structure CoeffGcd (xs : List R) where
+  value : R
+  divides : ∀ x, x ∈ xs → value ∣ x
+  greatest : ∀ d, (∀ x, x ∈ xs → d ∣ x) → d ∣ value
+
+/-- Transitivity derived from the multiplication-oriented divisibility law. -/
+theorem dvdTrans [GcdDomainLaws R] {a b c : R}
+    (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  rcases (GcdDomainLaws.dvd_iff a b).mp hab with ⟨x, hb⟩
+  rcases (GcdDomainLaws.dvd_iff b c).mp hbc with ⟨y, hc⟩
+  apply (GcdDomainLaws.dvd_iff a c).mpr
+  refine ⟨x * y, ?_⟩
+  calc
+    c = b * y := hc
+    _ = (a * x) * y := by rw [hb]
+    _ = a * (x * y) := Lean.Grind.Semiring.mul_assoc a x y
+
+/-- Every finite coefficient list admits a greatest common divisor, including
+the empty list whose gcd is chosen as zero. -/
+theorem coeffGcd_nonempty [GcdDomainLaws R] (xs : List R) :
+    Nonempty (CoeffGcd xs) := by
+  induction xs with
+  | nil =>
+      refine ⟨⟨0, ?_, ?_⟩⟩
+      · intro x hx
+        simp at hx
+      · intro d _
+        apply (GcdDomainLaws.dvd_iff d 0).mpr
+        refine ⟨0, ?_⟩
+        exact (Lean.Grind.Semiring.mul_zero d).symm
+  | cons a xs ih =>
+      rcases ih with ⟨c, hc, hgreat⟩
+      rcases GcdDomainLaws.gcd_exists a c with ⟨g, hga, hgc, hgreatG⟩
+      refine ⟨⟨g, ?_, ?_⟩⟩
+      · intro x hx
+        rcases List.mem_cons.mp hx with rfl | hx
+        · exact hga
+        · exact dvdTrans hgc (hc x hx)
+      · intro d hd
+        apply hgreatG d
+        · exact hd a (List.mem_cons_self ..)
+        · apply hgreat d
+          intro x hx
+          exact hd x (List.mem_cons_of_mem a hx)
+
+/-- Proof-only choice of a finite coefficient gcd. This is intentionally
+`noncomputable` and must not be called by an executable content operation. -/
+noncomputable def chooseCoeffGcdData [GcdDomainLaws R]
+    (xs : List R) : CoeffGcd xs :=
+  Classical.choice (coeffGcd_nonempty xs)
+
+noncomputable def chooseCoeffGcd [GcdDomainLaws R] (xs : List R) : R :=
+  (chooseCoeffGcdData xs).value
+
+theorem chooseCoeffGcd_divides [GcdDomainLaws R] (xs : List R)
+    {x : R} (hx : x ∈ xs) : chooseCoeffGcd xs ∣ x :=
+  (chooseCoeffGcdData xs).divides x hx
+
+theorem dvd_chooseCoeffGcd [GcdDomainLaws R] (xs : List R) (d : R)
+    (hd : ∀ x, x ∈ xs → d ∣ x) : d ∣ chooseCoeffGcd xs :=
+  (chooseCoeffGcdData xs).greatest d hd
+
+end CoeffFold
+
+namespace MvPoly
+
+universe v
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+/-- The scalar coefficient list used only by proof-side content. -/
+def coefficientList [Zero R] (p : MvPoly n R cmp) : List R :=
+  p.termsList.map Prod.snd
+
+/-- A polynomial is primitive when every scalar common divisor of its stored
+coefficients is a unit. This is a semantic predicate, not the executable
+primitive-part operation. -/
+def Primitive [Lean.Grind.CommRing R] [Dvd R]
+    (p : MvPoly n R cmp) : Prop :=
+  ∀ d, (∀ c, c ∈ coefficientList p → d ∣ c) → ∃ u, d * u = 1
+
+section Fraction
+
+variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [Div R] [ExactDivLaws R] [Hex.Fraction.NonzeroOne R]
+
+/-- Coefficientwise embedding into the Mathlib-free fraction field used by
+the subresultant development. -/
+def fractionMap (p : MvPoly n R cmp) :
+    MvPoly n (Hex.Fraction R) cmp :=
+  mapCoeffs Hex.Fraction.ofCoeff p
+
+@[simp] theorem fractionMap_zero :
+    fractionMap (0 : MvPoly n R cmp) = 0 := by
+  exact mapCoeffs_zero Hex.Fraction.ofCoeff_zero
+
+theorem fractionMap_add (f g : MvPoly n R cmp) :
+    fractionMap (f + g) = fractionMap f + fractionMap g := by
+  exact mapCoeffs_add Hex.Fraction.ofCoeff_zero Hex.Fraction.ofCoeff_add f g
+
+theorem fractionMap_mul (f g : MvPoly n R cmp) :
+    fractionMap (f * g) = fractionMap f * fractionMap g := by
+  exact mapCoeffs_mul Hex.Fraction.ofCoeff_zero Hex.Fraction.ofCoeff_add
+    Hex.Fraction.ofCoeff_mul f g
+
+theorem fractionMap_injective :
+    Function.Injective (fractionMap (n := n) (R := R) (cmp := cmp)) := by
+  sorry
+
+/-- Coprimality after embedding the coefficients into the fraction field. -/
+def CoprimeOverFraction (f g : MvPoly n R cmp) : Prop :=
+  ∀ d, d ∣ fractionMap f → d ∣ fractionMap g →
+    ∃ u, d * u = 1
+
+/-- Gcd data for univariate polynomials over the fraction field. This is a
+proof-side existence package and does not select a multivariate producer. -/
+structure FractionPolyGcd
+    (f g : DensePoly (Hex.Fraction R)) where
+  value : DensePoly (Hex.Fraction R)
+  dvdLeft : value ∣ f
+  dvdRight : value ∣ g
+  greatest : ∀ d, d ∣ f → d ∣ g → d ∣ value
+
+/-- Univariate polynomials over the coefficient fraction field admit gcds. -/
+theorem fractionPolyGcd_nonempty
+    (f g : DensePoly (Hex.Fraction R)) :
+    Nonempty (FractionPolyGcd f g) := by
+  sorry
+
+/-- Primitive descent: fraction-field coprimality of primitive inputs rules
+out every nonunit common divisor back in the coefficient ring. -/
+theorem primitive_descent [GcdDomainLaws R]
+    {f g d : MvPoly n R cmp}
+    (hf : Primitive f) (hg : Primitive g)
+    (hcop : CoprimeOverFraction f g)
+    (hdf : d ∣ f) (hdg : d ∣ g) :
+    ∃ u, d * u = 1 := by
+  sorry
+
+end Fraction
+
+section Lift
+
+variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [GcdDomainLaws R]
+
+/-- Gauss's lemma lifts proof-only gcd-domain structure through every finite
+multivariate arity. -/
+theorem gcdDomainLaws : GcdDomainLaws (MvPoly n R cmp) := by
+  sorry
+
+instance (priority := 100) instGcdDomainLawsMvPoly :
+    GcdDomainLaws (MvPoly n R cmp) :=
+  gcdDomainLaws
+
+/-- The lifted gcd-domain laws supply the common-factor cancellation used by
+checked gcd maximality. -/
+theorem coprimeCancelLaws : CoprimeCancelLaws (MvPoly n R cmp) := by
+  exact coprimeCancelOfGcdDomain
+
+instance (priority := 100) instCoprimeCancelLawsMvPoly :
+    CoprimeCancelLaws (MvPoly n R cmp) :=
+  coprimeCancelLaws
+
+/-- Named common-factor step consumed by `CheckedGcdResult.greatest`. -/
+theorem cancelCommonFactor
+    (g a b d : MvPoly n R cmp)
+    (hcop : ∀ e, e ∣ a → e ∣ b → ∃ u, e * u = 1)
+    (hda : d ∣ g * a) (hdb : d ∣ g * b) : d ∣ g := by
+  exact CoprimeCancelLaws.cancel_coprime g a b d hcop hda hdb
+
+end Lift
+
+end MvPoly
+
+end Hex

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -1,0 +1,487 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+
+public import HexMvGcd.Gauss
+public import HexMvGcd.Brown
+public import HexPolyZGcd
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Public multivariate gcd, content, and primitive-part API.
+
+This milestone exposes the deterministic checked PRS route. Later fast
+producers may propose certificates, but every public result remains gated by
+the same checker and falls back here.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+
+/-- Complete checked dispatch. Proposals affect performance and random state,
+but rejection always falls through to the deterministic PRS route. -/
+def gcdCertWith (cfg : GcdConfig)
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : GcdRun n R cmp :=
+  let proposal := GcdProducer.propose cmp cfg f h
+  match proposal.cert? with
+  | some candidate =>
+      if checkGcd f h candidate then ⟨candidate, proposal.rand⟩
+      else ⟨prsCert f h, proposal.rand⟩
+  | none => ⟨prsCert f h, proposal.rand⟩
+
+/-- Canonical checked gcd certificate. -/
+def gcdCert [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : GcdCert n R cmp :=
+  (gcdCertWith GcdConfig.default f h).cert
+
+/-- Every public certificate has passed executable replay. -/
+theorem gcdCert_checks [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : checkGcd f h (gcdCert f h) = true := by
+  sorry
+
+theorem gcdCertWith_checks [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (cfg : GcdConfig) (f h : MvPoly n R cmp) :
+    checkGcd f h (gcdCertWith cfg f h).cert = true := by
+  sorry
+
+/-- Certified coefficient content in a named main variable. -/
+def contentInCert {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    ContentCert n R cmp' :=
+  let coeffs := (toUnivariate i cmp' p).toArray.toList
+  contentCertWith (fun f h => gcdCert f h) coeffs
+
+/-- Content in a named main variable. -/
+def contentIn {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    MvPoly n R cmp' :=
+  (contentInCert i cmp' p).value
+
+/-- Primitive part in a named main variable. -/
+def primPartIn {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    MvPoly (n + 1) R cmp :=
+  quotient p (constIn i cmp' (contentIn i cmp' p))
+
+theorem contentInCert_checks
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    checkContent (toUnivariate i cmp' p).toArray.toList
+      (contentInCert i cmp' p) = true := by
+  sorry
+
+theorem contentIn_mul_primPartIn
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    constIn i cmp' (contentIn i cmp' p) * primPartIn i cmp' p = p := by
+  sorry
+
+theorem contentIn_dvd_coeff
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) (k : Nat) :
+    contentIn i cmp' p ∣ (toUnivariate i cmp' p).coeff k := by
+  sorry
+
+/-- Universal property of named-variable content. -/
+theorem dvd_contentIn
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp)
+    (d : MvPoly n R cmp')
+    (hd : ∀ k, d ∣ (toUnivariate i cmp' p).coeff k) :
+    d ∣ contentIn i cmp' p := by
+  sorry
+
+@[simp] theorem contentIn_zero
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] :
+    contentIn (R := R) (cmp := cmp) i cmp' 0 = 0 := by
+  sorry
+
+@[simp] theorem primPartIn_zero
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] :
+    primPartIn (R := R) (cmp := cmp) i cmp' 0 = 0 := by
+  sorry
+
+theorem primPartIn_content
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] {p : MvPoly (n + 1) R cmp} (hp : p ≠ 0) :
+    contentIn i cmp' (primPartIn i cmp' p) = 1 := by
+  sorry
+
+theorem contentIn_mul
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p q : MvPoly (n + 1) R cmp) :
+    contentIn i cmp' (p * q) = contentIn i cmp' p * contentIn i cmp' q := by
+  sorry
+
+theorem primPartIn_mul
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p q : MvPoly (n + 1) R cmp) :
+    primPartIn i cmp' (p * q) = primPartIn i cmp' p * primPartIn i cmp' q := by
+  sorry
+
+/-- Canonically normalized gcd. -/
+def gcd [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : MvPoly n R cmp :=
+  (gcdCert f h).gcd
+
+def cofactors [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : MvPoly n R cmp × MvPoly n R cmp :=
+  let cert := gcdCert f h
+  (cert.cofL, cert.cofR)
+
+def gcdWith [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (cfg : GcdConfig) (f h : MvPoly n R cmp) : MvPoly n R cmp × Rand :=
+  let run := gcdCertWith cfg f h
+  (run.cert.gcd, run.rand)
+
+def isCoprime [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : Bool :=
+  polyIsUnit (gcd f h)
+
+def gcdList [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (ps : List (MvPoly n R cmp)) : MvPoly n R cmp :=
+  ps.foldl gcd 0
+
+def lcm [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : MvPoly n R cmp :=
+  let cert := gcdCert f h
+  polyNormalize (cert.gcd * cert.cofL * cert.cofR)
+
+/-! Install the executable operations before stating contracts that use the
+polynomial `GcdOps.isUnit` spelling.  The lawful instance is assembled from
+those contracts below. -/
+
+instance instGcdOpsMvPoly [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R] :
+    GcdOps (MvPoly n R cmp) where
+  gcd := gcd
+  exactDiv := quotient
+  isUnit := polyIsUnit
+  normUnit := polyNormUnit
+
+theorem gcd_dvd_left [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : gcd f h ∣ f := by
+  sorry
+
+theorem gcd_dvd_right [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : gcd f h ∣ h := by
+  sorry
+
+theorem dvd_gcd [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h d : MvPoly n R cmp) (hf : d ∣ f) (hh : d ∣ h) : d ∣ gcd f h := by
+  sorry
+
+theorem gcd_normalized [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : polyNormalize (gcd f h) = gcd f h := by
+  sorry
+
+@[simp] theorem gcd_zero_zero [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R] :
+    gcd (0 : MvPoly n R cmp) 0 = 0 := by
+  sorry
+
+@[simp] theorem gcd_zero_right [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f : MvPoly n R cmp) : gcd f 0 = polyNormalize f := by
+  sorry
+
+@[simp] theorem gcd_zero_left [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f : MvPoly n R cmp) : gcd 0 f = polyNormalize f := by
+  sorry
+
+theorem gcd_eq_one_of_left_unit [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) (hf : polyIsUnit f = true) : gcd f h = 1 := by
+  sorry
+
+theorem gcd_eq_one_of_right_unit [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) (hh : polyIsUnit h = true) : gcd f h = 1 := by
+  sorry
+
+theorem gcd_mul_cofactor_left [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    gcd f h * (cofactors f h).1 = f := by
+  sorry
+
+theorem gcd_mul_cofactor_right [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    gcd f h * (cofactors f h).2 = h := by
+  sorry
+
+theorem cofactors_spec [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    f = gcd f h * (cofactors f h).1 ∧
+      h = gcd f h * (cofactors f h).2 := by
+  sorry
+
+theorem cofactors_coprime [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    ∀ d, d ∣ (cofactors f h).1 → d ∣ (cofactors f h).2 →
+      GcdOps.isUnit d = true := by
+  sorry
+
+theorem isCoprime_iff [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    isCoprime f h = true ↔
+      ∀ d, d ∣ f → d ∣ h → GcdOps.isUnit d = true := by
+  sorry
+
+@[simp] theorem gcdList_nil [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R] :
+    gcdList ([] : List (MvPoly n R cmp)) = 0 := rfl
+
+theorem gcdList_dvd [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    {p : MvPoly n R cmp} {ps : List (MvPoly n R cmp)} (hp : p ∈ ps) :
+    gcdList ps ∣ p := by
+  sorry
+
+theorem dvd_gcdList [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    {d : MvPoly n R cmp} {ps : List (MvPoly n R cmp)}
+    (hd : ∀ p ∈ ps, d ∣ p) : d ∣ gcdList ps := by
+  sorry
+
+@[simp] theorem lcm_zero_left [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f : MvPoly n R cmp) : lcm 0 f = 0 := by
+  sorry
+
+@[simp] theorem lcm_zero_right [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f : MvPoly n R cmp) : lcm f 0 = 0 := by
+  sorry
+
+theorem dvd_lcm_left [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : f ∣ lcm f h := by
+  sorry
+
+theorem dvd_lcm_right [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : h ∣ lcm f h := by
+  sorry
+
+theorem lcm_dvd [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h m : MvPoly n R cmp) (hf : f ∣ m) (hh : h ∣ m) :
+    lcm f h ∣ m := by
+  sorry
+
+theorem lcm_normalized [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : polyNormalize (lcm f h) = lcm f h := by
+  sorry
+
+theorem gcd_reorder
+    {cmp' : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) :
+    ∃ u v : R, u * v = 1 ∧
+      gcd (reorder cmp' f) (reorder cmp' h) =
+        reorder cmp' (gcd f h) * C u := by
+  sorry
+
+/-- Convert an arity-one integer polynomial to the actual `ZPoly` kernel. -/
+def toZPoly {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f : MvPoly 1 Int cmp) : ZPoly :=
+  let i : Fin 1 := ⟨0, by omega⟩
+  let q := toUnivariate i Mono.lex f
+  DensePoly.ofList <| (List.range q.size).map fun k => coeff Mono.zero (q.coeff k)
+
+/-- Convert an integer univariate kernel value back to arity one. -/
+def ofZPoly {cmp : Mono 1 → Mono 1 → Ordering}
+    [IsMonomialOrder cmp] (f : ZPoly) : MvPoly 1 Int cmp :=
+  let i : Fin 1 := ⟨0, by omega⟩
+  ofUnivariate (cmp := cmp) i Mono.lex <|
+    DensePoly.ofList <| (List.range f.size).map fun k => C (f.coeff k)
+
+instance instLawfulGcdOpsMvPoly [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R] :
+    LawfulGcdOps (MvPoly n R cmp) := by
+  constructor <;> intros <;> sorry
+
+end Hex.MvPoly
+
+namespace Hex
+
+/-! The actual `HexPolyZGcd` kernel supplies the required `DensePoly Int`
+coefficient instance. -/
+
+instance instGcdOpsZPoly : GcdOps ZPoly where
+  gcd := ZPoly.gcd
+  exactDiv f g := (ZPoly.divExact? f g).getD 0
+  isUnit f := decide (f.size = 1 ∧ (f.coeff 0 = 1 ∨ f.coeff 0 = -1))
+  normUnit f := if f = 0 ∨ 0 < f.leadingCoeff then 1 else -1
+
+instance instLawfulGcdOpsZPoly : LawfulGcdOps ZPoly := by
+  constructor <;> intros <;> sorry
+
+end Hex

--- a/HexMvGcd/Heu.lean
+++ b/HexMvGcd/Heu.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModular.SymMod
+public import HexMvGcd.Fast
+
+@[expose] public section
+
+/-! Bounded route-2 proposal and concrete coefficient backends. -/
+
+namespace Hex.MvPoly
+
+universe u
+
+/-- A conservative projected-size bound for the Kronecker route. -/
+def heuristicProjectedBits {n : Nat}
+    (degrees : Mono n) (coefficientBits : Nat) : Nat :=
+  coefficientBits * (List.finRange n).foldl
+    (fun acc i => acc * (degrees[i] + 1)) 1
+
+/-- Mixed-radix stride of variable `i`. -/
+def heuristicStride {n : Nat} (degrees : Mono n) (i : Fin n) : Nat :=
+  (List.finRange n).foldl
+    (fun stride j =>
+      if j.val < i.val then stride * (degrees[j] + 1) else stride) 1
+
+/-- Number of collision-free mixed-radix coefficient slots. -/
+def heuristicSlots {n : Nat} (degrees : Mono n) : Nat :=
+  (List.finRange n).foldl (fun slots i => slots * (degrees[i] + 1)) 1
+
+/-- Decode a Kronecker digit position back to its exponent vector. -/
+def heuristicDecode {n : Nat} (degrees : Mono n) (index : Nat) : Mono n :=
+  Hex.Vector.ofFn' fun i =>
+    index / heuristicStride degrees i % (degrees[i] + 1)
+
+/-- Symmetric base digits, low digit first and explicitly fuel bounded. -/
+def heuristicDigits (base : Nat) : Int → Nat → List Int
+  | _, 0 => []
+  | value, fuel + 1 =>
+      if value = 0 then []
+      else
+        let digit := Modular.symMod value base
+        digit :: heuristicDigits base ((value - digit) / Int.ofNat base) fuel
+
+/-- Largest absolute input coefficient. -/
+def heuristicCoeffNorm {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n Int cmp) : Nat :=
+  p.termsList.foldl (fun bound term => max bound term.2.natAbs) 0
+
+/-- Collision-free mixed-radix evaluation. -/
+def heuristicEval {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (degrees : Mono n) (base : Nat) (p : MvPoly n Int cmp) : Int :=
+  eval (fun i => Int.ofNat base ^ heuristicStride degrees i) p
+
+/-- Reconstruct a sparse integer polynomial from symmetric Kronecker digits.
+Positions beyond the mixed-radix box are ignored. -/
+def heuristicReconstruct {n : Nat}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp] (degrees : Mono n) (base : Nat)
+    (value : Int) : MvPoly n Int cmp :=
+  let slots := heuristicSlots degrees
+  let digits := heuristicDigits base value (slots + 1)
+  ofTerms <| (List.range (min slots digits.length)).map fun index =>
+    (heuristicDecode degrees index, digits.getD index 0)
+
+/-- One genuine GCDHEU candidate over integers.  Accidental factors in the
+evaluated cofactors remain possible and are intentionally left for
+`checkedCandidate?` to reject. -/
+def intHeuristicCandidateAt {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n Int cmp) (base : Nat) : MvPoly n Int cmp :=
+  let fPrimitive := primPart f
+  let hPrimitive := primPart h
+  let degrees := Mono.lcm fPrimitive.degrees hPrimitive.degrees
+  let fValue := heuristicEval degrees base fPrimitive
+  let hValue := heuristicEval degrees base hPrimitive
+  let value : Int := Int.ofNat (Int.gcd fValue hValue)
+  let raw := heuristicReconstruct (cmp := cmp) degrees base value
+  let commonContent := GcdOps.gcd (content f) (content h)
+  polyNormalize (C commonContent * primPart raw)
+
+/-- Projected bit cost of one mixed-radix evaluation. -/
+def intHeuristicCost {n : Nat}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (f h : MvPoly n Int cmp) (base : Nat) : Nat :=
+  let degrees := Mono.lcm f.degrees h.degrees
+  let coeffBits := Nat.log2
+    (max 2 (max (heuristicCoeffNorm f) (heuristicCoeffNorm h))) + 1
+  coeffBits + heuristicSlots degrees * (Nat.log2 (max 2 base) + 1)
+
+/-- Retry GCDHEU while charging every growing evaluation against the caller's
+projected-bit budget. -/
+def intHeuristicLoop {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n Int cmp) : Nat → Nat → Option (GcdCert n Int cmp)
+  | _, 0 => none
+  | base, remaining + 1 =>
+      let cost := intHeuristicCost f h base
+      if cost > remaining + 1 then none
+      else
+        match checkedCandidate? f h (intHeuristicCandidateAt f h base) with
+        | some cert => some cert
+        | none =>
+            intHeuristicLoop f h (2 * base + 1)
+              (remaining + 1 - max 1 cost)
+termination_by _ remaining => remaining
+decreasing_by
+  omega
+
+/-- Route 2 over integers. -/
+def intHeuristicCert? {n : Nat}
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (cfg : GcdConfig) (f h : MvPoly n Int cmp) :
+    Option (GcdCert n Int cmp) :=
+  let norm := max (heuristicCoeffNorm f) (heuristicCoeffNorm h)
+  let base := max 3 (2 * norm + 1)
+  intHeuristicLoop f h base cfg.heuristicBitBudget
+
+instance fpPolyProducer {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] : GcdProducer (@FpPoly p hp) where
+  propose := fun cmp _ cfg f h => fpFastProposal cmp cfg f h
+
+end Hex.MvPoly

--- a/HexMvGcd/Instances.lean
+++ b/HexMvGcd/Instances.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexArith.ExtGcd
+public import HexMvGcd.Normalize
+public import HexPolyFp.Field
+public import HexResultant.ExactDiv
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Base coefficient instances for the multivariate gcd kernel.
+
+The field gcd convention is `0` only for the pair `(0, 0)` and `1`
+otherwise. `normUnit` is defined at zero as `1`, as required by
+`LawfulGcdOps`; the inverse is used only on nonzero inputs.
+-/
+
+namespace Hex
+
+/-! # Integers -/
+
+@[reducible] instance instGcdOpsInt : GcdOps Int where
+  gcd a b := (Int.gcd a b : Int)
+  exactDiv a b := a / b
+  isUnit a := decide (a = 1 ∨ a = -1)
+  normUnit a := if a < 0 then -1 else 1
+
+instance instBezoutOpsInt : BezoutOps Int where
+  gcd := GcdOps.gcd
+  exactDiv := GcdOps.exactDiv
+  isUnit := GcdOps.isUnit
+  normUnit := GcdOps.normUnit
+  xgcd a b :=
+    let r := HexArith.Int.extGcd a b
+    (r.2.1, r.2.2)
+
+instance instLawfulGcdOpsInt : LawfulGcdOps Int := by
+  constructor <;> intros <;> sorry
+
+instance instLawfulBezoutOpsInt : LawfulBezoutOps Int := by
+  constructor
+  intro a b
+  simp only [BezoutOps.xgcd, instBezoutOpsInt]
+  rw [HexArith.Int.extGcd_bezout_gcd]
+  sorry
+
+/-! # Rationals -/
+
+/-- Divisibility in a field, stated in the same multiplication orientation as
+the polynomial instances. -/
+instance instDvdRat : Dvd Rat where
+  dvd a b := ∃ c, b = a * c
+
+def ratXgcd (a b : Rat) : Rat × Rat :=
+  if a = 0 then
+    if b = 0 then (0, 0) else (0, b⁻¹)
+  else
+    (a⁻¹, 0)
+
+@[reducible] instance instGcdOpsRat : GcdOps Rat where
+  gcd a b := if a = 0 ∧ b = 0 then 0 else 1
+  exactDiv a b := a / b
+  isUnit a := decide (a ≠ 0)
+  normUnit a := if a = 0 then 1 else a⁻¹
+
+instance instBezoutOpsRat : BezoutOps Rat where
+  gcd := GcdOps.gcd
+  exactDiv := GcdOps.exactDiv
+  isUnit := GcdOps.isUnit
+  normUnit := GcdOps.normUnit
+  xgcd := ratXgcd
+
+instance instLawfulGcdOpsRat : LawfulGcdOps Rat := by
+  constructor <;> intros <;> sorry
+
+instance instLawfulBezoutOpsRat : LawfulBezoutOps Rat := by
+  constructor
+  intro a b
+  sorry
+
+/-! # Bounded prime fields -/
+
+namespace ZMod64
+
+variable {p : Nat} [hp : Bounds p] [PrimeModulus p]
+
+def fieldXgcd (a b : @ZMod64 p hp) : @ZMod64 p hp × @ZMod64 p hp :=
+  if a = 0 then
+    if b = 0 then (0, 0) else (0, b⁻¹)
+  else
+    (a⁻¹, 0)
+
+end ZMod64
+
+/-- Field divisibility, in multiplication orientation. -/
+instance instDvdZMod64 {p : Nat} [hp : ZMod64.Bounds p] :
+    Dvd (@ZMod64 p hp) where
+  dvd a b := ∃ c, b = a * c
+
+@[reducible] instance instGcdOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p] :
+    GcdOps (@ZMod64 p hp) where
+  gcd a b := if a = 0 ∧ b = 0 then 0 else 1
+  exactDiv a b := a / b
+  isUnit a := decide (a ≠ 0)
+  normUnit a := if a = 0 then 1 else a⁻¹
+
+instance instBezoutOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p] :
+    BezoutOps (@ZMod64 p hp) where
+  gcd := GcdOps.gcd
+  exactDiv := GcdOps.exactDiv
+  isUnit := GcdOps.isUnit
+  normUnit := GcdOps.normUnit
+  xgcd := ZMod64.fieldXgcd
+
+instance instLawfulGcdOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    @LawfulGcdOps (@ZMod64 p hp) _ _ _ _ instDvdZMod64 instGcdOpsZMod64 := by
+  sorry
+
+instance instLawfulBezoutOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    @LawfulBezoutOps (@ZMod64 p hp) _ _ _ _ instDvdZMod64 instBezoutOpsZMod64
+      instLawfulGcdOpsZMod64 := by
+  sorry
+
+/-! # Univariate prime-field polynomials -/
+
+namespace FpPoly
+
+variable {p : Nat} [hp : ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+
+/-- Unit which makes the leading coefficient one, with `1` at zero. -/
+@[reducible] def normUnit (f : @FpPoly p hp) : @FpPoly p hp :=
+  if f = 0 then 1 else DensePoly.C f.leadingCoeff⁻¹
+
+/-- The Euclidean gcd made monic by its leading coefficient. -/
+@[reducible] def normalizedGcd (f g : @FpPoly p hp) : @FpPoly p hp :=
+  let d := DensePoly.gcd f g
+  d * normUnit d
+
+/-- Extended-gcd coefficients scaled by the same unit as the gcd. -/
+def normalizedXgcd (f g : @FpPoly p hp) : @FpPoly p hp × @FpPoly p hp :=
+  let r := DensePoly.xgcd f g
+  let u := normUnit r.gcd
+  (r.left * u, r.right * u)
+
+end FpPoly
+
+/-- Canonical dense-polynomial ring instance exposed for `FpPoly`. -/
+instance instCommRingFpPoly {p : Nat} [hp : ZMod64.Bounds p] :
+    Lean.Grind.CommRing (@FpPoly p hp) :=
+  Hex.instGrindCommRingDensePoly
+
+@[reducible] instance instGcdOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p] :
+    GcdOps (@FpPoly p hp) where
+  gcd := FpPoly.normalizedGcd
+  exactDiv f g := f / g
+  isUnit f := decide (f.size = 1)
+  normUnit := FpPoly.normUnit
+
+instance instBezoutOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p] :
+    BezoutOps (@FpPoly p hp) where
+  gcd := GcdOps.gcd
+  exactDiv := GcdOps.exactDiv
+  isUnit := GcdOps.isUnit
+  normUnit := GcdOps.normUnit
+  xgcd := FpPoly.normalizedXgcd
+
+instance instLawfulGcdOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    @LawfulGcdOps (@FpPoly p hp) instCommRingFpPoly _ _ _ _ instGcdOpsFpPoly := by
+  sorry
+
+instance instLawfulBezoutOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    @LawfulBezoutOps (@FpPoly p hp) instCommRingFpPoly _ _ _ _ instBezoutOpsFpPoly
+      instLawfulGcdOpsFpPoly := by
+  sorry
+
+/-! Instance-graph checks for every base coefficient family. -/
+
+example : GcdOps Int := inferInstance
+example : BezoutOps Int := inferInstance
+example : LawfulGcdOps Int := inferInstance
+example : GcdOps Rat := inferInstance
+example : BezoutOps Rat := inferInstance
+example : LawfulGcdOps Rat := inferInstance
+
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    GcdOps (ZMod64 p) := inferInstance
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    GcdOps (FpPoly p) := inferInstance
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    LawfulGcdOps (ZMod64 p) := inferInstance
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    LawfulBezoutOps (ZMod64 p) := inferInstance
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    LawfulGcdOps (FpPoly p) := inferInstance
+example {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    LawfulBezoutOps (FpPoly p) := inferInstance
+
+end Hex

--- a/HexMvGcd/Kernel.lean
+++ b/HexMvGcd/Kernel.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Gcd
+
+public section
+
+/-! Small kernel-reduced checker replays. Full route-4 producers are tested
+with VM evaluation in `HexMvGcd.Eval`; these examples deliberately isolate
+the certificate branches so the kernel can reduce them without compiling the
+entire recursive PRS producer. -/
+
+namespace Hex.MvPoly
+
+private abbrev P0 := MvPoly 0 Int Mono.lex
+private abbrev P1 := MvPoly 1 Int Mono.lex
+
+private def zeroCert : GcdCert 0 Int Mono.lex :=
+  .mk 0 1 1 .unit
+
+example : checkGcd (0 : P0) 0 zeroCert = true := by
+  decide +kernel
+
+private def baseCert : GcdCert 0 Int Mono.lex :=
+  .mk (C 6) (C 2) (C 3) (.base (-1) 1)
+
+example : baseCheckCoprime (C 2 : P0) (C 3) (.base (-1) 1) = true := by
+  decide +kernel
+
+example : polyNormalize (C 6 : P0) == C 6 := by
+  decide +kernel
+
+example : (C 6 : P0) * C 2 == C 12 := by
+  decide +kernel
+
+example : checkGcd (C 12 : P0) (C 18) baseCert = true := by
+  decide +kernel
+
+private def unitCert : GcdCert 1 Int Mono.lex :=
+  .mk 1 1 (X 0 + 2) .unit
+
+example : checkGcd (1 : P1) (X 0 + 2) unitCert = true := by
+  decide +kernel
+
+private def contentStep₁ : GcdCert 0 Int Mono.lex :=
+  .mk (C 2) 0 1 .unit
+
+private def contentStep₂ : GcdCert 0 Int Mono.lex :=
+  .mk (C 2) 1 (C 2) .unit
+
+private def contentCert : ContentCert 0 Int Mono.lex :=
+  .ofSteps (C 2) [contentStep₁, contentStep₂]
+
+example : checkContent ([C 2, C 4] : List P0) contentCert = true := by
+  decide +kernel
+
+private def badBaseCert : GcdCert 0 Int Mono.lex :=
+  .mk (C 6) (C 2) (C 2) (.base (-1) 1)
+
+example : checkGcd (C 12 : P0) (C 18) badBaseCert = false := by
+  decide +kernel
+
+private def ratLift : RatLiftCert 0 Mono.lex where
+  scaleL := 2
+  scaleR := 3
+  left := 1
+  right := 1
+  cert := .unit
+
+example : checkRatLift (C 2) (C 3) ratLift = true := by
+  decide +kernel
+
+private def ratLiftCoprime : CoprimeCert 0 Rat Mono.lex :=
+  .ratLift 2 3 1 1 .unit
+
+example : checkCoprime (C 2) (C 3) ratLiftCoprime = true := by
+  decide +kernel
+
+private def intEmbedding : CoeffEmbedding Int Int where
+  toFun := fun z => z
+
+/-- The universe-polymorphic implementation constructor must not turn mere
+nonzero scaling into a coprimality witness outside a field. -/
+private def nonunitLift : CoprimeCert 0 Int Mono.lex :=
+  .ratLiftCore intEmbedding (by rfl) (by rfl)
+    (by intros; rfl) (by intros; rfl) (by intro a b h; exact h)
+    2 2 1 1 1 1 .unit
+
+example : checkCoprime (C 2) (C 2) nonunitLift = false := by
+  decide +kernel
+
+end Hex.MvPoly

--- a/HexMvGcd/KernelTests.lean
+++ b/HexMvGcd/KernelTests.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Gauss
+public meta import HexMvGcd.Gauss
+public meta import HexMvPoly.Basic
+public meta import HexMvPoly.Ring
+
+public section
+
+/-!
+Kernel-facing examples for the checked multivariate division API.
+-/
+
+namespace Hex.MvPoly.KernelTests
+
+open Hex
+open scoped Hex
+
+abbrev P := MvPoly 2 Int Mono.lex
+abbrev P1 := MvPoly 1 Int Mono.lex
+
+@[expose] def x : P := X 0
+@[expose] def y : P := X 1
+@[expose] def left : P := x + y
+@[expose] def right : P := x - y
+@[expose] def product : P := left * right
+
+#guard divExact? product left == some right
+
+#guard divExact? product (left + C 1) == none
+
+example : divExact? product 0 = none := by
+  decide +kernel
+
+example : divMod product 0 = (0, product) := by
+  decide +kernel
+
+#guard divMod product left == (right, 0)
+
+@[expose] def lower : P1 := X 0 + C 2
+
+#guard toUnivariate 0 Mono.lex
+    (constIn (cmp := Mono.lex) 0 Mono.lex lower) == DensePoly.C lower
+
+#guard polyIsUnit (C (-1) : P)
+
+#guard !polyIsUnit x
+
+#guard scalarContent left == 1
+
+#guard polyNormalize (-left) == left
+
+example : Nonempty (CoeffGcd ([12, 18, 30] : List Int)) :=
+  coeffGcd_nonempty _
+
+end Hex.MvPoly.KernelTests

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.View
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Producer-free unit, normalization, and scalar-content operations.
+
+None of these definitions calls the multivariate gcd producer. This is
+important because certificate replay needs them before the public
+`GcdOps (MvPoly ...)` instance can be assembled.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+  [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [GcdOps R]
+
+/-- The constant unit selected from the leading coefficient, with `1` at
+zero. -/
+@[reducible] def polyNormUnit [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) : MvPoly n R cmp :=
+  match p.termsList.getLast? with
+  | none => 1
+  | some (_, c) => C (GcdOps.normUnit c)
+
+/-- Canonical associate selected by the unit attached to the leading
+coefficient. -/
+@[reducible] def polyNormalize [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) : MvPoly n R cmp :=
+  p * polyNormUnit p
+
+/-- Recognize exactly a one-term constant polynomial whose coefficient is a
+unit in the base ring. -/
+@[reducible] def polyIsUnit (p : MvPoly n R cmp) : Bool :=
+  match p.termsList with
+  | [(m, c)] => decide (m = Mono.zero) && GcdOps.isUnit c
+  | _ => false
+
+/-- Normalized gcd fold of the distributed scalar coefficients. The empty
+fold is the specified zero content; a nonempty fold starts at the first
+coefficient rather than relying on an unstated `gcd 0 a` law. -/
+@[reducible] def scalarContent (p : MvPoly n R cmp) : R :=
+  match p.termsList with
+  | [] => 0
+  | (_, c) :: terms =>
+      normalize (terms.foldl (fun g term => GcdOps.gcd g term.2) c)
+
+/-- The normalization unit at zero is the constant one polynomial. -/
+@[simp] theorem polyNormUnit_zero [IsMonomialOrder cmp] :
+    polyNormUnit (0 : MvPoly n R cmp) = 1 := by
+  sorry
+
+/-- Polynomial normalization preserves zero. -/
+@[simp] theorem polyNormalize_zero [IsMonomialOrder cmp] :
+    polyNormalize (0 : MvPoly n R cmp) = 0 := by
+  rw [polyNormalize, polyNormUnit_zero, Lean.Grind.Semiring.zero_mul]
+
+/-- Scalar content uses the explicit zero convention. -/
+@[simp] theorem scalarContent_zero :
+    scalarContent (0 : MvPoly n R cmp) = 0 := by
+  rfl
+
+/-- Unit recognition is sound and complete under the coefficient gcd laws. -/
+theorem polyIsUnit_iff [LawfulGcdOps R] (p : MvPoly n R cmp) :
+    polyIsUnit p = true ↔ ∃ q, p * q = 1 := by
+  sorry
+
+/-- The chosen normalization multiplier is a polynomial unit. -/
+theorem polyNormUnit_isUnit [IsMonomialOrder cmp] [LawfulGcdOps R]
+    (p : MvPoly n R cmp) :
+    polyIsUnit (polyNormUnit p) = true := by
+  sorry
+
+/-- Polynomial normalization is idempotent. -/
+theorem polyNormalize_idem [IsMonomialOrder cmp] [LawfulGcdOps R]
+    (p : MvPoly n R cmp) :
+    polyNormalize (polyNormalize p) = polyNormalize p := by
+  sorry
+
+end Hex.MvPoly

--- a/HexMvGcd/Prs.lean
+++ b/HexMvGcd/Prs.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Content
+public import HexResultant.SubresultantExt
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+The deterministic extended-subresultant fallback.
+
+Candidate production is structurally recursive in the arity.  At a successor
+arity the extended Brown chain supplies the terminal identity; all content
+folds and the residual coprimality obligation use the already-constructed
+lower-arity operations.  The public wrapper replays `checkGcd` and exposes no
+unchecked candidate.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+/-- Operations constructed together at one arity. Keeping the pair together
+makes every recursive call visibly decrease the arity. -/
+structure PrsOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+  gcdCert : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp
+  coprimeCert : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    MvPoly n R cmp → MvPoly n R cmp → CoprimeCert n R cmp
+
+/-- Stable total form of exact division used only at route invariants proved
+below. Final outputs are independently replayed by `checkGcd`. -/
+def quotient {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (f g : MvPoly n R cmp) : MvPoly n R cmp :=
+  (divExact? f g).getD 0
+
+/-- The default arm in `quotient` is unreachable at every route use: a known
+nonzero exact divisor makes the checked division return a concrete quotient. -/
+theorem quotient_mul_of_dvd {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+    {f g : MvPoly n R cmp} (hg : g ≠ 0) (hd : g ∣ f) :
+    quotient f g * g = f := by
+  sorry
+
+/-- Direct computational form used when a producer already has the checked
+division result in hand. -/
+theorem quotient_eq_of_some {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    {f g q : MvPoly n R cmp} (hq : divExact? f g = some q) :
+    quotient f g = q := by
+  simp [quotient, hq]
+
+/-- The last extended-chain entry. Nonzero inputs make the chain nonempty;
+the route completeness theorem establishes that invariant. -/
+def terminal {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
+    [Div S] (f h : DensePoly S) :
+    DensePoly S × DensePoly S × DensePoly S :=
+  let chain := DensePoly.subresultantChainExt f h
+  chain.getD (chain.size - 1) (0, 0, 0)
+
+/-- Nonzero input pairs give a nonempty extended chain, so `terminal` never
+observes its stable default on the PRS route. -/
+theorem chainExt_nonempty {S : Type u} [Lean.Grind.CommRing S]
+    [DecidableEq S] [Div S] (f h : DensePoly S)
+    (hn : f ≠ 0 ∨ h ≠ 0) :
+    0 < (DensePoly.subresultantChainExt f h).size := by
+  sorry
+
+/-- The selected terminal triple is an actual extended-chain entry whenever
+the route's nonzero-input invariant holds. -/
+theorem terminal_mem {S : Type u} [Lean.Grind.CommRing S]
+    [DecidableEq S] [Div S] (f h : DensePoly S)
+    (hn : f ≠ 0 ∨ h ≠ 0) :
+    ∃ k, ∃ hk : k < (DensePoly.subresultantChainExt f h).size,
+      terminal f h = (DensePoly.subresultantChainExt f h)[k]'hk := by
+  sorry
+
+/-- Arity-zero coprimality witness from the base extended gcd. -/
+def baseCoprime {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R]
+    (cmp : Mono 0 → Mono 0 → Ordering) [IsMonomialOrder cmp]
+    (f h : MvPoly 0 R cmp) : CoprimeCert 0 R cmp :=
+  let uv := BezoutOps.xgcd (coeff Mono.zero f) (coeff Mono.zero h)
+  .base uv.1 uv.2
+
+/-- Arity-zero gcd candidate. Every quotient is replayed by the checker. -/
+def baseGcd {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R]
+    (cmp : Mono 0 → Mono 0 → Ordering) [IsMonomialOrder cmp]
+    (f h : MvPoly 0 R cmp) : GcdCert 0 R cmp :=
+  if f == 0 && h == 0 then
+    .mk 0 1 1 .unit
+  else
+    let a := coeff Mono.zero f
+    let b := coeff Mono.zero h
+    let g := polyNormalize (C (GcdOps.gcd a b))
+    let cofL := quotient f g
+    let cofR := quotient h g
+    .mk g cofL cofR (baseCoprime cmp cofL cofR)
+
+/-- Build the successor-arity `splitBezout` witness from an extended chain
+and recursively certified coefficient contents. -/
+def succCoprime {n : Nat} {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (lower : PrsOpsAt R n)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    [IsMonomialOrder cmp]
+    (f h : MvPoly (n + 1) R cmp) : CoprimeCert (n + 1) R cmp :=
+  if polyIsUnit f || polyIsUnit h then
+    .unit
+  else
+    let i : Fin (n + 1) := ⟨0, Nat.zero_lt_succ n⟩
+    let fView := toUnivariate i Mono.lex f
+    let hView := toUnivariate i Mono.lex h
+    let e := terminal fView hView
+    let u := ofUnivariate (cmp := cmp) i Mono.lex e.1
+    let v := ofUnivariate (cmp := cmp) i Mono.lex e.2.1
+    let r := e.2.2.coeff 0
+    let left := contentCertWith (lower.gcdCert Mono.lex) fView.toArray.toList
+    let right := contentCertWith (lower.gcdCert Mono.lex) hView.toArray.toList
+    let rest := lower.coprimeCert Mono.lex left.value right.value
+    .splitBezout i Mono.lex u v r left right rest
+
+/-- Successor-arity gcd candidate from input contents and the primitive part
+of the terminal extended subresultant. -/
+def succGcd {n : Nat} {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (lower : PrsOpsAt R n)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    [IsMonomialOrder cmp]
+    (f h : MvPoly (n + 1) R cmp) : GcdCert (n + 1) R cmp :=
+  if f == 0 && h == 0 then
+    .mk 0 1 1 .unit
+  else if f == 0 then
+    let g := polyNormalize h
+    let cofR := quotient h g
+    .mk g 0 cofR .unit
+  else if h == 0 then
+    let g := polyNormalize f
+    let cofL := quotient f g
+    .mk g cofL 0 .unit
+  else
+    let i : Fin (n + 1) := ⟨0, Nat.zero_lt_succ n⟩
+    let fView := toUnivariate i Mono.lex f
+    let hView := toUnivariate i Mono.lex h
+    let fContent :=
+      contentCertWith (lower.gcdCert Mono.lex) fView.toArray.toList
+    let hContent :=
+      contentCertWith (lower.gcdCert Mono.lex) hView.toArray.toList
+    let common := lower.gcdCert Mono.lex fContent.value hContent.value
+    let fPrimitive := quotient f (constIn i Mono.lex fContent.value)
+    let hPrimitive := quotient h (constIn i Mono.lex hContent.value)
+    let e := terminal (toUnivariate i Mono.lex fPrimitive)
+      (toUnivariate i Mono.lex hPrimitive)
+    let terminalPoly := ofUnivariate (cmp := cmp) i Mono.lex e.2.2
+    let terminalContent := contentCertWith (lower.gcdCert Mono.lex)
+      e.2.2.toArray.toList
+    let primitiveGcd := quotient terminalPoly
+      (constIn i Mono.lex terminalContent.value)
+    let raw := constIn i Mono.lex common.gcd * primitiveGcd
+    let g := polyNormalize raw
+    let cofL := quotient f g
+    let cofR := quotient h g
+    .mk g cofL cofR (succCoprime lower cmp cofL cofR)
+
+/-- Construct deterministic gcd and coprimality operations by arity. -/
+def prsOps {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    (n : Nat) → PrsOpsAt R n
+  | 0 =>
+      { gcdCert := baseGcd
+        coprimeCert := baseCoprime }
+  | n + 1 =>
+      let lower := prsOps n
+      { gcdCert := succGcd lower
+        coprimeCert := succCoprime lower }
+
+/-- Raw deterministic route-4 certificate. -/
+def rawPrsCert {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    (f h : MvPoly n R cmp) : GcdCert n R cmp :=
+  (prsOps (R := R) n).gcdCert cmp f h
+
+/-- Route 4 always constructs an accepted certificate. The proof combines
+the extended-chain transformation law, exact divisions, and the recursive
+content checker. -/
+theorem rawPrsCert_checks {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    (f h : MvPoly n R cmp) :
+    checkGcd f h (rawPrsCert f h) = true := by
+  sorry
+
+/-- Deterministic route-4 certificate.  Runtime construction is entirely
+data-level; acceptance is established separately by `prsCert_checks`. -/
+def prsCert {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    (f h : MvPoly n R cmp) : GcdCert n R cmp :=
+  rawPrsCert f h
+
+theorem prsCert_checks {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    (f h : MvPoly n R cmp) :
+    checkGcd f h (prsCert f h) = true := by
+  sorry
+
+end Hex.MvPoly

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -8,7 +8,7 @@ correspondence, and supplies the decidability instances that make the
 operations usable from a Mathlib goal.
 
 This SPEC expands the "Multivariate gcd and squarefree decomposition"
-entry in [future-work](../future-work.md) and depends on the representation
+entry in [future-work](../../SPEC/future-work.md) and depends on the representation
 fixed by [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md). The coprimality
 certificate inherited from the modular-gcd item does not generalise as
 written; "The certificate" gives the complete replacement. The algorithms
@@ -19,7 +19,7 @@ structural and no parallel arity-preserving API is introduced.
 
 **Rational expression simplification.** `cancel`, the second of the three
 pieces of the `Together` / `Apart` item in
-[future-work](../future-work.md), reduces `p / q` to lowest terms. That
+[future-work](../../SPEC/future-work.md), reduces `p / q` to lowest terms. That
 is a multivariate gcd plus its cofactors, and nothing else. It is the
 consumer with the highest call volume, and it is dominated by the case
 `gcd = 1`, which is why coprime detection gets its own fast path below
@@ -79,11 +79,11 @@ factorization into irreducibles (that is `hex-mv-factor`,
 and it depends on this library), Gröbner bases, resultants themselves
 (hex-resultant computes them once this library supplies the instances),
 multivariate Hensel lifting (that is
-[hex-mv-hensel](hex-mv-hensel.md), which depends on this library), and
+[hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md), which depends on this library), and
 the sparse Hensel gcd route (see "Routes not specified here").
 
 Also not in scope: the univariate integer case, which is
-[hex-poly-z-gcd](hex-poly-z-gcd.md). That library computes gcds of
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md). That library computes gcds of
 `ZPoly` for the consumers that hold `DensePoly Int` and would otherwise
 convert, its certificate is the arity-one specialisation of the one
 below with an unconditional soundness theorem, and this
@@ -103,21 +103,20 @@ namespace Hex
 /-- Executable operations a coefficient ring must supply. `exactDiv a b`
 is required to be correct only when `b ∣ a` and `b ≠ 0`; other inputs
 return a stable junk value. -/
-class GcdOps (R : Type u) [Zero R] [One R] [Add R] [Mul R] [Dvd R] where
+class GcdOps (R : Type u) where
   gcd      : R → R → R
   exactDiv : R → R → R
   isUnit   : R → Bool
   normUnit : R → R
 
 /-- The canonical associate chosen by `GcdOps`. -/
-def normalize [Zero R] [One R] [Add R] [Mul R] [Dvd R] [GcdOps R]
+def normalize [Mul R] [GcdOps R]
     (a : R) : R :=
   a * GcdOps.normUnit a
 
 /-- Coefficient rings in which coprimality is witnessed by a Bézout
 identity. Required of the base ring only, never of `MvPoly`. -/
-class BezoutOps (R : Type u) [Zero R] [One R] [Add R] [Mul R] [Dvd R]
-    extends GcdOps R where
+class BezoutOps (R : Type u) extends GcdOps R where
   xgcd : R → R → R × R
 
 /-- The algebraic hypotheses the gcd algorithms need of `R`. Separated
@@ -165,6 +164,15 @@ class CoprimeCancelLaws (S : Type u) [Lean.Grind.CommRing S] [Dvd S] : Prop wher
 
 with `normalize a = a * GcdOps.normUnit a`, matching Mathlib's naming so
 the companion's transport lemmas do not have to rename anything.
+
+The executable structures do not carry `Zero`, `One`, `Add`, or `Mul`
+dictionaries as class parameters: none of their stored operations needs
+those dictionaries.  Algebraic structure is required only by `normalize`
+and the law packages.  Besides keeping the operation classes minimal, this
+avoids an instance diamond for dependent carriers such as `ZMod64 p` and
+`FpPoly p`, where forming `LawfulGcdOps` after the ring dictionaries have
+already been fixed otherwise prevents Lean from synthesizing the canonical
+`GcdOps` instance.
 
 Five of the `LawfulGcdOps` fields are load-bearing and easy to leave out.
 `one_ne_zero` supplies the nontriviality required by `Fraction`.
@@ -251,7 +259,8 @@ def divExact? [IsMonomialOrder cmp] (f g : MvPoly n R cmp) :
     Option (MvPoly n R cmp)
 
 instance : Dvd (MvPoly n R cmp)  -- `∃ q, f = q * g`
-instance [IsMonomialOrder cmp] (f g : MvPoly n R cmp) : Decidable (g ∣ f)
+instance [IsMonomialOrder cmp] [LawfulGcdOps R]
+    (f g : MvPoly n R cmp) : Decidable (g ∣ f)
 
 /-- The total form, for hex-resultant's `[Div R]` interface. -/
 instance [IsMonomialOrder cmp] : Div (MvPoly n R cmp)
@@ -291,9 +300,18 @@ enough to run on every candidate.
 theorem divMod_spec : f = (divMod f g).1 * g + (divMod f g).2
 theorem divMod_reduced (hg : g ≠ 0) : ReducedBy (divMod f g).2 g
 theorem divExact?_zero_right : divExact? f 0 = none
-theorem divExact?_eq (hg : g ≠ 0) : divExact? f g = some q ↔ f = q * g
-theorem divExact?_isSome_of_dvd (hg : g ≠ 0) : g ∣ f → (divExact? f g).isSome
+theorem divExact?_eq [LawfulGcdOps R] (hg : g ≠ 0) :
+    divExact? f g = some q ↔ f = q * g
+theorem divExact?_isSome_of_dvd [LawfulGcdOps R] (hg : g ≠ 0) :
+    g ∣ f → (divExact? f g).isSome
 ```
+
+The lawful hypotheses on completeness and decidable divisibility are
+load-bearing. `GcdOps.exactDiv` is deliberately unconstrained away from exact
+inputs; without `LawfulGcdOps.exactDiv_cancel`, an implementation that always
+returns zero is a valid `GcdOps` and misses even the exact division `1 / 1`.
+Forward soundness of a returned quotient needs only the executable checker,
+but the reverse implication needs the cancellation law.
 
 The `g ≠ 0` hypothesis on `divExact?_eq` is not decoration. At `f = 0`
 and `g = 0` the right-hand side holds for every `q`, and a deterministic
@@ -429,7 +447,7 @@ division at every step, with proofs that each cofactor numerator is
 divisible by the Brown scalar it is divided by.
 
 The owning contract is now recorded under "Extended subresultant chain for
-gcd consumers" in [SPEC/future-work.md](../future-work.md), with a pointer
+gcd consumers" in [SPEC/future-work.md](../../SPEC/future-work.md), with a pointer
 from the Downstream contracts section of
 [hex-resultant's SPEC](../../HexResultant/SPEC/hex-resultant.md); its
 signature is repeated here only to show the consumer boundary:
@@ -547,12 +565,12 @@ they establish `g ∣ f` and `g ∣ h`, nothing more. Any common divisor
 whatever, `1` included, satisfies them. Maximality is a separate
 obligation, and the usable form of it is that the cofactors `f'` and `h'`
 have no nonunit common divisor. This is the case
-[future-work](../future-work.md) makes in its own preamble, and the
+[future-work](../../SPEC/future-work.md) makes in its own preamble, and the
 whole point of the certificate is to carry the second witness.
 
 ### Bézout does not witness coprimality here
 
-[future-work](../future-work.md) said of the modular gcd for `ℤ[x]` that
+[future-work](../../SPEC/future-work.md) said of the modular gcd for `ℤ[x]` that
 the certificate carries cofactors "together with a Bézout witness that
 `f'` and `h'` are coprime", and now records the correction instead. That
 witness does not exist, in one variable or in several. `ℤ[x]` is not a Bézout domain: `x` and `2` are coprime
@@ -793,7 +811,7 @@ rewriting `0 / 0` to `1 / 1` is false under Lean's total division. The
 tactic's obligation is the cofactor identities **plus** `h ≠ 0`, plus
 the cancellation law of the target field, which is the same
 denominator-nonvanishing side condition
-[future-work](../future-work.md) identifies for `Together` and `Apart`
+[future-work](../../SPEC/future-work.md) identifies for `Together` and `Apart`
 and resolves by matching `field_simp`. Coprimality is what makes the
 output fully reduced, which is a quality property of the answer rather
 than a soundness property of the rewrite.
@@ -1099,7 +1117,7 @@ early-termination theorem, diversification, field-size policy, collision
 handling, and restart semantics before assigning it performance claims.
 
 The random point is an explicit argument rather than a monad, following
-the pattern [hex-finite-field](hex-finite-field.md) sets under
+the pattern [hex-finite-field](../../SPEC/Libraries/hex-finite-field.md) sets under
 "Randomness", and drawn from the `Hex.Rand` generator that SPEC
 introduces.
 
@@ -1423,7 +1441,7 @@ rather than acquiring a new one.
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). A Lean driver at
 `conformance/HexMvGcd/EmitFixtures.lean` exposed as
 `lean_exe hexmvgcd_emit_fixtures`, a committed snapshot at
 `conformance-fixtures/HexMvGcd/mvgcd.jsonl`, and an oracle driver at
@@ -1509,7 +1527,7 @@ oracle's normalisation conventions.
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexMvGcd/Bench.lean`. Native only for throughput. A separate
 `bench/HexMvGcd/Kernel.lean` suite replays valid and one-field-corrupted
 certificates through `by decide +kernel`: base, modular split,
@@ -1599,7 +1617,7 @@ Over `ℚ` the content is a unit and the relative and ring-theoretic
 predicates agree. Over `ℤ`, the instance combines the checked primitive
 part with Mathlib's decision procedure for squarefreeness of the integer
 content (`DecidablePred (Squarefree : ℕ → Prop)`). What
-[hex-int-factor](hex-int-factor.md) adds is the square divisor and the
+[hex-int-factor](../../SPEC/Libraries/hex-int-factor.md) adds is the square divisor and the
 squarefree part as witnesses, which the decision procedure does not
 produce.
 
@@ -1680,14 +1698,14 @@ HexMvGcdMathlib/
 HexMvGcdMathlib.lean
 ```
 
-`libraries.yml` gains:
+`libraries.yml` records the active core library and the planned companion:
 
 ```yaml
   HexMvGcd:
     deps: [HexBasic, HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith, HexModular, HexPolyZGcd]
     mathlib: false
-    done_through: 0
-    status: planned
+    done_through: 1
+    status: active
   HexMvGcdMathlib:
     deps: [HexMvGcd, HexMvPolyMathlib]
     mathlib: true
@@ -1698,23 +1716,18 @@ HexMvGcdMathlib.lean
 `HexPolyZGcd` is the arity-one case, called rather than reimplemented;
 see "Scope". `HexPolyFp` and `HexModArith` are for the univariate images
 over `F_p`.
-`HexBasic` will supply the explicitly threaded `Rand` state specified in
-[hex-finite-field](hex-finite-field.md); that file is not landed yet.
+`HexBasic` supplies the explicitly threaded `Rand` state specified in
+[hex-finite-field](../../SPEC/Libraries/hex-finite-field.md).
 `HexModular` supplies CRT and reconstruction. `HexModArith` owns the
 bundled bounded-prime stream.
 `HexResultant` is for route 4 and for the `ExactDivLaws` interface.
 `HexArith` is for the integer gcd and the extended Euclidean algorithm.
 `HexPoly` comes in through `DensePoly`, which `toUnivariate` returns.
 
-`HexMvPoly`, `HexMvPolyMathlib`, and `HexResultant` are active.
-`HexModular` and `HexPolyZGcd` are planned and not yet registered in
-`libraries.yml`; their entries must be added and implemented before the
-block above can be applied. Three shared additions are also unlanded:
-`HexBasic.Rand`, the bundled modulus supply in `HexModArith`, and the
-extended-chain amendment to `HexResultant`.
-The new entries are nevertheless `planned`, not `draft`, because this SPEC
-fixes their required API and milestones; registration waits until the
-dependency entries exist.
+All dependencies named above are active. `HexMvGcd` is registered as active
+at `done_through: 1`; the prerequisite and coefficient-kernel milestone is
+complete. `HexMvGcdMathlib` remains a planned companion and is not yet
+registered in `libraries.yml`.
 
 ## Why gcd and squarefree decomposition are one library
 
@@ -1743,7 +1756,7 @@ decomposition. It is between verification and fast routes:
   Hensel lifting have different prerequisites and failure policies. The
   sparse stress benchmarks measure the gap, but this SPEC intentionally
   does not choose an underspecified route.
-  [hex-mv-hensel](hex-mv-hensel.md) has the same open question about its
+  [hex-mv-hensel](../../HexMvHensel/SPEC/hex-mv-hensel.md) has the same open question about its
   own dense diophantine recursion, and the two should be decided
   together: one sparse interpolation layer could serve both.
 - **Sparse exponent vectors.** hex-mv-poly leaves open whether a large

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -1,0 +1,272 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Gcd
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Characteristic-zero squarefree operations.
+
+The executable decomposition follows the named-variable recursive form of
+Yun's algorithm.  Coefficient content is decomposed one arity down; the
+primitive part is split into its multiplicity layers using one selected main
+variable, and equal-multiplicity factors are merged.  Scalar content is kept
+separately, matching the computer-algebra convention over `Int`.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+/-- Mathlib-free characteristic zero. -/
+class NatNoZero (R : Type u) [Zero R] [NatCast R] : Prop where
+  natCast_ne_zero : ∀ m : Nat, 0 < m → (m : R) ≠ 0
+
+instance instNatNoZeroInt : NatNoZero Int := by
+  constructor
+  intro m hm
+  omega
+
+instance instNatNoZeroRat : NatNoZero Rat := by
+  constructor
+  intro m hm
+  sorry
+
+instance instFractionNonzeroOneInt : Hex.Fraction.NonzeroOne Int :=
+  ⟨by decide⟩
+
+instance instFractionNonzeroOneRat : Hex.Fraction.NonzeroOne Rat :=
+  ⟨by decide⟩
+
+/-- The coefficient fraction field is perfect.  This is used only by the
+semantic decision theorem; the Boolean checker itself uses gcd replay. -/
+class PerfectFrac (R : Type u) [Lean.Grind.CommRing R] [Div R]
+    [ExactDivLaws R] [Hex.Fraction.NonzeroOne R] : Prop where
+  charZeroOrPerfect :
+    (∀ m : Nat, 0 < m → (m : Hex.Fraction R) ≠ 0) ∨
+    ∃ p : Nat, Hex.Nat.Prime p ∧ (p : Hex.Fraction R) = 0 ∧
+      ∀ a : Hex.Fraction R, ∃ b : Hex.Fraction R, b ^ p = a
+
+instance instPerfectFracInt : PerfectFrac Int := by
+  constructor
+  left
+  intro m hm
+  sorry
+
+instance instPerfectFracRat : PerfectFrac Rat := by
+  constructor
+  left
+  intro m hm
+  sorry
+
+/-- A polynomial has no variable in its support. -/
+def IsConst {n : Nat} {R : Type u} [Zero R]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n R cmp) : Prop :=
+  p.vars = []
+
+/-- Relative squarefreeness: repeated divisors must be constant. -/
+def Squarefree {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (p : MvPoly n R cmp) : Prop :=
+  p ≠ 0 ∧ ∀ d, d * d ∣ p → IsConst d
+
+structure SqfFactor (n : Nat) (R : Type u) [Zero R]
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  factor : MvPoly n R cmp
+  multiplicity : Nat
+
+structure SqfDecomp (n : Nat) (R : Type u) [Zero R]
+    (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  content : R
+  factors : List (SqfFactor n R cmp)
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+  [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+  [GcdProducer R]
+
+/-- All partial derivatives, in variable-index order. -/
+def derivatives [NatCast R] (p : MvPoly n R cmp) : List (MvPoly n R cmp) :=
+  (List.finRange n).map fun i => derivative i p
+
+/-- Merge one factor into the multiplicity-sorted accumulator, multiplying
+factors when the recursive content decomposition and the main-variable Yun
+decomposition contribute at the same multiplicity. -/
+def mergeSqfFactor (entry : SqfFactor n R cmp) :
+    List (SqfFactor n R cmp) → List (SqfFactor n R cmp)
+  | [] => [entry]
+  | head :: tail =>
+      if entry.multiplicity < head.multiplicity then entry :: head :: tail
+      else if entry.multiplicity = head.multiplicity then
+        { factor := entry.factor * head.factor
+          multiplicity := entry.multiplicity } :: tail
+      else head :: mergeSqfFactor entry tail
+
+/-- One decreasing Yun layer in the selected main variable.  The fuel is the
+total degree of the primitive input plus one; in characteristic zero every
+nonterminal layer removes at least one degree from `b`. -/
+def yunLoop [NatCast R] [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
+    (b d : MvPoly n R cmp) (acc : List (SqfFactor n R cmp)) :
+    List (SqfFactor n R cmp) :=
+  match fuel with
+  | 0 => acc.reverse
+  | fuel + 1 =>
+      if polyIsUnit b then acc.reverse
+      else
+        let factor := gcd b d
+        let nextB := quotient b factor
+        let nextC := quotient d factor
+        let nextD := nextC - derivative i nextB
+        let acc := if polyIsUnit factor then acc else ⟨factor, k⟩ :: acc
+        yunLoop i fuel (k + 1) nextB nextD acc
+
+/-- Move the normalization unit of the primitive part into the scalar output,
+so the polynomial sent to recursive decomposition is canonically normalized
+without losing the sign (or general coefficient-ring unit) in the product. -/
+def sqfPrimitiveSplit [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) : R × MvPoly n R cmp :=
+  let scalar := content p
+  let primitive := primPart p
+  let unitInv := GcdOps.exactDiv 1 (GcdOps.normUnit primitive.leadingCoeff)
+  (scalar * unitInv, polyNormalize primitive)
+
+/-- Arity-indexed decomposition operation.  Packaging the recursive call
+makes the coefficient-content descent structurally decreasing in the arity. -/
+structure SqfOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+  decomp : (cmp : Mono n → Mono n → Ordering) →
+    [IsMonomialOrder cmp] → MvPoly n R cmp → SqfDecomp n R cmp
+
+/-- The arity-zero polynomial is a scalar, including its normalization unit. -/
+def sqfBase : SqfOpsAt R 0 where
+  decomp := fun _ _ p =>
+    let split := sqfPrimitiveSplit p
+    ⟨split.1, []⟩
+
+/-- One recursive content split followed by Yun in a variable which occurs in
+the normalized primitive part. -/
+def sqfStep [NatCast R] {m : Nat} (lower : SqfOpsAt R m) :
+    SqfOpsAt R (m + 1) where
+  decomp := fun cmp _ p =>
+    let split := sqfPrimitiveSplit p
+    let scalar := split.1
+    let q := split.2
+    if q == 0 || polyIsUnit q then
+      ⟨scalar, []⟩
+    else
+      match q.vars with
+      | [] => ⟨scalar, []⟩
+      | i :: _ =>
+          let coefficientPart := contentIn i Mono.lex q
+          let coefficientDecomp := lower.decomp Mono.lex coefficientPart
+          let mainPart := primPartIn i Mono.lex q
+          let deriv := derivative i mainPart
+          let repeated := gcd mainPart deriv
+          let b := quotient mainPart repeated
+          let c := quotient deriv repeated
+          let d := c - derivative i b
+          let mainFactors :=
+            yunLoop i (mainPart.totalDegree + 1) 1 b d []
+          let liftedFactors := coefficientDecomp.factors.map fun factor =>
+            { factor := constIn (cmp := cmp) i Mono.lex factor.factor
+              multiplicity := factor.multiplicity }
+          let factors := liftedFactors.foldl
+            (fun acc factor => mergeSqfFactor factor acc) mainFactors
+          ⟨scalar * coefficientDecomp.content, factors⟩
+
+/-- Construct squarefree decomposition recursively in the arity. -/
+def sqfOps [NatCast R] : (m : Nat) → SqfOpsAt R m
+  | 0 => sqfBase
+  | m + 1 => sqfStep (sqfOps m)
+
+/-- Characteristic-zero squarefree decomposition with recursive content and
+scalar content split off. -/
+def sqfDecomp [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) : SqfDecomp n R cmp :=
+  (sqfOps (R := R) n).decomp cmp p
+
+/-- Product of the distinct polynomial factors; scalar content is omitted. -/
+def radical [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) : MvPoly n R cmp :=
+  let q := polyNormalize (primPart p)
+  if q == 0 then 0
+  else quotient q (gcdList (q :: derivatives q))
+
+/-- Exact Boolean squarefree decision under the relative CAS convention. -/
+def isSquarefree [IsMonomialOrder cmp] [NatCast R]
+    (p : MvPoly n R cmp) : Bool :=
+  let q := primPart p
+  polyIsUnit (gcdList (q :: derivatives q))
+
+theorem isSquarefree_iff [IsMonomialOrder cmp] [NatCast R]
+    [Div R] [ExactDivLaws R] [Hex.Fraction.NonzeroOne R] [PerfectFrac R]
+    (p : MvPoly n R cmp) :
+    isSquarefree p = true ↔ Squarefree p := by
+  sorry
+
+theorem radical_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) (hp : p ≠ 0) : Squarefree (radical p) := by
+  sorry
+
+theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) : radical p ∣ p := by
+  sorry
+
+@[simp] theorem radical_zero [IsMonomialOrder cmp] [NatCast R] [NatNoZero R] :
+    radical (0 : MvPoly n R cmp) = 0 := by
+  sorry
+
+theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) :
+    (sqfDecomp p).factors.foldl
+      (fun acc f => acc * f.factor ^ f.multiplicity)
+      (C (sqfDecomp p).content) = p := by
+  sorry
+
+theorem sqfDecomp_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) :
+    ∀ f ∈ (sqfDecomp p).factors, Squarefree f.factor := by
+  sorry
+
+theorem sqfDecomp_primitive [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) :
+    ∀ f ∈ (sqfDecomp p).factors, content f.factor = 1 := by
+  sorry
+
+theorem sqfDecomp_coprime [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+    (p : MvPoly n R cmp) :
+    ∀ f ∈ (sqfDecomp p).factors, ∀ g ∈ (sqfDecomp p).factors,
+      f.multiplicity ≠ g.multiplicity →
+        ∀ d, d ∣ f.factor → d ∣ g.factor → GcdOps.isUnit d = true := by
+  sorry
+
+theorem sqfDecomp_multiplicity_pos [IsMonomialOrder cmp]
+    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    ∀ f ∈ (sqfDecomp p).factors, 0 < f.multiplicity := by
+  sorry
+
+theorem sqfDecomp_multiplicity_sorted [IsMonomialOrder cmp]
+    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    List.Pairwise (fun f g => f.multiplicity < g.multiplicity)
+      (sqfDecomp p).factors := by
+  sorry
+
+theorem sqfDecomp_nonconstant [IsMonomialOrder cmp]
+    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    ∀ f ∈ (sqfDecomp p).factors, ¬ IsConst f.factor := by
+  sorry
+
+end Hex.MvPoly

--- a/HexMvGcd/View.lean
+++ b/HexMvGcd/View.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Divide
+public import HexMvPoly.Recursive
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+The constant embedding associated to the arity-dropping univariate view.
+
+Keeping this operation next to the gcd code avoids adding a second recursive
+view to `hex-mv-poly`: being constant in the selected variable is represented
+by applying `ofUnivariate` to a dense constant polynomial.
+-/
+
+namespace Hex.MvPoly
+
+universe u
+
+variable {n : Nat} {R : Type u}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+  [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+  [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+
+/-- Embed a polynomial in the remaining variables as a polynomial constant in
+the selected variable. -/
+def constIn (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (c : MvPoly n R cmp') : MvPoly (n + 1) R cmp :=
+  ofUnivariate (cmp := cmp) i cmp' (DensePoly.C c)
+
+/-- The recursive view of a constant embedding is a dense constant. -/
+@[simp] theorem toUnivariate_constIn (i : Fin (n + 1))
+    (c : MvPoly n R cmp') :
+    toUnivariate i cmp' (constIn (cmp := cmp) i cmp' c) = DensePoly.C c := by
+  exact toUnivariate_ofUnivariate i (DensePoly.C c)
+
+/-- The degree-`k` recursive coefficient of `constIn c` is `c` at zero and
+zero elsewhere. -/
+@[simp] theorem coeff_constIn (i : Fin (n + 1))
+    (c : MvPoly n R cmp') (k : Nat) :
+    (toUnivariate i cmp' (constIn (cmp := cmp) i cmp' c)).coeff k =
+      if k = 0 then c else 0 := by
+  rw [toUnivariate_constIn]
+  exact DensePoly.coeff_C c k
+
+/-- Constant embedding preserves zero. -/
+@[simp] theorem constIn_zero (i : Fin (n + 1)) :
+    constIn (R := R) (cmp := cmp) i cmp' 0 = 0 := by
+  sorry
+
+/-- Constant embedding preserves one. -/
+@[simp] theorem constIn_one (i : Fin (n + 1)) :
+    constIn (R := R) (cmp := cmp) i cmp' 1 = 1 := by
+  sorry
+
+/-- Constant embedding preserves addition. -/
+theorem constIn_add (i : Fin (n + 1)) (a b : MvPoly n R cmp') :
+    constIn (cmp := cmp) i cmp' (a + b) =
+      constIn i cmp' a + constIn i cmp' b := by
+  sorry
+
+/-- Constant embedding preserves multiplication. -/
+theorem constIn_mul (i : Fin (n + 1)) (a b : MvPoly n R cmp') :
+    constIn (cmp := cmp) i cmp' (a * b) =
+      constIn i cmp' a * constIn i cmp' b := by
+  sorry
+
+/-- Constant embedding is injective. -/
+theorem constIn_injective (i : Fin (n + 1)) :
+    Function.Injective (constIn (R := R) (cmp := cmp) i cmp') := by
+  intro a b h
+  have hview := congrArg (toUnivariate i cmp') h
+  rw [toUnivariate_constIn, toUnivariate_constIn] at hview
+  have hcoeff := congrArg (fun p : DensePoly (MvPoly n R cmp') => p.coeff 0) hview
+  simpa using hcoeff
+
+/-- The degree in the selected variable, with `none` distinguishing zero from
+a constant polynomial. -/
+def degreeIn? (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (p : MvPoly (n + 1) R cmp) : Option Nat :=
+  (toUnivariate i cmp' p).degree?
+
+/-- Coefficient slice at a named degree in the selected variable. -/
+def coeffIn (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (k : Nat) (p : MvPoly (n + 1) R cmp) : MvPoly n R cmp' :=
+  (toUnivariate i cmp' p).coeff k
+
+end Hex.MvPoly

--- a/HexMvHensel.lean
+++ b/HexMvHensel.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+
+public import HexMvHensel.Shift
+public import HexMvHensel.Modulus
+public import HexMvHensel.Uni
+public import HexMvHensel.Diophantine
+public import HexMvHensel.Seed
+public import HexMvHensel.Cert
+public import HexMvHensel.Lift
+public import HexMvHensel.Complete
+public import HexMvHensel.KernelTests
+public import HexMvHensel.UniTests
+public import HexMvHensel.DiophantineTests
+public import HexMvHensel.SeedTests
+public import HexMvHensel.CertTests
+public import HexMvHensel.LiftTests
+public import HexMvHensel.CompleteTests
+
+public section
+
+/-!
+Multivariate Hensel lifting infrastructure.
+
+The current module exposes the complete checked multivariate Hensel lift:
+coordinates and modulus arithmetic, univariate and multivariate correction
+solvers, seeding and validation, stagewise lifting, reconstruction, and the
+independent certificate checker, and conditional completeness and uniqueness
+contracts with an executable shifted-factor coefficient bound.
+-/

--- a/HexMvHensel/Cert.lean
+++ b/HexMvHensel/Cert.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Seed
+
+@[expose] public section
+
+/-!
+Executable validation and the small, modulus-independent lift certificate.
+The checker deliberately does not call `valid`: the prime power is search
+state, not part of what a successful decomposition means.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+open Hex.MvPoly
+
+/-- The lifted factor tuple is the complete certificate payload. -/
+structure Cert (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    [IsMonomialOrder cmp] where
+  factors : List (MvPoly (n + 1) Int cmp)
+  deriving BEq, DecidableEq
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-! # Ordered validation helpers -/
+
+def imagesPositive : List ZPoly → Bool
+  | [] => true
+  | F :: Fs =>
+      (match F.degree? with
+       | some degree => 0 < degree
+       | none => false) && imagesPositive Fs
+
+def firstLeadingImage? (point : Fin n → Int) :
+    Nat → List ZPoly → List (MvPoly n Int cmp') → Option Nat
+  | _, [], [] => none
+  | j, F :: Fs, L :: Ls =>
+      if MvPoly.eval point L != F.leadingCoeff then some j
+      else firstLeadingImage? point (j + 1) Fs Ls
+  | j, _, _ => some j
+
+def firstPrimeDivisor? (p : Nat) : Nat → List ZPoly → Option Nat
+  | _, [] => none
+  | j, F :: Fs =>
+      if F.leadingCoeff % (p : Int) = 0 then some j
+      else firstPrimeDivisor? p (j + 1) Fs
+
+def firstWitnessDegree? : Nat → List ZPoly → List ZPoly → Option Nat
+  | _, [], [] => none
+  | j, F :: Fs, sigma :: sigmas =>
+      let bad : Bool := match sigma.degree?, F.degree? with
+        | some ds, some dF => decide (dF ≤ ds)
+        | _, _ => false
+      if bad then some j else firstWitnessDegree? (j + 1) Fs sigmas
+  | j, _, _ => some j
+
+/-- The first failed V1--V6 condition, in the diagnostic order fixed by the
+SPEC. -/
+def failure? (inp : Input n cmp cmp') : Option Failure :=
+  let i := inp.setup.main
+  let point := inp.setup.point
+  let image := imageAt i cmp' point inp.target
+  let mainDegree := MvPoly.degreeOf i inp.target
+  if inp.images.length != inp.leading.length ||
+      inp.images.length != inp.witness.length || inp.images.isEmpty ||
+      inp.setup.exponent = 0 || mainDegree = 0 ||
+      !imagesPositive inp.images then
+    some .arity
+  else if image.degree?.getD 0 != mainDegree then
+    some .degreeDrop
+  else if uniProduct inp.images != image then
+    some .imageProduct
+  else if mvProduct inp.leading != lcIn i cmp' inp.target then
+    some .leadingProduct
+  else match firstLeadingImage? point 0 inp.images inp.leading with
+    | some j => some (.leadingImage j)
+    | none =>
+        match firstPrimeDivisor? inp.setup.prime.m 0 inp.images with
+        | some j => some (.primeDividesLc j)
+        | none =>
+            if !coeffsDivisible inp.setup.modulus
+                (zSub (uniCombination inp.witness
+                  (complements inp.images)) 1) then
+              some .notCoprime
+            else match firstWitnessDegree? 0 inp.images inp.witness with
+              | some j => some (.witnessDegree j)
+              | none => none
+
+/-- Boolean form of the V1--V6 input contract. -/
+def valid (inp : Input n cmp cmp') : Bool :=
+  (failure? inp).isNone
+
+/-! # Certificate checker -/
+
+/-- What a checked certificate witnesses. -/
+def IsLiftOf (inp : Input n cmp cmp')
+    (fs : List (MvPoly (n + 1) Int cmp)) : Prop :=
+  fs.length = inp.images.length ∧
+  mvProduct fs = inp.target ∧
+  (∀ j, j < inp.images.length →
+    imageAt inp.setup.main cmp' inp.setup.point (fs.getD j 0) =
+      inp.images.getD j 0) ∧
+  (∀ j, j < inp.images.length →
+    lcIn inp.setup.main cmp' (fs.getD j 0) = inp.leading.getD j 0)
+
+/-- Replay the exact product, image, and leading-coefficient conditions. -/
+def check (inp : Input n cmp cmp') (cert : Cert n cmp) : Bool :=
+  cert.factors.length == inp.images.length &&
+    mvProduct cert.factors == inp.target &&
+    (List.range inp.images.length).all (fun j =>
+      imageAt inp.setup.main cmp' inp.setup.point
+          (cert.factors.getD j 0) == inp.images.getD j 0) &&
+    (List.range inp.images.length).all (fun j =>
+      lcIn inp.setup.main cmp' (cert.factors.getD j 0) ==
+        inp.leading.getD j 0)
+
+/-- The executable checker implies the semantic certificate predicate. -/
+theorem check_sound {inp : Input n cmp cmp'} {cert : Cert n cmp}
+    (h : check inp cert = true) : IsLiftOf inp cert.factors := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/CertTests.lean
+++ b/HexMvHensel/CertTests.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Lift
+public meta import HexMvHensel.Lift
+public meta import HexMvHensel.Shift
+public meta import HexMvPoly.Mono
+public meta import HexMvPoly.Basic
+public meta import HexMvPoly.Operations
+public meta import HexMvPoly.Query
+public meta import HexMvPoly.Recursive
+public meta import HexMvPoly.Ring
+public meta import HexBasic.ExtTreeMap
+
+section
+
+namespace Hex.MvHensel.CertTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+def prime5 : ZMod64.Prime where
+  m := 5
+  bounds := { pPos := by omega, pLtR := by decide }
+  prime := Hex.Nat.isPrimeTrial_isPrime (by decide)
+
+def point0 : Fin 0 → Int := fun j => nomatch j
+
+abbrev P0 := MvPoly 1 Int Mono.lex
+abbrev L0 := MvPoly 0 Int Mono.lex
+
+def x0 : P0 := X 0
+def ux : ZPoly := DensePoly.ofCoeffs #[0, 1]
+def uxPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
+def twoX : ZPoly := DensePoly.ofCoeffs #[0, 2]
+
+def setup0 : Setup 0 :=
+  { main := 0, point := point0, prime := prime5, exponent := 1 }
+
+def good : Input 0 Mono.lex Mono.lex :=
+  { setup := setup0
+    target := x0
+    images := [ux]
+    leading := [(1 : L0)]
+    witness := [1] }
+
+#guard valid good
+
+def arityInput : Input 0 Mono.lex Mono.lex :=
+  { good with leading := [] }
+
+#guard failure? arityInput == some .arity
+
+def imageProductInput : Input 0 Mono.lex Mono.lex :=
+  { good with images := [uxPlusOne] }
+
+#guard failure? imageProductInput == some .imageProduct
+
+def leadingProductInput : Input 0 Mono.lex Mono.lex :=
+  { good with leading := [(2 : L0)] }
+
+#guard failure? leadingProductInput == some .leadingProduct
+
+def leadingImageInput : Input 0 Mono.lex Mono.lex :=
+  { setup := setup0
+    target := (2 : P0) * x0 ^ 2
+    images := [twoX, ux]
+    leading := [(1 : L0), (2 : L0)]
+    witness := [0, 0] }
+
+#guard failure? leadingImageInput == some (.leadingImage 0)
+
+def primeDividesInput : Input 0 Mono.lex Mono.lex :=
+  { setup := setup0
+    target := (5 : P0) * x0
+    images := [DensePoly.ofCoeffs #[0, 5]]
+    leading := [(5 : L0)]
+    witness := [1] }
+
+#guard failure? primeDividesInput == some (.primeDividesLc 0)
+
+def notCoprimeInput : Input 0 Mono.lex Mono.lex :=
+  { setup := setup0
+    target := x0 ^ 2
+    images := [ux, ux]
+    leading := [(1 : L0), (1 : L0)]
+    witness := [0, 0] }
+
+#guard failure? notCoprimeInput == some .notCoprime
+
+def unreducedWitness : ZPoly :=
+  DensePoly.ofCoeffs #[1, 5]
+
+def witnessDegreeInput : Input 0 Mono.lex Mono.lex :=
+  { setup := setup0
+    target := x0 * (x0 + 1)
+    images := [ux, uxPlusOne]
+    leading := [(1 : L0), (1 : L0)]
+    witness := [unreducedWitness, -1] }
+
+#guard failure? witnessDegreeInput == some (.witnessDegree 0)
+
+/- Degree drop needs a genuine second variable: `y*x + 1` becomes the
+constant `1` at `y = 0`. -/
+abbrev P1 := MvPoly 2 Int Mono.lex
+abbrev L1 := MvPoly 1 Int Mono.lex
+
+def x1 : P1 := X 0
+def y1 : P1 := X 1
+def ly : L1 := X 0
+def pointZero : Fin 1 → Int := fun _ => 0
+
+def degreeDropInput : Input 1 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointZero, prime := prime5, exponent := 1 }
+    target := y1 * x1 + 1
+    images := [ux]
+    leading := [ly]
+    witness := [1] }
+
+#guard failure? degreeDropInput == some .degreeDrop
+
+/- The public route preserves every validation diagnostic rather than
+collapsing malformed inputs to one generic failure. -/
+def reported0 (inp : Input 0 Mono.lex Mono.lex) : Option Failure :=
+  match lift inp with
+  | .error failure => some failure
+  | .ok _ => none
+
+def reported1 (inp : Input 1 Mono.lex Mono.lex) : Option Failure :=
+  match lift inp with
+  | .error failure => some failure
+  | .ok _ => none
+
+#guard reported0 arityInput == some .arity
+#guard reported0 imageProductInput == some .imageProduct
+#guard reported0 leadingProductInput == some .leadingProduct
+#guard reported0 leadingImageInput == some (.leadingImage 0)
+#guard reported0 primeDividesInput == some (.primeDividesLc 0)
+#guard reported0 notCoprimeInput == some .notCoprime
+#guard reported0 witnessDegreeInput == some (.witnessDegree 0)
+#guard reported1 degreeDropInput == some .degreeDrop
+
+def goodCert : Cert 0 Mono.lex := { factors := [x0] }
+
+#guard check good goodCert
+
+example : check good { factors := [] } = false := by
+  decide +kernel
+
+end Hex.MvHensel.CertTests

--- a/HexMvHensel/Complete.lean
+++ b/HexMvHensel/Complete.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Lift
+public import HexMvGcd.Gcd
+public import HexPolyZ.Mignotte
+
+@[expose] public section
+
+/-!
+Uniqueness and conditional completeness for multivariate Hensel lifting.
+
+The executable coefficient bound uses the mixed-radix Kronecker substitution
+from the SPEC, applied after translating the evaluation point to the origin.
+It computes the univariate image degree and coefficient norm directly from the
+sparse term list, without allocating a dense polynomial with potentially
+astronomical gaps.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+open Hex.MvPoly
+
+universe u
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-! # Rational coprimality and uniqueness -/
+
+/-- The checked modular partial-fraction witness implies pairwise
+coprimality of the integer images after extension to `Rat`.
+
+The bounds on `j` and `k` are essential because `Input.images` is a list and
+the total `getD` operation returns zero outside its range. -/
+theorem coprimeRat_of_witness {inp : Input n cmp cmp'}
+    (h : valid inp = true) (j k : Nat)
+    (hj : j < inp.images.length) (hk : k < inp.images.length)
+    (hjk : j ≠ k) :
+    ∃ u v : DensePoly Rat,
+      u * ZPoly.toRatPoly (inp.images.getD j 0) +
+        v * ZPoly.toRatPoly (inp.images.getD k 0) = 1 := by
+  sorry
+
+/-- At most one exact factor tuple is compatible with a valid lift input. -/
+theorem lift_unique {inp : Input n cmp cmp'}
+    {fs gs : List (MvPoly (n + 1) Int cmp)}
+    (h : valid inp = true) (h1 : IsLiftOf inp fs)
+    (h2 : IsLiftOf inp gs) : fs = gs := by
+  sorry
+
+/-! # Executable shifted coefficient bound -/
+
+/-- Every compatible factor tuple has coefficients of its shifted factors
+bounded in absolute value by `bound`. -/
+def BoundsFactors (inp : Input n cmp cmp') (bound : Nat) : Prop :=
+  ∀ fs, IsLiftOf inp fs → ∀ g, g ∈ fs → ∀ monomial,
+    (MvPoly.coeff monomial
+      (shift inp.setup.main inp.setup.point g)).natAbs ≤ bound
+
+/-- Product of the earlier side-variable radices. -/
+def kroneckerPrefix (sideDegrees : Fin n → Nat) (j : Fin n) : Nat :=
+  (List.finRange n).foldl
+    (fun radix k =>
+      if k.val < j.val then radix * (sideDegrees k + 1) else radix) 1
+
+/-- Mixed-radix weight of side variable `j`.  The factor `mainDegree + 1`
+is deliberately present: without it the main variable and the first side
+variable would both map to the same univariate monomial. -/
+def kroneckerWeight (mainDegree : Nat) (sideDegrees : Fin n → Nat)
+    (j : Fin n) : Nat :=
+  (mainDegree + 1) * kroneckerPrefix sideDegrees j
+
+/-- Exponent of a monomial under the mixed-radix Kronecker substitution. -/
+def kroneckerExponent (i : Fin (n + 1)) (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) (monomial : Mono (n + 1)) : Nat :=
+  (List.finRange n).foldl
+    (fun exponent j => exponent +
+      Mono.degreeOf (remainingVar i j) monomial *
+        kroneckerWeight mainDegree sideDegrees j)
+    (Mono.degreeOf i monomial)
+
+/-- Degree of the sparse Kronecker image, computed without materialising its
+dense zero gaps. -/
+def kroneckerDegree (i : Fin (n + 1)) (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) (p : MvPoly (n + 1) Int cmp) : Nat :=
+  p.foldTerms
+    (fun degree monomial _ =>
+      max degree (kroneckerExponent i mainDegree sideDegrees monomial)) 0
+
+/-- Squared Euclidean coefficient norm.  Mixed-radix injectivity means this is
+also the coefficient norm of the Kronecker image. -/
+def mvCoeffNormSq (p : MvPoly (n + 1) Int cmp) : Nat :=
+  p.foldTerms (fun norm _ coefficient => norm + coefficient.natAbs ^ 2) 0
+
+/-- A uniform factor-coefficient bound obtained by translating the target,
+using the corrected mixed-radix Kronecker substitution, and applying the
+closed-form univariate Mignotte bound. -/
+def coeffBound (inp : Input n cmp cmp') : Nat :=
+  let shifted := shift inp.setup.main inp.setup.point inp.target
+  let mainDegree := MvPoly.degreeOf inp.setup.main shifted
+  let sideDegrees : Fin n → Nat := fun j =>
+    MvPoly.degreeOf (remainingVar inp.setup.main j) shifted
+  let degree := kroneckerDegree inp.setup.main mainDegree sideDegrees shifted
+  Nat.binom degree (degree / 2) * ZPoly.ceilSqrt (mvCoeffNormSq shifted)
+
+/-! # Conditional completeness -/
+
+/-- Above twice a valid coefficient bound, every compatible factorization is
+found by the concrete lift. -/
+theorem lift_complete {inp : Input n cmp cmp'} {bound : Nat}
+    (h : valid inp = true) (hB : BoundsFactors inp bound)
+    (hq : 2 * bound < inp.setup.modulus)
+    (hex : ∃ fs, IsLiftOf inp fs) :
+    ∃ cert, lift inp = .ok cert := by
+  sorry
+
+/-- If no compatible factorization exists, progress forces the lift to end in
+a reconstruction failure. -/
+theorem lift_none {inp : Input n cmp cmp'}
+    (h : valid inp = true) (hno : ¬ ∃ fs, IsLiftOf inp fs) :
+    ∃ modulus, lift inp = .error (.reconstruct modulus) := by
+  rcases lift_progress h with hsuccess | hfailure
+  · rcases hsuccess with ⟨cert, hcert⟩
+    exact False.elim (hno ⟨cert.factors,
+      check_sound (lift_checks hcert)⟩)
+  · exact hfailure
+
+/-- Past the coefficient bound, reconstruction failure proves that the point
+admits no compatible factorization. -/
+theorem no_lift_of_reconstruct {inp : Input n cmp cmp'} {bound modulus : Nat}
+    (h : valid inp = true) (hB : BoundsFactors inp bound)
+    (hq : 2 * bound < inp.setup.modulus)
+    (hfail : lift inp = .error (.reconstruct modulus)) :
+    ¬ ∃ fs, IsLiftOf inp fs := by
+  intro hex
+  rcases lift_complete h hB hq hex with ⟨cert, hcert⟩
+  rw [hcert] at hfail
+  cases hfail
+
+/-! # Mathlib-free irreducibility predicate -/
+
+/-- No decomposition into two nonunits, stated without Mathlib so it applies
+uniformly to dense and multivariate polynomials. -/
+def Irred {α : Type u} [One α] [Mul α] (p : α) : Prop :=
+  (¬ ∃ u, p * u = 1) ∧
+    ∀ g h, p = g * h →
+      (∃ u, g * u = 1) ∨ (∃ u, h * u = 1)
+
+/-- With a valid primitive input and irreducible integer images, every factor
+in a checked lift is irreducible.  Primitivity is measured by the actual
+named-variable content operation supplied by `HexMvGcd`. -/
+theorem irreducible_of_image_irreducible
+    {inp : Input n cmp cmp'} {cert : Cert n cmp}
+    (hv : valid inp = true) (h : check inp cert = true)
+    (hprim : MvPoly.contentIn inp.setup.main cmp' inp.target = 1)
+    (hirr : ∀ j, j < inp.images.length →
+      Irred (inp.images.getD j 0)) :
+    ∀ j, j < cert.factors.length →
+      Irred (cert.factors.getD j 0) := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/CompleteTests.lean
+++ b/HexMvHensel/CompleteTests.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Complete
+public meta import HexMvHensel.Complete
+public meta import HexBasic.ExtTreeMap
+import all HexMvPoly.Mono
+import all HexMvPoly.Basic
+import all HexMvPoly.Operations
+import all HexMvPoly.Query
+import all HexMvPoly.Structural
+import all HexMvPoly.Ring
+import all HexPoly.Dense
+import all HexModArith.Prime
+
+section
+
+namespace Hex.MvHensel.CompleteTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+def prime5 : ZMod64.Prime where
+  m := 5
+  bounds := { pPos := by omega, pLtR := by decide }
+  prime := Hex.Nat.isPrimeTrial_isPrime (by decide)
+
+abbrev P := MvPoly 2 Int Mono.lex
+abbrev L := MvPoly 1 Int Mono.lex
+
+def x : P := X 0
+def y : P := X 1
+def pointZero : Fin 1 → Int := fun _ => 0
+def pointTen : Fin 1 → Int := fun _ => 10
+
+def dummyInput (point : Fin 1 → Int) (target : P) :
+    Input 1 Mono.lex Mono.lex :=
+  { setup := { main := 0, point := point, prime := prime5, exponent := 1 }
+    target := target
+    images := []
+    leading := []
+    witness := [] }
+
+/- The first side-variable weight contains the main-variable radix. -/
+#guard kroneckerWeight 1 (fun _ : Fin 1 => 2) 0 == 2
+#guard kroneckerWeight 1 (fun j : Fin 2 => if j.val = 0 then 2 else 3) 1 == 6
+
+/- Hence `x` and the first side variable receive distinct exponents. -/
+#guard kroneckerExponent 0 1 (fun _ : Fin 1 => 1) #v[1, 0] == 1
+#guard kroneckerExponent 0 1 (fun _ : Fin 1 => 1) #v[0, 1] == 2
+
+/- For `x + y`, the Kronecker image is `z + z^2`, its norm bound is two,
+and the central binomial factor is two. -/
+def linearInput : Input 1 Mono.lex Mono.lex :=
+  dummyInput pointZero (x + y)
+
+#guard coeffBound linearInput == 4
+
+/- Bounds are computed after shifting.  At `y = 10`, the target below has
+the amplified coefficients `20` and `100`; the executable bound must see
+them, rather than reuse the much smaller origin bound. -/
+def amplifiedTarget : P := (x + y ^ 2) * (x + 1)
+def originInput : Input 1 Mono.lex Mono.lex :=
+  dummyInput pointZero amplifiedTarget
+def shiftedInput : Input 1 Mono.lex Mono.lex :=
+  dummyInput pointTen amplifiedTarget
+
+#guard coeffBound originInput == 70
+#guard coeffBound shiftedInput == 5075
+#guard coeffBound originInput < coeffBound shiftedInput
+
+/- The exact norm computation remains sparse and includes every stored
+coefficient once. -/
+#guard mvCoeffNormSq (x + 3 * y + 4) == 26
+
+end Hex.MvHensel.CompleteTests

--- a/HexMvHensel/Diophantine.lean
+++ b/HexMvHensel/Diophantine.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Uni
+
+@[expose] public section
+
+/-!
+The recursive multivariate diophantine solver used by the Hensel stage loop.
+
+At one recursion level, `sliceVar y 0` sets the selected non-main variable to
+zero.  After solving that smaller problem, the solver corrects one power of
+`y` at a time.  The coefficient at each power is again a problem in one fewer
+active variable, and the recursion bottoms out in `solveUni`.
+
+Every partial operation is represented by `Option`: unequal tuples are never
+zipped or truncated, and a univariate right-hand side outside the degree range
+of the partial-fraction map stops the computation.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+open Hex.MvPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-! # Slicing and embedding -/
+
+/-- The coefficient of `x_j ^ e`, kept in the original arity with `x_j`
+removed from every retained monomial. -/
+def sliceVar (j : Fin (n + 1)) (e : Nat)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  p.foldTerms
+    (fun acc m c =>
+      if Mono.degreeOf j m = e then
+        acc.addMonomial (MvPoly.insertVar j 0 (MvPoly.removeVar j m)) c
+      else acc)
+    0
+
+/-- Multiply a coefficient slice by the power which places it back at its
+original coordinate. -/
+def embedPower (j : Fin (n + 1)) (e : Nat)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  p * X j ^ e
+
+/-- Embed an integer univariate polynomial in the selected main variable. -/
+def embedUni (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (f : ZPoly) : MvPoly (n + 1) Int cmp :=
+  MvPoly.ofUnivariate (cmp := cmp) i cmp'
+    (DensePoly.ofCoeffs (f.toArray.map fun c => MvPoly.C c))
+
+/-! # Checked tuple arithmetic -/
+
+/-- Add two polynomial tuples, rejecting unequal lengths. -/
+def tupleAdd? :
+    List (MvPoly (n + 1) Int cmp) →
+      List (MvPoly (n + 1) Int cmp) →
+        Option (List (MvPoly (n + 1) Int cmp))
+  | [], [] => some []
+  | a :: as, b :: bs => do
+      let tail ← tupleAdd? as bs
+      some ((a + b) :: tail)
+  | _, _ => none
+
+/-- Form `Σ_j coefficients[j] * bases[j]`, rejecting unequal lengths. -/
+def mvCombination? :
+    List (MvPoly (n + 1) Int cmp) →
+      List (MvPoly (n + 1) Int cmp) →
+        Option (MvPoly (n + 1) Int cmp)
+  | [], [] => some 0
+  | a :: as, b :: bs => do
+      let tail ← mvCombination? as bs
+      some (a * b + tail)
+  | _, _ => none
+
+/-- Whether a reduced univariate right-hand side lies in the image of the
+degree-bounded partial-fraction map.  The zero polynomial is below every
+degree; a zero product has no usable degree bound. -/
+def uniRange (q : Nat) (images : List ZPoly) (c : ZPoly) : Bool :=
+  match (uniProduct images).degree? with
+  | none => false
+  | some bound =>
+      match (reduceUni q c).degree? with
+      | none => true
+      | some degree => degree < bound
+
+/-- The base solve, including the degree-range and tuple-length checks which
+turn the total `solveUni` primitive into the partial public operation needed
+by the multivariate recursion. -/
+def solveUniChecked? (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (count : Nat) (images witness : List ZPoly) (c : ZPoly) :
+    Option (List (MvPoly (n + 1) Int cmp)) :=
+  if images.length != count || witness.length != count then none
+  else if !uniRange q images c then none
+  else
+    let answer := solveUni q images witness c
+    if answer.length != count then none
+    else some (answer.map (embedUni (cmp := cmp) i cmp'))
+
+/-! # Variable recursion -/
+
+/-- Recursive worker.  `active` lists the non-main variables still present.
+The public entry point supplies every remaining variable exactly once. -/
+def diophantineAux (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (d : Fin n → Nat) (images witness : List ZPoly) :
+    List (Fin n) → List (MvPoly (n + 1) Int cmp) →
+      MvPoly (n + 1) Int cmp →
+        Option (List (MvPoly (n + 1) Int cmp))
+  | [], bs, c =>
+      solveUniChecked? q i cmp' bs.length images witness
+        (imageAt i cmp' (fun _ => 0) c)
+  | y :: ys, bs, c => do
+      let selected := remainingVar i y
+      let lowerBs := bs.map (sliceVar selected 0)
+      let initial ← diophantineAux q i cmp' d images witness ys lowerBs
+        (sliceVar selected 0 c)
+      (List.range (d y)).foldlM
+        (fun current k => do
+          let sum ← mvCombination? current bs
+          let rhs := sliceVar selected (k + 1) (c - sum)
+          let correction ←
+            diophantineAux q i cmp' d images witness ys lowerBs rhs
+          let raised := correction.map (embedPower selected (k + 1))
+          tupleAdd? current raised)
+        initial
+termination_by active => active.length
+
+/-- Check the main-variable degree bounds of a candidate tuple. -/
+def mvDegreeBounded (i : Fin (n + 1)) (images : List ZPoly)
+    (answer : List (MvPoly (n + 1) Int cmp)) : Bool :=
+  images.length == answer.length &&
+    (List.range images.length).all fun j =>
+      MvPoly.degreeOf i (answer.getD j 0) <
+        (images.getD j 0).degree?.getD 0
+
+/-- Check the computed equation throughout the requested truncation box. -/
+def checkDiophantine (q : Nat) (i : Fin (n + 1)) (d : Fin n → Nat)
+    (bs answer : List (MvPoly (n + 1) Int cmp))
+    (c : MvPoly (n + 1) Int cmp) : Bool :=
+  match mvCombination? answer bs with
+  | none => false
+  | some sum => reduceMod q (truncate i d (sum - c)) == 0
+
+/-- Solve `Σ_j Δ_j b_j ≡ c (mod q)` inside the non-main degree box `d`,
+with `deg_i Δ_j < deg images[j]`.  A malformed tuple, an out-of-range
+recursive right-hand side, or a failed final equation returns `none`. -/
+def diophantine (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (d : Fin n → Nat) (bs : List (MvPoly (n + 1) Int cmp))
+    (images witness : List ZPoly) (c : MvPoly (n + 1) Int cmp) :
+    Option (List (MvPoly (n + 1) Int cmp)) := do
+  if q ≤ 1 || images.isEmpty || images.length != witness.length ||
+      images.length != bs.length then none else pure ()
+  let answer ← diophantineAux q i cmp' d images witness
+    (List.finRange n) bs c
+  if !mvDegreeBounded i images answer then none
+  else if !checkDiophantine q i d bs answer c then none
+  else some answer
+
+/-! # Mathematical contract -/
+
+/-- Under the partial-fraction hypotheses and the load-bearing degree bound
+on the multivariate bases, the recursive solve succeeds, satisfies the box
+equation, and preserves each factor's main-variable degree bound. -/
+theorem diophantine_spec {q : Nat} {i : Fin (n + 1)}
+    {d : Fin n → Nat} {bs : List (MvPoly (n + 1) Int cmp)}
+    {images witness : List ZPoly} {c : MvPoly (n + 1) Int cmp}
+    (huni : UniValid q images witness)
+    (hbs : bs.length = images.length)
+    (hc : MvPoly.degreeOf i c < (uniProduct images).degree?.getD 0)
+    (hb : ∀ j, j < bs.length →
+      imageAt i cmp' (fun _ => 0) (bs.getD j 0) =
+        (complements images).getD j 0)
+    (hbdeg : ∀ j, j < bs.length →
+      MvPoly.degreeOf i (bs.getD j 0) +
+          (images.getD j 0).degree?.getD 0 ≤
+        (uniProduct images).degree?.getD 0) :
+    ∃ answer sum,
+      diophantine q i cmp' d bs images witness c = some answer ∧
+      mvCombination? answer bs = some sum ∧
+      BoxCongr i d q sum c ∧
+      ∀ j, j < images.length →
+        MvPoly.degreeOf i (answer.getD j 0) <
+          (images.getD j 0).degree?.getD 0 := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/DiophantineTests.lean
+++ b/HexMvHensel/DiophantineTests.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Diophantine
+public meta import HexMvHensel.Diophantine
+public meta import HexMvHensel.Shift
+public meta import HexBasic.ExtTreeMap
+import all HexMvPoly.Mono
+import all HexMvPoly.Basic
+import all HexMvPoly.Operations
+import all HexMvPoly.Query
+import all HexMvPoly.Recursive
+import all HexMvPoly.Ring
+import all HexPoly.Dense
+import all HexPoly.Operations
+import all HexModular.SymMod
+
+section
+
+/-!
+Executable route checks for every depth of the multivariate recursion, plus
+small kernel checks for its exact slicing and length-failure primitives.
+-/
+
+namespace Hex.MvHensel.DiophantineTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+def ux : ZPoly := DensePoly.ofCoeffs #[0, 1]
+def uxPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
+def images : List ZPoly := [ux, uxPlusOne]
+def witness : List ZPoly := [1, -1]
+
+/-! # No non-main variables -/
+
+abbrev P0 := MvPoly 1 Int Mono.lex
+
+def x0 : P0 := X 0
+def d0 : Fin 0 → Nat := fun j => nomatch j
+
+#guard diophantine 5 (0 : Fin 1) Mono.lex d0
+    [x0 + 1, x0] images witness (1 : P0) ==
+  some ([1, -1] : List P0)
+
+/-! # One non-main variable -/
+
+abbrev P1 := MvPoly 2 Int Mono.lex
+
+def x1 : P1 := X 0
+def y1 : P1 := X 1
+def d1 : Fin 1 → Nat := fun _ => 1
+
+/- `1*(x+1) + (-1+y)*x = 1 + y*x`. -/
+#guard diophantine 5 (0 : Fin 2) Mono.lex d1
+    [x1 + 1, x1] images witness (1 + y1 * x1) ==
+  some ([1, -1 + y1] : List P1)
+
+/-! # Multiple non-main variables -/
+
+abbrev P2 := MvPoly 3 Int Mono.lex
+
+def x2 : P2 := X 0
+def y2 : P2 := X 1
+def z2 : P2 := X 2
+def d2 : Fin 2 → Nat := fun _ => 1
+
+/- This exercises two nested correction loops, including the mixed `y*z`
+coefficient. -/
+#guard diophantine 5 (0 : Fin 3) Mono.lex d2
+    [x2 + 1, x2] images witness
+      (1 + y2 * x2 + z2 * (x2 + 1) + y2 * z2) ==
+  some ([1 + z2 + y2 * z2, -1 + y2 - y2 * z2] : List P2)
+
+/-! # Required failures -/
+
+/- The image product has main degree two, so a nonzero `x^2` right-hand side
+is outside the degree-bounded partial-fraction map. -/
+#guard (diophantine 5 (0 : Fin 1) Mono.lex d0
+    [x0 + 1, x0] images witness (x0 * x0)).isNone
+
+/- A missing base is rejected rather than silently pairing only the common
+tuple prefix. -/
+#guard (diophantine 5 (0 : Fin 1) Mono.lex d0
+    [x0 + 1] images witness (1 : P0)).isNone
+
+/- The zero slice is valid, but the `y*x^3` term in the first base creates
+the SPEC's load-bearing `hbdeg` trap at the next coefficient. -/
+#guard (diophantine 5 (0 : Fin 2) Mono.lex d1
+    [x1 + 1 + y1 * (x1 ^ 3), x1] images witness (1 : P1)).isNone
+
+/-! # Kernel checks -/
+
+example : tupleAdd? ([] : List P0) [0] = none := by
+  rfl
+
+example : sliceVar (1 : Fin 2) 1 (1 + y1 * x1) = x1 := by
+  decide +kernel
+
+example : embedPower (1 : Fin 2) 2 x1 = x1 * y1 ^ 2 := by
+  decide +kernel
+
+end Hex.MvHensel.DiophantineTests

--- a/HexMvHensel/KernelTests.lean
+++ b/HexMvHensel/KernelTests.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Shift
+public import HexMvHensel.Modulus
+
+public section
+
+/-!
+Small kernel-reduction checks for the coordinate and modulus layer.
+-/
+
+namespace Hex.MvHensel.KernelTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+abbrev P2 := MvPoly 2 Int Mono.lex
+
+@[expose] def x : P2 := X 0
+@[expose] def y : P2 := X 1
+
+@[expose] def target : P2 := x * x + y * x + C 2 * y + C 1
+
+@[expose] def point3 : Fin 1 → Int := fun _ => 3
+
+example : shift 0 point3 target =
+    ofTerms
+      [(#v[2, 0], 1), (#v[1, 1], 1), (#v[1, 0], 3),
+       (#v[0, 1], 2), (Mono.zero, 7)] := by
+  decide +kernel
+
+example : unshift 0 point3 (shift 0 point3 target) = target := by
+  decide +kernel
+
+example : lcIn 0 Mono.lex target = (1 : MvPoly 1 Int Mono.lex) := by
+  decide +kernel
+
+@[expose] def outsideBox : P2 :=
+  ofTerms [(#v[2, 0], 1), (#v[1, 1], 2), (#v[0, 2], 3), (Mono.zero, 4)]
+
+example : truncate 0 (fun _ => 1) outsideBox =
+    ofTerms [(#v[2, 0], 1), (#v[1, 1], 2), (Mono.zero, 4)] := by
+  decide +kernel
+
+example : reduceMod 5
+    (ofTerms [(#v[1, 0], 7), (#v[0, 1], 3), (Mono.zero, -4)] : P2) =
+    ofTerms [(#v[1, 0], 2), (#v[0, 1], -2), (Mono.zero, 1)] := by
+  decide +kernel
+
+abbrev P1 := MvPoly 1 Int Mono.lex
+
+@[expose] def noPoint : Fin 0 → Int := fun j => nomatch j
+
+example : shift 0 noPoint ((X 0 : P1) * X 0 + C 2) =
+    (X 0 : P1) * X 0 + C 2 := by
+  decide +kernel
+
+end Hex.MvHensel.KernelTests

--- a/HexMvHensel/Lift.lean
+++ b/HexMvHensel/Lift.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Cert
+
+@[expose] public section
+
+/-!
+The stagewise EEZ lift.  Computation takes place after shifting the evaluation
+point to zero.  Every stage first installs the prescribed leading coefficient
+through the new variable, then corrects each power of that variable using the
+multivariate diophantine solver at the fixed coefficient modulus.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+open Hex.MvPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-! # Stage helpers -/
+
+/-- Multivariate complementary products, in tuple order. -/
+def mvComplements {k : Nat} {order : Mono k → Mono k → Ordering}
+    [IsMonomialOrder order] :
+    List (MvPoly k Int order) → List (MvPoly k Int order)
+  | [] => []
+  | f :: fs => mvProduct fs :: (mvComplements fs).map (fun b => f * b)
+
+/-- Install one prefix of the prescribed shifted leading coefficients. -/
+def installLeading? (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (count : Nat) :
+    List (MvPoly (n + 1) Int cmp) → List (MvPoly n Int cmp') →
+      Option (List (MvPoly (n + 1) Int cmp))
+  | [], [] => some []
+  | f :: fs, L :: Ls => do
+      let tail ← installLeading? i cmp' count fs Ls
+      some (setLc i cmp' (prefixVars count L) f :: tail)
+  | _, _ => none
+
+/-- Add one reduced, box-truncated correction at a selected variable power. -/
+def applyCorrections? (q : Nat) (i : Fin (n + 1))
+    (d : Fin n → Nat) (selected : Fin (n + 1)) (power : Nat) :
+    List (MvPoly (n + 1) Int cmp) →
+      List (MvPoly (n + 1) Int cmp) →
+        Option (List (MvPoly (n + 1) Int cmp))
+  | [], [] => some []
+  | f :: fs, delta :: deltas => do
+      let tail ← applyCorrections? q i d selected power fs deltas
+      let correction := embedPower selected power
+        (reduceMod q (truncate i d delta))
+      some ((f + correction) :: tail)
+  | _, _ => none
+
+/-- Lift through every power of one non-main variable. -/
+def liftStage (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (d : Fin n → Nat) (images witness : List ZPoly)
+    (shiftedTarget : MvPoly (n + 1) Int cmp)
+    (shiftedLeading : List (MvPoly n Int cmp'))
+    (y : Fin n) (factors : List (MvPoly (n + 1) Int cmp)) :
+    Option (List (MvPoly (n + 1) Int cmp)) := do
+  let installed ← installLeading? i cmp' (y.val + 1) factors shiftedLeading
+  let selected := remainingVar i y
+  let bases := mvComplements (installed.map (sliceVar selected 0))
+  let stageTarget := prefixNonMain i (y.val + 1) shiftedTarget
+  (List.range (d y)).foldlM
+    (fun current k => do
+      let error := reduceMod q
+        (truncate i d (stageTarget - mvProduct current))
+      let rhs := sliceVar selected (k + 1) error
+      let deltas ← diophantine q i cmp' d bases images witness rhs
+      applyCorrections? q i d selected (k + 1) current deltas)
+    installed
+
+/-- Run all non-main-variable stages in coordinate order. -/
+def liftStages (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (d : Fin n → Nat) (images witness : List ZPoly)
+    (shiftedTarget : MvPoly (n + 1) Int cmp)
+    (shiftedLeading : List (MvPoly n Int cmp'))
+    (initial : List (MvPoly (n + 1) Int cmp)) :
+    Option (List (MvPoly (n + 1) Int cmp)) :=
+  (List.finRange n).foldlM
+    (fun factors y =>
+      liftStage q i cmp' d images witness shiftedTarget shiftedLeading y factors)
+    initial
+
+/-- Build the shifted factors through full box precision. -/
+def liftShifted? (inp : Input n cmp cmp') :
+    Option (List (MvPoly (n + 1) Int cmp)) := do
+  let i := inp.setup.main
+  let point := inp.setup.point
+  let shiftedTarget := shift i point inp.target
+  let shiftedLeading := inp.leading.map (shiftAll point)
+  let initial ← seedTuple? i cmp' inp.images shiftedLeading
+  let d : Fin n → Nat := fun j =>
+    MvPoly.degreeOf (remainingVar i j) shiftedTarget
+  liftStages inp.setup.modulus i cmp' d inp.images inp.witness
+    shiftedTarget shiftedLeading initial
+
+/-- Return from shifted coordinates to the caller's coordinates. -/
+def reconstruct (i : Fin (n + 1)) (point : Fin n → Int)
+    (fs : List (MvPoly (n + 1) Int cmp)) :
+    List (MvPoly (n + 1) Int cmp) :=
+  fs.map (unshift i point)
+
+/-! # Public lift and retries -/
+
+/-- Perform one checked lift at the exponent stored in `inp.setup`. -/
+def lift (inp : Input n cmp cmp') : Except Failure (Cert n cmp) :=
+  match failure? inp with
+  | some failure => .error failure
+  | none =>
+      match liftShifted? inp with
+      | none => .error (.reconstruct inp.setup.modulus)
+      | some shifted =>
+          let cert : Cert n cmp :=
+            { factors := reconstruct inp.setup.main inp.setup.point shifted }
+          if check inp cert then .ok cert
+          else .error (.reconstruct inp.setup.modulus)
+
+/-- Rebuild an input at a new exponent and derive the corresponding witness. -/
+def raiseExponent? (inp : Input n cmp cmp') : Option (Input n cmp cmp') := do
+  let setup : Setup n :=
+    { main := inp.setup.main
+      point := inp.setup.point
+      prime := inp.setup.prime
+      exponent := 2 * inp.setup.exponent }
+  let witness ← witnessOf? setup inp.images
+  some
+    { setup := setup
+      target := inp.target
+      images := inp.images
+      leading := inp.leading
+      witness := witness }
+
+/-- Retry reconstruction by repeatedly doubling the exponent. -/
+def liftWithAux : Nat → Input n cmp cmp' → Except Failure (Cert n cmp)
+  | 0, inp => lift inp
+  | fuel + 1, inp =>
+      match lift inp with
+      | .ok cert => .ok cert
+      | .error failure@(.reconstruct _) =>
+          match raiseExponent? inp with
+          | none => .error failure
+          | some next => liftWithAux fuel next
+      | .error failure => .error failure
+
+/-- Lift with the configured number of exponent doublings. -/
+def liftWith (cfg : Config) (inp : Input n cmp cmp') :
+    Except Failure (Cert n cmp) :=
+  liftWithAux cfg.doublings inp
+
+/-! # Phase-1 correctness API -/
+
+/-- Every certificate returned by `lift` passes the independent checker. -/
+theorem lift_checks {inp : Input n cmp cmp'} {cert : Cert n cmp}
+    (h : lift inp = .ok cert) : check inp cert = true := by
+  sorry
+
+/-- Once V1--V6 hold, reconstruction is the only possible failure. -/
+theorem lift_progress {inp : Input n cmp cmp'} (h : valid inp = true) :
+    (∃ cert, lift inp = .ok cert) ∨
+      (∃ modulus, lift inp = .error (.reconstruct modulus)) := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/LiftTests.lean
+++ b/HexMvHensel/LiftTests.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Lift
+public meta import HexMvHensel.Lift
+public meta import HexMvHensel.Shift
+public meta import HexBasic.ExtTreeMap
+import all HexMvPoly.Mono
+import all HexMvPoly.Basic
+import all HexMvPoly.Operations
+import all HexMvPoly.Query
+import all HexMvPoly.Recursive
+import all HexMvPoly.Ring
+import all HexPoly.Dense
+import all HexPoly.Operations
+import all HexPoly.Euclid.DivGcd
+import all HexPoly.Euclid.MulRing
+import all HexPolyFp.Field
+import all HexModArith.Residue
+import all HexModArith.Ring
+import all HexModArith.Prime
+import all HexArith.ExtGcd
+import all HexModular.SymMod
+
+section
+
+namespace Hex.MvHensel.LiftTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+def prime5 : ZMod64.Prime where
+  m := 5
+  bounds := { pPos := by omega, pLtR := by decide }
+  prime := Hex.Nat.isPrimeTrial_isPrime (by decide)
+
+abbrev P := MvPoly 2 Int Mono.lex
+abbrev L := MvPoly 1 Int Mono.lex
+
+def x : P := X 0
+def y : P := X 1
+def uxPlusTwo : ZPoly := DensePoly.ofCoeffs #[2, 1]
+def uxPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
+def ux : ZPoly := DensePoly.ofCoeffs #[0, 1]
+
+def pointTwo : Fin 1 → Int := fun _ => 2
+def pointZero : Fin 1 → Int := fun _ => 0
+
+/- A nonzero evaluation point exercises both coordinate transforms. -/
+def successInput : Input 1 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointTwo, prime := prime5, exponent := 1 }
+    target := (x + y) * (x + 1)
+    images := [uxPlusTwo, uxPlusOne]
+    leading := [(1 : L), (1 : L)]
+    witness := [-1, 1] }
+
+def successCert : Cert 1 Mono.lex :=
+  { factors := [x + y, x + 1] }
+
+#guard valid successInput
+def successWorks : Bool :=
+  match lift successInput with
+  | .ok cert => cert.factors == successCert.factors
+  | .error _ => false
+
+#guard successWorks
+#guard check successInput successCert
+
+/- The next route requires the stage to install a nonconstant prescribed
+leading coefficient before solving the lower-degree correction. -/
+def leadingInput : Input 1 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointZero, prime := prime5, exponent := 1 }
+    target := ((y + 1) * x + y) * (x + 1)
+    images := [ux, uxPlusOne]
+    leading := [(X 0 + 1 : L), (1 : L)]
+    witness := [1, -1] }
+
+def leadingWorks : Bool :=
+  match lift leadingInput with
+  | .ok cert => cert.factors == [((y + 1) * x + y), x + 1]
+  | .error _ => false
+
+#guard leadingWorks
+
+/- Two non-main variables exercise the outer stage fold as well as the
+recursive diophantine solver used inside each stage. -/
+abbrev P2 := MvPoly 3 Int Mono.lex
+abbrev L2 := MvPoly 2 Int Mono.lex
+
+def x2 : P2 := X 0
+def y2 : P2 := X 1
+def z2 : P2 := X 2
+def pointZero2 : Fin 2 → Int := fun _ => 0
+
+def twoStageInput : Input 2 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointZero2, prime := prime5, exponent := 1 }
+    target := (x2 + y2 + z2) * (x2 + 1)
+    images := [ux, uxPlusOne]
+    leading := [(1 : L2), (1 : L2)]
+    witness := [1, -1] }
+
+def twoStagesWork : Bool :=
+  match lift twoStageInput with
+  | .ok cert => cert.factors == [x2 + y2 + z2, x2 + 1]
+  | .error _ => false
+
+#guard twoStagesWork
+
+/- The point `y = -1` splits `x^2+y` into `x-1` and `x+1`, although no
+compatible integer factorization exists.  Full box precision therefore ends
+in the distinct reconstruction failure. -/
+def pointNegOne : Fin 1 → Int := fun _ => -1
+def uxMinusOne : ZPoly := DensePoly.ofCoeffs #[-1, 1]
+
+def reconstructInput : Input 1 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointNegOne, prime := prime5, exponent := 1 }
+    target := x ^ 2 + y
+    images := [uxMinusOne, uxPlusOne]
+    leading := [(1 : L), (1 : L)]
+    witness := [DensePoly.C (-2), DensePoly.C 2] }
+
+#guard valid reconstructInput
+def reconstructionFails : Bool :=
+  match lift reconstructInput with
+  | .error (.reconstruct 5) => true
+  | _ => false
+
+#guard reconstructionFails
+
+/- A coefficient `3` is reconstructed as `-2` modulo five, but correctly
+after one exponent doubling to modulus twenty-five. -/
+def retryInput : Input 1 Mono.lex Mono.lex :=
+  { setup :=
+      { main := 0, point := pointZero, prime := prime5, exponent := 1 }
+    target := (x + 3 * y) * (x + 1)
+    images := [ux, uxPlusOne]
+    leading := [(1 : L), (1 : L)]
+    witness := [1, -1] }
+
+def retryCert : Cert 1 Mono.lex :=
+  { factors := [x + 3 * y, x + 1] }
+
+def firstRetryFails : Bool :=
+  match lift retryInput with
+  | .error (.reconstruct 5) => true
+  | _ => false
+
+def retryWorks : Bool :=
+  match liftWith { doublings := 1 } retryInput with
+  | .ok cert => cert.factors == retryCert.factors
+  | .error _ => false
+
+#guard firstRetryFails
+#guard retryWorks
+
+def exponentDoubles : Bool :=
+  (raiseExponent? retryInput).map (fun inp => inp.setup.exponent) == some 2
+
+#guard exponentDoubles
+
+end Hex.MvHensel.LiftTests

--- a/HexMvHensel/Modulus.lean
+++ b/HexMvHensel/Modulus.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Shift
+public import HexModular.SymMod
+
+@[expose] public section
+
+/-!
+Coefficient reduction and the two congruence relations used by multivariate
+Hensel lifting.
+
+`CongrAt` observes the total degree in all non-main variables, while
+`BoxCongr` observes the coordinatewise box computed by `truncate`.  Keeping
+the predicates distinct prevents a box-truncated intermediate from being
+mistaken for a representative modulo a power of the evaluation ideal.
+-/
+
+namespace Hex.MvHensel
+
+open Hex.MvPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  [IsMonomialOrder cmp]
+
+/-- Replace every coefficient by its symmetric representative modulo `m`,
+deleting terms whose representative is zero. -/
+def reduceMod (m : Nat) (p : MvPoly (n + 1) Int cmp) :
+    MvPoly (n + 1) Int cmp :=
+  MvPoly.mapCoeffs (fun c => Hex.Modular.symMod c m) p
+
+/-- The exact symmetric interval `(-m/2, m/2]`, written without division so
+the even-modulus endpoint convention is explicit. -/
+def SymCanonical (m : Nat) (p : MvPoly (n + 1) Int cmp) : Prop :=
+  ∀ u : Mono (n + 1),
+    -(m : Int) < 2 * MvPoly.coeff u p ∧
+      2 * MvPoly.coeff u p ≤ (m : Int)
+
+/-- Total exponent in all variables other than `i`. -/
+def nonMainDegree (i : Fin (n + 1)) (u : Mono (n + 1)) : Nat :=
+  (List.finRange n).foldl
+    (fun degree j => degree + Mono.degreeOf (remainingVar i j) u) 0
+
+/-- Coefficients of `p` and `q` agree modulo `m` through total non-main
+degree `k`. -/
+def CongrAt (i : Fin (n + 1)) (k m : Nat)
+    (p q : MvPoly (n + 1) Int cmp) : Prop :=
+  ∀ u : Mono (n + 1), nonMainDegree i u ≤ k →
+    (MvPoly.coeff u p - MvPoly.coeff u q) % (m : Int) = 0
+
+/-- Coefficients of `p` and `q` agree modulo `m` throughout the
+coordinatewise non-main degree box `d`. -/
+def BoxCongr (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
+    (p q : MvPoly (n + 1) Int cmp) : Prop :=
+  ∀ u : Mono (n + 1),
+    (∀ j : Fin n, Mono.degreeOf (remainingVar i j) u ≤ d j) →
+      (MvPoly.coeff u p - MvPoly.coeff u q) % (m : Int) = 0
+
+private theorem modDiff_symm {a b : Int} {m : Nat}
+    (h : (a - b) % (m : Int) = 0) :
+    (b - a) % (m : Int) = 0 := by
+  apply Int.emod_eq_zero_of_dvd
+  rw [show b - a = -(a - b) by omega]
+  exact Int.dvd_neg.mpr (Int.dvd_of_emod_eq_zero h)
+
+private theorem modDiff_trans {a b c : Int} {m : Nat}
+    (hab : (a - b) % (m : Int) = 0)
+    (hbc : (b - c) % (m : Int) = 0) :
+    (a - c) % (m : Int) = 0 := by
+  apply Int.emod_eq_zero_of_dvd
+  rw [show a - c = (a - b) + (b - c) by omega]
+  exact Int.dvd_add (Int.dvd_of_emod_eq_zero hab)
+    (Int.dvd_of_emod_eq_zero hbc)
+
+private theorem modDiff_add {a b c d : Int} {m : Nat}
+    (hab : (a - b) % (m : Int) = 0)
+    (hcd : (c - d) % (m : Int) = 0) :
+    ((a + c) - (b + d)) % (m : Int) = 0 := by
+  apply Int.emod_eq_zero_of_dvd
+  rw [show (a + c) - (b + d) = (a - b) + (c - d) by omega]
+  exact Int.dvd_add (Int.dvd_of_emod_eq_zero hab)
+    (Int.dvd_of_emod_eq_zero hcd)
+
+private theorem symMod_zero (m : Nat) : Hex.Modular.symMod 0 m = 0 := by
+  unfold Hex.Modular.symMod
+  split <;> simp_all
+
+private theorem symMod_modDiff (a : Int) (m : Nat) :
+    (Hex.Modular.symMod a m - a) % (m : Int) = 0 := by
+  cases m with
+  | zero => simp [Hex.Modular.symMod]
+  | succ m =>
+      apply Int.emod_eq_emod_iff_emod_sub_eq_zero.mp
+      exact Hex.Modular.symMod_emod (by omega)
+
+/-! Ideal-adic congruence laws. -/
+
+theorem congrAt_refl (i : Fin (n + 1)) (k m : Nat)
+    (p : MvPoly (n + 1) Int cmp) : CongrAt i k m p p := by
+  intro u _
+  simp
+
+theorem congrAt_symm {i : Fin (n + 1)} {k m : Nat}
+    {p q : MvPoly (n + 1) Int cmp} :
+    CongrAt i k m p q → CongrAt i k m q p := by
+  intro hpq u hu
+  exact modDiff_symm (hpq u hu)
+
+theorem congrAt_trans {i : Fin (n + 1)} {k m : Nat}
+    {p q r : MvPoly (n + 1) Int cmp} :
+    CongrAt i k m p q → CongrAt i k m q r → CongrAt i k m p r := by
+  intro hpq hqr u hu
+  exact modDiff_trans (hpq u hu) (hqr u hu)
+
+theorem congrAt_add {i : Fin (n + 1)} {k m : Nat}
+    {p p' q q' : MvPoly (n + 1) Int cmp}
+    (hp : CongrAt i k m p p') (hq : CongrAt i k m q q') :
+    CongrAt i k m (p + q) (p' + q') := by
+  intro u hu
+  rw [MvPoly.coeff_add, MvPoly.coeff_add]
+  exact modDiff_add (hp u hu) (hq u hu)
+
+theorem congrAt_mul {i : Fin (n + 1)} {k m : Nat}
+    {p p' q q' : MvPoly (n + 1) Int cmp}
+    (hp : CongrAt i k m p p') (hq : CongrAt i k m q q') :
+    CongrAt i k m (p * q) (p' * q') := by
+  sorry
+
+theorem congrAt_reduceMod (i : Fin (n + 1)) (k m : Nat)
+    (p : MvPoly (n + 1) Int cmp) :
+    CongrAt i k m (reduceMod m p) p := by
+  intro u _
+  unfold reduceMod
+  rw [MvPoly.coeff_mapCoeffs (symMod_zero m)]
+  exact symMod_modDiff _ _
+
+theorem congrAt_mono {i : Fin (n + 1)} {k k' m : Nat}
+    {p q : MvPoly (n + 1) Int cmp} (h : k' ≤ k)
+    (hpq : CongrAt i k m p q) : CongrAt i k' m p q := by
+  intro u hu
+  exact hpq u (Nat.le_trans hu h)
+
+/-! Box congruence laws. -/
+
+theorem boxCongr_refl (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
+    (p : MvPoly (n + 1) Int cmp) : BoxCongr i d m p p := by
+  intro u _
+  simp
+
+theorem boxCongr_symm {i : Fin (n + 1)} {d : Fin n → Nat} {m : Nat}
+    {p q : MvPoly (n + 1) Int cmp} :
+    BoxCongr i d m p q → BoxCongr i d m q p := by
+  intro hpq u hu
+  exact modDiff_symm (hpq u hu)
+
+theorem boxCongr_trans {i : Fin (n + 1)} {d : Fin n → Nat} {m : Nat}
+    {p q r : MvPoly (n + 1) Int cmp} :
+    BoxCongr i d m p q → BoxCongr i d m q r → BoxCongr i d m p r := by
+  intro hpq hqr u hu
+  exact modDiff_trans (hpq u hu) (hqr u hu)
+
+theorem boxCongr_add {i : Fin (n + 1)} {d : Fin n → Nat} {m : Nat}
+    {p p' q q' : MvPoly (n + 1) Int cmp}
+    (hp : BoxCongr i d m p p') (hq : BoxCongr i d m q q') :
+    BoxCongr i d m (p + q) (p' + q') := by
+  intro u hu
+  rw [MvPoly.coeff_add, MvPoly.coeff_add]
+  exact modDiff_add (hp u hu) (hq u hu)
+
+theorem boxCongr_mul {i : Fin (n + 1)} {d : Fin n → Nat} {m : Nat}
+    {p p' q q' : MvPoly (n + 1) Int cmp}
+    (hp : BoxCongr i d m p p') (hq : BoxCongr i d m q q') :
+    BoxCongr i d m (p * q) (p' * q') := by
+  sorry
+
+theorem boxCongr_reduceMod (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
+    (p : MvPoly (n + 1) Int cmp) :
+    BoxCongr i d m (reduceMod m p) p := by
+  intro u _
+  unfold reduceMod
+  rw [MvPoly.coeff_mapCoeffs (symMod_zero m)]
+  exact symMod_modDiff _ _
+
+/-- Truncating is invisible inside the truncation box. -/
+theorem boxCongr_truncate (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
+    (p : MvPoly (n + 1) Int cmp) :
+    BoxCongr i d m (truncate i d p) p := by
+  intro u hu
+  rw [coeff_truncate, if_pos hu, Int.sub_self, Int.zero_emod]
+
+/-- Total-degree congruence through the sum of the side degrees implies box
+congruence.  The converse is false. -/
+theorem boxCongr_of_congrAt (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
+    {p q : MvPoly (n + 1) Int cmp}
+    (h : CongrAt i ((List.finRange n).foldl (fun s j => s + d j) 0) m p q) :
+    BoxCongr i d m p q := by
+  sorry
+
+/-- Symmetric reduction lands in the exact canonical interval.  Positivity is
+necessary: at modulus zero the interval `(-m/2,m/2]` is empty. -/
+theorem reduceMod_symCanonical (m : Nat) (hm : 0 < m)
+    (p : MvPoly (n + 1) Int cmp) :
+    SymCanonical m (reduceMod m p) := by
+  sorry
+
+/-- Reducing an already symmetric-canonical polynomial changes nothing. -/
+theorem reduceMod_id (m : Nat) (p : MvPoly (n + 1) Int cmp)
+    (h : SymCanonical m p) : reduceMod m p = p := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/SPEC/hex-mv-hensel.md
+++ b/HexMvHensel/SPEC/hex-mv-hensel.md
@@ -9,9 +9,9 @@ congruences in Mathlib's language, transports the checked identities onto
 the Mathlib-free completeness theorem takes as a hypothesis.
 
 This SPEC expands the "Multivariate Hensel lifting" entry in
-[future-work](../future-work.md). It depends on the representation fixed
+[future-work](../../SPEC/future-work.md). It depends on the representation fixed
 by [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md) and on the exact
-division and gcd contract accepted in [hex-mv-gcd](hex-mv-gcd.md). It
+division and gcd contract accepted in [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md). It
 does not depend on [hex-hensel](../../HexHensel/SPEC/hex-hensel.md).
 "Why hex-hensel is a design model" says exactly why.
 
@@ -24,7 +24,7 @@ resulting univariate polynomial over `ℤ`, and then reconstruct the
 multivariate factors from that univariate splitting. The last step is
 this library, and it is the only step of the four that has no existing
 Hex implementation. Squarefree decomposition, content, and primitive part
-are in [hex-mv-gcd](hex-mv-gcd.md). Univariate factorization over `ℤ` is
+are in [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md). Univariate factorization over `ℤ` is
 in
 [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md).
 
@@ -310,9 +310,14 @@ theorem congrAt_mul  : CongrAt i k m p p' → CongrAt i k m q q' →
 theorem congrAt_reduceMod : CongrAt i k m (reduceMod m p) p
 theorem congrAt_mono (h : k' ≤ k) : CongrAt i k m p q → CongrAt i k' m p q
 theorem boxCongr_add, boxCongr_mul, boxCongr_reduceMod   -- the same laws
-theorem reduceMod_symCanonical : SymCanonical m (reduceMod m p)
+theorem reduceMod_symCanonical (hm : 0 < m) : SymCanonical m (reduceMod m p)
 theorem reduceMod_id (h : SymCanonical m p) : reduceMod m p = p
 ```
+
+Positivity in `reduceMod_symCanonical` is necessary: at `m = 0` the exact
+interval `(-m/2, m/2]` is empty even for the zero coefficient. Every working
+modulus below is a positive prime power, so the hypothesis is already present
+at all algorithmic call sites.
 
 The working modulus is `q = p^l` for a bounded prime `p` and an exponent
 `l ≥ 1`, held as `Nat` and applied to `Int` coefficients. `ZMod64 q` is
@@ -439,7 +444,7 @@ modulo `F_k` and hence each `F_m` with `m ≠ k` a unit modulo `F_k`.
 
 **Why a modulus appears at all.** `ℤ[x_i]` is not a Bézout domain, which
 is the same fact
-[hex-mv-gcd](hex-mv-gcd.md) records under "Bézout does not witness
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) records under "Bézout does not witness
 coprimality here": `x` and `2` are coprime in `ℤ[x]` and
 `u · x + v · 2 = 1` has no solution. Over `ℤ/q` with `p` not dividing the
 relevant leading coefficients, the identity does have a solution, which
@@ -468,10 +473,17 @@ contradiction. So:
 Writing `ratOf` for the coefficientwise `Int → Rat` map on `DensePoly`:
 
 ```lean
-theorem coprimeRat_of_witness (h : valid inp = true) (j k) (hjk : j ≠ k) :
+theorem coprimeRat_of_witness (h : valid inp = true) (j k : Nat)
+    (hj : j < inp.images.length) (hk : k < inp.images.length)
+    (hjk : j ≠ k) :
     ∃ u v : DensePoly Rat,
       u * ratOf inp.images[j] + v * ratOf inp.images[k] = 1
 ```
+
+The two range hypotheses are logically necessary for list-backed images.
+Without them, a valid input with two images and `j = 2`, `k = 3` would read
+both out-of-range entries as the `getD` default zero while still satisfying
+`j ≠ k`, and would falsely assert `u · 0 + v · 0 = 1`.
 
 No resultant is needed for this, which is why hex-resultant is not a
 dependency. The Gauss's-lemma step is hex-mv-gcd's, at arity one.
@@ -508,7 +520,7 @@ satisfies `deg τ_j < deg F_j`, so `σ_j + p^k τ_j` does too, and the
 degree bound is maintained for free.
 
 This is a producer in the sense of [design
-principle 4](../design-principles.md): `witnessOf?` is unverified, and
+principle 4](../../SPEC/design-principles.md): `witnessOf?` is unverified, and
 `valid` checks its output on every call. A caller that already has the
 tuple supplies it directly.
 
@@ -539,11 +551,15 @@ polynomial whose degree-`k` coefficient is `constIn (F.coeff k)` for
 ```lean
 theorem imageAt_seed  (h : MvPoly.eval a L = F.leadingCoeff) :
     imageAt i cmp' a (seed i cmp' L F) = F
-theorem lcIn_seed     (h : L ≠ 0) : lcIn i cmp' (seed i cmp' L F) = L
+theorem lcIn_seed     (hF : F.size ≠ 0) (h : L ≠ 0) :
+    lcIn i cmp' (seed i cmp' L F) = L
 theorem degreeOf_seed (h : L ≠ 0) : degreeOf i (seed i cmp' L F) = F.degree
 ```
 
-and the hypothesis on the first is exactly V4's second condition.
+The hypothesis on the first is exactly V4's second condition.  The nonzero
+image hypothesis on `lcIn_seed` is essential: `seed` deliberately returns
+zero at `F = 0`, so `F = 0` and `L = 1` would refute the version without it.
+V1 gives the stronger positive-degree fact at every lifting call site.
 
 **The invariant, and what installs it.** Write `L_j|_t` for `L_j` with
 the not-yet-introduced variables `y_{t+1}, …, y_n` set to zero. Every
@@ -797,7 +813,7 @@ a caller passing an arbitrary `c` has to be told when the equation is
 unsolvable rather than handed a junk value.
 
 **There is no total form to classify.** [Design
-principle 8](../design-principles.md) requires a total form of a partial
+principle 8](../../SPEC/design-principles.md) requires a total form of a partial
 helper to be classified as unreachable or audited, and offers as a third
 remedy propagating the `Option` upward until the public API takes
 responsibility. This library takes that third route everywhere: no
@@ -831,7 +847,7 @@ are bounded in terms of `f`, and once `q` exceeds twice that bound the
 symmetric representatives are the true ones and the product test
 succeeds. The Mathlib-free layer states the bound as a hypothesis and the
 companion discharges it, which is the arrangement [design
-principle 2](../design-principles.md) prescribes and the one
+principle 2](../../SPEC/design-principles.md) prescribes and the one
 [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md) already uses for
 Mignotte:
 
@@ -958,8 +974,8 @@ were found, and it plays no part in the statement that they are correct.
 def IsLiftOf (inp : Input n cmp cmp') (fs : List (MvPoly (n+1) Int cmp)) : Prop :=
   fs.length = inp.images.length ∧
   fs.foldl (· * ·) 1 = inp.target ∧
-  (∀ j, imageAt i cmp' a fs[j] = inp.images[j]) ∧
-  (∀ j, lcIn i cmp' fs[j] = inp.leading[j])
+  (∀ j, j < inp.images.length → imageAt i cmp' a fs[j] = inp.images[j]) ∧
+  (∀ j, j < inp.images.length → lcIn i cmp' fs[j] = inp.leading[j])
 
 theorem check_sound : check inp c = true → IsLiftOf inp c.factors
 theorem lift_checks : lift inp = .ok c → check inp c = true
@@ -1052,9 +1068,14 @@ theorem irreducible_of_image_irreducible
     (hv : valid inp = true)
     (h : check inp c = true)
     (hprim : contentIn i cmp' inp.target = 1)
-    (hirr : ∀ j, Irred (inp.images[j])) :
-    ∀ j, Irred (c.factors[j])
+    (hirr : ∀ j, j < inp.images.length → Irred (inp.images[j])) :
+    ∀ j, j < c.factors.length → Irred (c.factors[j])
 ```
+
+The range hypotheses here serve the same purpose as those on
+`coprimeRat_of_witness`: neither irreducibility premise nor conclusion is
+intended to make a claim about the default value returned by an out-of-range
+list lookup.
 
 **`valid` is not droppable here, even though `check_sound` does not need
 it.** `check` alone leaves the returned factors free to lose degree in
@@ -1271,7 +1292,7 @@ the asymptotic argument for `Array` does not apply.
 ## Complexity
 
 These are **probe counts** in the sense
-[hex-mv-gcd](hex-mv-gcd.md) uses: they count univariate diophantine
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) uses: they count univariate diophantine
 solves and coefficient operations rather than machine operations, and
 they omit the cost of each probe. Multiplying through would require the
 cost of arithmetic modulo `q` at `l` words, which depends on the modulus
@@ -1332,13 +1353,13 @@ certificate is sound at any modulus.
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). A Lean driver at
 `conformance/HexMvHensel/EmitFixtures.lean` exposed as
 `lean_exe hexmvhensel_emit_fixtures`, a committed snapshot at
 `conformance-fixtures/HexMvHensel/mvhensel.jsonl`, and an oracle driver
 at `scripts/oracle/mvhensel_sympy.py`. One tuple appended to `ORACLES` in
 `scripts/ci/run_oracles.sh`, not a new job, per
-[SPEC/CI.md](../CI.md):
+[SPEC/CI.md](../../SPEC/CI.md):
 
 ```
 "HexMvHensel|hexmvhensel_emit_fixtures|scripts/oracle/mvhensel_sympy.py|conformance-fixtures/HexMvHensel/mvhensel.jsonl"
@@ -1422,7 +1443,7 @@ SymPy's normalisation conventions.
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexMvHensel/Bench.lean`. Native only for throughput. A separate
 `bench/HexMvHensel/Kernel.lean` suite replays valid and
 one-field-corrupted certificates through `by decide +kernel`: two
@@ -1458,7 +1479,7 @@ multivariate-Hensel entry point, so any ratio against them compares this
 library against a whole factorizer. A required ratio therefore waits for
 `hex-mv-factor`, where an end-to-end comparison is meaningful, and this
 SPEC assigns none. That is the same reasoning
-[hex-mv-gcd](hex-mv-gcd.md) applies to FLINT's `fmpz_mpoly_gcd`.
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) applies to FLINT's `fmpz_mpoly_gcd`.
 
 ## The Mathlib layer
 
@@ -1518,7 +1539,7 @@ Mathlib-side form of `boxCongr_of_congrAt`.
 `boundsFactors_coeffBound` is the one theorem here that is not transport.
 It needs a factor-coefficient inequality, which is analysis, so it is on
 this side of the boundary by [design
-principle 2](../design-principles.md). The Kronecker route reduces it to
+principle 2](../../SPEC/design-principles.md). The Kronecker route reduces it to
 [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md)'s
 Mignotte bound and needs, in addition, the combinatorial fact that the
 corrected mixed-radix substitution is injective on the monomials of every
@@ -1537,7 +1558,7 @@ public semantic operation: `shift`, `imageAt`, `lcIn`, `truncate`,
 The dense recursion in `diophantine` costs `∏_j (d_j + 1)` univariate
 solves regardless of how many terms the answer has, which is the same
 shape of gap
-[hex-mv-gcd](hex-mv-gcd.md) records for Zippel interpolation. The known
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) records for Zippel interpolation. The known
 improvement is to solve each multivariate diophantine problem by sparse
 interpolation: learn the support of each `Δ_j` from one solve, then
 determine coefficients at later points by solving transposed Vandermonde
@@ -1609,14 +1630,14 @@ HexMvHenselMathlib/
 HexMvHenselMathlib.lean
 ```
 
-`libraries.yml` gains:
+`libraries.yml` records the active core library and the planned companion:
 
 ```yaml
   HexMvHensel:
     deps: [HexBasic, HexMvPoly, HexMvGcd, HexPoly, HexPolyZ, HexPolyFp, HexModArith, HexModular, HexArith]
     mathlib: false
-    done_through: 0
-    status: planned
+    done_through: 1
+    status: active
   HexMvHenselMathlib:
     deps: [HexMvHensel, HexMvPolyMathlib, HexPolyMathlib, HexPolyZMathlib]
     mathlib: true
@@ -1639,14 +1660,10 @@ the integer extended gcd underneath the `ZMod64` inverses.
 gives the reasons and "Open questions" records the amendment that would
 add it.
 
-`HexMvPoly`, `HexMvPolyMathlib`, `HexPoly`, `HexPolyZ`, `HexPolyFp`,
-`HexModArith`, and `HexArith` are active. `HexMvGcd` and `HexModular` are
-planned and not yet registered in `libraries.yml`; their entries must be
-added and implemented before the block above can be applied. The new
-entries are `planned` rather than `draft`, because this SPEC fixes their
-required API and milestones. Registration waits until the dependency
-entries exist, which is the same position
-[hex-mv-gcd](hex-mv-gcd.md) records for itself.
+All dependencies named above are active. `HexMvHensel` is registered as
+active at `done_through: 1`; the coordinates-and-modulus milestone is
+complete. `HexMvHenselMathlib` remains a planned companion and is not yet
+registered in `libraries.yml`.
 
 ## Why the lift and the diophantine solver are one library
 

--- a/HexMvHensel/Seed.lean
+++ b/HexMvHensel/Seed.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Diophantine
+
+@[expose] public section
+
+/-!
+Input data and leading-coefficient preparation for multivariate Hensel
+lifting.  `Setup` remains in `Uni`; this module extends that stable object
+with the full checked input contract.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+open Hex.MvPoly
+
+/-- The starting data for one multivariate lift. -/
+structure Input (n : Nat)
+    (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
+    (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp] [IsMonomialOrder cmp'] where
+  setup : Setup n
+  target : MvPoly (n + 1) Int cmp
+  images : List ZPoly
+  leading : List (MvPoly n Int cmp')
+  witness : List ZPoly
+
+/-- Failures retain the distinction between malformed input, an unsuitable
+point or prime, and failure to reconstruct at the available modulus. -/
+inductive Failure where
+  | arity
+  | degreeDrop
+  | imageProduct
+  | leadingProduct
+  | leadingImage (j : Nat)
+  | primeDividesLc (j : Nat)
+  | notCoprime
+  | witnessDegree (j : Nat)
+  | reconstruct (modulus : Nat)
+  deriving BEq, DecidableEq, Repr
+
+/-- Retry policy for reconstruction failures. -/
+structure Config where
+  doublings : Nat
+  deriving BEq, DecidableEq, Repr
+
+namespace Config
+
+/-- Six exponent doublings after the initial attempt. -/
+def default : Config := { doublings := 6 }
+
+end Config
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp] [IsMonomialOrder cmp']
+
+/-- Ordered product of multivariate polynomials. -/
+def mvProduct {k : Nat} {order : Mono k → Mono k → Ordering}
+    [IsMonomialOrder order] (fs : List (MvPoly k Int order)) :
+    MvPoly k Int order :=
+  fs.foldl (· * ·) 1
+
+/-- Replace the coefficient at the main-variable degree of `p` by `L`. -/
+def setLc (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (p : MvPoly (n + 1) Int cmp) :
+    MvPoly (n + 1) Int cmp :=
+  let q := MvPoly.toUnivariate i cmp' p
+  let degree := MvPoly.degreeOf i p
+  let size := max q.size (degree + 1)
+  let coefficients := Array.ofFn (n := size) fun k =>
+    if k.val = degree then L else q.coeff k.val
+  MvPoly.ofUnivariate (cmp := cmp) i cmp'
+    (DensePoly.ofCoeffs coefficients)
+
+/-- Embed a univariate image and replace its leading coefficient by `L`. -/
+def seed (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (F : ZPoly) :
+    MvPoly (n + 1) Int cmp :=
+  if F.size = 0 then 0
+  else
+    let coefficients := Array.ofFn (n := F.size) fun k =>
+      if k.val + 1 = F.size then L else MvPoly.C (F.coeff k.val)
+    MvPoly.ofUnivariate (cmp := cmp) i cmp'
+      (DensePoly.ofCoeffs coefficients)
+
+/-- Keep only variables whose indices are below `count`; this is evaluation
+of every later variable at zero without changing the arity. -/
+def prefixVars {k : Nat} {order : Mono k → Mono k → Ordering}
+    [IsMonomialOrder order] (count : Nat) (p : MvPoly k Int order) :
+    MvPoly k Int order :=
+  p.restrictBy fun m =>
+    decide (∀ j : Fin k, count ≤ j.val → Mono.degreeOf j m = 0)
+
+/-- Keep the main variable and the first `count` remaining variables, setting
+all later remaining variables to zero. -/
+def prefixNonMain (i : Fin (n + 1)) (count : Nat)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  p.restrictBy fun m =>
+    decide (∀ j : Fin n, count ≤ j.val →
+      Mono.degreeOf (remainingVar i j) m = 0)
+
+/-- Build all seeds without any default indexing or prefix truncation. -/
+def seedTuple? (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp'] :
+    List ZPoly → List (MvPoly n Int cmp') →
+      Option (List (MvPoly (n + 1) Int cmp))
+  | [], [] => some []
+  | F :: Fs, L :: Ls => do
+      let tail ← seedTuple? i cmp' Fs Ls
+      some (seed i cmp' (prefixVars 0 L) F :: tail)
+  | _, _ => none
+
+/-! The elementary seed laws are Phase-1 proof obligations. -/
+
+theorem imageAt_seed (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (L : MvPoly n Int cmp') (F : ZPoly)
+    (h : MvPoly.eval a L = F.leadingCoeff) :
+    imageAt i cmp' a (seed (cmp := cmp) i cmp' L F) = F := by
+  sorry
+
+theorem lcIn_seed (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (F : ZPoly) (hF : F.size ≠ 0) (hL : L ≠ 0) :
+    lcIn i cmp' (seed (cmp := cmp) i cmp' L F) = L := by
+  sorry
+
+theorem degreeOf_seed (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (F : ZPoly) (hL : L ≠ 0) :
+    MvPoly.degreeOf i (seed (cmp := cmp) i cmp' L F) =
+      F.degree?.getD 0 := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/SeedTests.lean
+++ b/HexMvHensel/SeedTests.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Seed
+public meta import HexMvHensel.Seed
+public meta import HexMvPoly.Mono
+public meta import HexMvPoly.Basic
+public meta import HexMvPoly.Operations
+public meta import HexMvPoly.Query
+public meta import HexMvPoly.Recursive
+public meta import HexMvPoly.Ring
+public meta import HexBasic.ExtTreeMap
+
+section
+
+namespace Hex.MvHensel.SeedTests
+
+open Hex
+open Hex.MvPoly
+open scoped Hex
+
+abbrev P := MvPoly 2 Int Mono.lex
+abbrev L := MvPoly 1 Int Mono.lex
+
+def x : P := X 0
+def y : P := X 1
+def ly : L := X 0
+def image : ZPoly := DensePoly.ofCoeffs #[2, 3]
+
+#guard seed (cmp := Mono.lex) (0 : Fin 2) Mono.lex (ly + 1) image ==
+  2 + (y + 1) * x
+
+#guard setLc (cmp := Mono.lex) (0 : Fin 2) Mono.lex (ly + 1)
+    (x ^ 2 + y * x + 1) == (y + 1) * x ^ 2 + y * x + 1
+
+#guard prefixVars 1 ((ly + 1) * ly) == (ly + 1) * ly
+#guard prefixVars 0 ((ly + 1) * ly) == 0
+
+example :
+    seedTuple? (cmp := Mono.lex) (0 : Fin 2) Mono.lex [image] [] = none := by
+  rfl
+
+example : Config.default.doublings = 6 := by
+  rfl
+
+end Hex.MvHensel.SeedTests

--- a/HexMvHensel/Shift.lean
+++ b/HexMvHensel/Shift.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvPoly
+
+@[expose] public section
+
+/-!
+Coordinate operations for multivariate Hensel lifting.
+
+The factorization algorithms work after translating every variable except a
+chosen main variable to put the evaluation point at the origin.  This module
+also exposes the recursive univariate image, leading coefficient, and the box
+truncation used by the stage loop.  None of these operations depends on gcd or
+factorization infrastructure.
+-/
+
+namespace Hex.MvHensel
+
+open Hex.MvPoly
+
+variable {n : Nat}
+  {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+  {cmp' : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp]
+
+/-- Remove the distinguished position `i` from an index `j ≠ i`.
+
+This is the index-level inverse of `i.succAbove`.  Keeping it explicit avoids
+making the coordinate transform depend on Mathlib's equivalence API. -/
+def remainingIndex (i j : Fin (n + 1)) (h : j ≠ i) : Fin n :=
+  if hlt : j.val < i.val then
+    ⟨j.val, by omega⟩
+  else
+    ⟨j.val - 1, by omega⟩
+
+/-- Insert a remaining-variable index around the distinguished position.  This
+is the Mathlib-free coordinate map denoted `Fin.succAbove i` in the SPEC. -/
+def remainingVar (i : Fin (n + 1)) (j : Fin n) : Fin (n + 1) :=
+  if j.val < i.val then
+    ⟨j.val, by omega⟩
+  else
+    ⟨j.val + 1, by omega⟩
+
+/-- Re-inserting a removed non-main index recovers the original index. -/
+@[simp] theorem remainingVar_remainingIndex (i j : Fin (n + 1)) (h : j ≠ i) :
+    remainingVar i (remainingIndex i j h) = j := by
+  unfold remainingIndex
+  split
+  case isTrue hlt =>
+    unfold remainingVar
+    rw [if_pos hlt]
+  case isFalse hnlt =>
+    have hval : j.val ≠ i.val := by
+      intro hv
+      exact h (Fin.ext hv)
+    have hinsert : ¬ (j.val - 1 < i.val) := by omega
+    unfold remainingVar
+    rw [if_neg hinsert]
+    apply Fin.ext
+    simp
+    omega
+
+/-- Translate every variable by the corresponding component of `a`. -/
+def shiftAll [IsMonomialOrder cmp'] (a : Fin n → Int) (p : MvPoly n Int cmp') :
+    MvPoly n Int cmp' :=
+  MvPoly.subst (fun j => X j + C (a j)) p
+
+/-- Translate every variable by the negative of the corresponding component. -/
+def unshiftAll [IsMonomialOrder cmp'] (a : Fin n → Int) (p : MvPoly n Int cmp') :
+    MvPoly n Int cmp' :=
+  shiftAll (fun j => -a j) p
+
+/-- Replacement polynomial for one variable in the affine coordinate shift.
+The main variable is fixed; every other variable receives the matching entry
+of the point with the main coordinate removed. -/
+def shiftVar (i : Fin (n + 1)) (a : Fin n → Int)
+    (j : Fin (n + 1)) : MvPoly (n + 1) Int cmp :=
+  if h : j = i then X j
+  else X j + C (a (remainingIndex i j h))
+
+/-- Substitute `x_(i.succAbove j) ↦ x_(i.succAbove j) + a j`, fixing the
+main variable `x_i`. -/
+def shift (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  MvPoly.subst (shiftVar i a) p
+
+/-- Undo `shift i a`. -/
+def unshift (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  shift i (fun j => -a j) p
+
+/-- The univariate image at `a`, obtained by evaluating every coefficient in
+the recursive view in the non-main variables. -/
+def imageAt (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (p : MvPoly (n + 1) Int cmp) : DensePoly Int :=
+  let q := MvPoly.toUnivariate i cmp' p
+  DensePoly.ofCoeffs (q.toArray.map fun c => MvPoly.eval a c)
+
+/-- Leading coefficient in the chosen main variable, as a polynomial in the
+remaining variables. -/
+def lcIn (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (p : MvPoly (n + 1) Int cmp) : MvPoly n Int cmp' :=
+  (MvPoly.toUnivariate i cmp' p).leadingCoeff
+
+/-- Delete every term whose exponent in a non-main variable exceeds the
+corresponding component of `d`. -/
+def truncate (i : Fin (n + 1)) (d : Fin n → Nat)
+    (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
+  p.restrictBy fun m =>
+    decide (∀ j : Fin n, Mono.degreeOf (remainingVar i j) m ≤ d j)
+
+/-! The coordinate laws used by the lift. -/
+
+@[simp] theorem shift_unshift (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int cmp) :
+    unshift i a (shift i a p) = p := by
+  sorry
+
+@[simp] theorem unshift_shift (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int cmp) :
+    shift i a (unshift i a p) = p := by
+  sorry
+
+theorem shift_add (i : Fin (n + 1)) (a : Fin n → Int)
+    (p q : MvPoly (n + 1) Int cmp) :
+    shift i a (p + q) = shift i a p + shift i a q := by
+  sorry
+
+theorem shift_mul (i : Fin (n + 1)) (a : Fin n → Int)
+    (p q : MvPoly (n + 1) Int cmp) :
+    shift i a (p * q) = shift i a p * shift i a q := by
+  sorry
+
+theorem degreeOf_shift (i j : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int cmp) :
+    MvPoly.degreeOf j (shift i a p) = MvPoly.degreeOf j p := by
+  sorry
+
+theorem lcIn_shift (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (p : MvPoly (n + 1) Int cmp) :
+    lcIn i cmp' (shift i a p) = shiftAll a (lcIn i cmp' p) := by
+  sorry
+
+theorem imageAt_shift (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (p : MvPoly (n + 1) Int cmp) :
+    imageAt i cmp' (fun _ => 0) (shift i a p) = imageAt i cmp' a p := by
+  sorry
+
+/-- Truncation has the expected coefficient projection. -/
+theorem coeff_truncate (i : Fin (n + 1)) (d : Fin n → Nat)
+    (m : Mono (n + 1)) (p : MvPoly (n + 1) Int cmp) :
+    MvPoly.coeff m (truncate i d p) =
+      if ∀ j : Fin n, Mono.degreeOf (remainingVar i j) m ≤ d j then
+        MvPoly.coeff m p
+      else 0 := by
+  unfold truncate
+  rw [MvPoly.coeff_restrictBy]
+  simp only [decide_eq_true_eq]
+
+end Hex.MvHensel

--- a/HexMvHensel/Uni.lean
+++ b/HexMvHensel/Uni.lean
@@ -1,0 +1,317 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvHensel.Modulus
+public import HexPolyFp
+public import HexPolyZ
+public import HexModArith.Modulus
+
+@[expose] public section
+
+/-!
+The univariate correction equation used at the bottom of multivariate Hensel
+lifting.
+
+The working modulus is an arbitrary-precision prime power, so `solveUni` does
+not pretend that it is a `ZMod64` modulus.  Only `witnessOf?` works at the
+word-sized residue prime: it computes the partial-fraction tuple there with
+`DensePoly.xgcd`, then lifts the tuple one power of the prime at a time.
+-/
+
+namespace Hex.MvHensel
+
+open Hex
+
+/- These direct-array arithmetic wrappers keep the executable producer out of
+the noncomputable reference definitions used to state polynomial laws. -/
+def zAdd (f g : ZPoly) : ZPoly := DensePoly.addImpl f g
+def zSub (f g : ZPoly) : ZPoly := DensePoly.subImpl f g
+def zMul (f g : ZPoly) : ZPoly := DensePoly.mulImpl f g
+
+/-- Coefficientwise reduction into the bounded residue field. -/
+def toFp (p : Nat) [ZMod64.Bounds p] (f : ZPoly) : FpPoly p :=
+  DensePoly.ofCoeffs (f.toArray.map fun c => ZMod64.intCast p c)
+
+/-- Lift residue coefficients to their standard nonnegative representatives. -/
+def fromFp {p : Nat} [ZMod64.Bounds p] (f : FpPoly p) : ZPoly :=
+  DensePoly.ofCoeffs (f.toArray.map fun c => (c.toNat : Int))
+
+/-- Where a multivariate lift takes place.  The coordinate fields are already
+needed by the witness-producing API even though the univariate layer only
+inspects `prime` and `exponent`. -/
+structure Setup (n : Nat) where
+  /-- The variable retained in the univariate image. -/
+  main : Fin (n + 1)
+  /-- Values assigned to the remaining variables. -/
+  point : Fin n → Int
+  /-- The bounded residue prime used to initialise the lift. -/
+  prime : ZMod64.Prime
+  /-- The requested prime-power exponent. -/
+  exponent : Nat
+
+namespace Setup
+
+/-- The arbitrary-precision working modulus `p ^ l`. -/
+def modulus (s : Setup n) : Nat := s.prime.m ^ s.exponent
+
+end Setup
+
+/-! # Integer-polynomial modular arithmetic -/
+
+/-- Coefficientwise symmetric reduction of an integer polynomial. -/
+def reduceUni (q : Nat) (f : ZPoly) : ZPoly :=
+  DensePoly.ofCoeffs (f.toArray.map fun c => Modular.symMod c q)
+
+/-- Coefficientwise congruence of integer polynomials modulo `q`. -/
+def UniCongr (q : Nat) (f g : ZPoly) : Prop :=
+  ∀ k : Nat, (f.coeff k - g.coeff k) % (q : Int) = 0
+
+/-- Every stored coefficient lies in the symmetric interval `(-q/2,q/2]`. -/
+def UniSymCanonical (q : Nat) (f : ZPoly) : Prop :=
+  ∀ k : Nat, -(q : Int) < 2 * f.coeff k ∧ 2 * f.coeff k ≤ (q : Int)
+
+/-- Ordered product of a list of integer polynomials. -/
+def uniProduct (fs : List ZPoly) : ZPoly :=
+  fs.foldl zMul 1
+
+/-- The product of every image other than the one at position `j`. -/
+def productExcept (images : List ZPoly) (j : Nat) : ZPoly :=
+  (List.range images.length).foldl
+    (fun acc k => if k = j then acc else zMul acc (images.getD k 1)) 1
+
+/-- Complementary products `b_j = ∏_{m ≠ j} F_m`, in image order. -/
+def complements (images : List ZPoly) : List ZPoly :=
+  (List.range images.length).map (productExcept images)
+
+/-- The partial-fraction linear combination `Σ_j σ_j b_j`. -/
+def uniCombination (coeffs bases : List ZPoly) : ZPoly :=
+  (coeffs.zip bases).foldl
+    (fun acc pair => zAdd acc (zMul pair.1 pair.2)) 0
+
+/-- Whether every coefficient of `f` is divisible by `q`. -/
+def coeffsDivisible (q : Nat) (f : ZPoly) : Bool :=
+  f.toArray.all fun c => c % (q : Int) = 0
+
+/-- Exact coefficientwise division, used only after a divisibility check. -/
+def divCoeffs? (q : Nat) (f : ZPoly) : Option ZPoly :=
+  if q = 0 then none
+  else if coeffsDivisible q f then
+    some (DensePoly.ofCoeffs (f.toArray.map fun c => c / (q : Int)))
+  else none
+
+/-- Invert an integer modulo `q`, returning the symmetric representative. -/
+def invMod? (a : Int) (q : Nat) : Option Int :=
+  if q ≤ 1 then none
+  else
+    let eg := Hex.pureIntExtGcd a (q : Int)
+    if eg.1 = 1 then some (Modular.symMod eg.2.1 q) else none
+
+/-- GMP-backed runtime implementation of `invMod?`. -/
+def invModImpl? (a : Int) (q : Nat) : Option Int :=
+  if q ≤ 1 then none
+  else
+    let eg := HexArith.Int.extGcd a (q : Int)
+    if eg.1 = 1 then some (Modular.symMod eg.2.1 q) else none
+
+/-- The runtime extended-gcd attachment computes the reference inverse. -/
+theorem invMod_eq_impl : invMod? = invModImpl? := by
+  funext a q
+  simp only [invMod?, invModImpl?, HexArith.Int.extGcd]
+  rfl
+
+@[csimp] theorem invMod_csimp : @invMod? = @invModImpl? := invMod_eq_impl
+
+/-- Fuelled long remainder in `(Z/qZ)[x]`.  The divisor is required to have a
+unit leading coefficient; failure of that executable precondition returns
+`none`. -/
+def remUnitAux (q : Nat) (g : ZPoly) (invLead : Int) :
+    Nat → ZPoly → ZPoly
+  | 0, r => reduceUni q r
+  | fuel + 1, r =>
+      let r := reduceUni q r
+      if r.size < g.size then
+        r
+      else
+        let k := r.size - g.size
+        let c := Modular.symMod (r.leadingCoeff * invLead) q
+        let cancel := DensePoly.scaleImpl c (DensePoly.shiftImpl k g)
+        remUnitAux q g invLead fuel (zSub r cancel)
+
+/-- Remainder modulo a polynomial whose leading coefficient is a unit modulo
+`q`. -/
+def remUnit? (q : Nat) (f g : ZPoly) : Option ZPoly :=
+  let g := reduceUni q g
+  if g.size = 0 then none
+  else
+    match invMod? g.leadingCoeff q with
+    | none => none
+    | some invLead => some (remUnitAux q g invLead (f.size + 1) f)
+
+/-- Pairwise worker for `solveUni`.  Equal list lengths are part of the checked
+lift input; the total fallback truncates at the shorter list. -/
+def solveUniGo (q : Nat) (c : ZPoly) :
+    List ZPoly → List ZPoly → List ZPoly
+  | F :: Fs, sigma :: sigmas =>
+      (remUnit? q (zMul sigma c) F).getD 0 :: solveUniGo q c Fs sigmas
+  | _, _ => []
+
+/-- Given a partial-fraction witness, return the symmetric-canonical,
+degree-bounded solution of the univariate correction equation. -/
+def solveUni (q : Nat) (images witness : List ZPoly) (c : ZPoly) :
+    List ZPoly :=
+  solveUniGo q c images witness
+
+/-! # Producing and lifting the partial-fraction tuple -/
+
+/-- Compute the inverse of the complementary product modulo image `j` over
+the residue prime. -/
+def baseWitnessAt? (p : Nat) [ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] (images : List ZPoly) (j : Nat) : Option ZPoly :=
+  let F := images.getD j 0
+  let Fp := toFp p F
+  if F.size < 2 || Fp.size != F.size then
+    none
+  else
+    let bp := toFp p (productExcept images j)
+    let raw := DensePoly.xgcd bp Fp
+    if raw.gcd.size != 1 || raw.gcd.leadingCoeff = 0 then
+      none
+    else
+      let scale := raw.gcd.leadingCoeff⁻¹
+      let sigma := DensePoly.scaleImpl scale raw.left % Fp
+      some (fromFp sigma)
+
+/-- Compute the partial-fraction tuple modulo the residue prime. -/
+def baseWitness? (prime : ZMod64.Prime)
+    (images : List ZPoly) : Option (List ZPoly) :=
+  letI : ZMod64.Bounds prime.m := prime.bounds
+  letI : ZMod64.PrimeModulus prime.m :=
+    ZMod64.primeModulusOfPrime prime.prime
+  if images.isEmpty then none
+  else do
+    let tuple ← (List.range images.length).mapM
+      (baseWitnessAt? prime.m images)
+    let identity := uniCombination tuple (complements images)
+    if coeffsDivisible prime.m (zSub identity 1) then
+      some tuple
+    else none
+
+/-- Solve one correction equation modulo the residue prime using the base
+partial-fraction tuple. -/
+def solveBase? (prime : ZMod64.Prime) (images base : List ZPoly)
+    (c : ZPoly) : Option (List ZPoly) :=
+  letI : ZMod64.Bounds prime.m := prime.bounds
+  letI : ZMod64.PrimeModulus prime.m :=
+    ZMod64.primeModulusOfPrime prime.prime
+  if images.length != base.length then none
+  else
+    (List.range images.length).mapM fun j =>
+      let Fp := toFp prime.m (images.getD j 0)
+      if Fp.size = 0 then none
+      else
+        let sigma := toFp prime.m (base.getD j 0)
+        let ep := toFp prime.m c
+        some (fromFp ((DensePoly.mulImpl sigma ep) % Fp))
+
+/-- Add the scaled correction tuple without reducing by the image factors.
+This preservation is essential: such a reduction would generally destroy the
+lifted partial-fraction identity. -/
+def addScaled (scale : Nat) : List ZPoly → List ZPoly → List ZPoly
+  | sigma :: sigmas, tau :: taus =>
+      zAdd sigma (DensePoly.scaleImpl (scale : Int) tau) ::
+        addScaled scale sigmas taus
+  | [], [] => []
+  | _, _ => []
+
+/-- Lift an already valid mod-`p` tuple through `steps` further powers. -/
+def liftWitness (prime : ZMod64.Prime) (images base : List ZPoly) :
+    (steps k : Nat) → List ZPoly → Option (List ZPoly)
+  | 0, _, current => some current
+  | steps + 1, k, current => do
+      let pk := prime.m ^ k
+      let residual := zSub (1 : ZPoly)
+        (uniCombination current (complements images))
+      let error ← divCoeffs? pk residual
+      let correction ← solveBase? prime images base error
+      let next := addScaled pk current correction
+      let nextModulus := pk * prime.m
+      if coeffsDivisible nextModulus
+          (zSub (uniCombination next (complements images)) 1) then
+        liftWitness prime images base steps (k + 1) next
+      else none
+
+/-- Produce the partial-fraction tuple modulo `p ^ l`, or `none` if an image
+loses degree modulo `p`, the images are not pairwise coprime there, or the
+requested exponent is zero. -/
+def witnessOf? (s : Setup n) (images : List ZPoly) : Option (List ZPoly) := do
+  if s.exponent = 0 then none else pure ()
+  let base ← baseWitness? s.prime images
+  let lifted ← liftWitness s.prime images base (s.exponent - 1) 1 base
+  if coeffsDivisible s.modulus
+      (zSub (uniCombination lifted (complements images)) 1) then
+    some lifted
+  else none
+
+/-! # The checked mathematical contract -/
+
+/-- The direct hypotheses on the univariate data extracted from V1, V5 and
+V6 of a valid multivariate lift input. -/
+structure UniValid (q : Nat) (images witness : List ZPoly) : Prop where
+  /-- A working prime power is nontrivial. -/
+  modulus : 1 < q
+  /-- There is one witness component per image. -/
+  lengths : witness.length = images.length
+  /-- Constant images have already been removed as content. -/
+  positiveDegree : ∀ j, j < images.length → 0 < (images.getD j 0).degree?.getD 0
+  /-- Every image has unit leading coefficient modulo the prime power. -/
+  unitLeading : ∀ j, j < images.length →
+    Int.gcd (images.getD j 0).leadingCoeff (q : Int) = 1
+  /-- The supplied tuple is a partial-fraction identity. -/
+  identity : UniCongr q (uniCombination witness (complements images)) 1
+  /-- Witness components use their degree-bounded representatives. -/
+  witnessDegree : ∀ j, j < images.length →
+    (witness.getD j 0).degree?.getD 0 <
+      (images.getD j 0).degree?.getD 0
+
+/-- `solveUni` reconstructs every right-hand side below the product degree. -/
+theorem solveUni_spec {q : Nat} {images witness : List ZPoly} {c : ZPoly}
+    (h : UniValid q images witness)
+    (hc : (reduceUni q c).degree?.getD 0 <
+      (uniProduct images).degree?.getD 0) :
+    UniCongr q
+      (uniCombination (solveUni q images witness c) (complements images)) c := by
+  sorry
+
+/-- Each component returned by `solveUni` has degree below its image. -/
+theorem solveUni_degree {q : Nat} {images witness : List ZPoly} {c : ZPoly}
+    (h : UniValid q images witness) (j : Nat) (hj : j < images.length) :
+    ((solveUni q images witness c).getD j 0).degree?.getD 0 <
+      (images.getD j 0).degree?.getD 0 := by
+  sorry
+
+/-- `solveUni` chooses the symmetric representative of each residue class. -/
+theorem solveUni_symCanonical {q : Nat} {images witness : List ZPoly}
+    {c : ZPoly} (h : UniValid q images witness) (j : Nat)
+    (hj : j < images.length) :
+    UniSymCanonical q ((solveUni q images witness c).getD j 0) := by
+  sorry
+
+/-- Degree-bounded solutions are unique coefficientwise modulo `q`. -/
+theorem solveUni_unique {q : Nat} {images witness tau : List ZPoly}
+    {c : ZPoly} (h : UniValid q images witness)
+    (hlen : tau.length = images.length)
+    (hdegree : ∀ j, j < images.length →
+      (tau.getD j 0).degree?.getD 0 <
+        (images.getD j 0).degree?.getD 0)
+    (hsum : UniCongr q (uniCombination tau (complements images)) c) :
+    ∀ j, j < images.length →
+      UniCongr q (tau.getD j 0)
+        ((solveUni q images witness c).getD j 0) := by
+  sorry
+
+end Hex.MvHensel

--- a/HexMvHensel/UniTests.lean
+++ b/HexMvHensel/UniTests.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Uni
+import all HexPoly.Dense
+import all HexPoly.Operations
+import all HexPoly.Euclid.DivGcd
+import all HexPoly.Euclid.MulRing
+import all HexPolyFp.Field
+import all HexModArith.Residue
+import all HexModArith.Ring
+import all HexModArith.Prime
+import all HexArith.ExtGcd
+import all HexModular.SymMod
+
+section
+
+/-!
+Executable route checks, plus small kernel-reduction checks, for the
+univariate Hensel layer.  They cover both the arbitrary-prime-power solver and
+production of a lifted partial-fraction tuple; no certificate theorem is
+trusted by the tests.
+-/
+
+namespace Hex.MvHensel.UniTests
+
+open Hex
+open scoped Hex
+
+def x : ZPoly := DensePoly.ofCoeffs #[0, 1]
+def xPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
+
+/- The tuple `(1,-1)` solves `1*(x+1) + (-1)*x = 1`.  For right-hand side
+`x`, the two degree-bounded residues are `(0,1)`. -/
+#guard solveUni 5 [x, xPlusOne] [1, -1] x ==
+  [0, DensePoly.C 1]
+
+/- Unit-leading division is genuinely over the composite prime power rather
+than a `ZMod64`: `3` is the symmetric inverse of `2` modulo `5`. -/
+#guard remUnit? 5 (DensePoly.ofCoeffs #[0, 1])
+  (DensePoly.ofCoeffs #[1, 2]) == some (DensePoly.C 2)
+
+def prime5 : ZMod64.Prime where
+  m := 5
+  bounds := { pPos := by omega, pLtR := by decide }
+  prime := Hex.Nat.isPrimeTrial_isPrime (by decide)
+
+def point0 : Fin 0 → Int := fun j => nomatch j
+
+example : invMod? 2 5 = some (-2) := by
+  unfold invMod? Hex.pureIntExtGcd
+  decide +kernel
+
+example :
+    ({ main := 0, point := point0, prime := prime5, exponent := 3 } :
+      Setup 0).modulus = 125 := by
+  rfl
+
+def liftWorks : Bool :=
+  witnessOf?
+    ({ main := 0, point := point0, prime := prime5, exponent := 3 } : Setup 0)
+    [x, xPlusOne] == some [DensePoly.C 1, DensePoly.C 124]
+
+/- The mod-5 tuple `(1,4)` lifts to `(1,124)` modulo `5^3`, maintaining
+`1*(x+1) + 124*x = 1 (mod 125)` without reducing witnesses by their images. -/
+#guard liftWorks
+
+def rejectsRepeated : Bool :=
+  (witnessOf?
+    ({ main := 0, point := point0, prime := prime5, exponent := 2 } : Setup 0)
+    [x, x]).isNone
+
+/- Repeated images have no partial-fraction tuple over the residue field. -/
+#guard rejectsRepeated
+
+def rejectsDegreeDrop : Bool :=
+  (witnessOf?
+    ({ main := 0, point := point0, prime := prime5, exponent := 2 } : Setup 0)
+    [DensePoly.ofCoeffs #[1, 5], xPlusOne]).isNone
+
+/- A leading coefficient killed by the residue prime is rejected before the
+extended-gcd route can silently change degrees. -/
+#guard rejectsDegreeDrop
+
+end Hex.MvHensel.UniTests

--- a/HexMvPoly/Query.lean
+++ b/HexMvPoly/Query.lean
@@ -100,7 +100,7 @@ theorem vars_eq [Zero R] (p : MvPoly n R cmp) :
   simp
 
 /-- Greatest supported term in the polynomial's monomial order. -/
-def leadingTerm [Zero R] [IsMonomialOrder cmp]
+@[expose] def leadingTerm [Zero R] [IsMonomialOrder cmp]
     (p : MvPoly n R cmp) : Option (Mono n × R) :=
   p.maxTerm?
 

--- a/HexPolyZ.lean
+++ b/HexPolyZ.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexPolyZ.IntegerPolynomial
+public import HexPolyZ.ExactDivision
 public import HexPolyZ.Kronecker
 public import HexPolyZ.Rational
 public import HexPolyZ.Decomposition

--- a/HexPolyZ/ExactDivision.lean
+++ b/HexPolyZ/ExactDivision.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ.IntegerPolynomial
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+Checked exact division for integer dense polynomials.
+
+This is the shared primitive used by integer-polynomial gcd and by
+Berlekamp--Zassenhaus recombination.  The latter adds its own policy about
+rejecting unit candidates; exact division itself accepts every nonzero exact
+divisor, including units.
+-/
+
+namespace Hex.ZPoly
+
+/-- The exact quotient `f / g`, or `none` when `g = 0` or the executable
+integer-polynomial division does not reconstruct `f` exactly. -/
+@[expose]
+def divExact? (f g : ZPoly) : Option ZPoly :=
+  if g.isZero then
+    none
+  else
+    let qr := DensePoly.divMod f g
+    if qr.2 = 0 && qr.1 * g == f then
+      some qr.1
+    else
+      none
+
+/-- Division by the zero polynomial is always rejected. -/
+@[simp] theorem divExact?_zero_right (f : ZPoly) : divExact? f 0 = none := by
+  have hz : (0 : ZPoly).isZero = true := by rfl
+  unfold divExact?
+  rw [hz]
+  simp
+
+/-- A successful exact division carries the checked multiplication witness. -/
+theorem divExact?_product
+    {f g q : ZPoly} (h : divExact? f g = some q) : q * g = f := by
+  unfold divExact? at h
+  split at h
+  · contradiction
+  · generalize hqr : DensePoly.divMod f g = qr at h
+    cases qr with
+    | mk quotient remainder =>
+        simp only at h
+        split at h
+        · rename_i hcheck
+          cases h
+          exact (by
+            simpa [Bool.and_eq_true, beq_iff_eq] using hcheck :
+              remainder = 0 ∧ q * g = f).2
+        · contradiction
+
+/-- Long division returns the witnessed quotient for every exact multiple by
+a nonzero integer polynomial. -/
+theorem divMod_eq_mul_of_ne_zero
+    (f g q : ZPoly) (hg : g ≠ 0) (hmul : q * g = f) :
+    DensePoly.divMod f g = (q, 0) := by
+  have hgpos : 0 < g.size := by
+    rcases Nat.lt_or_ge 0 g.size with hpos | hzero
+    · exact hpos
+    · exfalso
+      apply hg
+      exact (DensePoly.size_eq_zero_iff g).mp (Nat.eq_zero_of_le_zero hzero)
+  have hlc_ne : g.leadingCoeff ≠ 0 :=
+    DensePoly.leadingCoeff_ne_zero_of_pos_size g hgpos
+  apply DensePoly.divMod_eq_of_polynomial_mul f g q hg
+  · intro a
+    exact Int.mul_ediv_cancel a hlc_ne
+  · intro a ha
+    exact Int.mul_ne_zero ha hlc_ne
+  · exact hmul
+
+/-- Exact division succeeds exactly on a supplied multiplication witness when
+the divisor is nonzero. -/
+theorem divExact?_eq {f g q : ZPoly} (hg : g ≠ 0) :
+    divExact? f g = some q ↔ f = q * g := by
+  constructor
+  · intro h
+    exact (divExact?_product h).symm
+  · intro hmul
+    have hgpos : 0 < g.size := by
+      rcases Nat.lt_or_ge 0 g.size with hpos | hzero
+      · exact hpos
+      · exfalso
+        apply hg
+        exact (DensePoly.size_eq_zero_iff g).mp (Nat.eq_zero_of_le_zero hzero)
+    have hisZero : g.isZero = false := by
+      unfold DensePoly.isZero
+      have hsize : g.coeffs.size ≠ 0 := by
+        change g.size ≠ 0
+        exact Nat.ne_of_gt hgpos
+      simpa [Array.isEmpty_iff_size_eq_zero] using hsize
+    have hdiv : DensePoly.divMod f g = (q, 0) :=
+      divMod_eq_mul_of_ne_zero f g q hg hmul.symm
+    unfold divExact?
+    rw [hisZero, hdiv]
+    simp [hmul]
+
+/-- Every nonzero divisor is found by the executable exact-division check. -/
+theorem divExact?_isSome_of_dvd {f g : ZPoly} (hg : g ≠ 0) :
+    g ∣ f → (divExact? f g).isSome := by
+  rintro ⟨q, hq⟩
+  have hmul : f = q * g := by
+    rw [DensePoly.mul_comm_poly]
+    exact hq
+  have hsome : divExact? f g = some q := (divExact?_eq hg).2 hmul
+  rw [hsome]
+  rfl
+
+/-! Kernel regressions cover exact, inexact, unit, negative-unit, and
+zero-divisor behavior. -/
+
+example :
+    divExact? (DensePoly.ofList [2, 4, 2]) (DensePoly.ofList [1, 1]) =
+      some (DensePoly.ofList [2, 2]) := by
+  decide
+
+example :
+    divExact? (DensePoly.ofList [2, 4, 2]) (DensePoly.ofList [1, 2]) = none := by
+  decide
+
+example (f : ZPoly) : divExact? f 1 = some f := by
+  exact (divExact?_eq (by decide)).2 (by rw [DensePoly.mul_one_right_poly])
+
+example :
+    divExact? (DensePoly.ofList [2, -4]) (DensePoly.C (-1)) =
+      some (DensePoly.ofList [-2, 4]) := by
+  decide
+
+example (f : ZPoly) : divExact? f 0 = none := divExact?_zero_right f
+
+end Hex.ZPoly

--- a/HexPolyZGcd.lean
+++ b/HexPolyZGcd.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcd.Divide
+public import HexPolyZGcd.Cert
+public import HexPolyZGcd.Fast
+public import HexPolyZGcd.Brown
+public import HexPolyZGcd.Heu
+public import HexPolyZGcd.Prs
+public import HexPolyZGcd.Gcd
+public import HexPolyZGcd.Maximal
+public import HexPolyZGcd.SquareFree
+public import HexPolyZGcd.Kernel
+
+public section
+
+/-!
+Checked gcd and exact-divisibility infrastructure for integer dense
+polynomials.
+-/

--- a/HexPolyZGcd/Brown.lean
+++ b/HexPolyZGcd/Brown.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexModular.Crt
+public meta import HexPolyZGcd.Fast
+public import HexModular.Crt
+public import HexPolyZGcd.Fast
+
+public section
+
+/-!
+Brown's multi-prime gcd producer for `Int[x]`.
+
+The state records one scalar CRT accumulator per coefficient because the image
+degree is discovered at runtime.  Bad primes never enter the state.  Larger
+image degrees are discarded as unlucky, while a smaller degree restarts the
+whole accumulation.  Each reconstruction is primitive-normalized, has the
+integer content restored, and is offered to `checkedCandidate?`.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- One admissible, gamma-scaled modular gcd image. -/
+structure BrownImage where
+  degree : Nat
+  coeffs : Array Int
+
+/-- A running coefficientwise CRT accumulation at the smallest image degree
+seen so far. -/
+structure BrownState where
+  degree : Nat
+  coeffs : Array Modular.Crt
+
+/-- Outcomes needed both by the loop and by route-level tests. -/
+inductive BrownOffer where
+  /-- The prime destroys an input degree or the gamma scaling. -/
+  | bad
+  /-- The image gcd degree is larger than the running minimum. -/
+  | unlucky
+  /-- A smaller image degree discarded all previous CRT data. -/
+  | restarted (state : BrownState)
+  /-- An equal-degree image was folded into the current CRT data. -/
+  | accumulated (state : BrownState)
+
+/-- Compute the monic image gcd and restore the integer leading-coefficient
+multiple `gamma`.  Degree preservation checks reject bad primes before the
+image can affect reconstruction. -/
+def brownImage? (f h : ZPoly) (p : ZMod64.Prime) : Option BrownImage :=
+  letI : ZMod64.Bounds p.m := p.bounds
+  letI : ZMod64.PrimeModulus p.m := ZMod64.primeModulusOfPrime p.prime
+  let f0 := primitivePart f
+  let h0 := primitivePart h
+  let fp := reduceModP p.m f0
+  let hp := reduceModP p.m h0
+  if fp.size != f0.size || hp.size != h0.size then
+    none
+  else
+    let raw := DensePoly.gcd fp hp
+    if raw.isZero then
+      none
+    else
+      let unit := raw.leadingCoeff
+      if unit == 0 then
+        none
+      else
+        let monic := DensePoly.scale unit⁻¹ raw
+        let gamma : Int := Int.ofNat (Int.gcd f0.leadingCoeff h0.leadingCoeff)
+        let gammaP := ZMod64.intCast p.m gamma
+        if gammaP == 0 then
+          none
+        else
+          let scaled := DensePoly.scale gammaP monic
+          some
+            { degree := scaled.size - 1
+              coeffs := scaled.toArray.map fun c => Int.ofNat c.toNat }
+
+/-- Push corresponding scalar CRT entries, failing atomically on a length
+mismatch or on any non-coprime modulus. -/
+private def pushCoeffs : List Modular.Crt → List Int → Nat →
+    Option (List Modular.Crt)
+  | [], [], _ => some []
+  | c :: cs, r :: rs, p => do
+      let next ← c.push r p
+      let rest ← pushCoeffs cs rs p
+      pure (next :: rest)
+  | _, _, _ => none
+
+/-- Start a CRT state from one accepted image. -/
+private def BrownState.start (image : BrownImage) (p : Nat) : Option BrownState := do
+  let coeffs ← image.coeffs.toList.mapM fun r => Modular.Crt.init.push r p
+  pure { degree := image.degree, coeffs := coeffs.toArray }
+
+/-- Fold an equal-degree image into an existing state. -/
+private def BrownState.push (state : BrownState) (image : BrownImage)
+    (p : Nat) : Option BrownState := do
+  if image.degree != state.degree then none else pure ()
+  let coeffs ← pushCoeffs state.coeffs.toList image.coeffs.toList p
+  pure { degree := state.degree, coeffs := coeffs.toArray }
+
+/-- Offer one prime to a possibly empty Brown state, applying the exact
+bad/unlucky/restart rules before any CRT mutation. -/
+def brownOffer (f h : ZPoly) (state : Option BrownState)
+    (p : ZMod64.Prime) : BrownOffer :=
+  match brownImage? f h p with
+  | none => .bad
+  | some image =>
+      match state with
+      | none =>
+          match BrownState.start image p.m with
+          | some next => .accumulated next
+          | none => .bad
+      | some old =>
+          if image.degree > old.degree then
+            .unlucky
+          else if image.degree < old.degree then
+            match BrownState.start image p.m with
+            | some next => .restarted next
+            | none => .bad
+          else
+            match old.push image p.m with
+            | some next => .accumulated next
+            | none => .bad
+
+/-- Reconstruct and normalize the current integer gcd candidate. -/
+def BrownState.candidate (state : BrownState) (f h : ZPoly) : ZPoly :=
+  let raw : ZPoly := DensePoly.ofCoeffs (state.coeffs.map (fun c => c.value))
+  let primitive := normalizePrimitiveSign (primitivePart raw)
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- Fuel-bounded Brown loop.  Every successfully accumulated or restarted
+state is offered immediately to the exact certificate checker. -/
+private def brownLoop (f h : ZPoly) (supply : Array ZMod64.Prime)
+    (index fuel : Nat) (state : Option BrownState) : Option GcdCert :=
+  if fuel = 0 then
+    none
+  else if hi : index < supply.size then
+    let p := supply[index]
+    match brownOffer f h state p with
+    | .bad | .unlucky => brownLoop f h supply (index + 1) (fuel - 1) state
+    | .restarted next | .accumulated next =>
+        match checkedCandidate? f h (next.candidate f h) with
+        | some cert => some cert
+        | none => brownLoop f h supply (index + 1) (fuel - 1) (some next)
+  else
+    none
+termination_by fuel
+decreasing_by all_goals omega
+
+/-- Brown's modular gcd route over the first 55 primes.  Failure is benign:
+the dispatcher continues to its deterministic checked fallback. -/
+def brownCert? (f h : ZPoly) : Option GcdCert :=
+  let supply := (ZMod64.primesBelow 257 55).toList.reverse.toArray
+  brownLoop f h supply 0 supply.size none
+
+/-! Route-level executable pins for the three easy-to-miss Brown rules. -/
+
+private def primeAt? (p : Nat) : Option ZMod64.Prime :=
+  (ZMod64.primesBelow p 1)[0]?
+
+-- A prime dividing both leading coefficients is bad: both degrees drop.
+#guard
+  let f : ZPoly := DensePoly.ofList [1, 2]
+  let h : ZPoly := DensePoly.ofList [3, 2]
+  match primeAt? 2 with
+  | some p => (brownImage? f h p).isNone
+  | none => false
+
+-- At `p = 2`, `x` and `x+2` have an unlucky degree-one image gcd.  The
+-- degree-zero image at `p = 3` must restart the state.
+#guard
+  let f : ZPoly := DensePoly.ofList [0, 1]
+  let h : ZPoly := DensePoly.ofList [2, 1]
+  match primeAt? 2, primeAt? 3 with
+  | some p2, some p3 =>
+      match brownOffer f h none p2 with
+      | .accumulated state =>
+          match brownOffer f h (some state) p3 with
+          | .restarted _ => true
+          | _ => false
+      | _ => false
+  | _, _ => false
+
+-- Gamma scaling restores the nonmonic leading coefficient `2` to the image
+-- gcd `2*x+1` rather than reconstructing its monic associate.
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 2]
+  let f := common * DensePoly.ofList [1, 1]
+  let h := common * DensePoly.ofList [2, 1]
+  match primeAt? 5 with
+  | some p =>
+      match brownImage? f h p with
+      | some image => image.coeffs == #[1, 2]
+      | none => false
+  | none => false
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArith.Modulus
+public import HexPolyFp
+public import HexPolyZGcd.Divide
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+Checked certificates for integer-polynomial gcd candidates.
+
+Candidate production is deliberately kept out of this file.  The checker only
+replays two exact product identities, normalization, coprime integer contents,
+and one of two independently checkable coprimality witnesses.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- Coefficientwise reduction of an integer polynomial into a bundled
+word-sized residue ring.  This copy is local to the gcd checker so its kernel
+closure does not depend on the Hensel implementation. -/
+@[expose]
+def reduceModP (p : Nat) [ZMod64.Bounds p] (f : ZPoly) : FpPoly p :=
+  DensePoly.ofList <|
+    (List.range f.size).map (fun i => ZMod64.intCast p (f.coeff i))
+
+/-- Evidence that the two cofactors have no common nonunit factor. -/
+inductive CoprimeWitness
+  /-- A degree-preserving reduction and a Bezout identity over a prime field. -/
+  | modular (p : ZMod64.Prime)
+      (alpha beta : @FpPoly p.m p.bounds)
+  /-- An integral polynomial combination equal to a nonzero constant. -/
+  | constant (u v : ZPoly) (k : Int)
+
+/-- A gcd candidate, its two exact cofactors, and checked coprimality data. -/
+structure GcdCert where
+  gcd : ZPoly
+  cofL : ZPoly
+  cofR : ZPoly
+  coprime : CoprimeWitness
+
+/-- The normalization convention for integer gcds.  Zero is admitted for the
+unique degenerate answer `gcd 0 0`; every nonzero result has positive leading
+coefficient and positive content. -/
+@[expose]
+def NormalizedGcd (g : ZPoly) : Bool :=
+  g == 0 ||
+    (decide (0 < DensePoly.leadingCoeff g) && decide (0 < content g))
+
+/-- Replay the coprimality half of a gcd certificate. -/
+@[expose]
+def checkCoprime (f h : ZPoly) : CoprimeWitness → Bool
+  | .constant u v k =>
+      decide (k ≠ 0) && (u * f + v * h == DensePoly.C k)
+  | .modular p alpha beta =>
+      letI : ZMod64.Bounds p.m := p.bounds
+      letI : ZMod64.PrimeModulus p.m := ZMod64.primeModulusOfPrime p.prime
+      let fp := reduceModP p.m f
+      let hp := reduceModP p.m h
+      decide (fp.size = f.size) &&
+        decide (hp.size = h.size) &&
+        (alpha * fp + beta * hp == 1)
+
+/-- Check a gcd certificate.  Every producer, including deterministic
+fallbacks, must pass through this function before its candidate is exposed. -/
+@[expose]
+def checkGcd (f h : ZPoly) (c : GcdCert) : Bool :=
+  (c.gcd * c.cofL == f) &&
+    (c.gcd * c.cofR == h) &&
+    NormalizedGcd c.gcd &&
+    decide (Int.gcd (content c.cofL) (content c.cofR) = 1) &&
+    checkCoprime c.cofL c.cofR c.coprime
+
+/-- The cofactor identities together with absence of a common nonunit
+cofactor. -/
+def CoprimeCofactors (f h g : ZPoly) : Prop :=
+  ∃ f' h', f = g * f' ∧ h = g * h' ∧
+    ∀ d : ZPoly, d ∣ f' → d ∣ h' → IsUnit d
+
+/-- A successful checker establishes both exact cofactor identities and
+coprimality of the cofactors. -/
+theorem checkGcd_sound {f h : ZPoly} {c : GcdCert}
+    (hc : checkGcd f h c = true) :
+    f = c.gcd * c.cofL ∧ h = c.gcd * c.cofR ∧
+      ∀ d : ZPoly, d ∣ c.cofL → d ∣ c.cofR → IsUnit d := by
+  sorry
+
+/-- Checker soundness packaged in the public cofactor predicate. -/
+theorem coprimeCofactors_of_checkGcd {f h : ZPoly} {c : GcdCert}
+    (hc : checkGcd f h c = true) :
+    CoprimeCofactors f h c.gcd := by
+  rcases checkGcd_sound hc with ⟨hf, hh, hcop⟩
+  exact ⟨c.cofL, c.cofR, hf, hh, hcop⟩
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Divide.lean
+++ b/HexPolyZGcd/Divide.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ.ExactDivision
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+Decidable divisibility for integer dense polynomials, backed by the shared
+checked exact-division primitive in `hex-poly-z`.
+-/
+
+namespace Hex.ZPoly
+
+/-- A polynomial is divisible by zero exactly when it is zero. -/
+theorem zero_dvd_iff (f : ZPoly) : (0 : ZPoly) ∣ f ↔ f = 0 := by
+  constructor
+  · rintro ⟨q, hq⟩
+    grind
+  · intro hf
+    subst f
+    exact ⟨0, by grind⟩
+
+/-- Integer-polynomial divisibility is decided by checked exact division.
+The zero-divisor case is handled separately so `0 ∣ 0` remains true even
+though `divExact? f 0` deliberately returns `none`. -/
+instance (f g : ZPoly) : Decidable (g ∣ f) :=
+  if hg : g = 0 then
+    if hf : f = 0 then
+      isTrue (by subst g; exact (zero_dvd_iff f).2 hf)
+    else
+      isFalse (by subst g; exact fun h => hf ((zero_dvd_iff f).1 h))
+  else
+    match hq : divExact? f g with
+    | some q =>
+        isTrue ⟨q, by
+          rw [DensePoly.mul_comm_poly]
+          exact (divExact?_product hq).symm⟩
+    | none =>
+        isFalse fun hd => by
+          have hsome := divExact?_isSome_of_dvd hg hd
+          rw [hq] at hsome
+          contradiction
+
+end Hex.ZPoly

--- a/HexPolyZGcd/Fast.lean
+++ b/HexPolyZGcd/Fast.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcd.Cert
+
+public section
+
+/-!
+The one-image coprimality route.
+
+This route is intentionally asymmetric: a modular gcd of positive degree says
+nothing over the integers, while a checked modular Bezout identity proves the
+integer cofactors coprime and can return immediately.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- Try to construct a degree-preserving modular Bezout witness at one bundled
+prime.  The final call to `checkCoprime` keeps field normalization and all
+dependent-instance plumbing outside the trusted result. -/
+def modularWitnessAt (f h : ZPoly) (p : ZMod64.Prime) :
+    Option CoprimeWitness :=
+  letI : ZMod64.Bounds p.m := p.bounds
+  letI : ZMod64.PrimeModulus p.m := ZMod64.primeModulusOfPrime p.prime
+  let fp := reduceModP p.m f
+  let hp := reduceModP p.m h
+  if fp.size != f.size || hp.size != h.size then
+    none
+  else
+    let xg := DensePoly.xgcd fp hp
+    if xg.gcd.size != 1 then
+      none
+    else
+      let scalar := xg.gcd.coeff 0
+      if scalar == 0 then
+        none
+      else
+        let alpha := DensePoly.scale scalar⁻¹ xg.left
+        let beta := DensePoly.scale scalar⁻¹ xg.right
+        let witness := CoprimeWitness.modular p alpha beta
+        if checkCoprime f h witness then some witness else none
+
+/-- Search a finite prime supply for the first usable modular witness. -/
+private def modularWitness.go (f h : ZPoly) (supply : Array ZMod64.Prime)
+    (index fuel : Nat) : Option CoprimeWitness :=
+  if fuel = 0 then
+    none
+  else if hi : index < supply.size then
+    match modularWitnessAt f h supply[index] with
+    | some witness => some witness
+    | none => modularWitness.go f h supply (index + 1) (fuel - 1)
+  else
+    none
+termination_by fuel
+decreasing_by all_goals omega
+
+/-- Search the small primes in ascending order, so a replayed certificate pays
+for the cheapest available primality proof. -/
+def modularWitness (f h : ZPoly) : Option CoprimeWitness :=
+  let supply := (ZMod64.primesBelow 47 15).toList.reverse.toArray
+  modularWitness.go f h supply 0 supply.size
+
+/-- Route 1: offer `1` as the gcd and accept it only when the full checker
+validates the modular coprimality witness. -/
+def coprimeCert? (f h : ZPoly) : Option GcdCert := do
+  match modularWitness f h with
+  | none => none
+  | some witness =>
+      let candidate : GcdCert :=
+        { gcd := 1, cofL := f, cofR := h, coprime := witness }
+      if checkGcd f h candidate then some candidate else none
+
+/-- Offer an arbitrary nonzero gcd candidate to the checker.  Exact division
+builds its cofactors; a modular Bezout search supplies coprimality evidence.
+Failure at any stage rejects the candidate without exposing it. -/
+def checkedCandidate? (f h candidate : ZPoly) : Option GcdCert := do
+  if candidate == 0 then none else pure ()
+  let cofL ← divExact? f candidate
+  let cofR ← divExact? h candidate
+  let witness ← modularWitness cofL cofR
+  let cert : GcdCert := { gcd := candidate, cofL, cofR, coprime := witness }
+  if checkGcd f h cert then some cert else none
+
+/-- Every certificate returned by the coprime fast route was accepted by the
+full checker. -/
+theorem coprimeCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hc : coprimeCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold coprimeCert? at hc
+  generalize hw : modularWitness f h = witness? at hc
+  cases witness? with
+  | none => simp at hc
+  | some witness =>
+      simp only at hc
+      split at hc
+      · rename_i hcheck
+        cases hc
+        exact hcheck
+      · contradiction
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -1,0 +1,350 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexPolyZGcd.Brown
+public meta import HexPolyZGcd.Heu
+public meta import HexPolyZGcd.Prs
+public import HexPolyZGcd.Brown
+public import HexPolyZGcd.Heu
+public import HexPolyZGcd.Prs
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+The usable integer-polynomial gcd API.
+
+Fast candidates are replayed by one checker and fall through to the total
+extended-subresultant route.  The earlier rational implementation remains in
+this file as an independently named reference implementation and test oracle;
+it is not part of public dispatch.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- The canonical integer candidate obtained from the rational gcd, with the
+common integer content restored. -/
+def rationalGcdCandidate (f h : ZPoly) : ZPoly :=
+  let primitive :=
+    ratPolyPrimitivePart (DensePoly.gcd (toRatPoly f) (toRatPoly h))
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- The candidate is nonzero unless both inputs are zero. -/
+theorem rationalGcdCandidate_ne_zero {f h : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0) :
+    rationalGcdCandidate f h ≠ 0 := by
+  sorry
+
+/-- The rational gcd candidate exactly divides both integer inputs. -/
+theorem rationalGcdCandidate_divisions {f h : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0) :
+    (divExact? f (rationalGcdCandidate f h)).isSome = true ∧
+      (divExact? h (rationalGcdCandidate f h)).isSome = true := by
+  sorry
+
+/-- Least common denominator of the stored coefficients of a rational
+polynomial. -/
+private def ratDen (f : DensePoly Rat) : Nat :=
+  f.toArray.foldl (fun d q => Nat.lcm d q.den) 1
+
+/-- Clear a rational polynomial with a denominator known to be a common
+multiple of all coefficient denominators. -/
+private def clearRat (den : Nat) (f : DensePoly Rat) : ZPoly :=
+  DensePoly.ofList <|
+    (List.range f.size).map fun i =>
+      let q := f.coeff i
+      q.num * Int.ofNat (den / q.den)
+
+/-- Clear the extended rational gcd identity into an integral combination.
+For coprime cofactors the rational gcd is a nonzero constant, so the returned
+`k` is nonzero and the checker verifies the identity directly. -/
+def rationalCoprimeWitness (f h : ZPoly) : CoprimeWitness :=
+  let xg := DensePoly.xgcd (toRatPoly f) (toRatPoly h)
+  let scalar := xg.gcd.coeff 0
+  let den := Nat.lcm (ratDen xg.left) (Nat.lcm (ratDen xg.right) scalar.den)
+  let u := clearRat den xg.left
+  let v := clearRat den xg.right
+  let k := scalar.num * Int.ofNat (den / scalar.den)
+  .constant u v k
+
+/-- The canonical certificate for the doubly-zero input.  Unit cofactors keep
+the coprimality obligation meaningful even though the gcd itself is zero. -/
+def zeroGcdCert : GcdCert :=
+  { gcd := 0
+    cofL := 1
+    cofR := 1
+    coprime := .constant 1 0 1 }
+
+/-- Deterministic rational fallback certificate.
+
+The cofactors are the concrete long-division quotients.  Their exactness is
+part of `rationalGcdCert_checks`, but no proof is used to extract runtime
+data: if the rational-gcd or division implementation regresses, `checkGcd`
+reports the concrete certificate as invalid rather than extracting data from
+an impossible branch. -/
+def rationalGcdCert (f h : ZPoly) : GcdCert :=
+  if f = 0 ∧ h = 0 then
+    zeroGcdCert
+  else
+    let g := rationalGcdCandidate f h
+    let cofL := (DensePoly.divMod f g).1
+    let cofR := (DensePoly.divMod h g).1
+    { gcd := g
+      cofL
+      cofR
+      coprime := rationalCoprimeWitness cofL cofR }
+
+/-- Correctness of the deterministic rational fallback, concentrated in one
+proof obligation while the executable certificate remains fully concrete. -/
+theorem rationalGcdCert_checks (f h : ZPoly) :
+    checkGcd f h (rationalGcdCert f h) = true := by
+  sorry
+
+/-- The total deterministic fallback.  The name is retained for producer API
+compatibility; unlike the previous implementation, this definition does not
+use a theorem to manufacture data from a rejected checker branch.  Its
+checker contract is `rationalGcdCert_checks`. -/
+def checkedRationalGcdCert (f h : ZPoly) : GcdCert :=
+  rationalGcdCert f h
+
+/-- Scan the low coefficients for the exponent of the first nonzero term. -/
+private def xOrder.go (f : ZPoly) : Nat → Nat → Nat
+  | index, 0 => index
+  | index, fuel + 1 =>
+      if f.coeff index == 0 then xOrder.go f (index + 1) fuel else index
+
+/-- Largest exponent `k` such that `x^k` divides `f`; zero has order zero for
+the structural route, which handles it separately. -/
+def xOrder (f : ZPoly) : Nat :=
+  if f.isZero then 0 else xOrder.go f 0 f.size
+
+/-- The monic power `x^k`. -/
+def xPower (k : Nat) : ZPoly :=
+  DensePoly.ofList (List.replicate k 0 ++ [1])
+
+/-- Common scalar and `x`-power removed before every primitive route. -/
+structure StructuralReduction where
+  factor : ZPoly
+  left : ZPoly
+  right : ZPoly
+
+/-- Route 0: extract the common integer content and common power of `x`.
+Both divisions are explicit checked operations, so a representation or
+division regression declines instead of inventing a reduced input. -/
+def structuralReduction? (f h : ZPoly) : Option StructuralReduction := do
+  if f.isZero || h.isZero then none else pure ()
+  let commonPower := min (xOrder f) (xOrder h)
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  let factor := DensePoly.scale commonContent (xPower commonPower)
+  let left ← divExact? f factor
+  let right ← divExact? h factor
+  pure { factor, left, right }
+
+/-- Restore route 0's common factor around a certificate for the reduced
+pair.  The public checker is the only acceptance gate. -/
+def restoreStructural? (f h : ZPoly) (reduced : StructuralReduction)
+    (cert : GcdCert) : Option GcdCert :=
+  let restored : GcdCert :=
+    { gcd := normalizePrimitiveSign (reduced.factor * cert.gcd)
+      cofL := cert.cofL
+      cofR := cert.cofR
+      coprime := cert.coprime }
+  if checkGcd f h restored then some restored else none
+
+/-- Routes 1--4 on inputs after structural content and `x`-power removal. -/
+def reducedGcdCert (f h : ZPoly) : GcdCert :=
+  match coprimeCert? f h with
+  | some cert => cert
+  | none =>
+      match heuCert? f h with
+      | some cert => cert
+      | none =>
+          match brownCert? f h with
+          | some cert => cert
+          | none => prsCert f h
+
+/-- Produce a checked gcd certificate.  Route 0 runs first; rejected fast
+candidates and any failed structural restoration fall through to total,
+data-only extended-subresultant route 4. -/
+def gcdCert (f h : ZPoly) : GcdCert :=
+  if f.isZero || h.isZero then
+    prsCert f h
+  else
+    match structuralReduction? f h with
+    | none => prsCert f h
+    | some reduced =>
+        match restoreStructural? f h reduced
+            (reducedGcdCert reduced.left reduced.right) with
+        | some cert => cert
+        | none => prsCert f h
+
+/-- Every public certificate has passed the checker. -/
+theorem gcdCert_checks (f h : ZPoly) :
+    checkGcd f h (gcdCert f h) = true := by
+  sorry
+
+/-- Canonically normalized gcd of two integer polynomials. -/
+@[expose]
+def gcd (f h : ZPoly) : ZPoly :=
+  (gcdCert f h).gcd
+
+/-- Controlled unfolding lemma for the otherwise opaque producer-facing gcd
+definition. -/
+theorem gcd_eq_cert (f h : ZPoly) :
+    gcd f h = (gcdCert f h).gcd := rfl
+
+/-- Exact cofactors belonging to the checked gcd. -/
+def cofactors (f h : ZPoly) : ZPoly × ZPoly :=
+  let cert := gcdCert f h
+  (cert.cofL, cert.cofR)
+
+/-- Decide coprimality using the canonical gcd. -/
+def isCoprime (f h : ZPoly) : Bool :=
+  gcd f h == 1
+
+/-- Fold gcd over a list; the empty-list convention is zero. -/
+def gcdList (fs : List ZPoly) : ZPoly :=
+  fs.foldl gcd 0
+
+/-- Canonically normalized least common multiple. -/
+def lcm (f h : ZPoly) : ZPoly :=
+  if f.isZero || h.isZero then
+    0
+  else
+    let cert := gcdCert f h
+    normalizePrimitiveSign (cert.gcd * cert.cofL * cert.cofR)
+
+/-- Monic rational-polynomial gcd. -/
+def ratGcd (f h : DensePoly Rat) : DensePoly Rat :=
+  let fInt := clearRat (ratDen f) f
+  let hInt := clearRat (ratDen h) h
+  let g := toRatPoly (gcd fInt hInt)
+  if g.isZero then 0 else DensePoly.scale g.leadingCoeff⁻¹ g
+
+/-! Small executable pins for the degenerate contracts and content handling. -/
+
+-- Direct reference canaries.  These deliberately bypass dispatch so the
+-- retained rational implementation remains useful as an independent oracle.
+
+#guard
+  let f : ZPoly := 0
+  let h : ZPoly := 0
+  let cert := checkedRationalGcdCert f h
+  cert.gcd == 0 && checkGcd f h cert
+
+-- The degenerate direct fallback and its checker also remain reducible in the
+-- ordinary kernel while the definition is in scope.  Larger rational
+-- Euclidean searches intentionally stay outside the replay closure.
+example :
+    checkGcd (0 : ZPoly) 0 (checkedRationalGcdCert 0 0) = true := by
+  decide +kernel
+
+#guard
+  let f : ZPoly := DensePoly.ofList [2, 4, 2]
+  let h : ZPoly := 0
+  let cert := checkedRationalGcdCert f h
+  cert.gcd == f && checkGcd f h cert
+
+#guard
+  let f : ZPoly := DensePoly.ofList [0, 12]
+  let h : ZPoly := DensePoly.ofList [0, 18]
+  let cert := checkedRationalGcdCert f h
+  cert.gcd == DensePoly.ofList [0, 6] && checkGcd f h cert
+
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 1]
+  let f := common * DensePoly.ofList [2, 1]
+  let h := common * DensePoly.ofList [3, 1]
+  let cert := checkedRationalGcdCert f h
+  cert.gcd == common && checkGcd f h cert
+
+#guard gcd (0 : ZPoly) 0 == 0
+
+#guard
+  let two : ZPoly := DensePoly.C 2
+  let twoX : ZPoly := DensePoly.ofList [0, 2]
+  gcd two twoX == two
+
+#guard
+  let twelveX : ZPoly := DensePoly.ofList [0, 12]
+  let eighteenX : ZPoly := DensePoly.ofList [0, 18]
+  gcd twelveX eighteenX == DensePoly.ofList [0, 6]
+
+#guard
+  let f : ZPoly := DensePoly.ofList [0, 0, 0, 12, 12]
+  let h : ZPoly := DensePoly.ofList [0, 0, 36, 18]
+  match structuralReduction? f h with
+  | none => false
+  | some reduced =>
+      reduced.factor == DensePoly.ofList [0, 0, 6] &&
+        match restoreStructural? f h reduced
+            (prsCert reduced.left reduced.right) with
+        | some cert =>
+            cert.gcd == DensePoly.ofList [0, 0, 6] && checkGcd f h cert
+        | none => false
+
+#guard
+  let f : ZPoly := DensePoly.ofList [1, 1]
+  let h : ZPoly := DensePoly.ofList [2, 1]
+  isCoprime f h
+
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 1]
+  let f := common * DensePoly.ofList [2, 1]
+  let h := common * DensePoly.ofList [3, 1]
+  gcd f h == common && checkGcd f h (gcdCert f h)
+
+#guard
+  let common : ZPoly := DensePoly.ofList [2, 1]
+  let f := common * DensePoly.ofList [1, 2]
+  let h := common * DensePoly.ofList [1, 3]
+  gcd f h == common &&
+    checkCoprime (gcdCert f h).cofL (gcdCert f h).cofR
+      (gcdCert f h).coprime
+
+#guard
+  let f : ZPoly := DensePoly.ofList [1, 1]
+  let h : ZPoly := DensePoly.ofList [2, 1]
+  (coprimeCert? f h).isSome
+
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 1]
+  let f := common * DensePoly.ofList [2, 1]
+  let h := common * DensePoly.ofList [3, 1]
+  (coprimeCert? f h).isNone
+
+#guard
+  let twoX : ZPoly := DensePoly.ofList [0, 2]
+  let fourX : ZPoly := DensePoly.ofList [0, 4]
+  gcdList [twoX, fourX] == twoX && lcm twoX fourX == fourX
+
+#guard
+  let f : DensePoly Rat := DensePoly.ofList [1, 2]
+  let h : DensePoly Rat := DensePoly.ofList [2, 4]
+  ratGcd f h == DensePoly.ofList [1 / 2, 1]
+
+#guard
+  let common : DensePoly Rat :=
+    DensePoly.ofList [(1 : Rat) / 1000003, 1]
+  let f := common * DensePoly.ofList [(1 : Rat) / 1000033, 1]
+  let h := common * DensePoly.ofList [(1 : Rat) / 1000037, 1]
+  ratGcd f h == common
+
+#guard
+  let common : DensePoly Rat :=
+    DensePoly.ofList [-(1 : Rat) / 1000003, -1]
+  let f := common * DensePoly.ofList [(1 : Rat) / 1000033, 1]
+  let h := common * DensePoly.ofList [(1 : Rat) / 1000037, 1]
+  ratGcd f h == DensePoly.ofList [(1 : Rat) / 1000003, 1]
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Heu.lean
+++ b/HexPolyZGcd/Heu.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexModular.SymMod
+public meta import HexPolyZGcd.Fast
+public import HexModular.SymMod
+public import HexPolyZGcd.Fast
+
+public section
+
+/-!
+Checked heuristic integer-polynomial gcd candidates.
+
+Evaluation and symmetric-adic reconstruction are candidate production only.
+Accidental common factors in the evaluated cofactors are harmless because the
+result is returned exclusively through `checkedCandidate?`.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- Symmetric base-`base` digits of an integer, low digit first. -/
+private def symDigits (base : Nat) : Int → Nat → List Int
+  | _, 0 => []
+  | value, fuel + 1 =>
+      if value = 0 then
+        []
+      else
+        let digit := Modular.symMod value base
+        digit :: symDigits base ((value - digit) / Int.ofNat base) fuel
+
+/-- Reconstruct a polynomial from symmetric base digits. -/
+def heuReconstruct (value : Int) (base degreeBound : Nat) : ZPoly :=
+  if base ≤ 1 then
+    0
+  else
+    DensePoly.ofList (symDigits base value (degreeBound + 2))
+
+/-- One GCDHEU candidate.  Content is split before evaluation and restored
+after primitive normalization of the symmetric-adic reconstruction. -/
+def heuCandidateAt (f h : ZPoly) (base : Nat) : ZPoly :=
+  let f0 := primitivePart f
+  let h0 := primitivePart h
+  let fv := DensePoly.eval f0 (Int.ofNat base)
+  let hv := DensePoly.eval h0 (Int.ofNat base)
+  let value : Int := Int.ofNat (Int.gcd fv hv)
+  let degreeBound := min f0.size h0.size
+  let primitive := normalizePrimitiveSign (primitivePart (heuReconstruct value base degreeBound))
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- Maximum absolute input coefficient. -/
+private def coeffNorm (f : ZPoly) : Nat :=
+  f.toArray.foldl (fun n c => max n c.natAbs) 0
+
+/-- A positive estimate of the evaluated integer's bit size. -/
+private def projectedBits (f h : ZPoly) (base : Nat) : Nat :=
+  let degree := max f.size h.size
+  let coeffBits := Nat.log2 (max 2 (max (coeffNorm f) (coeffNorm h))) + 1
+  let baseBits := Nat.log2 (max 2 base) + 1
+  max 1 (coeffBits + degree * baseBits)
+
+/-- Retry with growing bases until the projected bit-size budget is exhausted.
+The budget, rather than a fixed retry count, controls work as evaluations grow.
+-/
+private def heuLoop (f h : ZPoly) (base remainingBits : Nat) : Option GcdCert :=
+  let cost := projectedBits f h base
+  if cost > remainingBits then
+    none
+  else
+    match checkedCandidate? f h (heuCandidateAt f h base) with
+    | some cert => some cert
+    | none => heuLoop f h (2 * base + 1) (remainingBits - cost)
+termination_by remainingBits
+decreasing_by
+  have hcostOne : 1 ≤ projectedBits f h base := by
+    unfold projectedBits
+    exact Nat.le_max_left 1 _
+  omega
+
+/-- Checked heuristic route with a 4096-bit projected evaluation budget. -/
+def heuCert? (f h : ZPoly) : Option GcdCert :=
+  let norm := max (coeffNorm f) (coeffNorm h)
+  let base := max 3 (2 * norm + 1)
+  heuLoop f h base 4096
+
+/-! Route-level pins: one genuine hit and one accidental evaluated factor. -/
+
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 1]
+  let f := common * DensePoly.ofList [2, 1]
+  let h := common * DensePoly.ofList [3, 1]
+  (checkedCandidate? f h (heuCandidateAt f h 101)).isSome
+
+#guard
+  let f : ZPoly := DensePoly.ofList [0, 1]
+  let h : ZPoly := DensePoly.ofList [5, 1]
+  -- Both evaluations at `5` share `5`, reconstructing the false candidate
+  -- `x`; exact trial division must reject it.
+  (checkedCandidate? f h (heuCandidateAt f h 5)).isNone
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Kernel.lean
+++ b/HexPolyZGcd/Kernel.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcd.Cert
+
+public section
+
+/-!
+Ordinary-kernel canaries for the certificate replay closure.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+private def kernelG : ZPoly := DensePoly.ofList [1, 1]
+private def kernelL : ZPoly := DensePoly.ofList [2, 1]
+private def kernelR : ZPoly := DensePoly.ofList [3, 1]
+private def kernelF : ZPoly := kernelG * kernelL
+private def kernelH : ZPoly := kernelG * kernelR
+
+private def kernelCert : GcdCert :=
+  { gcd := kernelG
+    cofL := kernelL
+    cofR := kernelR
+    coprime := .constant (-1) 1 1 }
+
+private theorem kernelCert_accepts :
+    checkGcd kernelF kernelH kernelCert = true := by
+  decide +kernel
+
+private theorem corruptGcd_rejected :
+    checkGcd kernelF kernelH { kernelCert with gcd := 1 } = false := by
+  decide +kernel
+
+private theorem zeroConstant_rejected :
+    checkGcd kernelF kernelH
+      { kernelCert with coprime := .constant (-1) 1 0 } = false := by
+  decide +kernel
+
+private theorem kernelBoundsTwo : ZMod64.Bounds 2 := by
+  constructor <;> decide
+
+private theorem kernelPrimeTwo : Hex.Nat.Prime 2 := by
+  apply Hex.Nat.isPrimeTrial_isPrime
+  decide
+
+private def kernelP2 : ZMod64.Prime :=
+  { m := 2, bounds := kernelBoundsTwo, prime := kernelPrimeTwo }
+
+private def kernelModG : ZPoly := DensePoly.ofList [1, 1]
+private def kernelModL : ZPoly := DensePoly.ofList [0, 1]
+private def kernelModR : ZPoly := DensePoly.ofList [1, 1]
+private def kernelModF : ZPoly := kernelModG * kernelModL
+private def kernelModH : ZPoly := kernelModG * kernelModR
+
+private def kernelModCert : GcdCert :=
+  let p := kernelP2
+  letI : ZMod64.Bounds p.m := p.bounds
+  { gcd := kernelModG
+    cofL := kernelModL
+    cofR := kernelModR
+    coprime := .modular p 1 1 }
+
+/-- The modular constructor also stays within the ordinary-kernel replay
+closure at the smallest prime. -/
+private theorem kernelModCert_accepts :
+    checkGcd kernelModF kernelModH kernelModCert = true := by
+  decide +kernel
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Maximal.lean
+++ b/HexPolyZGcd/Maximal.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcd.Gcd
+public import HexPolyZ.Decomposition
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+Gauss descent from coprime cofactors to gcd maximality.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- In one variable over the integers, exact coprime cofactors make their
+common factor maximal.  The proof rationalizes a primitive part of `d`, uses
+the field gcd laws over `Rat[x]`, and descends with
+`dvd_of_toRatPoly_dvd_of_primitive`. -/
+theorem dvd_gcd_of_coprimeCofactors {f h g : ZPoly}
+    (hc : CoprimeCofactors f h g) (d : ZPoly)
+    (hf : d ∣ f) (hh : d ∣ h) : d ∣ g := by
+  sorry
+
+/-- The public checked certificate packages coprime cofactors. -/
+theorem gcdCert_coprimeCofactors (f h : ZPoly) :
+    CoprimeCofactors f h (gcd f h) := by
+  let cert := gcdCert f h
+  have hcheck := gcdCert_checks f h
+  have hcop := coprimeCofactors_of_checkGcd hcheck
+  rw [gcd_eq_cert]
+  exact hcop
+
+/-- The canonical gcd divides the left input. -/
+theorem gcd_dvd_left (f h : ZPoly) : gcd f h ∣ f := by
+  let cert := gcdCert f h
+  have hcheck := gcdCert_checks f h
+  rcases checkGcd_sound hcheck with ⟨hf, _, _⟩
+  refine ⟨cert.cofL, ?_⟩
+  rw [gcd_eq_cert]
+  exact hf
+
+/-- The canonical gcd divides the right input. -/
+theorem gcd_dvd_right (f h : ZPoly) : gcd f h ∣ h := by
+  let cert := gcdCert f h
+  have hcheck := gcdCert_checks f h
+  rcases checkGcd_sound hcheck with ⟨_, hh, _⟩
+  refine ⟨cert.cofR, ?_⟩
+  rw [gcd_eq_cert]
+  exact hh
+
+/-- Every common divisor divides the canonical gcd. -/
+theorem dvd_gcd (d f h : ZPoly) (hf : d ∣ f) (hh : d ∣ h) :
+    d ∣ gcd f h :=
+  dvd_gcd_of_coprimeCofactors (gcdCert_coprimeCofactors f h) d hf hh
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/Prs.lean
+++ b/HexPolyZGcd/Prs.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexResultant.SubresultantExt
+public meta import HexPolyZGcd.Fast
+public import HexResultant.SubresultantExt
+public import HexPolyZGcd.Fast
+
+public section
+
+/-!
+Deterministic subresultant gcd candidates and constant witnesses.
+
+The terminal polynomial supplies the primitive gcd candidate.  A second
+extended chain on its exact cofactors supplies the nonzero constant Bezout
+identity required by `CoprimeWitness.constant`.  Both pieces are replayed by
+`checkGcd`, so Brown scaling conventions and extended-chain bookkeeping remain
+outside the trusted result.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- The first caller-order-sensitive row of the extended chain.  This is a
+genuine Bézout row even when one input is zero; it also gives a data-level
+initializer from which `prsTerminal` can fold a known-nonempty route without
+an option projection or a dummy default. -/
+def prsInitial (f h : ZPoly) : DensePoly.SubresultantExt.Entry Int :=
+  if f.isZero then (0, 1, h)
+  else if h.isZero then (1, 0, f)
+  else if f.size < h.size then (0, 1, h)
+  else (1, 0, f)
+
+/-- Last extended-subresultant row, computed as a fold from the actual first
+row.  The doubly-zero input is handled before this helper is used by
+`prsCert`; on every other input `prsInitial` is exactly the chain's first row.
+-/
+def prsTerminal (f h : ZPoly) : DensePoly.SubresultantExt.Entry Int :=
+  (DensePoly.subresultantChainExt f h).foldl (fun _ entry => entry)
+    (prsInitial f h)
+
+/-- Primitive-normalized PRS gcd candidate with common integer content
+restored. -/
+def prsCandidate (f h : ZPoly) : ZPoly :=
+  let terminal := prsTerminal (primitivePart f) (primitivePart h)
+  let primitive := normalizePrimitiveSign (primitivePart terminal.2.2)
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- Extract and replay a constant Bezout identity from the terminal extended
+chain of two candidate cofactors. -/
+def prsCoprimeWitness (f h : ZPoly) : CoprimeWitness :=
+  let terminal := prsTerminal f h
+  let k := terminal.2.2.coeff 0
+  CoprimeWitness.constant terminal.1 terminal.2.1 k
+
+/-- Route 4: a total, deterministic extended-subresultant certificate.  The
+only special case is the mathematically degenerate pair `(0, 0)`.  Every
+other field is computed directly from the Brown chain and ordinary long
+division; correctness is the separate theorem `prsCert_checks` and no proof
+is inspected to manufacture runtime data. -/
+def prsCert (f h : ZPoly) : GcdCert :=
+  if f.isZero && h.isZero then
+    { gcd := 0
+      cofL := 1
+      cofR := 1
+      coprime := .constant 1 0 1 }
+  else
+    let candidate := prsCandidate f h
+    let cofL := (DensePoly.divMod f candidate).1
+    let cofR := (DensePoly.divMod h candidate).1
+    { gcd := candidate
+      cofL
+      cofR
+      coprime := prsCoprimeWitness cofL cofR }
+
+/-- Completeness of the deterministic extended-subresultant fallback. -/
+theorem prsCert_checks (f h : ZPoly) : checkGcd f h (prsCert f h) = true := by
+  sorry
+
+/-- Checked optional view retained for route-level diagnostics.  Public
+dispatch uses total `prsCert` directly. -/
+def prsCert? (f h : ZPoly) : Option GcdCert :=
+  let cert := prsCert f h
+  if checkGcd f h cert then some cert else none
+
+/-! Executable pin for the extended-chain route, including rationally
+nonmonic cofactors. -/
+
+#guard
+  let common : ZPoly := DensePoly.ofList [2, 1]
+  let f := common * DensePoly.ofList [1, 2]
+  let h := common * DensePoly.ofList [1, 3]
+  let cert := prsCert f h
+  cert.gcd == common && checkGcd f h cert
+
+#guard checkGcd (0 : ZPoly) 0 (prsCert 0 0)
+
+end ZPoly
+
+end Hex

--- a/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
+++ b/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
@@ -7,9 +7,9 @@ that make them fast. Mathlib-free. The companion
 `Polynomial ℤ` and supplies the decidability instances.
 
 This SPEC expands the "Modular gcd for `ℤ[x]`" bullet of the "Modular
-techniques" entry in [future-work](../future-work.md). It uses the
-reconstruction operations of [hex-modular](hex-modular.md), and it is the
-one-variable case of [hex-mv-gcd](hex-mv-gcd.md), which is written
+techniques" entry in [future-work](../../SPEC/future-work.md). It uses the
+reconstruction operations of [hex-modular](../../HexModular/SPEC/hex-modular.md), and it is the
+one-variable case of [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md), which is written
 against a different polynomial representation and should call this
 library rather than reimplement it. The relationship is set out under
 "Why this is not hex-mv-gcd at arity one".
@@ -17,7 +17,7 @@ library rather than reimplement it. The relationship is set out under
 The future-work bullet says the certificate carries "a Bézout witness
 that `f'` and `h'` are coprime". No such witness exists: `ℤ[x]` is not a
 Bézout domain, since `x` and `2` are coprime and `u·x + v·2 = 1` has no
-solution there. [hex-mv-gcd](hex-mv-gcd.md) already records the
+solution there. [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) already records the
 correction for the multivariate case. The univariate replacement is
 smaller and better than the multivariate one, and it is specified below
 under "The certificate".
@@ -57,13 +57,13 @@ route below and is much slower than the modular one.
 
 **Rational function simplification wants the cofactors.** `cancel`, the
 second piece of the `Together` and `Apart` item in
-[future-work](../future-work.md), reduces `p/q` to lowest terms. In one
+[future-work](../../SPEC/future-work.md), reduces `p/q` to lowest terms. In one
 variable over `ℚ` that is this library plus clearing denominators, and it
 is reachable long before the multivariate machinery lands.
 
 ## Why this is not hex-mv-gcd at arity one
 
-[hex-mv-gcd](hex-mv-gcd.md) computes gcds of `MvPoly n R cmp`, and at
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) computes gcds of `MvPoly n R cmp`, and at
 `n = 1` the mathematics is the same. Three things make a separate library
 right anyway.
 
@@ -84,7 +84,7 @@ correction per point, and no interpolation. What remains is a loop over
 primes.
 
 **Both checkers are unconditional; the maximality developments differ.**
-[hex-mv-gcd](hex-mv-gcd.md) now separates certificate replay from the
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) now separates certificate replay from the
 Gauss/common-factor theorem that turns coprime cofactors into gcd
 maximality. Its recursive content proof needs primitive descent at every
 arity. Here the content is an integer and the corresponding fact is
@@ -146,7 +146,7 @@ check. That is the first prerequisite below.
 The `g ≠ 0` hypothesis on `divExact?_eq` is not decoration: at `f = 0`
 and `g = 0` the right-hand side holds for every `q`, and a deterministic
 `Option` returns at most one, so the unconditional biconditional is
-false. This is the same statement [hex-mv-gcd](hex-mv-gcd.md) makes about
+false. This is the same statement [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes about
 its own `divExact?`, and the two should be provable by the same argument
 in different representations.
 
@@ -256,7 +256,7 @@ computes the image gcd, and a result other than `1` means "try another
 prime".
 
 **The prime should be the smallest usable one.**
-[hex-modular](hex-modular.md) measures the cost of a kernel-replayed
+[hex-modular](../../HexModular/SPEC/hex-modular.md) measures the cost of a kernel-replayed
 primality proof: 0.04 s at 16 bits and 6.2 s at 31 bits. A certificate
 replayed by `decide +kernel` pays that, and the `modular` case names a
 prime, so the producer tries small primes first. Most small primes work,
@@ -266,7 +266,7 @@ prime is still valid and merely more expensive to replay, and the
 
 The rule is a consequence of trial division rather than of the
 certificate design. The "Better primality" item in
-[future-work](../future-work.md) points at Pocklington certificates,
+[future-work](../../SPEC/future-work.md) points at Pocklington certificates,
 whose checker is a handful of modular exponentiations, and once one
 exists a certificate field replaces the `Hex.Nat.Prime` field here and
 the size preference goes away. The
@@ -431,7 +431,7 @@ coefficient divides. For each prime `p` in turn:
   the accumulated state and restart from this prime. Both cases occur,
   and the second is the one an implementation forgets.
 - Fold the coefficient vector into a `CrtVec` from
-  [hex-modular](hex-modular.md).
+  [hex-modular](../../HexModular/SPEC/hex-modular.md).
 - Take the primitive part of the symmetric reconstruction, multiply back
   the content gcd from route 0, and offer the result to `checkGcd`.
   Accept on success.
@@ -469,25 +469,12 @@ The proof obligation is concentrated: `checkGcd_sound` (short, and given
 above) plus completeness of route 4, which is the standard subresultant
 argument.
 
-**This route is a scheduling dependency, not a mathematical one.**
-hex-resultant is at `done_through: 1`, and its correctness theorems
-additionally require `Lean.Grind.CommRing` on the coefficient type, which
-`Int` has, and `ExactDivLaws Int`, which `HexBasic/ExactDiv.lean`
-supplies as `instExactDivLawsInt`. So the executable chain runs today and
-its theorems apply, and what is missing is the phases of hex-resultant
-rather than anything about this library. Milestone 2 below is written so
-that a working `gcd` exists before that dependency matters, by using the
-`DensePoly Rat` Euclidean route as the initial fallback and swapping in
-the subresultant chain when it is ready.
-
-The extended chain is the one genuinely new piece.
-`subresultantAux` keeps only the remainder of each `pseudoDivMod` and
-discards the quotient (`HexResultant/Subresultant.lean:609` and `:616`), so
-accumulating the transformation is a new recurrence with proofs that each
-cofactor numerator is divisible by the Brown scalar it is divided by.
-[hex-mv-gcd](hex-mv-gcd.md) specifies the same addition as
-`subresultantChainExt` for its own `splitBezout` constructor, and it
-should be written once, in hex-resultant, for both.
+The shared `subresultantChainExt` implementation is now available from
+hex-resultant. Its recurrence tracks the transformation pair through the
+pseudo-scalings and is used here and by
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md). The preserved
+`DensePoly Rat` Euclidean implementation is a named reference and test
+oracle only; it is not a dispatch fallback.
 
 ## Prerequisite changes in other libraries
 
@@ -507,11 +494,11 @@ recombination loop rather than about division.
 Bézout cofactors of the chain to produce the `constant` witness, and
 `subresultantAux` discards the quotient of each `pseudoDivMod`
 (`HexResultant/Subresultant.lean:609` and `:616`).
-[hex-mv-gcd](hex-mv-gcd.md) asks for the same addition under the same
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) asks for the same addition under the same
 name for its `splitBezout` constructor, so it should be written once.
 
 **`Modulus` and the bundled `Prime` belong in hex-mod-arith**, as
-[hex-modular](hex-modular.md) sets out. The `modular` witness names one.
+[hex-modular](../../HexModular/SPEC/hex-modular.md) sets out. The `modular` witness names one.
 
 ## Complexity
 
@@ -529,7 +516,7 @@ evaluation, or a trial division, not machine operations.
 | heuristic | one evaluation and one `Int.gcd` at `O(n·(b + log ξ))` bits | 1 integer gcd |
 | Brown | one image gcd per prime, plus one trial division per candidate | `O(B/w)` image gcds |
 | subresultant | the chain over `Int` | `O(n)` pseudo-divisions, coefficients to `O(n·b)` bits |
-| rational Euclid (today's route) | Euclid over `ℚ` | `O(n)` divisions, coefficients growing exponentially |
+| rational Euclid (reference) | Euclid over `ℚ` | `O(n)` divisions, coefficients growing exponentially |
 
 The last two rows are the comparison, and the last row is what the
 library replaces. An image gcd is `O(n²)` word operations, so Brown costs
@@ -553,14 +540,14 @@ subresultant chain are search, they never appear in a proof term, and
 they should not pay for exposure.
 
 The primality proof is the one expensive element, and the size table in
-[hex-modular](hex-modular.md) is why the producer prefers a small prime.
+[hex-modular](../../HexModular/SPEC/hex-modular.md) is why the producer prefers a small prime.
 A certificate over a 16-bit prime replays in about a fortieth of a second
 and one over a 31-bit prime in about six seconds, for a witness that is
 equally valid either way.
 
 ## Conformance
 
-Fixtures follow [SPEC/testing.md](../testing.md). A Lean driver at
+Fixtures follow [SPEC/testing.md](../../SPEC/testing.md). A Lean driver at
 `conformance/HexPolyZGcd/EmitFixtures.lean` exposed as
 `lean_exe hexpolyzgcd_emit_fixtures`, a committed snapshot at
 `conformance-fixtures/HexPolyZGcd/zgcd.jsonl`, and an oracle driver at
@@ -629,7 +616,7 @@ search for one.
 
 ## Benchmarking
 
-Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexPolyZGcd/Bench.lean`. Native and kernel: the kernel suite
 measures `checkGcd` replay at a small prime, since that is what a
 downstream certificate consumer pays.
@@ -699,7 +686,7 @@ Mathlib has no `NormalizedGCDMonoid (Polynomial ℤ)` instance in the
 elaborator's path, so the statements above are in terms of divisibility
 rather than an equation between named gcds, and an `Associated` version
 is derived where a caller has such an instance in scope. This matches
-what [hex-mv-gcd](hex-mv-gcd.md) does for the multivariate case, and for
+what [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) does for the multivariate case, and for
 the same reason.
 
 Following the project split, no theorem about `ZPoly` belongs in the
@@ -762,8 +749,8 @@ HexPolyZGcdMathlib.lean
   HexPolyZGcd:
     deps: [HexPolyZ, HexPolyFp, HexPoly, HexModular, HexModArith, HexArith, HexResultant]
     mathlib: false
-    done_through: 0
-    status: planned
+    done_through: 1
+    status: active
     phase4:
       comparators:
         - tool: FLINT fmpz_poly_gcd via python-flint
@@ -787,9 +774,9 @@ HexPolyZGcdMathlib.lean
     status: planned
 ```
 
-`HexResultant` is a dependency for route 4 only, and it is the one
-dependency at `done_through: 1`. Milestone 2 is arranged so that nothing
-before milestone 5 needs it.
+`HexResultant` supplies the extended-chain API used by route 4. The
+rational implementation remains available as the reference and
+benchmark baseline, not as a dispatch fallback.
 
 ## Open questions
 
@@ -807,7 +794,7 @@ before milestone 5 needs it.
   recompute it.** Carrying it makes the certificate self-contained and
   makes its size depend on the proof term. Recomputing it makes the
   checker run `isPrimeTrial`, priced in the table in
-  [hex-modular](hex-modular.md). The measurement that settles this is
+  [hex-modular](../../HexModular/SPEC/hex-modular.md). The measurement that settles this is
   the kernel bench family.
 - **Whether to use a prime power rather than several primes.** Lifting a
   single image modulo `p^k` by Hensel's lemma is an alternative to

--- a/HexPolyZGcd/SquareFree.lean
+++ b/HexPolyZGcd/SquareFree.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexPolyZGcd.Gcd
+public import HexPolyZGcd.Gcd
+
+public section
+
+/-!
+Fast primitive square-free normalization driven by the checked integer gcd.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- Integer-gcd replacement for `primitiveSquareFreeDecomposition`'s rational
+Euclidean bottleneck.  The return type and normalization convention are shared
+with the existing reference implementation. -/
+def sqfDecomp (f : ZPoly) : PrimitiveSquareFreeDecomposition :=
+  let primitive := primitivePart f
+  if primitive.isZero then
+    { primitive, squareFreeCore := 0, repeatedPart := 0 }
+  else
+    let derivative := DensePoly.derivative primitive
+    if derivative.isZero then
+      { primitive
+        squareFreeCore := normalizePrimitiveSign primitive
+        repeatedPart := 1 }
+    else
+      let cert := gcdCert primitive derivative
+      { primitive
+        squareFreeCore := normalizePrimitiveSign cert.cofL
+        repeatedPart := cert.gcd }
+
+/-- The fast decomposition's repeated part is the checked gcd of the primitive
+input and its derivative in the nondegenerate branch. -/
+theorem sqfDecomp_repeatedPart (f : ZPoly)
+    (hp : (primitivePart f).isZero = false)
+    (hd : (DensePoly.derivative (primitivePart f)).isZero = false) :
+    (sqfDecomp f).repeatedPart =
+      gcd (primitivePart f) (DensePoly.derivative (primitivePart f)) := by
+  simp [sqfDecomp, hp, hd, gcd_eq_cert]
+
+/-- The fast square-free core and repeated part reassemble the primitive input
+up to the normalization sign. -/
+theorem sqfDecomp_reassembly_signed (f : ZPoly) :
+    let d := sqfDecomp f
+    ∃ ε : Int, (ε = 1 ∨ ε = -1) ∧
+      DensePoly.scale ε (d.squareFreeCore * d.repeatedPart) = d.primitive := by
+  sorry
+
+/-- Every nonzero fast square-free core is square-free over `Rat[x]`. -/
+theorem sqfDecomp_squareFreeCore (f : ZPoly)
+    (hcore : (sqfDecomp f).squareFreeCore ≠ 0) :
+    SquareFreeRat (sqfDecomp f).squareFreeCore := by
+  sorry
+
+#guard
+  let x1 : ZPoly := DensePoly.ofList [1, 1]
+  let x2 : ZPoly := DensePoly.ofList [2, 1]
+  let f := x1 * x1 * x2
+  let d := sqfDecomp f
+  d.repeatedPart == x1 && d.squareFreeCore == x1 * x2
+
+end ZPoly
+
+end Hex

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -15,6 +15,7 @@ public import HexResultant.DeterminantAlgebra
 public import HexResultant.BlockDeterminant
 public import HexResultant.BrownTraub
 public import HexResultant.Subresultant
+public import HexResultant.SubresultantExt
 public import HexResultant.Discriminant
 
 public section

--- a/HexResultant/SubresultantExt.lean
+++ b/HexResultant/SubresultantExt.lean
@@ -1,0 +1,331 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.Subresultant
+public meta import HexResultant.Subresultant
+
+public section
+
+/-!
+Extended Brown subresultant chains.
+
+The worker in this file follows exactly the same Brown recurrence and zero
+conventions as `subresultantChain`.  In addition to each stored polynomial it
+carries the two transformation cofactors expressing that polynomial in terms
+of the caller's inputs.  Keeping this extension beside the original worker
+lets integer and multivariate gcd consumers share both the sign convention and
+the exact-scalar bookkeeping.
+-/
+
+namespace Hex
+
+universe u
+
+namespace DensePoly
+
+variable {R : Type u} [Zero R] [DecidableEq R]
+
+namespace SubresultantExt
+
+/-- One extended Brown-chain entry `(u, v, s)`, representing `u*f + v*g = s`.
+-/
+abbrev Entry (R : Type u) [Zero R] [DecidableEq R] :=
+  DensePoly R × DensePoly R × DensePoly R
+
+/-- The polynomial component of an extended Brown-chain entry. -/
+@[inline, expose]
+def value (e : Entry R) : DensePoly R := e.2.2
+
+/-- The numerator update for one transformation cofactor in a pseudo-division
+step: `lc(curr)^d * prevCofactor - quotient * currCofactor`. -/
+@[inline, expose]
+def numerator [Add R] [Mul R] [Sub R]
+    (a : R) (q prev curr : DensePoly R) :
+    DensePoly R :=
+  scaleImpl a prev - q * curr
+
+end SubresultantExt
+
+open SubresultantExt
+
+/-- Fuel-bounded extended Brown recurrence after the initial pseudo-division.
+
+The polynomial branch decisions and polynomial successor are byte-for-byte the
+same expressions used by `subresultantAux`; the additional divisions update
+only the two transformation cofactors. -/
+@[expose]
+def subresultantAuxExt [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (prev curr : DensePoly R) (hPrev : R)
+    (prevU prevV currU currV : DensePoly R)
+    (chain : Array (Entry R)) : Nat → Array (Entry R)
+  | 0 => chain
+  | fuel + 1 =>
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let qr := pseudoDivMod prev curr
+      let q := qr.1
+      let p := qr.2
+      if p.isZero then
+        chain
+      else
+        let divisor :=
+          negOnePow (delta + 1) * prev.leadingCoeff * powNat hPrev delta
+        let next := divScalarImpl p divisor
+        if next.isZero then
+          chain
+        else
+          let a := powNat curr.leadingCoeff (delta + 1)
+          let nextU := divScalarImpl (numerator a q prevU currU) divisor
+          let nextV := divScalarImpl (numerator a q prevV currV) divisor
+          subresultantAuxExt curr next hCurr currU currV nextU nextV
+            (chain.push (nextU, nextV, next)) fuel
+
+/-- Extended Brown recurrence for two nonzero, degree-ordered inputs, supplied
+with their transformation cofactors relative to the caller's inputs. -/
+@[expose]
+def subresultantOrderedExt [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g fU fV gU gV : DensePoly R) : Array (Entry R) :=
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let qr := pseudoDivMod f g
+  let q := qr.1
+  let p := qr.2
+  let seed := #[(fU, fV, f), (gU, gV, g)]
+  if p.isZero then
+    seed
+  else
+    let sign := negOnePow (delta + 1)
+    let g₃ := scaleImpl sign p
+    if g₃.isZero then
+      seed
+    else
+      let a := powNat g.leadingCoeff (delta + 1)
+      let g₃U := scaleImpl sign (numerator a q fU gU)
+      let g₃V := scaleImpl sign (numerator a q fV gV)
+      subresultantAuxExt g g₃ h₂ gU gV g₃U g₃V
+        (seed.push (g₃U, g₃V, g₃)) (g.size + 1)
+
+/-- Brown's nonzero subresultant chain together with a caller-order-sensitive
+Bezout representation for every stored entry.
+
+Zero inputs follow `subresultantChain`: they are omitted, and the one remaining
+input receives its evident unit cofactor.  Two nonzero inputs are ordered by
+decreasing dense degree; equal-degree inputs retain caller order. -/
+@[expose]
+def subresultantChainExt [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g : DensePoly R) : Array (DensePoly R × DensePoly R × DensePoly R) :=
+  if f.isZero then
+    if g.isZero then #[] else #[(0, 1, g)]
+  else if g.isZero then
+    #[(1, 0, f)]
+  else if f.size < g.size then
+    subresultantOrderedExt g f 0 1 1 0
+  else
+    subresultantOrderedExt f g 1 0 0 1
+
+/-- Projecting an extended worker result to its polynomial components gives
+the original Brown worker result. -/
+private theorem subresultantAuxExt_values [One R] [Add R] [Sub R] [Mul R]
+    [Div R] (prev curr : DensePoly R) (hPrev : R)
+    (prevU prevV currU currV : DensePoly R)
+    (chain : Array (Entry R)) (plain : Array (DensePoly R)) (fuel : Nat)
+    (hchain : chain.map value = plain) :
+    (subresultantAuxExt prev curr hPrev prevU prevV currU currV chain fuel).map
+        value =
+      (subresultantAux prev curr hPrev plain fuel).chain := by
+  induction fuel generalizing prev curr hPrev prevU prevV currU currV chain plain with
+  | zero =>
+      simpa [subresultantAuxExt, subresultantAux] using hchain
+  | succ fuel ih =>
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let qr := pseudoDivMod prev curr
+      let q := qr.1
+      let p := qr.2
+      cases hp : p.isZero with
+      | true =>
+          simpa [subresultantAuxExt, subresultantAux, delta, hCurr, qr, q,
+            p, hp] using hchain
+      | false =>
+          let divisor :=
+            negOnePow (delta + 1) * prev.leadingCoeff * powNat hPrev delta
+          let next := divScalarImpl p divisor
+          cases hnext : next.isZero with
+          | true =>
+              simpa [subresultantAuxExt, subresultantAux, delta, hCurr, qr,
+                q, p, hp, divisor, next, hnext] using hchain
+          | false =>
+              let a := powNat curr.leadingCoeff (delta + 1)
+              let nextU :=
+                divScalarImpl (numerator a q prevU currU) divisor
+              let nextV :=
+                divScalarImpl (numerator a q prevV currV) divisor
+              have hpush :
+                  (chain.push (nextU, nextV, next)).map value =
+                    plain.push next := by
+                simp only [Array.map_push, value]
+                rw [hchain]
+              have hrec := ih curr next hCurr currU currV nextU nextV
+                (chain.push (nextU, nextV, next)) (plain.push next) hpush
+              simpa [subresultantAuxExt, subresultantAux, delta, hCurr, qr,
+                q, p, hp, divisor, next, hnext, a, nextU, nextV] using hrec
+
+/-- Projecting an extended degree-ordered run gives the existing ordered
+Brown chain. -/
+private theorem subresultantOrderedExt_values [One R] [Add R] [Sub R] [Mul R]
+    [Div R] (f g fU fV gU gV : DensePoly R) :
+    (subresultantOrderedExt f g fU fV gU gV).map value =
+      (subresultantOrdered f g).chain := by
+  unfold subresultantOrderedExt subresultantOrdered subresultantOrderedFuel
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let qr := pseudoDivMod f g
+  let q := qr.1
+  let p := qr.2
+  let seed : Array (Entry R) := #[(fU, fV, f), (gU, gV, g)]
+  have hseed : seed.map value = #[f, g] := by
+    simp [seed, value]
+  cases hp : p.isZero with
+  | true =>
+      simp [qr, p, hp, value]
+  | false =>
+      let sign := negOnePow (R := R) (delta + 1)
+      let g₃ := scaleImpl sign p
+      cases hg₃ : g₃.isZero with
+      | true =>
+          simp [delta, qr, p, hp, sign, g₃, hg₃, value]
+      | false =>
+          let a := powNat g.leadingCoeff (delta + 1)
+          let g₃U := scaleImpl sign (numerator a q fU gU)
+          let g₃V := scaleImpl sign (numerator a q fV gV)
+          have hseed₃ :
+              (seed.push (g₃U, g₃V, g₃)).map value = #[f, g, g₃] := by
+            simp [seed, value]
+          have haux := subresultantAuxExt_values g g₃ h₂ gU gV g₃U g₃V
+            (seed.push (g₃U, g₃V, g₃)) #[f, g, g₃] (g.size + 1)
+            hseed₃
+          simpa [delta, h₂, qr, q, p, seed, hp, sign, g₃, hg₃, a,
+            g₃U, g₃V] using haux
+
+/-- Forgetting the two cofactors recovers `subresultantChain`, including its
+input ordering and all zero-input conventions. -/
+theorem subresultantChainExt_values [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g : DensePoly R) :
+    (subresultantChainExt f g).map SubresultantExt.value =
+      subresultantChain f g := by
+  unfold subresultantChainExt subresultantChain subresultantRun
+  cases hf : f.isZero with
+  | true =>
+      cases hg : g.isZero with
+      | true => simp
+      | false => simp [SubresultantExt.value]
+  | false =>
+      cases hg : g.isZero with
+      | true => simp [SubresultantExt.value]
+      | false =>
+          by_cases hfg : f.size < g.size
+          · simpa [hf, hg, hfg] using
+              subresultantOrderedExt_values g f (0 : DensePoly R) 1 1 0
+          · simpa [hf, hg, hfg] using
+              subresultantOrderedExt_values f g (1 : DensePoly R) 0 0 1
+
+namespace SubresultantExt
+
+/-- Brown's accumulated principal-subresultant scale associated to a stored
+chain entry.  The value at index `1` is the ordered worker's initial `h₂`;
+later values apply the unchanged `divExp` recurrence. -/
+def brownScale [One R] [Mul R] [Div R] (chain : Array (Entry R)) : Nat → R
+  | 0 => 1
+  | 1 =>
+      let first := value (chain.getD 0 (0, 0, 0))
+      let second := value (chain.getD 1 (0, 0, 0))
+      powNat second.leadingCoeff (first.size - second.size)
+  | i + 2 =>
+      let prev := value (chain.getD (i + 1) (0, 0, 0))
+      let curr := value (chain.getD (i + 2) (0, 0, 0))
+      divExp curr.leadingCoeff (brownScale chain (i + 1))
+        (prev.size - curr.size)
+
+/-- Exact coefficientwise divisibility at a noninitial Brown step.
+
+Index `2` is the signed first pseudo-remainder and involves no exact scalar
+division.  Every entry at index at least `3` is obtained from the two preceding
+entries by the scalar division recorded here. -/
+def CofactorStep [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (chain : Array (Entry R)) (i : Nat) : Prop :=
+  let prev := chain.getD (i - 2) (0, 0, 0)
+  let curr := chain.getD (i - 1) (0, 0, 0)
+  let next := chain.getD i (0, 0, 0)
+  let delta := (value prev).size - (value curr).size
+  let a := powNat (value curr).leadingCoeff (delta + 1)
+  let q := (pseudoDivMod (value prev) (value curr)).1
+  let divisor :=
+    negOnePow (delta + 1) * (value prev).leadingCoeff *
+      powNat (brownScale chain (i - 2)) delta
+  numerator a q prev.1 curr.1 = scale divisor next.1 ∧
+    numerator a q prev.2.1 curr.2.1 = scale divisor next.2.1
+
+/-- Algebraic contract of an extended Brown chain: every stored triple is a
+Bezout identity for the caller's inputs, and every post-initial transformation
+row is coefficientwise divisible by the exact Brown scalar before division. -/
+def Law [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g : DensePoly R) (chain : Array (Entry R)) : Prop :=
+  (∀ e, e ∈ chain → e.1 * f + e.2.1 * g = value e) ∧
+    ∀ i, 3 ≤ i → i < chain.size → CofactorStep chain i
+
+end SubresultantExt
+
+/-- The extended Brown recurrence has exact transformation rows and every
+stored entry satisfies its caller-order-sensitive Bezout identity. -/
+theorem subresultantChainExt_law {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) :
+    SubresultantExt.Law f g (subresultantChainExt f g) := by
+  sorry
+
+/-- Every extended-chain entry reconstructs from the two caller inputs. -/
+theorem subresultantChainExt_bezout {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (e : SubresultantExt.Entry S)
+    (he : e ∈ subresultantChainExt f g) :
+    e.1 * f + e.2.1 * g = e.2.2 :=
+  (subresultantChainExt_law f g).1 e he
+
+/-- At every divided Brown step, both transformation numerators reconstruct
+as the Brown scalar times the stored executable quotients. -/
+theorem subresultantChainExt_exact {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (i : Nat) (hi : 3 ≤ i)
+    (hbound : i < (subresultantChainExt f g).size) :
+    SubresultantExt.CofactorStep (subresultantChainExt f g) i :=
+  (subresultantChainExt_law f g).2 i hi hbound
+
+/-! # Core executable pins -/
+
+-- A four-entry defective chain exercises both transformation-row divisions.
+#guard
+  let f : DensePoly Int := ofList [0, 0, 0, 0, -1]
+  let g : DensePoly Int := ofList [-1, 0, 0, 2]
+  let ext := subresultantChainExt f g
+  ext.size = 4 &&
+    ext.map SubresultantExt.value = subresultantChain f g &&
+    ext.all fun e => e.1 * f + e.2.1 * g = e.2.2
+
+-- Caller-sensitive cofactors survive degree ordering and the zero wrappers.
+#guard
+  let linear : DensePoly Int := ofList [1, 1]
+  let quadratic : DensePoly Int := ofList [1, 0, 1]
+  let reversed := subresultantChainExt linear quadratic
+  reversed.getD 0 (0, 0, 0) = (0, 1, quadratic) &&
+    reversed.getD 1 (0, 0, 0) = (1, 0, linear) &&
+    subresultantChainExt (0 : DensePoly Int) linear = #[(0, 1, linear)] &&
+    subresultantChainExt linear 0 = #[(1, 0, linear)] &&
+    subresultantChainExt (0 : DensePoly Int) 0 = #[]
+
+end DensePoly
+end Hex

--- a/HexSparsePoly/SPEC/hex-sparse-poly.md
+++ b/HexSparsePoly/SPEC/hex-sparse-poly.md
@@ -782,7 +782,7 @@ The remainder-degree statements use `degree?.getD 0` because that is the
 shape `DensePoly.DivModLaws` states them in, and `degree?_toDense` is
 what moves them across. `divExactMonic?_eq_some` needs no `t ≠ 0` side
 condition, unlike the `divExact?` of
-[hex-poly-z-gcd](../../SPEC/Libraries/hex-poly-z-gcd.md): a monic divisor is nonzero.
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md): a monic divisor is nonzero.
 
 **No claim is made that any of this stays sparse.** Sparsity survives
 in special cases and not in general, and the special cases are what make
@@ -817,7 +817,7 @@ exists, this SPEC authorises the conversion route and nothing more.
 
 Exact division by an arbitrary, possibly nonmonic integer polynomial is
 not specified here. That is hex-poly-z's `divExact?`, which
-[hex-poly-z-gcd](../../SPEC/Libraries/hex-poly-z-gcd.md) schedules, and a consumer that wants
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) schedules, and a consumer that wants
 it already depends on hex-poly-z and can apply it to `toDense`. Adding a
 second one here would be inventing an operation this library has no
 consumer for.

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -209,8 +209,8 @@ polynomial consumer both need, so it sits below both. `hex-modular-matrix`
 and `hex-poly-z-gcd` each sit above it beside the type they compute with,
 and neither depends on the other. `hex-mv-gcd` gains a dependency on
 `hex-poly-z-gcd`, which is its arity-one case, once that library exists.
-The reasoning is in [hex-modular §Why not inside hex-arith](hex-modular.md)
-and [hex-poly-z-gcd §Why this is not hex-mv-gcd at arity one](hex-poly-z-gcd.md).
+The reasoning is in [hex-modular §Why not inside hex-arith](../../HexModular/SPEC/hex-modular.md)
+and [hex-poly-z-gcd §Why this is not hex-mv-gcd at arity one](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md).
 
 ## Library DAG
 
@@ -416,7 +416,7 @@ lifting direction is the evaluation ideal and the prime only makes the
 univariate coefficient arithmetic invertible, so no hex-hensel entry
 point has a parameter in the position this library needs one. The
 reasoning is in
-[hex-mv-hensel §Why hex-hensel is a design model](hex-mv-hensel.md).
+[hex-mv-hensel §Why hex-hensel is a design model](../../HexMvHensel/SPEC/hex-mv-hensel.md).
 
 ```text
 hex-mv-gcd ────┐
@@ -437,9 +437,9 @@ returned unfactored, following the same convention as
 `hex-berlekamp-zassenhaus` and `sqfDecomp`, and a caller who wants the
 constant primes composes the two answers. The boundary with the lifting
 engine is drawn in
-[hex-mv-hensel §What stays in the downstream consumer](hex-mv-hensel.md),
+[hex-mv-hensel §What stays in the downstream consumer](../../HexMvHensel/SPEC/hex-mv-hensel.md),
 and what the product check does and does not prove is in
-[hex-mv-factor §The two claims, and why they have separate types](hex-mv-factor.md).
+[hex-mv-factor §The two claims, and why they have separate types](../../HexMvFactor/SPEC/hex-mv-factor.md#the-two-claims-and-why-they-have-separate-types).
 
 ```text
 hex-mv-hensel ─────────────┐
@@ -575,7 +575,7 @@ for developments whose source-local move has not happened yet.
 - [hex-mod-arith](../../HexModArith/SPEC/hex-mod-arith.md): `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
 - [hex-finite-field.md](hex-finite-field.md): the Mathlib-free `F_q` interface, the generic `q`-power Frobenius, and the equal-degree stage (Cantor-Zassenhaus) it makes worthwhile, specified as hex-berlekamp amendments
 - [hex-mod-arith-mathlib](../../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md): `ZMod64 p ≃+* ZMod p`
-- [hex-modular.md](hex-modular.md): integer CRT, rational reconstruction, symmetric representatives, and the modulus supply (the Mathlib companion is specified in the same file)
+- [hex-modular.md](../../HexModular/SPEC/hex-modular.md): integer CRT, rational reconstruction, symmetric representatives, and the modulus supply (the Mathlib companion is specified in the same file)
 - [hex-padics.md](hex-padics.md): fixed-precision `ZpApprox` and `QpApprox` approximations, the valuation and approximate zero, precision-aware arithmetic with exact loss formulas, partial inversion and division, and exactification (the Mathlib companion is specified in the same file)
 - [hex-modular-matrix.md](hex-modular-matrix.md): multi-modular determinant, certified rank, and Dixon p-adic linear solving (the Mathlib companion is specified in the same file)
 - [hex-poly](../../HexPoly/SPEC/hex-poly.md): dense polynomial library, operations, GCD, CRT
@@ -583,9 +583,9 @@ for developments whose source-local move has not happened yet.
 - [hex-sparse-poly](../../HexSparsePoly/SPEC/hex-sparse-poly.md): canonical sparse univariate polynomials, the operations that keep sparsity, and the dense conversions (the Mathlib companion is specified in the same file)
 - [hex-mv-poly](../../HexMvPoly/SPEC/hex-mv-poly.md): canonical distributed multivariate polynomials with explicit monomial orders
 - [hex-mv-poly-mathlib](../../HexMvPolyMathlib/SPEC/hex-mv-poly-mathlib.md): `MvPoly n R cmp ≃+* MvPolynomial (Fin n) R`, `aeval`, and operation correspondence
-- [hex-mv-gcd](hex-mv-gcd.md): multivariate gcd with cofactors, content and primitive part, exact division, squarefree decomposition
-- [hex-mv-hensel.md](hex-mv-hensel.md): multivariate Hensel lifting against an evaluation ideal, its coprimality witness and leading-coefficient contract, reconstruction, and the checked-decomposition certificate (the Mathlib companion is specified in the same file)
-- [hex-mv-factor.md](hex-mv-factor.md): factorization of `Z[x_1, ..., x_n]` by Wang's EEZ algorithm, the evaluation-point and leading-coefficient search, the checked product decomposition, and the separate irreducibility certificate (the Mathlib companion is specified in the same file)
+- [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md): multivariate gcd with cofactors, content and primitive part, exact division, squarefree decomposition
+- [hex-mv-hensel.md](../../HexMvHensel/SPEC/hex-mv-hensel.md): multivariate Hensel lifting against an evaluation ideal, its coprimality witness and leading-coefficient contract, reconstruction, and the checked-decomposition certificate (the Mathlib companion is specified in the same file)
+- [hex-mv-factor.md](../../HexMvFactor/SPEC/hex-mv-factor.md): factorization of `Z[x_1, ..., x_n]` by Wang's EEZ algorithm, the evaluation-point and leading-coefficient search, the checked product decomposition, and the separate irreducibility certificate (the Mathlib companion is specified in the same file)
 - [hex-truncated-series.md](hex-truncated-series.md): power series truncated at a precision fixed in the type, Newton inversion, square root, `exp`, `log`, composition, and reversion (the Mathlib companion is specified in the same file)
 - [hex-poly-fp](../../HexPolyFp/SPEC/hex-poly-fp.md): polynomials over `F_p`, Frobenius, square-free decomposition
 - [hex-gf2](../../HexGF2/SPEC/hex-gf2.md): packed bitwise polynomials over `F_2`, `GF(2^n)` elements
@@ -593,7 +593,7 @@ for developments whose source-local move has not happened yet.
 - [hex-poly-fp-mathlib](../../HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md): `FpPoly p ≃+* Polynomial (ZMod p)`, the crossing point to Mathlib's polynomial type
 - [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound
 - [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md): Mignotte bound proof via Mathlib's Mahler measure
-- [hex-poly-z-gcd.md](hex-poly-z-gcd.md): modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division (the Mathlib companion is specified in the same file)
+- [hex-poly-z-gcd.md](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md): modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division (the Mathlib companion is specified in the same file)
 - [hex-cyclotomic.md](hex-cyclotomic.md): dense integer cyclotomic polynomials indexed by a checked factorization, the squarefree-kernel and divisor-recursion routes, the divisor family, and the factorization of `x^n - 1` (the Mathlib companion is specified in the same file)
 - [hex-roots.md](../../HexRoots/SPEC/hex-roots.md): certified complex root isolation for `Z[x]`
 - [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`

--- a/SPEC/Libraries/hex-cyclotomic.md
+++ b/SPEC/Libraries/hex-cyclotomic.md
@@ -438,7 +438,7 @@ checked route.
 normalization step. `ZPoly.primitivePart` and `ZPoly.content` are
 hex-poly-z's, and nothing here calls them. The statement is recorded
 because a caller who reaches this library from
-[hex-poly-z-gcd](hex-poly-z-gcd.md) or from Berlekamp-Zassenhaus is used
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) or from Berlekamp-Zassenhaus is used
 to content-normalising every integer polynomial it holds, and here that
 is a no-op.
 
@@ -947,7 +947,7 @@ the largest polynomial this library ever writes, which is why the factor
 matters here and not elsewhere.
 
 **hex-poly-z** must have `divExact?`, which
-[hex-poly-z-gcd](hex-poly-z-gcd.md) already schedules as its first
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) already schedules as its first
 prerequisite and sites in hex-poly-z. This library needs only the monic
 case. No new primitive is requested, and in particular no second copy of
 exact integer-polynomial division: the count of those in the tree is

--- a/SPEC/Libraries/hex-finite-field.md
+++ b/SPEC/Libraries/hex-finite-field.md
@@ -192,7 +192,7 @@ list at the end reflects them.
 
 ## The interface
 
-Two classes, split the way [hex-mv-gcd](hex-mv-gcd.md) splits `GcdOps`
+Two classes, split the way [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) splits `GcdOps`
 from `LawfulGcdOps`: operations a consumer may compute with, and laws a
 consumer may prove with.
 
@@ -598,7 +598,7 @@ a separate ideal model of independent uniform coefficient draws. It
 motivates the retry budget but is not a theorem about splitmix64.
 
 `Rand` belongs in **hex-basic**, not here. It has no dependencies, and
-it has a second consumer already specified: [hex-mv-gcd](hex-mv-gcd.md)
+it has a second consumer already specified: [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md)
 route 4 draws random evaluation points for Zippel's interpolation, and
 says so. Two consumers in different subtrees is the argument for a root
 library.
@@ -1256,7 +1256,7 @@ route-level tests in Lean (in hex-berlekamp for prime fields and
 hex-gfq for concrete extensions) asserting that EDF produced the split, that
 the sweep did not run, and that the attempt count was within the
 expected range for the seed. This is the same split
-[hex-mv-gcd](hex-mv-gcd.md) makes between route-level tests and oracle
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes between route-level tests and oracle
 fixtures, and for the same reason.
 
 ## Benchmarking

--- a/SPEC/Libraries/hex-int-factor.md
+++ b/SPEC/Libraries/hex-int-factor.md
@@ -43,7 +43,7 @@ rather than the whole verification story.
 **Squarefree content over `ℤ`, but not for the reason hex-mv-gcd
 gives.** `12x` is not squarefree in `ℤ[x]` because `4 ∣ 12`, so the
 ring-theoretic predicate over `ℤ` is partly a question about an
-integer. [hex-mv-gcd](hex-mv-gcd.md) says the `ℤ` instance of
+integer. [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) says the `ℤ` instance of
 `Decidable (Squarefree p)` "waits on the integer factorization item".
 It does not: Mathlib already has
 `instance : DecidablePred (Squarefree : ℕ → Prop)`
@@ -875,7 +875,7 @@ found the factor within the expected iteration count for a fixed seed,
 that ECM stage 1 distinguished its three gcd outcomes, and that
 `cyclotomicSplit?` ran before the generic dispatch on a `b^n − 1`
 input. This is the same division
-[hex-mv-gcd](hex-mv-gcd.md) makes, and it is worth more than the oracle
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes, and it is worth more than the oracle
 half.
 
 ## Benchmarking

--- a/SPEC/Libraries/hex-min-poly.md
+++ b/SPEC/Libraries/hex-min-poly.md
@@ -762,7 +762,7 @@ gets a conformance fixture.
 - **No randomness.** Unlike a generic-vector or Wiedemann approach, the
   basis sweep is deterministic, so this library takes no `Rand` state
   and its answer does not depend on a seed. The contrast with
-  [hex-mv-gcd](hex-mv-gcd.md), which does carry `Rand`, is deliberate.
+  [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md), which does carry `Rand`, is deliberate.
 
 ## Complexity
 
@@ -1033,7 +1033,7 @@ with contracts `lcm p 0 = lcm 0 q = 0`, `lcm 0 0 = 0`, `lcmList [] = 1`,
   `gcd 0 0 = 0` and `monicize 0 = 0`, so without the guard the definition
   would divide by zero. The chosen values match Mathlib's
   `GCDMonoid` convention (`lcm a 0 = 0`) and the conventions
-  [hex-poly-z-gcd](hex-poly-z-gcd.md) and [hex-mv-gcd](hex-mv-gcd.md)
+  [hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md) and [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md)
   already fix for their types.
 - **`lcmList [] = 1`, not `0`.** The empty family has every polynomial as
   a common multiple, so the least one is the unit. This is the value

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -10,10 +10,10 @@ results with `Matrix.det`, `Matrix.rank`, and `Matrix.mulVec`.
 
 This SPEC expands three of the five bullets in the "Modular techniques"
 entry of [future-work](../future-work.md), and depends on the
-reconstruction operations specified in [hex-modular](hex-modular.md). The
+reconstruction operations specified in [hex-modular](../../HexModular/SPEC/hex-modular.md). The
 fourth bullet, the modular gcd for `ℤ[x]`, is
-[hex-poly-z-gcd](hex-poly-z-gcd.md); the fifth, rational reconstruction
-itself, is in [hex-modular](hex-modular.md).
+[hex-poly-z-gcd](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md); the fifth, rational reconstruction
+itself, is in [hex-modular](../../HexModular/SPEC/hex-modular.md).
 
 ## Why this library exists
 
@@ -108,7 +108,7 @@ which the arithmetic discovers rather than assumes. `detMod?` returning
 `some d` at a composite modulus is as good an image as any. Distinctness is not
 the right property either, since distinct moduli need not be coprime;
 coprimality is what the reconstruction needs and `Crt.push` checks it.
-[hex-modular](hex-modular.md) sets this out in full under "Primality is
+[hex-modular](../../HexModular/SPEC/hex-modular.md) sets this out in full under "Primality is
 not what the checkers need". Primality does appear here, once: the rank
 of an image modulo `p` is a rank only when `F_p` is a field, and the
 statement of `rankModP` says so.
@@ -263,7 +263,7 @@ modulus divides `L = lcm(1, …, 2^31 - 1)` and so does every product of
 pairwise coprime allowed moduli. On the `1 x 1` matrix `[L]` the
 determinant is `L`, the Hadamard bound is `L`, every image is zero, and
 the accumulated modulus never exceeds `2L`. No amount of fuel helps.
-[hex-modular](hex-modular.md) records the same obstruction for the
+[hex-modular](../../HexModular/SPEC/hex-modular.md) records the same obstruction for the
 supply as a whole. Under design principle 8 the classification is neither
 of the two fallback modes: `detModular?` propagates its `Option` upward,
 and `det` is a dispatch between two complete algorithms rather than a
@@ -313,7 +313,7 @@ is easy to get wrong:
 - **The pair must be reduced first.** The divisibility conclusion needs
   `gcd(gcd_i y_i, d) = 1`. Dixon's reconstruction returns a common
   denominator that need not be the least one
-  ([hex-modular](hex-modular.md) says so explicitly under "Vectors with a
+  ([hex-modular](../../HexModular/SPEC/hex-modular.md) says so explicitly under "Vectors with a
   common denominator"), so `detViaDivisor` divides `y` and `d` through by
   their common gcd before using `d`. Omitting that step gives a `d` that
   does not divide the determinant and a wrong answer with no symptom.
@@ -575,11 +575,11 @@ listed here because this library is a second consumer.
 
 **The modulus supply should move to hex-mod-arith.** `ZMod64.Modulus`,
 the bundled `ZMod64.Prime`, and `ZMod64.primesBelow` belong beside `ZMod64`,
-per [hex-modular §The supply](hex-modular.md). This library is their
+per [hex-modular §The supply](../../HexModular/SPEC/hex-modular.md). This library is their
 main consumer, and it passes bare `Nat` moduli on to `crtLoop`.
 
 **`zmod64FieldOfPrime` should move to hex-mod-arith.** Set out in
-[hex-modular](hex-modular.md). Without it, `rankModP` forces a dependency
+[hex-modular](../../HexModular/SPEC/hex-modular.md). Without it, `rankModP` forces a dependency
 on hex-poly-fp for one instance about a `ZMod64` type.
 
 **An entrywise `Matrix.mapEntries` is missing.** hex-matrix has

--- a/SPEC/Libraries/hex-padics.md
+++ b/SPEC/Libraries/hex-padics.md
@@ -105,7 +105,7 @@ Each dependency is used for a named thing and none is decorative.
   used in display and in the reconstruction bound, and `ratRecon?` for
   the exactification described under "Exactification". Reimplementing
   the truncated Euclidean run here would duplicate the one piece of
-  [hex-modular](hex-modular.md) that costs real work.
+  [hex-modular](../../HexModular/SPEC/hex-modular.md) that costs real work.
 - **hex-primality** supplies `CheckedPrimeCert p`. "The checked prime"
   explains what requires it and how the requirement is enforced.
 
@@ -1074,7 +1074,7 @@ theorem toRat?_complete (hr : a.rel? = some r)
 ```
 
 The implementation scales by `p^(-val)` to land in `ℤ_p`, reads the
-residue, calls [hex-modular](hex-modular.md)'s `ratRecon?` at modulus
+residue, calls [hex-modular](../../HexModular/SPEC/hex-modular.md)'s `ratRecon?` at modulus
 `p^r`, and **checks that the result lies in the ball** before returning
 it. `mem_toRat?` follows from the check alone and needs no bound
 hypothesis, exactly as [hex-modular-matrix](hex-modular-matrix.md)'s

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -87,6 +87,8 @@ lean_lib HexPoly where
 
 lean_lib HexMvPoly where
 
+lean_lib HexMvGcd where
+
 lean_lib HexSparsePoly where
 
 lean_lib HexModArith where
@@ -95,10 +97,14 @@ lean_lib HexModArith where
   -- we pass only the system GMP library rather than an explicit static-lib path.
   moreLinkArgs := #["-lgmp"]
 
+lean_lib HexModular where
+
 lean_lib HexGF2 where
   precompileModules := true
 
 lean_lib HexPolyZ where
+
+lean_lib HexPolyZGcd where
 
 lean_lib HexRoots where
 
@@ -120,6 +126,10 @@ lean_lib HexHensel where
   -- `WordPoly.mul` has a native convolution extern used by downstream
   -- interpreter-time guards, so its module dynlib must export the stub.
   precompileModules := true
+
+lean_lib HexMvHensel where
+
+lean_lib HexMvFactor where
 
 lean_lib HexConway where
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -127,6 +127,11 @@ libraries:
           description: Sparse rename, partial-evaluation, and substitution cases where distinct source terms collide.
         - name: sum-of-squares-arithmetic
           description: Representative sum-of-squares-shaped identities measured as compiled Mathlib-free arithmetic.
+  HexMvGcd:
+    deps: [HexBasic, HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith, HexModular, HexPolyZGcd]
+    mathlib: false
+    done_through: 1
+    status: active
   HexSparsePoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
@@ -211,6 +216,11 @@ libraries:
           description: Barrett-context multiplication chains over the UInt64 residue wrapper on the shared small odd prime modulus.
         - name: montgomery-hot-loop
           description: Montgomery conversion, Montgomery-form multiplication chains, and conversion back on the shared small odd prime modulus.
+  HexModular:
+    deps: [HexArith]
+    mathlib: false
+    done_through: 1
+    status: active
   HexGramSchmidt:
     deps: [HexRowReduce, HexDeterminant, HexBareiss]
     mathlib: false
@@ -260,6 +270,11 @@ libraries:
           description: Dense integer polynomials with nontrivial coefficient content for content and primitive-part normalization.
         - name: mignotte-helpers
           description: Central binomial, square-root, coefficient-norm, and Mignotte coefficient-bound helper computations over deterministic integer-polynomial fixtures.
+  HexPolyZGcd:
+    deps: [HexPolyZ, HexPolyFp, HexPoly, HexModular, HexModArith, HexArith, HexResultant]
+    mathlib: false
+    done_through: 1
+    status: active
 
   # ---------- Depth 2 ----------
   HexLLL:
@@ -600,6 +615,16 @@ libraries:
           description: Seed-0xC0FFEE bounded-coefficient equal-degree dense integer polynomial pairs with nonzero leading coefficients; drives Brown chains, resultants, and discriminants on the shared 4-through-32 ladder.
         - name: bounded-dense-pseudo-division
           description: Seed-0xC0FFEE bounded-coefficient dense integer polynomials with both leading coefficients fixed at two; drives degree-n by degree-n/2 pseudo-division on the 24-through-128 ladder.
+  HexMvHensel:
+    deps: [HexBasic, HexMvPoly, HexMvGcd, HexPoly, HexPolyZ, HexPolyFp, HexModArith, HexModular, HexArith]
+    mathlib: false
+    done_through: 1
+    status: active
+  HexMvFactor:
+    deps: [HexBasic, HexMvPoly, HexMvGcd, HexMvHensel, HexPoly, HexPolyZ, HexPolyZGcd, HexBerlekampZassenhaus, HexPolyFp, HexModArith, HexModular, HexArith]
+    mathlib: false
+    done_through: 1
+    status: active
   HexInterval:
     deps: []
     mathlib: false

--- a/reports/bench-results/hexbz-factor-sweep-35c7ab82-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-35c7ab82-chungus2.json
@@ -1,0 +1,6037 @@
+{
+  "env": {
+    "lean_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "platform_target": null,
+    "os": "linux",
+    "arch": "x86_64",
+    "cpu_model": null,
+    "cpu_cores": 96,
+    "hostname": "chungus2",
+    "exe_name": "factor_sweep",
+    "lean_bench_version": null,
+    "git_commit": "35c7ab8245829c37ad3b0e657db851d417ead1c8",
+    "git_dirty": false,
+    "timestamp_unix_ms": 1787470728967,
+    "timestamp_iso": "2026-08-23T07:38:48Z"
+  },
+  "config": {
+    "cutoff_seconds": 10.0,
+    "repeats_policy": "median-of-5 when first call < 1s, else single call",
+    "overhead_repeats": 21,
+    "corpus_path": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "early_terminate_run": 3,
+    "early_terminate_families": [
+      "conway",
+      "hoeij-zimmermann",
+      "sd-products",
+      "swinnerton-dyer"
+    ],
+    "systems": [
+      "hex-factor"
+    ],
+    "system_versions": {
+      "hex-factor": "leanprover/lean4:v4.33.0-rc1"
+    },
+    "per_system_overhead_nanos": {
+      "hex-factor": 22824
+    }
+  },
+  "results": [
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi5",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 38778,
+      "min_nanos": 37135,
+      "max_nanos": 50024,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi7",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 45348,
+      "min_nanos": 43575,
+      "max_nanos": 49954,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi15",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 104575,
+      "min_nanos": 100629,
+      "max_nanos": 129541,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi11",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 95902,
+      "min_nanos": 93879,
+      "max_nanos": 113729,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi13",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 215159,
+      "min_nanos": 208860,
+      "max_nanos": 244894,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi17",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 101340,
+      "min_nanos": 97955,
+      "max_nanos": 107569,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi19",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 114440,
+      "min_nanos": 112667,
+      "max_nanos": 120859,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi25",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 125936,
+      "min_nanos": 123333,
+      "max_nanos": 130534,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi23",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 247928,
+      "min_nanos": 243020,
+      "max_nanos": 274788,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi35",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 355416,
+      "min_nanos": 346363,
+      "max_nanos": 387244,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi29",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 202851,
+      "min_nanos": 201258,
+      "max_nanos": 210492,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi64",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 328808,
+      "min_nanos": 321076,
+      "max_nanos": 342097,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi37",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 654180,
+      "min_nanos": 638126,
+      "max_nanos": 800287,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi41",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1956090,
+      "min_nanos": 1948499,
+      "max_nanos": 1970942,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi49",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 372432,
+      "min_nanos": 370739,
+      "max_nanos": 388445,
+      "factor_count": 1,
+      "factor_degrees": [
+        42
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi105",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 5169293,
+      "min_nanos": 5150696,
+      "max_nanos": 5228301,
+      "factor_count": 1,
+      "factor_degrees": [
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi53",
+      "degree": 52,
+      "status": "ok",
+      "median_nanos": 537026,
+      "min_nanos": 531608,
+      "max_nanos": 549995,
+      "factor_count": 1,
+      "factor_degrees": [
+        52
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi81",
+      "degree": 54,
+      "status": "ok",
+      "median_nanos": 658066,
+      "min_nanos": 653990,
+      "max_nanos": 662191,
+      "factor_count": 1,
+      "factor_degrees": [
+        54
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi61",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 6300420,
+      "min_nanos": 6281412,
+      "max_nanos": 6316734,
+      "factor_count": 1,
+      "factor_degrees": [
+        60
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi128",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 972361,
+      "min_nanos": 967594,
+      "max_nanos": 1002846,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi165",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 7823018,
+      "min_nanos": 7812071,
+      "max_nanos": 7868746,
+      "factor_count": 1,
+      "factor_degrees": [
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi89",
+      "degree": 88,
+      "status": "ok",
+      "median_nanos": 1317203,
+      "min_nanos": 1312636,
+      "max_nanos": 1356140,
+      "factor_count": 1,
+      "factor_degrees": [
+        88
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi121",
+      "degree": 110,
+      "status": "ok",
+      "median_nanos": 42535489,
+      "min_nanos": 42270275,
+      "max_nanos": 42856194,
+      "factor_count": 1,
+      "factor_degrees": [
+        110
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi256",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 3812932,
+      "min_nanos": 3798872,
+      "max_nanos": 3860323,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi151",
+      "degree": 150,
+      "status": "ok",
+      "median_nanos": 30626234,
+      "min_nanos": 30353228,
+      "max_nanos": 31400101,
+      "factor_count": 1,
+      "factor_degrees": [
+        150
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi243",
+      "degree": 162,
+      "status": "ok",
+      "median_nanos": 5094362,
+      "min_nanos": 5030959,
+      "max_nanos": 5219848,
+      "factor_count": 1,
+      "factor_degrees": [
+        162
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi179",
+      "degree": 178,
+      "status": "ok",
+      "median_nanos": 33786849,
+      "min_nanos": 33648123,
+      "max_nanos": 34184849,
+      "factor_count": 1,
+      "factor_degrees": [
+        178
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi275",
+      "degree": 200,
+      "status": "ok",
+      "median_nanos": 641189019,
+      "min_nanos": 631292538,
+      "max_nanos": 649510315,
+      "factor_count": 1,
+      "factor_degrees": [
+        200
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi385",
+      "degree": 240,
+      "status": "ok",
+      "median_nanos": 113648133,
+      "min_nanos": 113536397,
+      "max_nanos": 114301811,
+      "factor_count": 1,
+      "factor_degrees": [
+        240
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi257",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 9776684,
+      "min_nanos": 9732298,
+      "max_nanos": 10035087,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi331",
+      "degree": 330,
+      "status": "ok",
+      "median_nanos": 16406052,
+      "min_nanos": 16277451,
+      "max_nanos": 16551647,
+      "factor_count": 1,
+      "factor_degrees": [
+        330
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi625",
+      "degree": 500,
+      "status": "ok",
+      "median_nanos": 40686748,
+      "min_nanos": 40397800,
+      "max_nanos": 41218206,
+      "factor_count": 1,
+      "factor_degrees": [
+        500
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi509",
+      "degree": 508,
+      "status": "ok",
+      "median_nanos": 38088236,
+      "min_nanos": 37839587,
+      "max_nanos": 38831227,
+      "factor_count": 1,
+      "factor_degrees": [
+        508
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi1031",
+      "degree": 1030,
+      "status": "ok",
+      "median_nanos": 2582301837,
+      "min_nanos": 2582301837,
+      "max_nanos": 2582301837,
+      "factor_count": 1,
+      "factor_degrees": [
+        1030
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow6_minus1",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 104434,
+      "min_nanos": 94330,
+      "max_nanos": 214568,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow12_minus1",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 239285,
+      "min_nanos": 231653,
+      "max_nanos": 257872,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow15_minus1",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 285613,
+      "min_nanos": 279194,
+      "max_nanos": 316660,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi12_x_phi13",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 383739,
+      "min_nanos": 369979,
+      "max_nanos": 403128,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi7_x_phi11",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 249340,
+      "min_nanos": 245063,
+      "max_nanos": 267977,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow20_minus1",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 471108,
+      "min_nanos": 451048,
+      "max_nanos": 494854,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi15_x_phi17",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 605668,
+      "min_nanos": 598558,
+      "max_nanos": 646328,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow24_minus1",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 2332468,
+      "min_nanos": 2329714,
+      "max_nanos": 2370585,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow30_minus1",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1723435,
+      "min_nanos": 1714932,
+      "max_nanos": 1757706,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi24_x_phi35",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6509109,
+      "min_nanos": 6496351,
+      "max_nanos": 6520907,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow36_minus1",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 2685050,
+      "min_nanos": 2656599,
+      "max_nanos": 2705491,
+      "factor_count": 9,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi32_x_phi45",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2427078,
+      "min_nanos": 2423063,
+      "max_nanos": 2461139,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow48_minus1",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 10626674,
+      "min_nanos": 10587035,
+      "max_nanos": 10709747,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow60_minus1",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 5615435,
+      "min_nanos": 5591019,
+      "max_nanos": 5639971,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi64_x_phi105",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 16278122,
+      "min_nanos": 16262819,
+      "max_nanos": 16358021,
+      "factor_count": 2,
+      "factor_degrees": [
+        32,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow105_minus1",
+      "degree": 105,
+      "status": "ok",
+      "median_nanos": 45012250,
+      "min_nanos": 44599198,
+      "max_nanos": 45401006,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi105_x_phi128",
+      "degree": 112,
+      "status": "ok",
+      "median_nanos": 28551988,
+      "min_nanos": 28452090,
+      "max_nanos": 28559459,
+      "factor_count": 2,
+      "factor_degrees": [
+        48,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow120_minus1",
+      "degree": 120,
+      "status": "ok",
+      "median_nanos": 148930108,
+      "min_nanos": 148032938,
+      "max_nanos": 149026671,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi128_x_phi165",
+      "degree": 144,
+      "status": "ok",
+      "median_nanos": 62885126,
+      "min_nanos": 62423352,
+      "max_nanos": 63043081,
+      "factor_count": 2,
+      "factor_degrees": [
+        64,
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 53099,
+      "min_nanos": 47981,
+      "max_nanos": 90274,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2_shift1",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 51577,
+      "min_nanos": 51005,
+      "max_nanos": 55172,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 166958,
+      "min_nanos": 162471,
+      "max_nanos": 191754,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 164894,
+      "min_nanos": 158815,
+      "max_nanos": 168390,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift2",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 160388,
+      "min_nanos": 160278,
+      "max_nanos": 164744,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 854057,
+      "min_nanos": 843000,
+      "max_nanos": 891351,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 781428,
+      "min_nanos": 776732,
+      "max_nanos": 801308,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift3",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 851703,
+      "min_nanos": 845333,
+      "max_nanos": 877050,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6816966,
+      "min_nanos": 6775104,
+      "max_nanos": 6867270,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 7201937,
+      "min_nanos": 7194015,
+      "max_nanos": 7216208,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift2",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 8663894,
+      "min_nanos": 8651717,
+      "max_nanos": 8797732,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 27128037,
+      "min_nanos": 26893029,
+      "max_nanos": 27321343,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift1",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 31070231,
+      "min_nanos": 31022170,
+      "max_nanos": 31588850,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift5",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 30052433,
+      "min_nanos": 30014196,
+      "max_nanos": 30466737,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd7",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 195449292,
+      "min_nanos": 194669126,
+      "max_nanos": 199450614,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_phi12",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 137634,
+      "min_nanos": 130153,
+      "max_nanos": 207137,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_sd2shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 136042,
+      "min_nanos": 134309,
+      "max_nanos": 148269,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi15",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 486541,
+      "min_nanos": 476286,
+      "max_nanos": 537798,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi24",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 569244,
+      "min_nanos": 562374,
+      "max_nanos": 603185,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_sd3shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 849800,
+      "min_nanos": 841427,
+      "max_nanos": 882248,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi17",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 2723237,
+      "min_nanos": 2716687,
+      "max_nanos": 2749276,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_sd4shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 16751043,
+      "min_nanos": 16724995,
+      "max_nanos": 16827276,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi35",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 17141722,
+      "min_nanos": 17095234,
+      "max_nanos": 17446333,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi11",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 134486866,
+      "min_nanos": 134183567,
+      "max_nanos": 134661425,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi45",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 312361173,
+      "min_nanos": 310717106,
+      "max_nanos": 312570294,
+      "factor_count": 2,
+      "factor_degrees": [
+        24,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_sd5shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi13",
+      "degree": 76,
+      "status": "ok",
+      "median_nanos": 2935362350,
+      "min_nanos": 2935362350,
+      "max_nanos": 2935362350,
+      "factor_count": 2,
+      "factor_degrees": [
+        12,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi105",
+      "degree": 112,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_sd6shift1",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 40670,
+      "min_nanos": 32988,
+      "max_nanos": 20376398,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 29804,
+      "min_nanos": 28793,
+      "max_nanos": 31577,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 36885,
+      "min_nanos": 35602,
+      "max_nanos": 45347,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 55753,
+      "min_nanos": 54160,
+      "max_nanos": 79768,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 38838,
+      "min_nanos": 36654,
+      "max_nanos": 44196,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 65948,
+      "min_nanos": 63203,
+      "max_nanos": 74901,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 96252,
+      "min_nanos": 90024,
+      "max_nanos": 118917,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 69553,
+      "min_nanos": 67661,
+      "max_nanos": 81570,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 69273,
+      "min_nanos": 63624,
+      "max_nanos": 73019,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 65727,
+      "min_nanos": 62423,
+      "max_nanos": 73339,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 54772,
+      "min_nanos": 53570,
+      "max_nanos": 62903,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 138485,
+      "min_nanos": 137634,
+      "max_nanos": 151725,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 89823,
+      "min_nanos": 88741,
+      "max_nanos": 96373,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 108271,
+      "min_nanos": 105316,
+      "max_nanos": 115381,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 146166,
+      "min_nanos": 141460,
+      "max_nanos": 167248,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 115381,
+      "min_nanos": 112317,
+      "max_nanos": 125876,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 159787,
+      "min_nanos": 157213,
+      "max_nanos": 172646,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 187307,
+      "min_nanos": 177604,
+      "max_nanos": 196932,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 283430,
+      "min_nanos": 276420,
+      "max_nanos": 307325,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 207708,
+      "min_nanos": 201158,
+      "max_nanos": 217963,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 131755,
+      "min_nanos": 128230,
+      "max_nanos": 141360,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 225725,
+      "min_nanos": 220918,
+      "max_nanos": 265013,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 488885,
+      "min_nanos": 468304,
+      "max_nanos": 522164,
+      "factor_count": 3,
+      "factor_degrees": [
+        2,
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 268088,
+      "min_nanos": 263401,
+      "max_nanos": 295869,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 522164,
+      "min_nanos": 506761,
+      "max_nanos": 564067,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 706267,
+      "min_nanos": 694650,
+      "max_nanos": 751284,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3,
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 414574,
+      "min_nanos": 409637,
+      "max_nanos": 446732,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 576234,
+      "min_nanos": 567311,
+      "max_nanos": 613299,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 38798,
+      "min_nanos": 37435,
+      "max_nanos": 50525,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 40030,
+      "min_nanos": 39018,
+      "max_nanos": 45788,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 68241,
+      "min_nanos": 66107,
+      "max_nanos": 75562,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 95511,
+      "min_nanos": 93769,
+      "max_nanos": 108851,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 80920,
+      "min_nanos": 77155,
+      "max_nanos": 84976,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 167048,
+      "min_nanos": 163052,
+      "max_nanos": 178965,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 178334,
+      "min_nanos": 173998,
+      "max_nanos": 188259,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 283811,
+      "min_nanos": 281617,
+      "max_nanos": 303550,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 226105,
+      "min_nanos": 225394,
+      "max_nanos": 238463,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 623845,
+      "min_nanos": 613900,
+      "max_nanos": 654740,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 532139,
+      "min_nanos": 525429,
+      "max_nanos": 562835,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1275701,
+      "min_nanos": 1262852,
+      "max_nanos": 1333217,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1850744,
+      "min_nanos": 1842232,
+      "max_nanos": 1871534,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 974805,
+      "min_nanos": 969448,
+      "max_nanos": 1011920,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1695724,
+      "min_nanos": 1674612,
+      "max_nanos": 1723455,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 6969743,
+      "min_nanos": 6947630,
+      "max_nanos": 6994940,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 1834189,
+      "min_nanos": 1809222,
+      "max_nanos": 1871345,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 8332844,
+      "min_nanos": 8283140,
+      "max_nanos": 8419451,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 2937765,
+      "min_nanos": 2926158,
+      "max_nanos": 3018044,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 3662120,
+      "min_nanos": 3638234,
+      "max_nanos": 3694687,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 35352,
+      "min_nanos": 33760,
+      "max_nanos": 57165,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 60800,
+      "min_nanos": 59138,
+      "max_nanos": 72638,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 89513,
+      "min_nanos": 86138,
+      "max_nanos": 99878,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 103032,
+      "min_nanos": 99708,
+      "max_nanos": 111496,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 148310,
+      "min_nanos": 143833,
+      "max_nanos": 165224,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 121219,
+      "min_nanos": 117664,
+      "max_nanos": 130954,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 117594,
+      "min_nanos": 116592,
+      "max_nanos": 125786,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 225675,
+      "min_nanos": 223121,
+      "max_nanos": 245965,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 169391,
+      "min_nanos": 165385,
+      "max_nanos": 294146,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 358301,
+      "min_nanos": 350570,
+      "max_nanos": 385241,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 388826,
+      "min_nanos": 377009,
+      "max_nanos": 407014,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 552650,
+      "min_nanos": 540772,
+      "max_nanos": 578017,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 686878,
+      "min_nanos": 682732,
+      "max_nanos": 712957,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 914916,
+      "min_nanos": 899604,
+      "max_nanos": 954164,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1014083,
+      "min_nanos": 1006472,
+      "max_nanos": 1054603,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1665249,
+      "min_nanos": 1640332,
+      "max_nanos": 1693491,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 930069,
+      "min_nanos": 927595,
+      "max_nanos": 958080,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1625810,
+      "min_nanos": 1611018,
+      "max_nanos": 1656446,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 2604892,
+      "min_nanos": 2589970,
+      "max_nanos": 2655316,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 5011019,
+      "min_nanos": 4971310,
+      "max_nanos": 5144466,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 85356,
+      "min_nanos": 80649,
+      "max_nanos": 116042,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 135521,
+      "min_nanos": 132187,
+      "max_nanos": 146167,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 200978,
+      "min_nanos": 196131,
+      "max_nanos": 211734,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 448815,
+      "min_nanos": 442375,
+      "max_nanos": 470618,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 595913,
+      "min_nanos": 588383,
+      "max_nanos": 621702,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 852824,
+      "min_nanos": 834167,
+      "max_nanos": 880666,
+      "factor_count": 14,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1146580,
+      "min_nanos": 1132789,
+      "max_nanos": 1193329,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1651880,
+      "min_nanos": 1634924,
+      "max_nanos": 1684467,
+      "factor_count": 18,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2185130,
+      "min_nanos": 2174313,
+      "max_nanos": 2212841,
+      "factor_count": 20,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 3423225,
+      "min_nanos": 3408814,
+      "max_nanos": 3476063,
+      "factor_count": 24,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 5222592,
+      "min_nanos": 5216033,
+      "max_nanos": 5241261,
+      "factor_count": 28,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6585022,
+      "min_nanos": 6575839,
+      "max_nanos": 6614716,
+      "factor_count": 32,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 9257143,
+      "min_nanos": 9218587,
+      "max_nanos": 9289021,
+      "factor_count": 40,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_48",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 16134620,
+      "min_nanos": 16122602,
+      "max_nanos": 16184393,
+      "factor_count": 48,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_56",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 20945502,
+      "min_nanos": 20898542,
+      "max_nanos": 21096366,
+      "factor_count": 56,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_26",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 103223,
+      "min_nanos": 98366,
+      "max_nanos": 146657,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_22",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 204954,
+      "min_nanos": 196602,
+      "max_nanos": 220347,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_23",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 170102,
+      "min_nanos": 166747,
+      "max_nanos": 187488,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_25",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 172296,
+      "min_nanos": 169732,
+      "max_nanos": 185124,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_07",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 146347,
+      "min_nanos": 144354,
+      "max_nanos": 164013,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_13",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 209181,
+      "min_nanos": 202601,
+      "max_nanos": 235069,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_09",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 297340,
+      "min_nanos": 290030,
+      "max_nanos": 325272,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_14",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 207307,
+      "min_nanos": 199476,
+      "max_nanos": 225394,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_04",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 331331,
+      "min_nanos": 326163,
+      "max_nanos": 351041,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_08",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 342027,
+      "min_nanos": 340064,
+      "max_nanos": 365902,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_16",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 218103,
+      "min_nanos": 216762,
+      "max_nanos": 236521,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_20",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 310630,
+      "min_nanos": 304842,
+      "max_nanos": 322248,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_28",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 562404,
+      "min_nanos": 552659,
+      "max_nanos": 656784,
+      "factor_count": 5,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_29",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 316399,
+      "min_nanos": 313555,
+      "max_nanos": 345613,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_06",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 357861,
+      "min_nanos": 352382,
+      "max_nanos": 378881,
+      "factor_count": 3,
+      "factor_degrees": [
+        4,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_17",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 245725,
+      "min_nanos": 235879,
+      "max_nanos": 271232,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_01",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 264122,
+      "min_nanos": 260016,
+      "max_nanos": 297441,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_05",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 320676,
+      "min_nanos": 311091,
+      "max_nanos": 362076,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_19",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 242219,
+      "min_nanos": 234898,
+      "max_nanos": 267106,
+      "factor_count": 2,
+      "factor_degrees": [
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_27",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 424370,
+      "min_nanos": 418321,
+      "max_nanos": 453522,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_11",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 379252,
+      "min_nanos": 370169,
+      "max_nanos": 408345,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        7,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_00",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 788029,
+      "min_nanos": 770753,
+      "max_nanos": 813707,
+      "factor_count": 3,
+      "factor_degrees": [
+        5,
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_03",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 720699,
+      "min_nanos": 701049,
+      "max_nanos": 738084,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_12",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 422566,
+      "min_nanos": 406462,
+      "max_nanos": 456627,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        3,
+        7,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_24",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 471890,
+      "min_nanos": 457709,
+      "max_nanos": 508003,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_02",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 739677,
+      "min_nanos": 724914,
+      "max_nanos": 771764,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_10",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 582804,
+      "min_nanos": 570086,
+      "max_nanos": 616904,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_15",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 655912,
+      "min_nanos": 639237,
+      "max_nanos": 687859,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_18",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 957500,
+      "min_nanos": 941356,
+      "max_nanos": 996487,
+      "factor_count": 3,
+      "factor_degrees": [
+        6,
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_21",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1309050,
+      "min_nanos": 1285896,
+      "max_nanos": 1346446,
+      "factor_count": 3,
+      "factor_degrees": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S7",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 190938836,
+      "min_nanos": 189198476,
+      "max_nanos": 192446882,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_M12_f132",
+      "degree": 132,
+      "status": "ok",
+      "median_nanos": 952564192,
+      "min_nanos": 946781760,
+      "max_nanos": 957787006,
+      "factor_count": 1,
+      "factor_degrees": [
+        132
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F190",
+      "degree": 190,
+      "status": "ok",
+      "median_nanos": 3245417348,
+      "min_nanos": 3245417348,
+      "max_nanos": 3245417348,
+      "factor_count": 3,
+      "factor_degrees": [
+        10,
+        90,
+        90
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F192",
+      "degree": 192,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F256",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S8",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 3980142799,
+      "min_nanos": 3980142799,
+      "max_nanos": 3980142799,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F351",
+      "degree": 351,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_P7",
+      "degree": 384,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S9",
+      "degree": 512,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F630",
+      "degree": 630,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 29254,
+      "min_nanos": 22974,
+      "max_nanos": 20192666,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 23194,
+      "min_nanos": 22844,
+      "max_nanos": 26079,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22163,
+      "min_nanos": 21912,
+      "max_nanos": 23305,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22613,
+      "min_nanos": 22343,
+      "max_nanos": 24196,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22784,
+      "min_nanos": 22123,
+      "max_nanos": 25428,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22043,
+      "min_nanos": 21161,
+      "max_nanos": 29534,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22664,
+      "min_nanos": 22383,
+      "max_nanos": 24296,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22123,
+      "min_nanos": 21802,
+      "max_nanos": 22453,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22072,
+      "min_nanos": 21983,
+      "max_nanos": 23245,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 29303,
+      "min_nanos": 28533,
+      "max_nanos": 39238,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 37336,
+      "min_nanos": 35642,
+      "max_nanos": 59459,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28852,
+      "min_nanos": 28252,
+      "max_nanos": 35743,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28091,
+      "min_nanos": 27761,
+      "max_nanos": 28673,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 38907,
+      "min_nanos": 34912,
+      "max_nanos": 41271,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 25698,
+      "min_nanos": 24967,
+      "max_nanos": 32598,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 40780,
+      "min_nanos": 37075,
+      "max_nanos": 44797,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34261,
+      "min_nanos": 33810,
+      "max_nanos": 38287,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 35513,
+      "min_nanos": 34291,
+      "max_nanos": 38918,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 44095,
+      "min_nanos": 42773,
+      "max_nanos": 51567,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 27941,
+      "min_nanos": 27170,
+      "max_nanos": 31757,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 37806,
+      "min_nanos": 37446,
+      "max_nanos": 43444,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28422,
+      "min_nanos": 27101,
+      "max_nanos": 30635,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 39068,
+      "min_nanos": 38697,
+      "max_nanos": 41581,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28903,
+      "min_nanos": 28352,
+      "max_nanos": 31036,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 30706,
+      "min_nanos": 30395,
+      "max_nanos": 33870,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 43845,
+      "min_nanos": 39869,
+      "max_nanos": 44336,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 30565,
+      "min_nanos": 29193,
+      "max_nanos": 40640,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 57425,
+      "min_nanos": 55913,
+      "max_nanos": 67300,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 60800,
+      "min_nanos": 59127,
+      "max_nanos": 64957,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 46219,
+      "min_nanos": 43935,
+      "max_nanos": 46650,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33890,
+      "min_nanos": 33479,
+      "max_nanos": 35833,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 37806,
+      "min_nanos": 36253,
+      "max_nanos": 39098,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 49774,
+      "min_nanos": 48301,
+      "max_nanos": 53098,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 69443,
+      "min_nanos": 67150,
+      "max_nanos": 73629,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 48131,
+      "min_nanos": 46519,
+      "max_nanos": 50485,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33069,
+      "min_nanos": 32849,
+      "max_nanos": 34862,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 44156,
+      "min_nanos": 43694,
+      "max_nanos": 47631,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 37075,
+      "min_nanos": 36615,
+      "max_nanos": 40140,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 50685,
+      "min_nanos": 49694,
+      "max_nanos": 55603,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 37074,
+      "min_nanos": 36414,
+      "max_nanos": 37465,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 56303,
+      "min_nanos": 54812,
+      "max_nanos": 60499,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 70544,
+      "min_nanos": 66048,
+      "max_nanos": 79398,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 64545,
+      "min_nanos": 62953,
+      "max_nanos": 68842,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 53339,
+      "min_nanos": 50625,
+      "max_nanos": 59508,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 44526,
+      "min_nanos": 42563,
+      "max_nanos": 52177,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 65116,
+      "min_nanos": 63384,
+      "max_nanos": 73429,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43916,
+      "min_nanos": 43414,
+      "max_nanos": 49894,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 46159,
+      "min_nanos": 43043,
+      "max_nanos": 50755,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 82482,
+      "min_nanos": 81841,
+      "max_nanos": 91756,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 52879,
+      "min_nanos": 51236,
+      "max_nanos": 57735,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 72899,
+      "min_nanos": 70845,
+      "max_nanos": 74360,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 45518,
+      "min_nanos": 43515,
+      "max_nanos": 49524,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 78537,
+      "min_nanos": 76554,
+      "max_nanos": 85687,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 68151,
+      "min_nanos": 63184,
+      "max_nanos": 68351,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 65898,
+      "min_nanos": 63284,
+      "max_nanos": 67500,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 46949,
+      "min_nanos": 45788,
+      "max_nanos": 49804,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 70474,
+      "min_nanos": 68562,
+      "max_nanos": 73069,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 55132,
+      "min_nanos": 52938,
+      "max_nanos": 56284,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 63103,
+      "min_nanos": 62312,
+      "max_nanos": 65868,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 72508,
+      "min_nanos": 70805,
+      "max_nanos": 73779,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 99647,
+      "min_nanos": 97464,
+      "max_nanos": 110964,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 69353,
+      "min_nanos": 67269,
+      "max_nanos": 73930,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 100419,
+      "min_nanos": 98386,
+      "max_nanos": 109903,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 60209,
+      "min_nanos": 59008,
+      "max_nanos": 70055,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 101290,
+      "min_nanos": 100048,
+      "max_nanos": 109983,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 82533,
+      "min_nanos": 78416,
+      "max_nanos": 87810,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 77365,
+      "min_nanos": 72608,
+      "max_nanos": 79507,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 84746,
+      "min_nanos": 82593,
+      "max_nanos": 88642,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 84114,
+      "min_nanos": 80489,
+      "max_nanos": 92267,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 61491,
+      "min_nanos": 59078,
+      "max_nanos": 63234,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 96994,
+      "min_nanos": 90044,
+      "max_nanos": 103413,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 100339,
+      "min_nanos": 97695,
+      "max_nanos": 106799,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 108781,
+      "min_nanos": 106008,
+      "max_nanos": 117794,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 73519,
+      "min_nanos": 71906,
+      "max_nanos": 75762,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 70114,
+      "min_nanos": 68541,
+      "max_nanos": 72217,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 156822,
+      "min_nanos": 155551,
+      "max_nanos": 171194,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 125626,
+      "min_nanos": 118425,
+      "max_nanos": 138986,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 68912,
+      "min_nanos": 66238,
+      "max_nanos": 68962,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 79448,
+      "min_nanos": 75842,
+      "max_nanos": 85066,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 152076,
+      "min_nanos": 147849,
+      "max_nanos": 162120,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 128080,
+      "min_nanos": 123053,
+      "max_nanos": 138355,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 89022,
+      "min_nanos": 87800,
+      "max_nanos": 99698,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 203061,
+      "min_nanos": 198774,
+      "max_nanos": 227547,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 172836,
+      "min_nanos": 168229,
+      "max_nanos": 182100,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 91415,
+      "min_nanos": 90574,
+      "max_nanos": 94009,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 79348,
+      "min_nanos": 77044,
+      "max_nanos": 81351,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 102823,
+      "min_nanos": 100609,
+      "max_nanos": 103634,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 225705,
+      "min_nanos": 211734,
+      "max_nanos": 259465,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 153978,
+      "min_nanos": 149882,
+      "max_nanos": 169762,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 113088,
+      "min_nanos": 110524,
+      "max_nanos": 117554,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 136312,
+      "min_nanos": 133187,
+      "max_nanos": 137964,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 158234,
+      "min_nanos": 157754,
+      "max_nanos": 158856,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 215860,
+      "min_nanos": 210392,
+      "max_nanos": 252044,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 113999,
+      "min_nanos": 112637,
+      "max_nanos": 119608,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 147078,
+      "min_nanos": 142231,
+      "max_nanos": 158425,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 187949,
+      "min_nanos": 183582,
+      "max_nanos": 199936,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 119807,
+      "min_nanos": 117224,
+      "max_nanos": 123934,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 127228,
+      "min_nanos": 124094,
+      "max_nanos": 128371,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 291372,
+      "min_nanos": 283500,
+      "max_nanos": 319725,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 273366,
+      "min_nanos": 264132,
+      "max_nanos": 297752,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 258633,
+      "min_nanos": 250601,
+      "max_nanos": 285032,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 109853,
+      "min_nanos": 108631,
+      "max_nanos": 121340,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 427964,
+      "min_nanos": 415507,
+      "max_nanos": 471840,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 296519,
+      "min_nanos": 290431,
+      "max_nanos": 326974,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 329518,
+      "min_nanos": 322959,
+      "max_nanos": 350519,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 151214,
+      "min_nanos": 150082,
+      "max_nanos": 155751,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 227478,
+      "min_nanos": 222690,
+      "max_nanos": 244132,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 289940,
+      "min_nanos": 278793,
+      "max_nanos": 311432,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 266986,
+      "min_nanos": 264802,
+      "max_nanos": 283039,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 125466,
+      "min_nanos": 124154,
+      "max_nanos": 130984,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 352032,
+      "min_nanos": 339984,
+      "max_nanos": 390059,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 124094,
+      "min_nanos": 122141,
+      "max_nanos": 134870,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 326674,
+      "min_nanos": 320646,
+      "max_nanos": 359042,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 188299,
+      "min_nanos": 187608,
+      "max_nanos": 192375,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 267577,
+      "min_nanos": 259525,
+      "max_nanos": 281928,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 244212,
+      "min_nanos": 238624,
+      "max_nanos": 264872,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 277441,
+      "min_nanos": 268188,
+      "max_nanos": 304902,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 186426,
+      "min_nanos": 185595,
+      "max_nanos": 192035,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 285504,
+      "min_nanos": 278172,
+      "max_nanos": 324161,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 266054,
+      "min_nanos": 257752,
+      "max_nanos": 294647,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 481884,
+      "min_nanos": 461053,
+      "max_nanos": 511709,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 205465,
+      "min_nanos": 201870,
+      "max_nanos": 210021,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 384159,
+      "min_nanos": 375036,
+      "max_nanos": 421014,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 419051,
+      "min_nanos": 410698,
+      "max_nanos": 456016,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 485260,
+      "min_nanos": 456287,
+      "max_nanos": 500362,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 174879,
+      "min_nanos": 173297,
+      "max_nanos": 179255,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 201489,
+      "min_nanos": 198704,
+      "max_nanos": 205685,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 297140,
+      "min_nanos": 286174,
+      "max_nanos": 326223,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 372312,
+      "min_nanos": 367565,
+      "max_nanos": 404090,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 233657,
+      "min_nanos": 231153,
+      "max_nanos": 234107,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 464279,
+      "min_nanos": 449587,
+      "max_nanos": 506731,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 440153,
+      "min_nanos": 432151,
+      "max_nanos": 467133,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 579219,
+      "min_nanos": 564457,
+      "max_nanos": 616815,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 216912,
+      "min_nanos": 215269,
+      "max_nanos": 220847,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 502905,
+      "min_nanos": 476997,
+      "max_nanos": 537206,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 439982,
+      "min_nanos": 432220,
+      "max_nanos": 468014,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 488995,
+      "min_nanos": 476927,
+      "max_nanos": 526290,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 272664,
+      "min_nanos": 269931,
+      "max_nanos": 279955,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 486341,
+      "min_nanos": 476747,
+      "max_nanos": 535413,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 528624,
+      "min_nanos": 502795,
+      "max_nanos": 568332,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 539740,
+      "min_nanos": 526340,
+      "max_nanos": 570807,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 211103,
+      "min_nanos": 208630,
+      "max_nanos": 234999,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 350540,
+      "min_nanos": 348567,
+      "max_nanos": 352683,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 578838,
+      "min_nanos": 559139,
+      "max_nanos": 630034,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 282408,
+      "min_nanos": 277962,
+      "max_nanos": 288367,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 299614,
+      "min_nanos": 299484,
+      "max_nanos": 302077,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 828087,
+      "min_nanos": 811683,
+      "max_nanos": 861297,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 660960,
+      "min_nanos": 648372,
+      "max_nanos": 684635,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 378521,
+      "min_nanos": 375857,
+      "max_nanos": 415176,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 230442,
+      "min_nanos": 227818,
+      "max_nanos": 238324,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 318402,
+      "min_nanos": 315267,
+      "max_nanos": 319673,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 343890,
+      "min_nanos": 326193,
+      "max_nanos": 386502,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 691665,
+      "min_nanos": 658957,
+      "max_nanos": 719837,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 360114,
+      "min_nanos": 354576,
+      "max_nanos": 364961,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 890680,
+      "min_nanos": 871301,
+      "max_nanos": 905332,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 935828,
+      "min_nanos": 917290,
+      "max_nanos": 966944,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 732496,
+      "min_nanos": 721639,
+      "max_nanos": 761079,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 273296,
+      "min_nanos": 269209,
+      "max_nanos": 278533,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 297492,
+      "min_nanos": 293986,
+      "max_nanos": 303900,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 661671,
+      "min_nanos": 645788,
+      "max_nanos": 690524,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 593740,
+      "min_nanos": 562684,
+      "max_nanos": 634320,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 358612,
+      "min_nanos": 349599,
+      "max_nanos": 360925,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 1119360,
+      "min_nanos": 1115514,
+      "max_nanos": 1151377,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 369858,
+      "min_nanos": 366713,
+      "max_nanos": 375517,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 507292,
+      "min_nanos": 504938,
+      "max_nanos": 518058,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 869269,
+      "min_nanos": 849229,
+      "max_nanos": 900194,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 429918,
+      "min_nanos": 428045,
+      "max_nanos": 437088,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 959232,
+      "min_nanos": 936088,
+      "max_nanos": 995856,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 385812,
+      "min_nanos": 383990,
+      "max_nanos": 392742,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 532881,
+      "min_nanos": 532099,
+      "max_nanos": 535013,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1446594,
+      "min_nanos": 1430871,
+      "max_nanos": 1477830,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 930148,
+      "min_nanos": 915648,
+      "max_nanos": 1070277,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 491469,
+      "min_nanos": 488334,
+      "max_nanos": 497467,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 968676,
+      "min_nanos": 954676,
+      "max_nanos": 990529,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1335229,
+      "min_nanos": 1320448,
+      "max_nanos": 1357002,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 1250033,
+      "min_nanos": 1244385,
+      "max_nanos": 1265546,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 371041,
+      "min_nanos": 370560,
+      "max_nanos": 379382,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 432161,
+      "min_nanos": 428946,
+      "max_nanos": 435136,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 919243,
+      "min_nanos": 910850,
+      "max_nanos": 943970,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 1572881,
+      "min_nanos": 1560053,
+      "max_nanos": 1591129,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 532990,
+      "min_nanos": 527853,
+      "max_nanos": 540191,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 498529,
+      "min_nanos": 495895,
+      "max_nanos": 504848,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 470788,
+      "min_nanos": 469607,
+      "max_nanos": 472581,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 1227911,
+      "min_nanos": 1220559,
+      "max_nanos": 1248741,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1316091,
+      "min_nanos": 1311434,
+      "max_nanos": 1334698,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 565028,
+      "min_nanos": 562113,
+      "max_nanos": 575373,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "certificate-boundary",
+      "name": "quartic_a4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 50114,
+      "min_nanos": 49473,
+      "max_nanos": 58878,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    }
+  ],
+  "cross_check": {
+    "mismatches": [],
+    "ok": true
+  }
+}

--- a/reports/figures/hexbz-cactus-certificate-boundary.svg
+++ b/reports/figures/hexbz-cactus-certificate-boundary.svg
@@ -1037,7 +1037,7 @@ z
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 290.301172 192.581773
+    <path d="M 290.301172 196.053325
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1053,7 +1053,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="192.581773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="196.053325" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_32">
@@ -1791,7 +1791,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1891,7 +1891,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-chebyshev.svg
+++ b/reports/figures/hexbz-cactus-chebyshev.svg
@@ -1407,34 +1407,34 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 279.216802
-L 101.569768 263.825034
-L 116.41548 255.264601
-L 131.261192 248.975771
-L 146.106905 242.640629
-L 160.952617 237.545604
-L 175.798329 233.501158
-L 190.644042 230.12205
-L 205.489754 227.184924
-L 220.335466 224.522819
-L 235.181179 221.497484
-L 250.026891 218.769404
-L 264.872603 216.114568
-L 279.718316 213.677861
-L 294.564028 211.253052
-L 309.40974 208.893655
-L 324.255453 206.778399
-L 339.101165 204.682596
-L 353.946877 202.551594
-L 368.79259 200.453045
-L 383.638302 198.36909
-L 398.484014 196.144437
-L 413.329727 194.064897
-L 428.175439 191.323931
-L 443.021151 188.556313
-L 457.866864 185.971369
-L 472.712576 183.496817
-L 487.558288 180.869076
+    <path d="M 86.724055 278.923234
+L 101.569768 263.722591
+L 116.41548 255.061049
+L 131.261192 248.908521
+L 146.106905 242.903065
+L 160.952617 238.282026
+L 175.798329 233.979796
+L 190.644042 230.467764
+L 205.489754 227.370242
+L 220.335466 224.700114
+L 235.181179 221.730941
+L 250.026891 218.995123
+L 264.872603 216.327988
+L 279.718316 213.84775
+L 294.564028 211.364511
+L 309.40974 209.064822
+L 324.255453 206.907734
+L 339.101165 204.801426
+L 353.946877 202.598817
+L 368.79259 200.423735
+L 383.638302 198.313588
+L 398.484014 196.079982
+L 413.329727 193.974828
+L 428.175439 191.265277
+L 443.021151 188.501436
+L 457.866864 185.93771
+L 472.712576 183.461971
+L 487.558288 180.813053
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1450,34 +1450,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="279.216802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="263.825034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="255.264601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="248.975771" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="146.106905" y="242.640629" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.952617" y="237.545604" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="233.501158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.644042" y="230.12205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.489754" y="227.184924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="224.522819" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.181179" y="221.497484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="250.026891" y="218.769404" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="216.114568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.718316" y="213.677861" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.564028" y="211.253052" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="208.893655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="324.255453" y="206.778399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.101165" y="204.682596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="202.551594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.79259" y="200.453045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.638302" y="198.36909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="196.144437" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.329727" y="194.064897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="428.175439" y="191.323931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="188.556313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.866864" y="185.971369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.712576" y="183.496817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="180.869076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="278.923234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="263.722591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="255.061049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="248.908521" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="146.106905" y="242.903065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.952617" y="238.282026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="233.979796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.644042" y="230.467764" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.489754" y="227.370242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="224.700114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.181179" y="221.730941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="250.026891" y="218.995123" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="216.327988" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.718316" y="213.84775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.564028" y="211.364511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="209.064822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="324.255453" y="206.907734" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.101165" y="204.801426" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="202.598817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.79259" y="200.423735" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.638302" y="198.313588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="196.079982" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.329727" y="193.974828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="428.175439" y="191.265277" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="188.501436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.866864" y="185.93771" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.712576" y="183.461971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="180.813053" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2530,7 +2530,7 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2590,6 +2590,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2637,7 +2667,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-combined.svg
+++ b/reports/figures/hexbz-cactus-combined.svg
@@ -1656,59 +1656,61 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <path d="M 86.724055 274.090148
-L 89.260981 262.385333
-L 91.797906 254.477243
-L 94.334832 249.080466
-L 96.871757 244.89943
-L 99.408683 241.529998
-L 101.945609 238.720601
-L 104.482534 236.267594
-L 107.01946 234.092963
-L 109.556385 232.1098
-L 112.093311 229.933495
-L 114.630236 227.989899
-L 119.704087 224.454904
-L 124.777938 221.327247
-L 129.851789 218.505019
-L 134.92564 215.701299
-L 145.073342 210.376842
-L 150.147194 208.010366
-L 157.75797 204.841863
-L 170.442598 199.931059
-L 180.5903 196.456068
-L 193.274927 192.523719
-L 216.107257 186.132372
-L 269.382693 172.556956
-L 289.678097 167.593688
-L 315.047353 162.074074
-L 337.879682 157.063276
-L 348.027384 154.375543
-L 358.175087 151.573795
-L 363.248938 150.131603
-L 378.470491 144.83964
-L 393.692044 137.668294
-L 398.765895 135.524916
-L 406.376672 131.841797
-L 408.913597 130.074981
-L 413.987448 126.930135
-L 416.524374 125.490076
-L 419.061299 123.908939
-L 426.672076 118.469531
-L 434.282852 113.659168
-L 436.819778 111.994547
-L 439.356703 109.926405
-L 444.430554 103.524754
-L 446.96748 100.641275
-L 449.504405 97.485005
-L 452.041331 94.810862
-L 454.578257 91.276839
-L 457.115182 83.605268
-L 459.652108 72.069593
-L 462.189033 64.539272
-L 464.725959 58.886061
-L 467.262884 53.89278
-L 467.262884 53.89278
+    <path d="M 86.724055 274.615041
+L 89.260981 262.630563
+L 91.797906 254.850665
+L 94.334832 249.362777
+L 96.871757 245.049107
+L 99.408683 241.620147
+L 101.945609 238.772442
+L 104.482534 236.335144
+L 107.01946 234.15023
+L 109.556385 232.188499
+L 112.093311 230.049876
+L 114.630236 228.101338
+L 119.704087 224.638051
+L 129.851789 218.521339
+L 134.92564 215.603936
+L 142.536417 211.555897
+L 150.147194 207.97383
+L 155.221045 205.882283
+L 175.516449 198.241177
+L 183.127225 195.754348
+L 190.738002 193.383762
+L 211.033406 187.60538
+L 218.644183 185.578134
+L 238.939587 180.445398
+L 276.99347 170.755376
+L 287.141172 168.32366
+L 302.362725 164.988561
+L 335.342757 157.906114
+L 345.490459 155.378656
+L 353.101236 153.197523
+L 363.248938 150.354934
+L 378.470491 145.072469
+L 393.692044 137.880071
+L 401.302821 134.508957
+L 406.376672 132.041078
+L 408.913597 130.275427
+L 413.987448 127.154499
+L 416.524374 125.738268
+L 419.061299 124.156014
+L 424.13515 120.470901
+L 429.209001 117.235222
+L 431.745927 115.696718
+L 436.819778 112.330233
+L 439.356703 110.229659
+L 444.430554 103.832449
+L 446.96748 100.911028
+L 449.504405 97.784643
+L 452.041331 95.093445
+L 454.578257 91.527911
+L 457.115182 83.815594
+L 459.652108 72.201584
+L 462.189033 64.661324
+L 464.725959 59.015794
+L 467.262884 53.977528
+L 467.262884 53.977528
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1724,157 +1726,157 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.090148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.260981" y="262.385333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.797906" y="254.477243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.334832" y="249.080466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.871757" y="244.89943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.408683" y="241.529998" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.945609" y="238.720601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.482534" y="236.267594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.01946" y="234.092963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.556385" y="232.1098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.093311" y="229.933495" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.630236" y="227.989899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.167162" y="226.210816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.704087" y="224.454904" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="122.241013" y="222.85473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.777938" y="221.327247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.314864" y="219.862884" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="129.851789" y="218.505019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.388715" y="217.070712" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.92564" y="215.701299" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="137.462566" y="214.343054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.999491" y="212.95083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.536417" y="211.625202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.073342" y="210.376842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.610268" y="209.152144" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.147194" y="208.010366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="152.684119" y="206.917338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.221045" y="205.872958" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="157.75797" y="204.841863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.294896" y="203.85266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.831821" y="202.861593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="165.368747" y="201.854755" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="167.905672" y="200.867426" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="170.442598" y="199.931059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.979523" y="199.039223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.516449" y="198.153748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.053374" y="197.291419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.5903" y="196.456068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.127225" y="195.651792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.664151" y="194.825543" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.201076" y="194.035186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.738002" y="193.274005" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.274927" y="192.523719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.811853" y="191.801138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.348778" y="191.099289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.885704" y="190.400877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.42263" y="189.663831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.959555" y="188.949214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.496481" y="188.215931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.033406" y="187.497818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.570332" y="186.808674" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.107257" y="186.132372" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.644183" y="185.480885" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.181108" y="184.852649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.718034" y="184.225628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="226.254959" y="183.586708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="228.791885" y="182.936968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.32881" y="182.308189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="233.865736" y="181.652803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.402661" y="180.998475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.939587" y="180.358222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="241.476512" y="179.70019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.013438" y="179.047674" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="246.550363" y="178.37107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.087289" y="177.696327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.624215" y="177.046539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="254.16114" y="176.411115" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.698066" y="175.78201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="259.234991" y="175.132512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.771917" y="174.485302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.308842" y="173.833088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.845768" y="173.204412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="269.382693" y="172.556956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.919619" y="171.927529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="274.456544" y="171.263338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.99347" y="170.612721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.530395" y="169.985494" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.067321" y="169.359075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="284.604246" y="168.754695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="168.171311" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="289.678097" y="167.593688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.215023" y="167.030708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.751948" y="166.475118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.288874" y="165.912523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.8258" y="165.347716" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.362725" y="164.796357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.899651" y="164.262361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.436576" y="163.719329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.973502" y="163.19216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.510427" y="162.6392" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.047353" y="162.074074" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.584278" y="161.527282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.121204" y="160.960268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.658129" y="160.408573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.195055" y="159.873293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.73198" y="159.349649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="330.268906" y="158.80298" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="332.805831" y="158.229483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.342757" y="157.671613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="337.879682" y="157.063276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.416608" y="156.413787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.953533" y="155.760549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="345.490459" y="155.129159" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.027384" y="154.375543" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.56431" y="153.649177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.101236" y="152.95109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.638161" y="152.261395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="358.175087" y="151.573795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.712012" y="150.902553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.248938" y="150.131603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="365.785863" y="149.25343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.322789" y="148.388581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.859714" y="147.540975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.39664" y="146.703818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="375.933565" y="145.769632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.470491" y="144.83964" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.007416" y="143.625791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.544342" y="142.452957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="386.081267" y="141.268754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="388.618193" y="140.002438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="391.155118" y="138.81136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="393.692044" y="137.668294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.228969" y="136.59379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.765895" y="135.524916" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.302821" y="134.303639" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.839746" y="133.124071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.376672" y="131.841797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="408.913597" y="130.074981" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.450523" y="128.458305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.987448" y="126.930135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.524374" y="125.490076" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="419.061299" y="123.908939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="421.598225" y="122.055927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.13515" y="120.172247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.672076" y="118.469531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.209001" y="116.89326" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.745927" y="115.351646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="434.282852" y="113.659168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.819778" y="111.994547" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.356703" y="109.926405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.893629" y="106.696497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.430554" y="103.524754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.96748" y="100.641275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="449.504405" y="97.485005" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.041331" y="94.810862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="454.578257" y="91.276839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.115182" y="83.605268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.652108" y="72.069593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="462.189033" y="64.539272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="464.725959" y="58.886061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.262884" y="53.89278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.615041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.260981" y="262.630563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.797906" y="254.850665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.334832" y="249.362777" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.871757" y="245.049107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.408683" y="241.620147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.945609" y="238.772442" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.482534" y="236.335144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.01946" y="234.15023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.556385" y="232.188499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.093311" y="230.049876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.630236" y="228.101338" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.167162" y="226.307149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.704087" y="224.638051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="122.241013" y="223.07976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.777938" y="221.545348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.314864" y="219.977526" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="129.851789" y="218.521339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.388715" y="217.031928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.92564" y="215.603936" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="137.462566" y="214.218925" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.999491" y="212.875386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.536417" y="211.555897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.073342" y="210.323633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.610268" y="209.117284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.147194" y="207.97383" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="152.684119" y="206.901532" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.221045" y="205.882283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="157.75797" y="204.920239" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.294896" y="203.919195" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.831821" y="202.928197" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="165.368747" y="201.957183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="167.905672" y="200.971538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="170.442598" y="200.037189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.979523" y="199.142122" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.516449" y="198.241177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.053374" y="197.385185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.5903" y="196.560149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.127225" y="195.754348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.664151" y="194.944509" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.201076" y="194.150819" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.738002" y="193.383762" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.274927" y="192.649904" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.811853" y="191.937192" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.348778" y="191.250753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.885704" y="190.52606" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.42263" y="189.781829" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.959555" y="189.04591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.496481" y="188.313888" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.033406" y="187.60538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.570332" y="186.90251" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.107257" y="186.227796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.644183" y="185.578134" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.181108" y="184.948999" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.718034" y="184.311754" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="226.254959" y="183.672551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="228.791885" y="183.016366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.32881" y="182.380178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="233.865736" y="181.732006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.402661" y="181.078804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.939587" y="180.445398" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="241.476512" y="179.792989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.013438" y="179.144569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="246.550363" y="178.475827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.087289" y="177.828418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.624215" y="177.180202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="254.16114" y="176.537546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.698066" y="175.91058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="259.234991" y="175.254804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.771917" y="174.621088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.308842" y="173.975965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.845768" y="173.324502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="269.382693" y="172.677274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.919619" y="172.047927" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="274.456544" y="171.392143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.99347" y="170.755376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.530395" y="170.124412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.067321" y="169.505813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="284.604246" y="168.906509" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="168.32366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="289.678097" y="167.753608" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.215023" y="167.199506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.751948" y="166.647937" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.288874" y="166.105348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.8258" y="165.538389" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.362725" y="164.988561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.899651" y="164.451605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.436576" y="163.91182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.973502" y="163.374357" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.510427" y="162.829363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.047353" y="162.272237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.584278" y="161.728561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.121204" y="161.161387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.658129" y="160.611578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.195055" y="160.07855" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.73198" y="159.561223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="330.268906" y="159.015449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="332.805831" y="158.463252" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.342757" y="157.906114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="337.879682" y="157.297723" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.416608" y="156.645809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.953533" y="156.002222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="345.490459" y="155.378656" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.027384" y="154.628093" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.56431" y="153.904027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.101236" y="153.197523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.638161" y="152.508756" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="358.175087" y="151.805555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.712012" y="151.124714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.248938" y="150.354934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="365.785863" y="149.481223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.322789" y="148.625913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.859714" y="147.800862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.39664" y="146.954136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="375.933565" y="146.018619" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.470491" y="145.072469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.007416" y="143.858737" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.544342" y="142.680882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="386.081267" y="141.500495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="388.618193" y="140.228844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="391.155118" y="139.033636" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="393.692044" y="137.880071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.228969" y="136.777432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.765895" y="135.709512" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.302821" y="134.508957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.839746" y="133.314671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.376672" y="132.041078" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="408.913597" y="130.275427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.450523" y="128.664692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.987448" y="127.154499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.524374" y="125.738268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="419.061299" y="124.156014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="421.598225" y="122.306464" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.13515" y="120.470901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.672076" y="118.786682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.209001" y="117.235222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.745927" y="115.696718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="434.282852" y="114.013952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.819778" y="112.330233" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.356703" y="110.229659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.893629" y="106.995096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.430554" y="103.832449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.96748" y="100.911028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="449.504405" y="97.784643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.041331" y="95.093445" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="454.578257" y="91.527911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.115182" y="83.815594" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.652108" y="72.201584" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="462.189033" y="64.661324" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="464.725959" y="59.015794" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.262884" y="53.977528" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -3736,7 +3738,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3860,7 +3862,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-conway.svg
+++ b/reports/figures/hexbz-cactus-conway.svg
@@ -1637,41 +1637,40 @@ z
     </g>
    </g>
    <g id="line2d_157">
-    <path d="M 86.724055 275.707859
-L 88.890727 264.632321
-L 91.057398 258.177895
-L 93.22407 253.58517
-L 95.390742 249.995963
-L 97.557413 246.999349
-L 99.724085 244.460307
-L 104.057428 239.934631
-L 106.224099 237.919334
-L 108.390771 236.124463
-L 112.724114 232.956161
-L 117.057457 230.26585
-L 121.3908 227.932703
-L 130.057486 223.735327
-L 134.390829 221.866024
-L 140.890844 219.362496
-L 147.390858 217.067643
-L 156.057544 214.288809
-L 162.557559 212.415964
-L 179.890931 207.876627
-L 192.89096 204.713977
-L 203.724318 202.277837
-L 212.391004 200.46024
-L 227.557705 197.575913
-L 260.057778 191.678376
-L 299.057865 184.617982
-L 316.391238 181.316575
-L 344.557967 176.248648
-L 361.89134 173.430282
-L 426.891486 163.538465
-L 448.558201 160.421048
-L 457.224887 159.025831
-L 476.724931 155.498402
-L 487.558288 153.194271
-L 487.558288 153.194271
+    <path d="M 86.724055 275.25686
+L 88.890727 264.32504
+L 91.057398 257.920807
+L 93.22407 253.373073
+L 95.390742 249.784205
+L 97.557413 246.857031
+L 99.724085 244.377311
+L 104.057428 240.092814
+L 106.224099 238.082803
+L 108.390771 236.291395
+L 112.724114 233.169648
+L 117.057457 230.528336
+L 121.3908 228.205026
+L 130.057486 224.045599
+L 136.557501 221.266917
+L 143.057515 218.840009
+L 151.724201 215.89517
+L 158.224216 213.85048
+L 166.890902 211.403931
+L 182.057603 207.4975
+L 197.224303 203.846041
+L 210.224333 200.992312
+L 221.05769 198.856523
+L 253.557763 192.870218
+L 294.724522 185.492629
+L 335.891281 177.824779
+L 351.057982 175.205873
+L 368.391354 172.444326
+L 400.891427 167.430371
+L 429.058157 163.302649
+L 455.058215 159.561568
+L 474.558259 156.080321
+L 487.558288 153.315125
+L 487.558288 153.315125
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1687,192 +1686,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.707859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.890727" y="264.632321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.057398" y="258.177895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.22407" y="253.58517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="95.390742" y="249.995963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.557413" y="246.999349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.724085" y="244.460307" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.890756" y="242.141523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.057428" y="239.934631" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.224099" y="237.919334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.390771" y="236.124463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.557442" y="234.485275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.724114" y="232.956161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.890785" y="231.558788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.057457" y="230.26585" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.224128" y="229.058396" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.3908" y="227.932703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.557471" y="226.856176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.724143" y="225.766926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.890814" y="224.743498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="130.057486" y="223.735327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.224158" y="222.781407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.390829" y="221.866024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.557501" y="220.998379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.724172" y="220.175161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="140.890844" y="219.362496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.057515" y="218.574006" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.224187" y="217.808527" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.390858" y="217.067643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="149.55753" y="216.344019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="151.724201" y="215.641116" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.890873" y="214.950615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.057544" y="214.288809" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.224216" y="213.640908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.390887" y="213.017223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.557559" y="212.415964" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="164.72423" y="211.834638" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="211.263764" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.057574" y="210.699756" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.224245" y="210.117246" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.390917" y="209.542784" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.557588" y="208.985122" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.72426" y="208.421493" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.890931" y="207.876627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="182.057603" y="207.334501" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="184.224274" y="206.788113" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.390946" y="206.254842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.557617" y="205.728872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.724289" y="205.215523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.89096" y="204.713977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.057632" y="204.205045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.224303" y="203.710886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.390975" y="203.228273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.557646" y="202.748726" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.724318" y="202.277837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.89099" y="201.805927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.057661" y="201.347473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.224333" y="200.897899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.391004" y="200.46024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.557676" y="200.032176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.724347" y="199.613196" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.891019" y="199.201283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.05769" y="198.789636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.224362" y="198.383512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="225.391033" y="197.983878" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="227.557705" y="197.575913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.724376" y="197.17608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.891048" y="196.774141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.057719" y="196.379372" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.224391" y="195.993178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.391062" y="195.608048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.557734" y="195.215448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.724406" y="194.826484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.891077" y="194.43536" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="194.033576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.22442" y="193.631354" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.391092" y="193.233177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="253.557763" y="192.842129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.724435" y="192.456177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="257.891106" y="192.071028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="260.057778" y="191.678376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="262.224449" y="191.292043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.391121" y="190.903232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.557792" y="190.517442" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.724464" y="190.128649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="270.891135" y="189.731758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="273.057807" y="189.339894" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="275.224478" y="188.952665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="277.39115" y="188.573817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.557822" y="188.20304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.724493" y="187.812229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.891165" y="187.412793" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="286.057836" y="187.007329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="288.224508" y="186.609072" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="290.391179" y="186.21832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.557851" y="185.818742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.724522" y="185.428689" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="296.891194" y="185.019568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.057865" y="184.617982" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.224537" y="184.19285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="303.391208" y="183.776949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.55788" y="183.369624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.724551" y="182.952965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.891223" y="182.53843" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.057894" y="182.130546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="314.224566" y="181.722001" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="316.391238" y="181.316575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.557909" y="180.918497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.724581" y="180.526669" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.891252" y="180.133352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.057924" y="179.74311" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="179.359042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.391267" y="178.962831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.557938" y="178.559172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.72461" y="178.160119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.891281" y="177.766318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="338.057953" y="177.375073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.224624" y="176.993167" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.391296" y="176.617031" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.557967" y="176.248648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="346.724639" y="175.88239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.89131" y="175.517408" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="351.057982" y="175.156164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.224654" y="174.802298" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.391325" y="174.454668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="357.557997" y="174.109945" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="359.724668" y="173.767751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="361.89134" y="173.430282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.058011" y="173.097024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.224683" y="172.747339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.391354" y="172.399688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.558026" y="172.056593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="372.724697" y="171.709667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.891369" y="171.3621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="377.05804" y="171.016359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="379.224712" y="170.677057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.391383" y="170.344045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.558055" y="170.008067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="385.724726" y="169.677854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="387.891398" y="169.348718" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.05807" y="169.025396" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="392.224741" y="168.703916" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.391413" y="168.386275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.558084" y="168.046719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.724756" y="167.709654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="400.891427" y="167.378143" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.058099" y="167.049185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.22477" y="166.722721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="407.391442" y="166.400588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="409.558113" y="166.070166" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.724785" y="165.743658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.891456" y="165.420498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.058128" y="165.101687" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.224799" y="164.782575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.391471" y="164.469476" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="422.558142" y="164.156863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.724814" y="163.845278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.891486" y="163.538465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.058157" y="163.236606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.224829" y="162.930537" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="433.3915" y="162.625854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="435.558172" y="162.325775" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="437.724843" y="162.012211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.891515" y="161.697267" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="442.058186" y="161.387839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.224858" y="161.082079" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.391529" y="160.749731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="448.558201" y="160.421048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="450.724872" y="160.093891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.891544" y="159.747266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="455.058215" y="159.404782" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.224887" y="159.025831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.391558" y="158.641901" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="461.55823" y="158.261822" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.724902" y="157.875547" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.891573" y="157.49189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="468.058245" y="157.112646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="470.224916" y="156.741114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.391588" y="156.369096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="474.558259" y="155.944808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="476.724931" y="155.498402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="478.891602" y="155.058518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="481.058274" y="154.60106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="483.224945" y="154.155086" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="485.391617" y="153.688059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="153.194271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.25686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.890727" y="264.32504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.057398" y="257.920807" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.22407" y="253.373073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="95.390742" y="249.784205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.557413" y="246.857031" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.724085" y="244.377311" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.890756" y="242.199301" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.057428" y="240.092814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.224099" y="238.082803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.390771" y="236.291395" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.557442" y="234.66502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.724114" y="233.169648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.890785" y="231.801664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.057457" y="230.528336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.224128" y="229.348359" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.3908" y="228.205026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.557471" y="227.134319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.724143" y="226.057192" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.890814" y="225.024784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="130.057486" y="224.045599" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.224158" y="223.091034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.390829" y="222.152605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.557501" y="221.266917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.724172" y="220.422628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="140.890844" y="219.611456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.057515" y="218.840009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.224187" y="218.083664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.390858" y="217.35905" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="149.55753" y="216.636629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="151.724201" y="215.89517" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.890873" y="215.185919" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.057544" y="214.504517" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.224216" y="213.85048" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.390887" y="213.217355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.557559" y="212.595395" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="164.72423" y="211.98879" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="211.403931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.057574" y="210.831259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.224245" y="210.265009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.390917" y="209.700076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.557588" y="209.144891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.72426" y="208.585798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.890931" y="208.041248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="182.057603" y="207.4975" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="184.224274" y="206.960916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.390946" y="206.431837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.557617" y="205.895548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.724289" y="205.371907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.89096" y="204.859442" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.057632" y="204.350319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.224303" y="203.846041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.390975" y="203.353147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.557646" y="202.869553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.724318" y="202.384564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.89099" y="201.908883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.057661" y="201.444231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.224333" y="200.992312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.391004" y="200.548809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.557676" y="200.115264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.724347" y="199.692916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.891019" y="199.270295" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.05769" y="198.856523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.224362" y="198.449955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="225.391033" y="198.033152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="227.557705" y="197.62102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.724376" y="197.215299" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.891048" y="196.819271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.057719" y="196.418387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.224391" y="196.027211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.391062" y="195.63829" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.557734" y="195.25592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.724406" y="194.864007" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.891077" y="194.471453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="194.065366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.22442" y="193.658793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.391092" y="193.25973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="253.557763" y="192.870218" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.724435" y="192.486846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="257.891106" y="192.106985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="260.057778" y="191.714838" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="262.224449" y="191.328491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.391121" y="190.940421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.557792" y="190.558665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.724464" y="190.167185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="270.891135" y="189.771697" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="273.057807" y="189.381681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="275.224478" y="189.000607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="277.39115" y="188.623843" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.557822" y="188.253443" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.724493" y="187.868574" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.891165" y="187.463587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="286.057836" y="187.057787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="288.224508" y="186.659951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.391179" y="186.267119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.557851" y="185.876851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.724522" y="185.492629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="296.891194" y="185.083387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.057865" y="184.679851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.224537" y="184.260755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="303.391208" y="183.849227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.55788" y="183.447437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.724551" y="183.028555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.891223" y="182.617379" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.057894" y="182.211977" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="314.224566" y="181.806038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="316.391238" y="181.401491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.557909" y="181.005173" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.724581" y="180.603107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.891252" y="180.208004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.057924" y="179.817606" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="179.431398" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.391267" y="179.037612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.557938" y="178.631032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.72461" y="178.223454" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.891281" y="177.824779" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="338.057953" y="177.435093" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.224624" y="177.047671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.391296" y="176.668681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.557967" y="176.298499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="346.724639" y="175.931486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.89131" y="175.56648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="351.057982" y="175.205873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.224654" y="174.847918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.391325" y="174.496206" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="357.557997" y="174.146163" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="359.724668" y="173.803019" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="361.89134" y="173.466795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.058011" y="173.135272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.224683" y="172.790442" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.391354" y="172.444326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.558026" y="172.102734" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="372.724697" y="171.753968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.891369" y="171.406229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="377.05804" y="171.064567" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="379.224712" y="170.723972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.391383" y="170.389203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.558055" y="170.052624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="385.724726" y="169.722041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="387.891398" y="169.397154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.05807" y="169.073576" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="392.224741" y="168.751835" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.391413" y="168.43519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.558084" y="168.098324" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.724756" y="167.761569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="400.891427" y="167.430371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.058099" y="167.104318" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.22477" y="166.779153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="407.391442" y="166.46044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="409.558113" y="166.131101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.724785" y="165.80403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.891456" y="165.476135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.058128" y="165.152699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.224799" y="164.835069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.391471" y="164.522034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="422.558142" y="164.213559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.724814" y="163.906703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.891486" y="163.603093" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.058157" y="163.302649" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.224829" y="162.995549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="433.3915" y="162.691918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="435.558172" y="162.393967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="437.724843" y="162.097877" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.891515" y="161.793763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="442.058186" y="161.488186" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.224858" y="161.188227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.391529" y="160.886563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="448.558201" y="160.557402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="450.724872" y="160.234634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.891544" y="159.904157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="455.058215" y="159.561568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.224887" y="159.183034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.391558" y="158.795223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="461.55823" y="158.407518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.724902" y="158.01714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.891573" y="157.631736" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="468.058245" y="157.253265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="470.224916" y="156.874538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.391588" y="156.501104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="474.558259" y="156.080321" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="476.724931" y="155.631301" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="478.891602" y="155.186968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="481.058274" y="154.732312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="483.224945" y="154.284073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="485.391617" y="153.812421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="153.315125" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_158">
@@ -3788,7 +3787,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3895,7 +3894,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic-products.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic-products.svg
@@ -1423,25 +1423,25 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 272.982833
-L 108.992624 248.765228
-L 131.261192 237.570879
-L 153.529761 229.611031
-L 175.798329 222.371664
-L 198.066898 216.046232
-L 220.335466 209.645834
-L 242.604035 198.342508
-L 264.872603 189.126013
-L 287.141172 182.530489
-L 309.40974 177.094525
-L 331.678309 169.04081
-L 353.946877 162.555041
-L 376.215446 155.01084
-L 398.484014 147.138076
-L 420.752583 138.000641
-L 443.021151 128.951132
-L 465.28972 120.732396
-L 487.558288 108.936627
+    <path d="M 86.724055 272.626462
+L 108.992624 248.505791
+L 131.261192 237.461193
+L 153.529761 229.501393
+L 175.798329 222.164231
+L 198.066898 215.74302
+L 220.335466 209.675744
+L 242.604035 198.498407
+L 264.872603 189.311907
+L 287.141172 182.797413
+L 309.40974 177.417413
+L 331.678309 169.370344
+L 353.946877 162.846694
+L 376.215446 155.327823
+L 398.484014 147.456175
+L 420.752583 138.387737
+L 443.021151 129.265541
+L 465.28972 120.965142
+L 487.558288 109.103371
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1457,25 +1457,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.982833" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.992624" y="248.765228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="237.570879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="229.611031" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="222.371664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="216.046232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="209.645834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="198.342508" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="189.126013" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="182.530489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="177.094525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="169.04081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="162.555041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="155.01084" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="147.138076" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="138.000641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="128.951132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.28972" y="120.732396" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="108.936627" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.626462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.992624" y="248.505791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="237.461193" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="229.501393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="222.164231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="215.74302" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="209.675744" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="198.498407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="189.311907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="182.797413" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="177.417413" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="169.370344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="162.846694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="155.327823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="147.456175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="138.387737" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="129.265541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.28972" y="120.965142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="109.103371" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2411,7 +2411,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2464,6 +2464,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2511,7 +2541,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic.svg
@@ -1503,40 +1503,40 @@ z
     </g>
    </g>
    <g id="line2d_133">
-    <path d="M 86.724055 272.801537
-L 98.870547 258.367938
-L 111.017039 243.483552
-L 123.163531 235.144019
-L 135.310023 229.172111
-L 147.456515 224.427978
-L 159.603007 220.31187
-L 171.749499 215.25094
-L 183.895991 210.944817
-L 196.042483 206.957608
-L 208.188974 202.899522
-L 220.335466 199.177092
-L 232.481958 196.034271
-L 244.62845 192.259939
-L 256.774942 188.555989
-L 268.921434 185.417468
-L 281.067926 181.485371
-L 293.214418 177.333313
-L 305.36091 172.43404
-L 317.507402 165.676324
-L 329.653894 159.164529
-L 341.800385 154.335553
-L 353.946877 149.76743
-L 366.093369 145.332746
-L 378.239861 141.067706
-L 390.386353 135.615454
-L 402.532845 128.23873
-L 414.679337 122.547694
-L 426.825829 117.770291
-L 438.972321 113.683688
-L 451.118813 110.197081
-L 463.265305 103.276329
-L 475.411796 84.529137
-L 487.558288 61.169672
+    <path d="M 86.724055 272.618581
+L 98.870547 258.305884
+L 111.017039 244.245743
+L 123.163531 235.993118
+L 135.310023 230.152696
+L 147.456515 225.353523
+L 159.603007 221.204839
+L 171.749499 216.019763
+L 183.895991 211.756154
+L 196.042483 207.819451
+L 208.188974 203.62998
+L 220.335466 199.966442
+L 232.481958 196.776013
+L 244.62845 192.970858
+L 256.774942 189.195043
+L 268.921434 186.044213
+L 281.067926 182.19418
+L 293.214418 178.000194
+L 305.36091 173.130104
+L 317.507402 166.243387
+L 329.653894 159.81984
+L 341.800385 155.000693
+L 353.946877 150.441916
+L 366.093369 146.003804
+L 378.239861 141.633162
+L 390.386353 136.040197
+L 402.532845 128.701868
+L 414.679337 122.998399
+L 426.825829 118.159045
+L 438.972321 114.092962
+L 451.118813 110.624164
+L 463.265305 103.665266
+L 475.411796 84.834335
+L 487.558288 61.297745
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1552,40 +1552,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.801537" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.870547" y="258.367938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="111.017039" y="243.483552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.163531" y="235.144019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.310023" y="229.172111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.456515" y="224.427978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="159.603007" y="220.31187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.749499" y="215.25094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.895991" y="210.944817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="196.042483" y="206.957608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.188974" y="202.899522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="199.177092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="232.481958" y="196.034271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.62845" y="192.259939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.774942" y="188.555989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.921434" y="185.417468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.067926" y="181.485371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="293.214418" y="177.333313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.36091" y="172.43404" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.507402" y="165.676324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.653894" y="159.164529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="341.800385" y="154.335553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="149.76743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.093369" y="145.332746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.239861" y="141.067706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.386353" y="135.615454" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="402.532845" y="128.23873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="414.679337" y="122.547694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.825829" y="117.770291" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="438.972321" y="113.683688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="451.118813" y="110.197081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.265305" y="103.276329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="475.411796" y="84.529137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="61.169672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.618581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.870547" y="258.305884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="111.017039" y="244.245743" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.163531" y="235.993118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.310023" y="230.152696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.456515" y="225.353523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="159.603007" y="221.204839" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.749499" y="216.019763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.895991" y="211.756154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="196.042483" y="207.819451" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.188974" y="203.62998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="199.966442" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="232.481958" y="196.776013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.62845" y="192.970858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.774942" y="189.195043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.921434" y="186.044213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.067926" y="182.19418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="293.214418" y="178.000194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.36091" y="173.130104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.507402" y="166.243387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.653894" y="159.81984" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="341.800385" y="155.000693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="150.441916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.093369" y="146.003804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.239861" y="141.633162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.386353" y="136.040197" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="402.532845" y="128.701868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="414.679337" y="122.998399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.825829" y="118.159045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="438.972321" y="114.092962" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="451.118813" y="110.624164" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.265305" y="103.665266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="475.411796" y="84.834335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="61.297745" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -2643,7 +2643,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2703,6 +2703,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2750,7 +2780,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
@@ -791,8 +791,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 66.682344 277.258577
-L 507.6 277.258577
+      <path d="M 66.682344 277.251005
+L 507.6 277.251005
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
@@ -802,12 +802,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.258577" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.251005" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 281.057406) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 281.049833) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250
 Q 1547 4250 1301 3770
@@ -840,18 +840,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 66.682344 195.705575
-L 507.6 195.705575
+      <path d="M 66.682344 195.652638
+L 507.6 195.652638
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="195.705575" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="195.652638" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 199.504403) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 199.451466) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -862,18 +862,18 @@ L 507.6 195.705575
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 66.682344 114.152573
-L 507.6 114.152573
+      <path d="M 66.682344 114.054272
+L 507.6 114.054272
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="114.152573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="114.054272" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 117.951401) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 117.8531) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -881,18 +881,18 @@ L 507.6 114.152573
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 66.682344 32.59957
-L 507.6 32.59957
+      <path d="M 66.682344 32.455905
+L 507.6 32.455905
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="32.59957" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="32.455905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 36.398398) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 36.254733) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -901,8 +901,8 @@ L 507.6 32.59957
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 66.682344 301.808477
-L 507.6 301.808477
+      <path d="M 66.682344 301.814561
+L 507.6 301.814561
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -912,343 +912,343 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="301.808477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="301.814561" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_29">
-      <path d="M 66.682344 295.351009
-L 507.6 295.351009
+      <path d="M 66.682344 295.3535
+L 507.6 295.3535
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.351009" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.3535" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_31">
-      <path d="M 66.682344 289.891297
-L 507.6 289.891297
+      <path d="M 66.682344 289.890752
+L 507.6 289.890752
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.891297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.890752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
-      <path d="M 66.682344 285.16188
-L 507.6 285.16188
+      <path d="M 66.682344 285.158703
+L 507.6 285.158703
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.16188" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.158703" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_35">
-      <path d="M 66.682344 280.990238
-L 507.6 280.990238
+      <path d="M 66.682344 280.984741
+L 507.6 280.984741
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.990238" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.984741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_37">
-      <path d="M 66.682344 252.708677
-L 507.6 252.708677
+      <path d="M 66.682344 252.687449
+L 507.6 252.687449
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.708677" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.687449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_39">
-      <path d="M 66.682344 238.347907
-L 507.6 238.347907
+      <path d="M 66.682344 238.31869
+L 507.6 238.31869
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="238.347907" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="238.31869" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_41">
-      <path d="M 66.682344 228.158778
-L 507.6 228.158778
+      <path d="M 66.682344 228.123893
+L 507.6 228.123893
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="228.158778" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="228.123893" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 66.682344 220.255475
-L 507.6 220.255475
+      <path d="M 66.682344 220.216194
+L 507.6 220.216194
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.255475" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.216194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 66.682344 213.798007
-L 507.6 213.798007
+      <path d="M 66.682344 213.755134
+L 507.6 213.755134
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.798007" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.755134" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 66.682344 208.338295
-L 507.6 208.338295
+      <path d="M 66.682344 208.292385
+L 507.6 208.292385
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.338295" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.292385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 66.682344 203.608878
-L 507.6 203.608878
+      <path d="M 66.682344 203.560337
+L 507.6 203.560337
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="203.608878" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="203.560337" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 66.682344 199.437236
-L 507.6 199.437236
+      <path d="M 66.682344 199.386375
+L 507.6 199.386375
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.437236" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.386375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 66.682344 171.155675
-L 507.6 171.155675
+      <path d="M 66.682344 171.089082
+L 507.6 171.089082
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="171.155675" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="171.089082" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_55">
-      <path d="M 66.682344 156.794904
-L 507.6 156.794904
+      <path d="M 66.682344 156.720323
+L 507.6 156.720323
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.794904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.720323" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_57">
-      <path d="M 66.682344 146.605775
-L 507.6 146.605775
+      <path d="M 66.682344 146.525526
+L 507.6 146.525526
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="146.605775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="146.525526" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_59">
-      <path d="M 66.682344 138.702473
-L 507.6 138.702473
+      <path d="M 66.682344 138.617827
+L 507.6 138.617827
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.702473" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.617827" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_61">
-      <path d="M 66.682344 132.245004
-L 507.6 132.245004
+      <path d="M 66.682344 132.156767
+L 507.6 132.156767
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="132.245004" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="132.156767" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_63">
-      <path d="M 66.682344 126.785293
-L 507.6 126.785293
+      <path d="M 66.682344 126.694018
+L 507.6 126.694018
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="126.785293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="126.694018" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_65">
-      <path d="M 66.682344 122.055875
-L 507.6 122.055875
+      <path d="M 66.682344 121.96197
+L 507.6 121.96197
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.055875" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="121.96197" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_67">
-      <path d="M 66.682344 117.884233
-L 507.6 117.884233
+      <path d="M 66.682344 117.788008
+L 507.6 117.788008
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="117.884233" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="117.788008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_69">
-      <path d="M 66.682344 89.602673
-L 507.6 89.602673
+      <path d="M 66.682344 89.490716
+L 507.6 89.490716
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.602673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.490716" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_71">
-      <path d="M 66.682344 75.241902
-L 507.6 75.241902
+      <path d="M 66.682344 75.121956
+L 507.6 75.121956
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.241902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.121956" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_73">
-      <path d="M 66.682344 65.052773
-L 507.6 65.052773
+      <path d="M 66.682344 64.92716
+L 507.6 64.92716
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="65.052773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="64.92716" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_75">
-      <path d="M 66.682344 57.14947
-L 507.6 57.14947
+      <path d="M 66.682344 57.019461
+L 507.6 57.019461
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="57.14947" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="57.019461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_77">
-      <path d="M 66.682344 50.692002
-L 507.6 50.692002
+      <path d="M 66.682344 50.558401
+L 507.6 50.558401
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="50.692002" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="50.558401" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_79">
-      <path d="M 66.682344 45.23229
-L 507.6 45.23229
+      <path d="M 66.682344 45.095652
+L 507.6 45.095652
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.23229" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.095652" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_81">
-      <path d="M 66.682344 40.502873
-L 507.6 40.502873
+      <path d="M 66.682344 40.363604
+L 507.6 40.363604
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.502873" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.363604" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_83">
-      <path d="M 66.682344 36.331231
-L 507.6 36.331231
+      <path d="M 66.682344 36.189641
+L 507.6 36.189641
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.331231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.189641" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1326,9 +1326,9 @@ z
     </g>
    </g>
    <g id="line2d_85">
-    <path d="M 86.724055 171.581106
-L 136.828335 108.951081
-L 186.932614 61.4158
+    <path d="M 86.724055 172.732124
+L 136.828335 109.302201
+L 186.932614 61.638932
 L 237.036893 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1345,22 +1345,22 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="171.581106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.828335" y="108.951081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.932614" y="61.4158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="172.732124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.828335" y="109.302201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.932614" y="61.638932" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="237.036893" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_86">
     <path d="M 86.724055 290.872308
-L 136.828335 245.021104
-L 186.932614 213.005479
-L 237.036893 175.479696
-L 287.141172 155.538218
-L 337.245451 125.577459
-L 387.34973 107.812656
-L 437.454009 90.914855
-L 487.558288 73.304518
+L 136.828335 244.995599
+L 186.932614 212.962166
+L 237.036893 175.415508
+L 287.141172 155.462938
+L 337.245451 125.485513
+L 387.34973 107.710828
+L 437.454009 90.803628
+L 487.558288 73.183495
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1371,26 +1371,26 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.828335" y="245.021104" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="186.932614" y="213.005479" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="237.036893" y="175.479696" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="155.538218" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="337.245451" y="125.577459" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="387.34973" y="107.812656" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="437.454009" y="90.914855" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="73.304518" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.828335" y="244.995599" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="186.932614" y="212.962166" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="237.036893" y="175.415508" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="155.462938" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="337.245451" y="125.485513" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="387.34973" y="107.710828" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="437.454009" y="90.803628" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="73.183495" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_87">
-    <path d="M 86.724055 257.460326
-L 136.828335 218.383675
-L 186.932614 181.906498
-L 237.036893 159.106301
-L 287.141172 134.114998
-L 337.245451 118.174544
-L 387.34973 97.273036
-L 437.454009 80.026345
-L 487.558288 65.716508
+    <path d="M 86.724055 257.441741
+L 136.828335 218.343353
+L 186.932614 181.845885
+L 237.036893 159.033006
+L 287.141172 134.027801
+L 337.245451 118.07848
+L 387.34973 97.165346
+L 437.454009 79.909061
+L 487.558288 65.591264
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1400,27 +1400,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="257.460326" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.828335" y="218.383675" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="186.932614" y="181.906498" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="237.036893" y="159.106301" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="134.114998" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="337.245451" y="118.174544" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="387.34973" y="97.273036" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="437.454009" y="80.026345" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="65.716508" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="257.441741" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.828335" y="218.343353" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="186.932614" y="181.845885" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="237.036893" y="159.033006" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="134.027801" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="337.245451" y="118.07848" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="387.34973" y="97.165346" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="437.454009" y="79.909061" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="65.591264" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_88">
-    <path d="M 86.724055 257.836104
-L 136.828335 224.285971
-L 186.932614 199.994676
-L 237.036893 164.178739
-L 287.141172 145.334703
-L 337.245451 131.128833
-L 387.34973 110.745871
-L 437.454009 96.758986
-L 487.558288 80.379541
+    <path d="M 86.724055 257.817727
+L 136.828335 224.248932
+L 186.932614 199.944125
+L 237.036893 164.108265
+L 287.141172 145.253747
+L 337.245451 131.039975
+L 387.34973 110.645675
+L 437.454009 96.65101
+L 487.558288 80.262453
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1439,15 +1439,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="257.836104" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.828335" y="224.285971" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="186.932614" y="199.994676" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="237.036893" y="164.178739" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="145.334703" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="337.245451" y="131.128833" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="387.34973" y="110.745871" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="437.454009" y="96.758986" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="80.379541" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="257.817727" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.828335" y="224.248932" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="186.932614" y="199.944125" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="237.036893" y="164.108265" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="145.253747" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="337.245451" y="131.039975" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="387.34973" y="110.645675" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="437.454009" y="96.65101" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="80.262453" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1931,7 +1931,7 @@ z
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2055,7 +2055,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-laguerre.svg
+++ b/reports/figures/hexbz-cactus-laguerre.svg
@@ -1489,26 +1489,26 @@ z
     </g>
    </g>
    <g id="line2d_131">
-    <path d="M 86.724055 276.208907
-L 107.820594 257.682305
-L 128.917133 245.48795
-L 150.013671 237.254803
-L 171.11021 230.736094
-L 192.206748 225.839116
-L 213.303287 221.207095
-L 234.399825 216.959725
-L 255.496364 212.49258
-L 276.592903 206.962652
-L 297.689441 202.440965
-L 318.78598 197.495242
-L 339.882518 192.663618
-L 360.979057 187.719212
-L 382.075595 183.753883
-L 403.172134 180.227184
-L 424.268673 175.64466
-L 445.365211 171.870961
-L 466.46175 167.161753
-L 487.558288 160.509766
+    <path d="M 86.724055 276.869849
+L 107.820594 258.030372
+L 128.917133 245.640865
+L 150.013671 237.329266
+L 171.11021 230.89567
+L 192.206748 225.979545
+L 213.303287 221.314579
+L 234.399825 217.103373
+L 255.496364 212.647474
+L 276.592903 207.213162
+L 297.689441 202.682267
+L 318.78598 197.684664
+L 339.882518 192.893878
+L 360.979057 187.965032
+L 382.075595 184.004129
+L 403.172134 180.464101
+L 424.268673 175.892893
+L 445.365211 172.136697
+L 466.46175 167.445978
+L 487.558288 160.787829
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1524,26 +1524,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="276.208907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="257.682305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="245.48795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="237.254803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="230.736094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="225.839116" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="221.207095" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="216.959725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="212.49258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="206.962652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="202.440965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="197.495242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="192.663618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="187.719212" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="183.753883" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="180.227184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="175.64466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="171.870961" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="167.161753" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="160.509766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="276.869849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="258.030372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="245.640865" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="237.329266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="230.89567" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="225.979545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="221.314579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="217.103373" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="212.647474" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="207.213162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="202.682267" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="197.684664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="192.893878" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="187.965032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="184.004129" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="180.464101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="175.892893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="172.136697" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="167.445978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="160.787829" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_132">
@@ -2477,7 +2477,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2547,6 +2547,36 @@ L 3597 3500
 L 2059 -325
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2594,7 +2624,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-legendre.svg
+++ b/reports/figures/hexbz-cactus-legendre.svg
@@ -1477,26 +1477,26 @@ z
     </g>
    </g>
    <g id="line2d_129">
-    <path d="M 86.724055 273.439062
-L 107.820594 259.799596
-L 128.917133 247.796954
-L 150.013671 239.589611
-L 171.11021 232.695218
-L 192.206748 224.598112
-L 213.303287 218.489504
-L 234.399825 212.74681
-L 255.496364 207.310269
-L 276.592903 199.960703
-L 297.689441 193.973496
-L 318.78598 187.313948
-L 339.882518 180.916519
-L 360.979057 174.796393
-L 382.075595 169.863161
-L 403.172134 165.873166
-L 424.268673 160.835105
-L 445.365211 155.995817
-L 466.46175 149.252015
-L 487.558288 143.396716
+    <path d="M 86.724055 273.687885
+L 107.820594 259.912661
+L 128.917133 247.794312
+L 150.013671 239.275479
+L 171.11021 232.476244
+L 192.206748 224.386302
+L 213.303287 218.360789
+L 234.399825 212.702207
+L 255.496364 207.349874
+L 276.592903 200.110621
+L 297.689441 194.069701
+L 318.78598 187.289837
+L 339.882518 180.954483
+L 360.979057 174.839706
+L 382.075595 169.861116
+L 403.172134 165.869139
+L 424.268673 160.849096
+L 445.365211 155.994492
+L 466.46175 149.170595
+L 487.558288 143.280756
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1512,26 +1512,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.439062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="259.799596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="247.796954" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="239.589611" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="232.695218" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="224.598112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="218.489504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="212.74681" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="207.310269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="199.960703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="193.973496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="187.313948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="180.916519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="174.796393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="169.863161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="165.873166" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="160.835105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="155.995817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="149.252015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="143.396716" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.687885" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="259.912661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="247.794312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="239.275479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="232.476244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="224.386302" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="218.360789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="212.702207" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="207.349874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="200.110621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="194.069701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="187.289837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="180.954483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="174.839706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="169.861116" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="165.869139" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="160.849096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="155.994492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="149.170595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="143.280756" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_130">
@@ -2480,7 +2480,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2550,6 +2550,36 @@ L 3597 3500
 L 2059 -325
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2597,7 +2627,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-random-products.svg
+++ b/reports/figures/hexbz-cactus-random-products.svg
@@ -1439,36 +1439,36 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 266.98621
-L 100.545925 249.515853
-L 114.367796 239.407816
-L 128.189666 232.685466
-L 142.011536 226.977993
-L 155.833406 222.554749
-L 169.655276 218.832649
-L 183.477146 215.559211
-L 197.299016 212.47285
-L 211.120886 209.800566
-L 224.942756 207.22858
-L 238.764627 204.703272
-L 252.586497 202.408306
-L 266.408367 200.279513
-L 280.230237 198.356859
-L 294.052107 196.5539
-L 307.873977 194.836395
-L 321.695847 193.203772
-L 335.517717 191.614446
-L 349.339587 189.999169
-L 363.161457 188.455541
-L 376.983328 186.90517
-L 390.805198 185.147675
-L 404.627068 183.524686
-L 418.448938 181.840781
-L 432.270808 180.137115
-L 446.092678 178.518427
-L 459.914548 176.941526
-L 473.736418 175.173837
-L 487.558288 172.975566
+    <path d="M 86.724055 267.331107
+L 100.545925 250.02291
+L 114.367796 239.833544
+L 128.189666 233.089847
+L 142.011536 227.261209
+L 155.833406 222.728178
+L 169.655276 219.018635
+L 183.477146 215.777986
+L 197.299016 212.713261
+L 211.120886 210.027647
+L 224.942756 207.500118
+L 238.764627 204.997274
+L 252.586497 202.684524
+L 266.408367 200.579616
+L 280.230237 198.654481
+L 294.052107 196.845963
+L 307.873977 195.139091
+L 321.695847 193.499267
+L 335.517717 191.899225
+L 349.339587 190.257916
+L 363.161457 188.737244
+L 376.983328 187.174204
+L 390.805198 185.460783
+L 404.627068 183.830309
+L 418.448938 182.144172
+L 432.270808 180.444754
+L 446.092678 178.841429
+L 459.914548 177.266283
+L 473.736418 175.50847
+L 487.558288 173.334925
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1484,36 +1484,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="266.98621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="249.515853" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="239.407816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="232.685466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="226.977993" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="222.554749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="218.832649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="215.559211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="212.47285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="209.800566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="207.22858" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="204.703272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="202.408306" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="200.279513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.230237" y="198.356859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="196.5539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.873977" y="194.836395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="193.203772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.517717" y="191.614446" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="189.999169" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.161457" y="188.455541" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="186.90517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.805198" y="185.147675" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="404.627068" y="183.524686" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.448938" y="181.840781" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="180.137115" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.092678" y="178.518427" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.914548" y="176.941526" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="473.736418" y="175.173837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="172.975566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="267.331107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="250.02291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="239.833544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="233.089847" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="227.261209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="222.728178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="219.018635" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="215.777986" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="212.713261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="210.027647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="207.500118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="204.997274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="202.684524" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="200.579616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.230237" y="198.654481" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="196.845963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.873977" y="195.139091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="193.499267" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.517717" y="191.899225" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="190.257916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.161457" y="188.737244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="187.174204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.805198" y="185.460783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="404.627068" y="183.830309" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.448938" y="182.144172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="180.444754" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.092678" y="178.841429" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.914548" y="177.266283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="473.736418" y="175.50847" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="173.334925" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2526,7 +2526,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2603,6 +2603,36 @@ L 3597 3500
 L 2059 -325
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2650,7 +2680,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-sd-products.svg
+++ b/reports/figures/hexbz-cactus-sd-products.svg
@@ -674,8 +674,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 277.501253
-L 507.6 277.501253
+      <path d="M 66.682344 277.492589
+L 507.6 277.492589
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -685,12 +685,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.501253" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.492589" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 281.300081) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 281.291417) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -701,18 +701,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 224.884455
-L 507.6 224.884455
+      <path d="M 66.682344 224.841697
+L 507.6 224.841697
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="224.884455" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="224.841697" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 228.683284) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 228.640525) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -721,18 +721,18 @@ L 507.6 224.884455
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 172.267658
-L 507.6 172.267658
+      <path d="M 66.682344 172.190805
+L 507.6 172.190805
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="172.267658" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="172.190805" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 176.066486) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 175.989633) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -742,18 +742,18 @@ L 507.6 172.267658
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 119.65086
-L 507.6 119.65086
+      <path d="M 66.682344 119.539913
+L 507.6 119.539913
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="119.65086" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="119.539913" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 123.449688) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 123.338742) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -764,18 +764,18 @@ L 507.6 119.65086
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 67.034062
-L 507.6 67.034062
+      <path d="M 66.682344 66.889022
+L 507.6 66.889022
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="67.034062" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="66.889022" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 70.83289) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 70.68785) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -783,8 +783,8 @@ L 507.6 67.034062
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 298.439582
-L 507.6 298.439582
+      <path d="M 66.682344 298.444485
+L 507.6 298.444485
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
@@ -794,499 +794,499 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.439582" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.444485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 293.340488
-L 507.6 293.340488
+      <path d="M 66.682344 293.342087
+L 507.6 293.342087
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.340488" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.342087" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 289.174224
-L 507.6 289.174224
+      <path d="M 66.682344 289.173124
+L 507.6 289.173124
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.174224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.173124" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 285.651698
-L 507.6 285.651698
+      <path d="M 66.682344 285.648315
+L 507.6 285.648315
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.651698" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.648315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 282.600348
-L 507.6 282.600348
+      <path d="M 66.682344 282.594988
+L 507.6 282.594988
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.600348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.594988" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 279.908866
-L 507.6 279.908866
+      <path d="M 66.682344 279.901762
+L 507.6 279.901762
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.908866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.901762" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 261.662019
-L 507.6 261.662019
+      <path d="M 66.682344 261.643091
+L 507.6 261.643091
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.662019" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.643091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 252.396661
-L 507.6 252.396661
+      <path d="M 66.682344 252.37173
+L 507.6 252.37173
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.396661" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.37173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 245.822784
-L 507.6 245.822784
+      <path d="M 66.682344 245.793594
+L 507.6 245.793594
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.822784" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.793594" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 240.72369
-L 507.6 240.72369
+      <path d="M 66.682344 240.691195
+L 507.6 240.691195
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="240.72369" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="240.691195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 236.557426
-L 507.6 236.557426
+      <path d="M 66.682344 236.522232
+L 507.6 236.522232
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="236.557426" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="236.522232" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 233.034901
-L 507.6 233.034901
+      <path d="M 66.682344 232.997424
+L 507.6 232.997424
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.034901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.997424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 229.98355
-L 507.6 229.98355
+      <path d="M 66.682344 229.944096
+L 507.6 229.944096
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.98355" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.944096" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 227.292068
-L 507.6 227.292068
+      <path d="M 66.682344 227.25087
+L 507.6 227.25087
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.292068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.25087" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 209.045221
-L 507.6 209.045221
+      <path d="M 66.682344 208.992199
+L 507.6 208.992199
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.045221" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.992199" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 199.779863
-L 507.6 199.779863
+      <path d="M 66.682344 199.720838
+L 507.6 199.720838
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.779863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.720838" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 193.205987
-L 507.6 193.205987
+      <path d="M 66.682344 193.142702
+L 507.6 193.142702
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="193.205987" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="193.142702" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 188.106892
-L 507.6 188.106892
+      <path d="M 66.682344 188.040303
+L 507.6 188.040303
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.106892" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.040303" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 183.940629
-L 507.6 183.940629
+      <path d="M 66.682344 183.87134
+L 507.6 183.87134
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.940629" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.87134" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 180.418103
-L 507.6 180.418103
+      <path d="M 66.682344 180.346532
+L 507.6 180.346532
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.418103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.346532" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 177.366752
-L 507.6 177.366752
+      <path d="M 66.682344 177.293204
+L 507.6 177.293204
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="177.366752" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="177.293204" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 174.67527
-L 507.6 174.67527
+      <path d="M 66.682344 174.599978
+L 507.6 174.599978
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="174.67527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="174.599978" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 156.428423
-L 507.6 156.428423
+      <path d="M 66.682344 156.341308
+L 507.6 156.341308
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.428423" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.341308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 147.163065
-L 507.6 147.163065
+      <path d="M 66.682344 147.069946
+L 507.6 147.069946
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.163065" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.069946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 140.589189
-L 507.6 140.589189
+      <path d="M 66.682344 140.49181
+L 507.6 140.49181
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.589189" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.49181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 135.490094
-L 507.6 135.490094
+      <path d="M 66.682344 135.389411
+L 507.6 135.389411
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.490094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.389411" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 131.323831
-L 507.6 131.323831
+      <path d="M 66.682344 131.220448
+L 507.6 131.220448
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.323831" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.220448" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 127.801305
-L 507.6 127.801305
+      <path d="M 66.682344 127.69564
+L 507.6 127.69564
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="127.801305" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="127.69564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 124.749955
-L 507.6 124.749955
+      <path d="M 66.682344 124.642312
+L 507.6 124.642312
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="124.749955" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="124.642312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 122.058473
-L 507.6 122.058473
+      <path d="M 66.682344 121.949086
+L 507.6 121.949086
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.058473" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="121.949086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 103.811626
-L 507.6 103.811626
+      <path d="M 66.682344 103.690416
+L 507.6 103.690416
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.811626" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.690416" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 94.546268
-L 507.6 94.546268
+      <path d="M 66.682344 94.419054
+L 507.6 94.419054
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="94.546268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="94.419054" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 87.972391
-L 507.6 87.972391
+      <path d="M 66.682344 87.840918
+L 507.6 87.840918
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.972391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.840918" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 82.873297
-L 507.6 82.873297
+      <path d="M 66.682344 82.738519
+L 507.6 82.738519
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="82.873297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="82.738519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 78.707033
-L 507.6 78.707033
+      <path d="M 66.682344 78.569556
+L 507.6 78.569556
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="78.707033" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="78.569556" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 75.184507
-L 507.6 75.184507
+      <path d="M 66.682344 75.044748
+L 507.6 75.044748
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.184507" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.044748" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 72.133157
-L 507.6 72.133157
+      <path d="M 66.682344 71.99142
+L 507.6 71.99142
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="72.133157" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="71.99142" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 69.441675
-L 507.6 69.441675
+      <path d="M 66.682344 69.298194
+L 507.6 69.298194
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="69.441675" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="69.298194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 51.194828
-L 507.6 51.194828
+      <path d="M 66.682344 51.039524
+L 507.6 51.039524
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="51.194828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="51.039524" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 41.92947
-L 507.6 41.92947
+      <path d="M 66.682344 41.768162
+L 507.6 41.768162
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.92947" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.768162" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 35.355594
-L 507.6 35.355594
+      <path d="M 66.682344 35.190026
+L 507.6 35.190026
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="35.355594" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="35.190026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 30.256499
-L 507.6 30.256499
+      <path d="M 66.682344 30.087627
+L 507.6 30.087627
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="30.256499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="30.087627" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1364,16 +1364,16 @@ z
     </g>
    </g>
    <g id="line2d_109">
-    <path d="M 86.724055 270.375609
-L 117.557458 254.419318
-L 148.39086 230.866983
-L 179.224263 218.117873
-L 210.057666 206.747605
-L 240.891068 187.874661
-L 271.724471 154.022117
-L 302.557873 140.647068
-L 333.391276 106.572822
-L 364.224678 83.251323
+    <path d="M 86.724055 270.454586
+L 117.557458 254.471686
+L 148.39086 231.11044
+L 179.224263 218.330066
+L 210.057666 207.029414
+L 240.891068 188.490604
+L 271.724471 154.524908
+L 302.557873 141.191082
+L 333.391276 106.969314
+L 364.224678 83.40469
 L 395.058081 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1390,34 +1390,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.375609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.419318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="230.866983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="218.117873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="206.747605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="187.874661" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="154.022117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="140.647068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="106.572822" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="83.251323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.454586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="254.471686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="231.11044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="218.330066" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="207.029414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="188.490604" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="154.524908" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="141.191082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="106.969314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="83.40469" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="395.058081" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_110">
     <path d="M 86.724055 290.872308
-L 117.557458 274.044176
-L 148.39086 259.010892
-L 179.224263 248.171757
-L 210.057666 238.582996
-L 240.891068 224.86084
-L 271.724471 211.8986
-L 302.557873 201.814599
-L 333.391276 193.212334
-L 364.224678 185.05888
-L 395.058081 170.467276
-L 425.891483 161.397372
-L 456.724886 153.017392
-L 487.558288 128.871372
+L 117.557458 274.033271
+L 148.39086 258.990247
+L 179.224263 248.144089
+L 210.057666 238.549114
+L 240.891068 224.818066
+L 271.724471 211.847428
+L 302.557873 201.756892
+L 333.391276 193.149054
+L 364.224678 184.990316
+L 395.058081 170.389257
+L 425.891483 161.313476
+L 456.724886 152.928066
+L 487.558288 128.7664
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1428,36 +1428,36 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="117.557458" y="274.044176" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="148.39086" y="259.010892" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="179.224263" y="248.171757" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="210.057666" y="238.582996" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="240.891068" y="224.86084" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="271.724471" y="211.8986" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="302.557873" y="201.814599" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="333.391276" y="193.212334" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="364.224678" y="185.05888" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="395.058081" y="170.467276" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="425.891483" y="161.397372" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="456.724886" y="153.017392" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="128.871372" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="117.557458" y="274.033271" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="148.39086" y="258.990247" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="179.224263" y="248.144089" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="210.057666" y="238.549114" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="240.891068" y="224.818066" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="271.724471" y="211.847428" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="302.557873" y="201.756892" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="333.391276" y="193.149054" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="364.224678" y="184.990316" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="395.058081" y="170.389257" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="425.891483" y="161.313476" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="456.724886" y="152.928066" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="128.7664" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_111">
-    <path d="M 86.724055 261.909692
-L 117.557458 244.644032
-L 148.39086 228.813778
-L 179.224263 219.069246
-L 210.057666 211.75797
-L 240.891068 200.03362
-L 271.724471 189.927392
-L 302.557873 179.775527
-L 333.391276 170.935377
-L 364.224678 163.668053
-L 395.058081 150.292727
-L 425.891483 141.012662
-L 456.724886 132.308077
-L 487.558288 111.120488
+    <path d="M 86.724055 261.890925
+L 117.557458 244.614077
+L 148.39086 228.773566
+L 179.224263 219.02272
+L 210.057666 211.706706
+L 240.891068 199.974759
+L 271.724471 189.861983
+L 302.557873 179.703539
+L 333.391276 170.857661
+L 364.224678 163.585628
+L 395.058081 150.201635
+L 425.891483 140.915557
+L 456.724886 132.205332
+L 487.558288 111.004014
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1467,37 +1467,37 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.909692" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="117.557458" y="244.644032" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="148.39086" y="228.813778" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="179.224263" y="219.069246" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="210.057666" y="211.75797" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="240.891068" y="200.03362" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="271.724471" y="189.927392" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="302.557873" y="179.775527" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="333.391276" y="170.935377" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="364.224678" y="163.668053" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="395.058081" y="150.292727" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="425.891483" y="141.012662" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="456.724886" y="132.308077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="111.120488" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.890925" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="117.557458" y="244.614077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="148.39086" y="228.773566" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="179.224263" y="219.02272" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="210.057666" y="211.706706" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="240.891068" y="199.974759" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="271.724471" y="189.861983" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="302.557873" y="179.703539" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="333.391276" y="170.857661" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="364.224678" y="163.585628" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="395.058081" y="150.201635" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="425.891483" y="140.915557" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="456.724886" y="132.205332" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="111.004014" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_112">
-    <path d="M 86.724055 283.877335
-L 117.557458 266.813159
-L 148.39086 251.216696
-L 179.224263 241.850866
-L 210.057666 235.000599
-L 240.891068 219.631116
-L 271.724471 207.153859
-L 302.557873 198.855582
-L 333.391276 188.399475
-L 364.224678 178.228902
-L 395.058081 166.566979
-L 425.891483 156.966535
-L 456.724886 146.266593
-L 487.558288 127.874425
+    <path d="M 86.724055 283.872802
+L 117.557458 266.797569
+L 148.39086 251.191001
+L 179.224263 241.819101
+L 210.057666 234.964396
+L 240.891068 219.584954
+L 271.724471 207.099611
+L 302.557873 198.795958
+L 333.391276 188.333075
+L 364.224678 178.155912
+L 395.058081 166.486433
+L 425.891483 156.879767
+L 456.724886 146.172893
+L 487.558288 127.768807
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1516,32 +1516,32 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.877335" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="117.557458" y="266.813159" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="148.39086" y="251.216696" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="179.224263" y="241.850866" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="210.057666" y="235.000599" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="240.891068" y="219.631116" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="271.724471" y="207.153859" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="302.557873" y="198.855582" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="333.391276" y="188.399475" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="364.224678" y="178.228902" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="395.058081" y="166.566979" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="425.891483" y="156.966535" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="456.724886" y="146.266593" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="127.874425" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.872802" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="117.557458" y="266.797569" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="148.39086" y="251.191001" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="179.224263" y="241.819101" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="210.057666" y="234.964396" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="240.891068" y="219.584954" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="271.724471" y="207.099611" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="302.557873" y="198.795958" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="333.391276" y="188.333075" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="364.224678" y="178.155912" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="395.058081" y="166.486433" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="425.891483" y="156.879767" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="456.724886" y="146.172893" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="127.768807" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_113">
-    <path d="M 86.724055 249.009356
-L 117.557458 230.342664
-L 148.39086 212.467788
-L 179.224263 202.220041
-L 210.057666 193.127064
-L 240.891068 175.765722
-L 271.724471 157.144281
-L 302.557873 137.608482
-L 333.391276 126.80544
+    <path d="M 86.724055 248.98223
+L 117.557458 230.303443
+L 148.39086 212.416984
+L 179.224263 202.162596
+L 210.057666 193.063728
+L 240.891068 175.691136
+L 271.724471 157.057629
+L 302.557873 137.509172
+L 333.391276 126.699129
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1558,23 +1558,23 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="249.009356" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="117.557458" y="230.342664" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="148.39086" y="212.467788" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="179.224263" y="202.220041" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="210.057666" y="193.127064" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="240.891068" y="175.765722" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="271.724471" y="157.144281" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="302.557873" y="137.608482" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="333.391276" y="126.80544" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.98223" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="117.557458" y="230.303443" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="148.39086" y="212.416984" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="179.224263" y="202.162596" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="210.057666" y="193.063728" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="240.891068" y="175.691136" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="271.724471" y="157.057629" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="302.557873" y="137.509172" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="333.391276" y="126.699129" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_114">
-    <path d="M 86.724055 214.031439
-L 117.557458 196.107774
-L 148.39086 103.477968
-L 179.224263 78.642573
-L 210.057666 66.304335
+    <path d="M 86.724055 213.981648
+L 117.557458 196.046369
+L 148.39086 103.356542
+L 179.224263 78.505055
+L 210.057666 66.158821
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #bcbd22; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1587,11 +1587,11 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="214.031439" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="117.557458" y="196.107774" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="148.39086" y="103.477968" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="179.224263" y="78.642573" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="210.057666" y="66.304335" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="213.981648" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="117.557458" y="196.046369" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="148.39086" y="103.356542" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="179.224263" y="78.505055" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="210.057666" y="66.158821" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2276,7 +2276,7 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2400,7 +2400,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-cactus-swinnerton-dyer.svg
@@ -1400,21 +1400,21 @@ z
     </g>
    </g>
    <g id="line2d_115">
-    <path d="M 86.724055 283.331089
-L 115.355072 267.928603
-L 143.986089 247.353216
-L 172.617105 236.878185
-L 201.248122 229.616797
-L 229.879139 211.373409
-L 258.510155 200.991457
-L 287.141172 193.925979
-L 315.772189 168.865656
-L 344.403205 156.974749
-L 373.034222 147.941902
-L 401.665238 132.325549
-L 430.296255 122.354429
-L 458.927272 115.390521
-L 487.558288 94.059007
+    <path d="M 86.724055 283.212478
+L 115.355072 267.845269
+L 143.986089 247.673164
+L 172.617105 237.171
+L 201.248122 230.047727
+L 229.879139 211.878278
+L 258.510155 201.43205
+L 287.141172 194.392374
+L 315.772189 169.068579
+L 344.403205 157.200871
+L 373.034222 148.302742
+L 401.665238 132.687527
+L 430.296255 122.919591
+L 458.927272 116.01218
+L 487.558288 94.333371
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1430,21 +1430,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.331089" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="267.928603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="247.353216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="236.878185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="229.616797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="211.373409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="200.991457" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="193.925979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="168.865656" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="156.974749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="147.941902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="132.325549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="122.354429" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="115.390521" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="94.059007" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.212478" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="267.845269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="247.673164" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="237.171" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="230.047727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="211.878278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="201.43205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="194.392374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="169.068579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="157.200871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="148.302742" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="132.687527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="122.919591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="116.01218" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="94.333371" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -2326,7 +2326,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2433,7 +2433,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-wilkinson.svg
+++ b/reports/figures/hexbz-cactus-wilkinson.svg
@@ -1352,21 +1352,21 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 270.835976
-L 115.355072 248.210781
-L 143.986089 233.05095
-L 172.617105 216.038858
-L 201.248122 203.87808
-L 229.879139 193.285785
-L 258.510155 183.94427
-L 287.141172 174.846921
-L 315.772189 166.591071
-L 344.403205 157.67539
-L 373.034222 148.502042
-L 401.665238 140.496496
-L 430.296255 132.5902
-L 458.927272 123.026747
-L 487.558288 114.577937
+    <path d="M 86.724055 270.229169
+L 115.355072 248.15511
+L 143.986089 233.132479
+L 172.617105 216.309477
+L 201.248122 204.203545
+L 229.879139 193.561464
+L 258.510155 184.235561
+L 287.141172 175.186997
+L 315.772189 166.932294
+L 344.403205 158.007563
+L 373.034222 148.797577
+L 401.665238 140.773036
+L 430.296255 132.782599
+L 458.927272 123.25282
+L 487.558288 114.834675
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1382,21 +1382,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.835976" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="248.210781" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="233.05095" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="216.038858" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="203.87808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="193.285785" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="183.94427" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="174.846921" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="166.591071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="157.67539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="148.502042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="140.496496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="132.5902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="123.026747" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="114.577937" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.229169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="248.15511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="233.132479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="216.309477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="204.203545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="193.561464" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="184.235561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="175.186997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="166.932294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="158.007563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="148.797577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="140.773036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="132.782599" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="123.25282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="114.834675" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -2278,7 +2278,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2402,7 +2402,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
+++ b/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
@@ -1139,7 +1139,7 @@ z
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 290.301172 192.581773
+    <path d="M 290.301172 196.053325
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1155,7 +1155,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="192.581773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="196.053325" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_40">
@@ -1851,7 +1851,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1951,7 +1951,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-chebyshev.svg
+++ b/reports/figures/hexbz-runtime-degree-chebyshev.svg
@@ -1403,34 +1403,34 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.469038 279.072608
-L 86.469038 272.550667
-L 105.313508 274.651309
-L 105.313508 264.234696
-L 124.157979 274.099837
-L 124.157979 263.409647
-L 143.002449 262.457332
-L 143.002449 256.197579
-L 161.846919 264.427351
-L 161.846919 263.922181
-L 180.69139 266.019099
-L 180.69139 248.791403
-L 199.53586 257.129938
-L 199.53586 253.993704
-L 218.380331 253.057067
-L 218.380331 248.615895
-L 256.069271 246.661028
-L 256.069271 244.202912
-L 312.602683 242.355502
-L 312.602683 236.052742
-L 331.447153 250.689888
-L 331.447153 240.371854
-L 369.136094 236.94122
-L 369.136094 225.355311
-L 406.825035 223.952785
-L 406.825035 218.49479
-L 482.202916 228.328895
-L 482.202916 222.226906
+    <path d="M 86.469038 278.775408
+L 86.469038 272.836046
+L 105.313508 274.702524
+L 105.313508 266.808937
+L 124.157979 273.716716
+L 124.157979 263.600203
+L 143.002449 262.583283
+L 143.002449 256.375801
+L 161.846919 263.664341
+L 161.846919 262.660357
+L 180.69139 267.148126
+L 180.69139 249.424836
+L 199.53586 257.69664
+L 199.53586 254.127531
+L 218.380331 252.912283
+L 218.380331 248.393425
+L 256.069271 246.691019
+L 256.069271 243.654783
+L 312.602683 241.679424
+L 312.602683 235.740371
+L 331.447153 250.376705
+L 331.447153 240.090027
+L 369.136094 236.803671
+L 369.136094 225.323981
+L 406.825035 224.065703
+L 406.825035 218.295178
+L 482.202916 228.474256
+L 482.202916 222.183053
 " clip-path="url(#pe3690171c9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1446,34 +1446,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pe3690171c9)">
-     <use xlink:href="#md73ba6276e" x="86.469038" y="279.072608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.469038" y="272.550667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="274.651309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="264.234696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="274.099837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="263.409647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="262.457332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="256.197579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="264.427351" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="263.922181" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="266.019099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="248.791403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="257.129938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="253.993704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="253.057067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="248.615895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="246.661028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="244.202912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="242.355502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="236.052742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="250.689888" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="240.371854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="236.94122" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="225.355311" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="223.952785" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="218.49479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="228.328895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="222.226906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="278.775408" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="272.836046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="274.702524" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="266.808937" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="273.716716" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="263.600203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="262.583283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="256.375801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="263.664341" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="262.660357" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="267.148126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="249.424836" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="257.69664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="254.127531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="252.912283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="248.393425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="246.691019" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="243.654783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="241.679424" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="235.740371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="250.376705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="240.090027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="236.803671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="225.323981" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="224.065703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="218.295178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="228.474256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="222.183053" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2427,7 +2427,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2487,6 +2487,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2534,7 +2564,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-conway.svg
+++ b/reports/figures/hexbz-runtime-degree-conway.svg
@@ -1583,90 +1583,89 @@ z
     </g>
    </g>
    <g id="line2d_139">
-    <path d="M 86.724055 273.494121
-L 86.724055 267.104306
-L 97.001856 268.464296
-L 97.001856 268.375197
-L 97.001856 261.504316
-L 107.279657 269.241262
-L 107.279657 260.209321
-L 117.557458 265.125697
-L 117.557458 252.024505
-L 127.835259 263.642511
-L 127.835259 263.622983
-L 127.835259 252.218314
-L 138.11306 260.734682
-L 138.11306 260.726368
-L 138.11306 249.328646
-L 148.39086 259.445002
-L 148.39086 249.511078
-L 158.668661 254.669162
-L 158.668661 245.49485
-L 168.946462 254.830655
-L 168.946462 245.286509
-L 179.224263 252.122569
-L 179.224263 237.044594
-L 189.502064 252.408719
-L 189.502064 238.02614
-L 199.779865 248.143987
-L 199.779865 232.647239
-L 210.057666 250.164623
-L 210.057666 231.512871
-L 220.335466 243.072192
-L 220.335466 237.061398
-L 230.613267 243.375216
-L 230.613267 231.642994
-L 240.891068 242.488402
-L 240.891068 226.60439
-L 251.168869 243.934864
-L 251.168869 219.345068
-L 261.44667 238.162854
-L 261.44667 224.167411
-L 271.724471 241.444149
-L 271.724471 222.982681
-L 282.002271 233.912477
-L 282.002271 224.009836
-L 292.280072 234.007905
-L 292.280072 226.523427
-L 302.557873 232.468028
-L 302.557873 217.474491
-L 312.835674 235.596024
-L 312.835674 217.660566
-L 323.113475 230.364722
-L 323.113475 217.821875
-L 333.391276 231.345992
-L 333.391276 213.492162
-L 343.669077 227.75416
-L 343.669077 215.592385
-L 353.946877 231.970983
-L 353.946877 209.542889
-L 364.224678 226.871715
-L 364.224678 207.302453
-L 374.502479 230.520395
-L 374.502479 221.596656
-L 384.78028 222.580078
-L 384.78028 205.096172
-L 395.058081 227.544204
-L 395.058081 209.720788
-L 405.335882 222.680522
-L 405.335882 213.667989
-L 415.613682 221.967485
-L 415.613682 201.757051
-L 425.891483 219.261945
-L 425.891483 206.629655
-L 436.169284 221.181075
-L 436.169284 197.462249
-L 446.447085 216.968747
-L 446.447085 198.818366
-L 456.724886 221.648704
-L 456.724886 200.098487
-L 467.002687 215.324346
-L 467.002687 195.905558
-L 477.280488 217.351235
-L 477.280488 200.340514
-L 487.558288 214.107478
-L 487.558288 198.876897
-L 487.558288 198.876897
+    <path d="M 86.724055 272.977284
+L 86.724055 267.866918
+L 97.001856 270.207094
+L 97.001856 261.869
+L 107.279657 268.696092
+L 107.279657 260.457802
+L 117.557458 265.653555
+L 117.557458 252.257275
+L 127.835259 263.589346
+L 127.835259 263.588859
+L 127.835259 251.97324
+L 138.11306 260.53125
+L 138.11306 249.150228
+L 148.39086 259.325381
+L 148.39086 250.035181
+L 158.668661 254.833653
+L 158.668661 245.441291
+L 168.946462 254.453222
+L 168.946462 245.611622
+L 179.224263 252.08364
+L 179.224263 237.548377
+L 189.502064 252.395876
+L 189.502064 238.10327
+L 199.779865 247.772457
+L 199.779865 232.882673
+L 210.057666 249.849679
+L 210.057666 230.973699
+L 220.335466 243.451854
+L 220.335466 237.386527
+L 230.613267 243.306979
+L 230.613267 231.778996
+L 240.891068 242.409709
+L 240.891068 226.362581
+L 251.168869 243.97591
+L 251.168869 219.42098
+L 261.44667 238.20591
+L 261.44667 224.141089
+L 271.724471 241.774893
+L 271.724471 241.576354
+L 271.724471 222.947717
+L 282.002271 234.245491
+L 282.002271 224.297607
+L 292.280072 234.425997
+L 292.280072 226.729935
+L 302.557873 232.670161
+L 302.557873 217.27832
+L 312.835674 235.580529
+L 312.835674 217.15226
+L 323.113475 230.348486
+L 323.113475 217.950342
+L 333.391276 231.691211
+L 333.391276 213.95634
+L 343.669077 227.560818
+L 343.669077 215.60676
+L 353.946877 232.181364
+L 353.946877 213.968221
+L 364.224678 226.926809
+L 364.224678 207.502276
+L 374.502479 230.598659
+L 374.502479 221.637729
+L 384.78028 222.537861
+L 384.78028 205.293726
+L 395.058081 227.519014
+L 395.058081 209.71709
+L 405.335882 222.61333
+L 405.335882 213.509246
+L 415.613682 222.05578
+L 415.613682 202.06016
+L 425.891483 219.338725
+L 425.891483 206.625916
+L 436.169284 221.293236
+L 436.169284 197.429491
+L 446.447085 216.92269
+L 446.447085 198.875977
+L 456.724886 221.998118
+L 456.724886 200.066493
+L 467.002687 215.458241
+L 467.002687 195.918215
+L 477.280488 217.698955
+L 477.280488 200.388902
+L 487.558288 214.404237
+L 487.558288 199.136656
+L 487.558288 199.136656
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1682,192 +1681,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.494121" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.142688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.09233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.969094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.757458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.253917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.081606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.939863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.104306" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.464296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.375197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.047431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="267.439342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="265.041049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.148261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.918643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="261.917771" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="261.504316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="269.241262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.488233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.30123" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.03403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="266.578898" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.546609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.191098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="261.211632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="260.209321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="265.125697" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="264.023109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="263.696814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="260.359384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.205145" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="257.680762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="255.525402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.987554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="252.024505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="263.642511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="263.622983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="259.876767" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="257.79347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="256.846089" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="255.345568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="252.998787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="252.218314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.734682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.726368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.318703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.278114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="256.290492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="253.783372" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="251.395412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="249.328646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="259.445002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="256.822302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.826149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.650592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.214365" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.419473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.241681" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="249.511078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="254.669162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="251.855626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="250.999914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="249.379568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="247.864167" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.896933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.620802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.49485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="254.830655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="248.936524" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="246.377321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="245.286509" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="252.122569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="251.170732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="244.088194" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="237.044594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="252.408719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="250.065324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="241.665947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="238.02614" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="248.143987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="241.168815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="235.72483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="232.647239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="250.164623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="247.317208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="244.88226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="231.512871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="243.072192" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="239.741479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="237.91758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="237.061398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="243.375216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="238.894496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="234.093377" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="231.642994" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="242.488402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="241.128057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="227.59469" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="226.60439" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="243.934864" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="228.560882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="225.721785" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="219.345068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="238.162854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="230.82765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="226.641484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="224.167411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="241.444149" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="241.212626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="227.760854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="222.982681" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="233.912477" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="229.355534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="228.308231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="224.009836" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="234.007905" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="228.093136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="227.227699" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="226.523427" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="232.468028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="221.33034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="219.599742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="217.474491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="235.596024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="233.031158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="226.278374" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="217.660566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="230.364722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="222.036701" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="218.784968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="217.821875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="231.345992" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="218.65449" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="216.245643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="213.492162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="227.75416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="216.949934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="216.619465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="215.592385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="231.970983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="222.627484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="213.629313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="209.542889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="226.871715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="225.879412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="211.442353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="207.302453" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="230.520395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="224.461628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="223.413928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="221.596656" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="222.580078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="211.15053" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="206.37389" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="205.096172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="227.544204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="226.017744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="211.620855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="209.720788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="222.680522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="213.667989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="221.967485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="216.190805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="201.757051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="219.261945" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="206.629655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="221.181075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="215.252794" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="205.03703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="197.462249" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="216.968747" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="205.324469" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="204.58734" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="198.818366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="221.648704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="219.023141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="205.64278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="200.098487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="215.324346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="195.905558" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="217.351235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="216.321283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="200.340514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="214.107478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="198.876897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.977284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.953544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.911871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.879253" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.516305" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.475627" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.380275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.058236" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="267.866918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="270.207094" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.599416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.116765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="267.836699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.014151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.366083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="263.46219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="262.717972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="261.869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.696092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.387898" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.084876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.075336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="266.99223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="263.236307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="262.643407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="260.560466" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="260.457802" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.653555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.210744" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="263.236307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="259.608343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.876415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.270326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="255.688485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="254.657279" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="252.257275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.589346" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.588859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="260.432841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="257.942831" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="257.021269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="256.044774" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.577991" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="251.97324" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.53125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.282169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="259.884302" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="259.631799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="257.177665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="253.418956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="251.380296" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="249.150228" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="259.325381" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="256.424276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.985965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.203402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.596384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.991166" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.477405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="250.035181" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="254.833653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="252.280692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="250.306666" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="249.139067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="248.661287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.736582" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.597231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.441291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="254.453222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="248.796449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="246.223833" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="245.611622" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="252.08364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="251.227377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="244.152979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="237.548377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="252.395876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="249.826938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="241.553342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="238.10327" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="247.772457" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="241.204025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="235.792714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="232.882673" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="249.849679" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="247.29349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="245.170058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="230.973699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.451854" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="240.079263" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.87884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.386527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="243.306979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="238.70667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="234.279085" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="231.778996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="242.409709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="241.324539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="227.51439" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="226.362581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="243.97591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="228.514745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="226.046403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="219.42098" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="238.20591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="230.832412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="226.451541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="224.141089" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.774893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.576354" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="227.940799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="222.947717" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="234.245491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="229.550706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="227.900874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="224.297607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="234.425997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="228.003942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="227.247213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="226.729935" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="232.670161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="221.370764" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="219.801005" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="217.27832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="235.580529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="233.023001" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="226.008627" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="217.15226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="230.348486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="221.936371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="218.913894" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="217.950342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="231.691211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="218.920911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="216.507347" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="213.95634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="227.560818" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="217.112081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="217.013813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.60676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="232.181364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="223.024407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="215.231002" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="213.968221" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="226.926809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="225.85891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="211.572656" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="207.502276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="230.598659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="224.76072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="223.370243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="221.637729" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="222.537861" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="210.75274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="206.186555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="205.293726" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="227.519014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="225.987249" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="211.553243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="209.71709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="222.61333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="213.509246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="222.05578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="216.350518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="202.06016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="219.338725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="206.625916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="221.293236" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="215.461934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="204.847708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="197.429491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="216.92269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="205.403653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="204.670805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="198.875977" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="221.998118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="219.244765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="205.616597" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="200.066493" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="215.458241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="195.918215" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="217.698955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="216.665152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="200.388902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="214.404237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="199.136656" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_140">
@@ -3865,7 +3864,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3925,6 +3924,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -3972,7 +4001,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
@@ -1455,25 +1455,25 @@ z
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 86.724055 271.680774
-L 104.151631 253.522187
-L 112.865418 249.562271
-L 115.770014 252.293129
-L 115.770014 243.494513
-L 127.388398 239.17723
-L 139.006781 232.09318
-L 139.006781 203.5731
-L 156.434357 210.052213
-L 162.243549 181.330506
-L 173.861932 200.228163
-L 185.480316 202.451036
-L 208.717083 170.488603
-L 243.572234 184.37592
-L 301.664151 161.281922
-L 374.279049 139.332788
-L 394.61122 148.874562
-L 417.847987 113.451931
-L 487.558288 132.193477
+    <path d="M 86.724055 271.298465
+L 104.151631 253.289096
+L 112.865418 249.444757
+L 115.770014 252.39499
+L 115.770014 243.029831
+L 127.388398 238.574196
+L 139.006781 233.116764
+L 139.006781 203.828456
+L 156.434357 210.401573
+L 162.243549 181.53612
+L 173.861932 200.770656
+L 185.480316 202.964781
+L 208.717083 170.888965
+L 243.572234 184.74404
+L 301.664151 161.62569
+L 374.279049 139.532388
+L 394.61122 149.420231
+L 417.847987 113.541586
+L 487.558288 132.269232
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1489,25 +1489,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.680774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.151631" y="253.522187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.865418" y="249.562271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="252.293129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="243.494513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.388398" y="239.17723" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="232.09318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="203.5731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.434357" y="210.052213" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.243549" y="181.330506" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.861932" y="200.228163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.480316" y="202.451036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.717083" y="170.488603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="243.572234" y="184.37592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.664151" y="161.281922" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.279049" y="139.332788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.61122" y="148.874562" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="417.847987" y="113.451931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="132.193477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.298465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.151631" y="253.289096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.865418" y="249.444757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="252.39499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="243.029831" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.388398" y="238.574196" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="233.116764" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="203.828456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.434357" y="210.401573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.243549" y="181.53612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.861932" y="200.770656" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.480316" y="202.964781" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.717083" y="170.888965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="243.572234" y="184.74404" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.664151" y="161.62569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.279049" y="139.532388" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.61122" y="149.420231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="417.847987" y="113.541586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="132.269232" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_120">
@@ -2365,7 +2365,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2497,7 +2497,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic.svg
@@ -1509,40 +1509,40 @@ z
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 272.263309
-L 87.505409 269.054344
-L 88.286762 251.825532
-L 89.068115 253.343088
-L 89.849469 238.461107
-L 91.412175 252.7606
-L 92.193528 250.718619
-L 92.974882 248.871903
-L 93.756235 235.661458
-L 94.537588 228.825338
-L 96.100295 240.193952
-L 97.663001 231.182345
-L 99.225708 217.973407
-L 100.788414 196.640091
-L 101.569768 228.520855
-L 103.913828 178.242985
-L 105.476534 221.464461
-L 106.257887 217.611742
-L 108.601947 174.467022
-L 110.164654 209.668068
-L 116.41548 170.398537
-L 119.540893 204.465578
-L 128.135779 138.323176
-L 135.167959 184.467368
-L 143.762845 144.545185
-L 148.450965 178.348047
-L 154.701791 142.805152
-L 163.296677 86.954635
-L 178.923743 119.833907
-L 185.174569 166.664848
-L 214.08464 156.961096
-L 280.499669 139.190141
-L 283.625082 140.767586
-L 487.558288 60.646829
+    <path d="M 86.724055 272.074903
+L 87.505409 269.096265
+L 88.286762 253.194922
+L 89.068115 254.842604
+L 89.849469 239.464391
+L 91.412175 253.792947
+L 92.193528 251.479328
+L 92.974882 249.657596
+L 93.756235 236.7665
+L 94.537588 229.912384
+L 96.100295 240.585438
+L 97.663001 231.3933
+L 99.225708 218.301539
+L 100.788414 197.456221
+L 101.569768 229.022378
+L 103.913828 178.961872
+L 105.476534 222.057091
+L 106.257887 218.188823
+L 108.601947 175.195961
+L 110.164654 210.758605
+L 116.41548 171.076568
+L 119.540893 204.981883
+L 128.135779 138.851551
+L 135.167959 184.753795
+L 143.762845 145.102971
+L 148.450965 179.239757
+L 154.701791 143.233822
+L 163.296677 87.220038
+L 178.923743 120.148238
+L 185.174569 166.833932
+L 214.08464 156.982405
+L 280.499669 139.697229
+L 283.625082 140.953234
+L 487.558288 60.707369
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1558,40 +1558,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.263309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="87.505409" y="269.054344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.286762" y="251.825532" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.068115" y="253.343088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.849469" y="238.461107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.412175" y="252.7606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.193528" y="250.718619" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.974882" y="248.871903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.756235" y="235.661458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.537588" y="228.825338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.100295" y="240.193952" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.663001" y="231.182345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.225708" y="217.973407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.788414" y="196.640091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="228.520855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="103.913828" y="178.242985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.476534" y="221.464461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.257887" y="217.611742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.601947" y="174.467022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.164654" y="209.668068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="170.398537" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.540893" y="204.465578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.135779" y="138.323176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.167959" y="184.467368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.762845" y="144.545185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.450965" y="178.348047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="154.701791" y="142.805152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.296677" y="86.954635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.923743" y="119.833907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.174569" y="166.664848" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.08464" y="156.961096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.499669" y="139.190141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.625082" y="140.767586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="60.646829" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.074903" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="87.505409" y="269.096265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.286762" y="253.194922" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.068115" y="254.842604" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.849469" y="239.464391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.412175" y="253.792947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.193528" y="251.479328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.974882" y="249.657596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.756235" y="236.7665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.537588" y="229.912384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.100295" y="240.585438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.663001" y="231.3933" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.225708" y="218.301539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.788414" y="197.456221" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="229.022378" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="103.913828" y="178.961872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.476534" y="222.057091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.257887" y="218.188823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.601947" y="175.195961" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.164654" y="210.758605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="171.076568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.540893" y="204.981883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.135779" y="138.851551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.167959" y="184.753795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.762845" y="145.102971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.450965" y="179.239757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="154.701791" y="143.233822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.296677" y="87.220038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.923743" y="120.148238" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.174569" y="166.833932" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.08464" y="156.982405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.499669" y="139.697229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.625082" y="140.953234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="60.707369" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_128">
@@ -2570,7 +2570,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2702,7 +2702,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
@@ -600,8 +600,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 66.682344 275.655651
-L 507.6 275.655651
+      <path d="M 66.682344 275.661944
+L 507.6 275.661944
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
@@ -611,12 +611,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.655651" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.661944" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.454479) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.460772) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-14" d="M 794 531
 L 1825 531
@@ -673,18 +673,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 66.682344 184.500321
-L 507.6 184.500321
+      <path d="M 66.682344 184.544317
+L 507.6 184.544317
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="184.500321" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="184.544317" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100ms -->
-      <g transform="translate(25.644844 188.299149) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 188.343145) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -695,18 +695,18 @@ L 507.6 184.500321
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 66.682344 93.344991
-L 507.6 93.344991
+      <path d="M 66.682344 93.42669
+L 507.6 93.42669
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="93.344991" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="93.42669" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1s -->
-      <g transform="translate(48.110469 97.143819) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 97.225518) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -714,8 +714,8 @@ L 507.6 93.344991
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 66.682344 303.096139
-L 507.6 303.096139
+      <path d="M 66.682344 303.091083
+L 507.6 303.091083
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
@@ -725,295 +725,295 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.096139" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.091083" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 66.682344 295.878346
-L 507.6 295.878346
+      <path d="M 66.682344 295.876276
+L 507.6 295.876276
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.878346" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.876276" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 66.682344 289.77579
-L 507.6 289.77579
+      <path d="M 66.682344 289.776243
+L 507.6 289.776243
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.77579" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.776243" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 66.682344 284.489515
-L 507.6 284.489515
+      <path d="M 66.682344 284.492155
+L 507.6 284.492155
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.489515" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.492155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 66.682344 279.82669
-L 507.6 279.82669
+      <path d="M 66.682344 279.831258
+L 507.6 279.831258
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.82669" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.831258" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 66.682344 248.215162
-L 507.6 248.215162
+      <path d="M 66.682344 248.232805
+L 507.6 248.232805
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.215162" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.232805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 66.682344 232.163505
-L 507.6 232.163505
+      <path d="M 66.682344 232.187788
+L 507.6 232.187788
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.163505" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.187788" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 66.682344 220.774674
-L 507.6 220.774674
+      <path d="M 66.682344 220.803666
+L 507.6 220.803666
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.774674" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.803666" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 66.682344 211.940809
-L 507.6 211.940809
+      <path d="M 66.682344 211.973456
+L 507.6 211.973456
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="211.940809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="211.973456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 66.682344 204.723017
-L 507.6 204.723017
+      <path d="M 66.682344 204.758649
+L 507.6 204.758649
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="204.723017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="204.758649" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 66.682344 198.62046
-L 507.6 198.62046
+      <path d="M 66.682344 198.658616
+L 507.6 198.658616
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.62046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.658616" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 66.682344 193.334185
-L 507.6 193.334185
+      <path d="M 66.682344 193.374528
+L 507.6 193.374528
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="193.334185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="193.374528" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 66.682344 188.67136
-L 507.6 188.67136
+      <path d="M 66.682344 188.713631
+L 507.6 188.713631
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.67136" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.713631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 66.682344 157.059832
-L 507.6 157.059832
+      <path d="M 66.682344 157.115178
+L 507.6 157.115178
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="157.059832" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="157.115178" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 66.682344 141.008176
-L 507.6 141.008176
+      <path d="M 66.682344 141.07016
+L 507.6 141.07016
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="141.008176" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="141.07016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 66.682344 129.619344
-L 507.6 129.619344
+      <path d="M 66.682344 129.686039
+L 507.6 129.686039
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="129.619344" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="129.686039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 66.682344 120.78548
-L 507.6 120.78548
+      <path d="M 66.682344 120.855829
+L 507.6 120.855829
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="120.78548" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="120.855829" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 66.682344 113.567687
-L 507.6 113.567687
+      <path d="M 66.682344 113.641022
+L 507.6 113.641022
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="113.567687" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="113.641022" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 66.682344 107.46513
-L 507.6 107.46513
+      <path d="M 66.682344 107.540989
+L 507.6 107.540989
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="107.46513" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="107.540989" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 66.682344 102.178855
-L 507.6 102.178855
+      <path d="M 66.682344 102.2569
+L 507.6 102.2569
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="102.178855" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="102.2569" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 66.682344 97.51603
-L 507.6 97.51603
+      <path d="M 66.682344 97.596004
+L 507.6 97.596004
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="97.51603" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="97.596004" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 66.682344 65.904503
-L 507.6 65.904503
+      <path d="M 66.682344 65.997551
+L 507.6 65.997551
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="65.904503" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="65.997551" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 66.682344 49.852846
-L 507.6 49.852846
+      <path d="M 66.682344 49.952533
+L 507.6 49.952533
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.852846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.952533" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63">
-      <path d="M 66.682344 38.464014
-L 507.6 38.464014
+      <path d="M 66.682344 38.568412
+L 507.6 38.568412
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.464014" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.568412" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_65">
-      <path d="M 66.682344 29.63015
-L 507.6 29.63015
+      <path d="M 66.682344 29.738202
+L 507.6 29.738202
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="29.63015" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="29.738202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1101,9 +1101,9 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 86.724055 157.535354
-L 89.917954 94.937159
-L 136.229479 46.388151
+    <path d="M 86.724055 158.949898
+L 89.917954 95.349796
+L 136.229479 46.84093
 L 188.9288 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1120,22 +1120,22 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="157.535354" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.917954" y="94.937159" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.229479" y="46.388151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="158.949898" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.917954" y="95.349796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.229479" y="46.84093" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="188.9288" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 86.724055 224.389326
+    <path d="M 86.724055 224.416824
 L 89.917954 290.872308
-L 136.229479 252.299609
-L 137.826428 128.310298
-L 188.9288 105.736918
-L 188.9288 84.783994
-L 264.783884 172.966962
-L 291.133545 178.741915
-L 487.558288 123.088683
+L 136.229479 252.315563
+L 137.826428 128.377535
+L 188.9288 105.813491
+L 188.9288 84.869234
+L 264.783884 173.015729
+L 291.133545 178.788293
+L 487.558288 123.158079
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1145,27 +1145,27 @@ z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="224.389326" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="224.416824" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      <use xlink:href="#meef3cfac8d" x="89.917954" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.229479" y="252.299609" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="137.826428" y="128.310298" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="105.736918" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="84.783994" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="264.783884" y="172.966962" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="291.133545" y="178.741915" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="123.088683" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.229479" y="252.315563" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="137.826428" y="128.377535" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="105.813491" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="84.869234" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="264.783884" y="173.015729" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="291.133545" y="178.788293" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="123.158079" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
-    <path d="M 86.724055 186.561613
-L 89.917954 253.526286
-L 136.229479 225.807837
-L 137.826428 138.02133
-L 188.9288 92.936682
-L 188.9288 82.812153
-L 264.783884 173.089591
-L 291.133545 142.611046
-L 487.558288 106.46528
+    <path d="M 86.724055 186.604757
+L 89.917954 253.541733
+L 136.229479 225.834748
+L 137.826428 138.084551
+L 188.9288 93.018549
+L 188.9288 82.898208
+L 264.783884 173.138307
+L 291.133545 142.672368
+L 487.558288 106.541552
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1175,27 +1175,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="186.561613" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="89.917954" y="253.526286" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.229479" y="225.807837" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="137.826428" y="138.02133" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="92.936682" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="82.812153" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="264.783884" y="173.089591" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="291.133545" y="142.611046" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="106.46528" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="186.604757" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="89.917954" y="253.541733" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.229479" y="225.834748" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="137.826428" y="138.084551" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="93.018549" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="82.898208" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="264.783884" y="173.138307" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="291.133545" y="142.672368" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="106.541552" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
-    <path d="M 86.724055 217.026104
-L 89.917954 253.946309
-L 136.229479 235.871775
-L 137.826428 163.245322
-L 188.9288 122.257177
-L 188.9288 118.244859
-L 264.783884 156.160807
-L 291.133545 167.162993
-L 487.558288 94.927467
+    <path d="M 86.724055 217.056648
+L 89.917954 253.961582
+L 136.229479 235.894524
+L 137.826428 163.29811
+L 188.9288 122.326918
+L 188.9288 118.316259
+L 264.783884 156.216525
+L 291.133545 167.21416
+L 487.558288 95.008512
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1214,15 +1214,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="217.026104" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.946309" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.229479" y="235.871775" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="137.826428" y="163.245322" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="122.257177" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="118.244859" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="264.783884" y="156.160807" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="291.133545" y="167.162993" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="94.927467" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="217.056648" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.961582" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.229479" y="235.894524" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="137.826428" y="163.29811" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="122.326918" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="118.316259" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="264.783884" y="156.216525" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="291.133545" y="167.21416" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="95.008512" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1711,7 +1711,7 @@ z
    </g>
   </g>
   <g id="text_16">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1818,7 +1818,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-laguerre.svg
+++ b/reports/figures/hexbz-runtime-degree-laguerre.svg
@@ -1424,26 +1424,26 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 275.202895
-L 100.545925 264.824229
-L 114.367796 257.279764
-L 128.189666 254.45906
-L 142.011536 247.068364
-L 155.833406 251.034581
-L 169.655276 251.334705
-L 183.477146 238.400667
-L 197.299016 244.076451
-L 211.120886 228.739891
-L 224.942756 227.443249
-L 238.764627 220.571738
-L 252.586497 215.819926
-L 266.408367 210.129692
-L 294.052107 208.193124
-L 321.695847 198.0293
-L 349.339587 209.829731
-L 376.983328 198.57082
-L 432.270808 189.022156
-L 487.558288 175.950199
+    <path d="M 86.724055 275.909182
+L 100.545925 264.999188
+L 114.367796 257.216728
+L 128.189666 254.386675
+L 142.011536 247.057508
+L 155.833406 251.115915
+L 169.655276 251.726787
+L 183.477146 238.611131
+L 197.299016 244.383404
+L 211.120886 229.309912
+L 224.942756 227.664896
+L 238.764627 220.590697
+L 252.586497 216.215877
+L 266.408367 210.447844
+L 294.052107 208.377296
+L 321.695847 198.397769
+L 349.339587 210.117335
+L 376.983328 198.880026
+L 432.270808 189.395559
+L 487.558288 176.231811
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1459,26 +1459,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.202895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="264.824229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="257.279764" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="254.45906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="247.068364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="251.034581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="251.334705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="238.400667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="244.076451" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="228.739891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="227.443249" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="220.571738" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="215.819926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="210.129692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="208.193124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="198.0293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="209.829731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="198.57082" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="189.022156" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="175.950199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.909182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="264.999188" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="257.216728" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="254.386675" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="247.057508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="251.115915" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="251.726787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="238.611131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="244.383404" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="229.309912" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="227.664896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="220.590697" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="216.215877" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="210.447844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="208.377296" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="198.397769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="210.117335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="198.880026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="189.395559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="176.231811" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2347,7 +2347,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2407,6 +2407,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2454,7 +2484,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-legendre.svg
+++ b/reports/figures/hexbz-runtime-degree-legendre.svg
@@ -1443,26 +1443,26 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 272.833522
-L 98.176462 272.482542
-L 109.628869 261.879071
-L 121.081275 254.970794
-L 132.533682 259.235024
-L 143.986089 243.941635
-L 155.438495 242.320852
-L 166.890902 232.766357
-L 189.795715 237.440988
-L 212.700529 217.297348
-L 235.605342 220.034909
-L 258.510155 202.655325
-L 281.414969 195.391876
-L 304.319782 208.595602
-L 327.224595 197.077838
-L 350.129408 168.999899
-L 373.034222 195.723054
-L 395.939035 165.34695
-L 441.748662 186.010545
-L 487.558288 181.714052
+    <path d="M 86.724055 273.090988
+L 98.176462 272.46244
+L 109.628869 261.737143
+L 121.081275 254.977319
+L 132.533682 258.310633
+L 143.986089 243.736817
+L 155.438495 242.422294
+L 166.890902 233.079662
+L 189.795715 237.65012
+L 212.700529 217.243677
+L 235.605342 220.440603
+L 258.510155 202.860293
+L 281.414969 195.378715
+L 304.319782 208.269298
+L 327.224595 197.137617
+L 350.129408 168.717284
+L 373.034222 195.559381
+L 395.939035 165.125677
+L 441.748662 186.088139
+L 487.558288 181.656738
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1478,26 +1478,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.833522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.176462" y="272.482542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.628869" y="261.879071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.081275" y="254.970794" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.533682" y="259.235024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="243.941635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.438495" y="242.320852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="232.766357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.795715" y="237.440988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.700529" y="217.297348" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.605342" y="220.034909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="202.655325" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.414969" y="195.391876" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.319782" y="208.595602" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="197.077838" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.129408" y="168.999899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="195.723054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.939035" y="165.34695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.748662" y="186.010545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="181.714052" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.090988" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.176462" y="272.46244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.628869" y="261.737143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.081275" y="254.977319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.533682" y="258.310633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="243.736817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.438495" y="242.422294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="233.079662" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.795715" y="237.65012" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.700529" y="217.243677" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.605342" y="220.440603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="202.860293" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.414969" y="195.378715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.319782" y="208.269298" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="197.137617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.129408" y="168.717284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="195.559381" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.939035" y="165.125677" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.748662" y="186.088139" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.656738" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2360,7 +2360,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2420,6 +2420,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2467,7 +2497,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-random-products.svg
+++ b/reports/figures/hexbz-runtime-degree-random-products.svg
@@ -1419,36 +1419,36 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 265.398045
-L 153.529761 254.995828
-L 153.529761 254.678288
-L 153.529761 251.500608
-L 175.798329 257.805061
-L 198.066898 250.735521
-L 220.335466 251.457548
-L 220.335466 243.156373
-L 242.604035 249.697934
-L 242.604035 242.588299
-L 242.604035 241.802554
-L 242.604035 241.131826
-L 242.604035 240.270493
-L 242.604035 229.340476
-L 264.872603 247.486423
-L 264.872603 239.544429
-L 287.141172 247.539726
-L 287.141172 245.49099
-L 287.141172 241.773535
-L 309.40974 235.605655
-L 331.678309 238.388636
-L 353.946877 236.340966
-L 353.946877 233.864605
-L 353.946877 224.755744
-L 353.946877 222.897682
-L 376.215446 224.054576
-L 398.484014 229.477332
-L 420.752583 226.806232
-L 443.021151 218.724779
-L 487.558288 212.048063
+    <path d="M 86.724055 265.765874
+L 153.529761 255.321952
+L 153.529761 255.053996
+L 153.529761 251.424877
+L 175.798329 258.466958
+L 198.066898 250.998045
+L 220.335466 251.186202
+L 220.335466 243.645027
+L 242.604035 250.124749
+L 242.604035 242.730778
+L 242.604035 242.346029
+L 242.604035 241.38186
+L 242.604035 240.71756
+L 242.604035 230.319131
+L 264.872603 247.631505
+L 264.872603 239.771348
+L 287.141172 247.931976
+L 287.141172 246.121953
+L 287.141172 242.065287
+L 309.40974 236.207266
+L 331.678309 238.55748
+L 353.946877 236.296338
+L 353.946877 233.988036
+L 353.946877 225.133805
+L 353.946877 223.266399
+L 376.215446 224.590351
+L 398.484014 229.574151
+L 420.752583 227.103277
+L 443.021151 219.193619
+L 487.558288 212.654885
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1464,36 +1464,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.398045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.995828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.678288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="251.500608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="257.805061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="250.735521" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="251.457548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="243.156373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="249.697934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="242.588299" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.802554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.131826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="240.270493" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="229.340476" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="247.486423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="239.544429" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="247.539726" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="245.49099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="241.773535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="235.605655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="238.388636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="236.340966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="233.864605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="224.755744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="222.897682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="224.054576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="229.477332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="226.806232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="218.724779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="212.048063" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="265.765874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="255.321952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="255.053996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="251.424877" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="258.466958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="250.998045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="251.186202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.645027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="250.124749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.730778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.346029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.38186" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.71756" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="230.319131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="247.631505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="239.771348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="247.931976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="246.121953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="242.065287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="236.207266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="238.55748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="236.296338" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="233.988036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="225.133805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="223.266399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="224.590351" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="229.574151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="227.103277" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="219.193619" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="212.654885" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2475,7 +2475,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2528,6 +2528,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2575,7 +2605,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-sd-products.svg
+++ b/reports/figures/hexbz-runtime-degree-sd-products.svg
@@ -612,8 +612,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 66.682344 277.311959
-L 507.6 277.311959
+      <path d="M 66.682344 277.304176
+L 507.6 277.304176
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
@@ -623,12 +623,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.311959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.304176" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100us -->
-      <g transform="translate(29.047969 281.110787) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 281.103004) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-58" d="M 544 1381
 L 544 3500
@@ -694,18 +694,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 66.682344 223.950265
-L 507.6 223.950265
+      <path d="M 66.682344 223.911855
+L 507.6 223.911855
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.950265" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.911855" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1ms -->
-      <g transform="translate(38.369844 227.749093) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.710683) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -714,18 +714,18 @@ L 507.6 223.950265
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 66.682344 170.588571
-L 507.6 170.588571
+      <path d="M 66.682344 170.519534
+L 507.6 170.519534
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="170.588571" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="170.519534" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 10ms -->
-      <g transform="translate(32.007344 174.387399) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 174.318362) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -735,18 +735,18 @@ L 507.6 170.588571
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 66.682344 117.226877
-L 507.6 117.226877
+      <path d="M 66.682344 117.127213
+L 507.6 117.127213
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="117.226877" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="117.127213" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 100ms -->
-      <g transform="translate(25.644844 121.025706) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 120.926042) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -757,18 +757,18 @@ L 507.6 117.226877
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 66.682344 63.865184
-L 507.6 63.865184
+      <path d="M 66.682344 63.734893
+L 507.6 63.734893
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="63.865184" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="63.734893" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1s -->
-      <g transform="translate(48.110469 67.664012) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 67.533721) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -776,8 +776,8 @@ L 507.6 63.865184
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 66.682344 298.546712
-L 507.6 298.546712
+      <path d="M 66.682344 298.551117
+L 507.6 298.551117
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
@@ -787,499 +787,499 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.546712" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.551117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 66.682344 293.37543
-L 507.6 293.37543
+      <path d="M 66.682344 293.376866
+L 507.6 293.376866
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.37543" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.376866" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 66.682344 289.150184
-L 507.6 289.150184
+      <path d="M 66.682344 289.149196
+L 507.6 289.149196
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.150184" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.149196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 66.682344 285.57779
-L 507.6 285.57779
+      <path d="M 66.682344 285.574751
+L 507.6 285.574751
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.57779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.574751" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 66.682344 282.483242
-L 507.6 282.483242
+      <path d="M 66.682344 282.478427
+L 507.6 282.478427
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.483242" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.478427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 66.682344 279.753656
-L 507.6 279.753656
+      <path d="M 66.682344 279.747275
+L 507.6 279.747275
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.753656" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.747275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 66.682344 261.248489
-L 507.6 261.248489
+      <path d="M 66.682344 261.231486
+L 507.6 261.231486
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.248489" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.231486" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 66.682344 251.851961
-L 507.6 251.851961
+      <path d="M 66.682344 251.829565
+L 507.6 251.829565
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="251.851961" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="251.829565" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 66.682344 245.185018
-L 507.6 245.185018
+      <path d="M 66.682344 245.158796
+L 507.6 245.158796
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.185018" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.158796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 66.682344 240.013736
-L 507.6 240.013736
+      <path d="M 66.682344 239.984545
+L 507.6 239.984545
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="240.013736" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="239.984545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 66.682344 235.78849
-L 507.6 235.78849
+      <path d="M 66.682344 235.756875
+L 507.6 235.756875
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="235.78849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="235.756875" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 66.682344 232.216096
-L 507.6 232.216096
+      <path d="M 66.682344 232.18243
+L 507.6 232.18243
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.216096" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.18243" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 66.682344 229.121548
-L 507.6 229.121548
+      <path d="M 66.682344 229.086106
+L 507.6 229.086106
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.121548" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.086106" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_49">
-      <path d="M 66.682344 226.391962
-L 507.6 226.391962
+      <path d="M 66.682344 226.354954
+L 507.6 226.354954
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.391962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.354954" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_51">
-      <path d="M 66.682344 207.886795
-L 507.6 207.886795
+      <path d="M 66.682344 207.839165
+L 507.6 207.839165
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.886795" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.839165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_53">
-      <path d="M 66.682344 198.490267
-L 507.6 198.490267
+      <path d="M 66.682344 198.437244
+L 507.6 198.437244
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.490267" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.437244" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_55">
-      <path d="M 66.682344 191.823324
-L 507.6 191.823324
+      <path d="M 66.682344 191.766475
+L 507.6 191.766475
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.823324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.766475" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_57">
-      <path d="M 66.682344 186.652042
-L 507.6 186.652042
+      <path d="M 66.682344 186.592224
+L 507.6 186.592224
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.652042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.592224" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_59">
-      <path d="M 66.682344 182.426796
-L 507.6 182.426796
+      <path d="M 66.682344 182.364554
+L 507.6 182.364554
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.426796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.364554" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_61">
-      <path d="M 66.682344 178.854402
-L 507.6 178.854402
+      <path d="M 66.682344 178.79011
+L 507.6 178.79011
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.854402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.79011" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_63">
-      <path d="M 66.682344 175.759854
-L 507.6 175.759854
+      <path d="M 66.682344 175.693785
+L 507.6 175.693785
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="175.759854" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="175.693785" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_65">
-      <path d="M 66.682344 173.030269
-L 507.6 173.030269
+      <path d="M 66.682344 172.962633
+L 507.6 172.962633
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="173.030269" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="172.962633" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_67">
-      <path d="M 66.682344 154.525101
-L 507.6 154.525101
+      <path d="M 66.682344 154.446844
+L 507.6 154.446844
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.525101" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.446844" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_69">
-      <path d="M 66.682344 145.128573
-L 507.6 145.128573
+      <path d="M 66.682344 145.044923
+L 507.6 145.044923
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.128573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.044923" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_71">
-      <path d="M 66.682344 138.46163
-L 507.6 138.46163
+      <path d="M 66.682344 138.374154
+L 507.6 138.374154
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.46163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.374154" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_73">
-      <path d="M 66.682344 133.290348
-L 507.6 133.290348
+      <path d="M 66.682344 133.199904
+L 507.6 133.199904
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.290348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.199904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_75">
-      <path d="M 66.682344 129.065103
-L 507.6 129.065103
+      <path d="M 66.682344 128.972233
+L 507.6 128.972233
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="129.065103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.972233" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_77">
-      <path d="M 66.682344 125.492708
-L 507.6 125.492708
+      <path d="M 66.682344 125.397789
+L 507.6 125.397789
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.492708" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.397789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_79">
-      <path d="M 66.682344 122.39816
-L 507.6 122.39816
+      <path d="M 66.682344 122.301464
+L 507.6 122.301464
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.39816" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.301464" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_81">
-      <path d="M 66.682344 119.668575
-L 507.6 119.668575
+      <path d="M 66.682344 119.570312
+L 507.6 119.570312
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.668575" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.570312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_83">
-      <path d="M 66.682344 101.163407
-L 507.6 101.163407
+      <path d="M 66.682344 101.054523
+L 507.6 101.054523
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.163407" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.054523" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_85">
-      <path d="M 66.682344 91.766879
-L 507.6 91.766879
+      <path d="M 66.682344 91.652602
+L 507.6 91.652602
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.766879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.652602" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_87">
-      <path d="M 66.682344 85.099937
-L 507.6 85.099937
+      <path d="M 66.682344 84.981833
+L 507.6 84.981833
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="85.099937" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.981833" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_89">
-      <path d="M 66.682344 79.928654
-L 507.6 79.928654
+      <path d="M 66.682344 79.807583
+L 507.6 79.807583
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="79.928654" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="79.807583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_91">
-      <path d="M 66.682344 75.703409
-L 507.6 75.703409
+      <path d="M 66.682344 75.579912
+L 507.6 75.579912
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.703409" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.579912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_93">
-      <path d="M 66.682344 72.131015
-L 507.6 72.131015
+      <path d="M 66.682344 72.005468
+L 507.6 72.005468
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="72.131015" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="72.005468" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_95">
-      <path d="M 66.682344 69.036466
-L 507.6 69.036466
+      <path d="M 66.682344 68.909143
+L 507.6 68.909143
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="69.036466" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.909143" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_97">
-      <path d="M 66.682344 66.306881
-L 507.6 66.306881
+      <path d="M 66.682344 66.177991
+L 507.6 66.177991
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="66.306881" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="66.177991" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_99">
-      <path d="M 66.682344 47.801713
-L 507.6 47.801713
+      <path d="M 66.682344 47.662202
+L 507.6 47.662202
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="47.801713" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="47.662202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_101">
-      <path d="M 66.682344 38.405185
-L 507.6 38.405185
+      <path d="M 66.682344 38.260281
+L 507.6 38.260281
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.405185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.260281" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_103">
-      <path d="M 66.682344 31.738243
-L 507.6 31.738243
+      <path d="M 66.682344 31.589512
+L 507.6 31.589512
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.738243" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.589512" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_105">
-      <path d="M 66.682344 26.56696
-L 507.6 26.56696
+      <path d="M 66.682344 26.415262
+L 507.6 26.415262
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="26.56696" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="26.415262" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1367,16 +1367,16 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 270.085438
-L 86.724055 269.848614
-L 113.446338 240.243138
-L 113.446338 236.776287
-L 113.446338 227.259649
-L 166.890902 199.764332
-L 166.890902 158.060994
-L 193.613184 157.385301
-L 200.293755 109.874229
-L 247.057749 90.668552
+    <path d="M 86.724055 270.167064
+L 86.724055 269.897287
+L 113.446338 240.617274
+L 113.446338 236.977038
+L 113.446338 227.685799
+L 166.890902 200.681634
+L 166.890902 158.55742
+L 193.613184 158.022824
+L 200.293755 110.256696
+L 247.057749 90.716326
 L 313.863454 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1393,34 +1393,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.085438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="269.848614" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="240.243138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="236.776287" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="227.259649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="199.764332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="158.060994" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.613184" y="157.385301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.293755" y="109.874229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="90.668552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.167064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="269.897287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="240.617274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="236.977038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="227.685799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="200.681634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="158.55742" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.613184" y="158.022824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.293755" y="110.256696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="90.716326" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="313.863454" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
     <path d="M 86.724055 290.872308
-L 86.724055 288.908119
-L 113.446338 275.470546
-L 113.446338 270.131292
-L 113.446338 262.660377
-L 166.890902 242.356252
-L 166.890902 224.437572
-L 193.613184 230.182748
-L 200.293755 218.696258
-L 247.057749 211.455454
-L 273.780031 186.164558
-L 313.863454 185.425995
-L 434.113724 178.433235
-L 487.558288 136.476256
+L 86.724055 288.906991
+L 113.446338 275.461707
+L 113.446338 270.119388
+L 113.446338 262.644185
+L 166.890902 242.328406
+L 166.890902 224.399442
+L 193.613184 230.147915
+L 200.293755 218.654832
+L 247.057749 211.409873
+L 273.780031 186.10446
+L 313.863454 185.365474
+L 434.113724 178.368701
+L 487.558288 136.38764
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1431,36 +1431,36 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="288.908119" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="275.470546" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="270.131292" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="262.660377" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="166.890902" y="242.356252" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="166.890902" y="224.437572" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="193.613184" y="230.182748" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="200.293755" y="218.696258" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="247.057749" y="211.455454" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="273.780031" y="186.164558" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="313.863454" y="185.425995" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="434.113724" y="178.433235" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="136.476256" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="288.906991" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="275.461707" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="270.119388" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="262.644185" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="166.890902" y="242.328406" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="166.890902" y="224.399442" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="193.613184" y="230.147915" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="200.293755" y="218.654832" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="247.057749" y="211.409873" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="273.780031" y="186.10446" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="313.863454" y="185.365474" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="434.113724" y="178.368701" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="136.38764" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_109">
-    <path d="M 86.724055 261.499668
-L 86.724055 258.691449
-L 113.446338 244.007798
-L 113.446338 242.570355
-L 113.446338 240.656106
-L 166.890902 219.904428
-L 166.890902 201.962934
-L 193.613184 212.341499
-L 200.293755 195.584729
-L 247.057749 192.004013
-L 273.780031 167.167161
-L 313.863454 164.321296
-L 434.113724 156.704368
-L 487.558288 120.24696
+    <path d="M 86.724055 261.48281
+L 86.724055 258.672979
+L 113.446338 243.9809
+L 113.446338 242.542632
+L 113.446338 240.627285
+L 166.890902 219.863696
+L 166.890902 201.911904
+L 193.613184 212.296426
+L 200.293755 195.530039
+L 247.057749 191.947268
+L 273.780031 167.09616
+L 313.863454 164.248662
+L 434.113724 156.627363
+L 487.558288 120.149029
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1470,37 +1470,37 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.499668" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="258.691449" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="244.007798" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="242.570355" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="240.656106" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="166.890902" y="219.904428" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="166.890902" y="201.962934" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="193.613184" y="212.341499" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="200.293755" y="195.584729" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="247.057749" y="192.004013" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="273.780031" y="167.167161" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="313.863454" y="164.321296" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="434.113724" y="156.704368" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="120.24696" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.48281" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="258.672979" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="243.9809" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="242.542632" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="240.627285" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="166.890902" y="219.863696" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="166.890902" y="201.911904" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="193.613184" y="212.296426" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="200.293755" y="195.530039" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="247.057749" y="191.947268" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="273.780031" y="167.09616" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="313.863454" y="164.248662" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="434.113724" y="156.627363" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="120.149029" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_110">
-    <path d="M 86.724055 283.778307
-L 86.724055 281.356959
-L 113.446338 266.967614
-L 113.446338 266.414413
-L 113.446338 265.51544
-L 166.890902 235.172426
-L 166.890902 226.031327
-L 193.613184 225.108498
-L 200.293755 210.167371
-L 247.057749 200.360533
-L 273.780031 186.058758
-L 313.863454 179.865762
-L 434.113724 167.017929
-L 487.558288 139.301662
+    <path d="M 86.724055 283.774235
+L 86.724055 281.351498
+L 113.446338 266.953894
+L 113.446338 266.400375
+L 113.446338 265.500886
+L 166.890902 235.140457
+L 166.890902 225.994111
+L 193.613184 225.070753
+L 200.293755 210.121051
+L 247.057749 200.308583
+L 273.780031 185.998601
+L 313.863454 179.80205
+L 434.113724 166.946842
+L 487.558288 139.214667
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1519,32 +1519,32 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.778307" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="281.356959" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.967614" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.414413" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="265.51544" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="166.890902" y="235.172426" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="166.890902" y="226.031327" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="193.613184" y="225.108498" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="200.293755" y="210.167371" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="247.057749" y="200.360533" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="273.780031" y="186.058758" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="313.863454" y="179.865762" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="434.113724" y="167.017929" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.301662" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.774235" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="281.351498" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.953894" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.400375" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="265.500886" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="166.890902" y="235.140457" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="166.890902" y="225.994111" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="193.613184" y="225.070753" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="200.293755" y="210.121051" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="247.057749" y="200.308583" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="273.780031" y="185.998601" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="313.863454" y="179.80205" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="434.113724" y="166.946842" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.214667" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_111">
-    <path d="M 86.724055 248.416702
-L 86.724055 242.997786
-L 113.446338 225.525784
-L 113.446338 224.552357
-L 113.446338 217.556933
-L 166.890902 188.752404
-L 166.890902 168.799522
-L 193.613184 148.276148
-L 200.293755 147.107224
+    <path d="M 86.724055 248.392335
+L 86.724055 242.970309
+L 113.446338 225.488278
+L 113.446338 224.514293
+L 113.446338 217.514853
+L 166.890902 188.693792
+L 166.890902 168.729458
+L 193.613184 148.194304
+L 200.293755 147.02471
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1561,23 +1561,23 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.416702" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="242.997786" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="225.525784" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="224.552357" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="217.556933" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="166.890902" y="188.752404" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="166.890902" y="168.799522" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="193.613184" y="148.276148" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="200.293755" y="147.107224" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.392335" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="242.970309" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="225.488278" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="224.514293" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="217.514853" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="166.890902" y="188.693792" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="166.890902" y="168.729458" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="193.613184" y="148.194304" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="200.293755" y="147.02471" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_112">
-    <path d="M 86.724055 212.943602
-L 86.724055 208.892535
-L 113.446338 101.230862
-L 113.446338 85.172284
-L 113.446338 83.383308
+    <path d="M 86.724055 212.898875
+L 86.724055 208.845483
+L 113.446338 101.122017
+L 113.446338 85.054222
+L 113.446338 83.264219
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1590,11 +1590,11 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="212.943602" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="208.892535" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="101.230862" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="85.172284" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="83.383308" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="212.898875" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="208.845483" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="101.122017" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="85.054222" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="83.264219" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2193,7 +2193,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2325,7 +2325,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
@@ -1363,21 +1363,21 @@ z
     </g>
    </g>
    <g id="line2d_105">
-    <path d="M 86.724055 282.643337
-L 86.724055 281.878509
-L 99.654192 255.003476
-L 99.654192 254.707186
-L 99.654192 253.830339
-L 125.514465 217.507007
-L 125.514465 215.712349
-L 125.514465 215.4315
-L 177.235011 166.712318
-L 177.235011 165.219517
-L 177.235011 160.441206
-L 280.676104 133.684796
-L 280.676104 130.653561
-L 280.676104 130.024293
-L 487.558288 87.221148
+    <path d="M 86.724055 282.513909
+L 86.724055 281.824907
+L 99.654192 255.635457
+L 99.654192 254.979038
+L 99.654192 254.684329
+L 125.514465 218.119364
+L 125.514465 216.079176
+L 125.514465 216.013786
+L 177.235011 166.802523
+L 177.235011 165.50102
+L 177.235011 161.122498
+L 280.676104 134.080966
+L 280.676104 131.655531
+L 280.676104 130.86645
+L 487.558288 87.296625
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1393,21 +1393,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="282.643337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="281.878509" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="255.003476" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="254.707186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="253.830339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="217.507007" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="215.712349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="215.4315" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="166.712318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="165.219517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="160.441206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="133.684796" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="130.653561" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="130.024293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="87.221148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="282.513909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="281.824907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="255.635457" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="254.979038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="254.684329" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="218.119364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="216.079176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="216.013786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="166.802523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="165.50102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="161.122498" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="134.080966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="131.655531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="130.86645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="87.296625" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_106">
@@ -2217,7 +2217,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2349,7 +2349,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-wilkinson.svg
+++ b/reports/figures/hexbz-runtime-degree-wilkinson.svg
@@ -1298,21 +1298,21 @@ z
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 86.724055 269.644267
-L 102.140757 257.328114
-L 117.557458 247.691546
-L 132.974159 227.700912
-L 148.39086 220.771899
-L 163.807562 212.182986
-L 179.224263 204.761456
-L 194.640964 195.653698
-L 210.057666 188.876224
-L 240.891068 177.866989
-L 271.724471 167.574883
-L 302.557873 161.862045
-L 364.224678 153.74278
-L 425.891483 139.752765
-L 487.558288 133.297291
+    <path d="M 86.724055 269.001369
+L 102.140757 257.629913
+L 117.557458 247.936692
+L 132.974159 228.174453
+L 148.39086 221.201376
+L 163.807562 212.38409
+L 179.224263 205.103497
+L 194.640964 196.122097
+L 210.057666 189.240588
+L 240.891068 178.19845
+L 271.724471 167.808081
+L 302.557873 162.106219
+L 364.224678 153.728267
+L 425.891483 140.06243
+L 487.558288 133.643474
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1328,21 +1328,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="269.644267" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="102.140757" y="257.328114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="247.691546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.974159" y="227.700912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="220.771899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.807562" y="212.182986" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="204.761456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="194.640964" y="195.653698" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="188.876224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="177.866989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="167.574883" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="161.862045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="153.74278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="139.752765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="133.297291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="269.001369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="102.140757" y="257.629913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="247.936692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.974159" y="228.174453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="221.201376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.807562" y="212.38409" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="205.103497" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="194.640964" y="196.122097" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="189.240588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="178.19845" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="167.808081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="162.106219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="153.728267" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="140.06243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="133.643474" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_100">
@@ -2168,7 +2168,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 55 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 56 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2228,6 +2228,36 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2275,7 +2305,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-18" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-18" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>


### PR DESCRIPTION
## Summary

- add the Rand, bundled-modulus, extended-subresultant, and exact-division prerequisites
- implement HexModular, HexPolyZGcd, HexMvGcd, and HexMvHensel
- implement the HexMvFactor checked decomposition, EEZ, recombination, irreducibility-certificate, and bounded Kronecker routes
- activate the five computational libraries and move their completed Phase-1 SPECs into the library trees

## Validation

- full repository `lake build` (9,834 jobs) before rebasing
- rebased focused build: `lake build HexModular HexPolyZGcd HexMvGcd HexMvHensel HexMvFactor` (537 jobs)
- `python3 scripts/check_dag.py`
- `git diff --check`

## Proof status

This lands the executable Phase-1 implementations and checkers. The theorem declarations intentionally retain grep-visible `sorry` proof obligations under the repository Phase-1 convention; no axioms, `native_decide`, unsafe declarations, or executable proof extraction were introduced.