### PR TITLE
ci: exempt the sparse-poly lakefile registrations from the factor sweep

### DIFF
--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -838,5 +838,11 @@
     "baseline_blob": "ff87edbbbf7524190b536ae4ce92a57968275aa9",
     "current_blob": "8f5ad6feadc9b8448e9fd7ebc12f62bf28ecebc7",
     "reason": "Adds the HexSparsePolyMathlib.LintTests glob to the HexSparsePolyTests verification target; no factorization module, executable, or build-flag changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "5d2ddd13644831ed8daf314cda768232ed045a0c",
+    "reason": "Registers the HexSparsePolyMathlib library and the sparse-poly conformance globs on top of the toolchain-bump measurement commit; no factorization module, executable, or build-flag changes."
   }
 ]


### PR DESCRIPTION
This PR records a proof-only runtime exemption for the current
`lakefile.lean` transition, so `check_factor_sweep_freshness.py` passes on
`main` again.

The toolchain bump (#9484) re-ran the factorization sweep and recorded
commit `5d48ebfd697a`, whose `lakefile.lean` predates the sparse-poly
registrations that landed in #9481, #9483 and #9485. After the squash
merge the recorded source and `HEAD` differ by exactly those
registrations: the `HexSparsePolyMathlib` library and the sparse-poly
conformance globs. Neither touches a factorization module, executable, or
build flag, so the measurements still cover their source.

🤖 Prepared with Claude Code
