### PR TITLE
feat(hex-gf2-mathlib): give GF2n a Mathlib Field instance

### DIFF
--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -8,6 +8,7 @@ module
 
 public import HexGF2.Field.Word
 public import HexGF2.Field.Poly
+public import HexGF2.Field.WordLaws
 public import HexGF2.Field.Roots
 public import HexGF2.Field.Grind
 
@@ -15,7 +16,8 @@ public import HexGF2.Field.Grind
 The `GF(2^n)` wrappers for `hex-gf2`.
 
 `HexGF2.Field.Word` holds the single-word `n < 64` case and the packed helpers
-both representations share. The arbitrary-degree case is layered:
+both representations share, with its bare algebraic laws in
+`HexGF2.Field.WordLaws`. The arbitrary-degree case is layered:
 `HexGF2.Field.Poly` is the representation and its arithmetic laws,
 `HexGF2.Field.Roots` the root-count and Frobenius development, and
 `HexGF2.Field.Grind` the bundled `Lean.Grind` instances built from both.

--- a/HexGF2/Field/Poly.lean
+++ b/HexGF2/Field/Poly.lean
@@ -271,6 +271,14 @@ def zero : GF2nPoly f hirr :=
 instance : Zero (GF2nPoly f hirr) where
   zero := zero
 
+/-- Reducing the zero polynomial gives the quotient zero. -/
+@[simp, grind =] theorem reducePoly_zero :
+    reducePoly (f := f) (hirr := hirr) 0 = 0 := by
+  apply eq_of_val_eq
+  rw [reducePoly_val_eq_mod]
+  change 0 % f = 0
+  exact GF2Poly.mod_eq_self_of_reduced 0 f (Or.inl rfl)
+
 /-- A polynomial reduces to the zero quotient element exactly when the modulus
 divides it in `GF(2)[X]`. -/
 theorem reducePoly_eq_zero_iff_dvd {p : GF2Poly} (hf : f ≠ 0) :
@@ -889,6 +897,22 @@ theorem mul_assoc (a b c : GF2nPoly f hirr) :
     exact h
   rw [hca, hcb, GF2Poly.mul_assoc]
 
+/-- The multiplicative identity is a left identity. -/
+@[simp, grind =] theorem one_mul (a : GF2nPoly f hirr) :
+    (1 : GF2nPoly f hirr) * a = a := by
+  apply eq_of_val_eq
+  rw [mul_val, one_val]
+  have h : ((1 : GF2Poly) % f * a.val) % f = ((1 : GF2Poly) * a.val) % f := by
+    have hh := mod_mul_mod_eq_mod_mul 1 a.val f
+    rw [val_mod_eq a] at hh
+    exact hh
+  rw [h, GF2Poly.one_mul, val_mod_eq]
+
+/-- The multiplicative identity is a right identity. -/
+@[simp, grind =] theorem mul_one (a : GF2nPoly f hirr) :
+    a * (1 : GF2nPoly f hirr) = a := by
+  rw [mul_comm, one_mul]
+
 /-- Multiplication distributes over addition on the left in the packed
 quotient. -/
 theorem left_distrib (a b c : GF2nPoly f hirr) :
@@ -925,6 +949,25 @@ theorem add_sq (a b : GF2nPoly f hirr) :
       rw [mul_comm b a]
     _ = a * a + b * b := by
       rw [add_self, add_zero]
+
+/-- The quotient identity is not zero under a positive-degree modulus. -/
+theorem one_ne_zero (hf_pos : 0 < f.degree) :
+    (1 : GF2nPoly f hirr) ≠ 0 := by
+  intro h
+  have hval := congrArg GF2nPoly.val h
+  have hone_val : (1 : GF2nPoly f hirr).val = (1 : GF2Poly) := by
+    rw [one_val]
+    exact GF2Poly.mod_eq_self_of_reduced (1 : GF2Poly) f
+      (Or.inr (by
+        change (GF2Poly.monomial 0).degree < f.degree
+        rw [show (GF2Poly.monomial 0).degree = 0 from by
+          exact GF2Poly.degree_eq_of_degree?_eq_some (GF2Poly.degree?_monomial 0)]
+        exact hf_pos))
+  rw [hone_val, zero_val] at hval
+  have hcoeff := congrArg (fun p : GF2Poly => p.coeff 0) hval
+  change (GF2Poly.monomial 0).coeff 0 = (0 : GF2Poly).coeff 0 at hcoeff
+  rw [GF2Poly.coeff_monomial_self, GF2Poly.coeff_zero] at hcoeff
+  contradiction
 
 end GF2nPoly
 

--- a/HexGF2/Field/Roots.lean
+++ b/HexGF2/Field/Roots.lean
@@ -240,22 +240,6 @@ Frobenius iterate. -/
     frobeniusIter (a * b) k = a * b := by
   rw [frobeniusIter_mul, ha, hb]
 
-/-- The multiplicative identity is a left identity. -/
-@[simp, grind =] theorem one_mul (a : GF2nPoly f hirr) :
-    (1 : GF2nPoly f hirr) * a = a := by
-  apply eq_of_val_eq
-  rw [mul_val, one_val]
-  have h : ((1 : GF2Poly) % f * a.val) % f = ((1 : GF2Poly) * a.val) % f := by
-    have hh := mod_mul_mod_eq_mod_mul 1 a.val f
-    rw [val_mod_eq a] at hh
-    exact hh
-  rw [h, GF2Poly.one_mul, val_mod_eq]
-
-/-- The multiplicative identity is a right identity. -/
-@[simp, grind =] theorem mul_one (a : GF2nPoly f hirr) :
-    a * (1 : GF2nPoly f hirr) = a := by
-  rw [mul_comm, one_mul]
-
 /-- One is fixed by every iterated Frobenius. -/
 @[simp, grind =] theorem frobeniusIter_one_eq (k : Nat) :
     frobeniusIter (1 : GF2nPoly f hirr) k = 1 := by
@@ -264,13 +248,6 @@ Frobenius iterate. -/
       rfl
   | succ k ih =>
       rw [frobeniusIter_succ, ih, one_mul]
-
-/-- Reducing the zero polynomial gives the quotient zero. -/
-@[simp, grind =] theorem reducePoly_zero :
-    reducePoly (f := f) (hirr := hirr) 0 = 0 := by
-  apply eq_of_val_eq
-  rw [reducePoly_val_eq_mod, zero_val]
-  exact GF2Poly.mod_eq_self_of_reduced 0 f (Or.inl rfl)
 
 /-- Reducing the constant-one monomial gives the quotient one. -/
 @[simp, grind =] theorem reducePoly_monomial_zero :
@@ -320,7 +297,8 @@ theorem frobeniusIter_reducePoly_ofBoolListFrom_eq_self_of_X_fixed {k : Nat}
         reducePoly (f := f) (hirr := hirr)
           (GF2Poly.Internal.ofBoolListFrom start bs)
   | start, [] => by
-      simp [GF2Poly.Internal.ofBoolListFrom]
+      rw [GF2Poly.Internal.ofBoolListFrom, reducePoly_zero]
+      exact frobeniusIter_zero_eq (f := f) (hirr := hirr) k
   | start, b :: bs => by
       have htail :=
         frobeniusIter_reducePoly_ofBoolListFrom_eq_self_of_X_fixed hX (start + 1) bs
@@ -331,7 +309,10 @@ theorem frobeniusIter_reducePoly_ofBoolListFrom_eq_self_of_X_fixed {k : Nat}
             reducePoly (f := f) (hirr := hirr)
               (if b then GF2Poly.monomial start else 0) := by
         cases b
-        · simp
+        · change frobeniusIter (reducePoly (f := f) (hirr := hirr) 0) k =
+              reducePoly (f := f) (hirr := hirr) 0
+          rw [reducePoly_zero]
+          exact frobeniusIter_zero_eq (f := f) (hirr := hirr) k
         · exact frobeniusIter_reducePoly_monomial_eq_self_of_X_fixed
             (f := f) (hirr := hirr) hX start
       have hsum :
@@ -891,25 +872,6 @@ theorem frobeniusIter_eq_linearPow_two_pow (a : GF2nPoly f hirr) (k : Nat) :
               rw [Nat.pow_succ, show 2 ^ k + 2 ^ k = 2 ^ k * 2 by omega]
 
 end Internal
-
-/-- The quotient identity is not zero under a positive-degree modulus. -/
-theorem one_ne_zero (hf_pos : 0 < f.degree) :
-    (1 : GF2nPoly f hirr) ≠ 0 := by
-  intro h
-  have hval := congrArg GF2nPoly.val h
-  have hone_val : (1 : GF2nPoly f hirr).val = (1 : GF2Poly) := by
-    rw [one_val]
-    exact GF2Poly.mod_eq_self_of_reduced (1 : GF2Poly) f
-      (Or.inr (by
-        change (GF2Poly.monomial 0).degree < f.degree
-        rw [show (GF2Poly.monomial 0).degree = 0 from by
-          exact GF2Poly.degree_eq_of_degree?_eq_some (GF2Poly.degree?_monomial 0)]
-        exact hf_pos))
-  rw [hone_val, zero_val] at hval
-  have hcoeff := congrArg (fun p : GF2Poly => p.coeff 0) hval
-  change (GF2Poly.monomial 0).coeff 0 = (0 : GF2Poly).coeff 0 at hcoeff
-  rw [GF2Poly.coeff_monomial_self, GF2Poly.coeff_zero] at hcoeff
-  contradiction
 
 /-- Coefficients for the characteristic-two polynomial `T^(2^k) + T`.
 

--- a/HexGF2/Field/WordLaws.lean
+++ b/HexGF2/Field/WordLaws.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexGF2.Field.Poly
+
+public section
+
+/-!
+The bare arithmetic laws for the packed single-word `GF2n` representation.
+
+The proofs compare a canonical word with the corresponding `GF2nPoly`
+quotient element. This keeps the computational library independent of Mathlib;
+the companion `hex-gf2-mathlib` package can assemble these theorems into its
+algebraic hierarchy without changing any executable operation.
+-/
+
+namespace Hex
+namespace GF2n
+
+variable {n : Nat} {irr : UInt64}
+variable {hn : 0 < n} {hn64 : n < 64}
+variable {hirr : GF2Poly.Irreducible (GF2Poly.ofUInt64Monic irr n)}
+
+/-- The arbitrary-degree quotient element represented by a single-word field
+element. Used only to transfer laws between the two executable packed models. -/
+private def toPoly (a : GF2n n irr hn hn64 hirr) :
+    GF2nPoly (GF2Poly.ofUInt64Monic irr n) hirr :=
+  GF2nPoly.reducePoly (GF2Poly.ofUInt64 a.val)
+
+/-- Reading back a reduced word gives its polynomial remainder modulo the
+packed field modulus. -/
+private theorem ofUInt64_reduce_val (w : UInt64) :
+    GF2Poly.ofUInt64
+        (reduce (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) w).val =
+      GF2Poly.ofUInt64 w % GF2Poly.ofUInt64Monic irr n := by
+  change GF2Poly.ofUInt64
+      (GF2Poly.canonicalWordLT n hn64
+        (GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w))) = _
+  have hcanonical :
+      GF2Poly.canonicalWordLT n hn64
+          (GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w)) =
+        GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w) := by
+    apply UInt64.toNat_inj.mp
+    simp [GF2Poly.canonicalWordLT,
+      Nat.mod_eq_of_lt (GF2Poly.packedReduceWord_toNat_lt hn64 _)]
+  rw [hcanonical]
+  apply GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt hn64
+  have hred :=
+    GF2Poly.mod_degree_lt (GF2Poly.ofUInt64 w) (GF2Poly.ofUInt64Monic irr n) hirr.1
+  rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64] at hred
+  exact hred
+
+/-- Reading back a reduced wide carry-less product gives its polynomial
+remainder modulo the packed field modulus. -/
+private theorem ofUInt64_reduceWide_val (hi lo : UInt64) :
+    GF2Poly.ofUInt64
+        (reduceWide (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
+          hi lo).val =
+      GF2Poly.ofWords #[lo, hi] % GF2Poly.ofUInt64Monic irr n := by
+  change GF2Poly.ofUInt64
+      (GF2Poly.canonicalWordLT n hn64
+        (GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi]))) = _
+  have hcanonical :
+      GF2Poly.canonicalWordLT n hn64
+          (GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi])) =
+        GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi]) := by
+    apply UInt64.toNat_inj.mp
+    simp [GF2Poly.canonicalWordLT,
+      Nat.mod_eq_of_lt (GF2Poly.packedReduceWord_toNat_lt hn64 _)]
+  rw [hcanonical]
+  apply GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt hn64
+  have hred := GF2Poly.mod_degree_lt (GF2Poly.ofWords #[lo, hi])
+    (GF2Poly.ofUInt64Monic irr n) hirr.1
+  rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64] at hred
+  exact hred
+
+/-- Bits at or above `k` vanish in a natural number below `2 ^ k`. -/
+private theorem testBit_eq_false_of_lt {x k i : Nat}
+    (hx : x < 2 ^ k) (hki : k ≤ i) : x.testBit i = false := by
+  have hbit : (x % 2 ^ k).testBit i = x.testBit i := by
+    rw [Nat.mod_eq_of_lt hx]
+  rw [Nat.testBit_mod_two_pow] at hbit
+  have hnot : ¬ i < k := Nat.not_lt_of_ge hki
+  simp [hnot] at hbit
+  exact hbit
+
+/-- A canonical single-word representative unpacks to a polynomial reduced
+below the extension degree. -/
+private theorem val_reduced (a : GF2n n irr hn hn64 hirr) :
+    (GF2Poly.ofUInt64 a.val).IsZero ∨ (GF2Poly.ofUInt64 a.val).degree < n := by
+  by_cases hzero : (GF2Poly.ofUInt64 a.val).isZero = true
+  · exact Or.inl hzero
+  · right
+    have hzeroFalse : (GF2Poly.ofUInt64 a.val).isZero = false := by
+      cases h : (GF2Poly.ofUInt64 a.val).isZero <;> simp [h] at hzero ⊢
+    obtain ⟨d, hd⟩ := GF2Poly.degree?_isSome_of_isZero_false hzeroFalse
+    rw [GF2Poly.degree_eq_of_degree?_eq_some hd]
+    by_cases hdn : d < n
+    · exact hdn
+    · have hnd : n ≤ d := Nat.le_of_not_gt hdn
+      have htrue := GF2Poly.coeff_eq_true_of_degree?_eq_some hd
+      have hfalse : (GF2Poly.ofUInt64 a.val).coeff d = false := by
+        by_cases hd64 : d < 64
+        · rw [GF2Poly.coeff_ofUInt64_eq_testBit a.val hd64]
+          exact testBit_eq_false_of_lt (k := n) a.val_lt hnd
+        · exact GF2Poly.coeff_ofUInt64_eq_false_of_ge_64 a.val
+            (Nat.le_of_not_lt hd64)
+      rw [htrue] at hfalse
+      exact Bool.noConfusion hfalse
+
+/-- A canonical representative is unchanged by polynomial reduction. -/
+private theorem val_mod_eq (a : GF2n n irr hn hn64 hirr) :
+    GF2Poly.ofUInt64 a.val % GF2Poly.ofUInt64Monic irr n =
+      GF2Poly.ofUInt64 a.val := by
+  apply GF2Poly.mod_eq_self_of_reduced
+  rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]
+  exact val_reduced a
+
+/-- The comparison with `GF2nPoly` is injective. -/
+private theorem toPoly_injective :
+    Function.Injective (toPoly (n := n) (irr := irr) (hn := hn) (hn64 := hn64)
+      (hirr := hirr)) := by
+  intro a b h
+  have hval := congrArg GF2nPoly.val h
+  simp only [toPoly, GF2nPoly.reducePoly_val_eq_mod, val_mod_eq] at hval
+  have hab := GF2Poly.ofUInt64_injective hval
+  cases a
+  cases b
+  simp at hab
+  subst hab
+  rfl
+
+/-- The comparison preserves addition. -/
+private theorem toPoly_add (a b : GF2n n irr hn hn64 hirr) :
+    toPoly (a + b) = toPoly a + toPoly b := by
+  unfold toPoly
+  change GF2nPoly.reducePoly (GF2Poly.ofUInt64 (a + b).val) =
+    GF2nPoly.reducePoly
+      ((GF2nPoly.reducePoly (GF2Poly.ofUInt64 a.val)).val +
+        (GF2nPoly.reducePoly (GF2Poly.ofUInt64 b.val)).val)
+  rw [← GF2nPoly.reducePoly_add_eq]
+  change GF2nPoly.reducePoly (GF2Poly.ofUInt64 (reduce (a.val ^^^ b.val)).val) = _
+  rw [ofUInt64_reduce_val, ← GF2Poly.ofUInt64_xor, GF2nPoly.reducePoly_mod_eq]
+
+/-- The comparison preserves multiplication. -/
+private theorem toPoly_mul (a b : GF2n n irr hn hn64 hirr) :
+    toPoly (a * b) = toPoly a * toPoly b := by
+  unfold toPoly
+  change GF2nPoly.reducePoly (GF2Poly.ofUInt64 (a * b).val) =
+    GF2nPoly.reducePoly
+      ((GF2nPoly.reducePoly (GF2Poly.ofUInt64 a.val)).val *
+        (GF2nPoly.reducePoly (GF2Poly.ofUInt64 b.val)).val)
+  rw [← GF2nPoly.reducePoly_mul_eq]
+  change GF2nPoly.reducePoly
+      (GF2Poly.ofUInt64 (reduceWide (clmul a.val b.val).fst (clmul a.val b.val).snd).val) = _
+  rw [ofUInt64_reduceWide_val, GF2Poly.ofUInt64_mul_ofUInt64,
+    GF2nPoly.reducePoly_mod_eq]
+
+/-- The comparison preserves zero. -/
+private theorem toPoly_zero :
+    toPoly (0 : GF2n n irr hn hn64 hirr) = 0 := by
+  unfold toPoly
+  change GF2nPoly.reducePoly (GF2Poly.ofUInt64 0) = 0
+  rw [GF2Poly.ofUInt64_zero, GF2nPoly.reducePoly_zero]
+  rfl
+
+/-- The comparison preserves one. -/
+private theorem toPoly_one :
+    toPoly (1 : GF2n n irr hn hn64 hirr) = 1 := by
+  unfold toPoly
+  change GF2nPoly.reducePoly (GF2Poly.ofUInt64 (reduce 1).val) = 1
+  rw [ofUInt64_reduce_val, GF2nPoly.reducePoly_mod_eq]
+  rfl
+
+/-! # Bare ring laws -/
+
+/-- Addition is commutative on the packed single-word field. -/
+theorem add_comm (a b : GF2n n irr hn hn64 hirr) : a + b = b + a := by
+  apply toPoly_injective
+  rw [toPoly_add, toPoly_add, GF2nPoly.add_comm]
+
+/-- Addition is associative on the packed single-word field. -/
+theorem add_assoc (a b c : GF2n n irr hn hn64 hirr) :
+    (a + b) + c = a + (b + c) := by
+  apply toPoly_injective
+  rw [toPoly_add, toPoly_add, toPoly_add, toPoly_add, GF2nPoly.add_assoc]
+
+/-- The additive identity is a left identity. -/
+@[simp, grind =] theorem zero_add (a : GF2n n irr hn hn64 hirr) : 0 + a = a := by
+  apply toPoly_injective
+  rw [toPoly_add, toPoly_zero, GF2nPoly.zero_add]
+
+/-- The additive identity is a right identity. -/
+@[simp, grind =] theorem add_zero (a : GF2n n irr hn hn64 hirr) : a + 0 = a := by
+  rw [add_comm, zero_add]
+
+/-- Every element is its own additive inverse in characteristic two. -/
+@[simp, grind =] theorem add_self (a : GF2n n irr hn hn64 hirr) : a + a = 0 := by
+  apply toPoly_injective
+  rw [toPoly_add, toPoly_zero, GF2nPoly.add_self]
+
+/-- Negation cancels addition. -/
+@[simp, grind =] theorem neg_add_cancel (a : GF2n n irr hn hn64 hirr) : -a + a = 0 := by
+  change a + a = 0
+  exact add_self a
+
+/-- Multiplication is commutative on the packed single-word field. -/
+theorem mul_comm (a b : GF2n n irr hn hn64 hirr) : a * b = b * a := by
+  apply toPoly_injective
+  rw [toPoly_mul, toPoly_mul, GF2nPoly.mul_comm]
+
+/-- Multiplication is associative on the packed single-word field. -/
+theorem mul_assoc (a b c : GF2n n irr hn hn64 hirr) :
+    (a * b) * c = a * (b * c) := by
+  apply toPoly_injective
+  rw [toPoly_mul, toPoly_mul, toPoly_mul, toPoly_mul, GF2nPoly.mul_assoc]
+
+/-- The multiplicative identity is a left identity. -/
+@[simp, grind =] theorem one_mul (a : GF2n n irr hn hn64 hirr) : 1 * a = a := by
+  apply toPoly_injective
+  rw [toPoly_mul, toPoly_one, GF2nPoly.one_mul]
+
+/-- The multiplicative identity is a right identity. -/
+@[simp, grind =] theorem mul_one (a : GF2n n irr hn hn64 hirr) : a * 1 = a := by
+  rw [mul_comm, one_mul]
+
+/-- Zero annihilates multiplication on the left. -/
+@[simp, grind =] theorem zero_mul (a : GF2n n irr hn hn64 hirr) : 0 * a = 0 := by
+  apply toPoly_injective
+  rw [toPoly_mul, toPoly_zero, GF2nPoly.zero_mul]
+
+/-- Zero annihilates multiplication on the right. -/
+@[simp, grind =] theorem mul_zero (a : GF2n n irr hn hn64 hirr) : a * 0 = 0 := by
+  rw [mul_comm, zero_mul]
+
+/-- Multiplication distributes over addition on the left. -/
+theorem left_distrib (a b c : GF2n n irr hn hn64 hirr) :
+    a * (b + c) = a * b + a * c := by
+  apply toPoly_injective
+  rw [toPoly_mul, toPoly_add, toPoly_add, toPoly_mul, toPoly_mul,
+    GF2nPoly.left_distrib]
+
+/-- Multiplication distributes over addition on the right. -/
+theorem right_distrib (a b c : GF2n n irr hn hn64 hirr) :
+    (a + b) * c = a * c + b * c := by
+  rw [mul_comm (a + b) c, left_distrib, mul_comm c a, mul_comm c b]
+
+/-- The packed identity is nonzero for every accepted single-word modulus. -/
+theorem one_ne_zero : (1 : GF2n n irr hn hn64 hirr) ≠ 0 := by
+  intro h
+  have hpoly := congrArg (toPoly (n := n) (irr := irr) (hn := hn) (hn64 := hn64)
+    (hirr := hirr)) h
+  rw [toPoly_one, toPoly_zero] at hpoly
+  exact GF2nPoly.one_ne_zero
+    (by simpa using (show 0 < (GF2Poly.ofUInt64Monic irr n).degree by
+      rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]
+      exact hn)) hpoly
+
+end GF2n
+end Hex

--- a/HexGF2/Field/WordLaws.lean
+++ b/HexGF2/Field/WordLaws.lean
@@ -32,28 +32,35 @@ private def toPoly (a : GF2n n irr hn hn64 hirr) :
     GF2nPoly (GF2Poly.ofUInt64Monic irr n) hirr :=
   GF2nPoly.reducePoly (GF2Poly.ofUInt64 a.val)
 
-/-- Reading back a reduced word gives its polynomial remainder modulo the
-packed field modulus. -/
-private theorem ofUInt64_reduce_val (w : UInt64) :
+/-- Reading back a packed polynomial reduction gives the corresponding
+polynomial remainder. -/
+private theorem ofUInt64_packedReduce_val
+    (hirr : GF2Poly.Irreducible (GF2Poly.ofUInt64Monic irr n)) (p : GF2Poly) :
     GF2Poly.ofUInt64
-        (reduce (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) w).val =
-      GF2Poly.ofUInt64 w % GF2Poly.ofUInt64Monic irr n := by
-  change GF2Poly.ofUInt64
       (GF2Poly.canonicalWordLT n hn64
-        (GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w))) = _
+        (GF2Poly.packedReduceWord n irr p)) =
+      p % GF2Poly.ofUInt64Monic irr n := by
   have hcanonical :
       GF2Poly.canonicalWordLT n hn64
-          (GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w)) =
-        GF2Poly.packedReduceWord n irr (GF2Poly.ofUInt64 w) := by
+          (GF2Poly.packedReduceWord n irr p) =
+        GF2Poly.packedReduceWord n irr p := by
     apply UInt64.toNat_inj.mp
     simp [GF2Poly.canonicalWordLT,
       Nat.mod_eq_of_lt (GF2Poly.packedReduceWord_toNat_lt hn64 _)]
   rw [hcanonical]
   apply GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt hn64
   have hred :=
-    GF2Poly.mod_degree_lt (GF2Poly.ofUInt64 w) (GF2Poly.ofUInt64Monic irr n) hirr.1
+    GF2Poly.mod_degree_lt p (GF2Poly.ofUInt64Monic irr n) hirr.1
   rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64] at hred
   exact hred
+
+/-- Reading back a reduced word gives its polynomial remainder modulo the
+packed field modulus. -/
+private theorem ofUInt64_reduce_val (w : UInt64) :
+    GF2Poly.ofUInt64
+        (reduce (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) w).val =
+      GF2Poly.ofUInt64 w % GF2Poly.ofUInt64Monic irr n := by
+  exact ofUInt64_packedReduce_val (hn64 := hn64) hirr (GF2Poly.ofUInt64 w)
 
 /-- Reading back a reduced wide carry-less product gives its polynomial
 remainder modulo the packed field modulus. -/
@@ -62,32 +69,7 @@ private theorem ofUInt64_reduceWide_val (hi lo : UInt64) :
         (reduceWide (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
           hi lo).val =
       GF2Poly.ofWords #[lo, hi] % GF2Poly.ofUInt64Monic irr n := by
-  change GF2Poly.ofUInt64
-      (GF2Poly.canonicalWordLT n hn64
-        (GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi]))) = _
-  have hcanonical :
-      GF2Poly.canonicalWordLT n hn64
-          (GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi])) =
-        GF2Poly.packedReduceWord n irr (GF2Poly.ofWords #[lo, hi]) := by
-    apply UInt64.toNat_inj.mp
-    simp [GF2Poly.canonicalWordLT,
-      Nat.mod_eq_of_lt (GF2Poly.packedReduceWord_toNat_lt hn64 _)]
-  rw [hcanonical]
-  apply GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt hn64
-  have hred := GF2Poly.mod_degree_lt (GF2Poly.ofWords #[lo, hi])
-    (GF2Poly.ofUInt64Monic irr n) hirr.1
-  rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64] at hred
-  exact hred
-
-/-- Bits at or above `k` vanish in a natural number below `2 ^ k`. -/
-private theorem testBit_eq_false_of_lt {x k i : Nat}
-    (hx : x < 2 ^ k) (hki : k ≤ i) : x.testBit i = false := by
-  have hbit : (x % 2 ^ k).testBit i = x.testBit i := by
-    rw [Nat.mod_eq_of_lt hx]
-  rw [Nat.testBit_mod_two_pow] at hbit
-  have hnot : ¬ i < k := Nat.not_lt_of_ge hki
-  simp [hnot] at hbit
-  exact hbit
+  exact ofUInt64_packedReduce_val (hn64 := hn64) hirr (GF2Poly.ofWords #[lo, hi])
 
 /-- A canonical single-word representative unpacks to a polynomial reduced
 below the extension degree. -/
@@ -107,7 +89,8 @@ private theorem val_reduced (a : GF2n n irr hn hn64 hirr) :
       have hfalse : (GF2Poly.ofUInt64 a.val).coeff d = false := by
         by_cases hd64 : d < 64
         · rw [GF2Poly.coeff_ofUInt64_eq_testBit a.val hd64]
-          exact testBit_eq_false_of_lt (k := n) a.val_lt hnd
+          exact Nat.testBit_lt_two_pow
+            (Nat.lt_of_lt_of_le a.val_lt (Nat.pow_le_pow_right (by decide) hnd))
         · exact GF2Poly.coeff_ofUInt64_eq_false_of_ge_64 a.val
             (Nat.le_of_not_lt hd64)
       rw [htrue] at hfalse

--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -145,8 +145,8 @@ variable {hn : 0 < n} {hn64 : n < 64}
 variable {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
 
 /-- The packed single-word quotient is a Mathlib field, with its executable
-operations retained. Its positive extension degree is part of the type, so
-unlike `GF2nPoly` it needs no extra nontriviality hypothesis. -/
+core operations retained. Its positive extension degree is part of the type,
+so unlike `GF2nPoly` it needs no extra nontriviality hypothesis. -/
 noncomputable instance field : Field (Hex.GF2n n irr hn hn64 hirr) :=
   Field.ofMinimalAxioms (Hex.GF2n n irr hn hn64 hirr)
     Hex.GF2n.add_assoc
@@ -159,6 +159,24 @@ noncomputable instance field : Field (Hex.GF2n n irr hn hn64 hirr) :=
     Hex.GF2n.inv_zero
     Hex.GF2n.left_distrib
     ⟨1, 0, Hex.GF2n.one_ne_zero⟩
+
+/-! # The instance is usable, and keeps the executable core operations -/
+
+section Checks
+
+/-- The single-word field instance keeps the executable operations named by
+the computational API. -/
+example (a b : Hex.GF2n n irr hn hn64 hirr) :
+    a * b = Hex.GF2n.mul a b ∧ -a = Hex.GF2n.neg a ∧
+      a - b = Hex.GF2n.sub a b ∧ a⁻¹ = Hex.GF2n.inv a ∧
+      a / b = Hex.GF2n.div a b := by
+  exact ⟨rfl, rfl, rfl, rfl, rfl⟩
+
+/-- The single-word instance reaches Mathlib's field lemmas directly. -/
+example (a : Hex.GF2n n irr hn hn64 hirr) (ha : a ≠ 0) : a * a⁻¹ = 1 :=
+  mul_inv_cancel₀ ha
+
+end Checks
 
 end GF2n
 
@@ -190,7 +208,7 @@ noncomputable instance field [hdeg : Fact (0 < f.degree)] :
     Hex.GF2nPoly.left_distrib
     ⟨1, 0, Hex.GF2nPoly.one_ne_zero hdeg.out⟩
 
-/-! # The instances are usable, and keep the executable operations -/
+/-! # The instances are usable -/
 
 section Checks
 
@@ -231,20 +249,6 @@ example : UniqueFactorizationMonoid Hex.GF2Poly := inferInstance
 Euclidean-domain instance. -/
 example : IsPrincipalIdealRing Hex.GF2Poly := inferInstance
 example : IsBezout Hex.GF2Poly := inferInstance
-
-/-- The single-word field instance keeps the executable operations, including
-the characteristic-two spellings of negation and subtraction. -/
-example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
-    {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
-    (a b : Hex.GF2n n irr hn hn64 hirr) :
-    a * b = Hex.GF2n.mul a b ∧ -a = Hex.GF2n.neg a ∧ a - b = Hex.GF2n.sub a b := by
-  exact ⟨rfl, rfl, rfl⟩
-
-/-- The single-word instance reaches Mathlib's field lemmas directly. -/
-example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
-    {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
-    (a : Hex.GF2n n irr hn hn64 hirr) (ha : a ≠ 0) : a * a⁻¹ = 1 :=
-  mul_inv_cancel₀ ha
 
 /-- The field instance is found by synthesis given the degree fact, and its
 inverse is still the executable one. -/

--- a/HexGF2Mathlib/Algebra.lean
+++ b/HexGF2Mathlib/Algebra.lean
@@ -138,6 +138,30 @@ theorem euclidean_gcd_eq_packed (p q : Hex.GF2Poly) :
 
 end GF2Poly
 
+namespace GF2n
+
+variable {n : Nat} {irr : UInt64}
+variable {hn : 0 < n} {hn64 : n < 64}
+variable {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
+
+/-- The packed single-word quotient is a Mathlib field, with its executable
+operations retained. Its positive extension degree is part of the type, so
+unlike `GF2nPoly` it needs no extra nontriviality hypothesis. -/
+noncomputable instance field : Field (Hex.GF2n n irr hn hn64 hirr) :=
+  Field.ofMinimalAxioms (Hex.GF2n n irr hn hn64 hirr)
+    Hex.GF2n.add_assoc
+    Hex.GF2n.zero_add
+    Hex.GF2n.neg_add_cancel
+    Hex.GF2n.mul_assoc
+    Hex.GF2n.mul_comm
+    Hex.GF2n.one_mul
+    Hex.GF2n.mul_inv_cancel
+    Hex.GF2n.inv_zero
+    Hex.GF2n.left_distrib
+    ⟨1, 0, Hex.GF2n.one_ne_zero⟩
+
+end GF2n
+
 namespace GF2nPoly
 
 variable {f : Hex.GF2Poly} {hirr : Hex.GF2Poly.Irreducible f}
@@ -207,6 +231,20 @@ example : UniqueFactorizationMonoid Hex.GF2Poly := inferInstance
 Euclidean-domain instance. -/
 example : IsPrincipalIdealRing Hex.GF2Poly := inferInstance
 example : IsBezout Hex.GF2Poly := inferInstance
+
+/-- The single-word field instance keeps the executable operations, including
+the characteristic-two spellings of negation and subtraction. -/
+example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
+    {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
+    (a b : Hex.GF2n n irr hn hn64 hirr) :
+    a * b = Hex.GF2n.mul a b ∧ -a = Hex.GF2n.neg a ∧ a - b = Hex.GF2n.sub a b := by
+  exact ⟨rfl, rfl, rfl⟩
+
+/-- The single-word instance reaches Mathlib's field lemmas directly. -/
+example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
+    {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
+    (a : Hex.GF2n n irr hn hn64 hirr) (ha : a ≠ 0) : a * a⁻¹ = 1 :=
+  mul_inv_cancel₀ ha
 
 /-- The field instance is found by synthesis given the degree fact, and its
 inverse is still the executable one. -/

--- a/HexGF2Mathlib/README.md
+++ b/HexGF2Mathlib/README.md
@@ -61,7 +61,10 @@ example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
   computable `finEquiv` indexings they are built from.
 - `CommRing Hex.GF2Poly`, `EuclideanDomain Hex.GF2Poly`, a `GCDMonoid` whose
   gcd is definitionally `GF2Poly.gcd`, `Field (Hex.GF2n n irr hn hn64 hirr)`,
-  and `Field (Hex.GF2nPoly f hirr)` for a nonconstant modulus.
+  and `Field (Hex.GF2nPoly f hirr)` for a nonconstant modulus. The `GF2n`
+  instance keeps its packed multiplication, negation, inversion, subtraction,
+  and division definitions; the constructor supplies the remaining derived
+  hierarchy operations.
 
 The equivalences are Mathlib's `≃+*`, not a project-local record, so they
 compose with other `RingEquiv`s and are accepted by Mathlib's equivalence APIs.

--- a/HexGF2Mathlib/README.md
+++ b/HexGF2Mathlib/README.md
@@ -60,8 +60,8 @@ example {n : Nat} {irr : UInt64} {hn : 0 < n} {hn64 : n < 64}
 - `Fintype` instances for both wrappers, their cardinality theorems, and the
   computable `finEquiv` indexings they are built from.
 - `CommRing Hex.GF2Poly`, `EuclideanDomain Hex.GF2Poly`, a `GCDMonoid` whose
-  gcd is definitionally `GF2Poly.gcd`, and `Field (Hex.GF2nPoly f hirr)` for a
-  nonconstant modulus.
+  gcd is definitionally `GF2Poly.gcd`, `Field (Hex.GF2n n irr hn hn64 hirr)`,
+  and `Field (Hex.GF2nPoly f hirr)` for a nonconstant modulus.
 
 The equivalences are Mathlib's `≃+*`, not a project-local record, so they
 compose with other `RingEquiv`s and are accepted by Mathlib's equivalence APIs.
@@ -112,14 +112,11 @@ transported across the ring equivalence. The `Fintype` instances are
 deliberately `noncomputable`: the carriers have `2 ^ n` elements, so a compiled
 `Finset.univ` over one is a footgun. The `Equiv`s underneath stay computable.
 
-The `Field` instance on `GF2nPoly` takes `Fact (0 < f.degree)`, and the
-hypothesis is not redundant: `GF2Poly.Irreducible` admits the constant `1`, and
-the quotient by a constant is the trivial ring where `0 = 1`.
-
-One thing is absent. `GF2n` has no Mathlib `Field` instance, because hex-gf2
-does not prove its ring laws as bare theorems the way it does for `GF2Poly` and
-`GF2nPoly`, so reaching Mathlib from a `GF2n` today means going through
-`GF2n.equiv`.
+The `GF2n` field instance needs no additional hypothesis because its type
+already carries `0 < n`. The `Field` instance on `GF2nPoly` takes
+`Fact (0 < f.degree)`, and the hypothesis is not redundant:
+`GF2Poly.Irreducible` admits the constant `1`, and the quotient by a constant
+is the trivial ring where `0 = 1`.
 
 Use [`hex-gf2`](https://github.com/leanprover/hex-gf2) alone for computation;
 this package is for theorem statements and interoperability involving Mathlib.

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -34,10 +34,13 @@ footgun rather than a feature.
 
 **Algebraic structure.** `CommRing GF2Poly`, `EuclideanDomain GF2Poly`, `Field
 (GF2n n irr hn hn64 hirr)`, and, for a nonconstant modulus, `Field (GF2nPoly f
-hirr)` are built from laws hex-gf2 already proves, so the operations stay the
-executable ones: `*` is packed carry-less multiplication, `/` and `%` are
-packed long division, and each agrees with its `GF2Poly` implementation by
-`rfl`. Building these structures by transport along the ring equivalence
+hirr)` are built from laws hex-gf2 already proves. The `GF2Poly` multiplication,
+division, and remainder stay the executable packed operations. The primitive
+operations accepted by the field constructor stay executable too; for `GF2n`,
+the default subtraction and division also agree definitionally with the packed
+API. Thus both `p * q = GF2Poly.mul p q` and `a * b = GF2n.mul a b` close by
+`rfl`. The remaining derived hierarchy operations use Mathlib's constructor
+defaults. Building the structures by transport along the ring equivalences
 instead would attach the right laws to the wrong operations.
 
 The Euclidean relation measures zero at `0` and a nonzero polynomial at one

--- a/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
+++ b/HexGF2Mathlib/SPEC/hex-gf2-mathlib.md
@@ -32,13 +32,13 @@ The `Equiv`s are computable, the `Fintype` instances deliberately are not: the
 carriers have `2 ^ n` elements, so a compiled `Finset.univ` over one is a
 footgun rather than a feature.
 
-**Algebraic structure.** `CommRing GF2Poly`, `EuclideanDomain GF2Poly`, and,
-for a nonconstant modulus, `Field (GF2nPoly f hirr)` are built from laws
-hex-gf2 already proves, so the operations stay the executable ones: `*` is
-packed carry-less multiplication, `/` and `%` are packed long division, and
-each agrees with its `GF2Poly` implementation by `rfl`. Building these
-structures by transport along the ring equivalence instead would attach the
-right laws to the wrong operations.
+**Algebraic structure.** `CommRing GF2Poly`, `EuclideanDomain GF2Poly`, `Field
+(GF2n n irr hn hn64 hirr)`, and, for a nonconstant modulus, `Field (GF2nPoly f
+hirr)` are built from laws hex-gf2 already proves, so the operations stay the
+executable ones: `*` is packed carry-less multiplication, `/` and `%` are
+packed long division, and each agrees with its `GF2Poly` implementation by
+`rfl`. Building these structures by transport along the ring equivalence
+instead would attach the right laws to the wrong operations.
 
 The Euclidean relation measures zero at `0` and a nonzero polynomial at one
 greater than its degree. The remainder-decrease proof is therefore exactly
@@ -59,11 +59,6 @@ redundant: `GF2Poly.Irreducible` admits the constant `1`, and `GF2nPoly 1 _` is
 the trivial ring where `0 = 1`, so neither `zero_ne_one` nor characteristic two
 holds for every modulus the type accepts. hex-gfq-field avoids the same trap by
 carrying the degree bound as a type parameter.
-
-`GF2n` has no Mathlib `Field` instance yet, because hex-gf2 does not prove its
-ring laws as bare theorems the way it does for `GF2Poly` and `GF2nPoly`;
-reaching Mathlib from a `GF2n` today means going through
-`GF2n.equiv`.
 
 The computational hex-gf2 library stays Mathlib-free.
 


### PR DESCRIPTION
Closes #9502

## Summary

- prove the packed `GF2n` ring laws in the Mathlib-free `hex-gf2` layer by an injective comparison with `GF2nPoly`
- assemble a Mathlib `Field` instance with `Field.ofMinimalAxioms`, preserving the executable multiplication, negation, and subtraction definitions
- move the few basic `GF2nPoly` laws needed by that comparison from the roots layer into the arithmetic layer and update the package documentation

## Verification

- `lake build` (9,973 jobs)
- after rebasing onto current `main`: `lake build HexGF2.Field.Roots HexGF2Mathlib.Algebra`