### PR TITLE
perf(mvhensel): share Kronecker weights

### DIFF
--- a/HexMvHensel/Complete.lean
+++ b/HexMvHensel/Complete.lean
@@ -66,35 +66,199 @@ def BoundsFactors (inp : Input n cmp cmp') (bound : Nat) : Prop :=
     (MvPoly.coeff monomial
       (shift inp.setup.main inp.setup.point g)).natAbs ≤ bound
 
-/-- Product of the earlier side-variable radices. -/
-def kroneckerPrefix (sideDegrees : Fin n → Nat) (j : Fin n) : Nat :=
-  (List.finRange n).foldl
-    (fun radix k =>
-      if k.val < j.val then radix * (sideDegrees k + 1) else radix) 1
+/-- Prefix-product weights for a list of degree bounds. -/
+def weightScan : List Nat → Nat → List Nat
+  | [], _ => []
+  | bound :: bounds, weight =>
+      weight :: weightScan bounds (weight * (bound + 1))
+
+/-- Degree bounds in mixed-radix digit order: main variable first. -/
+def kroneckerBounds (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) : List Nat :=
+  mainDegree :: (List.finRange n).map sideDegrees
+
+/-- Monomial exponents in mixed-radix digit order: main variable first. -/
+def kroneckerDigits (i : Fin (n + 1))
+    (monomial : Mono (n + 1)) : List Nat :=
+  Mono.degreeOf i monomial :: (List.finRange n).map fun j =>
+    Mono.degreeOf (remainingVar i j) monomial
+
+/-- All mixed-radix weights, computed in one left-to-right pass. -/
+def kroneckerWeights (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) : List Nat :=
+  weightScan (kroneckerBounds mainDegree sideDegrees) 1
+
+/-- Dot product of equal-shape digit and weight lists.  The total fallback
+truncates only for malformed direct calls; `kroneckerWeights` and
+`kroneckerDigits` always have the same length. -/
+def weightedSum : List Nat → List Nat → Nat
+  | weight :: weights, digit :: digits =>
+      digit * weight + weightedSum weights digits
+  | _, _ => 0
 
 /-- Mixed-radix weight of side variable `j`.  The factor `mainDegree + 1`
 is deliberately present: without it the main variable and the first side
 variable would both map to the same univariate monomial. -/
 def kroneckerWeight (mainDegree : Nat) (sideDegrees : Fin n → Nat)
     (j : Fin n) : Nat :=
-  (mainDegree + 1) * kroneckerPrefix sideDegrees j
+  (kroneckerWeights mainDegree sideDegrees).getD (j.val + 1) 1
+
+/-- Exponent of a monomial with the side-variable weights already tabulated. -/
+def kroneckerExponentWith (i : Fin (n + 1)) (weights : List Nat)
+    (monomial : Mono (n + 1)) : Nat :=
+  weightedSum weights (kroneckerDigits i monomial)
 
 /-- Exponent of a monomial under the mixed-radix Kronecker substitution. -/
 def kroneckerExponent (i : Fin (n + 1)) (mainDegree : Nat)
     (sideDegrees : Fin n → Nat) (monomial : Mono (n + 1)) : Nat :=
-  (List.finRange n).foldl
-    (fun exponent j => exponent +
-      Mono.degreeOf (remainingVar i j) monomial *
-        kroneckerWeight mainDegree sideDegrees j)
-    (Mono.degreeOf i monomial)
+  kroneckerExponentWith i (kroneckerWeights mainDegree sideDegrees) monomial
+
+/-! # Mixed-radix injectivity -/
+
+/-- Horner form of a mixed-radix digit string. -/
+private def radixCode : List Nat → List Nat → Nat
+  | bound :: bounds, digit :: digits =>
+      digit + (bound + 1) * radixCode bounds digits
+  | _, _ => 0
+
+/-- The digit list has the same shape as its bounds and lies inside them. -/
+private def DigitsBounded : List Nat → List Nat → Prop
+  | [], [] => True
+  | bound :: bounds, digit :: digits =>
+      digit ≤ bound ∧ DigitsBounded bounds digits
+  | _, _ => False
+
+/-- The precomputed-weight dot product is the corresponding Horner code. -/
+private theorem weightedSum_weightScan (bounds digits : List Nat)
+    (weight : Nat) (hlen : bounds.length = digits.length) :
+    weightedSum (weightScan bounds weight) digits =
+      weight * radixCode bounds digits := by
+  induction bounds generalizing digits weight with
+  | nil =>
+      cases digits <;> simp_all [weightScan, weightedSum, radixCode]
+  | cons bound bounds ih =>
+      cases digits with
+      | nil => simp at hlen
+      | cons digit digits =>
+          have hlen' : bounds.length = digits.length := by
+            simp only [List.length_cons] at hlen
+            omega
+          rw [weightScan, weightedSum, radixCode,
+            ih digits (weight * (bound + 1)) hlen']
+          simp [Nat.add_mul, Nat.mul_add, Nat.mul_assoc, Nat.mul_comm]
+          rw [← Nat.mul_assoc, Nat.mul_comm bound weight, Nat.mul_assoc]
+
+/-- Horner mixed-radix coding is injective on bounded digit strings. -/
+private theorem radixCode_inj {bounds xs ys : List Nat}
+    (hx : DigitsBounded bounds xs) (hy : DigitsBounded bounds ys)
+    (hcode : radixCode bounds xs = radixCode bounds ys) : xs = ys := by
+  induction bounds generalizing xs ys with
+  | nil =>
+      cases xs <;> cases ys <;> simp_all [DigitsBounded]
+  | cons bound bounds ih =>
+      cases xs with
+      | nil => simp [DigitsBounded] at hx
+      | cons x xs =>
+          cases ys with
+          | nil => simp [DigitsBounded] at hy
+          | cons y ys =>
+              have hx' : x ≤ bound ∧ DigitsBounded bounds xs := hx
+              have hy' : y ≤ bound ∧ DigitsBounded bounds ys := hy
+              have hxlt : x < bound + 1 := by omega
+              have hylt : y < bound + 1 := by omega
+              have hmod := congrArg (fun value => value % (bound + 1)) hcode
+              have hxy : x = y := by
+                simpa [radixCode, Nat.mod_eq_of_lt hxlt,
+                  Nat.mod_eq_of_lt hylt] using hmod
+              subst y
+              have hdiv := congrArg (fun value => value / (bound + 1)) hcode
+              have htail : radixCode bounds xs = radixCode bounds ys := by
+                simpa [radixCode, Nat.div_eq_of_lt hxlt,
+                  Nat.add_mul_div_left, Nat.succ_pos] using hdiv
+              rw [ih hx'.2 hy'.2 htail]
+
+/-- Pointwise bounds give a bounded mapped digit string. -/
+private theorem digitsBounded_map (js : List (Fin n))
+    (bounds digits : Fin n → Nat)
+    (h : ∀ j, j ∈ js → digits j ≤ bounds j) :
+    DigitsBounded (js.map bounds) (js.map digits) := by
+  induction js with
+  | nil => simp [DigitsBounded]
+  | cons j js ih =>
+      simp only [List.map_cons, DigitsBounded]
+      exact ⟨h j (by simp), ih fun k hk => h k (by simp [hk])⟩
+
+/-- A monomial lies inside the degree box used by the Kronecker bound. -/
+def InDegreeBox (i : Fin (n + 1)) (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) (monomial : Mono (n + 1)) : Prop :=
+  Mono.degreeOf i monomial ≤ mainDegree ∧
+    ∀ j, Mono.degreeOf (remainingVar i j) monomial ≤ sideDegrees j
+
+/-- Corrected mixed-radix substitution is injective on its degree box. -/
+theorem kroneckerExponent_inj (i : Fin (n + 1)) (mainDegree : Nat)
+    (sideDegrees : Fin n → Nat) {a b : Mono (n + 1)}
+    (ha : InDegreeBox i mainDegree sideDegrees a)
+    (hb : InDegreeBox i mainDegree sideDegrees b)
+    (hcode : kroneckerExponent i mainDegree sideDegrees a =
+      kroneckerExponent i mainDegree sideDegrees b) : a = b := by
+  have hla :
+      (kroneckerBounds mainDegree sideDegrees).length =
+        (kroneckerDigits i a).length := by
+    simp [kroneckerBounds, kroneckerDigits]
+  have hlb :
+      (kroneckerBounds mainDegree sideDegrees).length =
+        (kroneckerDigits i b).length := by
+    simp [kroneckerBounds, kroneckerDigits]
+  have hcode' :
+      radixCode (kroneckerBounds mainDegree sideDegrees)
+          (kroneckerDigits i a) =
+        radixCode (kroneckerBounds mainDegree sideDegrees)
+          (kroneckerDigits i b) := by
+    simpa [kroneckerExponent, kroneckerExponentWith, kroneckerWeights,
+      weightedSum_weightScan _ _ 1 hla,
+      weightedSum_weightScan _ _ 1 hlb] using hcode
+  have hba : DigitsBounded (kroneckerBounds mainDegree sideDegrees)
+      (kroneckerDigits i a) := by
+    simp only [kroneckerBounds, kroneckerDigits, DigitsBounded]
+    exact ⟨ha.1, digitsBounded_map _ _ _ fun j _ => ha.2 j⟩
+  have hbb : DigitsBounded (kroneckerBounds mainDegree sideDegrees)
+      (kroneckerDigits i b) := by
+    simp only [kroneckerBounds, kroneckerDigits, DigitsBounded]
+    exact ⟨hb.1, digitsBounded_map _ _ _ fun j _ => hb.2 j⟩
+  have hdigits := radixCode_inj hba hbb hcode'
+  have hmain : Mono.degreeOf i a = Mono.degreeOf i b :=
+    (List.cons.inj hdigits).1
+  have hsides :
+      (List.finRange n).map
+          (fun j => Mono.degreeOf (remainingVar i j) a) =
+        (List.finRange n).map
+          (fun j => Mono.degreeOf (remainingVar i j) b) :=
+    (List.cons.inj hdigits).2
+  have hside (j : Fin n) :
+      Mono.degreeOf (remainingVar i j) a =
+        Mono.degreeOf (remainingVar i j) b :=
+    (List.map_inj_left.mp hsides) j (List.mem_finRange j)
+  apply Vector.ext
+  intro k hk
+  let j : Fin (n + 1) := ⟨k, hk⟩
+  change Mono.degreeOf j a = Mono.degreeOf j b
+  by_cases hji : j = i
+  · simpa [hji] using hmain
+  · have h := hside (remainingIndex i j hji)
+    simpa using h
+
+/-- Degree of the sparse Kronecker image with its weights already tabulated. -/
+def kroneckerDegreeWith (i : Fin (n + 1)) (weights : List Nat)
+    (p : MvPoly (n + 1) Int cmp) : Nat :=
+  p.foldTerms
+    (fun degree monomial _ =>
+      max degree (kroneckerExponentWith i weights monomial)) 0
 
 /-- Degree of the sparse Kronecker image, computed without materialising its
 dense zero gaps. -/
 def kroneckerDegree (i : Fin (n + 1)) (mainDegree : Nat)
     (sideDegrees : Fin n → Nat) (p : MvPoly (n + 1) Int cmp) : Nat :=
-  p.foldTerms
-    (fun degree monomial _ =>
-      max degree (kroneckerExponent i mainDegree sideDegrees monomial)) 0
+  kroneckerDegreeWith i (kroneckerWeights mainDegree sideDegrees) p
 
 /-- Squared Euclidean coefficient norm.  Mixed-radix injectivity means this is
 also the coefficient norm of the Kronecker image. -/
@@ -109,7 +273,8 @@ def coeffBound (inp : Input n cmp cmp') : Nat :=
   let mainDegree := MvPoly.degreeOf inp.setup.main shifted
   let sideDegrees : Fin n → Nat := fun j =>
     MvPoly.degreeOf (remainingVar inp.setup.main j) shifted
-  let degree := kroneckerDegree inp.setup.main mainDegree sideDegrees shifted
+  let weights := kroneckerWeights mainDegree sideDegrees
+  let degree := kroneckerDegreeWith inp.setup.main weights shifted
   Nat.binom degree (degree / 2) * ZPoly.ceilSqrt (mvCoeffNormSq shifted)
 
 /-! # Conditional completeness -/

--- a/HexMvHensel/CompleteTests.lean
+++ b/HexMvHensel/CompleteTests.lean
@@ -51,6 +51,24 @@ def dummyInput (point : Fin 1 → Int) (target : P) :
 #guard kroneckerWeight 1 (fun _ : Fin 1 => 2) 0 == 2
 #guard kroneckerWeight 1 (fun j : Fin 2 => if j.val = 0 then 2 else 3) 1 == 6
 
+/- The upper corner of the full degree box maps to one below its radix size. -/
+#guard kroneckerExponent 0 2
+    (fun j : Fin 2 => if j.val = 0 then 1 else 2) #v[2, 1, 2] == 17
+
+def noDegrees : Fin 0 → Nat := fun j => nomatch j
+
+/- With no side variables, the weight table is empty and the main exponent is
+unchanged. -/
+#guard kroneckerWeights 4 noDegrees == [1]
+#guard kroneckerExponent 0 4 noDegrees #v[4] == 4
+
+example (a b : Mono 1) (ha : Mono.degreeOf 0 a ≤ 4)
+    (hb : Mono.degreeOf 0 b ≤ 4)
+    (h : kroneckerExponent 0 4 noDegrees a =
+      kroneckerExponent 0 4 noDegrees b) : a = b :=
+  kroneckerExponent_inj 0 4 noDegrees
+    ⟨ha, fun j => nomatch j⟩ ⟨hb, fun j => nomatch j⟩ h
+
 /- Hence `x` and the first side variable receive distinct exponents. -/
 #guard kroneckerExponent 0 1 (fun _ : Fin 1 => 1) #v[1, 0] == 1
 #guard kroneckerExponent 0 1 (fun _ : Fin 1 => 1) #v[0, 1] == 2

--- a/HexMvHensel/SPEC/hex-mv-hensel.md
+++ b/HexMvHensel/SPEC/hex-mv-hensel.md
@@ -906,6 +906,21 @@ image has degree `(D + 1) · ∏_t (e_t + 1) - 1`, so the binomial factor in
 Mignotte's bound is astronomically large as soon as there are several
 variables.
 
+The executable computes the whole weight list in one prefix-product scan and
+passes it to `kroneckerExponentWith` for every sparse term; no term recomputes
+the earlier-radix product for each coordinate. The Mathlib-free fact used by
+the companion's coefficient-bound proof is:
+
+```lean
+def InDegreeBox (i : Fin (n+1)) (D : Nat) (e : Fin n → Nat)
+    (m : Mono (n+1)) : Prop
+
+theorem kroneckerExponent_inj (i : Fin (n+1)) (D : Nat)
+    (e : Fin n → Nat) {a b : Mono (n+1)}
+    (ha : InDegreeBox i D e a) (hb : InDegreeBox i D e b)
+    (h : kroneckerExponent i D e a = kroneckerExponent i D e b) : a = b
+```
+
 The one worth having is **Mahler's length inequality**, which bounds the
 product of the one-norms of the factors by `2^(D + Σ_t e_t)` times the
 one-norm of the shifted target, with the exponent linear in the sum of
@@ -1274,6 +1289,7 @@ def setLc      (i : Fin (n+1)) (cmp') : MvPoly n Int cmp' → MvPoly (n+1) Int c
 def seed       (i : Fin (n+1)) (cmp') : MvPoly n Int cmp' → ZPoly → MvPoly (n+1) Int cmp
 def witnessOf? (s : Setup n) (images : List ZPoly) : Option (List ZPoly)
 def coeffBound (inp : Input n cmp cmp') : Nat
+def InDegreeBox (i : Fin (n+1)) (D : Nat) (e : Fin n → Nat) (m : Mono (n+1)) : Prop
 
 -- Solving
 def solveUni     (q : Nat) (images witness : List ZPoly) (c : ZPoly) : List ZPoly
@@ -1316,6 +1332,7 @@ main variable, `d_j` the degree in non-main variable `j`, `t` terms in
 | `imageAt` | Horner per `x_i`-slice of the recursive view | `O(t · n)` coefficient operations |
 | `lcIn` | the top slice of `toUnivariate` | `O(n · t log t)` machine operations |
 | `truncate` | `restrictBy` on the exponent vector | `O(n · t)` machine operations |
+| `coeffBound` | one coordinate-degree pass, one mixed-radix weight scan shared across the sparse support, then one encoded-degree pass | `O(n · t)` exponent operations, plus arithmetic in the encoded degree and norm |
 | `witnessOf?` | one prefix/suffix complement pass, one `FpPoly` xgcd per factor, then `l` linear steps carrying their modulus | `O(r)` complement multiplications, `r` xgcds, and `r · l` divisions |
 | `solveUni` | `r` multiplications and remainders modulo `F_j` | `r` divisions of degree `d₁` |
 | `diophantine` at `m` variables | recursion, `d_m + 1` right-hand sides per level | `∏_{k ≤ m} (d_k + 1)` univariate solves |


### PR DESCRIPTION
## Summary

- precompute the complete mixed-radix weight table in one prefix scan
- reuse that table across every sparse term in the Kronecker degree calculation
- prove bounded-box injectivity of the corrected Kronecker encoding without Mathlib
- cover the upper-corner boundary and zero-side-variable cases
- document the reusable API and linear-in-support complexity

No new `sorry`, `axiom`, or `native_decide` is introduced; the four existing Phase-5 placeholders in `Complete.lean` are unchanged.

## Validation

- `lake build HexMvHensel.CompleteTests`
- `lake build HexMvHensel HexMvFactor HexReleaseTests` (9,392 targets)
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_phase4.py --base origin/main`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `python3 scripts/release/check_trust_surface.py`
- `git diff --check origin/main...HEAD`

Closes #9453