### PR TITLE
perf(mv-gcd): linearize content certificates

### DIFF
--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -46,7 +46,8 @@ def primPart (p : MvPoly n R cmp) : MvPoly n R cmp :=
   if c = 0 then 0 else mapCoeffs (fun a => GcdOps.exactDiv a c) p
 
 /-- Fold a concrete lower-arity gcd-certificate producer over coefficients.
-The returned certificate stores every step that the checker replays. -/
+The returned certificate stores every step that the checker replays. Steps are
+consed into a reversed accumulator and reversed once after the fold. -/
 def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
@@ -54,9 +55,9 @@ def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
   let pair := coeffs.foldl
     (fun state q =>
       let step := produce state.1 q
-      (step.gcd, state.2 ++ [step]))
+      (step.gcd, step :: state.2))
     (0, [])
-  .ofSteps pair.1 pair.2
+  .ofSteps pair.1 pair.2.reverse
 
 /-- A producer-built fold has exactly one step per coefficient. -/
 theorem contentCertWith_length {R : Type u}

--- a/HexMvGcd/Kernel.lean
+++ b/HexMvGcd/Kernel.lean
@@ -59,6 +59,16 @@ private def contentCert : ContentCert 0 Int Mono.lex :=
 example : checkContent ([C 2, C 4] : List P0) contentCert = true := by
   decide +kernel
 
+private def orderedProducer (_ q : P0) : GcdCert 0 Int Mono.lex :=
+  .mk q 0 0 .unit
+
+private def orderedContent : ContentCert 0 Int Mono.lex :=
+  contentCertWith orderedProducer [C 2, C 3, C 5]
+
+/-- Producer accumulation preserves coefficient order in the public step list. -/
+example : orderedContent.steps.map GcdCert.gcd = [C 2, C 3, C 5] := by
+  decide +kernel
+
 private def badBaseCert : GcdCert 0 Int Mono.lex :=
   .mk (C 6) (C 2) (C 2) (.base (-1) 1)
 


### PR DESCRIPTION
Closes #9455.

Summary:
- replace the quadratic growing-prefix append in contentCertWith with a reversed cons accumulator and one final reverse
- preserve the public ContentCert step order and checker left-fold semantics
- add a kernel-reduced order regression that observes the producer steps in coefficient order

Sanity check:
- the directive is sound: repeated state.2 ++ [step] traverses every accumulated prefix, while cons plus one reverse is linear
- the empty fold, final gcd value, public certificate representation, and checker API are unchanged

Validation:
- lake build HexMvGcd.Content
- lake build HexMvGcd.Kernel
- lake build HexMvGcd HexReleaseTests HexMvHensel HexMvFactor (9,403 jobs)
- python3 scripts/check_dag.py
- python3 scripts/check_copyright_headers.py
- python3 scripts/check_phase4.py
- git diff --check
- added-line scan: no sorry, axiom, or native_decide

This revision has no dedicated HexMvGcd conformance or benchmark target; the full library, direct downstream libraries, kernel regression, and mandated aggregate release-test target cover the proportionate validation.