### PR TITLE
feat(hex-conway): identify normX with the field norm

### DIFF
--- a/HexConway/Compatibility.lean
+++ b/HexConway/Compatibility.lean
@@ -10,6 +10,7 @@ public import HexConway.Api
 public import HexPolyFp.ModCompose
 public import HexPolyFp.Frobenius
 public import HexPolyFp.QuotientCompose
+public import HexPolyFp.QuotientFrobenius
 
 public section
 
@@ -53,27 +54,19 @@ modular multiplications, with `n ≤ 8` and `k ≤ 8`, rather than a modular
 exponentiation with a six-digit exponent. Everything below is structurally
 recursive for the same reason: the kernel has to run it.
 
-# What is proved, and what is design rationale
+# What is proved
 
-The two displayed identities above are why `normX` is defined
-the way it is. Neither is a theorem in this file. What is proved is that
-`C(p, m)` vanishes at the class of `normX`
-(`eval_conwayPoly_subfieldGen_eq_zero`), which is what a
-subfield embedding needs and what makes the degree-`m` subfield canonical.
+The two displayed identities above are theorems below. The reusable bridges
+are `FpPoly.Quotient.reduce_powModMonicLinear_eq_pow`, which identifies the
+structural modular power in the quotient, and
+`FpPoly.Quotient.Internal.eval_X_eq_reduce`, which says evaluation at the class
+of `x` is quotient reduction. Together with
+`FpPoly.Quotient.Internal.eval_pow_prime`, they show that every modular
+composition in `frobeniusIter` is a Frobenius step.
 
-Proving `normX = α ^ ((p^n - 1) / (p^m - 1))` outright needs the step this file
-takes on faith: that composing with `x^p mod f` computes the `p`-th power on
-residues. The heart of that step is now available as
-`FpPoly.Quotient.Internal.eval_pow_prime`, which says evaluation
-commutes with the Frobenius (`g(β^p) = g(β)^p`, by freshman's dream over the
-Horner sum with Fermat fixing each coefficient).
-
-Two mechanical bridges are still missing before it can be applied here: that
-`powModMonicLinear X f p` reduces to `X^p` in the quotient, and that evaluating
-a polynomial at the class of `x` returns the class of the polynomial. Both are
-list inductions of the same shape as `eval_pow_prime` itself. The same two
-bridges are what would let `HexConway.Primitivity`'s committed facts become a
-statement about `orderOf`.
+Consequently `normX_eq_pow` identifies the computed norm representative with
+the geometric-sum power in any quotient, and `subfieldGen_eq_norm` rewrites
+that exponent as `(p^n - 1) / (p^m - 1)` for `0 < m` and `m ∣ n`.
 -/
 
 namespace Hex
@@ -101,6 +94,13 @@ def frobeniusIter (f xp : FpPoly p) (hmonic : DensePoly.Monic f) :
   | 0, g => g
   | k + 1, g => frobeniusIter f xp hmonic k (FpPoly.composeModMonicImpl g xp f hmonic)
 
+/-- The exponent `1 + q + ⋯ + q^(k-1)`, in a structural-recursion spelling
+that follows the norm accumulator. -/
+@[expose]
+def normExponent (q : Nat) : Nat → Nat
+  | 0 => 0
+  | k + 1 => 1 + q * normExponent q k
+
 /-- The norm accumulator: multiply together `k` successive `p^m`-th powers of
 the residue of `x`, reducing modulo `f` at each step.
 
@@ -124,6 +124,130 @@ explicitly so that the recursion is structural. -/
 def normX (f : FpPoly p) (hmonic : DensePoly.Monic f) (m k : Nat) :
     FpPoly p :=
   normAux f (frobeniusBase f hmonic) hmonic m k 1 FpPoly.X
+
+/-! # The computed norm is the field norm -/
+
+/-- The executable Frobenius base represents the `p`-th power of the quotient
+indeterminate. -/
+theorem reduce_frobeniusBase_eq_pow
+    {f : FpPoly p} {hmonic : DensePoly.Monic f} {hf_pos : 0 < f.degree?.getD 0} :
+    FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+        (frobeniusBase f hmonic) =
+      (FpPoly.Quotient.X (g := f) (hmonic := hmonic) (hg_pos := hf_pos)) ^ p := by
+  exact FpPoly.Quotient.reduce_powModMonicLinear_eq_pow FpPoly.X p
+
+/-- Iterating executable modular composition `k` times represents raising a
+quotient element to `p^k`. -/
+theorem reduce_frobeniusIter_eq_pow
+    {f xp : FpPoly p} {hmonic : DensePoly.Monic f} {hf_pos : 0 < f.degree?.getD 0}
+    (hxp : FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) xp =
+      (FpPoly.Quotient.X (g := f) (hmonic := hmonic) (hg_pos := hf_pos)) ^ p) :
+    ∀ (k : Nat) (a : FpPoly p),
+      FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+          (frobeniusIter f xp hmonic k a) =
+        (FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) a) ^
+          (p ^ k)
+  | 0, a => by
+      change FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) a =
+        FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) a ^ 1
+      rw [show (1 : Nat) = 0 + 1 from rfl, FpPoly.Quotient.pow_succ,
+        FpPoly.Quotient.pow_zero,
+        FpPoly.Quotient.one_mul]
+  | k + 1, a => by
+      rw [frobeniusIter, reduce_frobeniusIter_eq_pow hxp k]
+      have hstep :
+          FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+              (FpPoly.composeModMonicImpl a xp f hmonic) =
+            (FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) a) ^ p := by
+        rw [← FpPoly.Quotient.eval_reduce_eq_reduce_composeModMonicImpl, hxp,
+          FpPoly.Quotient.Internal.eval_pow_prime,
+          FpPoly.Quotient.Internal.eval_X_eq_reduce]
+      rw [hstep, FpPoly.Quotient.pow_mul, Nat.pow_succ, Nat.mul_comm p]
+
+/-- The norm accumulator represents its initial accumulator multiplied by the
+geometric sequence of Frobenius powers of its initial current value. -/
+theorem reduce_normAux_eq_pow
+    {f : FpPoly p} {hmonic : DensePoly.Monic f} {hf_pos : 0 < f.degree?.getD 0}
+    (m : Nat) : ∀ (k : Nat) (acc cur : FpPoly p),
+      FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+          (normAux f (frobeniusBase f hmonic) hmonic m k acc cur) =
+        FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) acc *
+          (FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) cur) ^
+            normExponent (p ^ m) k
+  | 0, acc, cur => by
+      rw [normAux, normExponent, FpPoly.Quotient.pow_zero, FpPoly.Quotient.mul_one]
+  | k + 1, acc, cur => by
+      rw [normAux, reduce_normAux_eq_pow m k]
+      have hacc :
+          FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+              (FpPoly.modByMonic f (acc * cur) hmonic) =
+            FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+              (acc * cur) := by
+        apply FpPoly.Quotient.ext
+        simp [FpPoly.Quotient.reduce_val, FpPoly.modByMonic,
+          DensePoly.modByMonic_eq_mod]
+      rw [hacc, FpPoly.Quotient.reduce_mul,
+        reduce_frobeniusIter_eq_pow reduce_frobeniusBase_eq_pow,
+        FpPoly.Quotient.pow_mul]
+      change (_ * _) * _ = _ * _ ^ (1 + p ^ m * normExponent (p ^ m) k)
+      rw [FpPoly.Quotient.mul_assoc]
+      apply congrArg (fun z =>
+        FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos) acc * z)
+      calc
+        FpPoly.Quotient.reduce cur *
+              FpPoly.Quotient.reduce cur ^ (p ^ m * normExponent (p ^ m) k) =
+            FpPoly.Quotient.reduce cur ^ 1 *
+              FpPoly.Quotient.reduce cur ^ (p ^ m * normExponent (p ^ m) k) := by
+                congr 1
+                change _ = _ ^ (0 + 1)
+                rw [FpPoly.Quotient.pow_succ, FpPoly.Quotient.pow_zero,
+                  FpPoly.Quotient.one_mul]
+        _ = FpPoly.Quotient.reduce cur ^
+              (1 + p ^ m * normExponent (p ^ m) k) :=
+            (FpPoly.Quotient.pow_add _ _ _).symm
+
+/-- The quotient class of `normX` is the geometric-sum power of the quotient
+indeterminate. -/
+theorem normX_eq_pow
+    {f : FpPoly p} {hmonic : DensePoly.Monic f} {hf_pos : 0 < f.degree?.getD 0}
+    (m k : Nat) :
+    FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+        (normX f hmonic m k) =
+      (FpPoly.Quotient.X (g := f) (hmonic := hmonic) (hg_pos := hf_pos)) ^
+        normExponent (p ^ m) k := by
+  rw [normX, reduce_normAux_eq_pow]
+  change (1 : FpPoly.Quotient f hmonic hf_pos) * _ = _
+  rw [FpPoly.Quotient.one_mul,
+    show FpPoly.Quotient.reduce (g := f) (hmonic := hmonic) (hg_pos := hf_pos)
+        FpPoly.X = FpPoly.Quotient.X from rfl]
+
+/-- The structural geometric exponent is the usual geometric-series quotient. -/
+theorem normExponent_eq_div {q : Nat} (hq : 1 < q) (k : Nat) :
+    normExponent q k = (q ^ k - 1) / (q - 1) := by
+  have hpow : ∀ j : Nat, q ^ j = (q - 1) * normExponent q j + 1 := by
+    intro j
+    induction j with
+    | zero => simp [normExponent]
+    | succ j ih =>
+        rw [Nat.pow_succ, ih, normExponent]
+        have hqsub : q - 1 + 1 = q := Nat.sub_add_cancel (by omega)
+        calc
+          ((q - 1) * normExponent q j + 1) * q =
+              (q - 1) * (normExponent q j * q) + q := by
+                rw [Nat.add_mul, Nat.one_mul, Nat.mul_assoc]
+          _ = (q - 1) * (normExponent q j * q) + ((q - 1) + 1) := by rw [hqsub]
+          _ = (q - 1) * (normExponent q j * q) + (q - 1) + 1 := by
+                rw [Nat.add_assoc]
+          _ = (q - 1) * (normExponent q j * q) + (q - 1) * 1 + 1 := by
+                rw [Nat.mul_one]
+          _ = (q - 1) * (normExponent q j * q + 1) + 1 := by rw [Nat.mul_add]
+          _ = (q - 1) * (1 + q * normExponent q j) + 1 := by
+                rw [Nat.add_comm (normExponent q j * q) 1,
+                  Nat.mul_comm (normExponent q j) q]
+  have hsub : q ^ k - 1 = (q - 1) * normExponent q k := by
+    rw [hpow k, Nat.add_sub_cancel]
+  rw [hsub]
+  exact (Nat.mul_div_cancel_left (normExponent q k) (by omega)).symm
 
 /-- The Tier 2 compatibility check for a committed pair of entries: is the norm
 of `α` down to the degree-`m` subfield a root of `C(p, m)`?
@@ -179,6 +303,29 @@ def subfieldGen (p m n : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
       (conwayPoly_degree_pos p n hn) :=
   FpPoly.Quotient.reduce
     (normX (conwayPoly p n hn) (conwayPoly_monic p n hn) m (n / m))
+
+/-- The canonical subfield generator is the field norm of the ambient Conway
+generator.
+
+The positivity assumption excludes the meaningless degree-zero denominator;
+divisibility identifies `p ^ (m * (n / m))` with `p ^ n`. -/
+theorem subfieldGen_eq_norm
+    {p m n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (hn : SupportedEntry p n) (hm_pos : 0 < m) (hmn : m ∣ n) :
+    subfieldGen p m n hn =
+      (FpPoly.Quotient.X
+        (g := conwayPoly p n hn) (hmonic := conwayPoly_monic p n hn)
+        (hg_pos := conwayPoly_degree_pos p n hn)) ^
+          ((p ^ n - 1) / (p ^ m - 1)) := by
+  unfold subfieldGen
+  rw [normX_eq_pow]
+  have hp : 1 < p := by
+    have hp_two := (ZMod64.PrimeModulus.prime (p := p)).two_le
+    omega
+  rw [normExponent_eq_div (Nat.one_lt_pow (Nat.ne_of_gt hm_pos) hp)]
+  have hpow : (p ^ m) ^ (n / m) = p ^ n := by
+    rw [← Nat.pow_mul, Nat.mul_comm m, Nat.div_mul_cancel hmn]
+  rw [hpow]
 
 /--
 The subfield generator is a root of the smaller Conway polynomial.

--- a/HexConway/Compatibility.lean
+++ b/HexConway/Compatibility.lean
@@ -56,8 +56,9 @@ recursive for the same reason: the kernel has to run it.
 
 # What is proved
 
-The two displayed identities above are theorems below. The reusable bridges
-are `FpPoly.Quotient.reduce_powModMonicLinear_eq_pow`, which identifies the
+The norm and geometric-exponent identities in the first two displays are
+theorems below. The reusable bridges are
+`FpPoly.Quotient.reduce_powModMonicLinear_eq_pow`, which identifies the
 structural modular power in the quotient, and
 `FpPoly.Quotient.Internal.eval_X_eq_reduce`, which says evaluation at the class
 of `x` is quotient reduction. Together with
@@ -94,13 +95,6 @@ def frobeniusIter (f xp : FpPoly p) (hmonic : DensePoly.Monic f) :
   | 0, g => g
   | k + 1, g => frobeniusIter f xp hmonic k (FpPoly.composeModMonicImpl g xp f hmonic)
 
-/-- The exponent `1 + q + ⋯ + q^(k-1)`, in a structural-recursion spelling
-that follows the norm accumulator. -/
-@[expose]
-def normExponent (q : Nat) : Nat → Nat
-  | 0 => 0
-  | k + 1 => 1 + q * normExponent q k
-
 /-- The norm accumulator: multiply together `k` successive `p^m`-th powers of
 the residue of `x`, reducing modulo `f` at each step.
 
@@ -126,6 +120,12 @@ def normX (f : FpPoly p) (hmonic : DensePoly.Monic f) (m k : Nat) :
   normAux f (frobeniusBase f hmonic) hmonic m k 1 FpPoly.X
 
 /-! # The computed norm is the field norm -/
+
+/-- The exponent `1 + q + ⋯ + q^(k-1)`, in a structural-recursion spelling
+that follows the norm accumulator. -/
+def normExponent (q : Nat) : Nat → Nat
+  | 0 => 0
+  | k + 1 => 1 + q * normExponent q k
 
 /-- The executable Frobenius base represents the `p`-th power of the quotient
 indeterminate. -/
@@ -349,6 +349,26 @@ theorem eval_conwayPoly_subfieldGen_eq_zero
         (hg_pos := conwayPoly_degree_pos p n hn) := by
   apply FpPoly.Quotient.eval_reduce_eq_zero_of_composeModMonicImpl_eq_zero
   exact beq_iff_eq.mp hcompat
+
+/-- The explicit finite-field norm power is a root of the smaller Conway
+polynomial. -/
+theorem eval_norm_eq_zero
+    {p m n : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (hm : SupportedEntry p m) (hn : SupportedEntry p n)
+    (hcompat : Compatible p m n hm hn) (hm_pos : 0 < m) (hmn : m ∣ n) :
+    FpPoly.Quotient.Internal.eval
+        (g := conwayPoly p n hn) (hmonic := conwayPoly_monic p n hn)
+        (hg_pos := conwayPoly_degree_pos p n hn)
+        (conwayPoly p m hm)
+        ((FpPoly.Quotient.X
+          (g := conwayPoly p n hn) (hmonic := conwayPoly_monic p n hn)
+          (hg_pos := conwayPoly_degree_pos p n hn)) ^
+            ((p ^ n - 1) / (p ^ m - 1))) =
+      FpPoly.Quotient.zero (g := conwayPoly p n hn)
+        (hmonic := conwayPoly_monic p n hn)
+        (hg_pos := conwayPoly_degree_pos p n hn) := by
+  rw [← subfieldGen_eq_norm hn hm_pos hmn]
+  exact eval_conwayPoly_subfieldGen_eq_zero hm hn hcompat
 
 /-! # Towards the subfield embedding
 

--- a/HexConway/README.md
+++ b/HexConway/README.md
@@ -59,7 +59,9 @@ example : DensePoly.Monic f := conwayPoly_monic 3 4 supportedEntry_3_4
   `conwayPoly_nonconstant` and `conwayPoly_monic` are the facts a field
   construction needs.
 - `Compatible p m n hm hn` is the decidable divisor-compatibility statement,
-  computed by `compatCheck`. `subfieldGen` names the norm element it is about.
+  computed by `compatCheck`. `subfieldGen` names the norm element it is about,
+  and `subfieldGen_eq_norm` proves that it is
+  `X ^ ((p^n - 1) / (p^m - 1))` in the quotient.
 - `Primitive p n h qs es fullDigits perPrimeDigits` is primitivity, computed by
   `primitiveCheck`, which validates the supplied factorization of `p^n - 1`
   before running the two power conditions.

--- a/HexConway/SPEC/hex-conway.md
+++ b/HexConway/SPEC/hex-conway.md
@@ -145,7 +145,8 @@ geometric-series exponent in any quotient, and `subfieldGen_eq_norm` rewrites
 it to `(p^n - 1) / (p^m - 1)` for `0 < m` and `m ∣ n`. The reusable bridges
 are `FpPoly.Quotient.reduce_powModMonicLinear_eq_pow` for structural modular
 powers and `FpPoly.Quotient.Internal.eval_X_eq_reduce` for evaluation at the
-quotient class of `X`.
+quotient class of `X`. `eval_norm_eq_zero` then states directly that this
+explicit norm power is a root of `C(p, m)`.
 
 `eval_conwayPoly_subfieldGen_eq_zero` promotes the computation to a statement
 about field elements: `C(p, m)` evaluated at `subfieldGen`, an element of

--- a/HexConway/SPEC/hex-conway.md
+++ b/HexConway/SPEC/hex-conway.md
@@ -139,6 +139,14 @@ exponent is `1 + p^m + ... + p^((k-1)m)`, so the norm is a product of Frobenius
 images and each Frobenius step is a modular composition. The whole block costs
 seventeen seconds, against minutes for the Tier 1 certificates.
 
+The executable spelling and the displayed field formula are connected by
+theorems, not merely by the design of the checker. `normX_eq_pow` proves the
+geometric-series exponent in any quotient, and `subfieldGen_eq_norm` rewrites
+it to `(p^n - 1) / (p^m - 1)` for `0 < m` and `m ∣ n`. The reusable bridges
+are `FpPoly.Quotient.reduce_powModMonicLinear_eq_pow` for structural modular
+powers and `FpPoly.Quotient.Internal.eval_X_eq_reduce` for evaluation at the
+quotient class of `X`.
+
 `eval_conwayPoly_subfieldGen_eq_zero` promotes the computation to a statement
 about field elements: `C(p, m)` evaluated at `subfieldGen`, an element of
 `F_p[x] / (C(p, n))`, is zero. The promotion goes through

--- a/HexGFqMathlib/README.md
+++ b/HexGFqMathlib/README.md
@@ -120,12 +120,12 @@ noncomputable def conwayEmbed (p m n : Nat) [Hex.ZMod64.Bounds p]
 
 `normX` is a computed representative: the product of `n / m` successive
 Frobenius images of the residue of `x`, reduced at each step. Hex-conway's
-`subfieldGen_eq_norm` proves that its quotient class is the field norm
+`subfieldGen_eq_norm` proves that its quotient class is the explicit
+finite-field norm power
 `α ^ ((p^n - 1) / (p^m - 1))`. Here, `conwayEmbed_X` proves that the
 embedding sends the source generator to `conwayGen`, and
-`conwayGen_eq_norm` identifies that target with the same explicit power. Thus
-the canonicality claim is visible in theorem statements as well as in the
-committed compatibility checks.
+`conwayGen_eq_norm` identifies that target with the same explicit power;
+`conwayEmbed_X_eq_norm` combines them into the direct canonicality statement.
 
 The primitivity transport is assembled from `ofPolyHom_linPowMod`,
 `ofPolyHom_digitPowMod`, `ofPolyHom_eq_one_iff`, `mathlibPrime_of_hexPrime` and

--- a/HexGFqMathlib/README.md
+++ b/HexGFqMathlib/README.md
@@ -118,13 +118,14 @@ noncomputable def conwayEmbed (p m n : Nat) [Hex.ZMod64.Bounds p]
 `Conway.normX` reduces to zero, and `substHom_conwayPoly_eq_zero` promotes that
 `Bool` to the well-definedness input the embedding needs.
 
-Be clear about what `normX` is not. It is a computed representative, the
-product of `n / m` successive Frobenius images of the residue of `x`, reduced
-at each step. Reading it as the field norm `α ^ ((p^n - 1) / (p^m - 1))` is the
-design rationale for the definition, not a theorem proved here or in hex-conway,
-which is explicit that two evaluation and Frobenius bridges are missing first.
-Nothing in this package depends on that reading; the root property is what the
-embedding uses.
+`normX` is a computed representative: the product of `n / m` successive
+Frobenius images of the residue of `x`, reduced at each step. Hex-conway's
+`subfieldGen_eq_norm` proves that its quotient class is the field norm
+`α ^ ((p^n - 1) / (p^m - 1))`. Here, `conwayEmbed_X` proves that the
+embedding sends the source generator to `conwayGen`, and
+`conwayGen_eq_norm` identifies that target with the same explicit power. Thus
+the canonicality claim is visible in theorem statements as well as in the
+committed compatibility checks.
 
 The primitivity transport is assembled from `ofPolyHom_linPowMod`,
 `ofPolyHom_digitPowMod`, `ofPolyHom_eq_one_iff`, `mathlibPrime_of_hexPrime` and

--- a/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
+++ b/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
@@ -61,10 +61,10 @@ hypotheses on the equivalence rather than on the field type.
 `Conway.normX` is a computed representative: the product of `k = n / m`
 successive Frobenius images of the residue of `x`, reduced modulo `C(p, n)` at
 each step, structured that way so the kernel can replay it.
-`Conway.subfieldGen_eq_norm` proves that its quotient class is the field norm
-`α ^ ((p^n - 1) / (p^m - 1))`; `eval_conwayPoly_subfieldGen_eq_zero` proves
-that `C(p, m)` vanishes there, which is the well-definedness input the embedding
-needs.
+`Conway.subfieldGen_eq_norm` proves that its quotient class is the explicit
+finite-field norm power `α ^ ((p^n - 1) / (p^m - 1))`;
+`eval_conwayPoly_subfieldGen_eq_zero` proves that `C(p, m)` vanishes there,
+which is the well-definedness input the embedding needs.
 
 `conwayEmbed` is the resulting ring homomorphism `GFq p m →+* GFq p n`. Its
 domain is a committed divisor pair carrying a `Conway.Compatible` witness
@@ -79,8 +79,10 @@ examples.
 
 The canonicality statement is exposed directly. `conwayEmbed_X` says that
 `conwayEmbed` sends the source class of `X` to `conwayGen`, while
-`conwayGen_eq_norm` identifies `conwayGen` with the explicit field-norm power
-of the target class of `X` whenever `0 < m` and `m ∣ n`.
+`conwayGen_eq_norm` identifies `conwayGen` with the explicit finite-field norm
+power of the target class of `X`. `conwayEmbed_X_eq_norm` combines these into
+one theorem for a divisor pair; positivity of `m` follows from the source's
+committed entry.
 
 ## Primitivity transport
 

--- a/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
+++ b/HexGFqMathlib/SPEC/hex-gfq-mathlib.md
@@ -60,13 +60,10 @@ hypotheses on the equivalence rather than on the field type.
 `Subfield.lean` defines the map hex-conway's Tier 2 evidence licenses.
 `Conway.normX` is a computed representative: the product of `k = n / m`
 successive Frobenius images of the residue of `x`, reduced modulo `C(p, n)` at
-each step, structured that way so the kernel can replay it. Reading it as the
-field norm `α ^ ((p^n - 1) / (p^m - 1))` is the design rationale for the
-definition, not a theorem; hex-conway is explicit that two evaluation and
-Frobenius bridges are missing before that identity can be proved, so this SPEC
-does not lean on it. What compatibility does prove, in
-`eval_conwayPoly_subfieldGen_eq_zero`, is that `C(p, m)` vanishes at the class
-of `normX`, and that root property is the well-definedness input the embedding
+each step, structured that way so the kernel can replay it.
+`Conway.subfieldGen_eq_norm` proves that its quotient class is the field norm
+`α ^ ((p^n - 1) / (p^m - 1))`; `eval_conwayPoly_subfieldGen_eq_zero` proves
+that `C(p, m)` vanishes there, which is the well-definedness input the embedding
 needs.
 
 `conwayEmbed` is the resulting ring homomorphism `GFq p m →+* GFq p n`. Its
@@ -79,6 +76,11 @@ Hex side has to supply is that the executable substitution agrees with it,
 which is additive and monomial data. `GF(2^2)` and `GF(2^3)` inside `GF(2^6)`,
 `GF(13)` inside `GF(13^6)`, and `GF(2^4)` inside `GF(2^8)` are checked here as
 examples.
+
+The canonicality statement is exposed directly. `conwayEmbed_X` says that
+`conwayEmbed` sends the source class of `X` to `conwayGen`, while
+`conwayGen_eq_norm` identifies `conwayGen` with the explicit field-norm power
+of the target class of `X` whenever `0 < m` and `m ∣ n`.
 
 ## Primitivity transport
 

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -230,6 +230,12 @@ section Conway
 
 variable {m n : Nat}
 
+/-- The class of `X` in the Conway presentation of `GFq p n`. -/
+noncomputable def conwayX (p n : Nat) [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p] (hn : Hex.Conway.SupportedEntry p n) :
+    Hex.GFq p n hn :=
+  ofPolyHom _ _ _ _ Hex.FpPoly.X
+
 /-- The norm element of `GFq p n`, as a field element rather than a
 representative: where the generator of the degree-`m` subfield goes. -/
 noncomputable def conwayGen (p m n : Nat) [Hex.ZMod64.Bounds p]
@@ -238,6 +244,34 @@ noncomputable def conwayGen (p m n : Nat) [Hex.ZMod64.Bounds p]
   ofPolyHom _ _ _ _
     (Hex.Conway.normX (Hex.Conway.conwayPoly p n hn)
       (Hex.Conway.conwayPoly_monic p n hn) m (n / m))
+
+/-- The computed Conway subfield generator is the field norm of the ambient
+generator. -/
+theorem conwayGen_eq_norm (p : Nat) [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p] (hn : Hex.Conway.SupportedEntry p n)
+    (hm_pos : 0 < m) (hmn : m ∣ n) :
+    conwayGen p m n hn =
+      (conwayX p n hn) ^ ((p ^ n - 1) / (p ^ m - 1)) := by
+  unfold conwayGen conwayX
+  rw [← map_pow, ← HexPolyFpMathlib.linearPow_eq_pow]
+  apply (Hex.GFq.ofPoly_eq_ofPoly_iff_reduceMod_eq hn _ _).2
+  have hnorm := Hex.Conway.subfieldGen_eq_norm hn hm_pos hmn
+  unfold Hex.Conway.subfieldGen at hnorm
+  have hpow := Hex.FpPoly.Quotient.reduce_linearPow_eq_pow
+    (g := Hex.Conway.conwayPoly p n hn)
+    (hmonic := Hex.Conway.conwayPoly_monic p n hn)
+    (hg_pos := Hex.Conway.conwayPoly_degree_pos p n hn)
+    Hex.FpPoly.X ((p ^ n - 1) / (p ^ m - 1))
+  have hval := congrArg Hex.FpPoly.Quotient.val (hnorm.trans hpow.symm)
+  simp only [Hex.FpPoly.Quotient.reduce_val] at hval
+  have hred (g : Hex.FpPoly p) :
+      Hex.GFqRing.reduceMod (Hex.Conway.conwayPoly p n hn) g =
+        Hex.FpPoly.modByMonic (Hex.Conway.conwayPoly p n hn) g
+          (Hex.Conway.conwayPoly_monic p n hn) := by
+    rw [Hex.FpPoly.modByMonic, Hex.DensePoly.modByMonic_eq_mod]
+    rfl
+  rw [hred, hred]
+  exact hval
 
 /-- Substituting the norm element kills the smaller Conway polynomial.
 
@@ -328,6 +362,21 @@ noncomputable def conwayEmbed (p m n : Nat) [Hex.ZMod64.Bounds p]
     show substHom _ _ _ _ _ (Hex.GFqField.repr (a * b)) = _
     rw [Hex.GFqField.repr_mul, substHom_reduceMod _ _
       (substHom_conwayPoly_eq_zero p hm hn hcompat), map_mul]
+
+/-- The Conway embedding sends the source generator to the computed subfield
+generator. Together with {name}`conwayGen_eq_norm`, this identifies its image
+with the field norm in the target. -/
+theorem conwayEmbed_X (p : Nat) [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p]
+    (hm : Hex.Conway.SupportedEntry p m) (hn : Hex.Conway.SupportedEntry p n)
+    (hcompat : Hex.Conway.Compatible p m n hm hn) :
+    conwayEmbed p m n hm hn hcompat (conwayX p m hm) = conwayGen p m n hn := by
+  unfold conwayEmbed conwayX conwayGen
+  change substHom _ _ _ _ _ (Hex.GFqField.repr (ofPolyHom _ _ _ _ Hex.FpPoly.X)) =
+    ofPolyHom _ _ _ _ _
+  rw [ofPolyHom_apply, Hex.GFqField.repr_ofPoly, substHom_reduceMod _ _
+    (substHom_conwayPoly_eq_zero p hm hn hcompat), substHom_apply,
+    Hex.FpPoly.compose_X]
 
 /-! # The embedding on committed entries
 

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -245,8 +245,8 @@ noncomputable def conwayGen (p m n : Nat) [Hex.ZMod64.Bounds p]
     (Hex.Conway.normX (Hex.Conway.conwayPoly p n hn)
       (Hex.Conway.conwayPoly_monic p n hn) m (n / m))
 
-/-- The computed Conway subfield generator is the field norm of the ambient
-generator. -/
+/-- The computed Conway subfield generator is the explicit finite-field norm
+power of the ambient class of `X`. -/
 theorem conwayGen_eq_norm (p : Nat) [Hex.ZMod64.Bounds p]
     [Hex.ZMod64.PrimeModulus p] (hn : Hex.Conway.SupportedEntry p n)
     (hm_pos : 0 < m) (hmn : m ∣ n) :
@@ -363,9 +363,9 @@ noncomputable def conwayEmbed (p m n : Nat) [Hex.ZMod64.Bounds p]
     rw [Hex.GFqField.repr_mul, substHom_reduceMod _ _
       (substHom_conwayPoly_eq_zero p hm hn hcompat), map_mul]
 
-/-- The Conway embedding sends the source generator to the computed subfield
+/-- The Conway embedding sends the source class of `X` to the computed subfield
 generator. Together with {name}`conwayGen_eq_norm`, this identifies its image
-with the field norm in the target. -/
+with the finite-field norm power in the target. -/
 theorem conwayEmbed_X (p : Nat) [Hex.ZMod64.Bounds p]
     [Hex.ZMod64.PrimeModulus p]
     (hm : Hex.Conway.SupportedEntry p m) (hn : Hex.Conway.SupportedEntry p n)
@@ -377,6 +377,19 @@ theorem conwayEmbed_X (p : Nat) [Hex.ZMod64.Bounds p]
   rw [ofPolyHom_apply, Hex.GFqField.repr_ofPoly, substHom_reduceMod _ _
     (substHom_conwayPoly_eq_zero p hm hn hcompat), substHom_apply,
     Hex.FpPoly.compose_X]
+
+/-- The Conway embedding sends the source class of `X` directly to the
+explicit finite-field norm power of the target class of `X`. -/
+theorem conwayEmbed_X_eq_norm (p : Nat) [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p]
+    (hm : Hex.Conway.SupportedEntry p m) (hn : Hex.Conway.SupportedEntry p n)
+    (hcompat : Hex.Conway.Compatible p m n hm hn) (hmn : m ∣ n) :
+    conwayEmbed p m n hm hn hcompat (conwayX p m hm) =
+      (conwayX p n hn) ^ ((p ^ n - 1) / (p ^ m - 1)) := by
+  have hm_pos : 0 < m := by
+    rw [← GFq.conwayPoly_degree hm]
+    exact Hex.Conway.conwayPoly_nonconstant p m hm
+  exact (conwayEmbed_X p hm hn hcompat).trans (conwayGen_eq_norm p hn hm_pos hmn)
 
 /-! # The embedding on committed entries
 

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -1009,6 +1009,15 @@ private theorem composeCoeffPowerSumUpTo_self_X_eq_self
     rw [if_neg (by intro ⟨_, h⟩; omega : ¬ (0 ≤ k ∧ k < 0 + w.size))]
     exact (DensePoly.coeff_eq_zero_of_size_le w hk').symm
 
+/-- Substituting the polynomial indeterminate into `w` returns `w`.
+
+Together with {name}`Hex.FpPoly.compose_X`, this says that `FpPoly.X` is the
+two-sided identity for polynomial composition. -/
+@[simp, grind =] theorem compose_X_right [ZMod64.PrimeModulus p] (w : FpPoly p) :
+    DensePoly.compose w FpPoly.X = w := by
+  rw [compose_eq_coeff_power_sum_upTo_size w FpPoly.X,
+    composeCoeffPowerSumUpTo_self_X_eq_self]
+
 /-- Compose-form Frobenius: substituting `linearPow X p` for {name}`X` in `w`
 yields `linearPow w p`, over `F_p`. This is Freshman's dream packaged
 through the polynomial composition surface: viewed as

--- a/HexPolyFp/QuotientCompose.lean
+++ b/HexPolyFp/QuotientCompose.lean
@@ -122,7 +122,7 @@ class.
 
 This is the quotient evaluation map's defining property, stated for the
 project-side evaluator and executable reduction used by Conway compatibility. -/
-@[simp, grind =] theorem Internal.eval_X_eq_reduce (f : FpPoly p) :
+theorem Internal.eval_X_eq_reduce (f : FpPoly p) :
     Internal.eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f
         (X (g := g) (hmonic := hmonic) (hg_pos := hg_pos)) =
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f := by

--- a/HexPolyFp/QuotientCompose.lean
+++ b/HexPolyFp/QuotientCompose.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexPolyFp.Compose
 public import HexPolyFp.ModCompose
 public import HexPolyFp.Quotient
 
@@ -115,6 +116,22 @@ theorem eval_reduce_eq_reduce_composeModMonicImpl (f b : FpPoly p) :
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (composeModMonicImpl f b g hmonic) := by
   rw [eval_reduce_eq_reduce_composeModMonic, composeModMonic_eq_composeModMonicImpl]
+
+/-- Evaluating a polynomial at the quotient class of `X` returns its quotient
+class.
+
+This is the quotient evaluation map's defining property, stated for the
+project-side evaluator and executable reduction used by Conway compatibility. -/
+@[simp, grind =] theorem Internal.eval_X_eq_reduce (f : FpPoly p) :
+    Internal.eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f
+        (X (g := g) (hmonic := hmonic) (hg_pos := hg_pos)) =
+      reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f := by
+  rw [show X (g := g) (hmonic := hmonic) (hg_pos := hg_pos) =
+      reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) FpPoly.X from rfl,
+    eval_reduce_eq_reduce_composeModMonic,
+    composeModMonic_eq_modByMonic_compose, FpPoly.compose_X_right]
+  apply ext
+  simp [reduce_val, FpPoly.modByMonic, DensePoly.modByMonic_eq_mod]
 
 /--
 A vanishing modular composition says the polynomial has the class of `b` as a

--- a/HexPolyFp/QuotientFrobenius.lean
+++ b/HexPolyFp/QuotientFrobenius.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexPolyFp.Quotient
+public import HexPolyFp.Frobenius
 public import HexPolyFp.SquareFree
 
 public section
@@ -75,6 +76,22 @@ theorem pow_eq_reduce_linearPow (a : Quotient g hmonic hg_pos) (n : Nat) :
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (FpPoly.linearPow a.val n) := by
   rw [reduce_linearPow_eq_pow, reduce_val_self]
+
+/-- Structural modular exponentiation represents ordinary powering in the
+quotient.
+
+The executable loop reduces after every multiplication; quotient reduction
+forgets those intermediate choices and returns the power of the base class. -/
+theorem reduce_powModMonicLinear_eq_pow (base : FpPoly p) (n : Nat) :
+    reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
+        (FpPoly.powModMonicLinear base g hmonic n) =
+      (reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) base) ^ n := by
+  rw [← reduce_linearPow_eq_pow]
+  apply ext
+  rw [reduce_val, reduce_val, FpPoly.modByMonic, FpPoly.modByMonic,
+    DensePoly.modByMonic_eq_mod, DensePoly.modByMonic_eq_mod,
+    FpPoly.powModMonicLinear_eq_powModMonic,
+    FpPoly.powModMonic_mod_eq_linearPow]
 
 /-- Freshman's dream on the quotient (prime case): raising a sum to the
 characteristic distributes additively. -/

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -898,5 +898,23 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "2cea1c0addfba1a78d74b905e0297eb1f3441778",
     "reason": "Moves the existing HexModular.LoopTests module from the public library umbrella into the build-only HexMvFactorizationTests verification target; no factorization runtime definition, executable, build flag, or dependency changes."
+  },
+  {
+    "path": "HexPolyFp/Compose.lean",
+    "baseline_blob": "5f2ddb7456186793f29a6187c490c3e7dea90686",
+    "current_blob": "79fe5d281f3009f42744ff252d82ec2d47ee2ccf",
+    "reason": "Adds only a theorem that X is the right identity for polynomial composition; no executable definition or factorization runtime call path changes."
+  },
+  {
+    "path": "HexPolyFp/QuotientCompose.lean",
+    "baseline_blob": "48cd72f73100465311303e0a6ab1e34f6fcfdf63",
+    "current_blob": "9641f1d1c9b112dcdcff9cf9c999b721982729e6",
+    "reason": "Adds an import and a quotient-evaluation theorem only; no executable definition or factorization runtime call path changes."
+  },
+  {
+    "path": "HexPolyFp/QuotientFrobenius.lean",
+    "baseline_blob": "dc13ffdd544ac3037114ffba1000eddd09ecde90",
+    "current_blob": "cbef5cd34b581e312d21c2f76da11d6989b2aa6a",
+    "reason": "Adds an import and a quotient-power theorem only; no executable definition or factorization runtime call path changes."
   }
 ]


### PR DESCRIPTION
Closes #9501.

## Summary
- prove structural modular powers and evaluation at the quotient class of `X` agree with quotient powering/reduction
- identify `normX` and `subfieldGen` with the explicit field-norm exponent
- expose the Mathlib-facing generator image and norm theorems for `conwayEmbed`
- update the HexConway and HexGFqMathlib specs/readmes to reflect the proved identity

## Verification
- `lake build` (9,972 jobs)