### PR TITLE
perf(mvhensel): linearize complement products

### DIFF
--- a/HexMvHensel/Lift.lean
+++ b/HexMvHensel/Lift.lean
@@ -32,9 +32,8 @@ variable {n : Nat}
 /-- Multivariate complementary products, in tuple order. -/
 def mvComplements {k : Nat} {order : Mono k → Mono k → Ordering}
     [IsMonomialOrder order] :
-    List (MvPoly k Int order) → List (MvPoly k Int order)
-  | [] => []
-  | f :: fs => mvProduct fs :: (mvComplements fs).map (fun b => f * b)
+    List (MvPoly k Int order) → List (MvPoly k Int order) :=
+  complementProducts (· * ·) 1
 
 /-- Install one prefix of the prescribed shifted leading coefficients. -/
 def installLeading? (i : Fin (n + 1))

--- a/HexMvHensel/LiftTests.lean
+++ b/HexMvHensel/LiftTests.lean
@@ -52,6 +52,11 @@ def ux : ZPoly := DensePoly.ofCoeffs #[0, 1]
 def pointTwo : Fin 1 → Int := fun _ => 2
 def pointZero : Fin 1 → Int := fun _ => 0
 
+/- Multivariate complements use the same linear prefix/suffix construction. -/
+#guard mvComplements [x] == [1]
+#guard mvComplements [x, y, x + y] ==
+  [y * (x + y), x * (x + y), x * y]
+
 /- A nonzero evaluation point exercises both coordinate transforms. -/
 def successInput : Input 1 Mono.lex Mono.lex :=
   { setup :=

--- a/HexMvHensel/SPEC/hex-mv-hensel.md
+++ b/HexMvHensel/SPEC/hex-mv-hensel.md
@@ -512,6 +512,13 @@ linear correction hex-hensel uses on factors: with
 `deg τ_j < deg F_j` using the mod-`p` tuple, and set
 `σ_j ← σ_j + p^k τ_j`.
 
+Build all `b_j` together with prefix and suffix products, so their
+construction takes `O(r)` polynomial multiplications rather than multiplying
+all but one factor separately for each `j`. The producer retains that list and
+the mod-`p` tuple throughout the lift. Its loop state also carries the current
+modulus, advancing it by one multiplication by `p`; it does not recompute
+`p^k` at each step.
+
 **Do not reduce `σ_j` modulo `F_j` between steps.** That would change
 `σ_j` by a multiple of `F_j`, hence change `Σ_j σ_j b_j` by a multiple of
 `F = ∏_j F_j`, which is not a multiple of `q` and so breaks the very
@@ -680,7 +687,8 @@ statement the box truncation supports.
 
 Only the base-level witness is fixed data. The `b_j` used at stage `t`
 are recomputed from the current factors, because the ring the equation is
-solved in changes from stage to stage.
+solved in changes from stage to stage. Within one stage they are again built
+by one prefix/suffix pass and retained for every power of `y_t`.
 
 **Truncation is sound, not an approximation.** Any integer factor `g` of
 `f` satisfies `deg_{y_j} g ≤ deg_{y_j} f = d_j`, because degrees are
@@ -1308,7 +1316,7 @@ main variable, `d_j` the degree in non-main variable `j`, `t` terms in
 | `imageAt` | Horner per `x_i`-slice of the recursive view | `O(t · n)` coefficient operations |
 | `lcIn` | the top slice of `toUnivariate` | `O(n · t log t)` machine operations |
 | `truncate` | `restrictBy` on the exponent vector | `O(n · t)` machine operations |
-| `witnessOf?` | one `FpPoly` xgcd per factor, then `l` linear steps | `r` xgcds plus `r · l` divisions |
+| `witnessOf?` | one prefix/suffix complement pass, one `FpPoly` xgcd per factor, then `l` linear steps carrying their modulus | `O(r)` complement multiplications, `r` xgcds, and `r · l` divisions |
 | `solveUni` | `r` multiplications and remainders modulo `F_j` | `r` divisions of degree `d₁` |
 | `diophantine` at `m` variables | recursion, `d_m + 1` right-hand sides per level | `∏_{k ≤ m} (d_k + 1)` univariate solves |
 | one stage-`t` step | one product update and one solve | `∏_{k < t} (d_k + 1)` univariate solves |

--- a/HexMvHensel/Uni.lean
+++ b/HexMvHensel/Uni.lean
@@ -79,14 +79,22 @@ def UniSymCanonical (q : Nat) (f : ZPoly) : Prop :=
 def uniProduct (fs : List ZPoly) : ZPoly :=
   fs.foldl zMul 1
 
+/-- Products omitting each list entry, built with one prefix and one suffix
+pass.  The order of the retained entries is preserved. -/
+def complementProducts {α : Type} (mul : α → α → α) (one : α)
+    (xs : List α) : List α :=
+  let prefixes := xs.scanl mul one
+  let suffixes :=
+    (xs.reverse.scanl (fun suffix x => mul x suffix) one).reverse.drop 1
+  List.zipWith mul prefixes suffixes
+
 /-- The product of every image other than the one at position `j`. -/
 def productExcept (images : List ZPoly) (j : Nat) : ZPoly :=
-  (List.range images.length).foldl
-    (fun acc k => if k = j then acc else zMul acc (images.getD k 1)) 1
+  (complementProducts zMul 1 images).getD j 1
 
 /-- Complementary products `b_j = ∏_{m ≠ j} F_m`, in image order. -/
 def complements (images : List ZPoly) : List ZPoly :=
-  (List.range images.length).map (productExcept images)
+  complementProducts zMul 1 images
 
 /-- The partial-fraction linear combination `Σ_j σ_j b_j`. -/
 def uniCombination (coeffs bases : List ZPoly) : ZPoly :=
@@ -171,13 +179,14 @@ def solveUni (q : Nat) (images witness : List ZPoly) (c : ZPoly) :
 /-- Compute the inverse of the complementary product modulo image `j` over
 the residue prime. -/
 def baseWitnessAt? (p : Nat) [ZMod64.Bounds p]
-    [ZMod64.PrimeModulus p] (images : List ZPoly) (j : Nat) : Option ZPoly :=
+    [ZMod64.PrimeModulus p] (images bases : List ZPoly)
+    (j : Nat) : Option ZPoly :=
   let F := images.getD j 0
   let Fp := toFp p F
   if F.size < 2 || Fp.size != F.size then
     none
   else
-    let bp := toFp p (productExcept images j)
+    let bp := toFp p (bases.getD j 1)
     let raw := DensePoly.xgcd bp Fp
     if raw.gcd.size != 1 || raw.gcd.leadingCoeff = 0 then
       none
@@ -188,15 +197,15 @@ def baseWitnessAt? (p : Nat) [ZMod64.Bounds p]
 
 /-- Compute the partial-fraction tuple modulo the residue prime. -/
 def baseWitness? (prime : ZMod64.Prime)
-    (images : List ZPoly) : Option (List ZPoly) :=
+    (images bases : List ZPoly) : Option (List ZPoly) :=
   letI : ZMod64.Bounds prime.m := prime.bounds
   letI : ZMod64.PrimeModulus prime.m :=
     ZMod64.primeModulusOfPrime prime.prime
   if images.isEmpty then none
   else do
     let tuple ← (List.range images.length).mapM
-      (baseWitnessAt? prime.m images)
-    let identity := uniCombination tuple (complements images)
+      (baseWitnessAt? prime.m images bases)
+    let identity := uniCombination tuple bases
     if coeffsDivisible prime.m (zSub identity 1) then
       some tuple
     else none
@@ -228,21 +237,29 @@ def addScaled (scale : Nat) : List ZPoly → List ZPoly → List ZPoly
   | [], [] => []
   | _, _ => []
 
+/-- The changing part of a partial-fraction witness lift. -/
+structure WitnessState where
+  /-- The prime power at which `tuple` is currently valid. -/
+  modulus : Nat
+  /-- The current lifted partial-fraction tuple. -/
+  tuple : List ZPoly
+
 /-- Lift an already valid mod-`p` tuple through `steps` further powers. -/
-def liftWitness (prime : ZMod64.Prime) (images base : List ZPoly) :
-    (steps k : Nat) → List ZPoly → Option (List ZPoly)
-  | 0, _, current => some current
-  | steps + 1, k, current => do
-      let pk := prime.m ^ k
+def liftWitness (prime : ZMod64.Prime)
+    (images bases base : List ZPoly) :
+    Nat → WitnessState → Option WitnessState
+  | 0, state => some state
+  | steps + 1, state => do
       let residual := zSub (1 : ZPoly)
-        (uniCombination current (complements images))
-      let error ← divCoeffs? pk residual
+        (uniCombination state.tuple bases)
+      let error ← divCoeffs? state.modulus residual
       let correction ← solveBase? prime images base error
-      let next := addScaled pk current correction
-      let nextModulus := pk * prime.m
+      let next := addScaled state.modulus state.tuple correction
+      let nextModulus := state.modulus * prime.m
       if coeffsDivisible nextModulus
-          (zSub (uniCombination next (complements images)) 1) then
-        liftWitness prime images base steps (k + 1) next
+          (zSub (uniCombination next bases) 1) then
+        liftWitness prime images bases base steps
+          { modulus := nextModulus, tuple := next }
       else none
 
 /-- Produce the partial-fraction tuple modulo `p ^ l`, or `none` if an image
@@ -250,11 +267,13 @@ loses degree modulo `p`, the images are not pairwise coprime there, or the
 requested exponent is zero. -/
 def witnessOf? (s : Setup n) (images : List ZPoly) : Option (List ZPoly) := do
   if s.exponent = 0 then none else pure ()
-  let base ← baseWitness? s.prime images
-  let lifted ← liftWitness s.prime images base (s.exponent - 1) 1 base
-  if coeffsDivisible s.modulus
-      (zSub (uniCombination lifted (complements images)) 1) then
-    some lifted
+  let bases := complements images
+  let base ← baseWitness? s.prime images bases
+  let lifted ← liftWitness s.prime images bases base (s.exponent - 1)
+    { modulus := s.prime.m, tuple := base }
+  if coeffsDivisible lifted.modulus
+      (zSub (uniCombination lifted.tuple bases) 1) then
+    some lifted.tuple
   else none
 
 /-! # The checked mathematical contract -/

--- a/HexMvHensel/UniTests.lean
+++ b/HexMvHensel/UniTests.lean
@@ -34,6 +34,13 @@ open scoped Hex
 
 def x : ZPoly := DensePoly.ofCoeffs #[0, 1]
 def xPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
+def xPlusTwo : ZPoly := DensePoly.ofCoeffs #[2, 1]
+
+/- Prefix/suffix complements handle the unit edge case and preserve tuple
+order for more than two factors. -/
+#guard complements [x] == [1]
+#guard complements [x, xPlusOne, xPlusTwo] ==
+  [zMul xPlusOne xPlusTwo, zMul x xPlusTwo, zMul x xPlusOne]
 
 /- The tuple `(1,-1)` solves `1*(x+1) + (-1)*x = 1`.  For right-hand side
 `x`, the two degree-bounded residues are `(0,1)`. -/


### PR DESCRIPTION
Closes #9452.

## What changed

- build all omitted-factor products in one prefix/suffix pass and share the implementation between the univariate and multivariate layers
- compute the univariate bases once, reuse them for every residue-field inverse, lift step, and final validation
- carry the current prime-power modulus alongside the lifted tuple instead of recomputing `p^k`
- retain multivariate complements within a stage while correctly rebuilding them between stages, where the coefficient ring changes
- document the complexity contract and add singleton and three-factor regressions

## Validation

- `lake build HexMvHensel.UniTests HexMvHensel.LiftTests`
- `lake build HexMvHensel HexReleaseTests`
- dependency DAG, copyright, Phase 4, factor-sweep freshness, published trust-surface, forbidden-token, and diff checks