### PR TITLE
feat(interval): execute built-in typed runtime rules

### DIFF
--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -24,6 +24,7 @@ public import HexIntervalMathlib.Program
 public import HexIntervalMathlib.Proof
 public import HexIntervalMathlib.RuntimeProof
 public import HexIntervalMathlib.RuntimeTerminal
+public import HexIntervalMathlib.RuntimeRule
 public import HexIntervalMathlib.Rule
 public import HexIntervalMathlib.Frontend
 public import HexIntervalMathlib.Tactic
@@ -46,12 +47,16 @@ input; general split settlement remains blocked by the runtime/proof child
 equality-arena mismatch documented by that module.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
+`HexIntervalMathlib.RuntimeRule` supplies the aligned executable half: its
+callbacks recompute those operations into typed fact batches, and its combined
+builder seals exact replay-format/schema coverage while admitting explicitly
+paired packages for configured opaque operations.
 `HexIntervalMathlib.Controller` supplies explicit stable application-table,
 runtime/proof-registry alignment and bounded deterministic policy iteration
 over the sealed retained tree, including caller-measured caps on each retained
-policy state. Its current conformance callbacks are toy packages; concrete
-built-in arithmetic driver adapters, package discovery, and public split-search
-tactic integration remain separate.
+policy state. Automatic package discovery, typed terminal correlation,
+repeated-port controller scheduling, and public split-search tactic integration
+remain separate.
 `HexIntervalMathlib.Frontend` supplies bounded recursive arithmetic reification,
 source-driven version-zero facts, and flat programmatic replay/closure
 combinators.

--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -54,9 +54,8 @@ paired packages for configured opaque operations.
 `HexIntervalMathlib.Controller` supplies explicit stable application-table,
 runtime/proof-registry alignment and bounded deterministic policy iteration
 over the sealed retained tree, including caller-measured caps on each retained
-policy state. Automatic package discovery, typed terminal correlation,
-repeated-port controller scheduling, and public split-search tactic integration
-remain separate.
+policy state. Automatic package discovery and public split-search tactic
+integration remain separate.
 `HexIntervalMathlib.Frontend` supplies bounded recursive arithmetic reification,
 source-driven version-zero facts, and flat programmatic replay/closure
 combinators.

--- a/HexIntervalMathlib/RuntimeRule.lean
+++ b/HexIntervalMathlib/RuntimeRule.lean
@@ -48,7 +48,7 @@ structure Cause where
   body : List Nat
   deriving DecidableEq, Repr
 
-/-- The private executable cache records committed callback count. Its logical
+/-- The executable cache records committed callback count. Its logical
 measure makes retained callback history independently resource-bounded. -/
 structure Cache where
   calls : Nat := 0

--- a/HexIntervalMathlib/RuntimeRule.lean
+++ b/HexIntervalMathlib/RuntimeRule.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.RuntimeProof
+public import HexIntervalMathlib.Rule
+
+@[expose] public section
+
+/-!
+# Executable built-in arithmetic rules
+
+This module owns the executable half of `Rule`'s arithmetic package. Each
+handler recomputes one checked public interval operation from its exact
+`RuleRequest`, returns one typed `Runtime.fact` event, and declares the same
+one-cell replay format as the corresponding theorem schema. `buildWithWithin`
+then seals bidirectional executable/proof coverage through
+`RuntimeProof.Registry.buildWithin`.
+
+The built-in handlers schedule only version-zero result nodes whose current
+fact is `Interval.whole`. This is the state produced for computed nodes by the
+supported frontend. It makes the callback's installed fact exactly its
+proposal without exposing the previous branch fact to the callback. The
+runtime predecessor check rejects a direct repeated invocation. A refused
+checked arithmetic operation returns an empty batch, which the sealed runtime
+rejects transactionally; callback failure never becomes theorem evidence.
+
+Additional opaque operations remain caller-owned. `buildWithWithin` accepts
+paired executable and proof packages for the configured `extraMeanings`, then
+checks exact registration and format/schema coverage across the complete
+registry. No raw assembly or proof-registry splice is exposed by the combined
+builder.
+-/
+
+namespace Hex.Interval.Rule.Runtime
+
+open Hex.Interval.Executable
+
+/-- Inert package-owned provenance retained in the fact history. RuntimeProof
+derives scope, schema, and body from the sealed tree and executable quote, not
+from this value. -/
+structure Cause where
+  rule : RuleKey
+  body : List Nat
+  deriving DecidableEq, Repr
+
+/-- The private executable cache records committed callback count. Its logical
+measure makes retained callback history independently resource-bounded. -/
+structure Cache where
+  calls : Nat := 0
+  deriving DecidableEq, Repr
+
+abbrev Assembly := RuntimeProof.Assembly Hex.Interval Cause
+
+abbrev Registry (config : Rule.Config) (Plan : Type := List Nat) :=
+  RuntimeProof.Registry Hex.Interval (Rule.semantics config) Cause Plan
+
+inductive Error where
+  | executable (error : Executable.Error)
+  | proof (error : Rule.BuildError)
+  | registry (error : RuntimeProof.Error)
+  deriving Repr
+
+private def buildValue? : BuildResult → Option Hex.Interval := Rule.ready?
+
+private def arithmeticValue? : Arithmetic.Result → Option Hex.Interval :=
+  Rule.arithmeticReady?
+
+private def proposal? (config : Rule.Config) (rule : RuleKey)
+    (inputs : List (FactView Hex.Interval)) : Option Hex.Interval :=
+  match rule, inputs with
+  | key, [] =>
+      if key == Rule.constantKey then
+        buildValue? (singletonWithin config.endpoint config.constant)
+      else none
+  | key, [input] =>
+      if key == Rule.negKey then
+        buildValue? (negWithin config.endpoint input.fact)
+      else if key == Rule.powKey then
+        arithmeticValue? (powWithin config.endpoint config.powerWork input.fact config.exponent)
+      else if key == Rule.absKey then
+        buildValue? (absWithin config.endpoint input.fact)
+      else if key == Rule.invKey then
+        arithmeticValue? (invWithin config.precisionLimits config.precision input.fact)
+      else if key == Rule.regularizeKey then
+        arithmeticValue?
+          (regularizeWithin config.precisionLimits config.precision input.fact)
+      else none
+  | key, [left, right] =>
+      if key == Rule.addKey then
+        buildValue? (addWithin config.endpoint left.fact right.fact)
+      else if key == Rule.subKey then
+        buildValue? (subWithin config.endpoint left.fact right.fact)
+      else if key == Rule.mulKey then
+        arithmeticValue? (mulWithin config.endpoint left.fact right.fact)
+      else if key == Rule.minKey then
+        buildValue? (minWithin config.endpoint left.fact right.fact)
+      else if key == Rule.maxKey then
+        buildValue? (maxWithin config.endpoint left.fact right.fact)
+      else if key == Rule.divKey then
+        arithmeticValue?
+          (divWithin config.precisionLimits config.precision left.fact right.fact)
+      else none
+  | _, _ => none
+
+private def quote (tag : Nat) : Executable.Quote :=
+  { role := .fact, schema := 1, body := [tag] }
+
+private def batch? (config : Rule.Config) (rule : RuleKey) (tag : Nat)
+    (request : RuleRequest Hex.Interval) : Option (Runtime.Batch Hex.Interval Cause) := do
+  let proposed ← proposal? config rule request.inputs
+  let output ← request.writes.getLast?
+  if request.writes != [output] || output != request.action.node then none
+  let replay := quote tag
+  pure
+    { events := #[.fact
+        { action := request.action
+          update :=
+            { programVersion := request.action.programVersion
+              node := output
+              previous := { node := output, version := 0 }
+              fact := proposed
+              version := 1
+              cause := { rule, body := replay.body } }
+          proposed
+          quote := replay }] }
+
+private def offered (config : Rule.Config) (rule : RuleKey) (tag : Nat)
+    (snapshot : Snapshot Hex.Interval) (request : RuleRequest Hex.Interval) : Bool :=
+  !snapshot.contradictory &&
+    snapshot.version? request.action.node == some 0 &&
+    snapshot.fact? request.action.node == some Hex.Interval.whole &&
+    (batch? config rule tag request).isSome
+
+private def format (tag : Nat) : ReplayFormat :=
+  { role := .fact, schema := 1, validateBody := fun body => body == [tag] }
+
+private def handler (config : Rule.Config) (registration : Registration) (tag : Nat) :
+    Handler Hex.Interval (Runtime.Batch Hex.Interval Cause) Cache :=
+  { registration
+    offers := offered config registration.key tag
+    invoke := fun cache request =>
+      match batch? config registration.key tag request with
+      | none => ({ result := { events := #[] } }, cache)
+      | some batch =>
+          ({ result := batch, quotes := #[quote tag] }, { calls := cache.calls + 1 })
+    formats := #[format tag] }
+
+/-- Executable arithmetic package in exactly the public registration order.
+Source nodes have no handler: their version-zero facts remain caller-owned. -/
+opaque package (config : Rule.Config) :
+    Executable.Package Hex.Interval (Runtime.Batch Hex.Interval Cause) :=
+  { Cache := Cache
+    cache := {}
+    operations := Rule.operations
+    handlers :=
+      #[handler config (Rule.unaryRegistration Rule.negKey Rule.negOp) 1,
+        handler config (Rule.binaryRegistration Rule.addKey Rule.addOp) 2,
+        handler config (Rule.binaryRegistration Rule.subKey Rule.subOp) 3,
+        handler config (Rule.binaryRegistration Rule.mulKey Rule.mulOp) 4,
+        handler config (Rule.unaryRegistration Rule.powKey Rule.powOp) 5,
+        handler config (Rule.unaryRegistration Rule.absKey Rule.absOp) 6,
+        handler config (Rule.binaryRegistration Rule.minKey Rule.minOp) 7,
+        handler config (Rule.binaryRegistration Rule.maxKey Rule.maxOp) 8,
+        handler config
+          { key := Rule.constantKey, head := Rule.constantOp.key, kind := .forward,
+            watches := [], writes := [.result] } 9,
+        handler config (Rule.unaryRegistration Rule.invKey Rule.invOp) 10,
+        handler config (Rule.binaryRegistration Rule.divKey Rule.divOp) 11,
+        handler config (Rule.unaryRegistration Rule.regularizeKey Rule.regularizeOp) 12]
+    measure :=
+      { metadata := { bytes := 12, work := 12 }
+        application := fun _ => { bytes := 1, work := 1 }
+        cache := fun cache => { bytes := cache.calls, work := cache.calls }
+        result := fun batch => { bytes := batch.events.size, work := batch.events.size } } }
+
+/-- Assemble the exact executable arithmetic package together with paired
+caller-owned packages for configured opaque operations. -/
+def assemblyWithWithin (limits : Executable.Limits) (config : Rule.Config)
+    (program : Program)
+    (extra : Array (Executable.Package Hex.Interval
+      (Runtime.Batch Hex.Interval Cause))) : Except Error Assembly :=
+  Executable.buildWithin limits (#[package config] ++ extra) program
+    |>.mapError Error.executable
+
+/-- Convenience executable assembly for the built-in arithmetic registry. -/
+def assemblyWithin (limits : Executable.Limits) (config : Rule.Config)
+    (program : Program) : Except Error Assembly :=
+  assemblyWithWithin limits config program #[]
+
+/-- Build and seal exact executable-format/theorem-schema ownership for the
+built-in arithmetic rules and paired caller-owned opaque-operation packages. -/
+def buildWithWithin (executableLimits : Executable.Limits)
+    (proofLimits : Proof.Limits) (key : RuntimeProof.Key) (config : Rule.Config)
+    (program : Program)
+    (extraExecutable : Array (Executable.Package Hex.Interval
+      (Runtime.Batch Hex.Interval Cause)))
+    (extraProof : Array (Proof.Package (Rule.semantics config))) :
+    Except Error (Registry config) := do
+  let assembly ← assemblyWithWithin executableLimits config program extraExecutable
+  let proof ← Rule.buildWithWithin proofLimits config program extraProof
+    |>.mapError Error.proof
+  RuntimeProof.Registry.buildWithin executableLimits key assembly proof
+    |>.mapError Error.registry
+
+/-- Convenience sealed registry for the built-in arithmetic package. -/
+def buildWithin (executableLimits : Executable.Limits)
+    (proofLimits : Proof.Limits) (key : RuntimeProof.Key) (config : Rule.Config)
+    (program : Program) : Except Error (Registry config) :=
+  buildWithWithin executableLimits proofLimits key config program #[] #[]
+
+end Hex.Interval.Rule.Runtime

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -82,18 +82,24 @@ generators with the same-order runtime and proof registries, regenerates
 resource-first deterministic offers from the authenticated current head, and
 runs bounded repeated policy selection over the sealed tree/session bundle.
 The explicit `Controller.Package` vertical still uses toy fact-event callbacks
-and application generators; it has no concrete built-in arithmetic
-`Driver.Package`. Concrete built-in arithmetic reaches the controller only
-through the separate `Controller.Executable` adapter, which consumes a sealed
-Mathlib-free `Executable.Assembly` and correlates accepted fact quotations with
-independently replayed theorem schemas. The Mathlib-free `Runtime.State`
-separately owns an executable assembly and
+and application generators. Concrete built-in arithmetic has two explicit
+adapters: the fact-only `Controller.Executable` route and the typed-batch
+`RuntimeRule` route. `RuntimeRule` recomputes all twelve supported arithmetic
+operations from exact executable requests, emits one typed fact batch with the
+matching one-cell format, and seals its assembly against the same-order
+`Rule` theorem registry through `RuntimeProof.Registry`. Paired caller packages
+extend both sides for configured opaque meanings. The Mathlib-free
+`Runtime.State` owns that executable assembly and
 atomically validates typed fact/equality/transport/instance batches, including
 an exact equality descriptor arena and append-only application/binding/node
 suffixes; `Search.Result.Tree` retains its sealed transition in a child.
-Wiring those typed batches to this controller and correlating their inert
-quotations with theorem events, automatic discovery/program extension, and
-public-tactic split search remain later edges.
+The built-in offers are deliberately one-shot: only a version-zero result node
+whose current fact is domain top is scheduled, so the callback installs its
+recomputed proposal as version one without raw access to the previous branch.
+Direct repeats fail the runtime predecessor check. Runtime-to-proof quotation
+is supported, but automatic discovery, typed terminal correlation,
+repeated-port controller scheduling, and public-tactic search remain later
+edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -304,8 +310,13 @@ The typed-proof registry and bundle constructors are likewise sealed;
 `import all HexIntervalMathlib.RuntimeProof` is rejected outside an
 exact reviewed allowlist, currently empty.
 Automatic arbitrary-function theorem-package discovery and default registries
-remain experimental; supported typed-runtime replay requires an explicit
-sealed executable/proof registry pair.
+remain experimental. `RuntimeRule.buildWithWithin` accepts only explicit paired
+executable and proof packages for configured opaque meanings and then seals
+bidirectional coverage over the complete registry; unpaired formats or schemas
+are rejected. Its package cache counts committed callbacks and is independently
+bounded by executable cache resources. Checked arithmetic refusal yields no
+fact batch and is rejected transactionally by the runtime rather than gaining
+theorem authority.
 The supported explicit fact-event controller can produce and replay
 search-selected recipes, while the tactic below remains a deliberately narrow
 direct forward client rather than that generic search bridge.
@@ -487,6 +498,13 @@ and guards the ordinary root/recursive axiom surfaces.
 after the ordinary typed chronology at the root and in both restarted split
 children, exact package-owned refutation, cross-schema/current-fact/input and
 resource refusals, private constructors, and the ordinary replay axiom surface.
+`HexIntervalMathlib.RuntimeRuleConformance` assembles every built-in arithmetic
+handler, starts `Runtime.State` from frontend-shaped version-zero facts,
+executes all unary and binary operations (including repeated argument slots),
+and quotes the pending retained chronology through `RuntimeProof` without a
+terminal or fallback theorem. It checks exact proposed/installed facts,
+one-cell bodies, schema ownership, sticky cache refusal and replayability,
+sealed rule mutation rejection, and a paired opaque-operation extension.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -97,9 +97,8 @@ The built-in offers are deliberately one-shot: only a version-zero result node
 whose current fact is domain top is scheduled, so the callback installs its
 recomputed proposal as version one without raw access to the previous branch.
 Direct repeats fail the runtime predecessor check. Runtime-to-proof quotation
-is supported, but automatic discovery, typed terminal correlation,
-repeated-port controller scheduling, and public-tactic search remain later
-edges.
+and exact target/refutation correlation are supported; automatic discovery and
+the public-tactic search route remain later edges.
 
 `HexIntervalMathlib.Tactic` is the first supported Meta client. It recursively
 parses real local variables and the registered forward arithmetic operations,
@@ -501,10 +500,11 @@ resource refusals, private constructors, and the ordinary replay axiom surface.
 `HexIntervalMathlib.RuntimeRuleConformance` assembles every built-in arithmetic
 handler, starts `Runtime.State` from frontend-shaped version-zero facts,
 executes all unary and binary operations (including repeated argument slots),
-and quotes the pending retained chronology through `RuntimeProof` without a
-terminal or fallback theorem. It checks exact proposed/installed facts,
-one-cell bodies, schema ownership, sticky cache refusal and replayability,
-sealed rule mutation rejection, and a paired opaque-operation extension.
+settles the exact final target, and consumes `RuntimeTerminal.Checked.replay`
+over the complete retained chronology without a fallback theorem. It checks
+exact proposed/installed facts, one-cell bodies, semantic schema execution,
+sticky cache refusal and replayability, sealed rule mutation rejection, and a
+paired opaque-operation extension.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
@@ -5,14 +5,16 @@ Authors: Kim Morrison
 -/
 
 import HexIntervalMathlib.RuntimeRule
+import HexIntervalMathlib.RuntimeTerminal
 
 /-!
 # Executable arithmetic-rule conformance
 
 The canary assembles every public arithmetic handler, starts a sealed typed
 runtime from the frontend-shaped version-zero facts, directly executes unary
-and repeated-input binary rules, and quotes the complete retained chronology
-through `RuntimeProof`. No target terminal or fallback theorem is used.
+and repeated-input binary rules, settles the exact final target, and replays
+the complete retained chronology through `RuntimeTerminal`. No fallback theorem
+or independently reconstructed arithmetic proof is used.
 -/
 
 namespace Hex.IntervalMathlib.RuntimeRuleConformance
@@ -168,7 +170,7 @@ private def exactFact (index : Nat)
 /-! ## Retained quotation without a terminal -/
 
 def searchLimits : Search.Limits :=
-  { maxSteps := 12, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
+  { maxSteps := 13, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
     maxDepth := 0, maxScopes := 1, leafFuel := 12 }
 
 def resultLimits : Search.Result.Limits :=
@@ -236,6 +238,54 @@ def bundle? : Option
               step.schema == Rule.schemaKey action.key &&
                 step.body == [index + 1] && step.proposed == step.installed
         | _ => false
+
+/-! ## Exact target settlement and semantic replay -/
+
+def input : Proof.Input Hex.Interval :=
+  { scope := { index := 0 }, program, facts,
+    target := { node := { index := 12 }, fact := point 1 } }
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 12, maxBytes := 4096, maxPairs := 64, maxWork := 64,
+    maxScore := 0 }
+
+def traceLimits : Trace.Limit :=
+  { maxEvents := 0, maxBytes := 0, maxWork := 0, maxCode := 16 }
+
+def envelope : Search.Envelope :=
+  { state := stateLimits, policy := policyLimits, trace := traceLimits,
+    search := searchLimits }
+
+def controllerLimits : Hex.Interval.Runtime.Controller.Limits :=
+  { maxChoices := 0, result := resultLimits }
+
+def checked? : Option (RuntimeTerminal.Checked Hex.Interval
+    (Rule.semantics config) Rule.Runtime.Cause (List Nat)) := do
+  let registry ← registry?
+  let (tree, runtime) ← treeRun?
+  let controller ← (Hex.Interval.Runtime.Controller.State.startWithin
+    controllerLimits envelope measure runtime tree).toOption
+  let active ← (RuntimeTerminal.Active.startWithin registry input controller).toOption
+  let lineage ← (active.targetWithin resultLimits measure (seen 12 1)).toOption
+  (lineage.quoteWithin adapterLimits measure).toOption
+
+/-- This calls the theorem fold owned by the checked token, then transports its
+dependent result only after confirming the token retained this exact input. -/
+def replay? : Option (Proof.Evidence ((Rule.semantics config).Entails input.program
+    (Proof.initialBase input) input.target)) :=
+  match checked? with
+  | none => none
+  | some checked =>
+      match RuntimeTerminal.Checked.replay adapterLimits measure
+          (Rule.domain config) (Rule.laws config) checked with
+      | .error _ => none
+      | .ok evidence =>
+          if h : RuntimeTerminal.Checked.input checked = input then
+            some (h ▸ evidence)
+          else none
+
+#guard checked?.isSome
+#guard replay?.isSome
 
 /-! ## Cache, resource, and seal failures -/
 

--- a/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
@@ -1,0 +1,474 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.RuntimeRule
+
+/-!
+# Executable arithmetic-rule conformance
+
+The canary assembles every public arithmetic handler, starts a sealed typed
+runtime from the frontend-shaped version-zero facts, directly executes unary
+and repeated-input binary rules, and quotes the complete retained chronology
+through `RuntimeProof`. No target terminal or fallback theorem is used.
+-/
+
+namespace Hex.IntervalMathlib.RuntimeRuleConformance
+
+open Hex.Interval
+open Hex.Interval.Executable
+open Hex.Interval.Rule
+open Hex.Interval.Rule.Runtime
+
+private def liftOption {α : Type} : Option α → Option (ULift.{1, 0} α)
+  | some value => some ⟨value⟩
+  | none => none
+
+/-- error: Unknown constant `Hex.Interval.Rule.Runtime.Registry.mk` -/
+#guard_msgs in
+#check Rule.Runtime.Registry.mk
+
+def d (value : Int) : Dyadic := .ofInt value
+
+def endpoint : EndpointLimit :=
+  { maxEndpointHeight := 64, maxAlignmentShift := 64 }
+
+def config : Rule.Config :=
+  { endpoint
+    powerWork := { maxExponent := 8 }
+    exponent := 2
+    precisionLimits :=
+      { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
+        maxTemporaryBits := 128 }
+    precision := 0
+    constant := d 0 }
+
+def node (op : Nat) (args : List Nat) : Node :=
+  { domain := Rule.realDomain, op := { index := op },
+    args := args.map fun index => { index } }
+
+/-- One source followed by one node for every executable built-in rule. Binary
+rows deliberately repeat the source node, exercising valid repeated slots. -/
+def program : Program :=
+  { operations := Rule.operations
+    nodes :=
+      #[node 0 [], node 1 [0], node 2 [0, 0], node 3 [0, 0], node 4 [0, 0],
+        node 5 [0], node 6 [0], node 7 [0, 0], node 8 [0, 0], node 9 [],
+        node 10 [0], node 11 [0, 0], node 12 [0]] }
+
+def point (value : Int) : Hex.Interval :=
+  match singletonWithin endpoint (d value) with
+  | .ready interval => interval
+  | .resourceLimit _ => Hex.Interval.empty
+
+def facts : Array Hex.Interval :=
+  #[point 1, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+    Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+    Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+    Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole]
+
+def stateLimits : State.Limits :=
+  { maxOperations := 13, maxNodes := 13, maxRules := 12,
+    maxRegistryEntries := 64, maxReplayFormats := 12, maxArity := 2,
+    maxScopeNodes := 0, maxApplications := 12, maxQueueEntries := 16,
+    maxActions := 12, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 12, maxRetainedSuggestions := 0, maxEffort := 0,
+    maxObservationValue := 16, maxDiagnosticValue := 16,
+    maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0,
+    maxProposalItems := 1, maxInstances := 0, maxGeneration := 0,
+    maxNodeDepth := 1, maxEqualities := 0, splitEndpointLimit := endpoint }
+
+def executableLimits : Executable.Limits :=
+  { state := stateLimits, maxPackages := 1,
+    maxMetadataBytes := 64, maxMetadataWork := 64,
+    maxCacheBytes := 12, maxCacheWork := 12,
+    maxResultBytes := 1, maxResultWork := 1,
+    maxQuotes := 1, maxQuoteCells := 1, maxAtom := 12, maxSchema := 1 }
+
+def runtimeLimits : Hex.Interval.Runtime.Limits :=
+  { executable := executableLimits, maxEvents := 1 }
+
+def proofLimits : Proof.Limits :=
+  { maxPackages := 1, maxSchemas := 12, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 12 }
+
+def key : RuntimeProof.Key := { name := "arithmetic-runtime", version := 1 }
+
+def registry? : Option (Rule.Runtime.Registry config) :=
+  (Rule.Runtime.buildWithin executableLimits proofLimits key config program).toOption
+
+def branch? : Option (State.Branch Hex.Interval Rule.Runtime.Cause) :=
+  (State.Branch.startWithin stateLimits program facts).toOption
+
+def runtime? : Option (Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) := do
+  match registry?, branch? with
+  | some registry, some branch =>
+      (Hex.Interval.Runtime.State.startWithin runtimeLimits registry.assembly branch).toOption
+  | _, _ => none
+
+def seen (index version : Nat) : SeenVersion :=
+  { node := { index }, version }
+
+def action (serial application rule : Nat) (key : RuleKey)
+    (inputs : List SeenVersion) : Action :=
+  { serial, programVersion := 0, application := { index := application },
+    rule := { index := rule }, key, node := { index := application + 1 },
+    kind := .forward, effort := 0, inputs, writes := [{ index := application + 1 }] }
+
+def actions : List Action :=
+  [action 0 0 0 Rule.negKey [seen 0 0],
+   action 1 1 1 Rule.addKey [seen 0 0, seen 0 0],
+   action 2 2 2 Rule.subKey [seen 0 0, seen 0 0],
+   action 3 3 3 Rule.mulKey [seen 0 0, seen 0 0],
+   action 4 4 4 Rule.powKey [seen 0 0],
+   action 5 5 5 Rule.absKey [seen 0 0],
+   action 6 6 6 Rule.minKey [seen 0 0, seen 0 0],
+   action 7 7 7 Rule.maxKey [seen 0 0, seen 0 0],
+   action 8 8 8 Rule.constantKey [],
+   action 9 9 9 Rule.invKey [seen 0 0],
+   action 10 10 10 Rule.divKey [seen 0 0, seen 0 0],
+   action 11 11 11 Rule.regularizeKey [seen 0 0]]
+
+private def run
+    (state : Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :
+    List Action → Option
+      (Array (Hex.Interval.Runtime.Applied Hex.Interval Rule.Runtime.Cause) ×
+        Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause)
+  | [] => some (#[], state)
+  | next :: rest => do
+      let (transition, state) ← (state.stepWithin runtimeLimits next).toOption
+      let (transitions, state) ← run state rest
+      pure (#[transition] ++ transitions, state)
+
+def run? := runtime?.bind fun state => run state actions
+
+private def exactFact (index : Nat)
+    (transition : Hex.Interval.Runtime.Applied Hex.Interval Rule.Runtime.Cause) : Bool :=
+  match transition.events[0]? with
+  | some (Hex.Interval.Runtime.Event.fact step) =>
+      step.action == actions[index]? && step.update.node.index == index + 1 &&
+        step.update.previous == seen (index + 1) 0 && step.update.version == 1 &&
+        step.proposed == step.update.fact && step.quote.role == .fact &&
+        step.quote.schema == 1 && step.quote.body == [index + 1] &&
+        step.update.cause.rule == step.action.key &&
+        step.update.cause.body == step.quote.body
+  | _ => false
+
+#guard program.check
+#guard registry?.isSome
+#guard branch?.isSome
+#guard runtime?.isSome
+#guard run?.any fun (transitions, state) =>
+  transitions.size == 12 && state.serial == 12 &&
+    (List.range 12).all fun index =>
+      transitions[index]?.any (exactFact index)
+
+/-! ## Retained quotation without a terminal -/
+
+def searchLimits : Search.Limits :=
+  { maxSteps := 12, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
+    maxDepth := 0, maxScopes := 1, leafFuel := 12 }
+
+def resultLimits : Search.Result.Limits :=
+  { search := searchLimits, runtime := runtimeLimits, maxNodes := 1,
+    maxBodyCells := 12, maxBytes := 65536, maxWork := 65536, maxCode := 16 }
+
+def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
+
+def measure : Search.Result.Measure Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key :=
+  { node := unitCost
+    branch := fun branch =>
+      { bytes := branch.program.nodes.size + branch.history.size,
+        work := branch.program.nodes.size + branch.history.size }
+    fact := fun _ => unitCost
+    action := fun _ => unitCost
+    plan := fun _ => unitCost
+    schema := fun _ => unitCost
+    body := fun _ => unitCost
+    code := fun _ => unitCost }
+
+def adapterLimits : RuntimeProof.Limits :=
+  { result := resultLimits, proof := proofLimits,
+    tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 12, maxWork := 32 },
+    maxTransitions := 12, maxEvents := 12, maxStructuralCells := 512 }
+
+private def runTree
+    (tree : Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key)
+    (state : Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :
+    List Action → Option
+      (Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key ×
+        Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause)
+  | [] => some (tree, state)
+  | next :: rest => do
+      let (transition, state) ← (state.stepWithin runtimeLimits next).toOption
+      let tree := (← liftOption
+        (Search.Result.advanceRuntimeWithin resultLimits measure tree transition).toOption).down
+      runTree tree state rest
+
+def treeRun? : Option
+    (Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key ×
+      Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :=
+  match branch?, runtime? with
+  | some branch, some runtime =>
+      match Search.Result.startWithin resultLimits measure { index := 0 } branch with
+      | .ok tree => runTree tree runtime actions
+      | .error _ => none
+  | _, _ => none
+
+def bundle? : Option
+    (RuntimeProof.Bundle Hex.Interval (Rule.semantics config) Rule.Runtime.Cause (List Nat)) := do
+  match registry?, treeRun? with
+  | some registry, some (tree, _) =>
+      (RuntimeProof.quoteTreeWithin adapterLimits measure registry tree).toOption
+  | _, _ => none
+
+#guard treeRun?.any fun (tree, _) =>
+  tree.transitions.size == 12 && tree.pending.length == 1
+#guard bundle?.any fun bundle =>
+  bundle.recipe.events.size == 1 &&
+    bundle.recipe.events[0]?.any fun events =>
+      events.length == 12 && (List.range 12).all fun index =>
+        match events[index]? with
+        | some (Proof.Event.fact step) =>
+            actions[index]?.any fun action =>
+              step.schema == Rule.schemaKey action.key &&
+                step.body == [index + 1] && step.proposed == step.installed
+        | _ => false
+
+/-! ## Cache, resource, and seal failures -/
+
+def oneCacheLimits : Hex.Interval.Runtime.Limits :=
+  { runtimeLimits with executable :=
+      { executableLimits with maxCacheBytes := 1, maxCacheWork := 1 } }
+
+def oneCacheRuntime? : Option
+    (Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) := do
+  match registry?, branch? with
+  | some registry, some branch =>
+      (Hex.Interval.Runtime.State.startWithin oneCacheLimits registry.assembly branch).toOption
+  | _, _ => none
+
+#guard oneCacheRuntime?.any fun state =>
+  match actions[0]?, actions[1]? with
+  | some first, some second =>
+      match state.stepWithin oneCacheLimits first with
+      | .ok (_, next) =>
+          match next.stepWithin oneCacheLimits second with
+          | .error (.executable (.resource .cacheBytes)) =>
+              (state.stepWithin oneCacheLimits first).isOk
+          | _ => false
+      | _ => false
+  | _, _ => false
+
+#guard runtime?.any fun state =>
+  actions[0]?.any fun first =>
+    match state.stepWithin runtimeLimits { first with key := Rule.addKey } with
+    | .error (.executable .invalidRequest) => true
+    | _ => false
+
+/-! ## Paired opaque-operation extension -/
+
+def opaqueOp : Operation :=
+  { key := { name := "conformance.runtime.opaque" },
+    inputs := [Rule.realDomain], output := Rule.realDomain }
+
+def opaqueMeaning : Program.Meaning ℝ :=
+  { operation := opaqueOp, relation := fun _ _ => True }
+
+def opaqueKey : RuleKey := { name := "conformance.runtime.opaque.forward" }
+
+def opaqueRule : Registration :=
+  Rule.unaryRegistration opaqueKey opaqueOp
+
+def opaqueQuote : Executable.Quote :=
+  { role := .fact, schema := 1, body := [13] }
+
+def opaqueBatch (request : RuleRequest Hex.Interval) :
+    Hex.Interval.Runtime.Batch Hex.Interval Rule.Runtime.Cause :=
+  { events := #[.fact
+      { action := request.action
+        update :=
+          { programVersion := request.action.programVersion
+            node := request.action.node
+            previous := { node := request.action.node, version := 0 }
+            fact := Hex.Interval.whole
+            version := 1
+            cause := { rule := opaqueKey, body := opaqueQuote.body } }
+        proposed := Hex.Interval.whole
+        quote := opaqueQuote }] }
+
+def opaqueHandler : Handler Hex.Interval
+    (Hex.Interval.Runtime.Batch Hex.Interval Rule.Runtime.Cause) Unit :=
+  { registration := opaqueRule
+    invoke := fun cache request =>
+      ({ result := opaqueBatch request, quotes := #[opaqueQuote] }, cache)
+    formats :=
+      #[{ role := .fact, schema := 1, validateBody := fun body => body == [13] }] }
+
+def opaqueExecutable : Executable.Package Hex.Interval
+    (Hex.Interval.Runtime.Batch Hex.Interval Rule.Runtime.Cause) :=
+  { Cache := Unit, cache := (), operations := #[opaqueOp], handlers := #[opaqueHandler]
+    measure :=
+      { metadata := { bytes := 1, work := 1 }
+        application := fun _ => { bytes := 1, work := 1 }
+        cache := fun _ => {}
+        result := fun batch => { bytes := batch.events.size, work := batch.events.size } } }
+
+def opaqueSchema : Proof.FactSchema (Rule.semantics
+    { config with extraMeanings := #[opaqueMeaning] }) :=
+  { key := { rule := opaqueKey, role := .fact, bodySchema := 1 }
+    Certificate := Unit
+    decode := fun body => if body == [13] then some () else none
+    prove := fun context _ =>
+      if proposed : context.proposed.fact = Hex.Interval.whole then
+        some
+          { proof := by
+              intro valuation _ _
+              have whole : Hex.Interval.whole.Contains
+                  (valuation context.proposed.node) := by
+                change Raw.Contains Hex.Interval.whole.view _
+                rw [Hex.Interval.view_whole]
+                exact ⟨trivial, trivial⟩
+              simpa [Rule.semantics, Proof.Semantics.ofMeanings, proposed] using whole }
+      else none }
+
+def opaqueProof : Proof.Package (Rule.semantics
+    { config with extraMeanings := #[opaqueMeaning] }) :=
+  { registrations := #[opaqueRule], facts := #[opaqueSchema] }
+
+def extendedConfig : Rule.Config :=
+  { config with extraMeanings := #[opaqueMeaning] }
+
+def opaqueNode : Node :=
+  { domain := Rule.realDomain, op := { index := 13 }, args := [{ index := 0 }] }
+
+def extendedProgram : Program :=
+  { operations := Rule.operations.push opaqueOp,
+    nodes := program.nodes.push opaqueNode }
+
+def extendedStateLimits : State.Limits :=
+  { maxOperations := 14, maxNodes := 14, maxRules := 13,
+    maxRegistryEntries := 72, maxReplayFormats := 13, maxArity := 2,
+    maxScopeNodes := 0, maxApplications := 13, maxQueueEntries := 16,
+    maxActions := 13, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 13, maxRetainedSuggestions := 0, maxEffort := 0,
+    maxObservationValue := 16, maxDiagnosticValue := 16,
+    maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0,
+    maxProposalItems := 1, maxInstances := 0, maxGeneration := 0,
+    maxNodeDepth := 1, maxEqualities := 0, splitEndpointLimit := endpoint }
+
+def extendedExecutableLimits : Executable.Limits :=
+  { state := extendedStateLimits, maxPackages := 2,
+    maxMetadataBytes := 72, maxMetadataWork := 72,
+    maxCacheBytes := 13, maxCacheWork := 13,
+    maxResultBytes := 1, maxResultWork := 1,
+    maxQuotes := 1, maxQuoteCells := 1, maxAtom := 13, maxSchema := 1 }
+
+def extendedRuntimeLimits : Hex.Interval.Runtime.Limits :=
+  { executable := extendedExecutableLimits, maxEvents := 1 }
+
+def extendedProofLimits : Proof.Limits :=
+  { maxPackages := 2, maxSchemas := 13, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 13 }
+
+def extendedRegistry? : Option (Rule.Runtime.Registry extendedConfig) :=
+  (Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
+    { name := "arithmetic-runtime-opaque", version := 1 } extendedConfig extendedProgram
+    #[opaqueExecutable] #[opaqueProof]).toOption
+
+def extendedFacts : Array Hex.Interval := facts.push Hex.Interval.whole
+
+def extendedRuntime? : Option
+    (Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :=
+  match extendedRegistry?,
+      State.Branch.startWithin extendedStateLimits extendedProgram extendedFacts with
+  | some registry, .ok branch =>
+      (Hex.Interval.Runtime.State.startWithin extendedRuntimeLimits
+        registry.assembly branch).toOption
+  | _, _ => none
+
+def opaqueAction : Action :=
+  { serial := 0, programVersion := 0, application := { index := 12 },
+    rule := { index := 12 }, key := opaqueKey, node := { index := 13 },
+    kind := .forward, effort := 0, inputs := [seen 0 0], writes := [{ index := 13 }] }
+
+#guard extendedProgram.check
+#guard extendedRegistry?.isSome
+#guard
+  match Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
+      { name := "missing-opaque-proof", version := 1 } extendedConfig extendedProgram
+      #[opaqueExecutable] #[] with
+  | .error (.registry .invalidRegistry) => true
+  | _ => false
+#guard
+  match Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
+      { name := "missing-opaque-runtime", version := 1 } extendedConfig extendedProgram
+      #[] #[opaqueProof] with
+  | .error (.registry .invalidRegistry) => true
+  | _ => false
+#guard
+  match Rule.Runtime.buildWithWithin
+      { extendedExecutableLimits with maxPackages := 1 }
+      extendedProofLimits { name := "opaque-package-limit", version := 1 }
+      extendedConfig extendedProgram #[opaqueExecutable] #[opaqueProof] with
+  | .error (.executable (.resource .packages)) => true
+  | _ => false
+#guard extendedRuntime?.any fun state =>
+  match state.stepWithin extendedRuntimeLimits opaqueAction with
+  | .ok (transition, next) =>
+      next.branch.factAt? (seen 13 1) == some Hex.Interval.whole &&
+        match transition.events[0]? with
+        | some (Hex.Interval.Runtime.Event.fact step) =>
+            step.quote == opaqueQuote && step.proposed == Hex.Interval.whole &&
+              step.update.fact == Hex.Interval.whole
+        | _ => false
+  | _ => false
+
+def extendedResultLimits : Search.Result.Limits :=
+  { search := { searchLimits with maxSteps := 1, leafFuel := 1 },
+    runtime := extendedRuntimeLimits, maxNodes := 1, maxBodyCells := 1,
+    maxBytes := 16384, maxWork := 16384, maxCode := 16 }
+
+def extendedMeasure : Search.Result.Measure Hex.Interval Rule.Runtime.Cause
+    (List Nat) Proof.Key :=
+  { measure with branch := fun branch =>
+      { bytes := branch.program.nodes.size + branch.history.size,
+        work := branch.program.nodes.size + branch.history.size } }
+
+def extendedAdapterLimits : RuntimeProof.Limits :=
+  { result := extendedResultLimits, proof := extendedProofLimits,
+    tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 1, maxWork := 4 },
+    maxTransitions := 1, maxEvents := 1, maxStructuralCells := 64 }
+
+def extendedBundle? : Option (RuntimeProof.Bundle Hex.Interval
+    (Rule.semantics extendedConfig) Rule.Runtime.Cause (List Nat)) :=
+  match extendedRegistry?,
+      State.Branch.startWithin extendedStateLimits extendedProgram extendedFacts with
+  | some registry, .ok branch =>
+      match Hex.Interval.Runtime.State.startWithin extendedRuntimeLimits
+          registry.assembly branch,
+        Search.Result.startWithin extendedResultLimits extendedMeasure { index := 0 } branch with
+      | .ok runtime, .ok tree =>
+          match runtime.stepWithin extendedRuntimeLimits opaqueAction with
+          | .ok (transition, _) =>
+              match Search.Result.advanceRuntimeWithin extendedResultLimits extendedMeasure
+                  tree transition with
+              | .ok tree =>
+                  (RuntimeProof.quoteTreeWithin extendedAdapterLimits extendedMeasure
+                    registry tree).toOption
+              | .error _ => none
+          | .error _ => none
+      | _, _ => none
+  | _, _ => none
+
+#guard extendedBundle?.any fun bundle =>
+  bundle.recipe.events[0]?.any fun events =>
+    match events with
+    | [.fact step] =>
+        step.schema == opaqueSchema.key && step.body == [13] &&
+          step.proposed == Hex.Interval.whole && step.installed == Hex.Interval.whole
+    | _ => false
+
+end Hex.IntervalMathlib.RuntimeRuleConformance

--- a/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
@@ -28,9 +28,9 @@ private def liftOption {α : Type} : Option α → Option (ULift.{1, 0} α)
   | some value => some ⟨value⟩
   | none => none
 
-/-- error: Unknown constant `Hex.Interval.Rule.Runtime.Registry.mk` -/
+/-- error: Unknown constant `Hex.Interval.RuntimeProof.Registry.mk` -/
 #guard_msgs in
-#check Rule.Runtime.Registry.mk
+#check RuntimeProof.Registry.mk
 
 def d (value : Int) : Dyadic := .ofInt value
 
@@ -167,6 +167,58 @@ private def exactFact (index : Nat)
     (List.range 12).all fun index =>
       transitions[index]?.any (exactFact index)
 
+/-! ## Distinct operand order -/
+
+def distinctProgram : Program :=
+  { operations := Rule.operations
+    nodes :=
+      #[node 0 [], node 0 [], node 3 [0, 1], node 11 [0, 1]] }
+
+def distinctFacts : Array Hex.Interval :=
+  #[point 1, point 2, Hex.Interval.whole, Hex.Interval.whole]
+
+def distinctRegistry? : Option (Rule.Runtime.Registry config) :=
+  (Rule.Runtime.buildWithin executableLimits proofLimits
+    { name := "arithmetic-runtime-distinct", version := 1 }
+    config distinctProgram).toOption
+
+def distinctRuntime? : Option
+    (Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :=
+  match distinctRegistry?,
+      State.Branch.startWithin stateLimits distinctProgram distinctFacts with
+  | some registry, .ok branch =>
+      (Hex.Interval.Runtime.State.startWithin runtimeLimits
+        registry.assembly branch).toOption
+  | _, _ => none
+
+def distinctAction (serial application rule node : Nat) (key : RuleKey) : Action :=
+  { serial, programVersion := 0, application := { index := application },
+    rule := { index := rule }, key, node := { index := node },
+    kind := .forward, effort := 0, inputs := [seen 0 0, seen 1 0],
+    writes := [{ index := node }] }
+
+def distinctActions : List Action :=
+  [distinctAction 0 0 2 2 Rule.subKey,
+   distinctAction 1 1 10 3 Rule.divKey]
+
+def distinctRun? := distinctRuntime?.bind fun state => run state distinctActions
+
+private def proposedAt (index : Nat)
+    (transitions : Array (Hex.Interval.Runtime.Applied Hex.Interval Rule.Runtime.Cause)) :
+    Option Hex.Interval := do
+  let transition ← transitions[index]?
+  let event ← transition.events[0]?
+  match event with
+  | .fact step => some step.proposed
+  | _ => none
+
+#guard distinctProgram.check
+#guard distinctRun?.any fun (transitions, state) =>
+  transitions.size == 2 && state.serial == 2 &&
+    proposedAt 0 transitions == Rule.ready? (subWithin endpoint (point 1) (point 2)) &&
+    proposedAt 1 transitions == Rule.arithmeticReady?
+      (divWithin config.precisionLimits config.precision (point 1) (point 2))
+
 /-! ## Retained quotation without a terminal -/
 
 def searchLimits : Search.Limits :=
@@ -269,23 +321,20 @@ def checked? : Option (RuntimeTerminal.Checked Hex.Interval
   let lineage ← (active.targetWithin resultLimits measure (seen 12 1)).toOption
   (lineage.quoteWithin adapterLimits measure).toOption
 
-/-- This calls the theorem fold owned by the checked token, then transports its
-dependent result only after confirming the token retained this exact input. -/
+/-- This calls the theorem fold owned by the checked token through its exact
+anti-transplant entry point. -/
 def replay? : Option (Proof.Evidence ((Rule.semantics config).Entails input.program
     (Proof.initialBase input) input.target)) :=
-  match checked? with
-  | none => none
-  | some checked =>
-      match RuntimeTerminal.Checked.replay adapterLimits measure
-          (Rule.domain config) (Rule.laws config) checked with
-      | .error _ => none
-      | .ok evidence =>
-          if h : RuntimeTerminal.Checked.input checked = input then
-            some (h ▸ evidence)
-          else none
+  checked?.bind fun checked =>
+    (RuntimeTerminal.Checked.replayWithin adapterLimits measure
+      (Rule.domain config) (Rule.laws config) input checked).toOption
 
 #guard checked?.isSome
 #guard replay?.isSome
+
+/-- info: 'Hex.IntervalMathlib.RuntimeRuleConformance.replay?' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms replay?
 
 /-! ## Cache, resource, and seal failures -/
 
@@ -365,6 +414,16 @@ def opaqueExecutable : Executable.Package Hex.Interval
         application := fun _ => { bytes := 1, work := 1 }
         cache := fun _ => {}
         result := fun batch => { bytes := batch.events.size, work := batch.events.size } } }
+
+def wrongFormatHandler : Handler Hex.Interval
+    (Hex.Interval.Runtime.Batch Hex.Interval Rule.Runtime.Cause) Unit :=
+  { opaqueHandler with
+    formats :=
+      #[{ role := .equality, schema := 1, validateBody := fun body => body == [13] }] }
+
+def wrongFormatExecutable : Executable.Package Hex.Interval
+    (Hex.Interval.Runtime.Batch Hex.Interval Rule.Runtime.Cause) :=
+  { opaqueExecutable with handlers := #[wrongFormatHandler] }
 
 def opaqueSchema : Proof.FactSchema (Rule.semantics
     { config with extraMeanings := #[opaqueMeaning] }) :=
@@ -456,6 +515,12 @@ def opaqueAction : Action :=
   match Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
       { name := "missing-opaque-runtime", version := 1 } extendedConfig extendedProgram
       #[] #[opaqueProof] with
+  | .error (.registry .invalidRegistry) => true
+  | _ => false
+#guard
+  match Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
+      { name := "mismatched-opaque-format", version := 1 } extendedConfig extendedProgram
+      #[wrongFormatExecutable] #[opaqueProof] with
   | .error (.registry .invalidRegistry) => true
   | _ => false
 #guard

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -578,6 +578,7 @@ lean_lib HexConformance where
       `HexInterval.RuntimeConformance,
       `HexIntervalMathlib.RuntimeProofConformance,
       `HexIntervalMathlib.RuntimeTerminalConformance,
+      `HexIntervalMathlib.RuntimeRuleConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/2026-08-24T02-57-25Z.md
+++ b/progress/2026-08-24T02-57-25Z.md
@@ -1,0 +1,27 @@
+# Built-in runtime rule CI integration
+
+## Accomplished
+
+- Rebased the built-in typed runtime rule callbacks and semantic replay canary
+  onto the current terminal-adapter head.
+- Rebuilt `HexIntervalMathlib.RuntimeRuleConformance` and
+  `HexIntervalMathlib` under Lean 4.34; all 8,808 jobs passed.
+- Added the exact proof-only factor-sweep exemption for the combined terminal
+  and RuntimeRule conformance glob registration.
+- Re-ran the DAG checker, its unit test, the published trust-surface check, and
+  diff hygiene successfully.
+
+## Current frontier
+
+The RuntimeRule layer is ready to restack once the terminal PR is squash
+merged. Its conformance now executes all twelve theorem callbacks through
+terminal replay, and the lakefile registration is classified narrowly for CI.
+
+## Next step
+
+Rebase onto the squash-merged terminal commit, open the RuntimeRule PR, obtain
+exact-head Claude review, and merge only after exact-head CI succeeds.
+
+## Blockers
+
+Publication depends on PR #9436 merging first.

--- a/progress/2026-08-24T03-52-27Z.md
+++ b/progress/2026-08-24T03-52-27Z.md
@@ -1,0 +1,30 @@
+# RuntimeRule final review hardening
+
+## Accomplished
+
+- Addressed every conformance-quality observation from the exact-head Claude
+  review of PR #9508.
+- Added an isolated two-source runtime that executes ordered subtraction and
+  division, while retaining repeated-slot coverage in the complete chronology.
+- Added the reverse executable-format/proof-schema mismatch canary and replaced
+  the vacuous abbreviation constructor check with the sealed underlying
+  `RuntimeProof.Registry` constructor check.
+- Routed the replay canary through `RuntimeTerminal.Checked.replayWithin` and
+  pinned its exact ordinary axiom surface.
+- Corrected the executable-cache docstring and rebuilt the focused 8,801-job
+  target plus freshness, DAG/unit, trust-surface, and source-hygiene gates.
+
+## Current frontier
+
+The RuntimeRule implementation and strengthened conformance are locally green
+on the squash-merged terminal adapter. PR #9508 needs a fresh exact-head review
+and CI run after this hardening commit.
+
+## Next step
+
+Push the hardening commit, obtain exact-head Claude approval and exact-head CI,
+then merge if `main` remains at the reviewed base. Restack RuntimeEmit afterward.
+
+## Blockers
+
+None.

--- a/progress/20260824T023911Z_runtime-rule-terminal-integration.md
+++ b/progress/20260824T023911Z_runtime-rule-terminal-integration.md
@@ -1,0 +1,26 @@
+# RuntimeRule terminal integration
+
+## Accomplished
+
+- Restacked the twelve built-in typed arithmetic callbacks on the sealed
+  runtime target/refutation adapter.
+- Added exact final-target settlement and recursive checked replay of the
+  complete twelve-event arithmetic chronology.
+- Reconciled the umbrella and SPEC with repeated-read scheduling and typed
+  target/refutation correlation now present.
+- Preserved paired executable/proof coverage tests for opaque operations and
+  the callback-cache resource boundary.
+
+## Current frontier
+
+- The Rule-owned typed runtime batch layer is ready to become a standalone PR
+  after its terminal-adapter base merges.
+
+## Next step
+
+- Rebase this branch onto the squash-merged terminal adapter, rerun the exact
+  checks, and open the RuntimeRule PR.
+
+## Blockers
+
+- The branch is intentionally stacked on the unmerged terminal adapter.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -938,7 +938,7 @@
   {
     "path": "lakefile.lean",
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
-    "current_blob": "f6e849c9cda52a76d1b4a111545755726e6dad06",
-    "reason": "Registers the build-only sparse, modular, and multivariate verification/conformance/fixture/benchmark targets, moves HexModular.LoopTests into the build-only test umbrella, and adds the proof-side HexIntervalMathlib.RuntimeTerminalConformance and RuntimeRuleConformance globs; none enters hexbz_factor_service or changes a factorization runtime library, executable definition, or build flag."
+    "current_blob": "b6feee43b834c71a5531fd02fb527756bd4a7a3d",
+    "reason": "Combines current main's build-only verification, conformance, fixture, benchmark, and truncated-series registrations with the proof-side HexIntervalMathlib.RuntimeRuleConformance registration; none enters hexbz_factor_service or changes a factorization runtime library, executable definition, or build flag."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -934,5 +934,11 @@
     "baseline_blob": "dc13ffdd544ac3037114ffba1000eddd09ecde90",
     "current_blob": "cbef5cd34b581e312d21c2f76da11d6989b2aa6a",
     "reason": "Adds an import and a quotient-power theorem only; no executable definition or factorization runtime call path changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "f6e849c9cda52a76d1b4a111545755726e6dad06",
+    "reason": "Registers the build-only sparse, modular, and multivariate verification/conformance/fixture/benchmark targets, moves HexModular.LoopTests into the build-only test umbrella, and adds the proof-side HexIntervalMathlib.RuntimeTerminalConformance and RuntimeRuleConformance globs; none enters hexbz_factor_service or changes a factorization runtime library, executable definition, or build flag."
   }
 ]


### PR DESCRIPTION
## Summary

- add sealed Runtime.Batch callbacks for all twelve built-in interval arithmetic rules
- assemble the exact typed runtime rule registry and execute unary, binary, and repeated-slot actions
- strengthen conformance by settling a terminal and replaying the complete retained chronology through RuntimeTerminal.Checked.replay
- classify the single proof-only conformance registration with an exact lakefile blob exemption

## Verification

- lake build HexIntervalMathlib.RuntimeRuleConformance HexIntervalMathlib
- factor-sweep freshness checker
- dependency DAG checker and unit test
- published trust-surface, copyright, line-count, banned-token, and diff hygiene checks

Depends on and is rebased onto merged PR #9436.