### PR TITLE
fix(mv-gcd): classify Brown images by main degree

### DIFF
--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -357,6 +357,17 @@ def brownMainIndex {n : Nat} {R : Type u}
           if degree < max (degreeOf j f) (degreeOf j h) then some i
           else best) none
 
+/-- Degree of a modular gcd image in Brown's selected main variable.  When
+both inputs are constant there is no selected variable and the degree is
+zero. -/
+def brownImageDegree {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (main : Option (Fin n)) (image : MvPoly n R cmp) : Nat :=
+  match main with
+  | none => 0
+  | some i => degreeOf i image
+
 /-- Involutive variable permutation which moves `main` to coordinate zero. -/
 def brownSwapToZero {n : Nat} (main : Fin n) : Fin n → Fin n :=
   let zero : Fin n := ⟨0, Nat.zero_lt_of_lt main.isLt⟩
@@ -397,9 +408,13 @@ def brownFieldCert? {n : Nat} {R : Type u}
 
 /-- A nondependent modular image, ready for prime classification and CRT. -/
 structure BrownModImage (n : Nat) where
+  /-- Prime modulus used for this image. -/
   modulus : Nat
-  degree : Nat
+  /-- Gcd degree in the main variable selected before modular reduction. -/
+  mainDegree : Nat
+  /-- Canonically ordered support used to align CRT coordinates. -/
   support : List (Mono n)
+  /-- Coefficients in the same order as `support`. -/
   residues : List Int
 deriving BEq, Repr
 
@@ -410,6 +425,7 @@ def intBrownImage? {n : Nat}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
     (pointFuel : Nat) (f h : MvPoly n Int cmp)
     (prime : ZMod64.Prime) : Option (BrownModImage n) :=
+  let main := brownMainIndex f h
   letI : ZMod64.Bounds prime.m := prime.bounds
   letI : ZMod64.PrimeModulus prime.m :=
     ZMod64.primeModulusOfPrime prime.prime
@@ -439,7 +455,7 @@ def intBrownImage? {n : Nat}
             -- but would destroy the cross-prime normalization needed by CRT.
             some
               { modulus := prime.m
-                degree := corrected.totalDegree
+                mainDegree := brownImageDegree main corrected
                 support := corrected.monomials
                 residues := corrected.termsList.map
                   (fun term => Int.ofNat term.2.toNat) }
@@ -502,7 +518,7 @@ def intBrownLoop {n : Nat}
       | none => intBrownLoop pointFuel f h primes fuel state
       | some image =>
           let oldPrime := state.map (fun s => s.prime) |>.getD {}
-          let offered := oldPrime.offer true true image.degree image.support
+          let offered := oldPrime.offer true true image.mainDegree image.support
           match offered.1 with
           | .bad | .unlucky =>
               intBrownLoop pointFuel f h primes fuel state

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -146,6 +146,26 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   same.1 == .stable && same.2.stableRounds == 1 &&
     changed.1 == .restart && changed.2.stableRounds == 0
 #guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let integral := x + C 2 * y ^ 3 + y ^ 2
+  match brownPrimeAt? 2, brownPrimeAt? 3 with
+  | some p2, some p3 =>
+      let low := mapCoeffs (@ZMod64.intCast p2.m p2.bounds) integral
+      let high := mapCoeffs (@ZMod64.intCast p3.m p3.bounds) integral
+      let main := brownMainIndex integral integral
+      let lowDegree := brownImageDegree main low
+      let highDegree := brownImageDegree main high
+      let first := ({} : BrownPrimeState 2).offer
+        true true highDegree high.monomials
+      let second := first.2.offer true true lowDegree low.monomials
+      let third := second.2.offer true true highDegree high.monomials
+      high.totalDegree == 3 && low.totalDegree == 2 &&
+        highDegree == 1 && lowDegree == 1 &&
+        first.1 == .accumulate && second.1 == .restart &&
+        third.1 == .restart && third.2.bestDegree? == some 1
+  | _, _ => false
+#guard
   match brownCorrectImage? (2 : Rat) (DensePoly.ofList [1, 1]) with
   | some image => image == DensePoly.ofList [2, 2]
   | none => false
@@ -222,9 +242,9 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
       match intBrownImage? 4 f h p2, intBrownImage? 4 f h p3 with
       | some image2, some image3 =>
           let first := ({} : BrownPrimeState 2).offer
-            true true image2.degree image2.support
+            true true image2.mainDegree image2.support
           let second := first.2.offer
-            true true image3.degree image3.support
+            true true image3.mainDegree image3.support
           first.1 == .accumulate && second.1 == .restart
       | _, _ => false
   | _, _ => false


### PR DESCRIPTION
Closes #9459.

Integer Brown images now record the gcd degree in the main variable selected before modular reduction, rather than total degree, and the CRT prime classifier consumes that explicitly named `mainDegree` field.

The regression reduces `x + 2*y^3 + y^2` modulo 3 and modulo 2: total degree falls from 3 to 2 when the unrelated cubic coefficient vanishes, while the selected `x`-degree stays 1. It verifies the support epochs restart as needed without lowering/poisoning the running Brown degree minimum or later misclassifying the restored support as unlucky.

Validation:
- full HexConformance/transitive suite: 9,718 jobs
- post-rebase HexMvGcd + HexMvHensel + HexMvFactor: 535 jobs
- DAG, factor-sweep freshness, and diff checks
- no new `sorry`, `axiom`, or `native_decide`
