### PR TITLE
refactor(bz): use bundled modular primes

### DIFF
--- a/HexBerlekampZassenhaus/Certificate.lean
+++ b/HexBerlekampZassenhaus/Certificate.lean
@@ -441,20 +441,20 @@ The block is returned only when the prime is admissible, every modular factor
 is Rabin-certified, and the assembled block self-verifies against `f` through
 `PrimeFactorData.checkForPolynomial` (so a block that survives here is exactly
 one the kernel checker will accept). This requires the modular image of `f` to
-be monic at `c.p`, i.e. `leadingCoeff f ≡ 1 (mod c.p)`; otherwise the recorded
-monic factors cannot multiply back to `ZPoly.modP c.p f` and the block is
+be monic at `c.m`, i.e. `leadingCoeff f ≡ 1 (mod c.m)`; otherwise the recorded
+monic factors cannot multiply back to `ZPoly.modP c.m f` and the block is
 rejected.
 -/
 private def buildPrimeFactorData? (f : ZPoly) (c : SmallPrimeCandidate) :
     Option PrimeFactorData :=
   letI := c.bounds
-  if isGoodPrime f c.p then
+  if isGoodPrime f c.m then
     let factors := berlekampFactorsModP f c
     match buildFactorCerts? factors with
     | none => none
     | some certs =>
       let data : PrimeFactorData :=
-        { p := c.p
+        { p := c.m
           factorDegrees := factors.map fun g => g.degree?.getD 0
           factorPolys := factors
           factorCerts := certs }

--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -144,11 +144,11 @@ structure PrimeChoiceDataScore where
 private def primeChoiceDataScore (f : ZPoly) (c : SmallPrimeCandidate) :
     Option PrimeChoiceDataScore :=
   letI := c.bounds
-  if isGoodPrime f c.p then
-    let fModP := ZPoly.modP c.p f
+  if isGoodPrime f c.m then
+    let fModP := ZPoly.modP c.m f
     let factorsModP := berlekampFactorsModP f c
     some
-      { data := { p := c.p, fModP, factorsModP }
+      { data := { p := c.m, fModP, factorsModP }
         factorCount := factorsModP.size }
   else
     none
@@ -192,7 +192,7 @@ def choosePrimeDataScoreStep
   -- First-suitable selection (matching the verified Isabelle/AFP
   -- `Berlekamp_Zassenhaus` `find_prime`): once a suitable prime has been found,
   -- keep it and stop; crucially, do **not** evaluate `primeChoiceDataScore f c`
-  -- (which factors `f mod c.p`) for any later candidate. The old "fewest modular
+  -- (which factors `f mod c.m`) for any later candidate. The old "fewest modular
   -- factors" rule factored at every good prime, costing ~95 modular
   -- factorizations per call; van Hoeij's recombination is polynomial in the
   -- factor count, so the optimisation bought almost nothing.
@@ -206,7 +206,7 @@ private theorem primeChoiceDataScore_prime
     Nat.Prime score.data.p := by
   unfold primeChoiceDataScore at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
     exact c.prime
@@ -214,12 +214,12 @@ private theorem primeChoiceDataScore_prime
 
 private theorem primeChoiceDataScore_p_le
     (f : ZPoly) (c : SmallPrimeCandidate) (score : PrimeChoiceDataScore)
-    (hc : c.p ≤ 500)
+    (hc : c.m ≤ 500)
     (hscore : primeChoiceDataScore f c = some score) :
     score.data.p ≤ 500 := by
   unfold primeChoiceDataScore at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
     exact hc
@@ -232,7 +232,7 @@ private theorem primeChoiceDataScore_fModP_eq
       @ZPoly.modP score.data.p score.data.bounds f := by
   unfold primeChoiceDataScore at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
     rfl
@@ -289,7 +289,7 @@ private theorem choosePrimeDataScoreStep_prime
 private theorem choosePrimeDataScoreStep_p_le
     (f : ZPoly) (best : Option PrimeChoiceDataScore) (c : SmallPrimeCandidate)
     (score : PrimeChoiceDataScore)
-    (hc : c.p ≤ 500)
+    (hc : c.m ≤ 500)
     (hbest : ∀ old, best = some old → old.data.p ≤ 500)
     (hscore : choosePrimeDataScoreStep f best c = some score) :
     score.data.p ≤ 500 := by
@@ -343,7 +343,7 @@ private theorem choosePrimeDataScore_fold_prime
 private theorem choosePrimeDataScore_fold_p_le
     (f : ZPoly) (candidates : List SmallPrimeCandidate)
     (best : Option PrimeChoiceDataScore) (score : PrimeChoiceDataScore)
-    (hcandidates : ∀ c ∈ candidates, c.p ≤ 500)
+    (hcandidates : ∀ c ∈ candidates, c.m ≤ 500)
     (hbest : ∀ old, best = some old → old.data.p ≤ 500)
     (hscore :
       candidates.foldl (choosePrimeDataScoreStep f) best = some score) :
@@ -384,7 +384,7 @@ private theorem primeChoiceDataScore_isGoodPrime
     @isGoodPrime f score.data.p score.data.bounds = true := by
   unfold primeChoiceDataScore at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
     exact hgood
@@ -606,13 +606,13 @@ private theorem improvePrimeData?_p_le
     (f : ZPoly) (first : PrimeChoiceDataScore)
     (hfirst : first.data.p ≤ 500) :
     ∀ extra candidates,
-      (∀ c ∈ candidates, c.p ≤ 500) →
+      (∀ c ∈ candidates, c.m ≤ 500) →
       (improvePrimeData? f first extra candidates).data.p ≤ 500 := by
   intro extra candidates hall
   induction candidates generalizing extra first with
   | nil => simp [improvePrimeData?, hfirst]
   | cons c candidates ih =>
-      have htail : ∀ d ∈ candidates, d.p ≤ 500 := by
+      have htail : ∀ d ∈ candidates, d.m ≤ 500 := by
         intro d hd
         exact hall d (List.mem_cons_of_mem c hd)
       cases extra with
@@ -680,14 +680,14 @@ private theorem chooseAdaptiveFrom?_property
 private theorem chooseAdaptiveFrom?_p_le
     (f : ZPoly) (extra : Nat) :
     ∀ candidates score,
-      (∀ c ∈ candidates, c.p ≤ 500) →
+      (∀ c ∈ candidates, c.m ≤ 500) →
       chooseAdaptiveFrom? f extra candidates = some score →
       score.data.p ≤ 500 := by
   intro candidates score hall h
   induction candidates generalizing score with
   | nil => simp [chooseAdaptiveFrom?] at h
   | cons c candidates ih =>
-      have htail : ∀ d ∈ candidates, d.p ≤ 500 := by
+      have htail : ∀ d ∈ candidates, d.m ≤ 500 := by
         intro d hd
         exact hall d (List.mem_cons_of_mem c hd)
       simp only [chooseAdaptiveFrom?] at h
@@ -892,10 +892,10 @@ theorem choosePrimeData?_isGoodPrime
 private theorem primeChoiceDataScore_eq_none_iff
     (f : ZPoly) (c : SmallPrimeCandidate) :
     primeChoiceDataScore f c = none ↔
-      @isGoodPrime f c.p c.bounds = false := by
+      @isGoodPrime f c.m c.bounds = false := by
   unfold primeChoiceDataScore
   letI := c.bounds
-  cases isGoodPrime f c.p with
+  cases isGoodPrime f c.m with
   | true => simp
   | false => simp
 
@@ -920,7 +920,7 @@ private theorem choosePrimeDataScore_fold_some_ne_none
 private theorem choosePrimeDataScore_fold_none_forall_isGoodPrime_false
     (f : ZPoly) (candidates : List SmallPrimeCandidate)
     (hfold : candidates.foldl (choosePrimeDataScoreStep f) none = none) :
-    ∀ c ∈ candidates, @isGoodPrime f c.p c.bounds = false := by
+    ∀ c ∈ candidates, @isGoodPrime f c.m c.bounds = false := by
   induction candidates with
   | nil => intro c hc; exact absurd hc List.not_mem_nil
   | cons c cs ih =>
@@ -933,7 +933,7 @@ private theorem choosePrimeDataScore_fold_none_forall_isGoodPrime_false
       cases hscore : primeChoiceDataScore f c with
       | none =>
           rw [hscore] at hfold
-          have hbad : @isGoodPrime f c.p c.bounds = false :=
+          have hbad : @isGoodPrime f c.m c.bounds = false :=
             (primeChoiceDataScore_eq_none_iff f c).mp hscore
           intro c' hc'
           rcases List.mem_cons.mp hc' with rfl | hin
@@ -953,7 +953,7 @@ candidate was tried and rejected.
 theorem mem_hotPathCandidates_isGoodPrime_false_of_choosePrimeData?_none
     {f : ZPoly} (hf : choosePrimeData? f = none)
     {c : SmallPrimeCandidate} (hc : c ∈ hotPathCandidates) :
-    @isGoodPrime f c.p c.bounds = false := by
+    @isGoodPrime f c.m c.bounds = false := by
   unfold choosePrimeData? at hf
   cases hsmall :
       smallPrimeCandidates.foldl (choosePrimeDataScoreStep f) none with
@@ -977,7 +977,7 @@ failure certificate. -/
 theorem choosePrimeData?_ne_none_of_good
     {f : ZPoly} {c : SmallPrimeCandidate}
     (hc : c ∈ hotPathCandidates)
-    (hgood : @isGoodPrime f c.p c.bounds = true) :
+    (hgood : @isGoodPrime f c.m c.bounds = true) :
     choosePrimeData? f ≠ none := by
   intro hnone
   have hbad :=
@@ -987,7 +987,7 @@ theorem choosePrimeData?_ne_none_of_good
 
 private theorem chooseAdaptiveFrom?_ne_none_of_good
     (f : ZPoly) (extra : Nat) {c : SmallPrimeCandidate}
-    (hgood : @isGoodPrime f c.p c.bounds = true) :
+    (hgood : @isGoodPrime f c.m c.bounds = true) :
     ∀ candidates, c ∈ candidates → chooseAdaptiveFrom? f extra candidates ≠ none := by
   intro candidates hc
   induction candidates with
@@ -1015,7 +1015,7 @@ to succeed; its look-ahead changes only which successful record is returned. -/
 theorem choosePrimeDataAdaptive?_ne_none_of_good
     {f : ZPoly} {c : SmallPrimeCandidate} {extra : Nat}
     (hc : c ∈ hotPathCandidates)
-    (hgood : @isGoodPrime f c.p c.bounds = true) :
+    (hgood : @isGoodPrime f c.m c.bounds = true) :
     choosePrimeDataAdaptive? f extra ≠ none := by
   unfold choosePrimeDataAdaptive?
   unfold hotPathCandidates at hc
@@ -1053,11 +1053,11 @@ private theorem primeChoiceDataScore_factorsModPBerlekampForm
     factorsModPBerlekampForm f score.data := by
   unfold primeChoiceDataScore at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
-    have hzero : (ZPoly.modP c.p f).isZero = false :=
-      isGoodPrime_modP_isZero_false f c.p hgood
+    have hzero : (ZPoly.modP c.m f).isZero = false :=
+      isGoodPrime_modP_isZero_false f c.m hgood
     refine ⟨c.prime, hzero, ?_⟩
     show berlekampFactorsModP f c = _
     exact berlekampFactorsModP_eq_of_isZero_false f c hzero
@@ -1125,7 +1125,7 @@ theorem probePrimeData?_prime
 /-- An explicit trial inherits any proved upper bound on its candidate prime. -/
 theorem probePrimeData?_p_le
     (f : ZPoly) (c : SmallPrimeCandidate) (data : PrimeChoiceData)
-    (hc : c.p ≤ 500)
+    (hc : c.m ≤ 500)
     (hdata : probePrimeData? f c = some data) :
     data.p ≤ 500 := by
   unfold probePrimeData? at hdata

--- a/HexBerlekampZassenhaus/Factorization.lean
+++ b/HexBerlekampZassenhaus/Factorization.lean
@@ -135,7 +135,7 @@ theorem bhksRecoveryCoreWithBound_ne_none_of_recovery_on_schedule
 private def bhksRecoveryGuardPrimeData : PrimeChoiceData :=
   letI := bounds_five
   let c : SmallPrimeCandidate :=
-    { p := 5, bounds := bounds_five, prime := prime_five }
+    { m := 5, bounds := bounds_five, prime := prime_five }
   { p := 5
     fModP := ZPoly.modP 5 cldGuardF
     factorsModP := berlekampFactorsModP cldGuardF c }

--- a/HexBerlekampZassenhaus/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhaus/Modular/PrimePlan.lean
@@ -324,8 +324,8 @@ which is all a wider candidate needs to be discarded. -/
 def probeDegreePattern? (f : ZPoly) (c : SmallPrimeCandidate) (target : Nat) :
     Option Berlekamp.DegreePattern :=
   letI := c.bounds
-  if isGoodPrime f c.p then
-    let fModP := ZPoly.modP c.p f
+  if isGoodPrime f c.m then
+    let fModP := ZPoly.modP c.m f
     if hzero : fModP.isZero = false then
       some (Berlekamp.scoutDegreePattern (monicModularImage fModP)
         (monicModularImage_monic c.prime fModP hzero) target)
@@ -352,16 +352,16 @@ def scoutBetterPattern (core : SquareFreeInput) :
   | 0, _, _, best => best
   | _, [], _, best => best
   | fuel + 1, candidate :: candidates, inc, best =>
-      if scoutPays core inc candidate.p (fuel + 1) then
+      if scoutPays core inc candidate.m (fuel + 1) then
         match probeDegreePattern? core.poly candidate inc.degrees.size with
         | none => scoutBetterPattern core (fuel + 1) candidates inc best
         | some pattern =>
             if pattern.complete then
               let candidateScore :=
-                directDegreeScore core candidate.p pattern.separated
+                directDegreeScore core candidate.m pattern.separated
               if scoreBetter inc.score candidateScore then
                 scoutBetterPattern core fuel candidates
-                  ⟨candidate.p, pattern.separated, candidateScore⟩
+                  ⟨candidate.m, pattern.separated, candidateScore⟩
                   (some ⟨candidate, pattern.separated⟩)
               else
                 scoutBetterPattern core fuel candidates inc best
@@ -398,7 +398,7 @@ def firstDirectPlan?
           let first := DirectPrimeProbe.ofData core candidate data
           some (planOfScout core first
             (scoutBetterPattern core scoutFuel candidates
-              ⟨candidate.p, first.factorDegrees, directProbeScore core first⟩
+              ⟨candidate.m, first.factorDegrees, directProbeScore core first⟩
               none))
 
 /-- Plan and cache a good direct-coordinate modular factorization. -/
@@ -564,7 +564,7 @@ private theorem scoutBetterPattern_mem
           exact Or.inl ⟨scouted, by simpa [scoutBetterPattern] using h, rfl⟩
       | succ fuel =>
           simp only [scoutBetterPattern] at h
-          by_cases hpays : scoutPays core inc candidate.p (fuel + 1) = true
+          by_cases hpays : scoutPays core inc candidate.m (fuel + 1) = true
           · rw [if_pos hpays] at h
             cases hpat :
                 probeDegreePattern? core.poly candidate inc.degrees.size with
@@ -580,11 +580,11 @@ private theorem scoutBetterPattern_mem
                 · rw [if_pos hcomplete] at h
                   by_cases hbetter :
                       scoreBetter inc.score
-                        (directDegreeScore core candidate.p pattern.separated) = true
+                        (directDegreeScore core candidate.m pattern.separated) = true
                   · rw [if_pos hbetter] at h
                     rcases ih fuel
-                        ⟨candidate.p, pattern.separated,
-                          directDegreeScore core candidate.p pattern.separated⟩
+                        ⟨candidate.m, pattern.separated,
+                          directDegreeScore core candidate.m pattern.separated⟩
                         (some ⟨candidate, pattern.separated⟩) scouted h with
                       ⟨b, hb, hc⟩ | hm
                     · exact Or.inr (by
@@ -660,14 +660,14 @@ private theorem firstDirectPlan?_probes_mem
           rcases planOfScout_probes_mem core
               (DirectPrimeProbe.ofData core candidate data)
               (scoutBetterPattern core scoutFuel candidates
-                ⟨candidate.p,
+                ⟨candidate.m,
                   (DirectPrimeProbe.ofData core candidate data).factorDegrees,
                   directProbeScore core (DirectPrimeProbe.ofData core candidate data)⟩
                 none) probe hmem with hfirst | ⟨s, hs, hsel⟩
           · rw [hfirst]
             exact List.mem_cons_self
           · rcases scoutBetterPattern_mem core scoutFuel candidates
-                ⟨candidate.p,
+                ⟨candidate.m,
                   (DirectPrimeProbe.ofData core candidate data).factorDegrees,
                   directProbeScore core (DirectPrimeProbe.ofData core candidate data)⟩
                 none s hs with ⟨b, hb, _⟩ | hm
@@ -694,7 +694,7 @@ theorem directPrimePlan?_probes_p_le_500
       (by simpa [directPrimePlan?] using h) probe hmem
   have hhot : probe.candidate ∈ hotPathCandidates := by
     simpa only [hotPathCandidates] using hmem'
-  have hc : probe.candidate.p ≤ 500 := (mem_hotPathCandidates_prime hhot).2.2
+  have hc : probe.candidate.m ≤ 500 := (mem_hotPathCandidates_prime hhot).2.2
   exact probePrimeData?_p_le core.poly probe.candidate probe.data hc
     ((directPrimePlan?_probes_trial core plan h probe hmem).1)
 

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -21,6 +21,7 @@ public import HexBerlekamp.Irreducibility
 public import HexHensel.Multifactor
 public import HexHensel.QuadraticMultifactor
 public import HexLLL
+public import HexModArith.Modulus
 -- Kernel-reducible `Array`/`Vector` equality; see `HexBasic.ArrayDecEq`.
 -- Drop once leanprover/lean4#14270 lands and the toolchain is bumped past it.
 public import HexBasic.ArrayDecEq
@@ -507,21 +508,10 @@ private theorem prime_seventy_one : Nat.Prime 71 := by
     | 71 => exact Or.inr rfl
     | _ + 72 => omega
 
-/--
-A small-prime candidate for the Berlekamp-Zassenhaus prime-selection hot path.
-
-Bundles a candidate prime `p` together with the `ZMod64.Bounds p` instance and
-the propositional primality witness needed to drive the modular Berlekamp
-factorisation. Exposed alongside `hotPathCandidates` so direct prime planning
-can retain the exact candidate and its primality evidence beside the cached
-factorization.
--/
-structure SmallPrimeCandidate where
-  /-- The candidate prime modulus. -/
-  p : Nat
-  [bounds : ZMod64.Bounds p]
-  /-- A proof that `p` is prime. -/
-  prime : Nat.Prime p
+/-- The Berlekamp--Zassenhaus hot path uses the shared bundled prime supplied
+by `hex-mod-arith`; it carries both the runtime modulus and its dependent
+bounds and primality evidence. -/
+abbrev SmallPrimeCandidate := ZMod64.Prime
 
 /-- Build a `SmallPrimeCandidate` from a trial-division primality witness and the
 small-modulus bound `p < 2^31` on `p`. -/
@@ -529,7 +519,7 @@ private def smallPrimeCandidateOfTrial (p : Nat)
     (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p < 2 ^ 31) :
     SmallPrimeCandidate :=
   let prime := Hex.Nat.isPrimeTrial_isPrime hprime
-  { p, bounds := { pPos := prime.pos, pLtR := hbound }, prime }
+  { m := p, bounds := { pPos := prime.pos, pLtR := hbound }, prime }
 
 /-- A scored admissible small-prime candidate for default prime selection. -/
 structure PrimeCandidateScore where
@@ -650,7 +640,7 @@ def hotPathCandidates : List SmallPrimeCandidate :=
 /-- Product of the fixed hot-path candidate primes. -/
 @[expose]
 def hotPathPrimorial : Nat :=
-  (hotPathCandidates.map fun c => c.p).prod
+  (hotPathCandidates.map fun c => c.m).prod
 
 #guard smallPrimeCandidates.length == 19
 #guard extendedSmallPrimeCandidates.length == 75
@@ -659,7 +649,7 @@ def hotPathPrimorial : Nat :=
 set_option maxRecDepth 10000 in
 /-- The fixed hot-path list contains no repeated prime values. -/
 theorem hotPathPrimeValues_nodup :
-    (hotPathCandidates.map fun c => c.p).Nodup := by
+    (hotPathCandidates.map fun c => c.m).Nodup := by
   decide
 
 /--
@@ -670,14 +660,14 @@ over the 94 explicit primes in the list.
 -/
 theorem mem_hotPathCandidates_prime
     {c : SmallPrimeCandidate} (hc : c ∈ hotPathCandidates) :
-    Hex.Nat.Prime c.p ∧ 3 ≤ c.p ∧ c.p ≤ 500 := by
-  have hmem : c.p ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) :=
+    Hex.Nat.Prime c.m ∧ 3 ≤ c.m ∧ c.m ≤ 500 := by
+  have hmem : c.m ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.m) :=
     List.mem_map_of_mem hc
   have hbounds :
-      ∀ q ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p),
+      ∀ q ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.m),
         3 ≤ q ∧ q ≤ 500 := by
     decide
-  exact ⟨c.prime, (hbounds c.p hmem).1, (hbounds c.p hmem).2⟩
+  exact ⟨c.prime, (hbounds c.m hmem).1, (hbounds c.m hmem).2⟩
 
 set_option maxRecDepth 4096 in
 /--
@@ -687,15 +677,15 @@ Coverage of the hot-path prime candidate list: every prime `p` with
 -/
 theorem exists_mem_hotPathCandidates_of_prime
     {p : Nat} (hprime : Hex.Nat.Prime p) (hge : 3 ≤ p) (hle : p ≤ 500) :
-    ∃ c ∈ hotPathCandidates, c.p = p := by
+    ∃ c ∈ hotPathCandidates, c.m = p := by
   have htrial : Hex.Nat.isPrimeTrial p = true :=
     Hex.Nat.isPrimeTrial_of_prime hprime
   have key : ∀ q : Fin 501,
       3 ≤ q.val → Hex.Nat.isPrimeTrial q.val = true →
-        q.val ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) := by
+        q.val ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.m) := by
     decide
   have hmem :
-      p ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) :=
+      p ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.m) :=
     key ⟨p, Nat.lt_succ_of_le hle⟩ hge htrial
   obtain ⟨c, hc, hcp⟩ := List.mem_map.mp hmem
   exact ⟨c, hc, hcp⟩
@@ -967,10 +957,10 @@ theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
         monicModularImage_mul_of_nonzero hp hhead_ne htail_prod_ne]
 
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
-    Array (@FpPoly c.p c.bounds) :=
+    Array (@FpPoly c.m c.bounds) :=
   letI := c.bounds
   letI := ZMod64.primeModulusOfPrime c.prime
-  let fModP := ZPoly.modP c.p f
+  let fModP := ZPoly.modP c.m f
   if hzero : fModP.isZero = false then
     ((Berlekamp.berlekampFactor
       (monicModularImage fModP)
@@ -993,11 +983,11 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
     (f : ZPoly) (c : SmallPrimeCandidate) :
     letI := c.bounds
     letI := ZMod64.primeModulusOfPrime c.prime
-    ∀ (hzero : (ZPoly.modP c.p f).isZero = false),
+    ∀ (hzero : (ZPoly.modP c.m f).isZero = false),
       berlekampFactorsModP f c =
         ((Berlekamp.berlekampFactor
-          (monicModularImage (ZPoly.modP c.p f))
-          (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.map
+          (monicModularImage (ZPoly.modP c.m f))
+          (monicModularImage_monic c.prime (ZPoly.modP c.m f) hzero)).factors.map
             monicModularImage).toArray := by
   letI := c.bounds
   letI := ZMod64.primeModulusOfPrime c.prime
@@ -1042,13 +1032,13 @@ def modularFactorDegreesAt? (f : ZPoly) (p : Nat) : Option (Array Nat) :=
       match found with
       | some degrees => some degrees
       | none =>
-          if c.p == p then
-            letI : ZMod64.Bounds c.p := c.bounds
-            if ZPoly.leadingCoeffModP f c.p != 0 then
-              match completeLinearDegreeSplit? f c.p with
+          if c.m == p then
+            letI : ZMod64.Bounds c.m := c.bounds
+            if ZPoly.leadingCoeffModP f c.m != 0 then
+              match completeLinearDegreeSplit? f c.m with
               | some degrees => some degrees
               | none =>
-                  if isGoodPrime f c.p then
+                  if isGoodPrime f c.m then
                     some ((berlekampFactorsModP f c).map (fun factor =>
                       factor.degree?.getD 0) |>.qsort (· ≤ ·))
                   else
@@ -1068,9 +1058,9 @@ private def prefixTwentyNineGuard : ZPoly :=
 /-- Score one small-prime candidate by its Berlekamp factor count when it is admissible for `f`. -/
 private def scoreCandidate (f : ZPoly) (c : SmallPrimeCandidate) : Option PrimeCandidateScore :=
   letI := c.bounds
-  if isGoodPrime f c.p then
+  if isGoodPrime f c.m then
     let factors := berlekampFactorsModP f c
-    some { p := c.p, factorCount := factors.size }
+    some { p := c.m, factorCount := factors.size }
   else
     none
 
@@ -1101,7 +1091,7 @@ private theorem scoreCandidate_isGoodPrime
       @isGoodPrime f score.p hbounds = true := by
   unfold scoreCandidate at hscore
   letI := c.bounds
-  by_cases hgood : isGoodPrime f c.p
+  by_cases hgood : isGoodPrime f c.m
   · simp [hgood] at hscore
     cases hscore
     exact ⟨c.bounds, hgood⟩

--- a/bench/HexBench/FactorService.lean
+++ b/bench/HexBench/FactorService.lean
@@ -803,13 +803,13 @@ there is no distinct-degree stage to attribute. -/
 private def modularSubPhases (sink : IO.Ref Nat) (core : ZPoly)
     (c : SmallPrimeCandidate) : IO Json :=
   letI := c.bounds
-  letI : ZMod64.PrimeModulus c.p := ZMod64.primeModulusOfPrime c.prime
+  letI : ZMod64.PrimeModulus c.m := ZMod64.primeModulusOfPrime c.prime
   do
   let m0 ← mark
-  let fModP := ZPoly.modP c.p core
+  let fModP := ZPoly.modP c.m core
   observeNat sink fModP.size
   let m1 ← mark
-  let good := isGoodPrime core c.p
+  let good := isGoodPrime core c.m
   observeNat sink (if good then 1 else 0)
   let m2 ← mark
   if hzero : fModP.isZero = false then
@@ -842,7 +842,7 @@ private def modularSubPhases (sink : IO.Ref Nat) (core : ZPoly)
     let factorNanos := m6.nanos - m5.nanos
     return Json.mkObj
       [ ("measurement", Json.str "repeat-at-selected-prime"),
-        ("prime", natJson c.p),
+        ("prime", natJson c.m),
         ("modularDegree", natJson (fModP.degree?.getD 0)),
         ("kernelDimension", natJson kernel.size),
         ("distinctDegree", Json.str "not-applicable"),
@@ -858,7 +858,7 @@ private def modularSubPhases (sink : IO.Ref Nat) (core : ZPoly)
   else
     return Json.mkObj
       [ ("measurement", Json.str "repeat-at-selected-prime"),
-        ("prime", natJson c.p),
+        ("prime", natJson c.m),
         ("modularImage", spanJson m0 m1),
         ("goodPrimeTest", spanJson m1 m2),
         ("zeroModularImage", Json.bool true) ]
@@ -1648,19 +1648,19 @@ private def scoutHorizon : Nat := 6
 private def kernelProfileAt (core : ZPoly) (c : SmallPrimeCandidate) :
     IO (List (String × Json)) :=
   letI := c.bounds
-  letI : ZMod64.PrimeModulus c.p := ZMod64.primeModulusOfPrime c.prime
+  letI : ZMod64.PrimeModulus c.m := ZMod64.primeModulusOfPrime c.prime
   do
-  let fModP := ZPoly.modP c.p core
+  let fModP := ZPoly.modP c.m core
   if hzero : fModP.isZero = false then
     let monic := monicModularImage fModP
     let hmonic := monicModularImage_monic c.prime fModP hzero
     let kernel ← HexBench.BerlekampKernel.kernelPhases monic hmonic
     return [ ("status", Json.str "ok"),
-             ("prime", natJson c.p),
+             ("prime", natJson c.m),
              ("modularDegree", natJson (fModP.degree?.getD 0)),
              ("kernel", kernel) ]
   else
-    return [ ("status", Json.str "zeroModularImage"), ("prime", natJson c.p) ]
+    return [ ("status", Json.str "zeroModularImage"), ("prime", natJson c.m) ]
 
 /-- Stage-by-stage attribution of the Berlekamp fixed-space kernel at the
 production-selected prime, together with the price of a packed contiguous
@@ -1701,15 +1701,15 @@ is what the split is checked against. -/
 private def scoutRow (sink : IO.Ref Nat) (core : SquareFreeInput) (target : Nat)
     (c : SmallPrimeCandidate) : IO (Option Json) :=
   letI := c.bounds
-  letI : ZMod64.PrimeModulus c.p := ZMod64.primeModulusOfPrime c.prime
+  letI : ZMod64.PrimeModulus c.m := ZMod64.primeModulusOfPrime c.prime
   do
   let m0 ← mark
-  let good := isGoodPrime core.poly c.p
+  let good := isGoodPrime core.poly c.m
   observeNat sink (if good then 1 else 0)
   let m1 ← mark
   if !good then
     return none
-  let fModP := ZPoly.modP c.p core.poly
+  let fModP := ZPoly.modP c.m core.poly
   if hzero : fModP.isZero = false then
     let n := fModP.degree?.getD 0
     let monic := monicModularImage fModP
@@ -1736,16 +1736,16 @@ private def scoutRow (sink : IO.Ref Nat) (core : SquareFreeInput) (target : Nat)
     let splitDegrees := (factors.map fun g => g.degree?.getD 0).toArray
     let scoutDegrees := pattern.getD #[]
     return some <| Json.mkObj
-      [ ("prime", natJson c.p),
+      [ ("prime", natJson c.m),
         ("modularDegree", natJson n),
         ("kernelDimension", natJson kernel.size),
         ("scoutTarget", natJson target),
         -- The two shape quantities `Hex.scoutPays` prices a plan at this prime
         -- by: the machine words of its Hensel modulus, and the recombination
         -- candidates a complete head-forced search over its factors visits.
-        ("liftWords", natJson (liftWords core c.p)),
+        ("liftWords", natJson (liftWords core c.m)),
         ("recombUnits",
-          natJson (directSubsetCost splitDegrees.size * liftWords core c.p)),
+          natJson (directSubsetCost splitDegrees.size * liftWords core c.m)),
         ("splitMaxDegree", natJson (splitDegrees.foldl max 0)),
         ("boundedScout", spanJson boundedStart boundedStop),
         ("boundedSeparated", natArrayJson bounded.separated),
@@ -1767,7 +1767,7 @@ private def scoutRow (sink : IO.Ref Nat) (core : SquareFreeInput) (target : Nat)
         ("fullSplit", spanJson splitStart splitStop) ]
   else
     return some <| Json.mkObj
-      [ ("prime", natJson c.p),
+      [ ("prime", natJson c.m),
         ("goodPrimeTest", spanJson m0 m1),
         ("zeroModularImage", Json.bool true) ]
 

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -730,5 +730,41 @@
     "baseline_blob": "1e8bbe3030db68a2b6753de8bf5ff2326d02813e",
     "current_blob": "072030c70a339c8965bff552de0e7673f3e3da76",
     "reason": "Registers the HexAggregateCheck released-aggregate mirror library only; the factorization service target and its executable dependency graph are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/Certificate.lean",
+    "baseline_blob": "3a97b9385574e3ddf48da545df6a157a2f96e8b4",
+    "current_blob": "5e102c460b63bbf2b79470b81189f25cbb92e021",
+    "reason": "Updates projections from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; certificate checks, arithmetic, and control flow are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/ChoosePrimeData.lean",
+    "baseline_blob": "9194dae7dc8cf4d433a7adbd8ce01a7133b3900c",
+    "current_blob": "4a0c3dba62c7c3c607545daff10ba4bf70351681",
+    "reason": "Updates projections from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; prime selection, arithmetic, and control flow are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/Factorization.lean",
+    "baseline_blob": "2d08c80028bc54024965a5c0f114bba51d18523e",
+    "current_blob": "8d796854822562cd7883e2308d444f9e07702b36",
+    "reason": "Updates one projection from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; factorization arithmetic and control flow are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/Modular/PrimePlan.lean",
+    "baseline_blob": "23dc012088d8513f1d8c1748c5367c9a33f4120c",
+    "current_blob": "bc4d2026af3dda89e2928c572570e4fb3866f8e8",
+    "reason": "Updates projections from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; modular planning arithmetic and control flow are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/PrimeSelection.lean",
+    "baseline_blob": "6d9fc0f2d2b6612450968694557bca925ce7522b",
+    "current_blob": "c5ab3913c20b4497962ed20851da5c54af208f04",
+    "reason": "Replaces a duplicate three-field prime record with an abbreviation of the representation-identical bundled ZMod64.Prime record and renames its modulus projection; the candidate list, proofs, arithmetic, and control flow are unchanged."
+  },
+  {
+    "path": "bench/HexBench/FactorService.lean",
+    "baseline_blob": "1063ee045056aabe060a319d7dbe48460e6fdd75",
+    "current_blob": "635c202971d2276a498505da9842deac1c833c9f",
+    "reason": "Updates diagnostic-service projections from the duplicate small-prime record to the representation-identical bundled ZMod64.Prime record; every measured operation and branch is unchanged."
   }
 ]


### PR DESCRIPTION
## Summary
- replace the duplicate `SmallPrimeCandidate` structure with `ZMod64.Prime`
- update prime selection and planning to use the shared modulus field
- keep all existing prime-selection behavior and proofs unchanged

## Validation
- `lake build HexBerlekampZassenhaus`
- `python3 scripts/check_dag.py`
- `git diff --check`

## Dependency
This branch contains the commits from #9443; the code change itself is independent, and this PR targets `main` so that dependency disappears from the diff when #9443 merges.