### PR TITLE
feat(modular): prove CRT loop provenance

### DIFF
--- a/HexModular.lean
+++ b/HexModular.lean
@@ -10,6 +10,7 @@ public import HexModular.Crt
 public import HexModular.Euclid
 public import HexModular.KernelTests
 public import HexModular.Loop
+public import HexModular.LoopTests
 public import HexModular.Recon
 public import HexModular.SymMod
 

--- a/HexModular/Loop.lean
+++ b/HexModular/Loop.lean
@@ -17,6 +17,41 @@ namespace Hex
 
 namespace Modular
 
+/-- Reachability through an exact prefix of the modulus supply.  Rejected
+images and failed CRT pushes advance the prefix without changing the state;
+successful pushes retain the equality consumed by the CRT congruence lemmas. -/
+inductive CrtTrace (image : Nat → Option (Vector Int k)) (supply : Array Nat) :
+    Nat → CrtVec k → Prop where
+  | init : CrtTrace image supply 0 (CrtVec.init k)
+  | skip {index : Nat} {state : CrtVec k}
+      (trace : CrtTrace image supply index state)
+      (hi : index < supply.size)
+      (himage : image supply[index] = none) :
+      CrtTrace image supply (index + 1) state
+  | reject {index : Nat} {state : CrtVec k}
+      (trace : CrtTrace image supply index state)
+      (hi : index < supply.size) {residues : Vector Int k}
+      (himage : image supply[index] = some residues)
+      (hpush : state.push residues supply[index] = none) :
+      CrtTrace image supply (index + 1) state
+  | push {index : Nat} {state next : CrtVec k}
+      (trace : CrtTrace image supply index state)
+      (hi : index < supply.size) {residues : Vector Int k}
+      (himage : image supply[index] = some residues)
+      (hpush : state.push residues supply[index] = some next) :
+      CrtTrace image supply (index + 1) next
+
+/-- A traced state has consumed no more than the available supply. -/
+theorem CrtTrace.le_size {image : Nat → Option (Vector Int k)}
+    {supply : Array Nat} {consumed : Nat} {state : CrtVec k}
+    (trace : CrtTrace image supply consumed state) :
+    consumed ≤ supply.size := by
+  induction trace with
+  | init => simp
+  | skip _ hi _ ih => omega
+  | reject _ hi _ _ ih => omega
+  | push _ hi _ _ ih => omega
+
 /-- Consume the remaining supply entries, skipping rejected images and
 non-coprime moduli and testing `accept` only after a successful CRT push. -/
 private def crtLoop.go (image : Nat → Option (Vector Int k))
@@ -48,36 +83,67 @@ def crtLoop (image : Nat → Option (Vector Int k))
     Option α :=
   crtLoop.go image accept supply fuel 0 (CrtVec.init k)
 
+/-- A successful loop result is accepted on a state reached by replaying the
+exact consumed supply prefix.  The consumed prefix is nonempty because the
+loop tests `accept` only after a successful push, and it cannot exceed fuel. -/
+theorem crtLoop_trace {image : Nat → Option (Vector Int k)}
+    {accept : CrtVec k → Option α} {supply : Array Nat} {fuel : Nat} {x : α}
+    (h : crtLoop image accept supply fuel = some x) :
+    ∃ consumed state,
+      0 < consumed ∧ consumed ≤ fuel ∧ consumed ≤ supply.size ∧
+        CrtTrace image supply consumed state ∧ accept state = some x := by
+  have go : ∀ (remaining index : Nat) (state : CrtVec k),
+      CrtTrace image supply index state →
+      crtLoop.go image accept supply remaining index state = some x →
+        ∃ consumed state',
+          index < consumed ∧ consumed ≤ index + remaining ∧
+            CrtTrace image supply consumed state' ∧ accept state' = some x := by
+    intro remaining
+    induction remaining with
+    | zero =>
+        intro index state trace h
+        simp [crtLoop.go] at h
+    | succ remaining ih =>
+        intro index state trace h
+        unfold crtLoop.go at h
+        simp only [Nat.succ_ne_zero, ↓reduceDIte] at h
+        split at h
+        · rename_i hi
+          split at h
+          · rename_i himage
+            obtain ⟨consumed, state', hindex, hbound, htrace, haccept⟩ :=
+              ih (index + 1) state (trace.skip hi himage) h
+            exact ⟨consumed, state', by omega, by omega, htrace, haccept⟩
+          · rename_i residues himage
+            split at h
+            · rename_i hpush
+              obtain ⟨consumed, state', hindex, hbound, htrace, haccept⟩ :=
+                ih (index + 1) state (trace.reject hi himage hpush) h
+              exact ⟨consumed, state', by omega, by omega, htrace, haccept⟩
+            · rename_i next hpush
+              split at h
+              · rename_i result haccept
+                cases h
+                exact ⟨index + 1, next, by omega, by omega,
+                  trace.push hi himage hpush, haccept⟩
+              · rename_i haccept
+                obtain ⟨consumed, state', hindex, hbound, htrace, haccept'⟩ :=
+                  ih (index + 1) next (trace.push hi himage hpush) h
+                exact ⟨consumed, state', by omega, by omega, htrace, haccept'⟩
+        · contradiction
+  obtain ⟨consumed, state, hpos, hfuel, trace, haccept⟩ :=
+    go fuel 0 (CrtVec.init k) .init h
+  exact ⟨consumed, state, hpos, by simpa using hfuel, trace.le_size,
+    trace, haccept⟩
+
 /-- Every successful loop result was returned by `accept` on some accumulated
 CRT state; the loop itself never manufactures a caller result. -/
 theorem crtLoop_of_some {image : Nat → Option (Vector Int k)}
     {accept : CrtVec k → Option α} {supply : Array Nat} {fuel : Nat} {x : α}
     (h : crtLoop image accept supply fuel = some x) :
     ∃ state, accept state = some x := by
-  have go : ∀ (remaining index : Nat) (state : CrtVec k),
-      crtLoop.go image accept supply remaining index state = some x →
-        ∃ state, accept state = some x := by
-    intro remaining
-    induction remaining with
-    | zero =>
-        intro index state h
-        simp [crtLoop.go] at h
-    | succ remaining ih =>
-        intro index state h
-        unfold crtLoop.go at h
-        simp only [Nat.succ_ne_zero, ↓reduceDIte] at h
-        split at h
-        · split at h
-          · exact ih _ _ h
-          · split at h
-            · exact ih _ _ h
-            · split at h
-              · rename_i result next hnext
-                cases h
-                exact ⟨_, by assumption⟩
-              · exact ih _ _ h
-        · contradiction
-  exact go fuel 0 (CrtVec.init k) h
+  obtain ⟨_, state, _, _, _, _, haccept⟩ := crtLoop_trace h
+  exact ⟨state, haccept⟩
 
 end Modular
 

--- a/HexModular/LoopTests.lean
+++ b/HexModular/LoopTests.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexModular.Loop
+public import HexModular.Loop
+
+public section
+
+/-! Focused conformance cases for the fuelled CRT loop. -/
+
+namespace Hex.Modular.LoopTests
+
+private def ones (_modulus : Nat) : Option (Vector Int 1) :=
+  some (Vector.replicate 1 1)
+
+private def skipTwo (modulus : Nat) : Option (Vector Int 1) :=
+  if modulus = 2 then none else ones modulus
+
+private def acceptModulus (target : Nat) (state : CrtVec 1) : Option Nat :=
+  if state.modulus = target then some state.modulus else none
+
+-- The first successful push may be accepted immediately.
+#guard crtLoop ones (acceptModulus 3) #[3] 1 == some 3
+
+-- Rejected reconstructions keep accumulating successful pushes.
+#guard crtLoop ones (acceptModulus 15) #[3, 5] 2 == some 15
+
+-- Missing images and non-coprime pushes consume supply entries without
+-- entering the accumulated state.
+#guard crtLoop skipTwo (acceptModulus 15) #[2, 3, 6, 5] 4 == some 15
+
+-- Fuel exhaustion is an ordinary failure and does not inspect later supply.
+#guard (crtLoop skipTwo (acceptModulus 15) #[2, 3, 6, 5] 3).isNone
+
+/-- The public provenance theorem instantiates on the skip/reject route. -/
+example (h : crtLoop skipTwo (acceptModulus 15) #[2, 3, 6, 5] 4 = some 15) :
+    ∃ consumed state,
+      0 < consumed ∧ consumed ≤ 4 ∧ consumed ≤ #[2, 3, 6, 5].size ∧
+        CrtTrace skipTwo #[2, 3, 6, 5] consumed state ∧
+          acceptModulus 15 state = some 15 :=
+  crtLoop_trace h
+
+/-- The equality retained by a push trace step feeds the public CRT facts
+without reconstructing or trusting the producer's residues. -/
+example {state next : CrtVec 1} {residues : Vector Int 1} {modulus divisor : Nat}
+    (hd : divisor ∣ state.modulus)
+    (hpush : state.push residues modulus = some next) :
+    next.modulus = state.modulus * modulus ∧
+      (∀ i : Fin 1, next.value[i] % (modulus : Int) = residues[i] % (modulus : Int)) ∧
+      (∀ i : Fin 1, next.value[i] % (divisor : Int) = state.value[i] % (divisor : Int)) :=
+  ⟨CrtVec.push_modulus hpush, CrtVec.push_congr_new hpush,
+    CrtVec.push_congr_old hd hpush⟩
+
+end Hex.Modular.LoopTests


### PR DESCRIPTION
Closes #9445.

## Summary

- add `CrtTrace`, an exact consumed-prefix trace that distinguishes skipped images, rejected CRT pushes, and successful pushes
- prove `crtLoop_trace` sorry-free, including positive consumed length and fuel/supply bounds, while preserving `crtLoop_of_some`
- retain each successful `CrtVec.push` equality so downstream proofs compose directly with `push_modulus`, `push_congr_new`, and `push_congr_old`
- compile focused cases for immediate acceptance, multiple pushes, skipped/rejected images, and fuel exhaustion

The SPEC describes a future oracle-backed `conformance/HexModular` package, but that package does not exist in the current tree. These loop-specific cases therefore live in the dedicated compiled `HexModular.LoopTests` module and are imported by the existing development umbrella, rather than introducing an unrelated oracle/CI surface.

## Validation

- `lake build HexModular` (68 jobs)
- `lake build HexModular HexMvGcd HexMvHensel HexMvFactor` (539 jobs)
- `lake build HexReleaseTests HexReleaseExamples HexAggregateCheck` (9,434 jobs)
- `python3 scripts/check_dag.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/release/check_trust_surface.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_phase4.py`
- `git diff --check origin/main...HEAD`
- added-line scan for `sorry`, `axiom`, and `native_decide`
