### PR TITLE
polish(sparse-poly): Phase-6 pass for the core and companion

### DIFF
--- a/HexSparsePoly/Arith.lean
+++ b/HexSparsePoly/Arith.lean
@@ -395,6 +395,7 @@ def ofCanonicalList (l : List (Nat × R))
     ⟨by simpa using hs,
      fun t ht => hnz t (by simpa using Array.mem_def.mp ht)⟩
 
+/-- Packaging a canonical term list keeps its list coefficients. -/
 @[simp] theorem coeff_ofCanonicalList (l : List (Nat × R))
     (hs : l.Pairwise (fun a b => a.1 < b.1)) (hnz : ∀ t ∈ l, t.2 ≠ 0)
     (e : Nat) : (ofCanonicalList l hs hnz).coeff e = coeffList l e := by
@@ -530,6 +531,7 @@ theorem coeff_add' [Add R] (h00 : (0 : R) + 0 = 0)
   rw [h]
   rfl
 
+/-- Grind-classes form of `coeff_add'`: addition is coefficientwise. -/
 @[simp, grind =] theorem coeff_add {S : Type u} [Lean.Grind.Semiring S]
     [DecidableEq S] (s t : SparsePoly S) (e : Nat) :
     (s + t).coeff e = s.coeff e + t.coeff e :=
@@ -559,6 +561,7 @@ theorem coeff_sub' [Sub R] (h00 : (0 : R) - 0 = 0)
   rw [h]
   rfl
 
+/-- Grind-classes form of `coeff_sub'`: subtraction is coefficientwise. -/
 @[simp, grind =] theorem coeff_sub {S : Type u} [Lean.Grind.Ring S]
     [DecidableEq S] (s t : SparsePoly S) (e : Nat) :
     (s - t).coeff e = s.coeff e - t.coeff e :=
@@ -586,6 +589,7 @@ theorem coeff_neg' [Sub R] (h00 : (0 : R) - 0 = 0) (s : SparsePoly R)
   exact coeffList_mapTerms_apply (g := id) s.pairwise_toList
     (fun u _ h => h) h00
 
+/-- Grind-classes form of `coeff_neg'`: negation is coefficientwise. -/
 @[simp, grind =] theorem coeff_neg {S : Type u} [Lean.Grind.Ring S]
     [DecidableEq S] (s : SparsePoly S) (e : Nat) :
     (-s).coeff e = 0 - s.coeff e :=
@@ -608,6 +612,7 @@ theorem coeff_scale' [Mul R] (hc0 : ∀ c : R, c * 0 = 0) (c : R)
   exact coeffList_mapTerms_apply (g := id) s.pairwise_toList
     (fun u _ h => h) (hc0 c)
 
+/-- Grind-classes form of `coeff_scale'`: scaling multiplies each coefficient. -/
 @[simp, grind =] theorem coeff_scale {S : Type u} [Lean.Grind.Semiring S]
     [DecidableEq S] (c : S) (s : SparsePoly S) (e : Nat) :
     (scale c s).coeff e = c * s.coeff e :=
@@ -644,6 +649,7 @@ theorem coeff_mulMonomial' [Mul R] (hc0 : ∀ c : R, c * 0 = 0)
   · rw [if_neg hef]
     exact coeffList_mapTerms_of_ne fun u _ h => by omega
 
+/-- Grind-classes form of `coeff_mulMonomial'`: a monomial multiple shifts and scales the coefficients. -/
 @[simp, grind =] theorem coeff_mulMonomial {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S] (s : SparsePoly S) (e : Nat)
     (c : S) (f : Nat) :
@@ -821,6 +827,7 @@ convention. -/
 instance [Add R] [Mul R] : Dvd (SparsePoly R) where
   dvd p q := ∃ r, q = p * r
 
+/-- Divisibility unfolds to a cofactor witness. -/
 theorem dvd_def [Add R] [Mul R] (p q : SparsePoly R) :
     p ∣ q ↔ ∃ r, q = p * r :=
   Iff.rfl
@@ -829,24 +836,28 @@ section Laws
 
 variable {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
 
+/-- Addition is commutative. -/
 theorem add_comm (s t : SparsePoly S) : s + t = t + s := by
   apply ext_coeff
   intro e
   simp only [coeff_add]
   grind
 
+/-- Addition is associative. -/
 theorem add_assoc (s t u : SparsePoly S) : s + t + u = s + (t + u) := by
   apply ext_coeff
   intro e
   simp only [coeff_add]
   grind
 
+/-- Zero is a right identity for addition. -/
 @[simp, grind =] theorem add_zero (s : SparsePoly S) : s + 0 = s := by
   apply ext_coeff
   intro e
   simp only [coeff_add, coeff_zero]
   grind
 
+/-- Zero is a left identity for addition. -/
 @[simp, grind =] theorem zero_add (s : SparsePoly S) : 0 + s = s := by
   apply ext_coeff
   intro e

--- a/HexSparsePoly/Basic.lean
+++ b/HexSparsePoly/Basic.lean
@@ -26,7 +26,7 @@ universe u v
 
 /-- A term array is canonical when its exponents are strictly increasing
 and no stored coefficient is zero. -/
-def SparsePolyCanonical {R : Type u} [Zero R] [DecidableEq R]
+def SparsePolyCanonical {R : Type u} [Zero R]
     (terms : Array (Nat × R)) : Prop :=
   terms.toList.Pairwise (fun a b => a.1 < b.1) ∧ ∀ t ∈ terms, t.2 ≠ 0
 
@@ -574,12 +574,12 @@ theorem coeffList_addTermList [Add R] {l : List (Nat × R)}
       · by_cases hf : f = e
         · subst hf
           simp [addTermList, coeffList, addCoeff, hc]
-        · simp [addTermList, coeffList, addCoeff, hc, hf]
+        · simp [addTermList, coeffList, hc, hf]
       · by_cases hf : f = e
         · subst hf
           simp [addTermList, coeffList, addCoeff, hc]
         · have hef : ¬e = f := fun h => hf h.symm
-          simp [addTermList, coeffList, addCoeff, hc, hef, hf]
+          simp [addTermList, coeffList, hc, hef, hf]
   | cons a as ih =>
       rw [List.pairwise_cons] at hs
       have hnza : a.2 ≠ 0 := hnz a (List.mem_cons_self ..)
@@ -600,7 +600,7 @@ theorem coeffList_addTermList [Add R] {l : List (Nat × R)}
           by_cases hf : f = e
           · subst hf
             rw [if_pos rfl, hcoeff_e, addCoeff]
-            simp only [coeffList, if_pos rfl]
+            simp only [coeffList]
             simp [hc]
           · rw [if_neg hf]
             simp only [coeffList]
@@ -654,7 +654,6 @@ theorem coeff_addTerm [Add R] (s : SparsePoly R) (e : Nat) (c : R)
     (s.addTerm e c).coeff f =
       if f = e then addCoeff (s.coeff e) c else s.coeff f := by
   unfold coeff addTerm
-  simp only [List.toList_toArray]
   exact coeffList_addTermList s.canonical.1
     (fun t ht => s.canonical.2 t (Array.mem_def.mpr ht)) e c f
 
@@ -673,6 +672,7 @@ termination_by hi - lo
 decreasing_by all_goals omega
 
 omit [DecidableEq R] in
+omit [Zero R] in
 /-- On a sorted range, {name}`lowerBound` splits the indices: every
 exponent below the returned position is below `e`, every exponent at or
 beyond it is at least `e`. -/
@@ -733,6 +733,7 @@ termination_by hi - lo
 decreasing_by all_goals omega
 
 omit [DecidableEq R] in
+omit [Zero R] in
 /-- {name}`lowerBound` never exceeds `hi`, with no sortedness needed:
 this is what makes the insertion index valid. -/
 theorem lowerBound_le (ts : Array (Nat × R)) (e : Nat) (lo hi : Nat)
@@ -777,7 +778,7 @@ theorem addTermList_splice [Add R] {l : List (Nat × R)} {e : Nat}
           simp only [List.getElem?_cons_zero]
           by_cases heq : a.1 = e
           · have hnotlt : ¬ e < a.1 := by omega
-            simp only [addTermList, if_neg hnotlt, if_pos heq, if_pos heq]
+            simp only [addTermList, if_neg hnotlt, if_pos heq]
             rw [heq]
             simp
           · have hlt : e < a.1 := by omega
@@ -850,7 +851,7 @@ theorem addTermArray_eq [Add R] {ts : Array (Nat × R)}
     (fun i h hip => hbelow i (by simpa using h) hip)
     (fun i h hpi => habove i (by simpa using h) hpi) c
   rw [← Array.toList_inj]
-  simp only [List.toList_toArray, hsplice]
+  simp only [hsplice]
   unfold addTermArray
   split
   · rename_i t hp
@@ -907,6 +908,7 @@ combining pass selected by `Hex.SparsePoly.ofTerms_eq_impl`. -/
 noncomputable def ofTerms [Add R] (ts : Array (Nat × R)) : SparsePoly R :=
   ts.foldl (fun s t => s.addTerm t.1 t.2) 0
 
+/-- The zero polynomial has zero coefficients. -/
 @[simp, grind =] theorem coeff_zero (e : Nat) :
     (0 : SparsePoly R).coeff e = 0 :=
   rfl
@@ -1283,14 +1285,17 @@ elsewhere, even when `c = 0`. -/
     · rw [if_pos (hf ▸ rfl), if_pos hf]
     · rw [if_neg (fun h : e = f => hf h.symm), if_neg hf]
 
+/-- A constant stores its value at exponent `0`. -/
 @[simp, grind =] theorem coeff_C (c : R) (f : Nat) :
     (C c).coeff f = if f = 0 then c else 0 :=
   coeff_monomial 0 c f
 
+/-- The one polynomial is the constant `1`. -/
 @[simp, grind =] theorem coeff_one [One R] (f : Nat) :
     (1 : SparsePoly R).coeff f = if f = 0 then 1 else 0 :=
   coeff_C 1 f
 
+/-- The variable has coefficient `1` at exponent `1`. -/
 @[simp, grind =] theorem coeff_X [One R] (f : Nat) :
     (X : SparsePoly R).coeff f = if f = 1 then 1 else 0 :=
   coeff_monomial 1 1 f

--- a/HexSparsePoly/Dense.lean
+++ b/HexSparsePoly/Dense.lean
@@ -71,6 +71,7 @@ theorem foldl_max_le {l : List (Nat × R)} {n : Nat}
       exact Nat.max_le.mpr ⟨h0, h a (List.mem_cons_self ..)⟩
 
 omit [DecidableEq R] in
+omit [Zero R] in
 /-- Writing a term list into an array does not change its size. -/
 theorem size_foldl_set (l : List (Nat × R)) (base : Array R) :
     (l.foldl (fun acc t => acc.setIfInBounds t.1 t.2) base).size =
@@ -79,6 +80,7 @@ theorem size_foldl_set (l : List (Nat × R)) (base : Array R) :
   | nil => rfl
   | cons a as ih => rw [List.foldl_cons, ih, Array.size_setIfInBounds]
 
+omit [DecidableEq R] in
 /-- Writing a sorted, in-bounds term list into an array puts each
 coefficient at its exponent and touches nothing else. -/
 theorem getD_foldl_set {l : List (Nat × R)}
@@ -344,12 +346,14 @@ theorem ofDense_eq_impl : @ofDense = @ofDenseImpl := by
   exact DensePoly.toList_getD_eq_coeff p e
 
 omit [DecidableEq R] in
+omit [Zero R] in
 /-- `getD` on an array agrees with `getD` on its list. -/
 theorem toList_getD (a : Array R) (i : Nat) (d : R) :
     a.toList.getD i d = a.getD i d := by
   rw [Array.getD_eq_getD_getElem?, List.getD_eq_getElem?_getD,
     Array.getElem?_toList]
 
+omit [DecidableEq R] in
 /-- The dense image of a sorted term array stores exactly its
 coefficients. -/
 theorem getD_coeffsOfTerms {ts : Array (Nat × R)}
@@ -481,6 +485,7 @@ theorem toDense_inj {s t : SparsePoly R} (h : s.toDense = t.toDense) :
     s = t := by
   rw [← ofDense_toDense s, ← ofDense_toDense t, h]
 
+/-- The conversion sends zero to zero. -/
 @[simp, grind =] theorem toDense_zero :
     (0 : SparsePoly R).toDense = 0 := by
   apply DensePoly.ext_coeff
@@ -488,6 +493,7 @@ theorem toDense_inj {s t : SparsePoly R} (h : s.toDense = t.toDense) :
   rw [coeff_toDense, coeff_zero]
   exact (DensePoly.coeff_eq_zero_of_size_le 0 (by simp)).symm
 
+/-- The conversion sends one to one. -/
 @[simp, grind =] theorem toDense_one [One R] :
     (1 : SparsePoly R).toDense = 1 := by
   apply DensePoly.ext_coeff
@@ -497,6 +503,7 @@ theorem toDense_inj {s t : SparsePoly R} (h : s.toDense = t.toDense) :
   rw [coeff_one, DensePoly.coeff_C]
   rfl
 
+/-- The conversion sends monomials to dense monomials. -/
 @[simp, grind =] theorem toDense_monomial (e : Nat) (c : R) :
     (monomial e c).toDense = DensePoly.monomial e c := by
   apply DensePoly.ext_coeff
@@ -504,6 +511,7 @@ theorem toDense_inj {s t : SparsePoly R} (h : s.toDense = t.toDense) :
   rw [coeff_toDense, coeff_monomial, DensePoly.coeff_monomial]
   rfl
 
+/-- The conversion is additive. -/
 theorem toDense_add {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
     (s t : SparsePoly S) : (s + t).toDense = s.toDense + t.toDense := by
   apply DensePoly.ext_coeff
@@ -511,6 +519,7 @@ theorem toDense_add {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
   rw [coeff_toDense, coeff_add,
     DensePoly.coeff_add _ _ _ (by grind), coeff_toDense, coeff_toDense]
 
+/-- The conversion commutes with negation. -/
 theorem toDense_neg {S : Type u} [Lean.Grind.Ring S] [DecidableEq S]
     (s : SparsePoly S) : (-s).toDense = -s.toDense := by
   apply DensePoly.ext_coeff
@@ -523,12 +532,14 @@ theorem toDense_neg {S : Type u} [Lean.Grind.Ring S] [DecidableEq S]
   rw [show (0 : DensePoly S).coeff e = 0 from
     DensePoly.coeff_eq_zero_of_size_le 0 (by simp)]
 
+/-- The reverse conversion sends zero to zero. -/
 theorem ofDense_zero : ofDense (0 : DensePoly R) = 0 := by
   apply ext_coeff
   intro e
   rw [coeff_ofDense, coeff_zero]
   exact DensePoly.coeff_eq_zero_of_size_le 0 (by simp)
 
+/-- The reverse conversion sends one to one. -/
 theorem ofDense_one [One R] : ofDense (1 : DensePoly R) = 1 := by
   apply ext_coeff
   intro e
@@ -537,6 +548,7 @@ theorem ofDense_one [One R] : ofDense (1 : DensePoly R) = 1 := by
   rw [DensePoly.coeff_C]
   rfl
 
+/-- The reverse conversion is additive. -/
 theorem ofDense_add {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
     (p q : DensePoly S) : ofDense (p + q) = ofDense p + ofDense q := by
   apply ext_coeff
@@ -544,6 +556,7 @@ theorem ofDense_add {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
   rw [coeff_ofDense, coeff_add, DensePoly.coeff_add _ _ _ (by grind),
     coeff_ofDense, coeff_ofDense]
 
+/-- The reverse conversion commutes with negation. -/
 theorem ofDense_neg {S : Type u} [Lean.Grind.Ring S] [DecidableEq S]
     (p : DensePoly S) : ofDense (-p) = -(ofDense p) := by
   apply ext_coeff
@@ -559,10 +572,12 @@ section MulSemiring
 
 variable {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
 
+omit [DecidableEq S] in
 private theorem zero_add_zero : (Zero.zero : S) + Zero.zero = Zero.zero := by
   show (0 : S) + 0 = 0
   grind
 
+/-- Fold congruence pointwise on the folded function and initial value. -/
 theorem foldl_congr' {α β : Type _} {l : List α} {f g : β → α → β}
     {i j : β} (hij : i = j) (hfg : ∀ b : β, ∀ a ∈ l, f b a = g b a) :
     l.foldl f i = l.foldl g j := by
@@ -605,6 +620,7 @@ private theorem dense_coeff_foldl_add {α : Type _} (l : List α)
       simp only [List.foldl_cons]
       rw [ih, DensePoly.coeff_add _ _ _ zero_add_zero]
 
+omit [DecidableEq S] in
 /-- One block of the pairwise product, folded at a target exponent: at
 most one product of a term of `s` with the sorted terms of `t` lands on
 any exponent, and its value is the {name}`mulMonomial` coefficient. -/
@@ -792,50 +808,59 @@ theorem coeff_mul (s t : SparsePoly S) (n : Nat) :
 {name}`toDense`. The dense side proves them at `Lean.Grind.CommRing`,
 so that is where they live here too. -/
 
+/-- Multiplication is associative. -/
 theorem mul_assoc (s t u : SparsePoly S) : s * t * u = s * (t * u) := by
   apply toDense_inj
   rw [toDense_mul, toDense_mul, toDense_mul, toDense_mul]
   exact DensePoly.mul_assoc_poly _ _ _
 
+/-- Multiplication is commutative. -/
 theorem mul_comm (s t : SparsePoly S) : s * t = t * s := by
   apply toDense_inj
   rw [toDense_mul, toDense_mul]
   exact DensePoly.mul_comm_poly _ _
 
+/-- One is a right identity for multiplication. -/
 @[simp, grind =] theorem mul_one (s : SparsePoly S) :
     s * 1 = s := by
   apply toDense_inj
   rw [toDense_mul, toDense_one]
   exact DensePoly.mul_one_right_poly _
 
+/-- One is a left identity for multiplication. -/
 @[simp, grind =] theorem one_mul (s : SparsePoly S) :
     1 * s = s := by
   rw [mul_comm]
   exact mul_one s
 
+/-- Zero absorbs on the right of multiplication. -/
 @[simp, grind =] theorem mul_zero (s : SparsePoly S) : s * 0 = 0 := by
   apply toDense_inj
   rw [toDense_mul, toDense_zero]
   rw [DensePoly.mul_comm_poly]
   exact DensePoly.zero_mul _
 
+/-- Zero absorbs on the left of multiplication. -/
 @[simp, grind =] theorem zero_mul (s : SparsePoly S) : 0 * s = 0 := by
   apply toDense_inj
   rw [toDense_mul, toDense_zero]
   exact DensePoly.zero_mul _
 
+/-- Multiplication distributes over addition on the left. -/
 theorem left_distrib (s t u : SparsePoly S) :
     s * (t + u) = s * t + s * u := by
   apply toDense_inj
   rw [toDense_mul, toDense_add, toDense_add, toDense_mul, toDense_mul]
   exact DensePoly.mul_add_right_poly _ _ _
 
+/-- Multiplication distributes over addition on the right. -/
 theorem right_distrib (s t u : SparsePoly S) :
     (s + t) * u = s * u + t * u := by
   apply toDense_inj
   rw [toDense_mul, toDense_add, toDense_add, toDense_mul, toDense_mul]
   exact DensePoly.mul_add_left_poly _ _ _
 
+/-- The zeroth power is one. -/
 @[simp, grind =] theorem pow_zero (s : SparsePoly S) : s ^ 0 = 1 := by
   show pow s 0 = 1
   rw [pow, dif_pos rfl]
@@ -1024,6 +1049,7 @@ where the degree is. -/
       congr 1
       omega
 
+/-- The leading coefficient transports through the dense conversion. -/
 @[simp, grind =] theorem leadingCoeff_toDense (s : SparsePoly R) :
     s.toDense.leadingCoeff = s.leadingCoeff := by
   cases hback : s.terms.back? with
@@ -1055,6 +1081,7 @@ def Monic [One R] (s : SparsePoly R) : Prop :=
 instance [One R] (s : SparsePoly R) : Decidable s.Monic :=
   inferInstanceAs (Decidable (s.leadingCoeff = 1))
 
+/-- Monicity transports through the dense conversion. -/
 @[simp] theorem monic_toDense [One R] (s : SparsePoly R) :
     s.toDense.Monic ↔ s.Monic := by
   unfold DensePoly.Monic Monic

--- a/HexSparsePoly/Euclid.lean
+++ b/HexSparsePoly/Euclid.lean
@@ -68,7 +68,7 @@ instance [One R] [Add R] [Sub R] [Mul R] [Div R] : Mod (SparsePoly R) where
 /-- Divide by the monomial `x^e`, the one division that stays sparse:
 `none` unless every stored exponent is at least `e`, and otherwise a
 subtraction on each exponent, `O(s)` with no filtering. -/
-def divMonomial? [Mul R] (s : SparsePoly R) (e : Nat) :
+def divMonomial? (s : SparsePoly R) (e : Nat) :
     Option (SparsePoly R) :=
   if h : ∀ t ∈ s.terms.toList, e ≤ t.1 then
     some (ofCanonicalList
@@ -123,6 +123,7 @@ section Laws
 
 variable {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
 
+omit [Div S] in
 /-- Divisibility transports back from the dense representation. -/
 theorem dvd_of_toDense_dvd {s t : SparsePoly S}
     (h : s.toDense ∣ t.toDense) : s ∣ t := by
@@ -130,12 +131,14 @@ theorem dvd_of_toDense_dvd {s t : SparsePoly S}
   exact ⟨ofDense r, toDense_inj (by
     rw [toDense_mul, toDense_ofDense, hr])⟩
 
+omit [Div S] in
 /-- Divisibility transports to the dense representation. -/
 theorem toDense_dvd {s t : SparsePoly S} (h : s ∣ t) :
     s.toDense ∣ t.toDense := by
   obtain ⟨r, hr⟩ := h
   exact ⟨r.toDense, by rw [← toDense_mul, ← hr]⟩
 
+omit [Div S] in
 /-- The degree transports through `ofDense`. -/
 theorem degree?_ofDense (p : DensePoly S) :
     (ofDense p).degree? = p.degree? := by
@@ -192,6 +195,7 @@ private theorem divModMonic_snd_eq_zero_of_dvd {s t : SparsePoly S}
     DensePoly.mod_eq_zero_of_dvd s.toDense t.toDense (toDense_dvd h)
   rw [hm, ofDense_zero]
 
+omit [Div S] [DensePoly.DivModLaws S] in
 /-- Monic factors cancel at the dense level: a product with a monic
 polynomial vanishes only if the cofactor does. The trivial-ring case is
 split off; otherwise the product's leading coefficient is the

--- a/HexSparsePoly/Eval.lean
+++ b/HexSparsePoly/Eval.lean
@@ -65,6 +65,7 @@ section EvalLaws
 
 variable {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
 
+omit [DecidableEq S] in
 /-- Powers of the square are even powers. -/
 theorem sq_pow (x : S) (n : Nat) : (x * x) ^ n = x ^ (2 * n) := by
   induction n with
@@ -94,6 +95,7 @@ theorem pow1_eq (x : S) (g : Nat) (hg : 1 ≤ g) : pow1 x g = x ^ g := by
       have hexp : 2 * ((g + 2) / 2) = g + 2 := by omega
       rw [hexp]
 
+omit [DecidableEq S] in
 /-- Powers at added exponents multiply. -/
 theorem pow_add' (x : S) (a b : Nat) : x ^ a * x ^ b = x ^ (a + b) := by
   grind
@@ -144,6 +146,7 @@ theorem evalShifted_eq {l : List (Nat × S)}
       rw [← hshift rest (fun u hu => Nat.le_of_lt (hs.1 u hu))]
       grind
 
+omit [DecidableEq S] in
 /-- Every term sum over the stored terms evaluates the polynomial: the
 bridge between the gap form and the dense fold-of-monomials form. -/
 private theorem foldl_add_eval_monomials {l : List (Nat × S)} (x : S) :
@@ -269,10 +272,10 @@ def substPow [Add R] (s : SparsePoly R) (k : Nat) : SparsePoly R :=
     ofCanonicalList
       (mapTerms (fun e => k * e) (fun _ c => c) s.terms.toList)
       (mapTerms_canonical s.pairwise_toList
-        (fun a _ b _ hab =>
+        (fun _ _ _ _ hab =>
           (Nat.mul_lt_mul_left (Nat.pos_of_ne_zero hk)).mpr hab)).1
       (mapTerms_canonical s.pairwise_toList
-        (fun a _ b _ hab =>
+        (fun _ _ _ _ hab =>
           (Nat.mul_lt_mul_left (Nat.pos_of_ne_zero hk)).mpr hab)).2
 
 /-- Coefficient law for the sparse substitution, positive case: the
@@ -423,6 +426,7 @@ def composeStep [Add R] [Mul R] (t : SparsePoly R)
           (st.1 + scale term.2 (p * polyPow1 t (g + 1)), term.1,
             some (p * polyPow1 t (g + 1)))
 
+/-- Substitute `t` for the variable of `s`: one fold of `composeStep` over the terms, carrying the running power of `t` across each exponent gap. -/
 def compose [Add R] [Mul R] (s t : SparsePoly R) : SparsePoly R :=
   (s.terms.foldl (composeStep t)
     ((0 : SparsePoly R), (0, (none : Option (SparsePoly R))))).1
@@ -508,19 +512,23 @@ theorem eval_mul (s t : SparsePoly K) (x : K) :
   rw [eval_toDense, toDense_mul, DensePoly.eval_mul_commring,
     ← eval_toDense, ← eval_toDense]
 
+/-- Evaluating a monomial multiplies its coefficient by the power. -/
 @[simp, grind =] theorem eval_monomial (e : Nat) (c : K) (x : K) :
     (monomial e c).eval x = c * x ^ e := by
   rw [eval_toDense, toDense_monomial, DensePoly.eval_monomial_semiring]
 
+/-- Constants evaluate to their value. -/
 @[simp, grind =] theorem eval_C (c : K) (x : K) : (C c).eval x = c := by
   show (monomial 0 c).eval x = c
   rw [eval_monomial]
   grind
 
+/-- One evaluates to `1`. -/
 @[simp, grind =] theorem eval_one (x : K) : (1 : SparsePoly K).eval x = 1 := by
   show (SparsePoly.C 1).eval x = 1
   rw [eval_C]
 
+/-- Zero evaluates to `0`. -/
 @[simp, grind =] theorem eval_zero (x : K) :
     (0 : SparsePoly K).eval x = 0 :=
   rfl
@@ -566,7 +574,6 @@ private theorem compose_go (t : SparsePoly K) (l : List (Nat × K)) :
         unfold composeStep
         cases hgap : u.1 - prev with
         | zero =>
-            simp only [hgap]
             have hpe : prev = u.1 := by omega
             refine ⟨tp, ?_, ?_, ?_⟩
             · cases tp with
@@ -587,7 +594,6 @@ private theorem compose_go (t : SparsePoly K) (l : List (Nat × K)) :
             · rw [htpv, hpe]
         | succ g =>
             have hg1 : g + 1 = u.1 - prev := hgap.symm
-            simp only [hgap]
             cases tp with
             | none =>
                 have h0 : prev = 0 := hnone rfl
@@ -783,6 +789,7 @@ private theorem coeff_monomial_foldl (l : List (Nat × K)) (k : Nat)
       intro init
       rw [List.foldl_cons, List.foldl_cons, ih, coeff_add, coeff_monomial]
 
+omit [DecidableEq K] in
 private theorem foldl_add_ifs_zero {l : List (Nat × K)}
     {g : Nat × K → K} (h : ∀ u ∈ l, g u = 0) :
     ∀ x : K, l.foldl (fun a u => a + g u) x = x := by
@@ -794,6 +801,7 @@ private theorem foldl_add_ifs_zero {l : List (Nat × K)}
         show x + (0 : K) = x from by grind]
       exact ih (fun v hv => h v (List.mem_cons_of_mem _ hv)) x
 
+omit [DecidableEq K] in
 private theorem foldl_single_match {l : List (Nat × K)}
     (hs : l.Pairwise (fun a b => a.1 < b.1)) {k : Nat} (hk : ¬ k = 0)
     (e : Nat) :

--- a/HexSparsePolyMathlib/LintTests.lean
+++ b/HexSparsePolyMathlib/LintTests.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexSparsePolyMathlib
+import Batteries.Tactic.Lint
+import Mathlib.Tactic.Linter.Lint
+import Mathlib.Tactic.Linter.Style
+import Mathlib.Tactic.Linter.TacticDocumentation
+
+/-!
+# Sparse-polynomial lint regression
+
+This file intentionally uses legacy file syntax rather than `module`.
+Imported docstring metadata is not available to the linter through
+module imports, which would make every imported declaration appear
+undocumented.
+
+Beyond Batteries' default linter set (which already includes `docBlame`
+for defs, structures, and other non-theorem declarations), this run
+enables theorem docstring coverage via `docBlameThm'` below, so the
+docstring-coverage bar of `SPEC/design-principles.md` is build-enforced
+rather than manual. `docBlame` is listed explicitly to record that the
+bar depends on it. The run covers both the Mathlib-free core and its
+Mathlib correspondence layer.
+-/
+
+open Batteries.Tactic.Lint in
+/-- `docBlameThm`, minus the compiler-generated `ofNat_ctorIdx` theorems
+of enum inductives and the `@[ext]`-generated `ext_coeff_iff`.
+Batteries' `Environment.isAutoDecl` filter predates those generated
+names, so plain `docBlameThm` reports them as undocumented; `@[nolint]`
+cannot repair this from here because it only applies in the defining
+module. -/
+@[env_linter disabled] def docBlameThm' : Linter :=
+  { docBlameThm with
+    test := fun declName => do
+      if declName.components.getLast? == some `ofNat_ctorIdx then return none
+      if declName.components.getLast? == some `ext_coeff_iff then return none
+      docBlameThm.test declName }
+
+#lint- docBlame docBlameThm' in HexSparsePoly
+
+#lint- docBlame docBlameThm' in HexSparsePolyMathlib

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -640,7 +640,7 @@ lean_lib HexFactorizationModules where
 -- release manifest's test_modules) when the split repository is published.
 @[default_target]
 lean_lib HexSparsePolyTests where
-  globs := #[`HexSparsePoly.KernelTests]
+  globs := #[`HexSparsePoly.KernelTests, `HexSparsePolyMathlib.LintTests]
 
 -- HexRCF is not yet a published split repository, so its verification-only
 -- modules stay separate from the release-manifest-backed target above.

--- a/libraries.yml
+++ b/libraries.yml
@@ -135,7 +135,7 @@ libraries:
   HexSparsePoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       comparators:
@@ -481,7 +481,7 @@ libraries:
   HexSparsePolyMathlib:
     deps: [HexSparsePoly, HexPolyMathlib, HexPoly]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexMatrixMathlib:
     deps: [HexMatrix]

--- a/progress/20260823T130642Z_sparse-poly-polish.md
+++ b/progress/20260823T130642Z_sparse-poly-polish.md
@@ -1,0 +1,56 @@
+# hex-sparse-poly + companion: Phase-6 polish
+
+## Accomplished
+
+- Warning sweep to zero across the core: 8 unused simp arguments
+  removed, 17 `omit [...]` clauses added for unused auto-included
+  section variables (including two revealed by the first pass), two
+  no-op `simp only [hgap]` lines deleted, two unused lambda binders
+  anonymised.
+- Two unused instance arguments dropped: `SparsePolyCanonical` loses
+  `[DecidableEq R]`, `divMonomial?` loses `[Mul R]`.
+- Build-enforced docstring coverage: `HexSparsePolyMathlib/LintTests.lean`
+  runs Batteries' default linter set plus `docBlame`/`docBlameThm'`
+  (the RCF pattern, additionally filtering the `@[ext]`-generated
+  `ext_coeff_iff`) over both libraries, wired into `HexSparsePolyTests`.
+  43 missing docstrings written (one def, 42 theorems). It lives under
+  the mathlib-true owner because it imports the Mathlib linter
+  framework.
+- Dead-declaration sweep: 262 public declarations, 25 referenced only
+  at their definition, all kept with documented interface roles: the
+  SPEC'd law/transport surface (round trips, `ofDense_*`/`toDense_*`
+  images, `divExactMonic?` iffs, `divMod_degree_lt`,
+  `mulMonomial_divMonomial`, `derivative_add`, `eval_substPow`,
+  `coeff_substScale`, `dvd_def`, the companion `equiv_*` lemmas and
+  the `_apply` conventions) plus two characterising helpers
+  (`coeffList_termsOfCoeffsList_of_lt`, `addCoeff_zero_left`).
+- Perf regression check against the Phase-4 headline numbers, one
+  registration per family at the top schedule rungs: mul at parity
+  (8.51 ms vs 8.67 ms at t=256), eval parity (13.8 µs vs 13.5 µs at
+  t=512), substPow flat (128 ns at k=32768 vs 126 ns), add and
+  convert-gcd about 2x faster than the recorded numbers (systematic
+  main-side improvement, not a regression).
+- Native-path criterion holds (no native_decide, csimp twins only);
+  no irreducibility claims in scope. `done_through: 6` for both.
+
+Also this session, stack maintenance: the Phase-4 checker grew a
+cost-model-derivation requirement on main; satisfied by amending the
+conformance-branch commit message (which owns the bench registration
+lines) with per-family derivations, and by naming the comparators
+verbatim in the headline report. #9374 merged; #9380 retargeted to
+main with auto-merge armed.
+
+## Current frontier
+
+Both libraries at Phase 7 (user-facing documentation).
+
+## Next step
+
+Phase 7: `HexManual/Chapters/HexSparsePoly.lean` Verso chapter with the
+Mathlib-correspondence section (check_phase7.py enforces the companion
+documents inside the parent chapter), `HexSparsePoly/README.md` per
+SPEC/readme.md, `done_through: 7` both. Then the release tail.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -832,5 +832,11 @@
     "baseline_blob": "ff87edbbbf7524190b536ae4ce92a57968275aa9",
     "current_blob": "08583d0e78edfe858267ffa07fde97ce95d5460a",
     "reason": "Adds the HexSparsePolyMathlib.Conformance glob on top of the HexSparsePolyMathlib lean_lib registration; no factorization module, executable, or build-flag changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "ff87edbbbf7524190b536ae4ce92a57968275aa9",
+    "current_blob": "8f5ad6feadc9b8448e9fd7ebc12f62bf28ecebc7",
+    "reason": "Adds the HexSparsePolyMathlib.LintTests glob to the HexSparsePolyTests verification target; no factorization module, executable, or build-flag changes."
   }
 ]


### PR DESCRIPTION
This PR bring both sparse-poly libraries through Phase 6: a zero-warning sweep over the core (unused simp arguments, `omit` clauses for unused auto-included section variables, no-op simp lines, anonymous binders), removal of two unused instance arguments (`SparsePolyCanonical` loses `[DecidableEq R]`, `divMonomial?` loses `[Mul R]`), 43 new docstrings with coverage build-enforced by `HexSparsePolyMathlib/LintTests.lean` (Batteries' default linter set plus `docBlame`/`docBlameThm'` over both libraries, following the HexRCF pattern), a dead-declaration sweep that keeps 25 unreferenced declarations with documented interface roles, and a per-family bench rerun showing parity or better against the Phase-4 headline numbers. `done_through: 6` for both libraries.

🤖 Prepared with Claude Code