### PR TITLE
fix(mvgcd): preserve structural reduction in fallback

### DIFF
--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -608,8 +608,8 @@ def intBrownCert? {n : Nat} (cmp : Mono n → Mono n → Ordering)
         | some cert => brownCheckedCandidate? f h (brownOfZPoly cert.gcd)
   | _ + 2, _, _, f, h => intBrownModularCert? cfg f h
 
-/-- Generic routes 0--3 for integer coefficients above the delegated
-arity-one case. -/
+/-- Generic routes 1--3 for route-0-reduced integer coefficients above the
+delegated arity-one case. -/
 def intConcreteProposalGeneric {n : Nat}
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
@@ -617,15 +617,9 @@ def intConcreteProposalGeneric {n : Nat}
   match fast.cert? with
   | some _ => fast
   | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, fast.rand⟩
-      | some reduced =>
-          match intHeuristicCert? cfg reduced.left reduced.right with
-          | some cert =>
-              ⟨restoreStructural? f h reduced cert, fast.rand⟩
-          | none =>
-              let cert? := intBrownCert? cmp cfg reduced.left reduced.right
-              ⟨cert?.bind (restoreStructural? f h reduced), fast.rand⟩
+      match intHeuristicCert? cfg f h with
+      | some cert => ⟨some cert, fast.rand⟩
+      | none => ⟨intBrownCert? cmp cfg f h, fast.rand⟩
 
 /-- Concrete integer producer.  Arity one delegates immediately to the
 released dense integer kernel; other arities use the multivariate routes. -/
@@ -741,23 +735,16 @@ def ratIntegerLiftCert? {n : Nat}
     let nextCfg := { cfg with rand := run.rand }
     ratCheckedCandidate? nextCfg f h (intModelToRat run.cert.gcd)
 
-/-- Routes 0--3 for rational coefficients. -/
+/-- Rational routes on an already route-0-reduced problem. -/
 def ratConcreteProposal {n : Nat}
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n Rat cmp) : GcdProposal n Rat cmp :=
-  match structuralCert? f h with
-  | some cert => ⟨some cert, cfg.rand⟩
+  let lifted := ratIntegerLiftCert? cfg f h
+  match lifted.cert? with
+  | some _ => lifted
   | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, cfg.rand⟩
-      | some reduced =>
-          let lifted := ratIntegerLiftCert? cfg reduced.left reduced.right
-          match lifted.cert? with
-          | some cert => ⟨restoreStructural? f h reduced cert, lifted.rand⟩
-          | none =>
-              let nextCfg := { cfg with rand := lifted.rand }
-              let cert? := ratBrownCert? nextCfg reduced.left reduced.right
-              ⟨cert?.bind (restoreStructural? f h reduced), lifted.rand⟩
+      let nextCfg := { cfg with rand := lifted.rand }
+      ⟨ratBrownCert? nextCfg f h, lifted.rand⟩
 
 /-- Dense Brown route over an already-prime coefficient field. -/
 def primeFieldBrownCert? {n p : Nat} [hp : ZMod64.Bounds p]
@@ -769,7 +756,8 @@ def primeFieldBrownCert? {n p : Nat} [hp : ZMod64.Bounds p]
     ZMod64.ofNat p point
   brownFieldCert? cfg.brownPointFuel points f h
 
-/-- Routes 0--3 over a bundled prime field. -/
+/-- Routes 1 and 3 over a bundled prime field on an already route-0-reduced
+problem. -/
 def primeConcreteProposal {n p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p]
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
@@ -778,12 +766,7 @@ def primeConcreteProposal {n p : Nat} [hp : ZMod64.Bounds p]
   let earlier := primeFastProposal cmp cfg f h
   match earlier.cert? with
   | some _ => earlier
-  | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, earlier.rand⟩
-      | some reduced =>
-          let cert? := primeFieldBrownCert? cfg reduced.left reduced.right
-          ⟨cert?.bind (restoreStructural? f h reduced), earlier.rand⟩
+  | none => ⟨primeFieldBrownCert? cfg f h, earlier.rand⟩
 
 instance ratProducer : GcdProducer Rat where
   propose := fun cmp _ cfg f h => ratConcreteProposal cmp cfg f h

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -20,9 +20,22 @@ private abbrev Q2 := MvPoly 2 Rat Mono.lex
 private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   (ZMod64.primesBelow p 1)[0]?
 #guard (smallPrimeSupply 47 5).map (fun P => P.m) == [2, 3, 5, 7, 11]
+/-- State marker proving that a backend received the route-0-reduced pair used
+by the fallback reconstruction guards below. -/
+private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp] (f h : MvPoly n Int cmp) : Rand :=
+  if content f == 2 && content h == 3 &&
+      monoContent f == Mono.zero && monoContent h == Mono.zero then
+    Rand.ofSeed 9457
+  else
+    Rand.ofSeed 1
+
+@[instance_reducible] private def decliningProducer : GcdProducer Int where
+  propose := fun _ _ _ f h => ⟨none, observedRand f h⟩
+
 @[instance_reducible] private def rejectingProducer : GcdProducer Int where
   propose := fun _ _ _ f h =>
-    ⟨some (.mk 1 f h .unit), Rand.ofSeed 99⟩
+    ⟨some (.mk 1 f h .unit), observedRand f h⟩
 #guard checkGcd (0 : P0) 0 (rawPrsCert 0 0)
 #guard
   let f : P0 := C 12
@@ -52,7 +65,12 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   let f := common * (x + 2)
   let h := common * (y + 3)
   checkGcd f h (rawPrsCert f h)
-#guard (fastProposal GcdConfig.default (0 : P1) 0).cert?.isSome
+#guard (structuralCert? (0 : P1) 0).isSome
+#guard
+  letI : GcdProducer Int := rejectingProducer
+  let cfg := { GcdConfig.default with rand := Rand.ofSeed 17 }
+  let run := gcdCertWith cfg (0 : P1) 0
+  checkGcd 0 0 run.cert && run.rand == cfg.rand
 #guard
   let x : P1 := X 0
   (intTryCoprimeCert? 8 (Rand.ofSeed 0) (x + 1) (x + 2)).1.isSome
@@ -70,10 +88,13 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   let y : P2 := X 1
   let f := C 6 * x * y * (x + 1)
   let h := C 9 * x * y * (y + 1)
-  let run := intFastProposal GcdConfig.default f h
-  match run.cert? with
-  | some cert => checkGcd f h cert && cert.gcd == C 3 * x * y
+  match structuralReduction? f h with
   | none => false
+  | some reduced =>
+      let run := intFastProposal GcdConfig.default reduced.left reduced.right
+      match run.cert?.bind (restoreStructural? f h reduced) with
+      | some cert => checkGcd f h cert && cert.gcd == C 3 * x * y
+      | none => false
 #guard
   let x : P1 := X 0
   let common := x + 1
@@ -108,13 +129,27 @@ private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   let h := x + 5
   (checkedCandidate? f h (intHeuristicCandidateAt f h 5)).isNone
 #guard
-  letI : GcdProducer Int := rejectingProducer
-  let x : P1 := X 0
+  letI : GcdProducer Int := decliningProducer
+  let x : P2 := X 0
+  let y : P2 := X 1
   let common := x + 1
-  let f := common * (x + 2)
-  let h := common * (x + 3)
+  let f := C 6 * x * y * common * (x + 2)
+  let h := C 9 * x * y * common * (y + 3)
   let run := gcdCertWith GcdConfig.default f h
-  checkGcd f h run.cert && run.rand == Rand.ofSeed 99
+  checkGcd f h run.cert &&
+    run.cert.gcd == C 3 * x * y * common &&
+    run.rand == Rand.ofSeed 9457
+#guard
+  letI : GcdProducer Int := rejectingProducer
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let common := x + 1
+  let f := C 6 * x * y * common * (x + 2)
+  let h := C 9 * x * y * common * (y + 3)
+  let run := gcdCertWith GcdConfig.default f h
+  checkGcd f h run.cert &&
+    run.cert.gcd == C 3 * x * y * common &&
+    run.rand == Rand.ofSeed 9457
 #guard
   let state : BrownPointState :=
     { bestDegree? := some 2, accepted := 3 }

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -66,6 +66,10 @@ structure GcdProposal (n : Nat) (R : Type u) [Zero R]
   cert? : Option (GcdCert n R cmp)
   rand : Rand
 
+/-- Coefficient-specific routes after the public dispatcher has removed the
+mandatory route-0 factor.  Implementations must treat their two polynomial
+arguments as the already-reduced problem and must not repeat structural
+reduction. -/
 class GcdProducer (R : Type u) [Zero R] where
   propose : {n : Nat} → (cmp : Mono n → Mono n → Ordering) →
     [IsMonomialOrder cmp] → GcdConfig →
@@ -77,24 +81,6 @@ class GcdProducer (R : Type u) [Zero R] where
 
 instance (priority := 10) instNoFastProducer {R : Type u} [Zero R] :
     GcdProducer R := noFastProducer
-
-/-- Complete checked dispatch. Proposals affect performance and random state,
-but rejection always falls through to the deterministic PRS route.  This
-plumbing lives below the concrete producers so one coefficient backend can
-invoke another without creating an import cycle. -/
-def gcdCertWith (cfg : GcdConfig)
-    {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
-    [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
-    [GcdProducer R]
-    (f h : MvPoly n R cmp) : GcdRun n R cmp :=
-  let proposal := GcdProducer.propose cmp cfg f h
-  match proposal.cert? with
-  | some candidate =>
-      if checkGcd f h candidate then ⟨candidate, proposal.rand⟩
-      else ⟨prsCert f h, proposal.rand⟩
-  | none => ⟨prsCert f h, proposal.rand⟩
 
 /-- Route 0: zero and unit cases, all represented by genuine replayable
 certificates. -/
@@ -153,6 +139,44 @@ def restoreStructural? {n : Nat} {R : Type u}
   let restored := GcdCert.mk (reduced.factor * cert.gcd)
     cert.cofL cert.cofR cert.coprime
   if checkGcd f h restored then some restored else none
+
+/-- Complete checked dispatch. Route 0 is computed once before coefficient
+dispatch. Proposals affect performance and random state, but rejection always
+falls through to route 4 on the reduced problem and is reconstructed through
+the same checker gate.  This plumbing lives below the concrete producers so
+one coefficient backend can invoke another without creating an import cycle. -/
+def gcdCertWith (cfg : GcdConfig)
+    {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (f h : MvPoly n R cmp) : GcdRun n R cmp :=
+  match structuralCert? f h with
+  | some cert =>
+      if checkGcd f h cert then ⟨cert, cfg.rand⟩
+      else ⟨prsCert f h, cfg.rand⟩
+  | none =>
+      match structuralReduction? f h with
+      | none => ⟨prsCert f h, cfg.rand⟩
+      | some reduced =>
+          -- The unreduced PRS arm is a fail-closed response to a violated
+          -- reduction/restoration invariant, not an ordinary fallback route.
+          let fallback (rand : Rand) : GcdRun n R cmp :=
+            let cert := prsCert reduced.left reduced.right
+            match restoreStructural? f h reduced cert with
+            | some restored => ⟨restored, rand⟩
+            | none => ⟨prsCert f h, rand⟩
+          let proposal := GcdProducer.propose cmp cfg reduced.left reduced.right
+          match proposal.cert? with
+          | some candidate =>
+              if checkGcd reduced.left reduced.right candidate then
+                match restoreStructural? f h reduced candidate with
+                | some restored => ⟨restored, proposal.rand⟩
+                | none => fallback proposal.rand
+              else
+                fallback proposal.rand
+          | none => fallback proposal.rand
 
 /-- Offer an arbitrary nonzero polynomial candidate to the full multivariate
 checker.  Exact division builds cofactors and route 4 supplies their
@@ -297,19 +321,12 @@ def intTryCoprimeCert? {n : Nat}
   let supply := smallPrimeSupply 47 primeFuel
   intCoprimeLoop f h supply primeFuel rand
 
-/-- Integer routes 0--1. -/
+/-- Integer route 1 on an already route-0-reduced problem. -/
 def intFastProposal {n : Nat}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
-  match structuralCert? f h with
-  | some cert => ⟨some cert, cfg.rand⟩
-  | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, cfg.rand⟩
-      | some reduced =>
-          let run := intTryCoprimeCert? cfg.brownPrimeFuel cfg.rand
-            reduced.left reduced.right
-          ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+  let run := intTryCoprimeCert? cfg.brownPrimeFuel cfg.rand f h
+  ⟨run.1, run.2⟩
 
 /-! # Concrete finite-field coefficient homomorphisms -/
 
@@ -341,47 +358,35 @@ def fpCoeffHom {p : Nat} [hp : ZMod64.Bounds p]
       intro f h
       simpa only [← DensePoly.eval_eq_evalImpl] using FpPoly.eval_mul f h point }
 
-/-- Routes 0--1 over a fixed bounded prime field. -/
+/-- Route 1 over a fixed bounded prime field on an already route-0-reduced
+problem. -/
 def primeFastProposal {n p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p]
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n (@ZMod64 p hp) cmp) :
     GcdProposal n (@ZMod64 p hp) cmp :=
-  match structuralCert? f h with
-  | some cert => ⟨some cert, cfg.rand⟩
-  | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, cfg.rand⟩
-      | some reduced =>
-          let P : ZMod64.Prime :=
-            { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
-          let run := tryCoprimeCert? P primeCoeffHom cfg.rand
-            reduced.left reduced.right
-          ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+  let P : ZMod64.Prime :=
+    { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
+  let run := tryCoprimeCert? P primeCoeffHom cfg.rand f h
+  ⟨run.1, run.2⟩
 
-/-- Routes 0--1 for `FpPoly` coefficients.  One random field point defines
-the total evaluation homomorphism carried by the certificate; subsequent
-draws are used for the multivariate image points. -/
+/-- Route 1 for `FpPoly` coefficients on an already route-0-reduced problem.
+One random field point defines the total evaluation homomorphism carried by
+the certificate; subsequent draws are used for the multivariate image
+points. -/
 def fpFastProposal {n p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p]
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n (@FpPoly p hp) cmp) :
     GcdProposal n (@FpPoly p hp) cmp :=
-  match structuralCert? f h with
-  | some cert => ⟨some cert, cfg.rand⟩
-  | none =>
-      match structuralReduction? f h with
-      | none => ⟨none, cfg.rand⟩
-      | some reduced =>
-          let P : ZMod64.Prime :=
-            { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
-          match cfg.rand.nat p 8 with
-          | .error error => ⟨none, randErrorState cfg.rand error⟩
-          | .ok (value, rand') =>
-              let point := ZMod64.ofNat p value
-              let run := tryCoprimeCert? P (fpCoeffHom point) rand'
-                reduced.left reduced.right
-              ⟨run.1.bind (restoreStructural? f h reduced), run.2⟩
+  let P : ZMod64.Prime :=
+    { m := p, bounds := hp, prime := ZMod64.PrimeModulus.prime }
+  match cfg.rand.nat p 8 with
+  | .error error => ⟨none, randErrorState cfg.rand error⟩
+  | .ok (value, rand') =>
+      let point := ZMod64.ofNat p value
+      let run := tryCoprimeCert? P (fpCoeffHom point) rand' f h
+      ⟨run.1, run.2⟩
 
 /-! Sampling pins: a non-power-of-two modulus gets one bounded draw per
 coordinate, with deterministic values and exactly the corresponding advanced
@@ -395,17 +400,15 @@ state. -/
       [points 0 |>.toNat, points 1 |>.toNat, points 2 |>.toNat] == [4, 3, 1] &&
         rand.state == (Rand.ofSeed 17).next.2.next.2.next.2.state
 
-/-- Coefficient-generic structural proposal.  Route 1 needs an explicit
-total `CoeffHom`, so concrete coefficient backends add it after this common
-route-0 pass. -/
+/-- Coefficient-generic post-structural proposal.  Route 1 needs an explicit
+total `CoeffHom`, so an abstract coefficient backend has no candidate after
+the public route-0 pass. -/
 def fastProposal {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [BezoutOps R] [LawfulGcdOps R]
-    (cfg : GcdConfig) (f h : MvPoly n R cmp) : GcdProposal n R cmp :=
-  match structuralCert? f h with
-  | some cert => ⟨some cert, cfg.rand⟩
-  | none => ⟨none, cfg.rand⟩
+    (cfg : GcdConfig) (_f _h : MvPoly n R cmp) : GcdProposal n R cmp :=
+  ⟨none, cfg.rand⟩
 
 end Hex.MvPoly


### PR DESCRIPTION
Closes #9457.

## Summary

- compute mandatory route-0 zero/unit and scalar/monomial reductions once in the checked dispatcher
- pass only the reduced problem to coefficient backends and deterministic PRS fallback, then replay structural reconstruction against the original inputs
- remove duplicate structural passes from integer, rational, finite-field, and polynomial-coefficient proposals while preserving random-state threading
- add route guards for immediate structural bypass, deliberate proposal decline, rejected candidates, and reconstructed scalar/monomial factors

## Validation

- `lake build HexMvGcd.Eval`
- `lake build HexMvGcd HexMvHensel HexMvFactor`
- `lake build HexConformance` (9,645 jobs)
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/conformance_targets.py --check`
- `git diff --check origin/main...HEAD`
- no added `sorry`, `axiom`, or `native_decide`