### PR TITLE
fix(polyzgcd): repair Brown CRT reconstruction budget

### DIFF
--- a/HexPolyZGcd/Brown.lean
+++ b/HexPolyZGcd/Brown.lean
@@ -7,8 +7,10 @@ Authors: Kim Morrison
 module
 
 public meta import HexModular.Crt
+public meta import HexPolyZ.Mignotte
 public meta import HexPolyZGcd.Fast
 public import HexModular.Crt
+public import HexPolyZ.Mignotte
 public import HexPolyZGcd.Fast
 
 public section
@@ -16,11 +18,12 @@ public section
 /-!
 Brown's multi-prime gcd producer for `Int[x]`.
 
-The state records one scalar CRT accumulator per coefficient because the image
-degree is discovered at runtime.  Bad primes never enter the state.  Larger
-image degrees are discarded as unlucky, while a smaller degree restarts the
-whole accumulation.  Each reconstruction is primitive-normalized, has the
-integer content restored, and is offered to `checkedCandidate?`.
+The image degree is discovered at runtime, then retained as the dependent
+length of one `CrtVec`.  Thus every offered modulus computes one inverse shared
+by all coefficients.  Bad primes never enter the state.  Larger image degrees
+are discarded as unlucky, while a smaller degree restarts the whole
+accumulation.  Each reconstruction is primitive-normalized, has the integer
+content restored, and is offered to `checkedCandidate?`.
 -/
 
 namespace Hex
@@ -32,11 +35,11 @@ structure BrownImage where
   degree : Nat
   coeffs : Array Int
 
-/-- A running coefficientwise CRT accumulation at the smallest image degree
-seen so far. -/
+/-- A running shared-vector CRT accumulation at the smallest image degree seen
+so far.  The degree discovered at runtime indexes the coefficient vector. -/
 structure BrownState where
   degree : Nat
-  coeffs : Array Modular.Crt
+  crt : Modular.CrtVec (degree + 1)
 
 /-- Outcomes needed both by the loop and by route-level tests. -/
 inductive BrownOffer where
@@ -81,28 +84,32 @@ def brownImage? (f h : ZPoly) (p : ZMod64.Prime) : Option BrownImage :=
             { degree := scaled.size - 1
               coeffs := scaled.toArray.map fun c => Int.ofNat c.toNat }
 
-/-- Push corresponding scalar CRT entries, failing atomically on a length
-mismatch or on any non-coprime modulus. -/
-private def pushCoeffs : List Modular.Crt → List Int → Nat →
-    Option (List Modular.Crt)
-  | [], [], _ => some []
-  | c :: cs, r :: rs, p => do
-      let next ← c.push r p
-      let rest ← pushCoeffs cs rs p
-      pure (next :: rest)
-  | _, _, _ => none
+/-- View an image's dynamically sized coefficient array at the length recorded
+by its degree.  The check keeps malformed externally constructed images from
+entering the dependent CRT state. -/
+private def BrownImage.vector? (image : BrownImage) :
+    Option (Vector Int (image.degree + 1)) :=
+  if h : image.coeffs.size = image.degree + 1 then
+    some ⟨image.coeffs, h⟩
+  else
+    none
 
 /-- Start a CRT state from one accepted image. -/
 private def BrownState.start (image : BrownImage) (p : Nat) : Option BrownState := do
-  let coeffs ← image.coeffs.toList.mapM fun r => Modular.Crt.init.push r p
-  pure { degree := image.degree, coeffs := coeffs.toArray }
+  let residues ← image.vector?
+  let crt ← (Modular.CrtVec.init (image.degree + 1)).push residues p
+  pure { degree := image.degree, crt }
 
 /-- Fold an equal-degree image into an existing state. -/
 private def BrownState.push (state : BrownState) (image : BrownImage)
     (p : Nat) : Option BrownState := do
-  if image.degree != state.degree then none else pure ()
-  let coeffs ← pushCoeffs state.coeffs.toList image.coeffs.toList p
-  pure { degree := state.degree, coeffs := coeffs.toArray }
+  if hdegree : image.degree = state.degree then
+    let residues ← image.vector?
+    let residues : Vector Int (state.degree + 1) := hdegree ▸ residues
+    let crt ← state.crt.push residues p
+    pure { degree := state.degree, crt }
+  else
+    none
 
 /-- Offer one prime to a possibly empty Brown state, applying the exact
 bad/unlucky/restart rules before any CRT mutation. -/
@@ -130,10 +137,42 @@ def brownOffer (f h : ZPoly) (state : Option BrownState)
 
 /-- Reconstruct and normalize the current integer gcd candidate. -/
 def BrownState.candidate (state : BrownState) (f h : ZPoly) : ZPoly :=
-  let raw : ZPoly := DensePoly.ofCoeffs (state.coeffs.map (fun c => c.value))
+  let raw : ZPoly := DensePoly.ofCoeffs state.crt.value.toArray
   let primitive := normalizePrimitiveSign (primitivePart raw)
   let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
   normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- Conservative coefficient bound for Brown's gamma-scaled reconstruction.
+The true primitive gcd degree is at most the smaller input degree.  Its
+coefficients are bounded by either input's Mignotte bound, and scaling the
+monic image by `gamma` costs at most one further factor of `gamma`. -/
+def brownCoeffBound (f h : ZPoly) : Nat :=
+  let f0 := primitivePart f
+  let h0 := primitivePart h
+  let degreeBound := min (f0.degree?.getD 0) (h0.degree?.getD 0)
+  let center := degreeBound / 2
+  let factorBound := min
+    (mignotteCoeffBound f0 degreeBound center)
+    (mignotteCoeffBound h0 degreeBound center)
+  let gamma := Int.gcd f0.leadingCoeff h0.leadingCoeff
+  gamma * factorBound
+
+/-- Number of moduli contributing at least 30 bits that suffice to make the
+CRT product strictly larger than twice the reconstruction bound. -/
+def brownModuliNeeded (f h : ZPoly) : Nat :=
+  let bits := (2 * brownCoeffBound f h).log2 + 1
+  (bits + 29) / 30
+
+/-- Finite Brown prime budget derived from the reconstruction bound.  Doubling
+the required good-modulus count and adding a small floor leaves room for bad
+and unlucky images; exhaustion remains a benign fall-through to PRS. -/
+def brownPrimeBudget (f h : ZPoly) : Nat :=
+  2 * brownModuliNeeded f h + 8
+
+/-- Word-sized primes whose moduli each contribute more than 30 bits. -/
+private def brownSupply (f h : ZPoly) : Array ZMod64.Prime :=
+  (ZMod64.primesBelow (2 ^ 31 - 1) (brownPrimeBudget f h)).filter
+    (fun p => 2 ^ 30 < p.m)
 
 /-- Fuel-bounded Brown loop.  Every successfully accumulated or restarted
 state is offered immediately to the exact certificate checker. -/
@@ -154,10 +193,11 @@ private def brownLoop (f h : ZPoly) (supply : Array ZMod64.Prime)
 termination_by fuel
 decreasing_by all_goals omega
 
-/-- Brown's modular gcd route over the first 55 primes.  Failure is benign:
-the dispatcher continues to its deterministic checked fallback. -/
+/-- Brown's modular gcd route with a finite modulus budget sized from the
+gamma-scaled Landau--Mignotte reconstruction bound.  Failure is benign: the
+dispatcher continues to its deterministic checked fallback. -/
 def brownCert? (f h : ZPoly) : Option GcdCert :=
-  let supply := (ZMod64.primesBelow 257 55).toList.reverse.toArray
+  let supply := brownSupply f h
   brownLoop f h supply 0 supply.size none
 
 /-! Route-level executable pins for the three easy-to-miss Brown rules. -/
@@ -199,6 +239,37 @@ private def primeAt? (p : Nat) : Option ZMod64.Prime :=
       match brownImage? f h p with
       | some image => image.coeffs == #[1, 2]
       | none => false
+  | none => false
+
+-- Equal-degree images share one vector CRT state and therefore one common
+-- product modulus, independent of the number of coefficients.
+#guard
+  let common : ZPoly := DensePoly.ofList [1, 2, 3, 4]
+  let f := common * DensePoly.ofList [1, 1]
+  let h := common * DensePoly.ofList [2, 1]
+  match primeAt? 5, primeAt? 7 with
+  | some p5, some p7 =>
+      match brownOffer f h none p5 with
+      | .accumulated state =>
+          match brownOffer f h (some state) p7 with
+          | .accumulated next =>
+              next.crt.modulus == 35 &&
+                next.crt.value.toArray == common.toArray
+          | _ => false
+      | _ => false
+  | _, _ => false
+
+-- This coefficient is larger than half the entire former 55-small-prime
+-- modulus.  The bound-sized route must continue beyond that old product and
+-- still return a checker-accepted certificate.
+#guard
+  let oldModulus := (ZMod64.primesBelow 257 55).foldl
+    (fun modulus p => modulus * p.m) 1
+  let common : ZPoly := DensePoly.ofList [Int.ofNat oldModulus + 1, 1]
+  let f := common * DensePoly.ofList [1, 1]
+  let h := common * DensePoly.ofList [2, 1]
+  match brownCert? f h with
+  | some cert => cert.gcd == common && checkGcd f h cert
   | none => false
 
 end ZPoly


### PR DESCRIPTION
Closes #9446.

## Summary

- replace the per-coefficient scalar CRT array with one dependently sized `Hex.Modular.CrtVec`, so each offered modulus computes and shares one inverse across every coefficient
- derive a conservative gamma-scaled reconstruction bound from `mignotteCoeffBound`, then size a finite supply of >30-bit moduli from its bit length with room for bad and unlucky images
- preserve bad-prime rejection, unlucky discard, smaller-degree restart, symmetric reconstruction, primitive/content normalization, and checker-gated acceptance
- add route-level guards for a shared vector modulus and successful checked reconstruction beyond the former 55-small-prime product

## Validation

- `lake build HexPolyZGcd.Brown`
- `lake build HexPolyZGcd`
- `lake build` (9,853 jobs)
- `lake build HexConformance` (9,645 jobs)
- `python3 scripts/check_dag.py`
- `python3 -m unittest scripts/test_check_dag.py`
- `git diff --check`
- added-token scan: no `sorry`, `axiom`, or `native_decide`