### PR TITLE
fix(mvgcd): dispatch rational lifts through integers

### DIFF
--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -621,6 +621,11 @@ def intConcreteProposal {n : Nat}
   | 1, _, _, f, h => ⟨some (intArityOneCert f h), cfg.rand⟩
   | _ + 2, cmp, _, f, h => intConcreteProposalGeneric cmp cfg f h
 
+/-- Register the concrete integer backend before rational lifting so that the
+latter can invoke checked integer dispatch without selecting itself. -/
+instance intProducer : GcdProducer Int where
+  propose := fun cmp _ cfg f h => intConcreteProposal cmp cfg f h
+
 /-- Dense Brown route over rationals.  Rational points are unbounded, so the
 caller-provided point fuel is the only point-supply limit. -/
 def ratBrownCert? {n : Nat}
@@ -668,49 +673,57 @@ def ratPrimitiveModel {n : Nat}
   ⟨scale, model⟩
 
 /-- Build the required rational cofactor witness from primitive integer
-models.  The integer PRS is run only on those models; both the nested integer
-certificate and the final rational transport are executable checker gates. -/
+models.  The checked integer dispatcher runs only on those models; both the
+nested integer certificate and the final rational transport are executable
+checker gates.  Its advanced random state is retained even when transport
+checking rejects the witness. -/
 def ratLiftCoprime? {n : Nat}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
-    (f h : MvPoly n Rat cmp) : Option (CoprimeCert n Rat cmp) :=
+    (cfg : GcdConfig) (f h : MvPoly n Rat cmp) :
+    Option (CoprimeCert n Rat cmp) × Rand :=
   let left := ratPrimitiveModel f
   let right := ratPrimitiveModel h
-  if left.scale == 0 || right.scale == 0 then none
+  if left.scale == 0 || right.scale == 0 then (none, cfg.rand)
   else
-    let intCert := rawPrsCert left.poly right.poly
+    let run := gcdCertWith cfg left.poly right.poly
     let cert := CoprimeCert.ratLift left.scale right.scale
-      left.poly right.poly intCert.coprime
-    if checkCoprime f h cert then some cert else none
+      left.poly right.poly run.cert.coprime
+    (if checkCoprime f h cert then some cert else none, run.rand)
 
 /-- Offer a rational gcd candidate using exact divisions and a `ratLift`
-cofactor certificate. -/
+cofactor certificate, threading the integer dispatcher's random state. -/
 def ratCheckedCandidate? {n : Nat}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
-    (f h candidate : MvPoly n Rat cmp) : Option (GcdCert n Rat cmp) :=
-  if candidate == 0 then none
+    (cfg : GcdConfig) (f h candidate : MvPoly n Rat cmp) :
+    GcdProposal n Rat cmp :=
+  if candidate == 0 then ⟨none, cfg.rand⟩
   else
     let normalized := polyNormalize candidate
     match divExact? f normalized, divExact? h normalized with
     | some cofL, some cofR =>
-        match ratLiftCoprime? cofL cofR with
-        | none => none
+        let run := ratLiftCoprime? cfg cofL cofR
+        match run.1 with
+        | none => ⟨none, run.2⟩
         | some coprime =>
             let cert := GcdCert.mk normalized cofL cofR coprime
-            if checkGcd f h cert then some cert else none
-    | _, _ => none
+            ⟨if checkGcd f h cert then some cert else none, run.2⟩
+    | _, _ => ⟨none, cfg.rand⟩
 
 /-- Rational gcd through primitive integer models.  Scaling either input by a
 nonzero rational unit does not change the monic gcd; candidate acceptance and
-cofactor transport are both checked concretely. -/
+cofactor transport are both checked concretely.  Both the gcd models and the
+resulting cofactor models go through checked integer dispatch, never rational
+dispatch. -/
 def ratIntegerLiftCert? {n : Nat}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
-    (f h : MvPoly n Rat cmp) : Option (GcdCert n Rat cmp) :=
+    (cfg : GcdConfig) (f h : MvPoly n Rat cmp) : GcdProposal n Rat cmp :=
   let left := ratPrimitiveModel f
   let right := ratPrimitiveModel h
-  if left.scale == 0 || right.scale == 0 then none
+  if left.scale == 0 || right.scale == 0 then ⟨none, cfg.rand⟩
   else
-    let intCert := rawPrsCert left.poly right.poly
-    ratCheckedCandidate? f h (intModelToRat intCert.gcd)
+    let run := gcdCertWith cfg left.poly right.poly
+    let nextCfg := { cfg with rand := run.rand }
+    ratCheckedCandidate? nextCfg f h (intModelToRat run.cert.gcd)
 
 /-- Routes 0--3 for rational coefficients. -/
 def ratConcreteProposal {n : Nat}
@@ -722,11 +735,13 @@ def ratConcreteProposal {n : Nat}
       match structuralReduction? f h with
       | none => ⟨none, cfg.rand⟩
       | some reduced =>
-          match ratIntegerLiftCert? reduced.left reduced.right with
-          | some cert => ⟨restoreStructural? f h reduced cert, cfg.rand⟩
+          let lifted := ratIntegerLiftCert? cfg reduced.left reduced.right
+          match lifted.cert? with
+          | some cert => ⟨restoreStructural? f h reduced cert, lifted.rand⟩
           | none =>
-              let cert? := ratBrownCert? cfg reduced.left reduced.right
-              ⟨cert?.bind (restoreStructural? f h reduced), cfg.rand⟩
+              let nextCfg := { cfg with rand := lifted.rand }
+              let cert? := ratBrownCert? nextCfg reduced.left reduced.right
+              ⟨cert?.bind (restoreStructural? f h reduced), lifted.rand⟩
 
 /-- Dense Brown route over an already-prime coefficient field. -/
 def primeFieldBrownCert? {n p : Nat} [hp : ZMod64.Bounds p]
@@ -753,9 +768,6 @@ def primeConcreteProposal {n p : Nat} [hp : ZMod64.Bounds p]
       | some reduced =>
           let cert? := primeFieldBrownCert? cfg reduced.left reduced.right
           ⟨cert?.bind (restoreStructural? f h reduced), earlier.rand⟩
-
-instance intProducer : GcdProducer Int where
-  propose := fun cmp _ cfg f h => intConcreteProposal cmp cfg f h
 
 instance ratProducer : GcdProducer Rat where
   propose := fun cmp _ cfg f h => ratConcreteProposal cmp cfg f h

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -178,7 +178,7 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   let y : Q2 := X 1
   let left := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
   let right := C ((1 : Rat) / 5) * x * y + x + 2
-  match ratLiftCoprime? left right with
+  match (ratLiftCoprime? GcdConfig.default left right).1 with
   | some cert => checkCoprime left right cert
   | none => false
 #guard
@@ -192,8 +192,30 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   let common := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
   let f := common * (x + C ((1 : Rat) / 5))
   let h := common * (y + C ((1 : Rat) / 7))
-  match ratIntegerLiftCert? f h with
+  match (ratIntegerLiftCert? GcdConfig.default f h).cert? with
   | some cert => checkGcd f h cert
+  | none => false
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let f := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
+  let h := C ((1 : Rat) / 5) * x * y + x + 2
+  let cfg := { GcdConfig.default with rand := Rand.ofSeed 23 }
+  let left := ratPrimitiveModel f
+  let right := ratPrimitiveModel h
+  let proposal := intConcreteProposal Mono.lex cfg left.poly right.poly
+  let first := gcdCertWith cfg left.poly right.poly
+  let nextCfg := { cfg with rand := first.rand }
+  let second := gcdCertWith nextCfg left.poly right.poly
+  let lifted := ratIntegerLiftCert? cfg f h
+  match proposal.cert? with
+  | some proposed =>
+      checkGcd left.poly right.poly proposed &&
+        first.cert.gcd == proposed.gcd &&
+        lifted.rand == second.rand && lifted.rand != cfg.rand &&
+        match lifted.cert? with
+        | some cert => checkGcd f h cert
+        | none => false
   | none => false
 #guard
   let x : P2 := X 0

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -60,6 +60,24 @@ class GcdProducer (R : Type u) [Zero R] where
 instance (priority := 10) instNoFastProducer {R : Type u} [Zero R] :
     GcdProducer R := noFastProducer
 
+/-- Complete checked dispatch. Proposals affect performance and random state,
+but rejection always falls through to the deterministic PRS route.  This
+plumbing lives below the concrete producers so one coefficient backend can
+invoke another without creating an import cycle. -/
+def gcdCertWith (cfg : GcdConfig)
+    {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : GcdRun n R cmp :=
+  let proposal := GcdProducer.propose cmp cfg f h
+  match proposal.cert? with
+  | some candidate =>
+      if checkGcd f h candidate then ⟨candidate, proposal.rand⟩
+      else ⟨prsCert f h, proposal.rand⟩
+  | none => ⟨prsCert f h, proposal.rand⟩
+
 /-- Route 0: zero and unit cases, all represented by genuine replayable
 certificates. -/
 def structuralCert? {n : Nat} {R : Type u}

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -28,21 +28,6 @@ universe u
 
 variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
 
-/-- Complete checked dispatch. Proposals affect performance and random state,
-but rejection always falls through to the deterministic PRS route. -/
-def gcdCertWith (cfg : GcdConfig)
-    [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
-    [GcdProducer R]
-    (f h : MvPoly n R cmp) : GcdRun n R cmp :=
-  let proposal := GcdProducer.propose cmp cfg f h
-  match proposal.cert? with
-  | some candidate =>
-      if checkGcd f h candidate then ⟨candidate, proposal.rand⟩
-      else ⟨prsCert f h, proposal.rand⟩
-  | none => ⟨prsCert f h, proposal.rand⟩
-
 /-- Canonical checked gcd certificate. -/
 def gcdCert [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]


### PR DESCRIPTION
Closes #9458.

## Summary

- move the unchanged checker-gated `gcdCertWith` dispatcher below the producer interface so rational lifting can invoke integer dispatch without an import cycle
- route both primitive integer gcd models and rational cofactor models through the concrete `Int` producer plus deterministic checked PRS fallback
- thread `Rand` across both integer dispatches and retain the advanced state on every rejection/fallback path
- keep rational transport and final gcd acceptance behind `checkCoprime`/`checkGcd`
- add a route-level guard showing a valid routes 0–3 integer proposal is selected during rational lifting and that its two dispatch state transitions are preserved

## Touched declarations

- `gcdCertWith` (relocated unchanged from `HexMvGcd.Gcd` to `HexMvGcd.Fast`)
- `intProducer` (relocated earlier within `HexMvGcd.Brown`)
- `ratLiftCoprime?`
- `ratCheckedCandidate?`
- `ratIntegerLiftCert?`
- `ratConcreteProposal`
- rational route guards in `HexMvGcd.Eval`

## Validation

- `lake build HexMvGcd.Fast HexMvGcd.Brown`
- `lake build HexMvGcd.Gcd HexMvGcd.Eval`
- `lake build HexMvGcd HexMvHensel HexMvFactor` (536 jobs)
- `python3 scripts/check_dag.py`
- `python3 -m unittest scripts/test_check_dag.py`
- `git diff --check origin/main...HEAD`
- added-token scan: no `sorry`, `axiom`, or `native_decide`