### PR TITLE
feat(mvhensel): implement Taylor shifts and Horner images

### DIFF
--- a/HexMvHensel.lean
+++ b/HexMvHensel.lean
@@ -16,6 +16,7 @@ public import HexMvHensel.Cert
 public import HexMvHensel.Lift
 public import HexMvHensel.Complete
 public import HexMvHensel.KernelTests
+public import HexMvHensel.ShiftTests
 public import HexMvHensel.UniTests
 public import HexMvHensel.DiophantineTests
 public import HexMvHensel.SeedTests

--- a/HexMvHensel/Shift.lean
+++ b/HexMvHensel/Shift.lean
@@ -66,10 +66,53 @@ def remainingVar (i : Fin (n + 1)) (j : Fin n) : Fin (n + 1) :=
     simp
     omega
 
+/-- One descending synthetic-division pass over low-to-high coefficients.
+The prefix below `k` is already final.  A right fold keeps the newly updated
+higher coefficient at the head of its accumulator, so every remaining
+coefficient is visited exactly once. -/
+def shiftPass {R : Type} [Lean.Grind.Semiring R]
+    (z : R) (coeffs : List R) (k : Nat) : List R :=
+  let finalized := coeffs.take k
+  let suffix := coeffs.drop k
+  finalized ++ suffix.foldr
+    (fun coefficient shifted =>
+      match shifted with
+      | [] => [coefficient]
+      | next :: _ => (coefficient + z * next) :: shifted)
+    []
+
+/-- Translate one dense univariate polynomial by repeated synthetic division,
+without materialising powers of the binomial `X + z`. -/
+def shiftDense {R : Type} [Lean.Grind.Semiring R] [DecidableEq R]
+    (z : R) (p : DensePoly R) : DensePoly R :=
+  let coeffs := (List.range p.size).foldl (shiftPass z) p.toArray.toList
+  DensePoly.ofList coeffs
+
+/-- Arity-indexed Taylor translation.  The recursive view shifts every
+coefficient in the remaining variables, then applies the dense synthetic
+division loop in variable zero. -/
+structure ShiftOpsAt (n : Nat) where
+  run : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
+    (Fin n → Int) → MvPoly n Int cmp → MvPoly n Int cmp
+
+def shiftOps : (n : Nat) → ShiftOpsAt n
+  | 0 =>
+      { run := fun _ _ _ p => p }
+  | n + 1 =>
+      let lower := shiftOps n
+      { run := fun cmp _ a p =>
+          let view := MvPoly.toUnivariate (0 : Fin (n + 1)) Mono.lex p
+          let coeffs := view.toArray.toList.map fun coefficient =>
+            lower.run Mono.lex (fun j => a j.succ) coefficient
+          let translated :=
+            if a 0 = 0 then DensePoly.ofList coeffs
+            else shiftDense (C (a 0)) (DensePoly.ofList coeffs)
+          MvPoly.ofUnivariate (cmp := cmp) (0 : Fin (n + 1)) Mono.lex translated }
+
 /-- Translate every variable by the corresponding component of `a`. -/
 def shiftAll [IsMonomialOrder cmp'] (a : Fin n → Int) (p : MvPoly n Int cmp') :
     MvPoly n Int cmp' :=
-  MvPoly.subst (fun j => X j + C (a j)) p
+  (shiftOps n).run cmp' a p
 
 /-- Translate every variable by the negative of the corresponding component. -/
 def unshiftAll [IsMonomialOrder cmp'] (a : Fin n → Int) (p : MvPoly n Int cmp') :
@@ -88,20 +131,20 @@ def shiftVar (i : Fin (n + 1)) (a : Fin n → Int)
 main variable `x_i`. -/
 def shift (i : Fin (n + 1)) (a : Fin n → Int)
     (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
-  MvPoly.subst (shiftVar i a) p
+  shiftAll (fun j => if h : j = i then 0 else a (remainingIndex i j h)) p
 
 /-- Undo `shift i a`. -/
 def unshift (i : Fin (n + 1)) (a : Fin n → Int)
     (p : MvPoly (n + 1) Int cmp) : MvPoly (n + 1) Int cmp :=
   shift i (fun j => -a j) p
 
-/-- The univariate image at `a`, obtained by evaluating every coefficient in
-the recursive view in the non-main variables. -/
+/-- The univariate image at `a`, obtained by sparse Horner evaluation of every
+coefficient in the recursive view in the non-main variables. -/
 def imageAt (i : Fin (n + 1))
     (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
     (a : Fin n → Int) (p : MvPoly (n + 1) Int cmp) : DensePoly Int :=
   let q := MvPoly.toUnivariate i cmp' p
-  DensePoly.ofCoeffs (q.toArray.map fun c => MvPoly.eval a c)
+  DensePoly.ofCoeffs (q.toArray.map fun c => MvPoly.evalHorner a c)
 
 /-- Leading coefficient in the chosen main variable, as a polynomial in the
 remaining variables. -/

--- a/HexMvHensel/ShiftTests.lean
+++ b/HexMvHensel/ShiftTests.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import all HexMvHensel.Shift
+public meta import HexMvHensel.Shift
+import all HexMvPoly
+
+section
+
+namespace Hex.MvHensel.ShiftTests
+
+open Hex
+open Hex.MvPoly
+
+abbrev P0 := MvPoly 0 Int Mono.lex
+abbrev P2 := MvPoly 2 Int Mono.lex
+abbrev P3 := MvPoly 3 Int Mono.lex
+
+/-- Direct substitution retained only as an executable reference oracle for
+the production synthetic-division shift. -/
+def directShiftAll {n : Nat} (a : Fin n → Int)
+    (p : MvPoly n Int Mono.lex) : MvPoly n Int Mono.lex :=
+  MvPoly.subst (fun j => X j + C (a j)) p
+
+def directShift {n : Nat} (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int Mono.lex) : MvPoly (n + 1) Int Mono.lex :=
+  MvPoly.subst (shiftVar i a) p
+
+def directImage {n : Nat} (i : Fin (n + 1)) (a : Fin n → Int)
+    (p : MvPoly (n + 1) Int Mono.lex) : DensePoly Int :=
+  let view := MvPoly.toUnivariate i Mono.lex p
+  DensePoly.ofCoeffs (view.toArray.map fun coefficient => MvPoly.eval a coefficient)
+
+def point2 : Fin 2 → Int
+  | ⟨0, _⟩ => 2
+  | ⟨1, _⟩ => -1
+
+def pointAround1 : Fin 2 → Int
+  | ⟨0, _⟩ => -2
+  | ⟨1, _⟩ => 3
+
+/- Arity zero and zero-degree inputs exercise the empty synthetic loop. -/
+#guard shiftAll (fun j : Fin 0 => nomatch j) (C 7 : P0) == C 7
+
+/- Sparse gaps, mixed terms, negative points, and cancellation agree with the
+direct substitution semantics. -/
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let p := 3 * x ^ 4 * y ^ 2 - 2 * x ^ 2 + 5 * y ^ 3 + x * y - 7
+  shiftAll point2 p == directShiftAll point2 p
+
+/- A named main variable is fixed while both surrounding variables shift. -/
+#guard
+  let x : P3 := X 0
+  let y : P3 := X 1
+  let z : P3 := X 2
+  let p := x ^ 3 * y ^ 2 + 2 * y * z ^ 2 - x * z + 4
+  shift (1 : Fin 3) pointAround1 p ==
+    directShift (1 : Fin 3) pointAround1 p
+
+#guard
+  let y : P3 := X 1
+  shift (1 : Fin 3) pointAround1 y == y
+
+#guard
+  let x : P3 := X 0
+  let y : P3 := X 1
+  let z : P3 := X 2
+  let p := x ^ 3 * y ^ 2 + 2 * y * z ^ 2 - x * z + 4
+  unshift (1 : Fin 3) pointAround1 (shift (1 : Fin 3) pointAround1 p) == p
+
+/- Horner evaluation of every main-variable slice agrees with the direct
+sparse evaluator, including a non-leading main variable. -/
+#guard
+  let x : P3 := X 0
+  let y : P3 := X 1
+  let z : P3 := X 2
+  let p := x ^ 4 * y ^ 3 + 2 * y ^ 2 * z ^ 5 - 3 * x * z + 9
+  imageAt (1 : Fin 3) Mono.lex pointAround1 p ==
+    directImage (1 : Fin 3) pointAround1 p
+
+end Hex.MvHensel.ShiftTests


### PR DESCRIPTION
Closes #9450.

Implements the completed coordinate-algorithm requirements:

- replaces substitution-based materialized shifts with arity-recursive Taylor translation and one descending synthetic-division pass per coefficient layer
- skips zero-coordinate passes, so the distinguished main variable is fixed without paying for no-op Taylor work
- evaluates every recursive-view slice through `MvPoly.evalHorner`
- adds direct-substitution/direct-evaluation oracle guards for arity zero, sparse gaps, mixed terms, negative points, a non-leading main variable, main-variable preservation, and inverse shifting
- preserves the existing kernel-reduction checks

Validation:

- `lake build HexMvHensel.KernelTests HexMvHensel.ShiftTests`
- `lake build HexMvHensel HexMvFactor HexReleaseTests` (9,392 jobs)
- `lake build HexConformance` (9,645 jobs)
- dependency DAG, factor-sweep freshness, copyright headers, diff hygiene
- no added `sorry`, `axiom`, or `native_decide`