### PR TITLE
docs(sparse-poly): Phase-7 manual chapter and READMEs

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -33,6 +33,7 @@ import HexManual.Chapters.HexBerlekampZassenhaus
 import HexManual.Chapters.FactorTactics
 -- Unreleased libraries (dependency order).
 import HexManual.Chapters.HexResultant
+import HexManual.Chapters.HexSparsePoly
 import HexManual.Chapters.HexRCF
 import HexManual.Chapters.HexNumberField
 import HexManual.Chapters.HexNumberFieldTower
@@ -147,6 +148,8 @@ split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexResultant}
+
+{include 2 HexManual.Chapters.HexSparsePoly}
 
 {include 2 HexManual.Chapters.HexRCF}
 

--- a/HexManual/Chapters/HexSparsePoly.lean
+++ b/HexManual/Chapters/HexSparsePoly.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexSparsePolyMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexSparsePoly: sparse univariate polynomials" =>
+%%%
+tag := "hex-sparse-poly"
+%%%
+
+# Introduction
+%%%
+tag := "hex-sparse-poly-intro"
+%%%
+
+`HexSparsePoly` provides canonical sparse univariate polynomials: a
+polynomial is a sorted array of `(exponent, coefficient)` terms with
+strictly increasing exponents and no stored zero coefficient. Costs
+scale with the number of stored terms rather than the degree, so a
+two-term polynomial of degree one million is two array entries. The
+representation is canonical, so equality is structural and decidable.
+
+The executable library is Mathlib-free. It depends on `HexBasic` for
+array equality and fold algebra, and on {ref "hex-poly"}[`HexPoly`] for
+the dense representation it converts to and from. It is a second
+representation next to `Hex.DensePoly`, not a replacement: callers name
+the representation they hold and convert explicitly, because the same
+named operation can differ in cost by a factor of the degree between
+the two. `HexSparsePolyMathlib`, described in
+{ref "hex-sparse-poly-mathlib"}[the correspondence section], identifies
+the type with Mathlib's `Polynomial R`.
+
+# The representation
+%%%
+tag := "hex-sparse-poly-representation"
+%%%
+
+{docstring Hex.SparsePoly}
+
+{docstring Hex.SparsePolyCanonical}
+
+Coefficient access is the semantic anchor: every equality of sparse
+polynomials reduces to coefficient extensionality, and the canonical
+invariant makes the stored exponents exactly the nonzero positions.
+
+{docstring Hex.SparsePoly.coeff}
+
+{docstring Hex.SparsePoly.mem_support_iff}
+
+Construction goes through {name}`Hex.SparsePoly.ofTerms`, which accepts
+arbitrary unsorted term arrays, combines duplicates in input order, and
+drops cancellations; its compiled implementation is a stable
+sort-and-combine selected by `@[csimp]`.
+
+{docstring Hex.SparsePoly.ofTerms}
+
+{docstring Hex.SparsePoly.addTerm}
+
+{docstring Hex.SparsePoly.monomial}
+
+# Arithmetic
+%%%
+tag := "hex-sparse-poly-arithmetic"
+%%%
+
+Addition is a linear merge of the two term lists; degree never appears
+in the cost. Multiplication's kernel-facing specification forms all
+pairwise products and canonicalises; the compiled implementation,
+selected by measurement in the project's benchmarking phase, folds the
+pairwise products into an `Std.ExtTreeMap` accumulator, which beat both
+the sort-and-combine route and a Johnson-style heap merge by about
+three times on low- and high-collision inputs alike.
+
+{docstring Hex.SparsePoly.add}
+
+{docstring Hex.SparsePoly.mul}
+
+{docstring Hex.SparsePoly.mulMonomial}
+
+{docstring Hex.SparsePoly.scale}
+
+{docstring Hex.SparsePoly.pow}
+
+The coefficient laws and the commutative-ring laws are proved under the
+`Lean.Grind` algebra classes; `coeff_mul` and the multiplicative laws
+are transported through the dense conversion.
+
+{docstring Hex.SparsePoly.coeff_mul}
+
+# Conversions
+%%%
+tag := "hex-sparse-poly-conversions"
+%%%
+
+The dense conversions are the boundary between the two representations
+and the proof route for the multiplicative laws. `toDense` is the one
+operation whose cost is governed by the degree.
+
+{docstring Hex.SparsePoly.toDense}
+
+{docstring Hex.SparsePoly.ofDense}
+
+{docstring Hex.SparsePoly.toDense_mul}
+
+Measured crossovers (recorded in the library SPEC): sparse addition
+beats dense up to about `t ≈ n/8` stored terms at degree `n`, sparse
+multiplication up to about `t ≈ n/4`, and sparse evaluation stays ahead
+to at least `t ≈ n/6`.
+
+# Evaluation and substitution
+%%%
+tag := "hex-sparse-poly-eval"
+%%%
+
+Evaluation is gap Horner: one pass over the stored terms with binary
+powering across exponent gaps, `O(t)` coefficient multiplications plus
+`O(t log (n/t))` squarings.
+
+{docstring Hex.SparsePoly.eval}
+
+{docstring Hex.SparsePoly.derivative}
+
+{docstring Hex.SparsePoly.substPow}
+
+{docstring Hex.SparsePoly.substScale}
+
+{docstring Hex.SparsePoly.compose}
+
+# The Euclidean layer
+%%%
+tag := "hex-sparse-poly-euclid"
+%%%
+
+Division and gcd route through the dense representation, and the
+library makes no claim that they stay sparse: the cost is the dense
+cost at the degree plus the conversions. The one division that stays
+sparse is division by a monomial.
+
+{docstring Hex.SparsePoly.divModMonic}
+
+{docstring Hex.SparsePoly.divMod}
+
+{docstring Hex.SparsePoly.gcd}
+
+{docstring Hex.SparsePoly.divExactMonic?}
+
+{docstring Hex.SparsePoly.divMonomial?}
+
+# The Mathlib correspondence
+%%%
+tag := "hex-sparse-poly-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. `HexSparsePolyMathlib`
+identifies the sparse representation with Mathlib's `Polynomial R`,
+composing a ring equivalence with the dense representation and
+`HexPolyMathlib`'s equivalence.
+
+{docstring HexSparsePolyMathlib.denseEquiv}
+
+{docstring HexSparsePolyMathlib.equiv}
+
+The identification is exact, coefficient by coefficient, and the stored
+exponents are exactly Mathlib's `support`, which is the sense in which
+the representation is sparse.
+
+{docstring HexSparsePolyMathlib.coeff_equiv}
+
+{docstring HexSparsePolyMathlib.equiv_support}
+
+One correspondence lemma per public operation transports evaluation,
+differentiation, composition, and exponent substitution, alongside the
+constructor and observer images.
+
+{docstring HexSparsePolyMathlib.equiv_eval}
+
+{docstring HexSparsePolyMathlib.equiv_derivative}
+
+{docstring HexSparsePolyMathlib.equiv_compose}
+
+{docstring HexSparsePolyMathlib.equiv_substPow}
+
+# Cross-references
+%%%
+tag := "hex-sparse-poly-cross-references"
+%%%
+
+* {ref "hex-poly"}[`HexPoly`] supplies the dense representation behind
+  the conversions and the Euclidean layer.
+* `HexBasic/ArrayDecEq.lean` supplies the array equality instance the
+  decidable equality routes through.
+* `HexSparsePolyMathlib` is the proof boundary: it imports Mathlib,
+  while `HexSparsePoly` and its executable consumers do not.

--- a/HexSparsePoly/README.md
+++ b/HexSparsePoly/README.md
@@ -1,0 +1,83 @@
+# hex-sparse-poly
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-sparse-poly` provides canonical sparse univariate polynomials: sorted
+term arrays whose costs scale with the number of stored terms rather than
+the degree. It depends on
+[`hex-basic`](https://github.com/leanprover/hex-basic) and
+[`hex-poly`](https://github.com/leanprover/hex-poly), with explicit
+conversions to and from the dense representation. See
+[`hex-sparse-poly-mathlib`](https://github.com/leanprover/hex-sparse-poly-mathlib)
+for the correspondence with Mathlib's `Polynomial`.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-sparse-poly"
+git = "https://github.com/leanprover/hex-sparse-poly.git"
+rev = "main"
+```
+
+```lean
+import HexSparsePoly
+
+open Hex Hex.SparsePoly
+
+def p : SparsePoly Int := #sp[(0, 3), (1, -2), (1000000, 1)]
+def q : SparsePoly Int := #sp[(1, 2), (1000000, -1)]
+
+#eval (p + q).numTerms                 -- 1: two cancellations
+#eval (p * q).coeff 2000000            -- -1
+#eval (p.substPow 3).degree?           -- some 3000000
+#eval #sp[(0, 1), (2, 3)].eval (5 : Int)  -- 76
+#eval (p.derivative).coeff 999999      -- 1000000
+```
+
+# Functionality
+
+- Canonical construction from arbitrary term arrays (`ofTerms`, `addTerm`,
+  `monomial`, `C`, `X`, the `#sp[...]` literal), with structural decidable
+  equality.
+- Term-count-scaled arithmetic: `add` as a linear merge, `mul` with a
+  measured `Std.ExtTreeMap` accumulation implementation, `mulMonomial`,
+  `scale`, `pow`, `neg`, `sub`.
+- Gap-Horner evaluation (`eval`), `derivative`, exponent substitution
+  `substPow`, argument scaling `substScale`, and full composition
+  (`compose`).
+- Explicit dense conversions (`toDense`, `ofDense`) and a Euclidean layer
+  routed through them (`divModMonic`, `divMod`, `gcd`, `divExactMonic?`),
+  plus the one division that stays sparse, `divMonomial?`.
+
+# Verification
+
+Every operation carries a kernel-facing specification whose compiled
+implementation is selected by a proved `@[csimp]` equality, and every
+public operation has a coefficient lemma; equalities reduce to
+coefficient extensionality:
+
+```lean
+theorem ext_coeff {s t : SparsePoly R}
+    (h : ∀ e : Nat, s.coeff e = t.coeff e) : s = t
+```
+
+The ring laws are proved under the `Lean.Grind` algebra classes, the
+multiplicative laws by transport through the proved dense conversion
+homomorphism. The division and gcd laws transport from `hex-poly`'s
+`DivModLaws`/`GcdLaws` packages. The identification with Mathlib's
+`Polynomial` (including the support characterisation that makes the
+representation "sparse") lives in
+[`hex-sparse-poly-mathlib`](https://github.com/leanprover/hex-sparse-poly-mathlib).
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this
+published mirror. Contributions are welcome as pull requests to the
+`SPEC/` directory there: describe the behaviour you want and leave the
+implementation to the maintainer.

--- a/HexSparsePolyMathlib/README.md
+++ b/HexSparsePolyMathlib/README.md
@@ -1,0 +1,76 @@
+# hex-sparse-poly-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-sparse-poly-mathlib` is the Mathlib correspondence layer for
+[`hex-sparse-poly`](https://github.com/leanprover/hex-sparse-poly). It
+identifies the executable canonical sparse representation with Mathlib's
+`Polynomial R` and transports one correspondence lemma per public
+operation. It depends on Mathlib,
+[`hex-sparse-poly`](https://github.com/leanprover/hex-sparse-poly), and
+[`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib).
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-sparse-poly-mathlib"
+git = "https://github.com/leanprover/hex-sparse-poly-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexSparsePolyMathlib
+
+open Hex HexSparsePolyMathlib
+
+#check (equiv : SparsePoly Int ≃+* Polynomial Int)
+
+example (p q : SparsePoly Int) : equiv (p * q) = equiv p * equiv q :=
+  map_mul equiv p q
+
+example (p : SparsePoly Int) (x : Int) : (equiv p).eval x = p.eval x := by
+  simp
+```
+
+# Functionality
+
+- The ring equivalences `denseEquiv` (with the executable dense
+  representation) and `equiv` (with Mathlib's `Polynomial R`), both at
+  `[CommRing R] [DecidableEq R]`.
+- The coefficientwise identification `coeff_equiv` and the support
+  characterisation `equiv_support`.
+- Operation correspondence: `equiv_eval`, `equiv_derivative`,
+  `equiv_compose`, `equiv_substPow`, and the constructor and observer
+  images `equiv_monomial`, `equiv_C`, `equiv_X`, `equiv_natDegree`,
+  `equiv_leadingCoeff`, `equiv_monic`.
+
+# Verification
+
+Everything is proved; there is no axiom and no `sorry`. The headline is
+the exact identification and its two semantic clauses:
+
+```lean
+theorem coeff_equiv (s : Hex.SparsePoly R) (e : Nat) :
+    (equiv s).coeff e = s.coeff e
+theorem equiv_support (s : Hex.SparsePoly R) :
+    (equiv s).support = s.support.toList.toFinset
+```
+
+The executable operations, their kernel-facing specifications, and the
+Mathlib-free algebra live in
+[`hex-sparse-poly`](https://github.com/leanprover/hex-sparse-poly); the
+dense-side equivalence this layer composes with lives in
+[`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib).
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this
+published mirror. Contributions are welcome as pull requests to the
+`SPEC/` directory there: describe the behaviour you want and leave the
+implementation to the maintainer.

--- a/libraries.yml
+++ b/libraries.yml
@@ -135,7 +135,7 @@ libraries:
   HexSparsePoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -481,7 +481,7 @@ libraries:
   HexSparsePolyMathlib:
     deps: [HexSparsePoly, HexPolyMathlib, HexPoly]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexMatrixMathlib:
     deps: [HexMatrix]

--- a/progress/20260823T130958Z_sparse-poly-docs.md
+++ b/progress/20260823T130958Z_sparse-poly-docs.md
@@ -1,0 +1,37 @@
+# hex-sparse-poly + companion: Phase-7 documentation
+
+## Accomplished
+
+- `HexManual/Chapters/HexSparsePoly.lean`: the Verso reference chapter
+  (representation, arithmetic with the measured multiplication
+  selection, conversions with the recorded crossovers, evaluation and
+  substitution, the Euclidean layer) with the required
+  `# The Mathlib correspondence` section documenting the companion
+  inside the parent chapter, wired into `HexManual.lean` under the
+  draft sections; `lake build HexManual` green; `check_phase7.py`
+  passes.
+- `HexSparsePoly/README.md` and `HexSparsePolyMathlib/README.md` per
+  `SPEC/readme.md`'s five-section shape, both quickstart snippets
+  build-checked through `lake env lean`.
+- `done_through: 7` for both libraries.
+
+## Current frontier
+
+Both libraries complete through Phase 7. All that remains of the plan
+is the release tail, plus shepherding the open PR stack into main
+(#9380 is retargeted to main with auto-merge armed; each successor gets
+the same treatment as its base merges).
+
+## Next step
+
+Release tail per PLAN/Releases.md: Kim/ops creates
+leanprover/hex-sparse-poly{,-mathlib} with Lake skeletons and widens a
+hex-publishing token; then released.yml entries (pins incl. the
+conformance-only hex-mod-arith), moving KernelTests into
+HexReleaseTests + test_modules at split time, the manual-split flip of
+the chapter, and the sync dry-run.
+
+## Blockers
+
+The release-tail repo creation and token widening need Kim (org-owner
+approval); everything up to that point is PR-able from here.


### PR DESCRIPTION
This PR complete Phase 7 for both sparse-poly libraries: the Verso reference chapter (representation, arithmetic with the measured multiplication selection, conversions with the recorded crossovers, evaluation and substitution, the Euclidean layer) with the required `# The Mathlib correspondence` section documenting the companion inside the parent chapter, wired into the manual's draft-sections list; and the two released-repo READMEs per SPEC/readme.md with build-checked quickstart snippets. `done_through: 7` for both libraries; `check_phase7.py` passes and `lake build HexManual` is green.

🤖 Prepared with Claude Code