### PR TITLE
chore(factor): attest eligible Phase 2 libraries

### DIFF
--- a/HexModular.lean
+++ b/HexModular.lean
@@ -8,7 +8,6 @@ module
 
 public import HexModular.Crt
 public import HexModular.Euclid
-public import HexModular.KernelTests
 public import HexModular.Loop
 public import HexModular.LoopTests
 public import HexModular.Recon

--- a/HexModular/Crt.lean
+++ b/HexModular/Crt.lean
@@ -78,12 +78,10 @@ def pushImpl (c : Crt) (r : Int) (m : Nat) : Option Crt :=
     none
 
 /-- The compiled CRT step agrees with its kernel-reducible reference. -/
-theorem push_eq_impl : @push = @pushImpl := by
+@[csimp] theorem push_eq_impl : @push = @pushImpl := by
   funext c r m
   simp only [push, pushImpl, HexArith.Int.extGcd]
   rfl
-
-@[csimp] theorem push_csimp : @push = @pushImpl := push_eq_impl
 
 /-- A successful scalar push multiplies the accumulated modulus by the new
 one. -/
@@ -200,12 +198,10 @@ def pushImpl (c : CrtVec k) (r : Vector Int k) (m : Nat) : Option (CrtVec k) :=
     none
 
 /-- The compiled vector CRT step agrees with its kernel-reducible reference. -/
-theorem push_eq_impl : @push = @pushImpl := by
+@[csimp] theorem push_eq_impl : @push = @pushImpl := by
   funext k c r m
   simp only [push, pushImpl, HexArith.Int.extGcd]
   rfl
-
-@[csimp] theorem push_csimp : @push = @pushImpl := push_eq_impl
 
 /-- A successful vector push multiplies the accumulated modulus by the new
 one. -/

--- a/HexMvFactor.lean
+++ b/HexMvFactor.lean
@@ -14,14 +14,6 @@ public import HexMvFactor.Point
 public import HexMvFactor.Input
 public import HexMvFactor.Eez
 public import HexMvFactor.Factor
-public import HexMvFactor.KernelTests
-public import HexMvFactor.KroneckerTests
-public import HexMvFactor.LeadingTests
-public import HexMvFactor.PointTests
-public import HexMvFactor.InputTests
-public import HexMvFactor.EezTests
-public import HexMvFactor.FactorTests
-public import HexMvFactor.CompleteTests
 
 public section
 

--- a/HexMvGcd.lean
+++ b/HexMvGcd.lean
@@ -12,7 +12,6 @@ public import HexMvGcd.View
 public import HexMvGcd.Normalize
 public import HexMvGcd.Instances
 public import HexMvGcd.Gauss
-public import HexMvGcd.KernelTests
 public import HexMvGcd.Cert
 public import HexMvGcd.Content
 public import HexMvGcd.Prs
@@ -21,9 +20,6 @@ public import HexMvGcd.Heu
 public import HexMvGcd.Brown
 public import HexMvGcd.Gcd
 public import HexMvGcd.Squarefree
-public import HexMvGcd.SquarefreeTests
-public import HexMvGcd.Kernel
-public import HexMvGcd.Eval
 
 public section
 

--- a/HexMvHensel.lean
+++ b/HexMvHensel.lean
@@ -15,14 +15,6 @@ public import HexMvHensel.Seed
 public import HexMvHensel.Cert
 public import HexMvHensel.Lift
 public import HexMvHensel.Complete
-public import HexMvHensel.KernelTests
-public import HexMvHensel.ShiftTests
-public import HexMvHensel.UniTests
-public import HexMvHensel.DiophantineTests
-public import HexMvHensel.SeedTests
-public import HexMvHensel.CertTests
-public import HexMvHensel.LiftTests
-public import HexMvHensel.CompleteTests
 
 public section
 

--- a/HexPolyZGcd.lean
+++ b/HexPolyZGcd.lean
@@ -15,7 +15,6 @@ public import HexPolyZGcd.Prs
 public import HexPolyZGcd.Gcd
 public import HexPolyZGcd.Maximal
 public import HexPolyZGcd.SquareFree
-public import HexPolyZGcd.Kernel
 
 public section
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -628,6 +628,33 @@ lean_lib HexReleaseTests where
     `HexRootsMathlib.Examples,
     `HexMvPoly.KernelTests]
 
+-- Verification-only modules for the incubating multivariate factorization
+-- stack. Keep this separate from the released-test target, whose module list
+-- must exactly mirror the repositories already present in the release manifest.
+lean_lib HexMvFactorizationTests where
+  globs := #[`HexModular.KernelTests,
+    `HexPolyZGcd.Kernel,
+    `HexMvGcd.KernelTests,
+    `HexMvGcd.Kernel,
+    `HexMvGcd.Eval,
+    `HexMvGcd.SquarefreeTests,
+    `HexMvHensel.KernelTests,
+    `HexMvHensel.ShiftTests,
+    `HexMvHensel.UniTests,
+    `HexMvHensel.DiophantineTests,
+    `HexMvHensel.SeedTests,
+    `HexMvHensel.CertTests,
+    `HexMvHensel.LiftTests,
+    `HexMvHensel.CompleteTests,
+    `HexMvFactor.KernelTests,
+    `HexMvFactor.KroneckerTests,
+    `HexMvFactor.LeadingTests,
+    `HexMvFactor.PointTests,
+    `HexMvFactor.InputTests,
+    `HexMvFactor.EezTests,
+    `HexMvFactor.FactorTests,
+    `HexMvFactor.CompleteTests]
+
 -- Complete development imports for the two factorization packages. Their
 -- ordinary umbrellas deliberately expose only the supported release API.
 lean_lib HexFactorizationModules where

--- a/libraries.yml
+++ b/libraries.yml
@@ -130,7 +130,7 @@ libraries:
   HexMvGcd:
     deps: [HexBasic, HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith, HexModular, HexPolyZGcd]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexSparsePoly:
     deps: [HexPoly, HexBasic]
@@ -273,7 +273,7 @@ libraries:
   HexPolyZGcd:
     deps: [HexPolyZ, HexPolyFp, HexPoly, HexModular, HexModArith, HexArith, HexResultant]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
 
   # ---------- Depth 2 ----------
@@ -618,7 +618,7 @@ libraries:
   HexMvHensel:
     deps: [HexBasic, HexMvPoly, HexMvGcd, HexPoly, HexPolyZ, HexPolyFp, HexModArith, HexModular, HexArith]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexMvFactor:
     deps: [HexBasic, HexMvPoly, HexMvGcd, HexMvHensel, HexPoly, HexPolyZ, HexPolyZGcd, HexBerlekampZassenhaus, HexPolyFp, HexModArith, HexModular, HexArith]

--- a/libraries.yml
+++ b/libraries.yml
@@ -219,7 +219,7 @@ libraries:
   HexModular:
     deps: [HexArith]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexGramSchmidt:
     deps: [HexRowReduce, HexDeterminant, HexBareiss]
@@ -623,7 +623,7 @@ libraries:
   HexMvFactor:
     deps: [HexBasic, HexMvPoly, HexMvGcd, HexMvHensel, HexPoly, HexPolyZ, HexPolyZGcd, HexBerlekampZassenhaus, HexPolyFp, HexModArith, HexModular, HexArith]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexInterval:
     deps: []

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -844,5 +844,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "5d2ddd13644831ed8daf314cda768232ed045a0c",
     "reason": "Registers the HexSparsePolyMathlib library and the sparse-poly conformance globs on top of the toolchain-bump measurement commit; no factorization module, executable, or build-flag changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "5d2ddd13644831ed8daf314cda768232ed045a0c",
+    "current_blob": "1f1dfc2c1ac92caf6b0d12142399a3756a1ec336",
+    "reason": "Registers only the build-only HexMvFactorizationTests verification umbrella; it adds no imports to hexbz_factor_service or any runtime library target and changes no executable definition or build flag."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -847,7 +847,7 @@
   },
   {
     "path": "lakefile.lean",
-    "baseline_blob": "5d2ddd13644831ed8daf314cda768232ed045a0c",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "1f1dfc2c1ac92caf6b0d12142399a3756a1ec336",
     "reason": "Registers only the build-only HexMvFactorizationTests verification umbrella; it adds no imports to hexbz_factor_service or any runtime library target and changes no executable definition or build flag."
   }

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -60,6 +60,7 @@ UMBRELLA_BUILD_TARGETS = {
     "HexRCFProofProbeScientific",
     "HexConformance",
     "HexFactorizationModules",
+    "HexMvFactorizationTests",
     "HexReleaseTests",
     "HexRCFTests",
     "HexSparsePolyTests",

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -33,6 +33,7 @@ BUILD_ONLY_LIBS = {
     "HexRCFProofProbeScientific",
     "HexConformance",
     "HexFactorizationModules",
+    "HexMvFactorizationTests",
     "HexReleaseTests",
     "HexRCFTests",
     "HexSparsePolyTests",

--- a/status/hex-modular.scaffolding-reviewed
+++ b/status/hex-modular.scaffolding-reviewed
@@ -1,0 +1,17 @@
+Independently reviewed against HexModular/SPEC/hex-modular.md.
+
+The executable audit covered symmetric representatives, scalar and vector
+Garner updates, truncated Euclid, scalar and vector rational reconstruction,
+and the fuelled modular loop.  The algorithms use the required outer
+reduction, share the vector extended-gcd work, validate reconstruction
+candidates before returning them, and contain no data-level placeholder or
+wrong-shape implementation.
+
+Issue #9445 records the missing loop-state provenance theorem needed by
+downstream formal clients.  It is a theorem/API follow-up rather than a
+data-level scaffolding defect.  Verification canaries are kept outside the
+public umbrella through the explicit development-test target, and the
+adjacent csimp aliases found by the review have been removed.
+
+The remaining `sorry` declarations are theorem-level proof obligations for
+Phase 5.

--- a/status/hex-mv-factor.scaffolding-reviewed
+++ b/status/hex-mv-factor.scaffolding-reviewed
@@ -1,0 +1,14 @@
+Independently reviewed against HexMvFactor/SPEC/hex-mv-factor.md.
+
+The review covered the executable decomposition, point search, EEZ input,
+recombination, Kronecker fallback, irreducibility, and completion surfaces.
+The identified construction-order and search-space gaps were resolved by
+checking the Kronecker budget before dense image construction, generating
+only the requested recombination levels, retaining lower-arity progress, and
+precomputing mixed-radix data.  The public irreducibility statement includes
+the primitive and nonconstant hypotheses required by the implementation.
+
+No Phase 2 blocking data placeholder, wrong-shape implementation, fake
+extern, native-type detour, or unreviewed verification import remains in the
+public umbrella.  The remaining `sorry` declarations are theorem-level proof
+obligations for Phase 5.

--- a/status/hex-mv-gcd.scaffolding-reviewed
+++ b/status/hex-mv-gcd.scaffolding-reviewed
@@ -1,0 +1,19 @@
+Independently reviewed against HexMvGcd/SPEC/hex-mv-gcd.md.
+
+The executable audit covered multivariate division, normalization, content,
+checked certificates, the extended-subresultant route, heuristic and Brown
+producers, structural reduction and restoration, coefficient instances,
+public gcd/cofactor/lcm operations, and squarefree decomposition.  Fast
+proposals cannot bypass replay, the generic producer's deliberate decline
+falls through to the complete PRS route, and no data-level placeholder,
+wrong-shape algorithm, fake extern, or native-type detour remains.
+
+Issues #9455--#9461 record the review findings and their fixes: linear content
+accumulation, independent random coordinates, structural fallback,
+integer-backed rational dispatch, main-degree image filtering, removal of
+executable proof constraints and adjacent aliases, and finite-field
+squarefree support.  Verification modules live in the explicit
+development-test target rather than the public umbrella.
+
+The remaining `sorry` declarations are theorem-level proof obligations for
+Phase 5.

--- a/status/hex-mv-hensel.scaffolding-reviewed
+++ b/status/hex-mv-hensel.scaffolding-reviewed
@@ -1,0 +1,19 @@
+Independently reviewed against HexMvHensel/SPEC/hex-mv-hensel.md.
+
+The executable audit covered coordinate shifts, modular truncation,
+univariate witness lifting, the recursive diophantine solver, seed and
+leading-coefficient installation, certificate validation, staged lifting,
+reconstruction retries, and coefficient-bound helpers.  Partial operations
+reject malformed tuples, every produced factorization passes the independent
+checker, and no data-level placeholder, wrong-shape algorithm, fake extern,
+or native-type detour remains.
+
+Issues #9450--#9454 record the review findings: true Taylor/Horner operations,
+active-prefix solves, linear complement construction, shared mixed-radix
+weights, and the stage-invariant proof API.  The first four fixes are present;
+#9454 has an implementation PR and is a theorem/API follow-up rather than a
+data-level scaffolding defect.  Verification modules live in the explicit
+development-test target rather than the public umbrella.
+
+The remaining `sorry` declarations are theorem-level proof obligations for
+Phase 5.

--- a/status/hex-poly-z-gcd.scaffolding-reviewed
+++ b/status/hex-poly-z-gcd.scaffolding-reviewed
@@ -1,0 +1,17 @@
+Independently reviewed against HexPolyZGcd/SPEC/hex-poly-z-gcd.md.
+
+The executable audit covered exact division, checked gcd certificates,
+modular coprimality witnesses, heuristic reconstruction, Brown CRT
+reconstruction, the extended-subresultant fallback, structural reduction,
+public gcd/cofactor/lcm operations, and squarefree decomposition.  Every
+producer is checked before acceptance, the deterministic fallback constructs
+real certificate data, and no data-level placeholder, wrong-shape algorithm,
+fake extern, or native-type detour remains.
+
+Issues #9446--#9449 record the review findings: bounded Brown reconstruction,
+exact-division prefilters, structural certificates, and dummy totalizations.
+Their fixes are present in the reviewed tree.  Verification modules live in
+the explicit development-test target rather than the public umbrella.
+
+The remaining `sorry` declarations are theorem-level proof obligations for
+Phase 5.


### PR DESCRIPTION
Completes the skeptical Phase-2 scaffolding review for the multivariate factorization stack now that every computational prerequisite has reached Phase 1.

Reviewed libraries:
- `HexModular`
- `HexPolyZGcd`
- `HexMvGcd`
- `HexMvHensel`
- `HexMvFactor`

The review findings are tracked in #9445--#9461 and the corresponding fixes are either merged or, for the Hensel stage-invariant theorem API (#9454), represented by an implementation PR. This PR records the five machine-checkable review tokens, advances each library to Phase 2, removes verification modules from public umbrellas, and registers the dedicated build-only test target.

Validation:
- `lake build HexModular HexPolyZGcd HexMvGcd HexMvHensel HexMvFactor HexMvFactorizationTests`
- `python3 scripts/check_dag.py`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `python3 scripts/check_copyright_headers.py`
- `git diff --check`