### PR TITLE
doc: add correspondence sections and the wave's released-repo READMEs

### DIFF
--- a/HexManual/Chapters/HexBerlekamp.lean
+++ b/HexManual/Chapters/HexBerlekamp.lean
@@ -88,6 +88,47 @@ certificate-backed `factor_poly` and `irreducibility` syntax for
 `FpPoly p`. Importing `HexBerlekampMathlib` adds the corresponding
 surface for `Polynomial (ZMod p)`.
 
+# The Mathlib correspondence
+%%%
+tag := "hex-berlekamp-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. `HexBerlekampMathlib`
+is the companion that transports it: `toMathlibPolynomial` maps a
+{name}`Hex.FpPoly` to `Polynomial (ZMod p)`, and the executable checks
+become statements about Mathlib's `Irreducible` predicate on the
+transported polynomial.
+
+The headline equivalence takes an arbitrary input. The computable test
+{name}`HexBerlekampMathlib.fpIsIrreducible` normalizes to a monic
+polynomial, runs Rabin's test on it, and agrees exactly with Mathlib
+irreducibility:
+
+{docstring HexBerlekampMathlib.fpIsIrreducible_iff}
+
+For a monic input the equivalence is Rabin's criterion itself, in both
+directions: the test succeeds exactly on the irreducible polynomials.
+The forward direction is what certificate checking uses; the reverse
+direction says the test never misses.
+
+{docstring HexBerlekampMathlib.rabin_irreducible}
+
+Factorization transports factor by factor. On a monic square-free input
+of positive degree, every entry of the list returned by
+{name}`Hex.Berlekamp.berlekampFactor` is irreducible in Mathlib's sense.
+Together with the Mathlib-free product theorem
+{name}`Hex.Berlekamp.prod_berlekampFactor` above, the returned list is a
+complete factorization into Mathlib irreducibles.
+
+{docstring HexBerlekampMathlib.irreducible_of_mem_berlekampFactor}
+
+The proof boundary follows the import boundary. The executable library
+proves what is statable without Mathlib: the product identity, degree
+accounting, and the loop invariants of the factor loop. The companion
+supplies the finite-field theory, such as the existence and subfield
+structure of `𝔽_(p^n)` behind Rabin's criterion, that reads those checks
+as irreducibility.
+
 # Verification
 
 The executable library proves product reconstruction and the algebra

--- a/HexManual/Chapters/HexBerlekampZassenhaus.lean
+++ b/HexManual/Chapters/HexBerlekampZassenhaus.lean
@@ -174,14 +174,49 @@ For a nonzero input, the result has signed content as its scalar;
 positive multiplicities; primitive, irreducible factors with positive
 leading coefficients; and no two associated factor entries. Its
 product is the input, and this normalized factorization is unique.
-
-{docstring HexBerlekampZassenhausMathlib.factorize_normalized}
+The next section states those guarantees as theorems.
 
 {name}`Hex.factorTraced` returns the same factorization together with
 the selected {name}`Hex.FactorMethod`, a possible classical decline,
 and measurements of the classical search. The trace is observational:
 all methods are checked by the same product and irreducibility
 theorems.
+
+# The Mathlib correspondence
+%%%
+tag := "hex-berlekamp-zassenhaus-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free.
+`HexBerlekampZassenhausMathlib` is the companion that restates the
+guarantees of {name}`Hex.ZPoly.factorize` against Mathlib's
+`Polynomial ℤ`, transported through `HexPolyZMathlib.toPolynomial`.
+
+The product identity holds unconditionally and is re-exported as a
+`simp` lemma:
+
+{docstring HexBerlekampZassenhausMathlib.factorize_product}
+
+Every emitted factor is irreducible, with no hypothesis on the input:
+
+{docstring HexBerlekampZassenhausMathlib.factorize_irreducible_of_nonUnit}
+
+The headline theorem bundles the full normal form of a nonzero input's
+factorization:
+
+{docstring HexBerlekampZassenhausMathlib.factorize_normalized}
+
+That normal form is canonical. Any two factorizations satisfying it
+with the same product agree up to the packing of multiplicities:
+
+{docstring HexBerlekampZassenhausMathlib.factorize_unique}
+
+The companion also carries the tactic surface across the boundary.
+The base library's `factor_poly` and `irreducibility` elaborators work
+on {name}`Hex.ZPoly` goals; importing `HexBerlekampZassenhausMathlib`
+upgrades them to accept `Polynomial ℤ` as well, and adds the
+kernel-checked `factor_poly!` and `irreducibility!` variants whose
+certificate checks reduce inside the kernel.
 
 # Relationship to the tactics
 

--- a/HexManual/Chapters/HexRoots.lean
+++ b/HexManual/Chapters/HexRoots.lean
@@ -218,6 +218,42 @@ in general, never enter the kernel: each is replaced by an exact dyadic bound
 on the correct side, so soundness is preserved at the cost of a factor-2 margin
 in how well-separated a root must be before its witness fires.
 
+# The Mathlib correspondence
+%%%
+tag := "hex-roots-mathlib"
+%%%
+
+Everything the driver computes is executable and Mathlib-free.
+`HexRootsMathlib` is the companion that interprets it: a {name}`Hex.ZPoly`
+input becomes a complex polynomial through {name}`HexRootsMathlib.toPolyℂ`,
+and the executable certificates become statements about its root set in
+`Polynomial ℂ`. The correspondence has two halves. Soundness is
+{name}`HexRootsMathlib.isolate_sound` from
+{ref "hex-roots-soundness"}[the certificate section]: a successful run
+enumerates exactly the distinct complex roots, at the requested precision.
+Completeness is the converse guarantee, that on a nonzero polynomial with
+only simple roots the search cannot fail, for every strategy and every
+requested precision:
+
+{docstring HexRootsMathlib.isolate_isSome}
+
+Completeness is what lets the total wrapper {name}`HexRootsMathlib.isolate!`
+from {ref "hex-roots-isolate"}[the entry-point section] drop the `Option`
+and return the atom array directly, with its run equation, root count,
+root set, and precision exposed by the `isolate!_*` theorems shown there.
+One further guarantee is stated on the wrapper: distinct atoms have
+disjoint closed circumscribed discs, so the certified enclosures never
+overlap and each root is separated from every other by exact dyadic data.
+
+{docstring HexRootsMathlib.isolate!_disjoint}
+
+Behind these statements the companion develops the analysis the
+certificates rely on: a ported Newton-Kantorovich contraction theorem, the
+argument principle and Rouché's theorem for counting roots in discs, and
+the Mahler separation bound that keeps subdivision terminating. None of
+that analysis runs; it justifies, once and for all, the fixed dyadic
+comparisons the kernel re-checks.
+
 # Cross-references
 %%%
 tag := "hex-roots-cross-references"

--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -1,0 +1,79 @@
+# hex-number-field
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Executable exact algebraic numbers in `ℂ`, implemented in Lean 4 without
+Mathlib. The package provides fixed-field arithmetic in one irreducible
+presentation, factorization-lazy arithmetic on certified roots, and a
+canonical minimal-polynomial form with decidable equality. It builds on
+[`hex-poly-z`](https://github.com/leanprover/hex-poly-z),
+[`hex-roots`](https://github.com/leanprover/hex-roots),
+[`hex-resultant`](https://github.com/leanprover/hex-resultant),
+[`hex-berlekamp-zassenhaus`](https://github.com/leanprover/hex-berlekamp-zassenhaus),
+and the matrix stack; its Mathlib counterpart is
+[`hex-number-field-mathlib`](https://github.com/leanprover/hex-number-field-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-number-field"
+git = "https://github.com/leanprover/hex-number-field.git"
+rev = "main"
+```
+
+```lean
+import HexNumberField
+
+open Hex
+
+def a : AlgebraicNumber := AlgebraicNumber.ofRat (3/2)
+
+#guard a + a == AlgebraicNumber.ofRat 3
+#guard a * a⁻¹ == 1
+#guard (0 : AlgebraicNumber)⁻¹ == 0
+```
+
+# Functionality
+
+Three complementary exact representations:
+
+- `Hex.QAdjoin p x`: rational power-basis coordinates in a fixed
+  irreducible presentation `ℚ(x)`, with `Hex.QAdjoin.reduce`, arithmetic,
+  extended-gcd inversion, and threaded dyadic approximation
+  (`Hex.QAdjoin.approx`).
+- `Hex.AlgebraicRoot`: a certified selected root of a squarefree integer
+  polynomial that need not be minimal. Arithmetic (`add?`, `mul?`, `inv?`,
+  `div?`) builds resultant eliminants and postpones factoring until
+  `Hex.AlgebraicRoot.exact` is requested.
+- `Hex.AlgebraicNumber`: the canonical form, a selected root of its
+  normalized irreducible minimal polynomial, with rational construction,
+  casts, powers, and Boolean equality that compares represented values.
+
+`Hex.AlgebraicPoly` supplies polynomials with algebraic coefficients and
+semantic trailing-zero normalization, with root APIs (`roots?`) for both
+fixed-field and algebraic-coefficient polynomials.
+
+# Verification
+
+Certificates are exact and kernel-checkable: every stored root carries a
+refined isolation, so identity and approximation are certified eagerly even
+though factorization is lazy. The `Option`-valued operations are the honest
+computational boundary; their total wrappers are backed by companion
+`_isSome` completeness theorems rather than silent assumptions. The
+companion
+[`hex-number-field-mathlib`](https://github.com/leanprover/hex-number-field-mathlib)
+interprets every representation in `ℂ`, proves the arithmetic computes the
+corresponding complex operations (including the convention `0⁻¹ = 0`),
+proves `Hex.AlgebraicNumber.toComplex` injective, and installs a lawful
+`Field` instance over the unchanged executable operations. See the
+[SPEC](SPEC/hex-number-field.md) for contracts and budgets.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexNumberFieldMathlib/README.md
+++ b/HexNumberFieldMathlib/README.md
@@ -1,0 +1,74 @@
+# hex-number-field-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Mathlib companion for
+[`hex-number-field`](https://github.com/leanprover/hex-number-field). It
+interprets the executable algebraic-number types in `ℂ` and proves
+fixed-field correspondence, canonicalization, lazy-arithmetic completeness,
+semantic equality, and root-API completeness. It depends on
+`hex-number-field` and the Mathlib companions of its inputs:
+[`hex-resultant-mathlib`](https://github.com/leanprover/hex-resultant-mathlib),
+[`hex-berlekamp-zassenhaus-mathlib`](https://github.com/leanprover/hex-berlekamp-zassenhaus-mathlib),
+[`hex-roots-mathlib`](https://github.com/leanprover/hex-roots-mathlib), and
+[`hex-poly-z-mathlib`](https://github.com/leanprover/hex-poly-z-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-number-field-mathlib"
+git = "https://github.com/leanprover/hex-number-field-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexNumberFieldMathlib
+
+open Hex
+
+example : Function.Injective AlgebraicNumber.toComplex :=
+  AlgebraicNumber.toComplex_injective
+
+-- The Field instance's data fields are the executable operations.
+example (a b : AlgebraicNumber) : a + b = AlgebraicNumber.add a b := rfl
+```
+
+# Functionality
+
+The proof-facing API interprets each executable representation in `ℂ`:
+
+- `Hex.AlgebraicRoot.toComplex` and `Hex.AlgebraicNumber.toComplex` select
+  the semantic root; `Hex.AlgebraicNumber.p_eq_minpoly` identifies the
+  stored polynomial with the minimal polynomial of that value.
+- `Hex.QAdjoin.toComplex`, `Hex.QAdjoin.adjoinRootEquiv`, and
+  `Hex.QAdjoin.embedding`: the reduced coordinates are ring-equivalent to
+  the monic rational `AdjoinRoot` quotient, and the complex interpretation
+  is a ring embedding. An opt-in scoped `Field` instance preserves the
+  computational operations and rational scalar action.
+- Completeness theorems (`add?_isSome`, `mul?_isSome`, `inv?_isSome`,
+  `div?_isSome`, `exact?_isSome` and relatives) prove that the bounded
+  certificate searches of the lazy layer always succeed, so the total
+  wrappers compute the corresponding complex operations.
+- `Hex.AlgebraicNumber.toComplex_injective`, `LawfulBEq`, and
+  `DecidableEq`: Boolean equality decides equality of complex values.
+- Root-API correctness for the fixed-field and algebraic-coefficient
+  `roots?` functions.
+
+# Verification
+
+Everything in this package is proved; it adds no executable operations. The
+lawful `Field AlgebraicNumber` instance is built over the unchanged
+executable data, so proofs about the Mathlib structure are proofs about the
+code that runs. The computational library stays Mathlib-free; complex
+semantics live here. See the [SPEC](SPEC/hex-number-field-mathlib.md) and
+the Hex manual's number-field chapter for the theorem chain.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexNumberFieldTower/README.md
+++ b/HexNumberFieldTower/README.md
@@ -1,0 +1,78 @@
+# hex-number-field-tower
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Executable successive algebraic extensions of `ℚ`, implemented in Lean 4
+without Mathlib. A tower is a field with a fixed embedding into `ℂ`: every
+level records an irreducible defining polynomial over the preceding tower
+and the absolute certified root chosen as its generator. The package builds
+on [`hex-number-field`](https://github.com/leanprover/hex-number-field),
+[`hex-resultant`](https://github.com/leanprover/hex-resultant), and
+[`hex-berlekamp-zassenhaus`](https://github.com/leanprover/hex-berlekamp-zassenhaus);
+its Mathlib counterpart is
+[`hex-number-field-tower-mathlib`](https://github.com/leanprover/hex-number-field-tower-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-number-field-tower"
+git = "https://github.com/leanprover/hex-number-field-tower.git"
+rev = "main"
+```
+
+```lean
+import HexNumberFieldTower
+
+open Hex NumberTower
+
+def a : Elem rat := rat.ofRat (3/2)
+
+#guard a * rat.ofRat 3 = rat.ofRat (9/2)
+#guard a⁻¹ * a = rat.ofRat 1
+```
+
+# Functionality
+
+`Hex.NumberTower` is a sealed validated tower; `Hex.NumberTower.Elem T`
+carries exact mixed-radix rational coordinates with decidable equality and
+full field arithmetic, totalized by `0⁻¹ = 0`. Only smart constructors can
+admit a level:
+
+- `Hex.NumberTower.rat`: the rational base tower.
+- `Hex.NumberTower.ofQAdjoin`: a one-level tower for an irreducible
+  presentation `ℚ(x)`.
+- `Hex.NumberTower.adjoin?`: adjoin a selected absolute algebraic root.
+- `Hex.NumberTower.factor?`: complete irreducible Trager factorization of a
+  `Poly T` with multiplicity.
+- `Hex.NumberTower.split?`: an extension in which a given polynomial splits
+  into linear factors.
+- `Hex.NumberTower.flatten?`: replace the tower by one canonical
+  primitive-element field, with coordinate maps in both directions.
+
+The `Option` results carry new dependent carrier indices and certificates,
+so there is no junk fallback value; the Mathlib companion proves every
+valid input succeeds.
+
+# Verification
+
+Every level stores a successful executable factorization check and a
+consistent chosen complex embedding by construction; the sealed
+representation means no other route can build a tower. This package does
+not itself turn those Boolean checks into semantic irreducibility or claim
+a law-bearing field instance. The companion
+[`hex-number-field-tower-mathlib`](https://github.com/leanprover/hex-number-field-tower-mathlib)
+interprets every validated tower as a finite extension of `ℚ` with a fixed
+complex embedding, proves the coordinate arithmetic computes the complex
+operations, and verifies Trager factorization, adjoining, splitting fields,
+and flattening. See the [SPEC](SPEC/hex-number-field-tower.md) for the
+representation and contracts.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexNumberFieldTowerMathlib/README.md
+++ b/HexNumberFieldTowerMathlib/README.md
@@ -1,0 +1,74 @@
+# hex-number-field-tower-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Mathlib companion for
+[`hex-number-field-tower`](https://github.com/leanprover/hex-number-field-tower).
+It interprets every validated tower as a finite extension of `ℚ` with a
+fixed embedding into `ℂ` and proves the coordinate field operations,
+Trager factorization, adjoining, splitting fields, and primitive-element
+flattening correct. It depends on `hex-number-field-tower`,
+[`hex-number-field-mathlib`](https://github.com/leanprover/hex-number-field-mathlib),
+[`hex-resultant-mathlib`](https://github.com/leanprover/hex-resultant-mathlib),
+[`hex-berlekamp-zassenhaus-mathlib`](https://github.com/leanprover/hex-berlekamp-zassenhaus-mathlib),
+and
+[`hex-row-reduce-mathlib`](https://github.com/leanprover/hex-row-reduce-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-number-field-tower-mathlib"
+git = "https://github.com/leanprover/hex-number-field-tower-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexNumberFieldTowerMathlib
+
+open Hex
+
+example (T : NumberTower) : Function.Injective T.toComplex :=
+  NumberTower.toComplex_injective T
+
+example (T : NumberTower) (a b : NumberTower.Elem T) :
+    T.toComplex (a + b) = T.toComplex a + T.toComplex b :=
+  NumberTower.map_add T a b
+```
+
+# Functionality
+
+The proof-facing API fixes one injective complex interpretation per tower
+and transports the executable operations across it:
+
+- `Hex.NumberTower.toComplex` with `Hex.NumberTower.toComplex_injective`:
+  the fixed complex interpretation of tower elements.
+- `Hex.NumberTower.map_add`, `map_mul`, and `map_inv`: coordinate
+  arithmetic, including recursive extended-gcd inversion and the
+  convention `0⁻¹ = 0`, computes the complex operations.
+- The level invariant: each defining polynomial is irreducible over the
+  semantic lower field, vanishes at its stored generator, and presents the
+  coordinate quotient as adjoining exactly that generator.
+- Correctness and completeness for the tower operations: `factor?` returns
+  a genuine irreducible factorization, `adjoin?` selects the factor
+  compatible with the fixed embedding, `split?` really splits, and
+  `flatten?` produces a primitive element of full degree with mutually
+  inverse coordinate maps.
+
+# Verification
+
+Everything in this package is proved; it adds no executable operations.
+The sealed constructors of the computational package mean the level
+invariant follows by induction over the smart constructors, so the
+theorems cover every tower a client can build. The computational library
+stays Mathlib-free; field structure and complex semantics live here. See
+the [SPEC](SPEC/hex-number-field-tower-mathlib.md) for the theorem chain.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexRCF/README.md
+++ b/HexRCF/README.md
@@ -1,0 +1,68 @@
+# hex-rcf
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+A proof-producing Lean tactic, `rcf`, deciding the univariate fragment of
+real-closed-field arithmetic: Boolean combinations of polynomial
+(in)equalities in one real variable under a single quantifier over `ℝ` or
+over a half-open dyadic interval. The package builds on
+[`hex-real-roots`](https://github.com/leanprover/hex-real-roots),
+[`hex-real-roots-mathlib`](https://github.com/leanprover/hex-real-roots-mathlib),
+[`hex-poly-z`](https://github.com/leanprover/hex-poly-z), and Mathlib. The
+tactic targets `ℝ`, so its soundness theorem lives in this same package;
+there is no separate `hex-rcf-mathlib`.
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-rcf"
+git = "https://github.com/leanprover/hex-rcf.git"
+rev = "main"
+```
+
+```lean
+import HexRCF
+
+example : ∀ x : ℝ, x ^ 2 + 1 > 0 := by rcf
+example : ∀ x : ℝ, 0 < x → x ^ 2 + 1 ≥ 2 * x := by rcf
+example : ∃ x : ℝ, x ^ 3 - x - 1 = 0 ∧ 1 < x ∧ x < 2 := by rcf
+```
+
+# Functionality
+
+For an in-fragment sentence the compiled builder constructs a squarefree
+carrier polynomial, isolates its real roots with Sturm certificates, and
+decides the sentence on the resulting cell decomposition of `ℝ`, the
+one-variable case of Tarski's theorem. Neither `polyrith` nor `nlinarith`
+is complete on this fragment, and `decide` does not apply to quantifiers
+over `ℝ`.
+
+- The `rcf` tactic reifies a goal, runs the builder, and replays the
+  returned certificate through a small kernel checker.
+- `Hex.RCF.decide`, `Hex.RCF.build?`, and the certificate types are the
+  programmatic surface beneath the tactic.
+- A `false` verdict is diagnostic only: the tactic reports the failing cell
+  but never proves a negation. Builder failure is a separate error channel
+  and is never reported as `false`.
+
+# Verification
+
+Every `true` verdict is kernel-checked. The headline theorem
+`Hex.RCF.check_sound` states that any certificate accepted by the public
+Boolean checker proves its sentence (`cert.check s = true → s.toProp`), and
+the kernel checks that Boolean reduction together with the reifier's
+equivalence with the original goal, so no unverified output of the compiled
+builder or reifier is trusted. Operational totality of the builder on
+in-fragment sentences follows from the completeness theorems of
+[`hex-real-roots-mathlib`](https://github.com/leanprover/hex-real-roots-mathlib);
+no completeness theorem is stated for `false` verdicts.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexResultant/README.md
+++ b/HexResultant/README.md
@@ -1,0 +1,76 @@
+# hex-resultant
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Polynomial resultants and discriminants for `Hex.DensePoly R` over a
+commutative exact-division domain, implemented in Lean 4 without Mathlib.
+The algorithm is the subresultant pseudo-remainder sequence of Collins and
+Brown, the standard fraction-free method. The package depends on
+[`hex-poly`](https://github.com/leanprover/hex-poly) and
+[`hex-basic`](https://github.com/leanprover/hex-basic); its Mathlib
+counterpart is
+[`hex-resultant-mathlib`](https://github.com/leanprover/hex-resultant-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-resultant"
+git = "https://github.com/leanprover/hex-resultant.git"
+rev = "main"
+```
+
+```lean
+import HexResultant
+
+open Hex
+
+def f : DensePoly Int := DensePoly.ofList [-2, 0, 1]  -- X^2 - 2
+def g : DensePoly Int := DensePoly.ofList [-3, 0, 1]  -- X^2 - 3
+
+#guard DensePoly.resultant f g = 1
+#guard DensePoly.disc f = 8
+```
+
+# Functionality
+
+- `Hex.DensePoly.pseudoDivMod`: total polynomial pseudo-division with all
+  coefficients kept in `R`.
+- `Hex.DensePoly.subresultantRun` and `Hex.DensePoly.subresultantChain`:
+  Brown's nonzero subresultant pseudo-remainder sequence with its corrected
+  terminal scale.
+- `Hex.DensePoly.resultant`: the resultant under Mathlib's
+  default-formal-degree conventions, total on zero and reversed inputs.
+- `Hex.DensePoly.disc`: the standard discriminant, with the
+  leading-coefficient correction that keeps the quotient exact in every
+  characteristic.
+
+The main instantiations are `Int`, `Hex.ZPoly` coefficients for bivariate
+elimination, and the number-tower element types used by
+[`hex-number-field-tower`](https://github.com/leanprover/hex-number-field-tower).
+The chain costs `O(n·m)` coefficient operations rather than the `O((n+m)³)`
+of a Sylvester determinant.
+
+# Verification
+
+The resultant surface has a complete correctness API. The companion
+[`hex-resultant-mathlib`](https://github.com/leanprover/hex-resultant-mathlib)
+proves the end-to-end theorem `Hex.DensePoly.toPolynomial_resultant`: the
+executable value agrees exactly with Mathlib's `Polynomial.resultant`,
+units, powers, and signs included, with no hypotheses beyond the
+algorithm's own typeclass context. This package itself proves the
+Mathlib-free algebra of the chain: pseudo-division identities, the
+Brown--Traub minor correspondence, and exact-division totality.
+
+The extended cofactor chain `subresultantChainExt` is currently provided
+for executable use only; its Bezout contract is stated but its proof is in
+progress, and no released consumer depends on it.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexResultantMathlib/README.md
+++ b/HexResultantMathlib/README.md
@@ -1,0 +1,70 @@
+# hex-resultant-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Mathlib companion for
+[`hex-resultant`](https://github.com/leanprover/hex-resultant). It proves
+that the executable subresultant algorithm computes `Polynomial.resultant`,
+together with the chain-level and specialization facts consumed by the
+number-field libraries. It depends on `hex-resultant`,
+[`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib), and
+Mathlib.
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-resultant-mathlib"
+git = "https://github.com/leanprover/hex-resultant-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexResultantMathlib
+
+open Hex
+
+example (f g : DensePoly ℤ) :
+    DensePoly.resultant f g =
+      Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g)
+        (m := f.degree?.getD 0) (n := g.degree?.getD 0) :=
+  DensePoly.toPolynomial_resultant f g
+```
+
+# Functionality
+
+The proof-facing API centres on the headline correspondence and its
+consumer surface:
+
+- `Hex.DensePoly.toPolynomial_resultant`: exact agreement of the executable
+  resultant with Mathlib's, values rather than mere simultaneous vanishing,
+  with no monicity, coprimality, or nonzero hypotheses.
+- `Hex.DensePoly.resultant_eq_zero_iff_common_root`: vanishing characterizes
+  a common root over a splitting field, the form used by number-field
+  eliminants.
+- Evaluation and specialization lemmas for resultants of mapped and
+  evaluated polynomials, and the discriminant correspondence.
+- Transport lemmas for pseudo-division and the subresultant minors
+  (`SubresultantMinor.det_eq_matrixDet` and its relatives), which carry the
+  Brown--Traub chain across the dense-polynomial correspondence.
+
+# Verification
+
+Everything in this package is proved; it contains no executable code of its
+own. The typeclass context of the headline theorem is the executable
+algorithm's own (`CommRing R`, `IsDomain R`, `DecidableEq R`, `Div R`,
+`Hex.ExactDivLaws R`), so the correspondence applies to every instantiation
+the computational package supports. The computational library stays
+Mathlib-free; algebraic semantics live here. See the
+[SPEC](SPEC/hex-resultant-mathlib.md) for the full public theorem list and
+the proof architecture.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.


### PR DESCRIPTION
This PR author the three remaining `# The Mathlib correspondence` sections (HexRoots, HexBerlekamp, HexBerlekampZassenhaus chapters, each tagged with unique docstring embeds presenting the companion's headline surface and the computational/proof boundary) and the seven released-repo READMEs for the number-field wave (HexResultant, HexResultantMathlib, HexNumberField, HexNumberFieldMathlib, HexNumberFieldTower, HexNumberFieldTowerMathlib, HexRCF), each in the SPEC/readme.md shape the release-manifest checker enforces, with every quickstart build-checked before landing (the HexNumberField quickstart is verified through a temporary lake module since its `#guard`s need the precompiled native symbols). The HexResultant README's Verification section honestly records that `subresultantChainExt_law` currently carries a theorem-level sorry from the multivariate-factorization stack; that regression is tracked separately. `lake build HexManual`, `check_phase7.py`, `check_manual_split.py`, and `check_released_manifest.py` are all green.

🤖 Prepared with Claude Code