### PR TITLE
refactor(mvgcd): separate runtime ops from proof laws

### DIFF
--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -203,7 +203,7 @@ def brownCheckedCandidate? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (f h candidate : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
   checkedCandidate? f h candidate
 
@@ -220,16 +220,16 @@ structure BrownOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
 /-- Exact base image at arity zero. -/
 def brownBaseOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : BrownOpsAt R 0 where
-  candidate? := fun _ _ _ _ f h => some (rawPrsCert f h).gcd
+    [Dvd R] [BezoutOps R] : BrownOpsAt R 0 where
+  candidate? := fun _ _ _ _ f h => some (prsCert f h).gcd
 
 /-- Exact univariate image.  This is the leaf reached after evaluating all
 outer variables and is intentionally the existing checked PRS kernel rather
 than a second polynomial Euclidean implementation. -/
 def brownUnaryOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : BrownOpsAt R 1 where
-  candidate? := fun _ _ _ _ f h => some (rawPrsCert f h).gcd
+    [Dvd R] [BezoutOps R] : BrownOpsAt R 1 where
+  candidate? := fun _ _ _ _ f h => some (prsCert f h).gcd
 
 /-- Exact bad-point predicate used by the interpolation loop and by
 route-level tests. -/
@@ -249,25 +249,25 @@ def brownPointBad {n : Nat} {R : Type u}
 variable; the last variable is evaluated and reconstructed. -/
 def brownStepOps {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (lower : BrownOpsAt R (n + 1)) : BrownOpsAt R (n + 2) where
   candidate? := fun cmp _ pointFuel points f h =>
     if f == 0 || h == 0 || polyIsUnit f || polyIsUnit h then
-      some (rawPrsCert f h).gcd
+      some (prsCert f h).gcd
     else
       let main : Fin (n + 2) := ⟨0, by omega⟩
       let outer : Fin (n + 2) := Fin.last (n + 1)
       let fView := toUnivariate main Mono.lex f
       let hView := toUnivariate main Mono.lex h
-      let fContent := contentCertWith (fun a b => rawPrsCert a b)
+      let fContent := contentCertWith (fun a b => prsCert a b)
         fView.toArray.toList
-      let hContent := contentCertWith (fun a b => rawPrsCert a b)
+      let hContent := contentCertWith (fun a b => prsCert a b)
         hView.toArray.toList
-      let common := rawPrsCert fContent.value hContent.value
+      let common := prsCert fContent.value hContent.value
       let fPrimitive := quotient f (constIn main Mono.lex fContent.value)
       let hPrimitive := quotient h (constIn main Mono.lex hContent.value)
       let gamma :=
-        (rawPrsCert (brownMainLeadingCoeff fPrimitive)
+        (prsCert (brownMainLeadingCoeff fPrimitive)
           (brownMainLeadingCoeff hPrimitive)).gcd
       let sampleTarget :=
         max (degreeOf outer fPrimitive) (degreeOf outer hPrimitive) + 1
@@ -308,7 +308,7 @@ def brownStepOps {n : Nat} {R : Type u}
                                 ofUnivariate (cmp := cmp) outer Mono.lex interpolation
                               let reconstructedView := toUnivariate main Mono.lex reconstructed
                               let reconstructedContent := contentCertWith
-                                (fun a b => rawPrsCert a b)
+                                (fun a b => prsCert a b)
                                 reconstructedView.toArray.toList
                               let primitive := quotient reconstructed
                                 (constIn main Mono.lex reconstructedContent.value)
@@ -323,7 +323,7 @@ def brownStepOps {n : Nat} {R : Type u}
                                 ofUnivariate (cmp := cmp) outer Mono.lex interpolation
                               let reconstructedView := toUnivariate main Mono.lex reconstructed
                               let reconstructedContent := contentCertWith
-                                (fun a b => rawPrsCert a b)
+                                (fun a b => prsCert a b)
                                 reconstructedView.toArray.toList
                               let primitive := quotient reconstructed
                                 (constIn main Mono.lex reconstructedContent.value)
@@ -335,7 +335,7 @@ def brownStepOps {n : Nat} {R : Type u}
 /-- Construct all recursive point layers by arity. -/
 def brownOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    [Dvd R] [BezoutOps R] :
     (n : Nat) → BrownOpsAt R n
   | 0 => brownBaseOps
   | 1 => brownUnaryOps
@@ -379,7 +379,7 @@ def brownCandidate? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (pointFuel : Nat) (points : List R)
     (f h : MvPoly n R cmp) : Option (MvPoly n R cmp) :=
   match brownMainIndex f h with
@@ -397,7 +397,7 @@ def brownFieldCert? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (pointFuel : Nat) (points : List R)
     (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
   match brownCandidate? pointFuel points f h with
@@ -574,7 +574,7 @@ def brownOfZPoly {cmp : Mono 1 → Mono 1 → Ordering}
 dense kernel supplies the gcd and cofactors; the multivariate checker receives
 a freshly constructed arity-one coprimality witness over those exact
 cofactors. -/
-def intArityOneRaw {cmp : Mono 1 → Mono 1 → Ordering}
+def intArityOneCert {cmp : Mono 1 → Mono 1 → Ordering}
     [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) : GcdCert 1 Int cmp :=
   let z := ZPoly.gcdCert (brownToZPoly f) (brownToZPoly h)
   let g := brownOfZPoly z.gcd
@@ -583,14 +583,10 @@ def intArityOneRaw {cmp : Mono 1 → Mono 1 → Ordering}
   let lower := prsOps (R := Int) 0
   .mk g cofL cofR (succCoprime lower cmp cofL cofR)
 
-theorem intArityOneRaw_checks {cmp : Mono 1 → Mono 1 → Ordering}
+theorem intArityOneCert_checks {cmp : Mono 1 → Mono 1 → Ordering}
     [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) :
-    checkGcd f h (intArityOneRaw f h) = true := by
+    checkGcd f h (intArityOneCert f h) = true := by
   sorry
-
-def intArityOneCert {cmp : Mono 1 → Mono 1 → Ordering}
-    [IsMonomialOrder cmp] (f h : MvPoly 1 Int cmp) : GcdCert 1 Int cmp :=
-  intArityOneRaw f h
 
 /-- Arity-indexed integer Brown producer.  The arity-one branch calls the
 actual `HexPolyZGcd` Brown route and then builds a fresh multivariate

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -36,35 +36,35 @@ private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
 @[instance_reducible] private def rejectingProducer : GcdProducer Int where
   propose := fun _ _ _ f h =>
     ⟨some (.mk 1 f h .unit), observedRand f h⟩
-#guard checkGcd (0 : P0) 0 (rawPrsCert 0 0)
+#guard checkGcd (0 : P0) 0 (prsCert 0 0)
 #guard
   let f : P0 := C 12
   let h : P0 := C 18
-  checkGcd f h (rawPrsCert f h)
+  checkGcd f h (prsCert f h)
 #guard
   let x : P1 := X 0
   let f := C 12 * x
   let h := C 18 * x
-  checkGcd f h (rawPrsCert f h)
+  checkGcd f h (prsCert f h)
 #guard
   let x : P1 := X 0
   let common := x + 1
   let f := common * (x + 2)
   let h := common * (x + 3)
-  checkGcd f h (rawPrsCert f h)
+  checkGcd f h (prsCert f h)
 #guard
   let x : P1 := X 0
   let common := x + 1
   let f := common * (x + 2)
   let h := common * (x + 3)
-  checkGcd f h (intArityOneRaw f h)
+  checkGcd f h (intArityOneCert f h)
 #guard
   let x : P2 := X 0
   let y : P2 := X 1
   let common := x + y + 1
   let f := common * (x + 2)
   let h := common * (y + 3)
-  checkGcd f h (rawPrsCert f h)
+  checkGcd f h (prsCert f h)
 #guard (structuralCert? (0 : P1) 0).isSome
 #guard
   letI : GcdProducer Int := rejectingProducer

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -88,7 +88,7 @@ def structuralCert? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
   if f == 0 && h == 0 then some (.mk 0 1 1 .unit)
   else if f == 0 then
@@ -117,7 +117,7 @@ def structuralReduction? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [GcdOps R] [LawfulGcdOps R]
+    [Dvd R] [GcdOps R]
     (f h : MvPoly n R cmp) : Option (StructuralReduction n R cmp) := do
   let commonMono := Mono.gcd (monoContent f) (monoContent h)
   let commonCoeff := GcdOps.gcd (content f) (content h)
@@ -149,7 +149,7 @@ def gcdCertWith (cfg : GcdConfig)
     {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : GcdRun n R cmp :=
   match structuralCert? f h with
@@ -185,14 +185,14 @@ def checkedCandidate? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (f h candidate : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
   if candidate == 0 then none
   else
     let normalized := polyNormalize candidate
     let cofL := quotient f normalized
     let cofR := quotient h normalized
-    let cofactorCert := rawPrsCert cofL cofR
+    let cofactorCert := prsCert cofL cofR
     let cert := GcdCert.mk normalized cofL cofR cofactorCert.coprime
     if checkGcd f h cert then some cert else none
 
@@ -224,7 +224,7 @@ structure CoprimeOpsAt (R : Type u) [Zero R] [One R] [Add R] [Mul R]
 /-- Arity-zero modular-coprimality leaf. -/
 def coprimeBase {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] : CoprimeOpsAt R 0 where
+    [Dvd R] [BezoutOps R] : CoprimeOpsAt R 0 where
   tryAt := fun cmp _ _ _ rand f h =>
     let cert := baseCoprime cmp f h
     (if checkCoprime f h cert then some cert else none, rand)
@@ -232,7 +232,7 @@ def coprimeBase {R : Type u}
 /-- One recursive modular image and coefficient-content descent. -/
 def coprimeStep {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (lower : CoprimeOpsAt R n) : CoprimeOpsAt R (n + 1) where
   tryAt := fun cmp _ prime φ rand f h =>
     letI : ZMod64.Bounds prime.m := prime.bounds
@@ -259,9 +259,9 @@ def coprimeStep {n : Nat} {R : Type u}
           else
             let alpha := DensePoly.scaleImpl scalar⁻¹ xg.left
             let beta := DensePoly.scaleImpl scalar⁻¹ xg.right
-            let left := contentCertWith (fun a b => rawPrsCert a b)
+            let left := contentCertWith (fun a b => prsCert a b)
               fView.toArray.toList
-            let right := contentCertWith (fun a b => rawPrsCert a b)
+            let right := contentCertWith (fun a b => prsCert a b)
               hView.toArray.toList
             let restRun := lower.tryAt Mono.lex prime φ rand'
               left.value right.value
@@ -275,7 +275,7 @@ def coprimeStep {n : Nat} {R : Type u}
 /-- Construct the per-variable modular coprimality route. -/
 def coprimeOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    [Dvd R] [BezoutOps R] :
     (n : Nat) → CoprimeOpsAt R n
   | 0 => coprimeBase
   | n + 1 => coprimeStep (coprimeOps n)
@@ -286,7 +286,7 @@ recursive checker. -/
 def tryCoprimeCert? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (P : ZMod64.Prime) (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
     (rand : Rand) (f h : MvPoly n R cmp) :
     Option (GcdCert n R cmp) × Rand :=
@@ -407,7 +407,7 @@ def fastProposal {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (cfg : GcdConfig) (_f _h : MvPoly n R cmp) : GcdProposal n R cmp :=
   ⟨none, cfg.rand⟩
 

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -31,7 +31,7 @@ variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
 /-- Canonical checked gcd certificate. -/
 def gcdCert [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : GcdCert n R cmp :=
   (gcdCertWith GcdConfig.default f h).cert
@@ -56,7 +56,7 @@ theorem gcdCertWith_checks [IsMonomialOrder cmp]
 def contentInCert {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
     [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
@@ -68,7 +68,7 @@ def contentInCert {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
 def contentIn {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
     [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
@@ -79,7 +79,7 @@ def contentIn {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
 def primPartIn {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
     [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
@@ -192,14 +192,14 @@ theorem primPartIn_mul
 /-- Canonically normalized gcd. -/
 def gcd [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : MvPoly n R cmp :=
   (gcdCert f h).gcd
 
 def cofactors [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : MvPoly n R cmp × MvPoly n R cmp :=
   let cert := gcdCert f h
@@ -207,7 +207,7 @@ def cofactors [IsMonomialOrder cmp]
 
 def gcdWith [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (cfg : GcdConfig) (f h : MvPoly n R cmp) : MvPoly n R cmp × Rand :=
   let run := gcdCertWith cfg f h
@@ -215,21 +215,21 @@ def gcdWith [IsMonomialOrder cmp]
 
 def isCoprime [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : Bool :=
   polyIsUnit (gcd f h)
 
 def gcdList [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (ps : List (MvPoly n R cmp)) : MvPoly n R cmp :=
   ps.foldl gcd 0
 
 def lcm [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R]
     (f h : MvPoly n R cmp) : MvPoly n R cmp :=
   let cert := gcdCert f h
@@ -241,7 +241,7 @@ those contracts below. -/
 
 instance instGcdOpsMvPoly [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [Dvd R] [BezoutOps R]
     [GcdProducer R] :
     GcdOps (MvPoly n R cmp) where
   gcd := gcd

--- a/HexMvGcd/Kernel.lean
+++ b/HexMvGcd/Kernel.lean
@@ -20,6 +20,26 @@ namespace Hex.MvPoly
 private abbrev P0 := MvPoly 0 Int Mono.lex
 private abbrev P1 := MvPoly 1 Int Mono.lex
 
+section OpsOnly
+
+universe u
+
+variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
+  [IsMonomialOrder cmp]
+  [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [BezoutOps R] [GcdProducer R]
+
+/-- Executable construction must not require either proof-law package. -/
+example (f h : MvPoly n R cmp) : GcdCert n R cmp :=
+  prsCert f h
+
+example (cfg : GcdConfig) (f h : MvPoly n R cmp) : GcdRun n R cmp :=
+  gcdCertWith cfg f h
+
+example : GcdOps (MvPoly n R cmp) := inferInstance
+
+end OpsOnly
+
 private def zeroCert : GcdCert 0 Int Mono.lex :=
   .mk 0 1 1 .unit
 

--- a/HexMvGcd/Prs.lean
+++ b/HexMvGcd/Prs.lean
@@ -120,7 +120,7 @@ def baseGcd {R : Type u}
 and recursively certified coefficient contents. -/
 def succCoprime {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (lower : PrsOpsAt R n)
     (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
     [IsMonomialOrder cmp]
@@ -144,7 +144,7 @@ def succCoprime {n : Nat} {R : Type u}
 of the terminal extended subresultant. -/
 def succGcd {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (lower : PrsOpsAt R n)
     (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
     [IsMonomialOrder cmp]
@@ -186,7 +186,7 @@ def succGcd {n : Nat} {R : Type u}
 /-- Construct deterministic gcd and coprimality operations by arity. -/
 def prsOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] :
+    [Dvd R] [BezoutOps R] :
     (n : Nat) → PrsOpsAt R n
   | 0 =>
       { gcdCert := baseGcd
@@ -196,37 +196,19 @@ def prsOps {R : Type u}
       { gcdCert := succGcd lower
         coprimeCert := succCoprime lower }
 
-/-- Raw deterministic route-4 certificate. -/
-def rawPrsCert {n : Nat} {R : Type u}
+/-- Deterministic route-4 certificate. Runtime construction uses only the
+coefficient operations; their laws enter separately in `prsCert_checks`. -/
+def prsCert {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R]
+    [Dvd R] [BezoutOps R]
     (f h : MvPoly n R cmp) : GcdCert n R cmp :=
   (prsOps (R := R) n).gcdCert cmp f h
 
 /-- Route 4 always constructs an accepted certificate. The proof combines
 the extended-chain transformation law, exact divisions, and the recursive
 content checker. -/
-theorem rawPrsCert_checks {n : Nat} {R : Type u}
-    {cmp : Mono n → Mono n → Ordering}
-    [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
-    (f h : MvPoly n R cmp) :
-    checkGcd f h (rawPrsCert f h) = true := by
-  sorry
-
-/-- Deterministic route-4 certificate.  Runtime construction is entirely
-data-level; acceptance is established separately by `prsCert_checks`. -/
-def prsCert {n : Nat} {R : Type u}
-    {cmp : Mono n → Mono n → Ordering}
-    [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
-    (f h : MvPoly n R cmp) : GcdCert n R cmp :=
-  rawPrsCert f h
-
 theorem prsCert_checks {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -878,6 +878,12 @@ def gcdList (ps : List (MvPoly n R cmp)) : MvPoly n R cmp
 def lcm (f h : MvPoly n R cmp) : MvPoly n R cmp
 ```
 
+The executable API deliberately requires only `BezoutOps` (and hence its
+parent `GcdOps`), not `LawfulGcdOps` or `LawfulBezoutOps`.  The deterministic
+fallback is the single `prsCert` definition and follows the same rule.  Law
+packages occur only on the acceptance and semantic theorems below; they are
+proof obligations, not runtime dictionaries.
+
 The concrete proposal instances are `intProducer`, `ratProducer`,
 `primeProducer`, and `fpPolyProducer`. An abstract coefficient ring does
 not silently receive the integer modular algorithm; it may use


### PR DESCRIPTION
Closes #9460.\n\n## Summary\n\n- make the executable multivariate GCD producers depend only on operational GCD/Bézout typeclasses, while retaining law classes on proof theorems\n- fold rawPrsCert into the canonical prsCert implementation and fold intArityOneRaw into intArityOneCert\n- preserve the route-0 dispatcher and rational-to-integer routing added by #9476 and #9469\n- add compile-only kernel guards showing the runtime API is usable without LawfulGcdOps or LawfulBezoutOps\n- document the runtime/proof typeclass boundary\n\n## Validation\n\n- lake build HexMvGcd.Kernel\n- lake build HexMvGcd.Eval\n- lake build HexMvGcd HexMvHensel HexMvFactor\n- python3 scripts/check_copyright_headers.py\n- python3 scripts/check_file_line_counts.py\n- python3 scripts/check_dag.py\n- python3 scripts/conformance_targets.py --check\n- python3 scripts/check_phase4.py\n- python3 scripts/release/check_trust_surface.py\n- git diff --check origin/main...HEAD\n- no added sorry, axiom, or native_decide; no remaining rawPrsCert or intArityOneRaw references