### PR TITLE
chore(release): prepare the sparse-poly split publication

### DIFF
--- a/HexAggregateCheck.lean
+++ b/HexAggregateCheck.lean
@@ -11,7 +11,9 @@ public import HexArith
 public import HexPoly
 public import HexMvPoly
 public import HexModArith
+public import HexSparsePoly
 public import HexPolyMathlib
+public import HexSparsePolyMathlib
 public import HexMvPolyMathlib
 public import HexPolyFp
 public import HexPolyZ

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -76,6 +76,8 @@ contracts and, for mature libraries, supply their proofs.
 
 {include 0 HexManual.Chapters.HexMvPoly}
 
+{include 0 HexManual.Chapters.HexSparsePoly}
+
 {include 0 HexManual.Chapters.HexModArith}
 
 {include 0 HexManual.Chapters.HexPolyFp}
@@ -148,8 +150,6 @@ split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexResultant}
-
-{include 2 HexManual.Chapters.HexSparsePoly}
 
 {include 2 HexManual.Chapters.HexRCF}
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -626,7 +626,8 @@ lean_lib HexReleaseTests where
     `HexRealRootsMathlib.IsolateRootsTests,
     `HexRealRootsMathlib.IsolateRootsElabTests,
     `HexRootsMathlib.Examples,
-    `HexMvPoly.KernelTests]
+    `HexMvPoly.KernelTests,
+    `HexSparsePoly.KernelTests]
 
 -- Verification-only modules for the incubating multivariate factorization
 -- stack. Keep this separate from the released-test target, whose module list
@@ -661,13 +662,12 @@ lean_lib HexFactorizationModules where
   globs := #[`HexBerlekampZassenhaus.All,
     `HexBerlekampZassenhausMathlib.All]
 
--- HexSparsePoly is not yet a published split repository, so its
--- verification-only kernel probes stay separate from the
--- release-manifest-backed target above; they join HexReleaseTests (and the
--- release manifest's test_modules) when the split repository is published.
+-- Monorepo-only lint regression for the sparse-poly pair; the kernel
+-- probes live in HexReleaseTests alongside the release manifest's
+-- test_modules entry.
 @[default_target]
 lean_lib HexSparsePolyTests where
-  globs := #[`HexSparsePoly.KernelTests, `HexSparsePolyMathlib.LintTests]
+  globs := #[`HexSparsePolyMathlib.LintTests]
 
 -- HexRCF is not yet a published split repository, so its verification-only
 -- modules stay separate from the release-manifest-backed target above.

--- a/progress/20260823T131303Z_sparse-poly-release.md
+++ b/progress/20260823T131303Z_sparse-poly-release.md
@@ -1,0 +1,46 @@
+# hex-sparse-poly + companion: release-tail preparation
+
+## Accomplished
+
+- `scripts/release/released.yml`: the `leanprover/hex-sparse-poly`
+  entry (component label, kernel-probe test_modules, bench,
+  conformance with fixtures and the SymPy oracle pair, pins
+  [hex-basic, hex-poly, hex-arith, hex-mod-arith]) placed after
+  hex-mod-arith, and the `leanprover/hex-sparse-poly-mathlib` entry
+  ahead of the other *-mathlib repos; both added to the aggregate
+  `leanprover/hex` pin list.
+- New manifest field `conformance_pins` in
+  `check_released_manifest.py`: a repo's conformance project may pin
+  libraries its published library does not (here hex-arith and
+  hex-mod-arith for the ZMod64 zero-divisor and characteristic cases,
+  exactly as the library SPEC records); the checker now accepts the
+  declared additions and rejects redundant declarations.
+- `HexSparsePoly.KernelTests` moved into the `HexReleaseTests` globs
+  to match the manifest's test_modules; `HexSparsePolyTests` remains
+  as the monorepo-only lint target.
+- `HexAggregateCheck.lean` mirrors the new aggregate pins; the manual
+  chapter moved from the draft section to the released side of
+  `HexManual.lean` (include level 2 to 0), and
+  `check_manual_split.py`, `check_released_manifest.py`,
+  `check_trust_surface.py`, the sync unit tests, `check_dag.py`, and
+  the factor-sweep freshness check all pass; full build green.
+
+## Current frontier
+
+The PR is prepared as a draft: it must merge only after the ops step
+that creates `leanprover/hex-sparse-poly` and
+`leanprover/hex-sparse-poly-mathlib` (Lake skeletons) and widens a
+`hex-publishing*` fine-grained token to include them, which needs
+org-owner approval. `sync_released.py` preflights and refuses
+otherwise, so an early merge cannot silently publish, but the ordering
+in PLAN/Releases.md puts the ops step first.
+
+## Next step
+
+After the ops step: mark the PR ready, merge the stack bottom-up, then
+`workflow_dispatch` of sync-released.yml as dry-run, inspect, and run
+with dry_run=false.
+
+## Blockers
+
+Repo creation and token widening are Kim's (org-owner approval).

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -850,5 +850,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "1f1dfc2c1ac92caf6b0d12142399a3756a1ec336",
     "reason": "Registers only the build-only HexMvFactorizationTests verification umbrella; it adds no imports to hexbz_factor_service or any runtime library target and changes no executable definition or build flag."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "cb8f437dbc9ed9ea5dc5c7e2794295ab16774099",
+    "reason": "Moves HexSparsePoly.KernelTests into the HexReleaseTests globs for the split publication, leaving HexSparsePolyTests as the monorepo-only lint target; no factorization module, executable, or build-flag changes."
   }
 ]

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -331,6 +331,19 @@ def main() -> int:
             for dependency in closure[lib]
             if dependency in repo_by_library
         }
+        # A repo's conformance project may import libraries its published
+        # library does not (declared per entry as `conformance_pins`); the
+        # SPEC of the owning library records why. These are sanctioned
+        # additions to the closure, never replacements.
+        conformance_extra = set(entry.get("conformance_pins", []))
+        undeclared = conformance_extra & expected
+        if undeclared:
+            fail(
+                f"{entry['repo']}: conformance_pins {sorted(undeclared)} are "
+                "already in the library dependency closure; list only the "
+                "conformance-only additions"
+            )
+        expected |= conformance_extra
         actual = set(entry["pins"])
         if actual != expected:
             fail(

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -135,6 +135,21 @@ repos:
     pins: [hex-arith]
     lakefile: lean
 
+  - repo: leanprover/hex-sparse-poly
+    component: Sparse univariate polynomials
+    lib: HexSparsePoly
+    test_modules: [HexSparsePoly.KernelTests]
+    umbrella: true
+    spec: hex-sparse-poly
+    bench: true
+    conformance: true
+    conformance_files: [HexSparsePolyFixtures.lean]
+    fixtures: [HexSparsePoly]
+    oracles: [sparsepoly_sympy.py, common.py]
+    pins: [hex-basic, hex-poly, hex-arith, hex-mod-arith]
+    conformance_pins: [hex-arith, hex-mod-arith]
+    lakefile: toml
+
   - repo: leanprover/hex-poly-mathlib
     lib: HexPolyMathlib
     umbrella: true
@@ -144,6 +159,17 @@ repos:
     fixtures: []
     oracles: []
     pins: [hex-poly]
+    lakefile: toml
+
+  - repo: leanprover/hex-sparse-poly-mathlib
+    lib: HexSparsePolyMathlib
+    umbrella: true
+    spec: hex-sparse-poly-mathlib
+    bench: false
+    conformance: true
+    fixtures: []
+    oracles: []
+    pins: [hex-basic, hex-poly, hex-sparse-poly, hex-poly-mathlib]
     lakefile: toml
 
   - repo: leanprover/hex-mv-poly-mathlib
@@ -616,5 +642,5 @@ repos:
   - repo: leanprover/hex
     pins_only: true
     readme_template: scripts/release/hex-README.md
-    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, hex-determinant, hex-bareiss, hex-char-poly, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-char-poly-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-sparse-poly, hex-poly-mathlib, hex-sparse-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, hex-determinant, hex-bareiss, hex-char-poly, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-char-poly-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
     lakefile: toml


### PR DESCRIPTION
This PR prepare the release tail for the sparse-poly pair: `released.yml` entries for `leanprover/hex-sparse-poly` (component label, kernel-probe `test_modules`, bench and conformance surfaces, the SymPy oracle pair, pins `[hex-basic, hex-poly, hex-arith, hex-mod-arith]`) and `leanprover/hex-sparse-poly-mathlib` (pins `[hex-basic, hex-poly, hex-sparse-poly, hex-poly-mathlib]`), both added to the aggregate `leanprover/hex` pin list and mirrored in `HexAggregateCheck.lean`. The conformance project pins two libraries the published library does not (the ZMod64 zero-divisor and characteristic cases the library SPEC records), declared through a new `conformance_pins` manifest field that `check_released_manifest.py` now validates. `HexSparsePoly.KernelTests` moves into the `HexReleaseTests` globs to match the manifest, leaving `HexSparsePolyTests` as the monorepo-only lint target, and the manual chapter moves to the released side of `HexManual.lean`.

Draft until the ops step exists: creating `leanprover/hex-sparse-poly` and `leanprover/hex-sparse-poly-mathlib` with their Lake skeletons and widening a `hex-publishing*` fine-grained token to include them (org-owner approval; `sync_released.py` preflights and refuses otherwise). After that: mark ready, merge, dispatch `sync-released.yml` dry-run, inspect, then `dry_run=false`.

🤖 Prepared with Claude Code