### PR TITLE
feat(mvgcd): support finite-field squarefree decisions

### DIFF
--- a/HexMvGcd.lean
+++ b/HexMvGcd.lean
@@ -21,6 +21,7 @@ public import HexMvGcd.Heu
 public import HexMvGcd.Brown
 public import HexMvGcd.Gcd
 public import HexMvGcd.Squarefree
+public import HexMvGcd.SquarefreeTests
 public import HexMvGcd.Kernel
 public import HexMvGcd.Eval
 

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -12,13 +12,15 @@ public import HexMvGcd.Gcd
 set_option backward.proofsInPublic true
 
 /-!
-Characteristic-zero squarefree operations.
+Squarefree decision and characteristic-zero decomposition.
 
-The executable decomposition follows the named-variable recursive form of
-Yun's algorithm.  Coefficient content is decomposed one arity down; the
-primitive part is split into its multiplicity layers using one selected main
-variable, and equal-multiplicity factors are merged.  Scalar content is kept
-separately, matching the computer-algebra convention over `Int`.
+The exact Boolean decision works over perfect coefficient fraction fields,
+including bounded prime fields.  The executable decomposition remains
+characteristic-zero: it follows the named-variable recursive form of Yun's
+algorithm.  Coefficient content is decomposed one arity down; the primitive
+part is split into its multiplicity layers using one selected main variable,
+and equal-multiplicity factors are merged.  Scalar content is kept separately,
+matching the computer-algebra convention over `Int`.
 -/
 
 namespace Hex.MvPoly
@@ -45,6 +47,21 @@ instance instFractionNonzeroOneInt : Hex.Fraction.NonzeroOne Int :=
 instance instFractionNonzeroOneRat : Hex.Fraction.NonzeroOne Rat :=
   ⟨by decide⟩
 
+/-- Bounded prime residues are nontrivial.  The lower priority retains a
+coherent instance for the carrier's direct ring operations while allowing the
+generic field bridge below to serve inherited field-operation diamonds. -/
+instance (priority := 50) instFractionNonzeroOneZMod64 {p : Nat}
+    [hp : ZMod64.Bounds p] [ZMod64.PrimeModulus p] :
+    Hex.Fraction.NonzeroOne (@ZMod64 p hp) :=
+  ⟨ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p))⟩
+
+/-- Every lightweight field supplies the nontriviality needed by the fraction
+construction.  Keeping this bridge generic also makes the inherited field
+operations coherent when a carrier has a separately declared ring instance. -/
+instance instFractionNonzeroOneField {K : Type u} [Lean.Grind.Field K] :
+    Hex.Fraction.NonzeroOne K :=
+  ⟨fun h => Lean.Grind.Field.zero_ne_one h.symm⟩
+
 /-- The coefficient fraction field is perfect.  This is used only by the
 semantic decision theorem; the Boolean checker itself uses gcd replay. -/
 class PerfectFrac (R : Type u) [Lean.Grind.CommRing R] [Div R]
@@ -65,6 +82,31 @@ instance instPerfectFracRat : PerfectFrac Rat := by
   left
   intro m hm
   sorry
+
+/-- The fraction field of a bounded prime field is perfect.  Every fraction is
+represented by a coefficient because its denominator is invertible, and
+Fermat's theorem makes the `p`th-power map the identity on those coefficients.
+-/
+instance instPerfectFracZMod64 {p : Nat} [hp : ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] :
+    PerfectFrac (@ZMod64 p hp) := by
+  constructor
+  right
+  refine ⟨p, ZMod64.PrimeModulus.prime (p := p), ?_, ?_⟩
+  · change Hex.Fraction.ofCoeff (p : ZMod64 p) = 0
+    rw [ZMod64.natCast_self]
+    exact Hex.Fraction.ofCoeff_zero
+  · intro a
+    induction a using Quotient.inductionOn with
+    | _ a =>
+        let q := a.num / a.den
+        refine ⟨Hex.Fraction.ofCoeff q, ?_⟩
+        rw [← Hex.Fraction.ofCoeff_pow, ZMod64.pow_prime_of_prime_modulus]
+        apply Quotient.sound
+        change (a.num / a.den) * a.den = a.num * 1
+        rw [Lean.Grind.Field.div_eq_mul_inv, Lean.Grind.Semiring.mul_assoc,
+          Lean.Grind.Field.inv_mul_cancel a.den_ne,
+          Lean.Grind.Semiring.mul_one]
 
 /-- A polynomial has no variable in its support. -/
 def IsConst {n : Nat} {R : Type u} [Zero R]

--- a/HexMvGcd/SquarefreeTests.lean
+++ b/HexMvGcd/SquarefreeTests.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexMvGcd.Gcd
+public meta import HexMvGcd.Prs
+public meta import HexMvGcd.Squarefree
+public meta import HexMvPoly.Ring
+public import HexMvGcd.Squarefree
+
+public section
+
+/-! Focused finite-field squarefree decision regressions. -/
+
+namespace Hex.MvPoly
+
+private theorem boundsThree : ZMod64.Bounds 3 :=
+  ⟨by decide, by decide⟩
+attribute [local instance] boundsThree
+
+private theorem primeThree : ZMod64.PrimeModulus 3 :=
+  ZMod64.primeModulusOfPrime (by decide)
+attribute [local instance] primeThree
+
+private abbrev F3P1 := MvPoly 1 (ZMod64 3) Mono.lex
+private abbrev F3P2 := MvPoly 2 (ZMod64 3) Mono.lex
+
+example : Hex.Fraction.NonzeroOne (ZMod64 3) := inferInstance
+example : PerfectFrac (ZMod64 3) := inferInstance
+
+example (p : F3P1) : isSquarefree p = true ↔ Squarefree p :=
+  isSquarefree_iff p
+
+#guard
+  let x : F3P1 := X 0
+  isSquarefree (x * (x + 1))
+
+-- One partial derivative vanishes, while the other witnesses squarefreeness.
+#guard
+  let x : F3P2 := X 0
+  let y : F3P2 := X 1
+  isSquarefree (x ^ 3 + y)
+
+#guard
+  let x : F3P1 := X 0
+  !isSquarefree ((x + 1) ^ 2)
+
+#guard
+  let x : F3P2 := X 0
+  let y : F3P2 := X 1
+  !isSquarefree ((x ^ 3 + y) ^ 2)
+
+#guard !isSquarefree (0 : F3P1)
+
+-- In characteristic three this is `(x + 1)^3`, and its derivative vanishes.
+#guard
+  let x : F3P1 := X 0
+  !isSquarefree (x ^ 3 + 1)
+
+end Hex.MvPoly


### PR DESCRIPTION
Closes #9461.

## Summary

- add coherent `Fraction.NonzeroOne` support for lightweight fields and bounded prime residues
- prove `PerfectFrac (ZMod64 p)` by reducing fractions to coefficients and applying Fermat Frobenius identity
- instantiate the existing `isSquarefree_iff` contract over `ZMod64`
- add focused F3 regressions for squarefree, repeated-factor, zero, all-derivatives-zero, and one-vanishing-partial cases
- keep `radical` and `sqfDecomp` characteristic-zero, as required by the SPEC

## Validation

- `lake build HexMvGcd.Squarefree HexMvGcd.SquarefreeTests`
- `lake build HexMvGcd HexMvHensel HexMvFactor` (536 jobs)
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_phase4.py`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `python3 scripts/release/check_trust_surface.py`
- added-lines scan: no new `sorry`, `axiom`, or `native_decide`
- `git diff --check`

Current `origin/main` has no `conformance/HexMvGcd` target, so this PR adds focused compiled regressions without creating unrelated CI/conformance surface.