### PR TITLE
feat(sparse-poly): transport substScale through the dense conversion and into the companion

### DIFF
--- a/HexManual/Chapters/HexSparsePoly.lean
+++ b/HexManual/Chapters/HexSparsePoly.lean
@@ -179,8 +179,8 @@ the representation is sparse.
 {docstring HexSparsePolyMathlib.equiv_support}
 
 One correspondence lemma per public operation transports evaluation,
-differentiation, composition, and exponent substitution, alongside the
-constructor and observer images.
+differentiation, composition, exponent substitution, and argument
+scaling, alongside the constructor and observer images.
 
 {docstring HexSparsePolyMathlib.equiv_eval}
 
@@ -189,6 +189,8 @@ constructor and observer images.
 {docstring HexSparsePolyMathlib.equiv_compose}
 
 {docstring HexSparsePolyMathlib.equiv_substPow}
+
+{docstring HexSparsePolyMathlib.equiv_substScale}
 
 # Cross-references
 %%%

--- a/HexSparsePoly/Eval.lean
+++ b/HexSparsePoly/Eval.lean
@@ -756,32 +756,31 @@ theorem compose_toDense (s t : SparsePoly K) :
   refine foldl_congr' rfl fun b u _ => ?_
   rw [toDense_mul, toDense_C, toDense_composePower]
 
-/-- Powers of a unit monomial are unit monomials. -/
-theorem monomial_one_pow (k : Nat) (e : Nat) :
-    (monomial k (1 : K)) ^ e = monomial (k * e) 1 := by
+/-- Powers of a monomial are monomials. -/
+theorem monomial_pow (k : Nat) (c : K) (e : Nat) :
+    (monomial k c) ^ e = monomial (k * e) (c ^ e) := by
   induction e with
   | zero =>
-      rw [pow_zero, Nat.mul_zero]
+      rw [pow_zero, Nat.mul_zero, show c ^ 0 = 1 from by grind]
       rfl
   | succ e ih =>
       rw [pow_succ, ih, monomial_mul_monomial,
         show k + k * e = k * (e + 1) from by
           rw [Nat.mul_succ, Nat.add_comm],
-        show (1 : K) * 1 = 1 from by grind]
+        show c * c ^ e = c ^ (e + 1) from by grind]
 
-/-- Constants scale unit monomials into monomials. -/
-theorem C_mul_monomial (c : K) (m : Nat) :
-    SparsePoly.C c * monomial m 1 = monomial m c := by
-  show monomial 0 c * monomial m 1 = monomial m c
-  rw [monomial_mul_monomial, Nat.zero_add,
-    show c * 1 = c from by grind]
+/-- Constants scale monomials by scaling their coefficient. -/
+theorem C_mul_monomial (c : K) (m : Nat) (d : K) :
+    SparsePoly.C c * monomial m d = monomial m (c * d) := by
+  show monomial 0 c * monomial m d = monomial m (c * d)
+  rw [monomial_mul_monomial, Nat.zero_add]
 
-private theorem coeff_monomial_foldl (l : List (Nat × K)) (k : Nat)
-    (f : Nat) :
+private theorem coeff_monomial_foldl (l : List (Nat × K))
+    (ex : Nat × K → Nat) (co : Nat × K → K) (f : Nat) :
     ∀ init : SparsePoly K,
-    (l.foldl (fun a u => a + monomial (k * u.1) u.2) init).coeff f =
+    (l.foldl (fun a u => a + monomial (ex u) (co u)) init).coeff f =
       l.foldl
-        (fun a u => a + (if f = k * u.1 then u.2 else 0))
+        (fun a u => a + (if f = ex u then co u else 0))
         (init.coeff f) := by
   induction l with
   | nil => intro init; rfl
@@ -837,7 +836,9 @@ theorem substPow_eq_compose (s : SparsePoly K) (k : Nat) :
       s.terms.toList.foldl
         (fun a u => a + monomial (k * u.1) u.2) 0 := by
     refine foldl_congr' rfl fun b u _ => ?_
-    rw [monomial_one_pow, C_mul_monomial]
+    rw [monomial_pow, C_mul_monomial,
+      show u.2 * (1 : K) ^ u.1 = u.2 from by
+        rw [Lean.Grind.Semiring.one_pow]; grind]
   rw [hfold]
   apply ext_coeff
   intro f
@@ -1020,6 +1021,53 @@ theorem coeff_substScale (s : SparsePoly K) (a : K) (e : Nat) :
   exact coeffList_substScaleGo a s.terms.toList 0 none
     s.pairwise_toList (fun u _ => Nat.zero_le _) (fun _ => rfl)
     (by show (1 : K) = a ^ 0; grind) e
+
+omit [DecidableEq K] in
+private theorem foldl_scale_match {l : List (Nat × K)}
+    (hs : l.Pairwise (fun x y => x.1 < y.1)) (a : K) (f : Nat) :
+    l.foldl (fun acc u => acc + (if f = u.1 then u.2 * a ^ u.1 else 0)) 0 =
+      coeffList l f * a ^ f := by
+  induction l with
+  | nil =>
+      show (0 : K) = 0 * a ^ f
+      grind
+  | cons u us ih =>
+      rw [List.pairwise_cons] at hs
+      rw [List.foldl_cons]
+      by_cases huf : f = u.1
+      · rw [if_pos huf,
+          show (0 : K) + u.2 * a ^ u.1 = u.2 * a ^ u.1 from by grind,
+          foldl_add_ifs_zero (fun v hv => by
+            rw [if_neg (fun h => by
+              have := hs.1 v hv
+              omega)])]
+        simp only [coeffList, if_pos huf.symm]
+        rw [huf]
+      · rw [if_neg huf, show (0 : K) + 0 = 0 from by grind, ih hs.2]
+        simp only [coeffList, if_neg (fun h : u.1 = f => huf h.symm)]
+
+/-- Argument scaling is composition with the degree-one monomial
+`a · x`: the sparse fast path and the general path agree. -/
+theorem substScale_eq_compose (s : SparsePoly K) (a : K) :
+    s.substScale a = s.compose (monomial 1 a) := by
+  rw [compose_eq_foldl]
+  have hfold : s.terms.toList.foldl
+      (fun b u => b + SparsePoly.C u.2 * monomial 1 a ^ u.1) 0 =
+      s.terms.toList.foldl
+        (fun b u => b + monomial u.1 (u.2 * a ^ u.1)) 0 := by
+    refine foldl_congr' rfl fun b u _ => ?_
+    rw [monomial_pow, C_mul_monomial, Nat.one_mul]
+  rw [hfold]
+  apply ext_coeff
+  intro f
+  rw [coeff_substScale, coeff_monomial_foldl, coeff_zero]
+  exact (foldl_scale_match s.pairwise_toList a f).symm
+
+/-- The scaling substitution transports to dense composition with the
+degree-one monomial. -/
+theorem substScale_toDense (s : SparsePoly K) (a : K) :
+    (s.substScale a).toDense = s.toDense.compose (DensePoly.monomial 1 a) := by
+  rw [substScale_eq_compose, compose_toDense, toDense_monomial]
 
 end Agreements
 

--- a/HexSparsePoly/Eval.lean
+++ b/HexSparsePoly/Eval.lean
@@ -761,7 +761,7 @@ theorem monomial_pow (k : Nat) (c : K) (e : Nat) :
     (monomial k c) ^ e = monomial (k * e) (c ^ e) := by
   induction e with
   | zero =>
-      rw [pow_zero, Nat.mul_zero, show c ^ 0 = 1 from by grind]
+      rw [pow_zero, Nat.mul_zero, Lean.Grind.Semiring.pow_zero]
       rfl
   | succ e ih =>
       rw [pow_succ, ih, monomial_mul_monomial,
@@ -836,9 +836,8 @@ theorem substPow_eq_compose (s : SparsePoly K) (k : Nat) :
       s.terms.toList.foldl
         (fun a u => a + monomial (k * u.1) u.2) 0 := by
     refine foldl_congr' rfl fun b u _ => ?_
-    rw [monomial_pow, C_mul_monomial,
-      show u.2 * (1 : K) ^ u.1 = u.2 from by
-        rw [Lean.Grind.Semiring.one_pow]; grind]
+    rw [monomial_pow, C_mul_monomial, Lean.Grind.Semiring.one_pow,
+      Lean.Grind.Semiring.mul_one]
   rw [hfold]
   apply ext_coeff
   intro f

--- a/HexSparsePoly/SPEC/hex-sparse-poly.md
+++ b/HexSparsePoly/SPEC/hex-sparse-poly.md
@@ -571,6 +571,8 @@ The specification is the coefficient identity and the agreement with
 ```lean
 theorem coeff_derivative, derivative_add, derivative_mul
 theorem substPow_eq_compose (s) (k) : s.substPow k = s.compose (monomial k 1)
+theorem substScale_eq_compose (s) (a) : s.substScale a = s.compose (monomial 1 a)
+theorem coeff_substScale (s) (a) (e) : (s.substScale a).coeff e = s.coeff e * a ^ e
 theorem eval_substPow (s) (k) (x) : (s.substPow k).eval x = s.eval (x ^ k)
 theorem eval_compose (s t) (x) : (s.compose t).eval x = s.eval (t.eval x)
 ```
@@ -582,7 +584,9 @@ themselves.
 
 `substPow_eq_compose` is the statement that the fast path and the
 general path agree, and it is what lets the cyclotomic adapter use
-`substPow` and reason with `compose`.
+`substPow` and reason with `compose`. `substScale_eq_compose` is the
+same statement for argument scaling, with the degree-one monomial
+`a · x` in place of `x^k`.
 
 ## Conversion to and from the dense representation
 
@@ -624,6 +628,8 @@ theorem toDense_zero, toDense_one, toDense_add, toDense_neg, toDense_mul
 theorem ofDense_zero, ofDense_one, ofDense_add, ofDense_neg, ofDense_mul
 theorem toDense_monomial (e c) : (monomial e c).toDense = DensePoly.monomial e c
 theorem eval_toDense, derivative_toDense, compose_toDense, substPow_toDense
+theorem substScale_toDense (s : SparsePoly R) (a : R) :
+    (s.substScale a).toDense = s.toDense.compose (DensePoly.monomial 1 a)
 ```
 
 The degree boundary transports too, and the Euclidean section needs it
@@ -1093,6 +1099,8 @@ theorem equiv_derivative (s : SparsePoly R) :
 theorem equiv_compose (s t : SparsePoly R) : (equiv s).comp (equiv t) = equiv (s.compose t)
 theorem equiv_substPow (s : SparsePoly R) (k : Nat) :
     (equiv s).comp (Polynomial.X ^ k) = equiv (s.substPow k)
+theorem equiv_substScale (s : SparsePoly R) (a : R) :
+    (equiv s).comp (Polynomial.C a * Polynomial.X) = equiv (s.substScale a)
 ```
 
 `equiv` is **defined** by composition, and the step that makes the

--- a/HexSparsePolyMathlib/Equiv.lean
+++ b/HexSparsePolyMathlib/Equiv.lean
@@ -135,6 +135,15 @@ theorem equiv_substPow [CommRing R] [DecidableEq R]
     HexPolyMathlib.toPolynomial_compose,
     HexPolyMathlib.toPolynomial_monomial, Polynomial.X_pow_eq_monomial]
 
+/-- Argument scaling corresponds to composition with `C a * X`. -/
+theorem equiv_substScale [CommRing R] [DecidableEq R]
+    (s : Hex.SparsePoly R) (a : R) :
+    (equiv s).comp (Polynomial.C a * Polynomial.X) =
+      equiv (s.substScale a) := by
+  rw [equiv_apply, equiv_apply, Hex.SparsePoly.substScale_toDense,
+    HexPolyMathlib.toPolynomial_compose,
+    HexPolyMathlib.toPolynomial_monomial, Polynomial.C_mul_X_eq_monomial]
+
 /-- Monomials correspond. -/
 @[simp, grind =]
 theorem equiv_monomial [CommRing R] [DecidableEq R] (e : Nat) (c : R) :

--- a/HexSparsePolyMathlib/README.md
+++ b/HexSparsePolyMathlib/README.md
@@ -45,9 +45,9 @@ example (p : SparsePoly Int) (x : Int) : (equiv p).eval x = p.eval x := by
 - The coefficientwise identification `coeff_equiv` and the support
   characterisation `equiv_support`.
 - Operation correspondence: `equiv_eval`, `equiv_derivative`,
-  `equiv_compose`, `equiv_substPow`, and the constructor and observer
-  images `equiv_monomial`, `equiv_C`, `equiv_X`, `equiv_natDegree`,
-  `equiv_leadingCoeff`, `equiv_monic`.
+  `equiv_compose`, `equiv_substPow`, `equiv_substScale`, and the
+  constructor and observer images `equiv_monomial`, `equiv_C`,
+  `equiv_X`, `equiv_natDegree`, `equiv_leadingCoeff`, `equiv_monic`.
 
 # Verification
 

--- a/HexSparsePolyMathlib/SPEC/hex-sparse-poly-mathlib.md
+++ b/HexSparsePolyMathlib/SPEC/hex-sparse-poly-mathlib.md
@@ -17,13 +17,12 @@ The layer owns correspondence only:
   `denseEquiv.trans HexPolyMathlib.equiv`;
 - one correspondence lemma per public core operation: `coeff_equiv`,
   `equiv_toDense`, `equiv_support`, `equiv_eval`, `equiv_derivative`,
-  `equiv_compose`, `equiv_substPow`, `equiv_monomial`, `equiv_C`,
-  `equiv_X`, `equiv_natDegree`, `equiv_leadingCoeff`, and
-  `equiv_monic`. Ring-structural images (zero, one, addition,
-  multiplication, negation, powers, divisibility) are free from the
-  `RingEquiv` via `map_*` and are deliberately not restated.
-  `substScale` transport is scheduled: it needs a core
-  `substScale_toDense` first.
+  `equiv_compose`, `equiv_substPow`, `equiv_substScale`,
+  `equiv_monomial`, `equiv_C`, `equiv_X`, `equiv_natDegree`,
+  `equiv_leadingCoeff`, and `equiv_monic`. Ring-structural images
+  (zero, one, addition, multiplication, negation, powers,
+  divisibility) are free from the `RingEquiv` via `map_*` and are
+  deliberately not restated.
 
 Following the project split, no theorem about `SparsePoly` itself
 belongs here: representation facts (including `mem_support_iff`, which

--- a/conformance/HexSparsePolyMathlib/Conformance.lean
+++ b/conformance/HexSparsePolyMathlib/Conformance.lean
@@ -47,7 +47,7 @@ instances selected, for two ordinary coefficient types. -/
 #guard Hex.SparsePoly.ofDense rq.toDense == rq
 
 private theorem transportSurface {R : Type} [CommRing R] [DecidableEq R]
-    (a b : SparsePoly R) (x : R) (k e : Nat) :
+    (a b : SparsePoly R) (x c : R) (k e : Nat) :
     equiv (a + b) = equiv a + equiv b ∧
       equiv (a * b) = equiv a * equiv b ∧
       equiv.symm (equiv a) = a ∧
@@ -56,8 +56,10 @@ private theorem transportSurface {R : Type} [CommRing R] [DecidableEq R]
       (equiv a).eval x = a.eval x ∧
       Polynomial.derivative (equiv a) = equiv a.derivative ∧
       (equiv a).comp (equiv b) = equiv (a.compose b) ∧
-      (equiv a).comp (Polynomial.X ^ k) = equiv (a.substPow k) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      (equiv a).comp (Polynomial.X ^ k) = equiv (a.substPow k) ∧
+      (equiv a).comp (Polynomial.C c * Polynomial.X) =
+        equiv (a.substScale c) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · exact map_add equiv a b
   · exact map_mul equiv a b
   · exact equiv.symm_apply_apply a
@@ -67,13 +69,14 @@ private theorem transportSurface {R : Type} [CommRing R] [DecidableEq R]
   · exact equiv_derivative a
   · exact equiv_compose a b
   · exact equiv_substPow a k
+  · exact equiv_substScale a c
 
 example (a b : P) (x : Int) : True := by
-  have _ := transportSurface a b x 3 5
+  have _ := transportSurface a b x 2 3 5
   trivial
 
 example (a b : Q) (x : Rat) : True := by
-  have _ := transportSurface a b x 3 5
+  have _ := transportSurface a b x 2 3 5
   trivial
 
 end HexSparsePolyMathlib.Conformance

--- a/progress/20260823T150000Z_substscale-transport.md
+++ b/progress/20260823T150000Z_substscale-transport.md
@@ -1,0 +1,34 @@
+# substScale transport across the dense conversion and into the companion (#9482)
+
+## Accomplished
+
+- `HexSparsePoly/Eval.lean`: `substScale_eq_compose` (argument scaling
+  is composition with the degree-one monomial `a · x`) and
+  `substScale_toDense`, completing the `*_toDense` transport list.
+- `HexSparsePolyMathlib/Equiv.lean`: `equiv_substScale`, closing the
+  last gap in the one-lemma-per-public-operation correspondence
+  surface.
+- Generalised two existing lemmas rather than adding near-duplicates:
+  `monomial_one_pow` → `monomial_pow` (arbitrary coefficient), and
+  `C_mul_monomial` to an arbitrary monomial coefficient; the private
+  `coeff_monomial_foldl` now takes the exponent and coefficient maps as
+  parameters so both substitution proofs share it.
+- Companion conformance target gained the `substScale` clause; SPECs,
+  READMEs, and the manual chapter updated.
+
+## Decisions
+
+- The dense-side normal form is `DensePoly.monomial 1 a`, not
+  `DensePoly.C a * DensePoly.X` as the issue suggested: `Hex.DensePoly`
+  has no `X`. This matches `substPow_toDense`, which lands on
+  `DensePoly.monomial k 1`. The companion still states the Mathlib-side
+  shape the issue asked for (`Polynomial.C a * Polynomial.X`), bridged
+  by `Polynomial.C_mul_X_eq_monomial`.
+
+## Verification
+
+`lake build HexSparsePoly HexSparsePolyMathlib
+HexSparsePolyMathlib.Conformance HexSparsePoly.Conformance
+HexSparsePolyTests` and `lake build HexManual` green; the repo lint
+scripts (copyright, line counts, DAG, phase 4/7, conformance targets,
+release manifest, manual split) pass. No new `sorry`, no `axiom`.


### PR DESCRIPTION
This PR completes the `substScale` transport: the core library gains
`substScale_eq_compose` and `substScale_toDense`, and the companion
gains `equiv_substScale`, so every public sparse operation now has a
correspondence lemma.

The dense-side normal form is `DensePoly.monomial 1 a` rather than the
`DensePoly.C a * DensePoly.X` the issue proposed, because `Hex.DensePoly`
has no `X`; this matches `substPow_toDense`, which lands on
`DensePoly.monomial k 1`. The companion states the Mathlib-side shape the
issue asked for, `(equiv s).comp (Polynomial.C a * Polynomial.X)`,
bridged by `Polynomial.C_mul_X_eq_monomial`.

Two existing lemmas are generalised rather than duplicated:
`monomial_one_pow` becomes `monomial_pow` at an arbitrary coefficient,
`C_mul_monomial` scales an arbitrary monomial, and the private
`coeff_monomial_foldl` takes the exponent and coefficient maps as
parameters so both substitution proofs share it.

The companion conformance target gains the `substScale` clause, and the
SPECs, READMEs, and manual chapter record the new lemmas.

Closes #9482

🤖 Prepared with Claude Code
