### PR TITLE
feat(hex-gfq-mathlib): prove Conway generator order

### DIFF
--- a/HexGFqMathlib/Primitivity.lean
+++ b/HexGFqMathlib/Primitivity.lean
@@ -18,15 +18,16 @@ The multiplicative order of the Conway generator.
 `HexConway.Primitivity` checks, for each committed entry, that the residue of
 `x` satisfies `α ^ N = 1` and `α ^ (N / q) ≠ 1` for every prime `q` of
 `N = p ^ n - 1`. Those are the hypotheses of Mathlib's
-`orderOf_eq_of_pow_and_pow_div_prime`, so the conclusion `orderOf α = N` is
-one transport away — but the transport is the work, because the check runs on
-`FpPoly` representatives with structural powers, while `orderOf` is about
-Mathlib's `^` in the field.
+`orderOf_eq_of_pow_and_pow_div_prime`. The transport is the work, because the
+check runs on `FpPoly` representatives with structural powers, while `orderOf`
+is about Mathlib's `^` in the field.
 
-This file supplies that transport. The bridge is
+`orderOf_gen_of_primitive` supplies that transport. The bridge is
 {name}`HexGFqMathlib.ofPolyHom`, which is a ring homomorphism, so it carries
-the executable powers to Mathlib powers by `map_mul` and `map_pow`; the only
-extra ingredient is that reducing modulo the modulus is invisible after it.
+the executable powers to Mathlib powers by `map_mul` and `map_pow`; reduced
+representatives reflect equality with one, and the validated factorization
+makes the supplied prime list exhaustive. The final section specializes the
+result to all thirty-seven committed entries with `p ^ n > 2`.
 -/
 
 namespace HexGFqMathlib
@@ -190,7 +191,7 @@ theorem mem_of_prime_dvd_primePowerProduct :
 /-! # The order of the Conway generator -/
 
 /-- A verified executable primitivity certificate proves that the Conway
-generator has the full multiplicative order `p ^ n - 1`.
+generator has multiplicative order `p ^ n - 1`.
 
 This is the assembly point for the component transport lemmas above. The
 factorization check makes `qs` exhaustive, while the two digit-power checks
@@ -202,13 +203,14 @@ theorem orderOf_gen_of_primitive {n : Nat} (h : Hex.Conway.SupportedEntry p n)
   have hcheck := hprimitive.check
   simp only [Hex.Conway.primitiveCheck, Bool.and_eq_true, beq_iff_eq,
     List.all_eq_true] at hcheck
+  -- Factorization, full digits, list length, per-prime digits, full power,
+  -- and per-prime powers, in `primitiveCheck` order.
   rcases hcheck with
     ⟨⟨⟨⟨⟨hfactor, hfullDigits⟩, hlength⟩, hperDigits⟩, hfullPower⟩, hperPower⟩
   apply orderOf_eq_of_pow_and_pow_div_prime
   · have hn : 0 < n := by
-      rw [← Hex.Conway.luebeckConwayPolynomial?_degree_eq
-        (Hex.Conway.luebeckConwayPolynomial?_conwayPoly h)]
-      exact Hex.Conway.conwayPoly_nonconstant p n h
+      simpa only [HexGFqMathlib.GFq.conwayPoly_degree h] using
+        Hex.Conway.conwayPoly_nonconstant p n h
     exact Nat.sub_pos_of_lt (Nat.one_lt_pow (Nat.ne_of_gt hn) h.prime.one_lt)
   · rw [← hfullDigits]
     change (ofPolyHom (Hex.Conway.conwayPoly p n h)
@@ -227,7 +229,7 @@ theorem orderOf_gen_of_primitive {n : Nat} (h : Hex.Conway.SupportedEntry p n)
       rw [List.map_fst_zip (Nat.le_of_eq hlength.symm)]
       exact hqmem
     obtain ⟨⟨r, ds⟩, hrds, hr⟩ := List.mem_map.mp hqmap
-    simp only at hr
+    change r = q at hr
     subst r
     have hds : ds ∈ perPrimeDigits := (List.of_mem_zip hrds).2
     have hdigits : Hex.Conway.digitsValue p ds = (p ^ n - 1) / q :=

--- a/HexGFqMathlib/Primitivity.lean
+++ b/HexGFqMathlib/Primitivity.lean
@@ -187,4 +187,261 @@ theorem mem_of_prime_dvd_primePowerProduct :
           · exact List.mem_cons_of_mem _
               (ih es hq (fun s hs => hall s (List.mem_cons_of_mem _ hs)) hright)
 
+/-! # The order of the Conway generator -/
+
+/-- A verified executable primitivity certificate proves that the Conway
+generator has the full multiplicative order `p ^ n - 1`.
+
+This is the assembly point for the component transport lemmas above. The
+factorization check makes `qs` exhaustive, while the two digit-power checks
+become the hypotheses of `orderOf_eq_of_pow_and_pow_div_prime`. -/
+theorem orderOf_gen_of_primitive {n : Nat} (h : Hex.Conway.SupportedEntry p n)
+    {qs es fullDigits : List Nat} {perPrimeDigits : List (List Nat)}
+    (hprimitive : Hex.Conway.Primitive p n h qs es fullDigits perPrimeDigits) :
+    orderOf (Hex.GFq.ofPoly h Hex.FpPoly.X) = p ^ n - 1 := by
+  have hcheck := hprimitive.check
+  simp only [Hex.Conway.primitiveCheck, Bool.and_eq_true, beq_iff_eq,
+    List.all_eq_true] at hcheck
+  rcases hcheck with
+    ⟨⟨⟨⟨⟨hfactor, hfullDigits⟩, hlength⟩, hperDigits⟩, hfullPower⟩, hperPower⟩
+  apply orderOf_eq_of_pow_and_pow_div_prime
+  · have hn : 0 < n := by
+      rw [← Hex.Conway.luebeckConwayPolynomial?_degree_eq
+        (Hex.Conway.luebeckConwayPolynomial?_conwayPoly h)]
+      exact Hex.Conway.conwayPoly_nonconstant p n h
+    exact Nat.sub_pos_of_lt (Nat.one_lt_pow (Nat.ne_of_gt hn) h.prime.one_lt)
+  · rw [← hfullDigits]
+    change (ofPolyHom (Hex.Conway.conwayPoly p n h)
+      (Hex.Conway.conwayPoly_nonconstant p n h) h.prime
+      (Hex.Conway.conwayPoly_irreducible p n h) Hex.FpPoly.X) ^
+        Hex.Conway.digitsValue p fullDigits = 1
+    rw [← ofPolyHom_digitPowMod_one
+      (Hex.Conway.conwayPoly_monic p n h) p Hex.FpPoly.X fullDigits]
+    rw [hfullPower, map_one]
+    rfl
+  · intro q hq hqdiv
+    have hqmem : q ∈ qs := mem_of_prime_dvd_primePowerProduct qs es hq
+      (fun r hr => mathlibPrime_of_hexPrime (hprimitive.primes r hr))
+      (hfactor.symm ▸ hqdiv)
+    have hqmap : q ∈ (qs.zip perPrimeDigits).map Prod.fst := by
+      rw [List.map_fst_zip (Nat.le_of_eq hlength.symm)]
+      exact hqmem
+    obtain ⟨⟨r, ds⟩, hrds, hr⟩ := List.mem_map.mp hqmap
+    simp only at hr
+    subst r
+    have hds : ds ∈ perPrimeDigits := (List.of_mem_zip hrds).2
+    have hdigits : Hex.Conway.digitsValue p ds = (p ^ n - 1) / q :=
+      hperDigits (q, ds) hrds
+    have hrep : Hex.Conway.digitPowMod (Hex.Conway.conwayPoly p n h)
+        (Hex.Conway.conwayPoly_monic p n h) p Hex.FpPoly.X 1 ds ≠ 1 := by
+      intro heq
+      have hnot := hperPower ds hds
+      rw [heq] at hnot
+      simp at hnot
+    have hdsne : ds ≠ [] := by
+      intro hnil
+      subst ds
+      exact hrep rfl
+    rw [← hdigits]
+    change (ofPolyHom (Hex.Conway.conwayPoly p n h)
+      (Hex.Conway.conwayPoly_nonconstant p n h) h.prime
+      (Hex.Conway.conwayPoly_irreducible p n h) Hex.FpPoly.X) ^
+        Hex.Conway.digitsValue p ds ≠ 1
+    rw [← ofPolyHom_digitPowMod_one
+      (Hex.Conway.conwayPoly_monic p n h) p Hex.FpPoly.X ds]
+    intro hone
+    exact hrep ((ofPolyHom_eq_one_iff
+      (reduceMod_digitPowMod (Hex.Conway.conwayPoly_monic p n h) p
+        Hex.FpPoly.X ds 1 hdsne)).mp hone)
+
+/-! # Committed generators
+
+The generic theorem specializes to every committed nontrivial entry without
+replaying its executable certificate. -/
+
+/-- The Conway generator of `GF(2 ^ 2)` has order `3`. -/
+theorem orderOf_gen_2_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_2 Hex.FpPoly.X) = 2 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_2
+
+/-- The Conway generator of `GF(2 ^ 3)` has order `7`. -/
+theorem orderOf_gen_2_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_3 Hex.FpPoly.X) = 2 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_3
+
+/-- The Conway generator of `GF(2 ^ 4)` has order `15`. -/
+theorem orderOf_gen_2_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_4 Hex.FpPoly.X) = 2 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_4
+
+/-- The Conway generator of `GF(2 ^ 5)` has order `31`. -/
+theorem orderOf_gen_2_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_5 Hex.FpPoly.X) = 2 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_5
+
+/-- The Conway generator of `GF(2 ^ 6)` has order `63`. -/
+theorem orderOf_gen_2_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_6 Hex.FpPoly.X) = 2 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_6
+
+/-- The Conway generator of `GF(2 ^ 7)` has order `127`. -/
+theorem orderOf_gen_2_7 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_7 Hex.FpPoly.X) = 2 ^ 7 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_7
+
+/-- The Conway generator of `GF(2 ^ 8)` has order `255`. -/
+theorem orderOf_gen_2_8 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_2_8 Hex.FpPoly.X) = 2 ^ 8 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_2_8
+
+/-- The Conway generator of `GF(3 ^ 1)` has order `2`. -/
+theorem orderOf_gen_3_1 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_1 Hex.FpPoly.X) = 3 ^ 1 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_1
+
+/-- The Conway generator of `GF(3 ^ 2)` has order `8`. -/
+theorem orderOf_gen_3_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_2 Hex.FpPoly.X) = 3 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_2
+
+/-- The Conway generator of `GF(3 ^ 3)` has order `26`. -/
+theorem orderOf_gen_3_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_3 Hex.FpPoly.X) = 3 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_3
+
+/-- The Conway generator of `GF(3 ^ 4)` has order `80`. -/
+theorem orderOf_gen_3_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_4 Hex.FpPoly.X) = 3 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_4
+
+/-- The Conway generator of `GF(3 ^ 5)` has order `242`. -/
+theorem orderOf_gen_3_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_5 Hex.FpPoly.X) = 3 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_5
+
+/-- The Conway generator of `GF(3 ^ 6)` has order `728`. -/
+theorem orderOf_gen_3_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_3_6 Hex.FpPoly.X) = 3 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_3_6
+
+/-- The Conway generator of `GF(5 ^ 1)` has order `4`. -/
+theorem orderOf_gen_5_1 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_1 Hex.FpPoly.X) = 5 ^ 1 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_1
+
+/-- The Conway generator of `GF(5 ^ 2)` has order `24`. -/
+theorem orderOf_gen_5_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_2 Hex.FpPoly.X) = 5 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_2
+
+/-- The Conway generator of `GF(5 ^ 3)` has order `124`. -/
+theorem orderOf_gen_5_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_3 Hex.FpPoly.X) = 5 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_3
+
+/-- The Conway generator of `GF(5 ^ 4)` has order `624`. -/
+theorem orderOf_gen_5_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_4 Hex.FpPoly.X) = 5 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_4
+
+/-- The Conway generator of `GF(5 ^ 5)` has order `3124`. -/
+theorem orderOf_gen_5_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_5 Hex.FpPoly.X) = 5 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_5
+
+/-- The Conway generator of `GF(5 ^ 6)` has order `15624`. -/
+theorem orderOf_gen_5_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_5_6 Hex.FpPoly.X) = 5 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_5_6
+
+/-- The Conway generator of `GF(7 ^ 1)` has order `6`. -/
+theorem orderOf_gen_7_1 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_1 Hex.FpPoly.X) = 7 ^ 1 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_1
+
+/-- The Conway generator of `GF(7 ^ 2)` has order `48`. -/
+theorem orderOf_gen_7_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_2 Hex.FpPoly.X) = 7 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_2
+
+/-- The Conway generator of `GF(7 ^ 3)` has order `342`. -/
+theorem orderOf_gen_7_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_3 Hex.FpPoly.X) = 7 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_3
+
+/-- The Conway generator of `GF(7 ^ 4)` has order `2400`. -/
+theorem orderOf_gen_7_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_4 Hex.FpPoly.X) = 7 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_4
+
+/-- The Conway generator of `GF(7 ^ 5)` has order `16806`. -/
+theorem orderOf_gen_7_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_5 Hex.FpPoly.X) = 7 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_5
+
+/-- The Conway generator of `GF(7 ^ 6)` has order `117648`. -/
+theorem orderOf_gen_7_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_7_6 Hex.FpPoly.X) = 7 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_7_6
+
+/-- The Conway generator of `GF(11 ^ 1)` has order `10`. -/
+theorem orderOf_gen_11_1 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_1 Hex.FpPoly.X) = 11 ^ 1 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_1
+
+/-- The Conway generator of `GF(11 ^ 2)` has order `120`. -/
+theorem orderOf_gen_11_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_2 Hex.FpPoly.X) = 11 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_2
+
+/-- The Conway generator of `GF(11 ^ 3)` has order `1330`. -/
+theorem orderOf_gen_11_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_3 Hex.FpPoly.X) = 11 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_3
+
+/-- The Conway generator of `GF(11 ^ 4)` has order `14640`. -/
+theorem orderOf_gen_11_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_4 Hex.FpPoly.X) = 11 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_4
+
+/-- The Conway generator of `GF(11 ^ 5)` has order `161050`. -/
+theorem orderOf_gen_11_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_5 Hex.FpPoly.X) = 11 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_5
+
+/-- The Conway generator of `GF(11 ^ 6)` has order `1771560`. -/
+theorem orderOf_gen_11_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_11_6 Hex.FpPoly.X) = 11 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_11_6
+
+/-- The Conway generator of `GF(13 ^ 1)` has order `12`. -/
+theorem orderOf_gen_13_1 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_1 Hex.FpPoly.X) = 13 ^ 1 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_1
+
+/-- The Conway generator of `GF(13 ^ 2)` has order `168`. -/
+theorem orderOf_gen_13_2 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_2 Hex.FpPoly.X) = 13 ^ 2 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_2
+
+/-- The Conway generator of `GF(13 ^ 3)` has order `2196`. -/
+theorem orderOf_gen_13_3 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_3 Hex.FpPoly.X) = 13 ^ 3 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_3
+
+/-- The Conway generator of `GF(13 ^ 4)` has order `28560`. -/
+theorem orderOf_gen_13_4 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_4 Hex.FpPoly.X) = 13 ^ 4 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_4
+
+/-- The Conway generator of `GF(13 ^ 5)` has order `371292`. -/
+theorem orderOf_gen_13_5 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_5 Hex.FpPoly.X) = 13 ^ 5 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_5
+
+/-- The Conway generator of `GF(13 ^ 6)` has order `4826808`. -/
+theorem orderOf_gen_13_6 :
+    orderOf (Hex.GFq.ofPoly Hex.Conway.supportedEntry_13_6 Hex.FpPoly.X) = 13 ^ 6 - 1 :=
+  orderOf_gen_of_primitive _ Hex.Conway.primitive_13_6
+
 end HexGFqMathlib

--- a/HexGFqMathlib/README.md
+++ b/HexGFqMathlib/README.md
@@ -60,9 +60,10 @@ example {p n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
   degree-`n` one for a committed divisor pair, instantiated at `GF(2^2)` and
   `GF(2^3)` inside `GF(2^6)`, `GF(13)` inside `GF(13^6)`, and `GF(2^4)` inside
   `GF(2^8)`.
-- The component lemmas that move
+- `orderOf_gen_of_primitive`, which moves
   [`hex-conway`](https://github.com/leanprover/hex-conway)'s executable
-  primitivity check towards Mathlib's `orderOf` vocabulary.
+  primitivity certificates into Mathlib's `orderOf` vocabulary, with named
+  corollaries for all 37 committed nontrivial entries.
 
 # Verification
 
@@ -125,14 +126,13 @@ which is explicit that two evaluation and Frobenius bridges are missing first.
 Nothing in this package depends on that reading; the root property is what the
 embedding uses.
 
-The primitivity transport is likewise partial. `ofPolyHom_linPowMod`,
+The primitivity transport is assembled from `ofPolyHom_linPowMod`,
 `ofPolyHom_digitPowMod`, `ofPolyHom_eq_one_iff`, `mathlibPrime_of_hexPrime` and
-`mem_of_prime_dvd_primePowerProduct` are the ingredients Mathlib's
-`orderOf_eq_of_pow_and_pow_div_prime` needs, each carried across `ofPolyHom`
-separately. But no declaration here consumes a `Conway.Primitive` witness or
-produces the per-prime hypothesis function that theorem quantifies over, so the
-glue from `Primitive.check` to those hypotheses does not exist yet, and the
-per-entry conclusion `orderOf α = p ^ n - 1` is correspondingly not assembled.
+`mem_of_prime_dvd_primePowerProduct`. `orderOf_gen_of_primitive` consumes a
+`Conway.Primitive` witness, builds the per-prime hypothesis function required by
+Mathlib's `orderOf_eq_of_pow_and_pow_div_prime`, and concludes
+`orderOf α = p ^ n - 1`. The `orderOf_gen_p_n` corollaries specialize this to
+all 37 committed entries with nontrivial multiplicative group.
 
 Use [`hex-gfq`](https://github.com/leanprover/hex-gfq) alone for computation;
 this package is for theorem statements and interoperability involving Mathlib.

--- a/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
+++ b/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
@@ -27,9 +27,10 @@ vocabulary.
 - `conwayEmbed : GFq p m →+* GFq p n`, the embedding of the degree-`m` Conway
   field into the degree-`n` one for a committed divisor pair carrying a
   `Conway.Compatible` witness, instantiated at four such pairs.
-- The component lemmas needed to transport hex-conway's executable primitivity
-  check to the hypotheses of Mathlib's
-  `orderOf_eq_of_pow_and_pow_div_prime`.
+- `orderOf_gen_of_primitive`, which transports a hex-conway executable
+  primitivity certificate to the Mathlib statement that the Conway generator
+  has order `p ^ n - 1`, plus named specializations for all thirty-seven
+  committed nontrivial entries.
 
 The `Fintype` instances are deliberately `noncomputable`. The carriers have
 `p ^ degree f` elements, so a compiled `Finset.univ` over one is a footgun
@@ -81,8 +82,8 @@ examples.
 
 ## Primitivity transport
 
-`Primitivity.lean` supplies the lemmas needed to transport hex-conway's
-executable order check across `ofPolyHom`. The check runs on `FpPoly`
+`Primitivity.lean` transports hex-conway's executable order check across
+`ofPolyHom`. The check runs on `FpPoly`
 representatives with structural powers, while `orderOf` is about Mathlib's `^`
 in the field, so each ingredient travels separately: `ofPolyHom_linPowMod` and
 `ofPolyHom_digitPowMod` move the powers through `map_mul` and `map_pow`,
@@ -92,11 +93,11 @@ primality predicate, and `mem_of_prime_dvd_primePowerProduct` shows that a
 validated prime-power product lists every prime dividing it, so a short prime
 list cannot weaken the test.
 
-Two things are deliberately recorded as absent. No declaration here consumes a
-`Conway.Primitive` witness or produces the per-prime hypothesis function
-Mathlib's `orderOf_eq_of_pow_and_pow_div_prime` quantifies over, so the glue
-from `Primitive.check` to those hypotheses does not exist yet; and the
-per-entry `orderOf α = p ^ n - 1` conclusion is correspondingly not assembled.
+`orderOf_gen_of_primitive` unpacks the validated Boolean conjunctions, aligns
+each listed prime with its digit witness, transports both power conditions,
+and applies Mathlib's `orderOf_eq_of_pow_and_pow_div_prime`. The named
+`orderOf_gen_p_n` corollaries expose the resulting `orderOf α = p ^ n - 1`
+statement for every committed entry with `p ^ n > 2`.
 
 ## Namespaces
 


### PR DESCRIPTION
This PR assembles hex-conway's executable primitivity certificates into Mathlib's multiplicative-order vocabulary.

Closes #9500

## Summary

- unpack `Conway.Primitive.check` into Mathlib's full-order hypotheses
- prove `orderOf_gen_of_primitive` using the validated factorization and transported digit powers
- expose all 37 committed nontrivial generator-order corollaries and update package docs

## Verification

- `lake build HexGFqMathlib.Primitivity`
- `lake build`