### PR TITLE
perf(mvhensel): restrict stage solves to active variables

### DIFF
--- a/HexMvHensel/Diophantine.lean
+++ b/HexMvHensel/Diophantine.lean
@@ -153,6 +153,24 @@ def checkDiophantine (q : Nat) (i : Fin (n + 1)) (d : Fin n → Nat)
   | none => false
   | some sum => reduceMod q (truncate i d (sum - c)) == 0
 
+/-- Solve `Σ_j Δ_j b_j ≡ c (mod q)` by recursing through the first `count`
+non-main variables, then check the result inside the full degree box `d`.
+Callers may omit a future-variable suffix known not to occur in the bases or
+right-hand side; the unchanged final checker rejects an incorrect omission. -/
+def diophantinePrefix (q : Nat) (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (count : Nat) (d : Fin n → Nat)
+    (bs : List (MvPoly (n + 1) Int cmp))
+    (images witness : List ZPoly) (c : MvPoly (n + 1) Int cmp) :
+    Option (List (MvPoly (n + 1) Int cmp)) := do
+  if q ≤ 1 || images.isEmpty || images.length != witness.length ||
+      images.length != bs.length then none else pure ()
+  let answer ← diophantineAux q i cmp' d images witness
+    ((List.finRange n).take count) bs c
+  if !mvDegreeBounded i images answer then none
+  else if !checkDiophantine q i d bs answer c then none
+  else some answer
+
 /-- Solve `Σ_j Δ_j b_j ≡ c (mod q)` inside the non-main degree box `d`,
 with `deg_i Δ_j < deg images[j]`.  A malformed tuple, an out-of-range
 recursive right-hand side, or a failed final equation returns `none`. -/
@@ -160,14 +178,8 @@ def diophantine (q : Nat) (i : Fin (n + 1))
     (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
     (d : Fin n → Nat) (bs : List (MvPoly (n + 1) Int cmp))
     (images witness : List ZPoly) (c : MvPoly (n + 1) Int cmp) :
-    Option (List (MvPoly (n + 1) Int cmp)) := do
-  if q ≤ 1 || images.isEmpty || images.length != witness.length ||
-      images.length != bs.length then none else pure ()
-  let answer ← diophantineAux q i cmp' d images witness
-    (List.finRange n) bs c
-  if !mvDegreeBounded i images answer then none
-  else if !checkDiophantine q i d bs answer c then none
-  else some answer
+    Option (List (MvPoly (n + 1) Int cmp)) :=
+  diophantinePrefix q i cmp' n d bs images witness c
 
 /-! # Mathematical contract -/
 

--- a/HexMvHensel/DiophantineTests.lean
+++ b/HexMvHensel/DiophantineTests.lean
@@ -78,6 +78,18 @@ coefficient. -/
       (1 + y2 * x2 + z2 * (x2 + 1) + y2 * z2) ==
   some ([1 + z2 + y2 * z2, -1 + y2 - y2 * z2] : List P2)
 
+/- Omitting future variables is computationally equivalent when the bases and
+right-hand side contain only the declared active prefix. -/
+#guard diophantinePrefix 5 (0 : Fin 3) Mono.lex 0 d2
+    [x2 + 1, x2] images witness 1 ==
+  diophantine 5 (0 : Fin 3) Mono.lex d2
+    [x2 + 1, x2] images witness 1
+
+#guard diophantinePrefix 5 (0 : Fin 3) Mono.lex 1 d2
+    [x2 + 1, x2] images witness (1 + y2 * x2) ==
+  diophantine 5 (0 : Fin 3) Mono.lex d2
+    [x2 + 1, x2] images witness (1 + y2 * x2)
+
 /-! # Required failures -/
 
 /- The image product has main degree two, so a nonzero `x^2` right-hand side

--- a/HexMvHensel/Lift.lean
+++ b/HexMvHensel/Lift.lean
@@ -79,7 +79,8 @@ def liftStage (q : Nat) (i : Fin (n + 1))
       let error := reduceMod q
         (truncate i d (stageTarget - mvProduct current))
       let rhs := sliceVar selected (k + 1) error
-      let deltas ← diophantine q i cmp' d bases images witness rhs
+      let deltas ←
+        diophantinePrefix q i cmp' y.val d bases images witness rhs
       applyCorrections? q i d selected (k + 1) current deltas)
     installed
 

--- a/HexMvHensel/SPEC/hex-mv-hensel.md
+++ b/HexMvHensel/SPEC/hex-mv-hensel.md
@@ -770,6 +770,18 @@ def diophantine (q : Nat) (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering
     Option (List (MvPoly (n+1) Int cmp))
 ```
 
+The stage loop uses the checked prefix form:
+
+```lean
+/-- As `diophantine`, but recurse through only the first `count` non-main
+variables before checking the result against the full degree box. -/
+def diophantinePrefix (q : Nat) (i : Fin (n+1))
+    (cmp' : Mono n → Mono n → Ordering) (count : Nat)
+    (d : Fin n → Nat) (bs : List (MvPoly (n+1) Int cmp))
+    (images witness : List ZPoly) (c : MvPoly (n+1) Int cmp) :
+    Option (List (MvPoly (n+1) Int cmp))
+```
+
 Recursion on the number of non-main variables actually present in the
 current stage. With none present the problem is `solveUni`. With `m`
 present, set `y_m = 0` to get a problem in `m - 1` variables, solve it,
@@ -777,6 +789,14 @@ and then correct in powers of `y_m`: at power `s`, the right-hand side is
 the coefficient of `y_m^s` in `c - Σ_j Δ_j b_j` for the partial solution
 `Δ` so far, and the correction is another `(m-1)`-variable solve. Stop at
 `s = d_m`.
+
+At stage `t`, the zero slice of every base and every recursive right-hand
+side contains only the prefix `y_1, …, y_(t-1)`, so the stage passes
+`count = t - 1`. The unrestricted entry point passes `count = n`. Both forms
+run the same full-box equation and degree checks after producing a tuple;
+omitting a variable that is actually needed can therefore cause `none`, but
+cannot produce an unchecked answer. In particular, later degree bounds do
+not create vacuous recursive correction loops in an earlier stage.
 
 This is the same linear scheme as the stage loop one level down, which is
 why the two share `BoxCongr` and the truncation bookkeeping.


### PR DESCRIPTION
Closes #9451.

## What changed

- add a checked `diophantinePrefix` entry point that recurses through only the first requested non-main variables
- keep the full-box equation and degree checks unchanged, so an invalid omission is rejected rather than trusted
- make stage `t` solve only through its `t` earlier variables instead of traversing the future-variable suffix
- add zero-prefix and one-variable-prefix equivalence tests against the unrestricted solver
- document the active-prefix contract in the completed SPEC

## Validation

- `lake build HexMvHensel.DiophantineTests HexMvHensel.LiftTests`
- `lake build HexMvHensel HexMvFactor HexReleaseTests`
- dependency DAG, copyright, Phase 4, factor-sweep freshness, trust-surface, forbidden-token, and diff checks