### PR TITLE
prove(modular): close CRT and reconstruction laws

### DIFF
--- a/HexModular/Crt.lean
+++ b/HexModular/Crt.lean
@@ -17,6 +17,117 @@ namespace Hex
 
 namespace Modular
 
+private theorem emod_eq_of_dvd {x y modulus : Int}
+    (h : modulus ∣ x - y) :
+    x % modulus = y % modulus := by
+  apply Int.emod_eq_emod_iff_emod_sub_eq_zero.mpr
+  exact Int.emod_eq_zero_of_dvd h
+
+private theorem symMod_emod_dvd {a : Int} {modulus divisor : Nat}
+    (hmodulus : 0 < modulus) (hdivisor : divisor ∣ modulus) :
+    symMod a modulus % (divisor : Int) = a % (divisor : Int) := by
+  apply emod_eq_of_dvd
+  apply Int.dvd_trans (Int.ofNat_dvd.mpr hdivisor)
+  exact Int.dvd_of_emod_eq_zero
+    (Int.emod_eq_emod_iff_emod_sub_eq_zero.mp (symMod_emod hmodulus))
+
+private theorem garner_congr_new {old new inverse delta : Int} {oldModulus modulus : Nat}
+    (holdModulus : 0 < oldModulus) (hmodulus : 0 < modulus)
+    (hdelta : delta % (modulus : Int) =
+      ((new - old) * inverse) % (modulus : Int))
+    (hinverse : (Int.ofNat oldModulus * inverse) % (modulus : Int) =
+      1 % (modulus : Int)) :
+    symMod (old + Int.ofNat oldModulus * delta) (oldModulus * modulus) %
+        (modulus : Int) =
+      new % (modulus : Int) := by
+  rw [symMod_emod_dvd (Nat.mul_pos holdModulus hmodulus) (Nat.dvd_mul_left _ _)]
+  apply emod_eq_of_dvd
+  have hdeltaDvd : (modulus : Int) ∣ delta - (new - old) * inverse :=
+    Int.dvd_of_emod_eq_zero
+      (Int.emod_eq_emod_iff_emod_sub_eq_zero.mp hdelta)
+  have hinverseDvd : (modulus : Int) ∣ Int.ofNat oldModulus * inverse - 1 :=
+    Int.dvd_of_emod_eq_zero
+      (Int.emod_eq_emod_iff_emod_sub_eq_zero.mp hinverse)
+  rw [show old + Int.ofNat oldModulus * delta - new =
+      Int.ofNat oldModulus * (delta - (new - old) * inverse) +
+        (new - old) * (Int.ofNat oldModulus * inverse - 1) by
+    simp only [Int.mul_sub, Int.mul_one]
+    have : Int.ofNat oldModulus * ((new - old) * inverse) =
+        (new - old) * (Int.ofNat oldModulus * inverse) := by
+      ac_rfl
+    rw [this]
+    omega]
+  exact Int.dvd_add (Int.dvd_mul_of_dvd_right hdeltaDvd)
+    (Int.dvd_mul_of_dvd_right hinverseDvd)
+
+private theorem garner_congr_old {old delta : Int} {oldModulus modulus divisor : Nat}
+    (holdModulus : 0 < oldModulus) (hmodulus : 0 < modulus)
+    (hdivisor : divisor ∣ oldModulus) :
+    symMod (old + Int.ofNat oldModulus * delta) (oldModulus * modulus) %
+        (divisor : Int) =
+      old % (divisor : Int) := by
+  rw [symMod_emod_dvd (Nat.mul_pos holdModulus hmodulus)
+    (Nat.dvd_trans hdivisor (Nat.dvd_mul_right _ _))]
+  apply emod_eq_of_dvd
+  rw [show old + Int.ofNat oldModulus * delta - old =
+      Int.ofNat oldModulus * delta by omega]
+  exact Int.dvd_mul_of_dvd_left (Int.ofNat_dvd.mpr hdivisor)
+
+private theorem garner_inverse {oldModulus modulus : Nat}
+    (hcoprime : (Hex.pureIntExtGcd
+      (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).1 = 1) :
+    (Int.ofNat oldModulus *
+        (Hex.pureIntExtGcd
+          (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1) %
+        (modulus : Int) =
+      1 % (modulus : Int) := by
+  have hbez := Hex.pureIntExtGcd_bezout_proj
+    (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)
+  rw [hcoprime] at hbez
+  apply emod_eq_of_dvd
+  have hrem : (modulus : Int) ∣
+      Int.ofNat oldModulus - Int.ofNat (oldModulus % modulus) := by
+    refine ⟨Int.ofNat (oldModulus / modulus), ?_⟩
+    have hnat := congrArg Int.ofNat (Nat.mod_add_div oldModulus modulus)
+    change Int.ofNat (oldModulus % modulus) +
+        (modulus : Int) * Int.ofNat (oldModulus / modulus) =
+      Int.ofNat oldModulus at hnat
+    omega
+  have hbezDvd : (modulus : Int) ∣
+      (Hex.pureIntExtGcd
+          (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 *
+          Int.ofNat (oldModulus % modulus) - 1 := by
+    rw [show
+      (Hex.pureIntExtGcd
+          (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 *
+            Int.ofNat (oldModulus % modulus) - 1 =
+          -((Hex.pureIntExtGcd
+            (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.2 *
+              Int.ofNat modulus) by
+      omega]
+    exact Int.dvd_neg.mpr (Int.dvd_mul_left _ _)
+  rw [show
+    Int.ofNat oldModulus *
+          (Hex.pureIntExtGcd
+            (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 - 1 =
+        (Hex.pureIntExtGcd
+          (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 *
+            (Int.ofNat oldModulus - Int.ofNat (oldModulus % modulus)) +
+          ((Hex.pureIntExtGcd
+              (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 *
+                Int.ofNat (oldModulus % modulus) - 1) by
+    simp only [Int.mul_sub]
+    have : Int.ofNat oldModulus *
+          (Hex.pureIntExtGcd
+            (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 =
+        (Hex.pureIntExtGcd
+          (Int.ofNat (oldModulus % modulus)) (Int.ofNat modulus)).2.1 *
+          Int.ofNat oldModulus := by
+      ac_rfl
+    rw [this]
+    omega]
+  exact Int.dvd_add (Int.dvd_mul_of_dvd_right hrem) hbezDvd
+
 /-- A residue accumulated from coprime moduli. `value` is the symmetric
 representative of their common solution modulo `modulus`. -/
 structure Crt where
@@ -103,14 +214,29 @@ theorem push_modulus {c c' : Crt} {r : Int} {m : Nat}
 theorem push_congr_new {c c' : Crt} {r : Int} {m : Nat}
     (h : c.push r m = some c') :
     c'.value % (m : Int) = r % (m : Int) := by
-  sorry
+  unfold push at h
+  split at h <;> try contradiction
+  next hm =>
+    dsimp only at h
+    split at h <;> try contradiction
+    next hg =>
+      cases h
+      apply garner_congr_new c.pos (by omega) (symMod_emod (by omega))
+      exact garner_inverse hg
 
 /-- A successful scalar push preserves the accumulated value modulo every
 divisor of the old accumulated modulus. -/
 theorem push_congr_old {c c' : Crt} {r : Int} {m d : Nat}
     (hd : d ∣ c.modulus) (h : c.push r m = some c') :
     c'.value % (d : Int) = c.value % (d : Int) := by
-  sorry
+  unfold push at h
+  split at h <;> try contradiction
+  next hm =>
+    dsimp only at h
+    split at h <;> try contradiction
+    next _ =>
+      cases h
+      exact garner_congr_old c.pos (by omega) hd
 
 /-- A successful scalar push preserves the symmetric-size invariant. -/
 theorem push_le {c c' : Crt} {r : Int} {m : Nat}
@@ -225,14 +351,55 @@ theorem push_modulus {c c' : CrtVec k} {r : Vector Int k} {m : Nat}
 theorem push_congr_new {c c' : CrtVec k} {r : Vector Int k} {m : Nat}
     (h : c.push r m = some c') :
     ∀ i : Fin k, c'.value[i] % (m : Int) = r[i] % (m : Int) := by
-  sorry
+  unfold push at h
+  split at h <;> try contradiction
+  next hm =>
+    dsimp only at h
+    split at h <;> try contradiction
+    next hg =>
+      cases h
+      intro i
+      change
+        (Vector.zipWith
+            (fun old new =>
+              symMod
+                (old + Int.ofNat c.modulus *
+                  symMod ((new - old) *
+                    (Hex.pureIntExtGcd
+                      (Int.ofNat (c.modulus % m)) (Int.ofNat m)).2.1) m)
+                (c.modulus * m))
+            c.value r)[i.val] % (m : Int) =
+          r[i.val] % (m : Int)
+      rw [Vector.getElem_zipWith i.isLt]
+      apply garner_congr_new c.pos (by omega) (symMod_emod (by omega))
+      exact garner_inverse hg
 
 /-- A successful vector push preserves every old accumulated residue modulo
 every divisor of the old modulus. -/
 theorem push_congr_old {c c' : CrtVec k} {r : Vector Int k} {m d : Nat}
     (hd : d ∣ c.modulus) (h : c.push r m = some c') :
     ∀ i : Fin k, c'.value[i] % (d : Int) = c.value[i] % (d : Int) := by
-  sorry
+  unfold push at h
+  split at h <;> try contradiction
+  next hm =>
+    dsimp only at h
+    split at h <;> try contradiction
+    next _ =>
+      cases h
+      intro i
+      change
+        (Vector.zipWith
+            (fun old new =>
+              symMod
+                (old + Int.ofNat c.modulus *
+                  symMod ((new - old) *
+                    (Hex.pureIntExtGcd
+                      (Int.ofNat (c.modulus % m)) (Int.ofNat m)).2.1) m)
+                (c.modulus * m))
+            c.value r)[i.val] % (d : Int) =
+          c.value[i.val] % (d : Int)
+      rw [Vector.getElem_zipWith i.isLt]
+      exact garner_congr_old c.pos (by omega) hd
 
 /-- A successful vector push preserves every symmetric-size invariant. -/
 theorem push_le {c c' : CrtVec k} {r : Vector Int k} {m : Nat}

--- a/HexModular/Euclid.lean
+++ b/HexModular/Euclid.lean
@@ -39,6 +39,299 @@ private def euclidUntil.go (P : Int) (oldR r : Nat) (oldT t : Int) : Row :=
 termination_by r
 decreasing_by exact Nat.mod_lt _ (Nat.pos_of_ne_zero _hr)
 
+private theorem cramer_fst (oldR r p q oldT t : Int) :
+    oldR * (p * t - r * q) + r * (oldR * q - p * oldT) =
+      p * (oldR * t - r * oldT) := by
+  simp only [Int.mul_sub]
+  have hcancel : oldR * (r * q) = r * (oldR * q) := by ac_rfl
+  have hleft : oldR * (p * t) = p * (oldR * t) := by ac_rfl
+  have hright : r * (p * oldT) = p * (r * oldT) := by ac_rfl
+  rw [hcancel, hleft, hright]
+  omega
+
+private theorem cramer_snd (oldR r p q oldT t : Int) :
+    oldT * (p * t - r * q) + t * (oldR * q - p * oldT) =
+      q * (oldR * t - r * oldT) := by
+  simp only [Int.mul_sub]
+  have hcancel : oldT * (p * t) = t * (p * oldT) := by ac_rfl
+  have hleft : oldT * (r * q) = q * (r * oldT) := by ac_rfl
+  have hright : t * (oldR * q) = q * (oldR * t) := by ac_rfl
+  rw [hcancel, hleft, hright]
+  omega
+
+private theorem lattice_rep {modulus oldR r : Nat} {a oldT t p q : Int}
+    (hmodulus : 0 < modulus)
+    (hold : (modulus : Int) ∣ oldT * a - Int.ofNat oldR)
+    (hcurrent : (modulus : Int) ∣ t * a - Int.ofNat r)
+    (htarget : (modulus : Int) ∣ q * a - p)
+    (hdet : Int.ofNat oldR * t - Int.ofNat r * oldT = (modulus : Int) ∨
+      Int.ofNat oldR * t - Int.ofNat r * oldT = -(modulus : Int)) :
+    ∃ alpha beta : Int,
+      p = alpha * Int.ofNat oldR + beta * Int.ofNat r ∧
+        q = alpha * oldT + beta * t := by
+  have halphaDvd : (modulus : Int) ∣ p * t - Int.ofNat r * q := by
+    have hsum := Int.dvd_add
+      (Int.dvd_mul_of_dvd_right (b := -t) htarget)
+      (Int.dvd_mul_of_dvd_right (b := q) hcurrent)
+    rw [show
+      -t * (q * a - p) + q * (t * a - Int.ofNat r) =
+        p * t - Int.ofNat r * q by
+      simp only [Int.mul_sub, Int.neg_mul]
+      have h₁ : t * (q * a) = q * (t * a) := by ac_rfl
+      have h₂ : t * p = p * t := by ac_rfl
+      have h₃ : q * Int.ofNat r = Int.ofNat r * q := by ac_rfl
+      rw [h₁, h₂, h₃]
+      omega] at hsum
+    exact hsum
+  have hbetaDvd : (modulus : Int) ∣ Int.ofNat oldR * q - p * oldT := by
+    have hdifference := Int.dvd_sub
+      (Int.dvd_mul_of_dvd_right (b := oldT) htarget)
+      (Int.dvd_mul_of_dvd_right (b := q) hold)
+    rw [show
+      oldT * (q * a - p) - q * (oldT * a - Int.ofNat oldR) =
+        Int.ofNat oldR * q - p * oldT by
+      simp only [Int.mul_sub]
+      have h₁ : oldT * (q * a) = q * (oldT * a) := by ac_rfl
+      have h₂ : oldT * p = p * oldT := by ac_rfl
+      have h₃ : q * Int.ofNat oldR = Int.ofNat oldR * q := by ac_rfl
+      rw [h₁, h₂, h₃]
+      omega] at hdifference
+    exact hdifference
+  let determinant := Int.ofNat oldR * t - Int.ofNat r * oldT
+  have hdetNe : determinant ≠ 0 := hdet.elim
+    (fun h => by dsimp only [determinant]; rw [h]; omega)
+    (fun h => by dsimp only [determinant]; rw [h]; omega)
+  have halphaDet : determinant ∣ p * t - Int.ofNat r * q := hdet.elim
+    (fun h => by simpa only [determinant, h] using halphaDvd)
+    (fun h => by simpa only [determinant, h, Int.neg_dvd] using halphaDvd)
+  have hbetaDet : determinant ∣ Int.ofNat oldR * q - p * oldT := hdet.elim
+    (fun h => by simpa only [determinant, h] using hbetaDvd)
+    (fun h => by simpa only [determinant, h, Int.neg_dvd] using hbetaDvd)
+  rcases halphaDet with ⟨alpha, halpha⟩
+  rcases hbetaDet with ⟨beta, hbeta⟩
+  refine ⟨alpha, beta, ?_, ?_⟩
+  · apply Int.eq_of_mul_eq_mul_left hdetNe
+    have hcramer := cramer_fst (Int.ofNat oldR) (Int.ofNat r) p q oldT t
+    rw [halpha, hbeta] at hcramer
+    calc
+      determinant * p = p * determinant := by ac_rfl
+      _ = Int.ofNat oldR * (determinant * alpha) +
+          Int.ofNat r * (determinant * beta) := by
+        simpa only [determinant] using hcramer.symm
+      _ = determinant *
+          (alpha * Int.ofNat oldR + beta * Int.ofNat r) := by
+        rw [Int.mul_add]
+        ac_rfl
+  · apply Int.eq_of_mul_eq_mul_left hdetNe
+    have hcramer := cramer_snd (Int.ofNat oldR) (Int.ofNat r) p q oldT t
+    rw [halpha, hbeta] at hcramer
+    calc
+      determinant * q = q * determinant := by ac_rfl
+      _ = oldT * (determinant * alpha) + t * (determinant * beta) := by
+        simpa only [determinant] using hcramer.symm
+      _ = determinant * (alpha * oldT + beta * t) := by
+        rw [Int.mul_add]
+        ac_rfl
+
+private theorem no_small_vector {oldR r : Nat} {oldT t p q : Int}
+    (hr : r < oldR)
+    (hsign : oldT ≤ 0 ∧ 0 < t ∨ t < 0 ∧ 0 ≤ oldT)
+    (hp : p.natAbs < oldR) (hq : 0 < q) (hqsmall : q < (t.natAbs : Int))
+    (hrep : ∃ alpha beta : Int,
+      p = alpha * Int.ofNat oldR + beta * Int.ofNat r ∧
+        q = alpha * oldT + beta * t) : False := by
+  rcases hrep with ⟨alpha, beta, hpRep, hqRep⟩
+  have holdR : (0 : Int) < Int.ofNat oldR :=
+    Int.ofNat_lt.mpr (Nat.zero_lt_of_lt hr)
+  have hrNonneg : (0 : Int) ≤ Int.ofNat r := Int.natCast_nonneg _
+  have hpAbs : (p.natAbs : Int) < Int.ofNat oldR := Int.ofNat_lt.mpr hp
+  have hpUpper : p < Int.ofNat oldR := Int.lt_of_le_of_lt Int.le_natAbs hpAbs
+  have hpLower : -Int.ofNat oldR < p := by
+    have hneg : -p ≤ (p.natAbs : Int) := by
+      simpa only [Int.natAbs_neg] using (Int.le_natAbs (a := -p))
+    omega
+  rcases hsign with hsign | hsign
+  · have htAbs : (t.natAbs : Int) = t := by
+      rw [Int.ofNat_natAbs_of_nonneg (Int.le_of_lt hsign.2)]
+    rw [htAbs] at hqsmall
+    by_cases hbeta : beta ≤ 0
+    · have hbetaT : beta * t ≤ 0 :=
+        Int.mul_nonpos_of_nonpos_of_nonneg hbeta (Int.le_of_lt hsign.2)
+      have halphaNeg : alpha < 0 := by
+        apply Int.lt_of_not_ge
+        intro halpha
+        have halphaT : alpha * oldT ≤ 0 :=
+          Int.mul_nonpos_of_nonneg_of_nonpos halpha hsign.1
+        omega
+      have halphaR : alpha * Int.ofNat oldR ≤ -Int.ofNat oldR := by
+        calc
+          alpha * Int.ofNat oldR ≤ (-1 : Int) * Int.ofNat oldR :=
+            Int.mul_le_mul_of_nonneg_right (show alpha ≤ -1 by omega)
+              (Int.le_of_lt holdR)
+          _ = -Int.ofNat oldR := by simp
+      have hbetaR : beta * Int.ofNat r ≤ 0 :=
+        Int.mul_nonpos_of_nonpos_of_nonneg hbeta hrNonneg
+      omega
+    · have hbetaPos : 0 < beta := Int.lt_of_not_ge hbeta
+      have hbetaT : t ≤ beta * t := by
+        calc
+          t = (1 : Int) * t := by simp
+          _ ≤ beta * t := Int.mul_le_mul_of_nonneg_right
+            (show (1 : Int) ≤ beta by omega) (Int.le_of_lt hsign.2)
+      have halphaPos : 0 < alpha := by
+        apply Int.lt_of_not_ge
+        intro halpha
+        have halphaT : 0 ≤ alpha * oldT :=
+          Int.mul_nonneg_of_nonpos_of_nonpos halpha hsign.1
+        omega
+      have halphaR : Int.ofNat oldR ≤ alpha * Int.ofNat oldR := by
+        calc
+          Int.ofNat oldR = (1 : Int) * Int.ofNat oldR := by simp
+          _ ≤ alpha * Int.ofNat oldR := Int.mul_le_mul_of_nonneg_right
+            (show (1 : Int) ≤ alpha by omega) (Int.le_of_lt holdR)
+      have hbetaR : 0 ≤ beta * Int.ofNat r :=
+        Int.mul_nonneg (Int.le_of_lt hbetaPos) hrNonneg
+      omega
+  · have htAbs : (t.natAbs : Int) = -t := by
+      rw [Int.ofNat_natAbs_of_nonpos (Int.le_of_lt hsign.1)]
+    rw [htAbs] at hqsmall
+    by_cases hbeta : 0 ≤ beta
+    · have hbetaT : beta * t ≤ 0 :=
+        Int.mul_nonpos_of_nonneg_of_nonpos hbeta (Int.le_of_lt hsign.1)
+      have halphaPos : 0 < alpha := by
+        apply Int.lt_of_not_ge
+        intro halpha
+        have halphaT : alpha * oldT ≤ 0 :=
+          Int.mul_nonpos_of_nonpos_of_nonneg halpha hsign.2
+        omega
+      have halphaR : Int.ofNat oldR ≤ alpha * Int.ofNat oldR := by
+        calc
+          Int.ofNat oldR = (1 : Int) * Int.ofNat oldR := by simp
+          _ ≤ alpha * Int.ofNat oldR := Int.mul_le_mul_of_nonneg_right
+            (show (1 : Int) ≤ alpha by omega) (Int.le_of_lt holdR)
+      have hbetaR : 0 ≤ beta * Int.ofNat r :=
+        Int.mul_nonneg hbeta hrNonneg
+      omega
+    · have hbetaNeg : beta < 0 := Int.lt_of_not_ge hbeta
+      have hbetaT : -t ≤ beta * t := by
+        have := Int.mul_le_mul_of_nonpos_right (show beta ≤ -1 by omega)
+          (Int.le_of_lt hsign.1)
+        simpa only [Int.neg_mul, Int.one_mul] using this
+      have halphaNeg : alpha < 0 := by
+        apply Int.lt_of_not_ge
+        intro halpha
+        have halphaT : 0 ≤ alpha * oldT :=
+          Int.mul_nonneg halpha hsign.2
+        omega
+      have halphaR : alpha * Int.ofNat oldR ≤ -Int.ofNat oldR := by
+        calc
+          alpha * Int.ofNat oldR ≤ (-1 : Int) * Int.ofNat oldR :=
+            Int.mul_le_mul_of_nonneg_right (show alpha ≤ -1 by omega)
+              (Int.le_of_lt holdR)
+          _ = -Int.ofNat oldR := by simp
+      have hbetaR : beta * Int.ofNat r ≤ 0 :=
+        Int.mul_nonpos_of_nonpos_of_nonneg (Int.le_of_lt hbetaNeg) hrNonneg
+      omega
+
+private theorem euclidUntil.go_spec (modulus : Nat) (a P : Int)
+    (oldR r : Nat) (oldT t : Int) :
+    0 < modulus → 0 ≤ P → r < oldR → P < Int.ofNat oldR →
+    (modulus : Int) ∣ oldT * a - Int.ofNat oldR →
+    (modulus : Int) ∣ t * a - Int.ofNat r →
+    (Int.ofNat oldR * t - Int.ofNat r * oldT = (modulus : Int) ∨
+      Int.ofNat oldR * t - Int.ofNat r * oldT = -(modulus : Int)) →
+    (oldT ≤ 0 ∧ 0 < t ∨ t < 0 ∧ 0 ≤ oldT) →
+    let row := euclidUntil.go P oldR r oldT t
+    0 ≤ row.r ∧ (row.r : Int) ≤ P ∧ row.t ≠ 0 ∧
+      (modulus : Int) ∣ row.t * a - row.r ∧
+      ∀ p q : Int, p.natAbs ≤ P → 0 < q →
+        (modulus : Int) ∣ q * a - p →
+        (row.t.natAbs : Int) ≤ q := by
+  fun_induction euclidUntil.go P oldR r oldT t with
+  | case1 oldR r oldT t hstop =>
+      intro hmodulus hP hr hcut hold hcurrent hdet hsign
+      dsimp only
+      have htNe : t ≠ 0 := by
+        rcases hsign with hsign | hsign <;> omega
+      refine ⟨Int.natCast_nonneg _, hstop, htNe, hcurrent, ?_⟩
+      intro p q hp hq htarget
+      apply Int.le_of_not_gt
+      intro hqsmall
+      have hpLt : p.natAbs < oldR := by
+        apply Int.ofNat_lt.mp
+        exact Int.lt_of_le_of_lt hp hcut
+      exact no_small_vector hr hsign hpLt hq hqsmall
+        (lattice_rep hmodulus hold hcurrent htarget hdet)
+  | case2 oldR oldT t hstop =>
+      intro _hmodulus hP
+      omega
+  | case3 oldR r oldT t hstop hrNe quotient ih =>
+      intro hmodulus hP hr hcut hold hcurrent hdet hsign
+      have hrPos : 0 < r := Nat.pos_of_ne_zero hrNe
+      have hquotientPos : 0 < quotient := by
+        dsimp only [quotient]
+        exact Nat.div_pos (Nat.le_of_lt hr) hrPos
+      have hdivmodNat := Nat.mod_add_div oldR r
+      have hdivmod : Int.ofNat (oldR % r) +
+          Int.ofNat r * Int.ofNat quotient = Int.ofNat oldR := by
+        dsimp only [quotient]
+        exact congrArg Int.ofNat hdivmodNat
+      have hnext : (modulus : Int) ∣
+          (oldT - Int.ofNat quotient * t) * a - Int.ofNat (oldR % r) := by
+        have hdifference := Int.dvd_sub hold
+          (Int.dvd_mul_of_dvd_right (b := Int.ofNat quotient) hcurrent)
+        rw [show
+          (oldT * a - Int.ofNat oldR) -
+              Int.ofNat quotient * (t * a - Int.ofNat r) =
+            (oldT - Int.ofNat quotient * t) * a - Int.ofNat (oldR % r) by
+          simp only [Int.mul_sub, Int.sub_mul]
+          have hmul : Int.ofNat quotient * (t * a) =
+              (Int.ofNat quotient * t) * a := by ac_rfl
+          have hcomm : Int.ofNat quotient * Int.ofNat r =
+              Int.ofNat r * Int.ofNat quotient := by ac_rfl
+          rw [hmul, hcomm]
+          omega] at hdifference
+        exact hdifference
+      have hdetNext :
+          Int.ofNat r * (oldT - Int.ofNat quotient * t) -
+                Int.ofNat (oldR % r) * t = (modulus : Int) ∨
+            Int.ofNat r * (oldT - Int.ofNat quotient * t) -
+                Int.ofNat (oldR % r) * t = -(modulus : Int) := by
+        have hnegDet :
+            Int.ofNat r * (oldT - Int.ofNat quotient * t) -
+                Int.ofNat (oldR % r) * t =
+              -(Int.ofNat oldR * t - Int.ofNat r * oldT) := by
+          simp only [Int.mul_sub]
+          have hmul : Int.ofNat r * (Int.ofNat quotient * t) =
+              (Int.ofNat r * Int.ofNat quotient) * t := by ac_rfl
+          rw [hmul]
+          have hsum :
+              Int.ofNat r * Int.ofNat quotient * t +
+                  Int.ofNat (oldR % r) * t = Int.ofNat oldR * t := by
+            rw [← Int.add_mul]
+            rw [Int.add_comm]
+            rw [hdivmod]
+          omega
+        rcases hdet with hdet | hdet
+        · exact Or.inr (by rw [hnegDet, hdet])
+        · exact Or.inl (by rw [hnegDet, hdet]; simp)
+      have hsignNext :
+          t ≤ 0 ∧ 0 < oldT - Int.ofNat quotient * t ∨
+            oldT - Int.ofNat quotient * t < 0 ∧ 0 ≤ t := by
+        have hquotientInt : (0 : Int) < Int.ofNat quotient :=
+          Int.ofNat_lt.mpr hquotientPos
+        rcases hsign with hsign | hsign
+        · have hproduct : 0 < Int.ofNat quotient * t :=
+            Int.mul_pos hquotientInt hsign.2
+          exact Or.inr ⟨by omega, Int.le_of_lt hsign.2⟩
+        · have hproduct : Int.ofNat quotient * t < 0 :=
+            Int.mul_neg_of_pos_of_neg hquotientInt hsign.1
+          exact Or.inl ⟨Int.le_of_lt hsign.1, by omega⟩
+      have hcutNext : P < Int.ofNat r := by
+        exact Int.lt_of_not_ge hstop
+      exact ih hmodulus hP (Nat.mod_lt oldR hrPos) hcutNext
+        hcurrent hnext hdetNext hsignNext
+
 /-- Return the first row of the extended Euclidean remainder sequence on
 `(m, a)` whose remainder is at most `P`. The modulus is interpreted up to
 sign, and `a` is reduced before entering the recurrence. -/
@@ -49,6 +342,41 @@ def euclidUntil (m a P : Int) : Row :=
   else
     let residue := (a % (Int.ofNat modulus)).natAbs
     euclidUntil.go P modulus residue 0 1
+
+/-- The truncated Euclidean row is a nonzero modular-lattice vector whose
+second coordinate is no larger than that of any bounded lattice vector. -/
+theorem euclidUntil_spec {modulus : Nat} {a P : Int}
+    (hmodulus : 0 < modulus) (hP : 0 ≤ P) (hcut : P < (modulus : Int)) :
+    let row := euclidUntil (Int.ofNat modulus) a P
+    0 ≤ row.r ∧ row.r ≤ P ∧ row.t ≠ 0 ∧
+      (modulus : Int) ∣ row.t * a - row.r ∧
+      ∀ p q : Int, p.natAbs ≤ P → 0 < q →
+        (modulus : Int) ∣ q * a - p →
+        (row.t.natAbs : Int) ≤ q := by
+  unfold euclidUntil
+  simp only [Int.natAbs_ofNat']
+  split
+  · omega
+  · have hresidueNonneg : (0 : Int) ≤ a % Int.ofNat modulus :=
+      Int.emod_nonneg _ (Int.ofNat_ne_zero.mpr (Nat.ne_of_gt hmodulus))
+    have hresidueEq :
+        Int.ofNat ((a % Int.ofNat modulus).natAbs) = a % Int.ofNat modulus :=
+      Int.ofNat_natAbs_of_nonneg hresidueNonneg
+    apply euclidUntil.go_spec modulus a P
+    · exact hmodulus
+    · exact hP
+    · apply Int.ofNat_lt.mp
+      change Int.ofNat ((a % Int.ofNat modulus).natAbs) < Int.ofNat modulus
+      rw [hresidueEq]
+      exact Int.emod_lt_of_pos _ (Int.ofNat_lt.mpr hmodulus)
+    · exact hcut
+    · simp
+    · simp only [Int.one_mul]
+      rw [hresidueEq]
+      simpa only [Int.ofNat_eq_natCast] using
+        (Int.dvd_self_sub_emod (x := a) (m := Int.ofNat modulus))
+    · exact Or.inl (by simp)
+    · exact Or.inl ⟨by omega, by omega⟩
 
 #guard euclidUntil 1 0 1 == { r := 0, t := 1 }
 #guard euclidUntil 101 51 2 == { r := 1, t := 2 }

--- a/HexModular/Recon.lean
+++ b/HexModular/Recon.lean
@@ -86,7 +86,22 @@ modulus. -/
 theorem ratRecon?_den_coprime {a : Int} {m : Nat} {P Q : Int} {x : Rat}
     (h : ratRecon? a m P Q = some x) :
     Nat.gcd x.den m = 1 := by
-  sorry
+  apply Nat.gcd_eq_one_iff.mpr
+  intro divisor hden hmodulus
+  have hcongr := ratRecon?_congr h
+  have hmodulusDvd : (m : Int) ∣ Int.ofNat x.den * a - x.num :=
+    Int.dvd_of_emod_eq_zero hcongr
+  have hdivisorDvd : (divisor : Int) ∣ Int.ofNat x.den * a - x.num :=
+    Int.dvd_trans (Int.ofNat_dvd.mpr hmodulus) hmodulusDvd
+  have hdenDvd : (divisor : Int) ∣ Int.ofNat x.den * a :=
+    Int.dvd_mul_of_dvd_left (Int.ofNat_dvd.mpr hden)
+  have hnumDvd : (divisor : Int) ∣ x.num := by
+    have := Int.dvd_sub hdenDvd hdivisorDvd
+    rw [show Int.ofNat x.den * a - (Int.ofNat x.den * a - x.num) =
+      x.num by omega] at this
+    exact this
+  exact Nat.gcd_eq_one_iff.mp x.reduced divisor
+    (Int.ofNat_dvd_left.mp hnumDvd) hden
 
 /-- Rational reconstruction is unique whenever twice the product of the two
 bounds is strictly smaller than the modulus. -/
@@ -97,7 +112,69 @@ theorem ratRecon_unique {a P Q : Int} {m : Nat} {y₁ y₂ : Rat}
     (b₁ : (y₁.num.natAbs : Int) ≤ P ∧ (y₁.den : Int) ≤ Q)
     (b₂ : (y₂.num.natAbs : Int) ≤ P ∧ (y₂.den : Int) ≤ Q) :
     y₁ = y₂ := by
-  sorry
+  have hmodulus : (0 : Int) < (m : Int) := by
+    have hden₁ : (0 : Int) < y₁.den := by exact_mod_cast y₁.den_pos
+    have hP : 0 ≤ P := Int.le_trans (Int.natCast_nonneg _) b₁.1
+    have hQ : 0 < Q := Int.lt_of_lt_of_le hden₁ b₁.2
+    have hprod : 0 ≤ 2 * P * Q :=
+      Int.mul_nonneg (Int.mul_nonneg (by omega) hP) (Int.le_of_lt hQ)
+    omega
+  have hm₁ : (m : Int) ∣ Int.ofNat y₁.den * a - y₁.num :=
+    Int.dvd_of_emod_eq_zero h₁
+  have hm₂ : (m : Int) ∣ Int.ofNat y₂.den * a - y₂.num :=
+    Int.dvd_of_emod_eq_zero h₂
+  let cross := y₁.num * Int.ofNat y₂.den -
+    y₂.num * Int.ofNat y₁.den
+  have hcrossDvd : (m : Int) ∣ cross := by
+    have hdifference := Int.dvd_sub
+      (Int.dvd_mul_of_dvd_right (b := Int.ofNat y₂.den) hm₁)
+      (Int.dvd_mul_of_dvd_right (b := Int.ofNat y₁.den) hm₂)
+    have hcancel : Int.ofNat y₂.den * (Int.ofNat y₁.den * a) =
+        Int.ofNat y₁.den * (Int.ofNat y₂.den * a) := by
+      ac_rfl
+    rw [show
+      Int.ofNat y₂.den * (Int.ofNat y₁.den * a - y₁.num) -
+          Int.ofNat y₁.den * (Int.ofNat y₂.den * a - y₂.num) =
+        -cross by
+      simp only [Int.mul_sub]
+      rw [hcancel]
+      dsimp only [cross]
+      have hmul₁ : Int.ofNat y₂.den * y₁.num =
+          y₁.num * Int.ofNat y₂.den := by ac_rfl
+      have hmul₂ : Int.ofNat y₁.den * y₂.num =
+          y₂.num * Int.ofNat y₁.den := by ac_rfl
+      rw [hmul₁, hmul₂]
+      omega] at hdifference
+    exact Int.dvd_neg.mp hdifference
+  have hP : 0 ≤ P := Int.le_trans (Int.natCast_nonneg _) b₁.1
+  have hden₁ : (0 : Int) ≤ y₁.den := Int.natCast_nonneg _
+  have hden₂ : (0 : Int) ≤ y₂.den := Int.natCast_nonneg _
+  have hterm₁ : (y₁.num.natAbs : Int) * Int.ofNat y₂.den ≤ P * Q := by
+    exact Int.le_trans
+      (Int.mul_le_mul_of_nonneg_right b₁.1 hden₂)
+      (Int.mul_le_mul_of_nonneg_left b₂.2 hP)
+  have hterm₂ : (y₂.num.natAbs : Int) * Int.ofNat y₁.den ≤ P * Q := by
+    exact Int.le_trans
+      (Int.mul_le_mul_of_nonneg_right b₂.1 hden₁)
+      (Int.mul_le_mul_of_nonneg_left b₁.2 hP)
+  have hcrossBound : (cross.natAbs : Int) < (m : Int) := by
+    have htriangle := Int.natAbs_sub_le
+      (y₁.num * Int.ofNat y₂.den) (y₂.num * Int.ofNat y₁.den)
+    have htriangleInt : (cross.natAbs : Int) ≤
+        (y₁.num.natAbs : Int) * Int.ofNat y₂.den +
+          (y₂.num.natAbs : Int) * Int.ofNat y₁.den := by
+      apply Int.ofNat_le.mpr
+      simpa only [cross, Int.natAbs_mul, Int.natAbs_natCast, Int.natAbs_ofNat',
+        Int.natCast_add, Int.natCast_mul] using htriangle
+    have hm' : 2 * (P * Q) < (m : Int) := by
+      simpa only [Int.mul_assoc] using hm
+    omega
+  have hcrossZero : cross = 0 := by
+    apply Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hcrossDvd
+    simpa only [Int.natAbs_natCast] using Int.ofNat_lt.mp hcrossBound
+  apply Rat.eq_iff_mul_eq_mul.mpr
+  dsimp only [cross] at hcrossZero
+  exact Int.sub_eq_zero.mp hcrossZero
 
 /-- Under the uniqueness bound, bounded reconstruction finds every rational
 that satisfies the congruence and bounds. -/
@@ -106,7 +183,92 @@ theorem ratRecon?_complete {a P Q : Int} {m : Nat} {y : Rat}
     (hy : (Int.ofNat y.den * a - y.num) % (m : Int) = 0)
     (hb : (y.num.natAbs : Int) ≤ P ∧ (y.den : Int) ≤ Q) :
     ratRecon? a m P Q = some y := by
-  sorry
+  have hdenPos : (0 : Int) < y.den := by exact_mod_cast y.den_pos
+  have hP : 0 ≤ P := Int.le_trans (Int.natCast_nonneg _) hb.1
+  have hQ : 0 < Q := Int.lt_of_lt_of_le hdenPos hb.2
+  have htwoP : 0 ≤ 2 * P := Int.mul_nonneg (by omega) hP
+  have hprodNonneg : 0 ≤ 2 * P * Q :=
+    Int.mul_nonneg htwoP (Int.le_of_lt hQ)
+  have hmodulusInt : (0 : Int) < (m : Int) := Int.lt_of_le_of_lt hprodNonneg hm
+  have hmodulus : 0 < m := Int.ofNat_lt.mp hmodulusInt
+  have hPLeProduct : P ≤ 2 * P * Q := by
+    have hPLeTwoP : P ≤ 2 * P := by omega
+    have hTwoPLe : 2 * P ≤ 2 * P * Q := by
+      calc
+        2 * P = (2 * P) * 1 := by simp
+        _ ≤ (2 * P) * Q := Int.mul_le_mul_of_nonneg_left (by omega) htwoP
+    exact Int.le_trans hPLeTwoP hTwoPLe
+  have hcut : P < (m : Int) := by omega
+  let row := euclidUntil (Int.ofNat m) a P
+  have hspec := euclidUntil_spec (a := a) (P := P) hmodulus hP hcut
+  dsimp only at hspec
+  have htargetDvd : (m : Int) ∣ Int.ofNat y.den * a - y.num :=
+    Int.dvd_of_emod_eq_zero hy
+  have htBound : (row.t.natAbs : Int) ≤ Int.ofNat y.den := by
+    exact hspec.2.2.2.2 y.num (Int.ofNat y.den) hb.1 hdenPos htargetDvd
+  let cross := row.r * Int.ofNat y.den - y.num * row.t
+  have hcrossDvd : (m : Int) ∣ cross := by
+    have hdifference := Int.dvd_sub
+      (Int.dvd_mul_of_dvd_right (b := row.t) htargetDvd)
+      (Int.dvd_mul_of_dvd_right (b := Int.ofNat y.den) hspec.2.2.2.1)
+    rw [show
+      row.t * (Int.ofNat y.den * a - y.num) -
+          Int.ofNat y.den * (row.t * a - row.r) = cross by
+      simp only [Int.mul_sub]
+      have h₁ : row.t * (Int.ofNat y.den * a) =
+          Int.ofNat y.den * (row.t * a) := by ac_rfl
+      have h₂ : row.t * y.num = y.num * row.t := by ac_rfl
+      have h₃ : Int.ofNat y.den * row.r = row.r * Int.ofNat y.den := by ac_rfl
+      rw [h₁, h₂, h₃]
+      dsimp only [cross]
+      omega] at hdifference
+    exact hdifference
+  have hrowAbs : (row.r.natAbs : Int) ≤ P := by
+    rw [Int.ofNat_natAbs_of_nonneg hspec.1]
+    exact hspec.2.1
+  have hterm₁ : (row.r.natAbs : Int) * Int.ofNat y.den ≤
+      P * Int.ofNat y.den :=
+    Int.mul_le_mul_of_nonneg_right hrowAbs (Int.natCast_nonneg _)
+  have hterm₂ : (y.num.natAbs : Int) * (row.t.natAbs : Int) ≤
+      P * Int.ofNat y.den := by
+    exact Int.le_trans
+      (Int.mul_le_mul_of_nonneg_right hb.1 (Int.natCast_nonneg _))
+      (Int.mul_le_mul_of_nonneg_left htBound hP)
+  have hdenProduct : 2 * P * Int.ofNat y.den ≤ 2 * P * Q :=
+    Int.mul_le_mul_of_nonneg_left hb.2 htwoP
+  have hcrossBound : (cross.natAbs : Int) < (m : Int) := by
+    have htriangle := Int.natAbs_sub_le
+      (row.r * Int.ofNat y.den) (y.num * row.t)
+    have htriangleInt : (cross.natAbs : Int) ≤
+        (row.r.natAbs : Int) * Int.ofNat y.den +
+          (y.num.natAbs : Int) * (row.t.natAbs : Int) := by
+      apply Int.ofNat_le.mpr
+      simpa only [cross, Int.natAbs_mul, Int.natAbs_ofNat',
+        Int.natCast_add, Int.natCast_mul] using htriangle
+    have hm' : 2 * (P * Int.ofNat y.den) < (m : Int) := by
+      have : 2 * P * Int.ofNat y.den < (m : Int) :=
+        Int.lt_of_le_of_lt hdenProduct hm
+      simpa only [Int.mul_assoc] using this
+    omega
+  have hcrossZero : cross = 0 := by
+    apply Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hcrossDvd
+    simpa only [Int.natAbs_natCast] using Int.ofNat_lt.mp hcrossBound
+  have hcandidate : Rat.divInt row.r row.t = y := by
+    rw [← Rat.num_divInt_den y]
+    apply (Rat.divInt_eq_divInt_iff hspec.2.2.1 (by omega)).mpr
+    dsimp only [cross] at hcrossZero
+    exact Int.sub_eq_zero.mp hcrossZero
+  have hcheck : ratReconCheck a m P Q y = true := by
+    simp only [ratReconCheck, Bool.and_eq_true, decide_eq_true_eq]
+    exact ⟨⟨⟨⟨hmodulus, hy⟩, hb.1⟩, hdenPos⟩, hb.2⟩
+  unfold ratRecon?
+  rw [ite_eq_right (Nat.ne_of_gt hmodulus)]
+  change (if row.t = 0 then none else
+      let candidate := Rat.divInt row.r row.t
+      if ratReconCheck a m P Q candidate then some candidate else none) = some y
+  rw [ite_eq_right hspec.2.2.1]
+  dsimp only
+  rw [hcandidate, ite_eq_left hcheck]
 
 /-- Check a vector reconstruction with common denominator. -/
 private def ratReconVecCheck (a y : Vector Int k) (m : Nat) (P Q d : Int) : Bool :=
@@ -116,6 +278,25 @@ private def ratReconVecCheck (a y : Vector Int k) (m : Nat) (P Q d : Int) : Bool
         decide ((d * ai - yi) % (m : Int) = 0) &&
           decide ((yi.natAbs : Int) ≤ P))
       a y).toArray.all (fun ok => ok)
+
+private theorem ratReconVecCheck_spec {a y : Vector Int k} {m : Nat} {P Q d : Int}
+    (h : ratReconVecCheck a y m P Q d = true) :
+    0 < d ∧ d ≤ Q ∧
+      ∀ i : Fin k,
+        (d * a[i] - y[i]) % (m : Int) = 0 ∧ (y[i].natAbs : Int) ≤ P := by
+  simp only [ratReconVecCheck, Bool.and_eq_true, decide_eq_true_eq] at h
+  rcases h with ⟨⟨⟨hmodulus, hden⟩, hdenBound⟩, hall⟩
+  refine ⟨hden, hdenBound, ?_⟩
+  intro i
+  have hi : i.val < (Vector.zipWith
+      (fun ai yi =>
+        decide ((d * ai - yi) % (m : Int) = 0) &&
+          decide ((yi.natAbs : Int) ≤ P)) a y).toArray.size := by
+    simp
+  have halli := Array.all_eq_true.mp hall i.val hi
+  simp only [Vector.getElem_toArray, Vector.getElem_zipWith,
+    Bool.and_eq_true, decide_eq_true_eq] at halli
+  exact halli
 
 /-- Process the remaining coordinates of a common-denominator reconstruction.
 The index increases until it reaches the statically known vector length. -/
@@ -178,7 +359,26 @@ theorem ratReconVec?_spec {a : Vector Int k} {m : Nat} {P Q d : Int}
     0 < d ∧ d ≤ Q ∧
       ∀ i : Fin k,
         (d * a[i] - y[i]) % (m : Int) = 0 ∧ (y[i].natAbs : Int) ≤ P := by
-  sorry
+  unfold ratReconVec? at h
+  split at h
+  · dsimp only at h
+    split at h <;> try contradiction
+    next hcheck =>
+      cases h
+      exact ratReconVecCheck_spec hcheck
+  · cases hfirst : ratRecon? a[0] m P Q with
+    | none => simp [hfirst] at h
+    | some first =>
+      cases hgo : ratReconVec.go a m P Q 1 (by omega)
+          ((Vector.replicate k (0 : Int)).set 0 first.num) first.den with
+      | none => simp [hfirst, hgo] at h
+      | some result =>
+        rcases result with ⟨nums, den⟩
+        simp only [Option.bind_eq_bind, hfirst, Option.bind_some, hgo] at h
+        split at h <;> try contradiction
+        next hcheck =>
+          cases h
+          exact ratReconVecCheck_spec hcheck
 
 /-- Track the row immediately preceding the largest quotient in an extended
 Euclidean run. -/
@@ -231,7 +431,7 @@ theorem ratReconMaxQuot?_congr {a : Int} {m : Nat} {x : Rat}
   split at h
   · cases h
     have hr : a % (m : Int) = 0 := Int.natAbs_eq_zero.mp (by assumption)
-    simpa [hr]
+    simp [hr]
   · split at h <;> try contradiction
     split at h <;> try contradiction
     try dsimp only at h


### PR DESCRIPTION
Closes the remaining proof obligations in `HexModular`:

- prove scalar and vector Garner congruence preservation
- establish the truncated extended-Euclidean minimal-denominator invariant
- prove rational reconstruction denominator coprimality, uniqueness, and completeness
- prove the common-denominator vector reconstruction contract

The Euclidean argument is Mathlib-free and exposes `euclidUntil_spec` as the characterizing theorem used by reconstruction completeness. No axioms, `sorry`, or `native_decide` remain in `HexModular`.

Validation:
- `lake build HexModular`
- `lake build HexModular.Recon` on Lean 4.34.0-rc2
- `python3 scripts/release/check_trust_surface.py`
- `git diff --check`