### PR TITLE
feat(mvhensel): expose stage invariant laws

### DIFF
--- a/HexMvHensel/Lift.lean
+++ b/HexMvHensel/Lift.lean
@@ -61,6 +61,35 @@ def applyCorrections? (q : Nat) (i : Fin (n + 1))
       some ((f + correction) :: tail)
   | _, _ => none
 
+/-- Two shifted factors have the same image, selected-variable leading
+coefficient, and selected-variable degree. -/
+def SameFrame (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (f g : MvPoly (n + 1) Int cmp) : Prop :=
+  imageAt i cmp' (fun _ => 0) g = imageAt i cmp' (fun _ => 0) f ∧
+  lcIn i cmp' g = lcIn i cmp' f ∧
+  MvPoly.degreeOf i g = MvPoly.degreeOf i f
+
+/-- A positive power in a non-main variable and a lower-main-degree
+correction preserve every factor's shifted image, leading coefficient, and
+main-variable degree. This is the exact preservation fact used by the stage
+loop after truncation and symmetric reduction. -/
+theorem applyCorrections_frame {q : Nat} {i : Fin (n + 1)}
+    {d : Fin n → Nat} {selected : Fin (n + 1)} {power : Nat}
+    {factors deltas updated : List (MvPoly (n + 1) Int cmp)}
+    (hselected : ∃ y : Fin n, selected = remainingVar i y)
+    (hpower : 0 < power)
+    (hlength : factors.length = deltas.length)
+    (hdegree : ∀ j, j < factors.length →
+      MvPoly.degreeOf i (deltas.getD j 0) <
+        MvPoly.degreeOf i (factors.getD j 0))
+    (happly : applyCorrections? q i d selected power factors deltas =
+      some updated) :
+    updated.length = factors.length ∧
+      ∀ j, j < factors.length →
+        SameFrame i cmp' (factors.getD j 0) (updated.getD j 0) := by
+  sorry
+
 /-- Lift through every power of one non-main variable. -/
 def liftStage (q : Nat) (i : Fin (n + 1))
     (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
@@ -108,6 +137,64 @@ def liftShifted? (inp : Input n cmp cmp') :
     MvPoly.degreeOf (remainingVar i j) shiftedTarget
   liftStages inp.setup.modulus i cmp' d inp.images inp.witness
     shiftedTarget shiftedLeading initial
+
+/-! # Stage invariant -/
+
+/-- The state carried between EEZ stages. It records exactly the facts used
+at the next `diophantinePrefix` call: fixed image and main degree, installed
+leading prefix, absence of future variables, and the product equation through
+the completed prefix. -/
+def IsStage (inp : Input n cmp cmp') (count : Nat)
+    (factors : List (MvPoly (n + 1) Int cmp)) : Prop :=
+  let i := inp.setup.main
+  let shiftedTarget := shift i inp.setup.point inp.target
+  let shiftedLeading := inp.leading.map (shiftAll inp.setup.point)
+  let d : Fin n → Nat := fun j =>
+    MvPoly.degreeOf (remainingVar i j) shiftedTarget
+  factors.length = inp.images.length ∧
+  (∀ j, j < inp.images.length →
+    imageAt i cmp' (fun _ => 0) (factors.getD j 0) =
+      inp.images.getD j 0) ∧
+  (∀ j, j < inp.images.length →
+    lcIn i cmp' (factors.getD j 0) =
+      prefixVars count (shiftedLeading.getD j 0)) ∧
+  (∀ j, j < inp.images.length →
+    MvPoly.degreeOf i (factors.getD j 0) =
+      (inp.images.getD j 0).degree?.getD 0) ∧
+  (∀ j, j < inp.images.length →
+    prefixNonMain i count (factors.getD j 0) = factors.getD j 0) ∧
+  BoxCongr i d inp.setup.modulus (mvProduct factors)
+    (prefixNonMain i count shiftedTarget)
+
+/-- Valid seeds establish the stage-zero invariant. -/
+theorem seedTuple_stage {inp : Input n cmp cmp'} (h : valid inp = true) :
+    ∃ initial,
+      seedTuple? inp.setup.main cmp' inp.images
+          (inp.leading.map (shiftAll inp.setup.point)) = some initial ∧
+        IsStage inp 0 initial := by
+  sorry
+
+/-- The stage invariant makes every internal diophantine solve reachable and
+is preserved while one more non-main variable is introduced. -/
+theorem liftStage_spec {inp : Input n cmp cmp'} (h : valid inp = true)
+    (y : Fin n) {factors : List (MvPoly (n + 1) Int cmp)}
+    (hstage : IsStage inp y.val factors) :
+    let i := inp.setup.main
+    let shiftedTarget := shift i inp.setup.point inp.target
+    let shiftedLeading := inp.leading.map (shiftAll inp.setup.point)
+    let d : Fin n → Nat := fun j =>
+      MvPoly.degreeOf (remainingVar i j) shiftedTarget
+    ∃ next,
+      liftStage inp.setup.modulus i cmp' d inp.images inp.witness
+          shiftedTarget shiftedLeading y factors = some next ∧
+        IsStage inp (y.val + 1) next := by
+  sorry
+
+/-- Consequently a valid input cannot take the partial `none` branch while
+building shifted factors. -/
+theorem liftShifted_some {inp : Input n cmp cmp'} (h : valid inp = true) :
+    ∃ shifted, liftShifted? inp = some shifted ∧ IsStage inp n shifted := by
+  sorry
 
 /-- Return from shifted coordinates to the caller's coordinates. -/
 def reconstruct (i : Fin (n + 1)) (point : Fin n → Int)

--- a/HexMvHensel/LiftTests.lean
+++ b/HexMvHensel/LiftTests.lean
@@ -35,6 +35,11 @@ open Hex
 open Hex.MvPoly
 open scoped Hex
 
+#check applyCorrections_frame
+#check seedTuple_stage
+#check liftStage_spec
+#check liftShifted_some
+
 def prime5 : ZMod64.Prime where
   m := 5
   bounds := { pPos := by omega, pLtR := by decide }

--- a/HexMvHensel/SPEC/hex-mv-hensel.md
+++ b/HexMvHensel/SPEC/hex-mv-hensel.md
@@ -563,6 +563,24 @@ theorem lcIn_seed     (hF : F.size ≠ 0) (h : L ≠ 0) :
 theorem degreeOf_seed (h : L ≠ 0) : degreeOf i (seed i cmp' L F) = F.degree
 ```
 
+The corresponding assignment and prefix laws are public because the stage
+proof must use the executable operations without re-expanding their sparse
+representations:
+
+```lean
+theorem lcIn_setLc (hL : L ≠ 0) : lcIn i cmp' (setLc i cmp' L p) = L
+theorem degreeOf_setLc (hL : L ≠ 0) :
+    degreeOf i (setLc i cmp' L p) = degreeOf i p
+theorem imageAt_setLc
+    (hL : eval a L = eval a (lcIn i cmp' p)) :
+    imageAt i cmp' a (setLc i cmp' L p) = imageAt i cmp' a p
+theorem prefixVars_min :
+    prefixVars a (prefixVars b p) = prefixVars (min a b) p
+theorem prefixNonMain_min :
+    prefixNonMain i a (prefixNonMain i b p) =
+      prefixNonMain i (min a b) p
+```
+
 The hypothesis on the first is exactly V4's second condition.  The nonzero
 image hypothesis on `lcIn_seed` is essential: `seed` deliberately returns
 zero at `F = 0`, so `F = 0` and `L = 1` would refute the version without it.
@@ -724,6 +742,11 @@ theorem solveUni_unique (h : valid inp = true)
     (hτ : ∀ j, (τ j).degree < (F j).degree)
     (hsum : Σ_j τ j * b_j ≡ c (mod q)) :
     ∀ j, τ j ≡ (solveUni q images witness c)[j]  (mod q)
+theorem solveUni_eq
+    (hτ : ∀ j, (τ j).degree < (F j).degree)
+    (hsum : Σ_j τ j * b_j ≡ c (mod q))
+    (hcanonical : ∀ j, UniSymCanonical q (τ j)) :
+    ∀ j, τ j = (solveUni q images witness c)[j]
 ```
 
 **Uniqueness is modulo `q`, and it cannot be an equality of `ZPoly`
@@ -805,6 +828,36 @@ run the same full-box equation and degree checks after producing a tuple;
 omitting a variable that is actually needed can therefore cause `none`, but
 cannot produce an unchecked answer. In particular, later degree bounds do
 not create vacuous recursive correction loops in an earlier stage.
+
+The production proof surface packages the induction state rather than asking
+callers to reconstruct it from the loop body. `IsStage inp t factors` records
+tuple length, exact univariate images, the installed leading prefix, exact
+main-variable degrees, absence of variables after prefix `t`, and the box
+congruence for the completed target prefix. The executable preservation laws
+are:
+
+```lean
+def SameFrame (i) (cmp') (f g : MvPoly (n+1) Int cmp) : Prop
+def IsStage (inp : Input n cmp cmp') (count : Nat)
+    (factors : List (MvPoly (n+1) Int cmp)) : Prop
+
+theorem applyCorrections_frame ... :
+    updated.length = factors.length ∧
+      ∀ j, SameFrame i cmp' factors[j] updated[j]
+theorem seedTuple_stage (h : valid inp = true) :
+    ∃ initial, seedTuple? ... = some initial ∧ IsStage inp 0 initial
+theorem liftStage_spec (h : valid inp = true)
+    (hstage : IsStage inp y.val factors) :
+    ∃ next, liftStage ... y factors = some next ∧
+      IsStage inp (y.val + 1) next
+theorem liftShifted_some (h : valid inp = true) :
+    ∃ shifted, liftShifted? inp = some shifted ∧ IsStage inp n shifted
+```
+
+Thus `none` remains meaningful for malformed direct calls to the public
+diophantine solver, but is unreachable along a valid lift. In particular,
+the stage theorem supplies the right-hand-side degree bound and both base
+hypotheses (`hb` and `hbdeg`) at the exact call site.
 
 This is the same linear scheme as the stage loop one level down, which is
 why the two share `BoxCongr` and the truncation bookkeeping.
@@ -1310,6 +1363,8 @@ def seed       (i : Fin (n+1)) (cmp') : MvPoly n Int cmp' → ZPoly → MvPoly (
 def witnessOf? (s : Setup n) (images : List ZPoly) : Option (List ZPoly)
 def coeffBound (inp : Input n cmp cmp') : Nat
 def InDegreeBox (i : Fin (n+1)) (D : Nat) (e : Fin n → Nat) (m : Mono (n+1)) : Prop
+def IsStage    (inp : Input n cmp cmp') (count : Nat)
+               (factors : List (MvPoly (n+1) Int cmp)) : Prop
 
 -- Solving
 def solveUni     (q : Nat) (images witness : List ZPoly) (c : ZPoly) : List ZPoly

--- a/HexMvHensel/Seed.lean
+++ b/HexMvHensel/Seed.lean
@@ -110,6 +110,50 @@ def prefixNonMain (i : Fin (n + 1)) (count : Nat)
     decide (∀ j : Fin n, count ≤ j.val →
       Mono.degreeOf (remainingVar i j) m = 0)
 
+/-! # Leading-coefficient and prefix laws -/
+
+/-- Installing a nonzero top coefficient makes it the exact leading
+coefficient in the selected variable. -/
+theorem lcIn_setLc (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (p : MvPoly (n + 1) Int cmp)
+    (hL : L ≠ 0) :
+    lcIn i cmp' (setLc i cmp' L p) = L := by
+  sorry
+
+/-- Installing a nonzero top coefficient preserves the selected-variable
+degree, including the degree-zero case. -/
+theorem degreeOf_setLc (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (L : MvPoly n Int cmp') (p : MvPoly (n + 1) Int cmp)
+    (hL : L ≠ 0) :
+    MvPoly.degreeOf i (setLc i cmp' L p) = MvPoly.degreeOf i p := by
+  sorry
+
+/-- Replacing the top slice preserves an image whenever the replacement has
+the same value at the image point. -/
+theorem imageAt_setLc (i : Fin (n + 1))
+    (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
+    (a : Fin n → Int) (L : MvPoly n Int cmp')
+    (p : MvPoly (n + 1) Int cmp)
+    (hL : MvPoly.eval a L = MvPoly.eval a (lcIn i cmp' p)) :
+    imageAt i cmp' a (setLc i cmp' L p) = imageAt i cmp' a p := by
+  sorry
+
+/-- Repeated coordinate prefixes retain exactly the smaller prefix. -/
+theorem prefixVars_min {k : Nat}
+    {order : Mono k → Mono k → Ordering} [IsMonomialOrder order]
+    (a b : Nat) (p : MvPoly k Int order) :
+    prefixVars a (prefixVars b p) = prefixVars (min a b) p := by
+  sorry
+
+/-- Repeated non-main prefixes retain exactly the smaller prefix. -/
+theorem prefixNonMain_min (i : Fin (n + 1)) (a b : Nat)
+    (p : MvPoly (n + 1) Int cmp) :
+    prefixNonMain i a (prefixNonMain i b p) =
+      prefixNonMain i (min a b) p := by
+  sorry
+
 /-- Build all seeds without any default indexing or prefix truncation. -/
 def seedTuple? (i : Fin (n + 1))
     (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp'] :

--- a/HexMvHensel/SeedTests.lean
+++ b/HexMvHensel/SeedTests.lean
@@ -24,6 +24,12 @@ open Hex
 open Hex.MvPoly
 open scoped Hex
 
+#check lcIn_setLc
+#check degreeOf_setLc
+#check imageAt_setLc
+#check prefixVars_min
+#check prefixNonMain_min
+
 abbrev P := MvPoly 2 Int Mono.lex
 abbrev L := MvPoly 1 Int Mono.lex
 

--- a/HexMvHensel/Uni.lean
+++ b/HexMvHensel/Uni.lean
@@ -333,4 +333,46 @@ theorem solveUni_unique {q : Nat} {images witness tau : List ZPoly}
         ((solveUni q images witness c).getD j 0) := by
   sorry
 
+/-- Two symmetric-canonical representatives of the same coefficientwise
+residue class are equal. -/
+theorem UniSymCanonical.eq_of_congr {q : Nat} {f g : ZPoly}
+    (hf : UniSymCanonical q f) (hg : UniSymCanonical q g)
+    (hfg : UniCongr q f g) : f = g := by
+  apply DensePoly.ext_coeff
+  intro k
+  have hf' := hf k
+  have hg' := hg k
+  have hq : 0 < q := by omega
+  have hdvd : (q : Int) ∣ f.coeff k - g.coeff k :=
+    Int.dvd_of_emod_eq_zero (hfg k)
+  have hlt : (f.coeff k - g.coeff k).natAbs < q := by
+    by_cases hnonneg : 0 ≤ f.coeff k - g.coeff k
+    · rw [← Int.ofNat_lt, Int.natAbs_of_nonneg hnonneg]
+      omega
+    · have hnonpos : f.coeff k - g.coeff k ≤ 0 := by omega
+      rw [← Int.ofNat_lt, Int.ofNat_natAbs_of_nonpos hnonpos]
+      omega
+  have hzero : f.coeff k - g.coeff k = 0 := by
+    apply Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hdvd
+    simpa using hlt
+  omega
+
+/-- A symmetric-canonical degree-bounded solution is the exact tuple
+component selected by `solveUni`, not merely a congruent representative. -/
+theorem solveUni_eq {q : Nat} {images witness tau : List ZPoly}
+    {c : ZPoly} (h : UniValid q images witness)
+    (hlen : tau.length = images.length)
+    (hdegree : ∀ j, j < images.length →
+      (tau.getD j 0).degree?.getD 0 <
+        (images.getD j 0).degree?.getD 0)
+    (hsum : UniCongr q (uniCombination tau (complements images)) c)
+    (hcanonical : ∀ j, j < images.length →
+      UniSymCanonical q (tau.getD j 0)) :
+    ∀ j, j < images.length →
+      tau.getD j 0 = (solveUni q images witness c).getD j 0 := by
+  intro j hj
+  apply UniSymCanonical.eq_of_congr (hcanonical j hj)
+    (solveUni_symCanonical h j hj)
+  exact solveUni_unique h hlen hdegree hsum j hj
+
 end Hex.MvHensel

--- a/HexMvHensel/UniTests.lean
+++ b/HexMvHensel/UniTests.lean
@@ -32,6 +32,9 @@ namespace Hex.MvHensel.UniTests
 open Hex
 open scoped Hex
 
+#check UniSymCanonical.eq_of_congr
+#check solveUni_eq
+
 def x : ZPoly := DensePoly.ofCoeffs #[0, 1]
 def xPlusOne : ZPoly := DensePoly.ofCoeffs #[1, 1]
 def xPlusTwo : ZPoly := DensePoly.ofCoeffs #[2, 1]


### PR DESCRIPTION
## Summary

- expose `setLc` image/leading/degree laws and nesting laws for both prefix operators
- package correction preservation as the reusable `SameFrame` predicate
- add the concrete `IsStage` state used by the executable EEZ call path
- state seed, single-stage, and full shifted-lift reachability theorems
- prove exact equality of symmetric-canonical univariate solutions from `solveUni_unique`
- document and compile-check every new public theorem shape

The canonical representative lemma and `solveUni_eq` are proved now. The nine algebra-heavy sparse-polynomial/stage obligations use explicit `sorry`, as directive #9454 permits for intentional Phase 5 work; executable bodies are unchanged and the new declarations identify the exact placeholders that the final sorry-free pass must close.

## Validation

- `lake build HexMvHensel.UniTests HexMvHensel.SeedTests HexMvHensel.LiftTests`
- `lake build HexMvHensel HexMvFactor`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_phase4.py --base origin/main`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `python3 scripts/release/check_trust_surface.py`
- `git diff --check origin/main...HEAD`

Closes #9454