### PR TITLE
fix(poly-z-gcd): remove dummy totalizations

### DIFF
--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -177,13 +177,6 @@ theorem rationalGcdCert_checks (f h : ZPoly) :
     checkGcd f h (rationalGcdCert f h) = true := by
   sorry
 
-/-- The total deterministic fallback.  The name is retained for producer API
-compatibility; unlike the previous implementation, this definition does not
-use a theorem to manufacture data from a rejected checker branch.  Its
-checker contract is `rationalGcdCert_checks`. -/
-def checkedRationalGcdCert (f h : ZPoly) : GcdCert :=
-  rationalGcdCert f h
-
 /-- Scan the low coefficients for the exponent of the first nonzero term. -/
 private def xOrder.go (f : ZPoly) : Nat → Nat → Nat
   | index, 0 => index
@@ -204,6 +197,14 @@ structure StructuralReduction where
   factor : ZPoly
   left : ZPoly
   right : ZPoly
+
+/-- Prefer the deterministic extended-subresultant certificate, with the
+rational implementation as the classified fallback if no actual terminal
+row exists. -/
+private def fallbackGcdCert (f h : ZPoly) : GcdCert :=
+  match prsCert? f h with
+  | some cert => cert
+  | none => rationalGcdCert f h
 
 /-- Route 0: extract the common integer content and common power of `x`.
 Both divisions are explicit checked operations, so a representation or
@@ -238,7 +239,7 @@ def reducedGcdCert (f h : ZPoly) : GcdCert :=
       | none =>
           match brownCert? f h with
           | some cert => cert
-          | none => prsCert f h
+          | none => fallbackGcdCert f h
 
 /-- Internal route tag used by executable dispatch guards. -/
 private inductive GcdRoute where
@@ -255,12 +256,12 @@ private def dispatchGcdCert (f h : ZPoly) : GcdCert × GcdRoute :=
   | some cert => (cert, .structural)
   | none =>
       match structuralReduction? f h with
-      | none => (prsCert f h, .fallback)
+      | none => (fallbackGcdCert f h, .fallback)
       | some reduced =>
           match restoreStructural? f h reduced
               (reducedGcdCert reduced.left reduced.right) with
           | some cert => (cert, .reduced)
-          | none => (prsCert f h, .fallback)
+          | none => (fallbackGcdCert f h, .fallback)
 
 /-- Produce a checked gcd certificate.  Mandatory zero and constant
 certificates run before content or `x` extraction.  Remaining route-0
@@ -274,7 +275,9 @@ theorem gcdCert_checks (f h : ZPoly) :
     checkGcd f h (gcdCert f h) = true := by
   sorry
 
-/-- Canonically normalized gcd of two integer polynomials. -/
+/-- Canonically normalized gcd of two integer polynomials.  Exposure is
+limited to the projection equation `gcd_eq_cert`; `gcdCert` and its route
+search remain opaque to kernel replay. -/
 @[expose]
 def gcd (f h : ZPoly) : ZPoly :=
   (gcdCert f h).gcd
@@ -412,33 +415,33 @@ def ratGcd (f h : DensePoly Rat) : DensePoly Rat :=
 #guard
   let f : ZPoly := 0
   let h : ZPoly := 0
-  let cert := checkedRationalGcdCert f h
+  let cert := rationalGcdCert f h
   cert.gcd == 0 && checkGcd f h cert
 
 -- The degenerate direct fallback and its checker also remain reducible in the
 -- ordinary kernel while the definition is in scope.  Larger rational
 -- Euclidean searches intentionally stay outside the replay closure.
 example :
-    checkGcd (0 : ZPoly) 0 (checkedRationalGcdCert 0 0) = true := by
+    checkGcd (0 : ZPoly) 0 (rationalGcdCert 0 0) = true := by
   decide +kernel
 
 #guard
   let f : ZPoly := DensePoly.ofList [2, 4, 2]
   let h : ZPoly := 0
-  let cert := checkedRationalGcdCert f h
+  let cert := rationalGcdCert f h
   cert.gcd == f && checkGcd f h cert
 
 #guard
   let f : ZPoly := DensePoly.ofList [0, 12]
   let h : ZPoly := DensePoly.ofList [0, 18]
-  let cert := checkedRationalGcdCert f h
+  let cert := rationalGcdCert f h
   cert.gcd == DensePoly.ofList [0, 6] && checkGcd f h cert
 
 #guard
   let common : ZPoly := DensePoly.ofList [1, 1]
   let f := common * DensePoly.ofList [2, 1]
   let h := common * DensePoly.ofList [3, 1]
-  let cert := checkedRationalGcdCert f h
+  let cert := rationalGcdCert f h
   cert.gcd == common && checkGcd f h cert
 
 #guard gcd (0 : ZPoly) 0 == 0
@@ -460,11 +463,13 @@ example :
   | none => false
   | some reduced =>
       reduced.factor == DensePoly.ofList [0, 0, 6] &&
-        match restoreStructural? f h reduced
-            (prsCert reduced.left reduced.right) with
-        | some cert =>
-            cert.gcd == DensePoly.ofList [0, 0, 6] && checkGcd f h cert
+        match prsCert? reduced.left reduced.right with
         | none => false
+        | some reducedCert =>
+            match restoreStructural? f h reduced reducedCert with
+            | some cert =>
+                cert.gcd == DensePoly.ofList [0, 0, 6] && checkGcd f h cert
+            | none => false
 
 #guard
   let f : ZPoly := DensePoly.ofList [1, 1]

--- a/HexPolyZGcd/Heu.lean
+++ b/HexPolyZGcd/Heu.lean
@@ -35,25 +35,30 @@ private def symDigits (base : Nat) : Int → Nat → List Int
         let digit := Modular.symMod value base
         digit :: symDigits base ((value - digit) / Int.ofNat base) fuel
 
-/-- Reconstruct a polynomial from symmetric base digits. -/
-def heuReconstruct (value : Int) (base degreeBound : Nat) : ZPoly :=
-  if base ≤ 1 then
-    0
-  else
-    DensePoly.ofList (symDigits base value (degreeBound + 2))
+/-- Reconstruct a polynomial from symmetric digits at a proved valid base. -/
+private def heuReconstruct (value : Int) (base degreeBound : Nat)
+    (_hbase : 1 < base) : ZPoly :=
+  DensePoly.ofList (symDigits base value (degreeBound + 2))
 
 /-- One GCDHEU candidate.  Content is split before evaluation and restored
 after primitive normalization of the symmetric-adic reconstruction. -/
-def heuCandidateAt (f h : ZPoly) (base : Nat) : ZPoly :=
+private def heuCandidateAt (f h : ZPoly) (base : Nat)
+    (hbase : 1 < base) : ZPoly :=
   let f0 := primitivePart f
   let h0 := primitivePart h
   let fv := DensePoly.eval f0 (Int.ofNat base)
   let hv := DensePoly.eval h0 (Int.ofNat base)
   let value : Int := Int.ofNat (Int.gcd fv hv)
   let degreeBound := min f0.size h0.size
-  let primitive := normalizePrimitiveSign (primitivePart (heuReconstruct value base degreeBound))
+  let primitive := normalizePrimitiveSign
+    (primitivePart (heuReconstruct value base degreeBound hbase))
   let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
   normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+
+/-- One checked GCDHEU candidate when the symmetric-digit base is valid.
+Invalid bases have no candidate rather than denoting the zero polynomial. -/
+def heuCandidateAt? (f h : ZPoly) (base : Nat) : Option ZPoly :=
+  if hbase : 1 < base then some (heuCandidateAt f h base hbase) else none
 
 /-- Maximum absolute input coefficient. -/
 private def coeffNorm (f : ZPoly) : Nat :=
@@ -69,14 +74,15 @@ private def projectedBits (f h : ZPoly) (base : Nat) : Nat :=
 /-- Retry with growing bases until the projected bit-size budget is exhausted.
 The budget, rather than a fixed retry count, controls work as evaluations grow.
 -/
-private def heuLoop (f h : ZPoly) (base remainingBits : Nat) : Option GcdCert :=
+private def heuLoop (f h : ZPoly) (base remainingBits : Nat)
+    (hbase : 1 < base) : Option GcdCert :=
   let cost := projectedBits f h base
   if cost > remainingBits then
     none
   else
-    match checkedCandidate? f h (heuCandidateAt f h base) with
+    match checkedCandidate? f h (heuCandidateAt f h base hbase) with
     | some cert => some cert
-    | none => heuLoop f h (2 * base + 1) (remainingBits - cost)
+    | none => heuLoop f h (2 * base + 1) (remainingBits - cost) (by omega)
 termination_by remainingBits
 decreasing_by
   have hcostOne : 1 ≤ projectedBits f h base := by
@@ -88,7 +94,7 @@ decreasing_by
 def heuCert? (f h : ZPoly) : Option GcdCert :=
   let norm := max (coeffNorm f) (coeffNorm h)
   let base := max 3 (2 * norm + 1)
-  heuLoop f h base 4096
+  heuLoop f h base 4096 (by omega)
 
 /-! Route-level pins: one genuine hit and one accidental evaluated factor. -/
 
@@ -96,14 +102,22 @@ def heuCert? (f h : ZPoly) : Option GcdCert :=
   let common : ZPoly := DensePoly.ofList [1, 1]
   let f := common * DensePoly.ofList [2, 1]
   let h := common * DensePoly.ofList [3, 1]
-  (checkedCandidate? f h (heuCandidateAt f h 101)).isSome
+  match heuCandidateAt? f h 101 with
+  | some candidate => (checkedCandidate? f h candidate).isSome
+  | none => false
 
 #guard
   let f : ZPoly := DensePoly.ofList [0, 1]
   let h : ZPoly := DensePoly.ofList [5, 1]
   -- Both evaluations at `5` share `5`, reconstructing the false candidate
   -- `x`; exact trial division must reject it.
-  (checkedCandidate? f h (heuCandidateAt f h 5)).isNone
+  match heuCandidateAt? f h 5 with
+  | some candidate => (checkedCandidate? f h candidate).isNone
+  | none => false
+
+-- Bases zero and one cannot silently stand for the zero candidate.
+#guard (heuCandidateAt? (1 : ZPoly) 1 0).isNone
+#guard (heuCandidateAt? (1 : ZPoly) 1 1).isNone
 
 end ZPoly
 

--- a/HexPolyZGcd/Prs.lean
+++ b/HexPolyZGcd/Prs.lean
@@ -27,68 +27,52 @@ namespace Hex
 
 namespace ZPoly
 
-/-- The first caller-order-sensitive row of the extended chain.  This is a
-genuine Bézout row even when one input is zero; it also gives a data-level
-initializer from which `prsTerminal` can fold a known-nonempty route without
-an option projection or a dummy default. -/
-def prsInitial (f h : ZPoly) : DensePoly.SubresultantExt.Entry Int :=
-  if f.isZero then (0, 1, h)
-  else if h.isZero then (1, 0, f)
-  else if f.size < h.size then (0, 1, h)
-  else (1, 0, f)
-
-/-- Last extended-subresultant row, computed as a fold from the actual first
-row.  The doubly-zero input is handled before this helper is used by
-`prsCert`; on every other input `prsInitial` is exactly the chain's first row.
--/
-def prsTerminal (f h : ZPoly) : DensePoly.SubresultantExt.Entry Int :=
-  (DensePoly.subresultantChainExt f h).foldl (fun _ entry => entry)
-    (prsInitial f h)
+/-- Last extended-subresultant row.  The doubly-zero chain is empty and has no
+synthetic terminal row. -/
+def prsTerminal? (f h : ZPoly) :
+    Option (DensePoly.SubresultantExt.Entry Int) :=
+  (DensePoly.subresultantChainExt f h).back?
 
 /-- Primitive-normalized PRS gcd candidate with common integer content
 restored. -/
-def prsCandidate (f h : ZPoly) : ZPoly :=
-  let terminal := prsTerminal (primitivePart f) (primitivePart h)
+def prsCandidate? (f h : ZPoly) : Option ZPoly := do
+  let terminal ← prsTerminal? (primitivePart f) (primitivePart h)
   let primitive := normalizePrimitiveSign (primitivePart terminal.2.2)
   let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
-  normalizePrimitiveSign (DensePoly.scale commonContent primitive)
+  pure (normalizePrimitiveSign (DensePoly.scale commonContent primitive))
 
 /-- Extract and replay a constant Bezout identity from the terminal extended
 chain of two candidate cofactors. -/
-def prsCoprimeWitness (f h : ZPoly) : CoprimeWitness :=
-  let terminal := prsTerminal f h
+def prsCoprimeWitness? (f h : ZPoly) : Option CoprimeWitness := do
+  let terminal ← prsTerminal? f h
   let k := terminal.2.2.coeff 0
-  CoprimeWitness.constant terminal.1 terminal.2.1 k
+  pure (CoprimeWitness.constant terminal.1 terminal.2.1 k)
 
-/-- Route 4: a total, deterministic extended-subresultant certificate.  The
-only special case is the mathematically degenerate pair `(0, 0)`.  Every
-other field is computed directly from the Brown chain and ordinary long
-division; correctness is the separate theorem `prsCert_checks` and no proof
-is inspected to manufacture runtime data. -/
-def prsCert (f h : ZPoly) : GcdCert :=
+/-- Route 4: a deterministic extended-subresultant certificate.  Absence of
+an actual terminal row is propagated to the dispatcher, which classifies the
+rational implementation as the audited fallback. -/
+def prsCert? (f h : ZPoly) : Option GcdCert :=
   if f.isZero && h.isZero then
-    { gcd := 0
-      cofL := 1
-      cofR := 1
-      coprime := .constant 1 0 1 }
-  else
-    let candidate := prsCandidate f h
+    some
+      { gcd := 0
+        cofL := 1
+        cofR := 1
+        coprime := .constant 1 0 1 }
+  else do
+    let candidate ← prsCandidate? f h
     let cofL := (DensePoly.divMod f candidate).1
     let cofR := (DensePoly.divMod h candidate).1
-    { gcd := candidate
-      cofL
-      cofR
-      coprime := prsCoprimeWitness cofL cofR }
+    let coprime ← prsCoprimeWitness? cofL cofR
+    pure
+      { gcd := candidate
+        cofL := cofL
+        cofR := cofR
+        coprime := coprime }
 
 /-- Completeness of the deterministic extended-subresultant fallback. -/
-theorem prsCert_checks (f h : ZPoly) : checkGcd f h (prsCert f h) = true := by
+theorem prsCert_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : prsCert? f h = some cert) : checkGcd f h cert = true := by
   sorry
-
-/-- Checked optional view retained for route-level diagnostics.  Public
-dispatch uses total `prsCert` directly. -/
-def prsCert? (f h : ZPoly) : Option GcdCert :=
-  let cert := prsCert f h
-  if checkGcd f h cert then some cert else none
 
 /-! Executable pin for the extended-chain route, including rationally
 nonmonic cofactors. -/
@@ -97,10 +81,17 @@ nonmonic cofactors. -/
   let common : ZPoly := DensePoly.ofList [2, 1]
   let f := common * DensePoly.ofList [1, 2]
   let h := common * DensePoly.ofList [1, 3]
-  let cert := prsCert f h
-  cert.gcd == common && checkGcd f h cert
+  match prsCert? f h with
+  | some cert => cert.gcd == common && checkGcd f h cert
+  | none => false
 
-#guard checkGcd (0 : ZPoly) 0 (prsCert 0 0)
+#guard
+  match prsCert? (0 : ZPoly) 0 with
+  | some cert => checkGcd 0 0 cert
+  | none => false
+
+-- The raw extended chain for `(0, 0)` is genuinely empty.
+#guard (prsTerminal? (0 : ZPoly) 0).isNone
 
 end ZPoly
 

--- a/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
+++ b/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
@@ -396,6 +396,12 @@ two values, and reconstruct a polynomial from the symmetric `ξ`-adic
 digits. In one variable the Kronecker substitution the multivariate
 version needs is just this evaluation, so the route is a few lines.
 
+The symmetric digit base must satisfy `1 < ξ`. The route carries that proof
+internally; the diagnostic entry point `heuCandidateAt?` returns `none` at
+bases zero and one. Those invalid inputs do not denote the zero polynomial,
+since zero would be a plausible but false gcd candidate rather than a
+totalization of the digit algorithm.
+
 Two things are worth stating because the multivariate version of this
 SPEC got them wrong first. Reconstruction being exact does not follow
 from the input coefficient sizes: the integer gcd can carry accidental
@@ -454,7 +460,9 @@ in practice it stops enormously earlier.
 
 Run hex-resultant's `subresultantChain` over `Int` unchanged, take the
 primitive part of the terminal nonzero entry, and multiply by the content
-gcd. The **extended** chain, which tracks the transformation pair through
+gcd. `prsTerminal?` projects the actual last array entry and returns `none`
+for the empty `(0, 0)` chain; it never invents a Bézout row. The
+**extended** chain, which tracks the transformation pair through
 the pseudo-scalings, supplies the `constant` witness for the cofactors:
 the resultant of two coprime polynomials is a nonzero integer in the
 ideal they generate, and the extended chain returns it with its
@@ -473,8 +481,12 @@ The shared `subresultantChainExt` implementation is now available from
 hex-resultant. Its recurrence tracks the transformation pair through the
 pseudo-scalings and is used here and by
 [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md). The preserved
-`DensePoly Rat` Euclidean implementation is a named reference and test
-oracle only; it is not a dispatch fallback.
+`DensePoly Rat` Euclidean implementation is the audited fallback when the
+optional PRS producer has no actual terminal row. Mandatory zero inputs are
+settled structurally before dispatch and every nonzero Brown chain is
+nonempty, so this arm is defensive rather than a competing ordinary route;
+unlike a synthetic row, it still computes and checks a mathematically valid
+certificate.
 
 ## Prerequisite changes in other libraries
 
@@ -717,8 +729,9 @@ companion beyond these and one correspondence lemma per public operation.
    code.
 
 5. **The heuristic and the subresultant fallback.** Route 2, and route 4
-   replacing the rational fallback once hex-resultant is far enough
-   along.
+   becoming the primary deterministic fallback once hex-resultant is far
+   enough along, with the rational implementation retained for an absent
+   extended-chain terminal.
 
 6. **The companion**, and the fast squarefree decomposition. The
    squarefree entry point is the benchmark that justifies the library, so


### PR DESCRIPTION
Closes #9449.

This implements the corrected directive boundary after verifying that removing exposure from ZPoly.gcd itself would break the exported projection theorem.

- makes GCDHEU reconstruction proof-indexed at bases greater than one and exposes invalid diagnostic bases as none
- replaces the synthetic PRS initial/terminal row with optional projection from the actual extended chain
- classifies the rational certificate as the fallback when no PRS terminal exists
- removes the checkedRationalGcdCert alias while retaining the narrowly documented gcd exposure needed by gcd_eq_cert
- updates route guards and the SPEC to match the non-synthetic APIs

Validation:
- lake build HexPolyZGcd HexMvGcd HexMvHensel HexMvFactor (539 jobs)
- lake build HexPolyZGcd.Gcd after final API/style adjustment
- git diff --check
- DAG, copyright, Phase 4, factor-freshness, trust-surface, and changed-file policy checks
- no new sorry, axiom, or native_decide occurrences