### PR TITLE
feat(hex-gf2-mathlib): add EuclideanDomain for GF2Poly

### DIFF
--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -373,6 +373,12 @@ remainder. -/
     (0 : GF2Poly) % q = 0 := by
   rw [← divMod_snd, divMod_zero_left]
 
+/-- The packed zero and one polynomials are distinct. -/
+theorem one_ne_zero : (1 : GF2Poly) ≠ 0 := by
+  intro h
+  have hwords := congrArg toWords h
+  exact (by decide : toWords (1 : GF2Poly) ≠ toWords (0 : GF2Poly)) hwords
+
 /-- Quotient/remainder reconstruction through the public `/` and `%`
 operations. -/
 @[grind =]
@@ -617,7 +623,7 @@ theorem dvd_gcd (d p q : GF2Poly) :
 
 /-- A nonzero packed polynomial of degree `0` equals `1`, the only degree-`0`
 GF(2) polynomial. -/
-private theorem nonzero_degree_zero_eq_one {p : GF2Poly}
+theorem eq_one_of_degree_zero {p : GF2Poly}
     (hp : p ≠ 0) (hdegree : p.degree = 0) :
     p = 1 := by
   have hpzeroFalse : p.isZero = false := by
@@ -667,6 +673,43 @@ theorem degree_le_of_dvd_nonzero {p q : GF2Poly}
   rw [degree_eq_of_degree?_eq_some hdp,
     degree_eq_of_degree?_eq_some hq_degree?]
   omega
+
+/-- Divisibility is antisymmetric for packed `GF(2)` polynomials. There is no
+unit ambiguity because `1` is the only nonzero degree-zero polynomial. -/
+theorem dvd_antisymm {p q : GF2Poly} (hpq : p ∣ q) (hqp : q ∣ p) :
+    p = q := by
+  by_cases hp : p = 0
+  · subst p
+    rcases hpq with ⟨r, hr⟩
+    simpa using hr.symm
+  · have hq : q ≠ 0 := by
+      intro hq
+      subst q
+      rcases hqp with ⟨r, hr⟩
+      apply hp
+      simpa using hr
+    rcases hpq with ⟨r, hr⟩
+    have hrne : r ≠ 0 := by
+      intro hrzero
+      apply hq
+      rw [hr, hrzero, mul_zero]
+    have hpzero : p.isZero = false :=
+      (isZero_eq_false_iff_ne_zero p).mpr hp
+    have hrzero : r.isZero = false :=
+      (isZero_eq_false_iff_ne_zero r).mpr hrne
+    obtain ⟨dp, hdp⟩ := degree?_isSome_of_isZero_false hpzero
+    obtain ⟨dr, hdr⟩ := degree?_isSome_of_isZero_false hrzero
+    have hqdegree : q.degree? = some (dp + dr) := by
+      rw [hr]
+      exact degree?_mul_of_degree?_eq_some hdp hdr
+    have hdegree := degree_le_of_dvd_nonzero hq hp hqp
+    rw [degree_eq_of_degree?_eq_some hqdegree,
+      degree_eq_of_degree?_eq_some hdp] at hdegree
+    have hdrzero : r.degree = 0 := by
+      rw [degree_eq_of_degree?_eq_some hdr]
+      omega
+    have hrone := eq_one_of_degree_zero hrne hdrzero
+    simpa [hrone] using hr.symm
 
 /-- A polynomial reduced below `bound` (either zero, or of degree `< bound`)
 has `coeff n = false` at every index `n ≥ bound`. -/
@@ -919,12 +962,12 @@ private theorem irreducible_common_divisor_eq_one_of_reduced
     apply ha
     rw [hs, hd, zero_mul]
   rcases hf.2 d r hr.symm with hd_degree | hr_degree
-  · exact nonzero_degree_zero_eq_one hdne hd_degree
+  · exact eq_one_of_degree_zero hdne hd_degree
   · have hrne : r ≠ 0 := by
       intro hzero
       apply hf.1
       rw [hr, hzero, mul_zero]
-    have hr_one : r = 1 := nonzero_degree_zero_eq_one hrne hr_degree
+    have hr_one : r = 1 := eq_one_of_degree_zero hrne hr_degree
     have hdf : d = f := by
       calc
         d = d * 1 := by rw [mul_one]

--- a/HexGF2/Irreducibility.lean
+++ b/HexGF2/Irreducibility.lean
@@ -282,12 +282,6 @@ This file proves the checker-to-`rabinTest` bridge; `HexGF2/RabinSoundness.lean`
 contains `rabinTest_imp_irreducible` and the certificate-to-irreducible
 corollaries. -/
 
-private theorem one_ne_zero_gf2poly : (1 : GF2Poly) ≠ 0 := by
-  intro h
-  have hwords := congrArg toWords h
-  have hbad : toWords (1 : GF2Poly) ≠ toWords (0 : GF2Poly) := by decide
-  exact hbad hwords
-
 private theorem one_degree_eq_zero : (1 : GF2Poly).degree = 0 := degree_one
 
 private theorem one_degree?_eq_some_zero : (1 : GF2Poly).degree? = some 0 := degree?_one
@@ -299,8 +293,8 @@ private theorem isUnitPolynomial_of_dvd_one {g : GF2Poly}
     rcases hdiv with ⟨r, hr⟩
     intro hg
     rw [hg, zero_mul] at hr
-    exact one_ne_zero_gf2poly hr
-  have hgle := degree_le_of_dvd_nonzero hg_ne one_ne_zero_gf2poly hdiv
+    exact one_ne_zero hr
+  have hgle := degree_le_of_dvd_nonzero hg_ne one_ne_zero hdiv
   rw [one_degree_eq_zero] at hgle
   have hgdeg : g.degree = 0 := Nat.eq_zero_of_le_zero hgle
   have hgzeroFalse : g.isZero = false := by

--- a/HexGF2Mathlib.lean
+++ b/HexGF2Mathlib.lean
@@ -19,5 +19,6 @@ generic proof-facing polynomial and finite-field constructions.
 It exposes the packed-polynomial equivalence `Hex.GF2Poly ≃+* Hex.FpPoly 2`
 together with the corresponding single-word/arbitrary-degree `GF(2^n)`
 correspondence modules, and carries Mathlib's `CommRing` and `Field`
-structure on the packed types.
+structure, together with Euclidean-domain and gcd-domain structure on packed
+polynomials.
 -/

--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -9,6 +9,7 @@ module
 public import HexGF2Mathlib.Field
 public import Mathlib.Algebra.Ring.MinimalAxioms
 public import Mathlib.Algebra.Field.MinimalAxioms
+public import Mathlib.RingTheory.EuclideanDomain
 
 public section
 
@@ -45,6 +46,84 @@ instance commRing : CommRing Hex.GF2Poly :=
     (fun a b c => by
       rw [Hex.GF2Poly.mul_comm a (b + c), Hex.GF2Poly.left_distrib,
         Hex.GF2Poly.mul_comm b a, Hex.GF2Poly.mul_comm c a])
+
+namespace GF2Poly
+
+/-- The Euclidean rank of a packed polynomial. Zero has rank zero and a
+nonzero polynomial has rank one greater than its degree. -/
+def euclideanRank (p : Hex.GF2Poly) : Nat :=
+  if p = 0 then 0 else p.degree + 1
+
+/-- The packed `F₂[x]` representation is a Euclidean domain whose quotient and
+remainder are the executable long-division operations from `hex-gf2`. -/
+instance euclideanDomain : EuclideanDomain Hex.GF2Poly where
+  toCommRing := commRing
+  toNontrivial := ⟨0, 1, by
+    intro h
+    have hwords := congrArg Hex.GF2Poly.toWords h
+    exact (by decide :
+      Hex.GF2Poly.toWords (0 : Hex.GF2Poly) ≠
+        Hex.GF2Poly.toWords (1 : Hex.GF2Poly)) hwords⟩
+  quotient := Hex.GF2Poly.div
+  quotient_zero := Hex.GF2Poly.div_zero_right
+  remainder := Hex.GF2Poly.mod
+  quotient_mul_add_remainder_eq := fun p q => by
+    rw [mul_comm]
+    exact Hex.GF2Poly.div_mul_add_mod p q
+  r := fun p q => euclideanRank p < euclideanRank q
+  r_wellFounded := (measure euclideanRank).wf
+  remainder_lt := fun p q hq => by
+    unfold euclideanRank
+    rw [_root_.ite_eq_right hq]
+    rcases Hex.GF2Poly.mod_degree_lt p q hq with hzero | hdegree
+    · change (Hex.GF2Poly.mod p q).isZero = true at hzero
+      rw [(Hex.GF2Poly.isZero_iff_eq_zero _).mp hzero, _root_.ite_eq_left rfl]
+      omega
+    · change (Hex.GF2Poly.mod p q).degree < q.degree at hdegree
+      by_cases hrem : Hex.GF2Poly.mod p q = 0
+      · rw [_root_.ite_eq_left hrem]
+        omega
+      · rw [_root_.ite_eq_right hrem]
+        omega
+  mul_left_not_lt := fun p q hq => by
+    unfold euclideanRank
+    by_cases hp : p = 0
+    · simp [hp]
+    · rw [_root_.ite_eq_right hp]
+      have hpzero : p.isZero = false :=
+        (Hex.GF2Poly.isZero_eq_false_iff_ne_zero p).mpr hp
+      have hqzero : q.isZero = false :=
+        (Hex.GF2Poly.isZero_eq_false_iff_ne_zero q).mpr hq
+      obtain ⟨dp, hdp⟩ :=
+        Hex.GF2Poly.degree?_isSome_of_isZero_false hpzero
+      obtain ⟨dq, hdq⟩ :=
+        Hex.GF2Poly.degree?_isSome_of_isZero_false hqzero
+      have hpqdeg : (p * q).degree? = some (dp + dq) :=
+        Hex.GF2Poly.degree?_mul_of_degree?_eq_some hdp hdq
+      have hpq : p * q ≠ 0 := by
+        intro hpq
+        rw [hpq] at hpqdeg
+        simp [Hex.GF2Poly.degree?] at hpqdeg
+      rw [_root_.ite_eq_right hpq,
+        Hex.GF2Poly.degree_eq_of_degree?_eq_some hdp,
+        Hex.GF2Poly.degree_eq_of_degree?_eq_some hpqdeg]
+      omega
+
+/-- The gcd-domain interface uses the packed executable gcd, not Mathlib's
+separate recursive Euclidean-domain implementation. -/
+noncomputable instance gcdMonoid : GCDMonoid Hex.GF2Poly :=
+  gcdMonoidOfGCD Hex.GF2Poly.gcd
+    Hex.GF2Poly.gcd_dvd_left
+    Hex.GF2Poly.gcd_dvd_right
+    (fun hdleft hdright => Hex.GF2Poly.dvd_gcd _ _ _ hdleft hdright)
+
+/-- Mathlib's gcd operation on packed polynomials is definitionally the
+executable `hex-gf2` gcd. -/
+theorem gcd_eq_packed (p q : Hex.GF2Poly) :
+    GCDMonoid.gcd p q = Hex.GF2Poly.gcd p q :=
+  rfl
+
+end GF2Poly
 
 namespace GF2nPoly
 
@@ -90,6 +169,21 @@ example (p q : Hex.GF2Poly) : p * q = Hex.GF2Poly.mul p q := rfl
 
 /-- Addition likewise. -/
 example (p q : Hex.GF2Poly) : p + q = Hex.GF2Poly.add p q := rfl
+
+/-- Euclidean division and remainder remain the executable packed operations. -/
+example (p q : Hex.GF2Poly) :
+    p / q = Hex.GF2Poly.div p q ∧ p % q = Hex.GF2Poly.mod p q :=
+  ⟨rfl, rfl⟩
+
+/-- The packed gcd is also the operation exposed through Mathlib's gcd-domain
+interface. -/
+example (p q : Hex.GF2Poly) :
+    GCDMonoid.gcd p q = Hex.GF2Poly.gcd p q :=
+  rfl
+
+/-- The Euclidean-domain instance reaches Mathlib's unique-factorization
+interface. -/
+example : UniqueFactorizationMonoid Hex.GF2Poly := inferInstance
 
 /-- The field instance is found by synthesis given the degree fact, and its
 inverse is still the executable one. -/

--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -54,16 +54,18 @@ nonzero polynomial has rank one greater than its degree. -/
 def euclideanRank (p : Hex.GF2Poly) : Nat :=
   if p = 0 then 0 else p.degree + 1
 
+@[simp] theorem euclideanRank_zero : euclideanRank 0 = 0 := by
+  simp [euclideanRank]
+
+@[simp] theorem euclideanRank_of_ne_zero {p : Hex.GF2Poly} (hp : p ≠ 0) :
+    euclideanRank p = p.degree + 1 := by
+  simp [euclideanRank, hp]
+
 /-- The packed `F₂[x]` representation is a Euclidean domain whose quotient and
 remainder are the executable long-division operations from `hex-gf2`. -/
 instance euclideanDomain : EuclideanDomain Hex.GF2Poly where
   toCommRing := commRing
-  toNontrivial := ⟨0, 1, by
-    intro h
-    have hwords := congrArg Hex.GF2Poly.toWords h
-    exact (by decide :
-      Hex.GF2Poly.toWords (0 : Hex.GF2Poly) ≠
-        Hex.GF2Poly.toWords (1 : Hex.GF2Poly)) hwords⟩
+  toNontrivial := ⟨0, 1, fun h => Hex.GF2Poly.one_ne_zero h.symm⟩
   quotient := Hex.GF2Poly.div
   quotient_zero := Hex.GF2Poly.div_zero_right
   remainder := Hex.GF2Poly.mod
@@ -73,23 +75,21 @@ instance euclideanDomain : EuclideanDomain Hex.GF2Poly where
   r := fun p q => euclideanRank p < euclideanRank q
   r_wellFounded := (measure euclideanRank).wf
   remainder_lt := fun p q hq => by
-    unfold euclideanRank
-    rw [_root_.ite_eq_right hq]
+    rw [euclideanRank_of_ne_zero hq]
     rcases Hex.GF2Poly.mod_degree_lt p q hq with hzero | hdegree
     · change (Hex.GF2Poly.mod p q).isZero = true at hzero
-      rw [(Hex.GF2Poly.isZero_iff_eq_zero _).mp hzero, _root_.ite_eq_left rfl]
+      rw [(Hex.GF2Poly.isZero_iff_eq_zero _).mp hzero, euclideanRank_zero]
       omega
     · change (Hex.GF2Poly.mod p q).degree < q.degree at hdegree
       by_cases hrem : Hex.GF2Poly.mod p q = 0
-      · rw [_root_.ite_eq_left hrem]
+      · rw [hrem, euclideanRank_zero]
         omega
-      · rw [_root_.ite_eq_right hrem]
+      · rw [euclideanRank_of_ne_zero hrem]
         omega
   mul_left_not_lt := fun p q hq => by
-    unfold euclideanRank
     by_cases hp : p = 0
     · simp [hp]
-    · rw [_root_.ite_eq_right hp]
+    · rw [euclideanRank_of_ne_zero hp]
       have hpzero : p.isZero = false :=
         (Hex.GF2Poly.isZero_eq_false_iff_ne_zero p).mpr hp
       have hqzero : q.isZero = false :=
@@ -104,7 +104,7 @@ instance euclideanDomain : EuclideanDomain Hex.GF2Poly where
         intro hpq
         rw [hpq] at hpqdeg
         simp [Hex.GF2Poly.degree?] at hpqdeg
-      rw [_root_.ite_eq_right hpq,
+      rw [euclideanRank_of_ne_zero hpq,
         Hex.GF2Poly.degree_eq_of_degree?_eq_some hdp,
         Hex.GF2Poly.degree_eq_of_degree?_eq_some hpqdeg]
       omega
@@ -122,6 +122,19 @@ executable `hex-gf2` gcd. -/
 theorem gcd_eq_packed (p q : Hex.GF2Poly) :
     GCDMonoid.gcd p q = Hex.GF2Poly.gcd p q :=
   rfl
+
+/-- Mathlib's recursive Euclidean gcd agrees with the executable packed gcd.
+Over `F₂[x]`, mutual divisibility determines equality because `1` is the only
+unit. -/
+theorem euclidean_gcd_eq_packed (p q : Hex.GF2Poly) :
+    EuclideanDomain.gcd p q = Hex.GF2Poly.gcd p q := by
+  apply Hex.GF2Poly.dvd_antisymm
+  · exact Hex.GF2Poly.dvd_gcd _ _ _
+      (EuclideanDomain.gcd_dvd_left p q)
+      (EuclideanDomain.gcd_dvd_right p q)
+  · exact EuclideanDomain.dvd_gcd
+      (Hex.GF2Poly.gcd_dvd_left p q)
+      (Hex.GF2Poly.gcd_dvd_right p q)
 
 end GF2Poly
 
@@ -179,11 +192,21 @@ example (p q : Hex.GF2Poly) :
 interface. -/
 example (p q : Hex.GF2Poly) :
     GCDMonoid.gcd p q = Hex.GF2Poly.gcd p q :=
-  rfl
+  GF2Poly.gcd_eq_packed p q
+
+/-- Mathlib's recursive Euclidean gcd is the packed gcd as well. -/
+example (p q : Hex.GF2Poly) :
+    EuclideanDomain.gcd p q = Hex.GF2Poly.gcd p q :=
+  GF2Poly.euclidean_gcd_eq_packed p q
 
 /-- The Euclidean-domain instance reaches Mathlib's unique-factorization
 interface. -/
 example : UniqueFactorizationMonoid Hex.GF2Poly := inferInstance
+
+/-- Principal-ideal and Bezout interfaces are also synthesized from the
+Euclidean-domain instance. -/
+example : IsPrincipalIdealRing Hex.GF2Poly := inferInstance
+example : IsBezout Hex.GF2Poly := inferInstance
 
 /-- The field instance is found by synthesis given the degree fact, and its
 inverse is still the executable one. -/

--- a/HexGF2Mathlib/README.md
+++ b/HexGF2Mathlib/README.md
@@ -11,8 +11,8 @@ construction from
 [`hex-gfq-field`](https://github.com/leanprover/hex-gfq-field), and reaches
 Mathlib's `Polynomial (ZMod 2)` by composing with
 [`hex-poly-fp-mathlib`](https://github.com/leanprover/hex-poly-fp-mathlib). It
-also carries finiteness, cardinality, and Mathlib's `CommRing` and `Field`
-structure on the packed types.
+also carries finiteness, cardinality, and Mathlib's `CommRing`,
+`EuclideanDomain`, gcd-domain, and `Field` structure on the packed types.
 
 # Quickstart
 
@@ -32,6 +32,8 @@ noncomputable example : GF2Poly ≃+* Polynomial (ZMod 2) :=
   HexGF2Mathlib.GF2Poly.equivPolynomial
 
 example (p q : GF2Poly) : p * q = GF2Poly.mul p q := rfl
+example (p q : GF2Poly) : p / q = GF2Poly.div p q := rfl
+example (p q : GF2Poly) : GCDMonoid.gcd p q = GF2Poly.gcd p q := rfl
 
 -- A single-word `GF(2^n)` is the generic quotient field, and has `2 ^ n` elements.
 example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
@@ -54,8 +56,9 @@ example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
   `GFqField.FiniteField` over the transported modulus.
 - `Fintype` instances for both wrappers, their cardinality theorems, and the
   computable `finEquiv` indexings they are built from.
-- `CommRing Hex.GF2Poly`, and `Field (Hex.GF2nPoly f hirr)` for a nonconstant
-  modulus, built through Mathlib's minimal-axioms constructors.
+- `CommRing Hex.GF2Poly`, `EuclideanDomain Hex.GF2Poly`, a `GCDMonoid` whose
+  gcd is definitionally `GF2Poly.gcd`, and `Field (Hex.GF2nPoly f hirr)` for a
+  nonconstant modulus.
 
 The equivalences are Mathlib's `≃+*`, not a project-local record, so they
 compose with other `RingEquiv`s and are accepted by Mathlib's equivalence APIs.
@@ -74,7 +77,10 @@ noncomputable def equivPolynomial : Hex.GF2Poly ≃+* Polynomial (ZMod 2)
 `equivPolynomial` is `noncomputable` because Mathlib's polynomial
 multiplication is; the packed side stays executable. The algebraic instances
 keep the executable operations rather than transported copies, so
-`p * q = GF2Poly.mul p q` closes by `rfl`.
+`p * q = GF2Poly.mul p q`, `p / q = GF2Poly.div p q`, and
+`GCDMonoid.gcd p q = GF2Poly.gcd p q` close by `rfl`. The Euclidean instance
+also makes Mathlib's Bezout, principal-ideal, and unique-factorization
+interfaces available on the packed type.
 
 The single-word wrapper, in namespace `HexGF2Mathlib.GF2n`:
 
@@ -105,12 +111,10 @@ The `Field` instance on `GF2nPoly` takes `Fact (0 < f.degree)`, and the
 hypothesis is not redundant: `GF2Poly.Irreducible` admits the constant `1`, and
 the quotient by a constant is the trivial ring where `0 = 1`.
 
-Two things are absent. `GF2n` has no Mathlib `Field` instance, because hex-gf2
+One thing is absent. `GF2n` has no Mathlib `Field` instance, because hex-gf2
 does not prove its ring laws as bare theorems the way it does for `GF2Poly` and
 `GF2nPoly`, so reaching Mathlib from a `GF2n` today means going through
-`GF2n.equiv`. There is no `EuclideanDomain GF2Poly` either; hex-gf2 already
-defines `Div` and `Mod` on `GF2Poly` and the class supplies its own, so the two
-have to be reconciled rather than stacked.
+`GF2n.equiv`.
 
 Use [`hex-gf2`](https://github.com/leanprover/hex-gf2) alone for computation;
 this package is for theorem statements and interoperability involving Mathlib.

--- a/HexGF2Mathlib/README.md
+++ b/HexGF2Mathlib/README.md
@@ -34,6 +34,9 @@ noncomputable example : GF2Poly ≃+* Polynomial (ZMod 2) :=
 example (p q : GF2Poly) : p * q = GF2Poly.mul p q := rfl
 example (p q : GF2Poly) : p / q = GF2Poly.div p q := rfl
 example (p q : GF2Poly) : GCDMonoid.gcd p q = GF2Poly.gcd p q := rfl
+example (p q : GF2Poly) :
+    EuclideanDomain.gcd p q = GF2Poly.gcd p q :=
+  HexGF2Mathlib.GF2Poly.euclidean_gcd_eq_packed p q
 
 -- A single-word `GF(2^n)` is the generic quotient field, and has `2 ^ n` elements.
 example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
@@ -80,7 +83,9 @@ keep the executable operations rather than transported copies, so
 `p * q = GF2Poly.mul p q`, `p / q = GF2Poly.div p q`, and
 `GCDMonoid.gcd p q = GF2Poly.gcd p q` close by `rfl`. The Euclidean instance
 also makes Mathlib's Bezout, principal-ideal, and unique-factorization
-interfaces available on the packed type.
+interfaces available on the packed type. The stated
+`GF2Poly.euclidean_gcd_eq_packed` lemma identifies the gcd in Mathlib's
+recursive Bezout theorem with the executable packed gcd.
 
 The single-word wrapper, in namespace `HexGF2Mathlib.GF2n`:
 

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -32,12 +32,22 @@ The `Equiv`s are computable, the `Fintype` instances deliberately are not: the
 carriers have `2 ^ n` elements, so a compiled `Finset.univ` over one is a
 footgun rather than a feature.
 
-**Algebraic structure.** `CommRing GF2Poly` and, for a nonconstant modulus,
-`Field (GF2nPoly f hirr)` are built with Mathlib's minimal-axioms constructors
-from the laws hex-gf2 already proves, so the operations stay the executable
-ones: `*` on the `CommRing` is packed carry-less multiplication, and `p * q =
-GF2Poly.mul p q` closes by `rfl`. Building them by transport along the ring
-equivalence instead would attach the right laws to the wrong operations.
+**Algebraic structure.** `CommRing GF2Poly`, `EuclideanDomain GF2Poly`, and,
+for a nonconstant modulus, `Field (GF2nPoly f hirr)` are built from laws
+hex-gf2 already proves, so the operations stay the executable ones: `*` is
+packed carry-less multiplication, `/` and `%` are packed long division, and
+each agrees with its `GF2Poly` implementation by `rfl`. Building these
+structures by transport along the ring equivalence instead would attach the
+right laws to the wrong operations.
+
+The Euclidean relation measures zero at `0` and a nonzero polynomial at one
+greater than its degree. The remainder-decrease proof is therefore exactly
+`GF2Poly.mod_degree_lt`, including the zero-remainder case, while multiplication
+of nonzero polynomials cannot lower the measure. The `GCDMonoid` instance is
+built directly from `GF2Poly.gcd_dvd_left`, `gcd_dvd_right`, and `dvd_gcd`, so
+`GCDMonoid.gcd p q = GF2Poly.gcd p q` holds definitionally. Mathlib's Bezout,
+principal-ideal, and unique-factorization interfaces are consequently available
+without replacing the packed arithmetic.
 
 The field instance takes `Fact (0 < f.degree)`. The degree hypothesis is not
 redundant: `GF2Poly.Irreducible` admits the constant `1`, and `GF2nPoly 1 _` is
@@ -48,10 +58,7 @@ carrying the degree bound as a type parameter.
 `GF2n` has no Mathlib `Field` instance yet, because hex-gf2 does not prove its
 ring laws as bare theorems the way it does for `GF2Poly` and `GF2nPoly`;
 reaching Mathlib from a `GF2n` today means going through
-`GF2n.equiv`. `EuclideanDomain GF2Poly` is also outstanding, and is not simply
-more of the same: hex-gf2 already defines `Div` and `Mod` on `GF2Poly`, and
-`EuclideanDomain` supplies its own, so the two have to be reconciled rather
-than stacked.
+`GF2n.equiv`.
 
 The computational hex-gf2 library stays Mathlib-free.
 

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -47,7 +47,12 @@ of nonzero polynomials cannot lower the measure. The `GCDMonoid` instance is
 built directly from `GF2Poly.gcd_dvd_left`, `gcd_dvd_right`, and `dvd_gcd`, so
 `GCDMonoid.gcd p q = GF2Poly.gcd p q` holds definitionally. Mathlib's Bezout,
 principal-ideal, and unique-factorization interfaces are consequently available
-without replacing the packed arithmetic.
+without replacing the packed arithmetic. The separately recursive
+`EuclideanDomain.gcd` is proved equal to `GF2Poly.gcd` by
+`GF2Poly.euclidean_gcd_eq_packed`, using antisymmetry of divisibility over
+`F₂[x]`, so Mathlib's explicit Euclidean Bezout theorem has the same gcd value.
+The `GCDMonoid` class also requires an `lcm`; that projection is supplied
+noncomputably by Mathlib's constructor and is not a packed executable API.
 
 The field instance takes `Fact (0 < f.degree)`. The degree hypothesis is not
 redundant: `GF2Poly.Irreducible` admits the constant `1`, and `GF2nPoly 1 _` is

--- a/HexManual/Chapters/HexGF2.lean
+++ b/HexManual/Chapters/HexGF2.lean
@@ -396,6 +396,10 @@ they keep the executable operations, and they do.
 
 {docstring HexGF2Mathlib.commRing}
 
+{docstring HexGF2Mathlib.GF2Poly.euclideanDomain}
+
+{docstring HexGF2Mathlib.GF2Poly.gcdMonoid}
+
 That instance is built from the laws `HexGF2` proves, not by copying
 Mathlib's operations across the equivalence, so multiplication under it
 is still packed carry-less multiplication.
@@ -404,7 +408,23 @@ is still packed carry-less multiplication.
 open Hex in
 example (p q : GF2Poly) :
     p * q = GF2Poly.mul p q := rfl
+
+example (p q : GF2Poly) :
+    p / q = GF2Poly.div p q ∧ p % q = GF2Poly.mod p q :=
+  ⟨rfl, rfl⟩
+
+example (p q : GF2Poly) :
+    GCDMonoid.gcd p q = GF2Poly.gcd p q := rfl
 ```
+
+Mathlib's recursive Euclidean gcd is a separate definition. Over `F₂[x]`
+the only unit is `1`, so mutual divisibility fixes the representative and the
+two gcd algorithms agree exactly:
+
+{docstring HexGF2Mathlib.GF2Poly.euclidean_gcd_eq_packed}
+
+The instance supplies Mathlib's Bezout, principal-ideal, and
+unique-factorization interfaces directly on the packed type.
 
 So Mathlib's ring automation applies directly to packed polynomials:
 


### PR DESCRIPTION
Summary:
- wire GF2Poly’s existing executable division and remainder into a EuclideanDomain instance
- use the packed gcd implementation for Mathlib’s GCDMonoid interface
- document the new Bezout, PID, and UFD interoperability

Verification:
- lake build HexGF2Mathlib.Algebra
- lake build (9970 jobs)

Fixes #9503