### PR TITLE
chore: roll HexResultant back to done_through 4

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -603,7 +603,7 @@ libraries:
   HexResultant:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 5
+    done_through: 4
     status: active
     phase4:
       comparators:

--- a/progress/2026-08-24T04-30-00Z.md
+++ b/progress/2026-08-24T04-30-00Z.md
@@ -1,0 +1,26 @@
+# HexResultant Phase-5 rollback
+
+## Accomplished
+
+- Rolled HexResultant back from done_through 5 to 4 per
+  PLAN/Conventions.md: the multivariate factorization stack landed
+  HexResultant/SubresultantExt.lean with the theorem-level sorry
+  subresultantChainExt_law, so the Phase-5 zero-sorry exit no longer
+  holds. Issue #9506 tracks the proof, now carrying the full
+  obstruction diagnosis (a determinantal Bezout-cofactor development
+  is required; no fold-threaded invariant suffices) and the
+  alternative of relocating the module to its consumers.
+
+## Current frontier
+
+- HexResultant returns to 5 when #9506 resolves by proof or by
+  relocation; nothing else in the wave regresses.
+
+## Next step
+
+- The owning multivariate-gcd workstream chooses between the cofactor
+  development and the relocation.
+
+## Blockers
+
+- None for the rollback itself.


### PR DESCRIPTION
This PR roll HexResultant back from `done_through: 5` to 4 per PLAN/Conventions.md's rollback rule. The multivariate factorization stack landed `HexResultant/SubresultantExt.lean` with the theorem-level sorry `subresultantChainExt_law`, so the Phase-5 zero-sorry exit no longer holds for the library as recorded. A sustained proof attempt established that the law is not provable from the existing Brown-Traub infrastructure by any fold-threaded invariant (the obstruction diagnosis, the missing determinantal Bezout-cofactor development it requires, and a relocation alternative are recorded on #9506, which stays open for the owning workstream). HexResultant returns to 5 when #9506 resolves.

🤖 Prepared with Claude Code