### PR TITLE
feat(poly-fp): complete Mathlib transport surface

### DIFF
--- a/HexBerlekampMathlib/FactorPoly.lean
+++ b/HexBerlekampMathlib/FactorPoly.lean
@@ -51,14 +51,6 @@ variable {p : Nat} [Hex.ZMod64.Bounds p]
 theorem nat_prime_of_hex {p : Nat} (hp : Hex.Nat.Prime p) : Nat.Prime p :=
   Nat.prime_def.mpr ⟨hp.1, hp.2⟩
 
-/-- The executable constant `1` transports to the Mathlib constant `1`.
-(`map_one` through `fpPolyEquiv` needs a `MulOneClass` instance `FpPoly` does
-not carry, so this is proved through `DensePoly.C`.) -/
-theorem toMathlibPolynomial_one :
-    toMathlibPolynomial (1 : Hex.FpPoly p) = 1 := by
-  have h : (1 : Hex.FpPoly p) = Hex.DensePoly.C 1 := rfl
-  rw [h, toMathlibPolynomial_C, HexModArithMathlib.ZMod64.toZMod_one, Polynomial.C_1]
-
 /-- List products commute with the finite-field polynomial transport. -/
 theorem toMathlibPolynomial_listProd (l : List (Hex.FpPoly p)) :
     toMathlibPolynomial l.prod = (l.map toMathlibPolynomial).prod := by

--- a/HexBerlekampMathlib/FactorPoly.lean
+++ b/HexBerlekampMathlib/FactorPoly.lean
@@ -59,20 +59,6 @@ theorem toMathlibPolynomial_one :
   have h : (1 : Hex.FpPoly p) = Hex.DensePoly.C 1 := rfl
   rw [h, toMathlibPolynomial_C, HexModArithMathlib.ZMod64.toZMod_one, Polynomial.C_1]
 
-/-- Negation commutes with the finite-field polynomial transport. -/
-theorem toMathlibPolynomial_neg (f : Hex.FpPoly p) :
-    toMathlibPolynomial (-f) = -toMathlibPolynomial f := by
-  apply Polynomial.ext
-  intro n
-  rw [Polynomial.coeff_neg, coeff_toMathlibPolynomial, coeff_toMathlibPolynomial,
-    Hex.DensePoly.coeff_neg f n (by show (0 : Hex.ZMod64 p) - 0 = 0; grind),
-    HexModArithMathlib.ZMod64.toZMod_sub]
-  calc HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) -
-        HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n)
-      = 0 - HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := by
-        rw [HexModArithMathlib.ZMod64.toZMod_zero]
-    _ = -HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := zero_sub _
-
 /-- List products commute with the finite-field polynomial transport. -/
 theorem toMathlibPolynomial_listProd (l : List (Hex.FpPoly p)) :
     toMathlibPolynomial l.prod = (l.map toMathlibPolynomial).prod := by

--- a/HexBerlekampMathlib/Irreducibility.lean
+++ b/HexBerlekampMathlib/Irreducibility.lean
@@ -37,63 +37,26 @@ open Polynomial
 -- sites spelling these `HexBerlekampMathlib.foo` keep resolving.
 export HexPolyFpMathlib (fpPolyToPolynomial polynomialToFpPoly
   coeff_fpPolyToPolynomial fpPolyEquiv toMathlibPolynomial fpPolyEquiv_apply
-  fpPolyEquiv_symm_apply coeff_toMathlibPolynomial
+  fpPolyEquiv_symm_apply coeff_toMathlibPolynomial coeff_polynomialToFpPoly
+  natDegree_toMathlibPolynomial leadingCoeff_toMathlibPolynomial
   toMathlibPolynomial_monic toMathlibPolynomial_derivative toMathlibPolynomial_mul
-  toMathlibPolynomial_add toMathlibPolynomial_sub toMathlibPolynomial_C
+  toMathlibPolynomial_add toMathlibPolynomial_sub toMathlibPolynomial_neg
+  toMathlibPolynomial_C toMathlibPolynomial_monomial
   toMathlibPolynomial_monomial_one toMathlibPolynomial_X toMathlibPolynomial_dvd
-  primeModulus_of_fact)
+  toMathlibPolynomial_dvd_iff eval₂_toMathlibPolynomial
+  polynomialToFpPoly_zero polynomialToFpPoly_one polynomialToFpPoly_C
+  polynomialToFpPoly_neg polynomialToFpPoly_sub polynomialToFpPoly_add
+  polynomialToFpPoly_monomial toMathlibPolynomial_compose primeModulus_of_fact)
 
 variable {p : Nat} [Hex.ZMod64.Bounds p]
 
 /-- The executable Berlekamp basis size is the Mathlib natural degree after
-transport. Requires `Nontrivial (ZMod p)`: over a trivial `ZMod p` the
-transport collapses to `0` while `basisSize` can be positive (e.g. `p = 1`,
-`f = X`). -/
-theorem natDegree_toMathlibPolynomial_eq_basisSize
-    [Nontrivial (ZMod p)]
-    (f : Hex.FpPoly p) (hmonic : Hex.DensePoly.Monic f) :
+transport. This is the algorithm-facing specialization of the representation
+theorem `natDegree_toMathlibPolynomial`. -/
+theorem natDegree_toMathlibPolynomial_eq_basisSize (f : Hex.FpPoly p) :
     (toMathlibPolynomial f).natDegree = Hex.Berlekamp.basisSize f := by
-  -- Monicity plus nontriviality forces the leading coefficient `1 ≠ 0`, so the
-  -- polynomial is nonzero and `f.size > 0`.
-  have hsize_pos : 0 < f.size := by
-    rcases Nat.eq_zero_or_pos f.size with h0 | hpos
-    · exfalso
-      have hf0 : f = 0 := by
-        apply Hex.DensePoly.ext_coeff
-        intro n
-        rw [Hex.DensePoly.coeff_zero]
-        exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
-      have h1 : f.leadingCoeff = 1 :=
-        Hex.DensePoly.leadingCoeff_eq_one_of_monic hmonic
-      rw [hf0, Hex.DensePoly.leadingCoeff_zero] at h1
-      -- `h1 : (0 : ZMod64 p) = 1`; transport to `ZMod p` to contradict
-      -- `Nontrivial`.
-      have hz : (0 : ZMod p) = (1 : ZMod p) := by
-        calc (0 : ZMod p)
-            = HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) :=
-              HexModArithMathlib.ZMod64.toZMod_zero.symm
-          _ = HexModArithMathlib.ZMod64.toZMod (1 : Hex.ZMod64 p) :=
-              congrArg _ h1
-          _ = (1 : ZMod p) := HexModArithMathlib.ZMod64.toZMod_one
-      exact one_ne_zero hz.symm
-    · exact hpos
-  have hlc : f.coeff (f.size - 1) = 1 := by
-    rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last f hsize_pos]
-    exact hmonic
-  have hcoeff_one : (toMathlibPolynomial f).coeff (f.size - 1) = 1 := by
-    rw [coeff_toMathlibPolynomial, hlc]
-    exact HexModArithMathlib.ZMod64.toZMod_one
-  have hub : (toMathlibPolynomial f).natDegree ≤ f.size - 1 := by
-    refine Polynomial.natDegree_le_iff_coeff_eq_zero.mpr ?_
-    intro N hN
-    rw [coeff_toMathlibPolynomial,
-      Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)]
-    exact HexModArithMathlib.ZMod64.toZMod_zero
-  have hlb : f.size - 1 ≤ (toMathlibPolynomial f).natDegree :=
-    Polynomial.le_natDegree_of_ne_zero (by rw [hcoeff_one]; exact one_ne_zero)
-  rw [le_antisymm hub hlb]
-  unfold Hex.Berlekamp.basisSize Hex.DensePoly.degree?
-  simp [Nat.ne_of_gt hsize_pos]
+  rw [natDegree_toMathlibPolynomial]
+  rfl
 
 /-- An executable unit polynomial (a nonzero constant) transports to a Mathlib
 unit. -/
@@ -429,22 +392,10 @@ theorem rabinTest_true_of_mathlib_checks
     · exact Or.inr h
   haveI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hp_hex
   obtain ⟨hn_pos, hdvd, hcoprime⟩ := hchecks
-  -- Transport executable divisibility along the ring iso, in both directions.
-  have transport : ∀ {a b : Hex.FpPoly p}, a ∣ b →
-      toMathlibPolynomial a ∣ toMathlibPolynomial b := by
-    rintro a b ⟨r, hr⟩
-    exact ⟨toMathlibPolynomial r, by rw [hr]; exact map_mul fpPolyEquiv a r⟩
-  have untransport : ∀ {a b : Hex.FpPoly p},
-      toMathlibPolynomial a ∣ toMathlibPolynomial b → a ∣ b := by
-    rintro a b ⟨R, hR⟩
-    refine ⟨fpPolyEquiv.symm R, ?_⟩
-    apply fpPolyEquiv.injective
-    rw [map_mul, fpPolyEquiv.apply_symm_apply]
-    exact hR
   rw [Hex.Berlekamp.rabinTest_eq_true_iff]
   refine ⟨by rw [hdegree]; exact hn_pos, ?_, ?_⟩
   · -- Divisibility leg: untransport `M f ∣ frobeniusPolynomial p n` to `f ∣ xPowSubX n`.
-    apply untransport
+    apply toMathlibPolynomial_dvd_iff.mp
     rw [toMathlibPolynomial_xPowSubX, hdegree]
     exact hdvd
   · -- Coprimality leg: each maximal-proper-divisor witness is accepted.
@@ -468,11 +419,11 @@ theorem rabinTest_true_of_mathlib_checks
           Hex.Berlekamp.xPowSubX (p := p) d :=
       Hex.Berlekamp.dvd_xPowSubX_of_dvd_frobeniusDiffMod hmonic hg_dvd_f hg_dvd_diff
     -- Transport the two divisibilities and read off a Bezout combination of `1`.
-    have hMg_dvd_Mf := transport hg_dvd_f
+    have hMg_dvd_Mf := toMathlibPolynomial_dvd hg_dvd_f
     have hMg_dvd_frob :
         toMathlibPolynomial (Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d)) ∣
           frobeniusPolynomial p d := by
-      have h := transport hg_dvd_xpow
+      have h := toMathlibPolynomial_dvd hg_dvd_xpow
       rwa [toMathlibPolynomial_xPowSubX] at h
     obtain ⟨u, v, huv⟩ := hcop_d
     have hMg_dvd_one :
@@ -491,7 +442,7 @@ theorem rabinTest_true_of_mathlib_checks
       · rw [if_neg hm, if_neg hm]; exact HexModArithMathlib.ZMod64.toZMod_zero
     have hg_dvd_one :
         Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d) ∣ (1 : Hex.FpPoly p) := by
-      apply untransport
+      apply toMathlibPolynomial_dvd_iff.mp
       rw [h_one]
       exact hMg_dvd_one
     exact Hex.Berlekamp.isUnitPolynomial_of_dvd_isUnitPolynomial hg_dvd_one
@@ -519,33 +470,20 @@ theorem toMathlibPolynomial_gcd_associated
     · exact Or.inl h
     · exact Or.inr h
   haveI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hp_hex
-  -- The executable `∣` is custom (`∃ r, b = a * r`), so transport it through the
-  -- iso by destructuring and re-multiplying rather than via `map_dvd`.
-  have transport : ∀ {a b : Hex.FpPoly p}, a ∣ b →
-      toMathlibPolynomial a ∣ toMathlibPolynomial b := by
-    rintro a b ⟨r, hr⟩
-    exact ⟨toMathlibPolynomial r, by rw [hr]; exact map_mul fpPolyEquiv a r⟩
-  have untransport : ∀ {a b : Hex.FpPoly p},
-      toMathlibPolynomial a ∣ toMathlibPolynomial b → a ∣ b := by
-    rintro a b ⟨R, hR⟩
-    refine ⟨fpPolyEquiv.symm R, ?_⟩
-    apply fpPolyEquiv.injective
-    rw [map_mul, fpPolyEquiv.apply_symm_apply]
-    exact hR
   apply associated_of_dvd_dvd
-  · exact dvd_gcd (transport (Hex.DensePoly.gcd_dvd_left f g))
-      (transport (Hex.DensePoly.gcd_dvd_right f g))
+  · exact dvd_gcd (toMathlibPolynomial_dvd (Hex.DensePoly.gcd_dvd_left f g))
+      (toMathlibPolynomial_dvd (Hex.DensePoly.gcd_dvd_right f g))
   · set d : Hex.FpPoly p :=
       fpPolyEquiv.symm (gcd (toMathlibPolynomial f) (toMathlibPolynomial g)) with hd
     have hsymm :
         toMathlibPolynomial d = gcd (toMathlibPolynomial f) (toMathlibPolynomial g) := by
       rw [hd]; exact fpPolyEquiv.apply_symm_apply _
     have hdf : d ∣ f := by
-      apply untransport; rw [hsymm]; exact gcd_dvd_left _ _
+      apply toMathlibPolynomial_dvd_iff.mp; rw [hsymm]; exact gcd_dvd_left _ _
     have hdg : d ∣ g := by
-      apply untransport; rw [hsymm]; exact gcd_dvd_right _ _
+      apply toMathlibPolynomial_dvd_iff.mp; rw [hsymm]; exact gcd_dvd_right _ _
     rw [← hsymm]
-    exact transport (Hex.DensePoly.dvd_gcd d f g hdf hdg)
+    exact toMathlibPolynomial_dvd (Hex.DensePoly.dvd_gcd d f g hdf hdg)
 
 /--
 Executable gcd transfers to Mathlib's gcd after coefficient transport, up to
@@ -785,7 +723,7 @@ theorem rabinTest_true_irreducible
     Rabin.rabinTest_true_to_mathlib_checks f hmonic rfl htest
   have hfM_monic : fM.Monic := toMathlibPolynomial_monic f hmonic
   have hfM_natDegree : fM.natDegree = n :=
-    natDegree_toMathlibPolynomial_eq_basisSize f hmonic
+    natDegree_toMathlibPolynomial_eq_basisSize f
   have hfM_pos : 0 < fM.natDegree := hfM_natDegree.symm ▸ hpos
   refine ⟨fun hunit => by
     have := Polynomial.natDegree_eq_zero_of_isUnit hunit
@@ -842,7 +780,7 @@ theorem rabin_irreducible
     set fM := toMathlibPolynomial f
     have hfM_monic : fM.Monic := toMathlibPolynomial_monic f hmonic
     have hfM_natDegree : fM.natDegree = n := by
-      simpa [fM, hdegree] using natDegree_toMathlibPolynomial_eq_basisSize f hmonic
+      simpa [fM, hdegree] using natDegree_toMathlibPolynomial_eq_basisSize f
     have hn_pos : 0 < n := by
       have hpos : 0 < fM.natDegree :=
         hfM_monic.natDegree_pos_of_not_isUnit hirr.not_isUnit

--- a/HexBerlekampMathlib/Irreducibility.lean
+++ b/HexBerlekampMathlib/Irreducibility.lean
@@ -41,11 +41,12 @@ export HexPolyFpMathlib (fpPolyToPolynomial polynomialToFpPoly
   natDegree_toMathlibPolynomial leadingCoeff_toMathlibPolynomial
   toMathlibPolynomial_monic toMathlibPolynomial_derivative toMathlibPolynomial_mul
   toMathlibPolynomial_add toMathlibPolynomial_sub toMathlibPolynomial_neg
+  toMathlibPolynomial_zero toMathlibPolynomial_one toMathlibPolynomial_pow
   toMathlibPolynomial_C toMathlibPolynomial_monomial
   toMathlibPolynomial_monomial_one toMathlibPolynomial_X toMathlibPolynomial_dvd
   toMathlibPolynomial_dvd_iff eval₂_toMathlibPolynomial
   polynomialToFpPoly_zero polynomialToFpPoly_one polynomialToFpPoly_C
-  polynomialToFpPoly_neg polynomialToFpPoly_sub polynomialToFpPoly_add
+  polynomialToFpPoly_neg polynomialToFpPoly_sub polynomialToFpPoly_add polynomialToFpPoly_mul
   polynomialToFpPoly_monomial toMathlibPolynomial_compose primeModulus_of_fact)
 
 variable {p : Nat} [Hex.ZMod64.Bounds p]

--- a/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
@@ -107,18 +107,12 @@ private theorem natDegree_toMathlibPolynomial_factorPolys_eq
   letI := primeData.bounds
   have hpair :=
     checkCertAtFactor_of_checkFactorCerts primeData hcheck i hi_deg hi_polys hi_certs
-  -- factor.leadingCoeff = 1, factor.degree? = some primeData.factorDegrees[i]
-  have hmonic : Hex.DensePoly.Monic primeData.factorPolys[i] := by
-    by_cases hmon : primeData.factorPolys[i].leadingCoeff = 1
-    · exact hmon
-    · exfalso
-      simp [Hex.PrimeFactorData.checkCertAtFactor, hmon] at hpair
   have hdegree :
       primeData.factorPolys[i].degree? = some primeData.factorDegrees[i] := by
     simp only [Hex.PrimeFactorData.checkCertAtFactor, Bool.and_eq_true, beq_iff_eq,
       decide_eq_true_eq] at hpair
     exact hpair.1.2
-  rw [HexBerlekampMathlib.natDegree_toMathlibPolynomial_eq_basisSize _ hmonic]
+  rw [HexBerlekampMathlib.natDegree_toMathlibPolynomial_eq_basisSize]
   show primeData.factorPolys[i].degree?.getD 0 = _
   rw [hdegree]
   rfl

--- a/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
@@ -90,13 +90,13 @@ private theorem checkCertAtFactor_of_checkFactorCerts
   exact hall _ hmem
 
 /--
-The Mathlib transport of an executable monic factor recorded in a
+The Mathlib transport of an executable factor recorded in a
 `PrimeFactorData` block has natural degree equal to the recorded factor
-degree. Uses the executable `degree?` slot, the recorded monicity, and the
-Mathlib basisSize identification.
+degree. This follows directly from the executable `degree?` slot and the
+Mathlib basis-size identification.
 -/
 private theorem natDegree_toMathlibPolynomial_factorPolys_eq
-    (primeData : Hex.PrimeFactorData) [Nontrivial (ZMod primeData.p)]
+    (primeData : Hex.PrimeFactorData)
     (hcheck : primeData.checkFactorCerts = true)
     (i : Nat) (hi_polys : i < primeData.factorPolys.size)
     (hi_deg : i < primeData.factorDegrees.size)

--- a/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
@@ -173,15 +173,12 @@ private theorem modP_dvd_monicModularImage
 /-- The recorded factor degrees are the Mathlib natural degrees of the
 transported modular factors. -/
 private theorem map_natDegree_factorsModP
-    {core : Hex.ZPoly} {data : Hex.PrimeChoiceData}
-    (_hval : ModPFactorization core data) :
+    {data : Hex.PrimeChoiceData} :
     letI := data.bounds
     data.factorsModP.toList.map
         (fun g => (HexBerlekampMathlib.toMathlibPolynomial g).natDegree) =
       (Hex.directFactorDegrees data).toList := by
   letI := data.bounds
-  haveI : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime _hval.prime⟩
-  haveI : Nontrivial (ZMod data.p) := inferInstance
   simp only [Hex.directFactorDegrees, Array.toList_map]
   refine List.map_congr_left ?_
   intro g _
@@ -272,7 +269,7 @@ theorem exists_subMultiset_directFactorDegrees_of_dvd
           HexBerlekampMathlib.toMathlibPolynomial).map Polynomial.natDegree =
         ((Hex.directFactorDegrees data).toList : Multiset Nat) := by
     rw [Multiset.map_coe, Multiset.map_coe, List.map_map]
-    exact congrArg _ (map_natDegree_factorsModP hval)
+    exact congrArg _ (map_natDegree_factorsModP (data := data))
   refine ⟨S, ?_, ?_⟩
   · rw [← hdegmap]
     exact hS

--- a/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
@@ -174,19 +174,18 @@ private theorem modP_dvd_monicModularImage
 transported modular factors. -/
 private theorem map_natDegree_factorsModP
     {core : Hex.ZPoly} {data : Hex.PrimeChoiceData}
-    (hval : ModPFactorization core data) :
+    (_hval : ModPFactorization core data) :
     letI := data.bounds
     data.factorsModP.toList.map
         (fun g => (HexBerlekampMathlib.toMathlibPolynomial g).natDegree) =
       (Hex.directFactorDegrees data).toList := by
   letI := data.bounds
-  haveI : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime hval.prime⟩
+  haveI : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime _hval.prime⟩
   haveI : Nontrivial (ZMod data.p) := inferInstance
   simp only [Hex.directFactorDegrees, Array.toList_map]
   refine List.map_congr_left ?_
-  intro g hg
-  have hmonic : Hex.DensePoly.Monic g := hval.monic g (by simpa using hg)
-  rw [HexBerlekampMathlib.natDegree_toMathlibPolynomial_eq_basisSize g hmonic]
+  intro g _
+  rw [HexBerlekampMathlib.natDegree_toMathlibPolynomial_eq_basisSize g]
   rfl
 
 /-- Reduction at a good prime sends an integer divisor of the input to a

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -168,23 +168,9 @@ theorem ofPolyHom_compose_eq_eval₂ (b : Hex.FpPoly p) (g : Hex.FpPoly p) :
         rw [map_add, Hex.FpPoly.compose_add, map_add, hP, hQ, Polynomial.eval₂_add]
     | monomial k c =>
         rw [Polynomial.eval₂_monomial]
-        have hsym : HexPolyFpMathlib.fpPolyEquiv.symm (Polynomial.monomial k c) =
-            (Hex.DensePoly.monomial k (HexModArithMathlib.ZMod64.ofZMod c) :
-              Hex.FpPoly p) := by
-          rw [RingEquiv.symm_apply_eq]
-          apply Polynomial.ext
-          intro i
-          rw [HexPolyFpMathlib.fpPolyEquiv_apply,
-            HexPolyFpMathlib.coeff_toMathlibPolynomial,
-            Hex.DensePoly.coeff_monomial, Polynomial.coeff_monomial]
-          by_cases hik : k = i
-          · subst hik
-            rw [if_pos rfl, if_pos rfl, HexModArithMathlib.ZMod64.toZMod_ofZMod]
-          · rw [if_neg hik, if_neg (fun h : i = k => hik h.symm),
-              show (0 : ZMod p) = HexModArithMathlib.ZMod64.toZMod 0 from
-                (HexModArithMathlib.ZMod64.toZMod_zero).symm]
-            rfl
-        rw [hsym, Hex.FpPoly.compose_monomial, HexPolyFpMathlib.linearPow_eq_pow,
+        rw [HexPolyFpMathlib.fpPolyEquiv_symm_apply,
+          HexPolyFpMathlib.polynomialToFpPoly_monomial,
+          Hex.FpPoly.compose_monomial, HexPolyFpMathlib.linearPow_eq_pow,
           map_mul, map_pow]
         rfl
   have := key (HexPolyFpMathlib.fpPolyEquiv g)

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -318,12 +318,17 @@ polynomial's Mathlib image carries no `RingEquiv` coercion.
 
 {docstring HexPolyFpMathlib.coeff_toMathlibPolynomial}
 
-The coefficient lemma is the normal form for the whole layer. Nearly
-every transport below is proved by taking coefficients on both sides and
-rewriting with it, and it is the `simp` rule a downstream proof reaches
-for first.
+{docstring HexPolyFpMathlib.coeff_polynomialToFpPoly}
+
+These coefficient lemmas are the normal forms for the two directions of
+the correspondence. They let downstream proofs cross the equivalence
+without unfolding either representation.
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_monic}
+
+{docstring HexPolyFpMathlib.natDegree_toMathlibPolynomial}
+
+{docstring HexPolyFpMathlib.leadingCoeff_toMathlibPolynomial}
 
 Monicity is the hypothesis the executable Euclidean operations carry, so
 transporting it is what lets a Mathlib-side argument apply
@@ -344,6 +349,8 @@ the rewrite-friendly form is what the finite-field proofs actually use.
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_sub}
 
+{docstring HexPolyFpMathlib.toMathlibPolynomial_neg}
+
 {docstring HexPolyFpMathlib.toMathlibPolynomial_mul}
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_derivative}
@@ -360,19 +367,42 @@ rewritten all the way down to `X` and constants.
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_X}
 
+{docstring HexPolyFpMathlib.toMathlibPolynomial_monomial}
+
 {docstring HexPolyFpMathlib.toMathlibPolynomial_monomial_one}
+
+Evaluation and Horner composition have direct correspondence theorems,
+so consumers can move a computation to Mathlib without re-running a
+polynomial induction.
+
+{docstring HexPolyFpMathlib.eval₂_toMathlibPolynomial}
+
+{docstring HexPolyFpMathlib.toMathlibPolynomial_compose}
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_dvd}
 
-That last one is the forward direction only: it is proved from a
-multiplication witness and
-{name}`HexPolyFpMathlib.toMathlibPolynomial_mul`, with no division and no
-gcd. The equivalence can reflect such a witness backward just as well, so
-the two-sided `dvd_iff` is a gap in the current API rather than a
-property of the correspondence. It is tracked as
-[hex-dev issue 9370](https://github.com/kim-em/hex-dev/issues/9370),
-along with the rest of the inverse transport family. What genuinely does
-not belong here is a
+{docstring HexPolyFpMathlib.toMathlibPolynomial_dvd_iff}
+
+The inverse map also has named rules for the basic constructors and ring
+operations. In particular, a caller going backward across the
+equivalence does not need to combine `RingEquiv.symm_apply_eq` with a
+forward coefficient proof.
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_zero}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_one}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_C}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_neg}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_sub}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_add}
+
+{docstring HexPolyFpMathlib.polynomialToFpPoly_monomial}
+
+The correspondence layer stops at representation-level facts. A
 statement mentioning Berlekamp's basis size or Rabin's test, even when
 its conclusion is about
 {name}`HexPolyFpMathlib.toMathlibPolynomial`: that is a fact about a

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -326,14 +326,14 @@ without unfolding either representation.
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_monic}
 
-{docstring HexPolyFpMathlib.natDegree_toMathlibPolynomial}
-
-{docstring HexPolyFpMathlib.leadingCoeff_toMathlibPolynomial}
-
 Monicity is the hypothesis the executable Euclidean operations carry, so
 transporting it is what lets a Mathlib-side argument apply
 `Polynomial.Monic` lemmas to a polynomial that came out of
 {name}`Hex.FpPoly.modByMonic` or out of the square-free decomposition.
+
+{docstring HexPolyFpMathlib.natDegree_toMathlibPolynomial}
+
+{docstring HexPolyFpMathlib.leadingCoeff_toMathlibPolynomial}
 
 ## The transport family
 %%%
@@ -371,9 +371,10 @@ rewritten all the way down to `X` and constants.
 
 {docstring HexPolyFpMathlib.toMathlibPolynomial_monomial_one}
 
-Evaluation and Horner composition have direct correspondence theorems,
-so consumers can move a computation to Mathlib without re-running a
-polynomial induction.
+The `eval₂` theorem exposes Mathlib evaluation as the finite coefficient sum
+represented by the executable polynomial. Horner composition has a direct
+operation-correspondence theorem, so consumers need not repeat its polynomial
+induction.
 
 {docstring HexPolyFpMathlib.eval₂_toMathlibPolynomial}
 
@@ -400,13 +401,15 @@ forward coefficient proof.
 
 {docstring HexPolyFpMathlib.polynomialToFpPoly_add}
 
+{docstring HexPolyFpMathlib.polynomialToFpPoly_mul}
+
 {docstring HexPolyFpMathlib.polynomialToFpPoly_monomial}
 
-The correspondence layer stops at representation-level facts. A
-statement mentioning Berlekamp's basis size or Rabin's test, even when
-its conclusion is about
-{name}`HexPolyFpMathlib.toMathlibPolynomial`: that is a fact about a
-factoring algorithm rather than about the representation, and it lives in
+The correspondence layer stops at representation-level facts. A statement
+mentioning Berlekamp's basis size or Rabin's test does not belong here even
+when its conclusion is about
+{name}`HexPolyFpMathlib.toMathlibPolynomial`: that is a fact about a factoring
+algorithm rather than about the representation, and it lives in
 `HexBerlekampMathlib`.
 
 ## Mathlib algebraic structure

--- a/HexPolyFpMathlib/Basic.lean
+++ b/HexPolyFpMathlib/Basic.lean
@@ -282,16 +282,14 @@ theorem toMathlibPolynomial_monic (f : Hex.FpPoly p) :
     exact HexModArithMathlib.ZMod64.toZMod_one
 
 /-- The executable degree transports to Mathlib's `natDegree`, with the zero
-polynomial mapping to degree `0`. -/
+polynomial mapping to degree `0`. No nontriviality hypothesis is needed: in the
+trivial ring every transported polynomial is zero and every executable
+coefficient is zero as well. -/
 @[simp, grind =]
 theorem natDegree_toMathlibPolynomial (f : Hex.FpPoly p) :
     (toMathlibPolynomial f).natDegree = f.degree?.getD 0 := by
   by_cases hsize : f.size = 0
-  · have hf_zero : f = 0 := by
-      apply Hex.DensePoly.ext_coeff
-      intro n
-      rw [Hex.DensePoly.coeff_zero]
-      exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
+  · have hf_zero : f = 0 := (Hex.DensePoly.size_eq_zero_iff f).mp hsize
     rw [hf_zero]
     change (toMathlibPolynomial (0 : Hex.FpPoly p)).natDegree = 0
     have hzero : toMathlibPolynomial (0 : Hex.FpPoly p) = 0 := by
@@ -328,11 +326,7 @@ theorem leadingCoeff_toMathlibPolynomial (f : Hex.FpPoly p) :
   rw [Polynomial.leadingCoeff, natDegree_toMathlibPolynomial,
     coeff_toMathlibPolynomial]
   by_cases hsize : f.size = 0
-  · have hf_zero : f = 0 := by
-      apply Hex.DensePoly.ext_coeff
-      intro n
-      rw [Hex.DensePoly.coeff_zero]
-      exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
+  · have hf_zero : f = 0 := (Hex.DensePoly.size_eq_zero_iff f).mp hsize
     rw [hf_zero, Hex.DensePoly.leadingCoeff_zero, Hex.DensePoly.coeff_zero]
   · have hpos : 0 < f.size := Nat.pos_of_ne_zero hsize
     rw [Hex.DensePoly.degree?_eq_some_of_pos_size f hpos, Option.getD_some,
@@ -417,6 +411,7 @@ theorem toMathlibPolynomial_monomial (m : Nat) (c : Hex.ZMod64 p) :
     exact HexModArithMathlib.ZMod64.toZMod_zero
 
 /-- The monic monomial `X^m` transports to `X^m` over `ZMod p`. -/
+@[simp, grind =]
 theorem toMathlibPolynomial_monomial_one (m : Nat) :
     toMathlibPolynomial (Hex.DensePoly.monomial m (1 : Hex.ZMod64 p)) =
       (Polynomial.X : Polynomial (ZMod p)) ^ m := by
@@ -505,6 +500,24 @@ instance commRing : CommRing (Hex.FpPoly p) :=
     neg := fun a => Hex.DensePoly.neg a
     sub_eq_add_neg := Hex.FpPoly.sub_eq_add_neg }
 
+/-- The executable zero polynomial transports to Mathlib's zero polynomial. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_zero :
+    toMathlibPolynomial (0 : Hex.FpPoly p) = 0 :=
+  map_zero fpPolyEquiv
+
+/-- The executable unit polynomial transports to Mathlib's unit polynomial. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_one :
+    toMathlibPolynomial (1 : Hex.FpPoly p) = 1 :=
+  map_one fpPolyEquiv
+
+/-- Powers commute with the finite-field polynomial transport. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_pow (f : Hex.FpPoly p) (n : Nat) :
+    toMathlibPolynomial (f ^ n) = toMathlibPolynomial f ^ n :=
+  map_pow fpPolyEquiv f n
+
 /-! # Inverse transport and composition
 
 The executable polynomial ring instance makes the standard `RingEquiv.symm`
@@ -564,6 +577,14 @@ theorem polynomialToFpPoly_add (f g : Polynomial (ZMod p)) :
       polynomialToFpPoly f + polynomialToFpPoly g := by
   change fpPolyEquiv.symm (f + g) = fpPolyEquiv.symm f + fpPolyEquiv.symm g
   exact map_add fpPolyEquiv.symm f g
+
+/-- The inverse transport commutes with polynomial multiplication. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_mul (f g : Polynomial (ZMod p)) :
+    polynomialToFpPoly (f * g) =
+      polynomialToFpPoly f * polynomialToFpPoly g := by
+  change fpPolyEquiv.symm (f * g) = fpPolyEquiv.symm f * fpPolyEquiv.symm g
+  exact map_mul fpPolyEquiv.symm f g
 
 /-- The inverse transport sends a Mathlib monomial to the corresponding
 executable monomial. -/

--- a/HexPolyFpMathlib/Basic.lean
+++ b/HexPolyFpMathlib/Basic.lean
@@ -237,6 +237,20 @@ theorem coeff_toMathlibPolynomial (f : Hex.FpPoly p) (n : Nat) :
     (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) :=
   coeff_fpPolyToPolynomial f n
 
+/-- Rebuilding a Mathlib polynomial preserves coefficients, transported back
+through the `ZMod64` equivalence. -/
+@[simp, grind =]
+theorem coeff_polynomialToFpPoly (f : Polynomial (ZMod p)) (n : Nat) :
+    (polynomialToFpPoly f).coeff n =
+      HexModArithMathlib.ZMod64.ofZMod (f.coeff n) := by
+  unfold polynomialToFpPoly
+  rw [Hex.DensePoly.coeff_ofList, HexPolyMathlib.list_getD_map_range_zero]
+  by_cases hn : n < f.natDegree + 1
+  · simp only [hn, ite_true, HexModArithMathlib.ZMod64.equiv_symm_apply]
+  · rw [ite_eq_right hn, Polynomial.coeff_eq_zero_of_natDegree_lt (by omega),
+      HexModArithMathlib.ZMod64.ofZMod_zero]
+    rfl
+
 /-- Monicity of executable finite-field polynomials transfers to Mathlib.
 
 No nontriviality hypothesis is required: when `ZMod p` is trivial every
@@ -266,6 +280,63 @@ theorem toMathlibPolynomial_monic (f : Hex.FpPoly p) :
   · rw [coeff_toMathlibPolynomial, hlc,
       Hex.DensePoly.leadingCoeff_eq_one_of_monic hmonic]
     exact HexModArithMathlib.ZMod64.toZMod_one
+
+/-- The executable degree transports to Mathlib's `natDegree`, with the zero
+polynomial mapping to degree `0`. -/
+@[simp, grind =]
+theorem natDegree_toMathlibPolynomial (f : Hex.FpPoly p) :
+    (toMathlibPolynomial f).natDegree = f.degree?.getD 0 := by
+  by_cases hsize : f.size = 0
+  · have hf_zero : f = 0 := by
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      rw [Hex.DensePoly.coeff_zero]
+      exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    rw [hf_zero]
+    change (toMathlibPolynomial (0 : Hex.FpPoly p)).natDegree = 0
+    have hzero : toMathlibPolynomial (0 : Hex.FpPoly p) = 0 := by
+      apply Polynomial.ext
+      intro n
+      rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_zero, Polynomial.coeff_zero]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
+    rw [hzero, Polynomial.natDegree_zero]
+  · have hpos : 0 < f.size := Nat.pos_of_ne_zero hsize
+    have hdegree_some : f.degree? = some (f.size - 1) := by
+      simp [Hex.DensePoly.degree?, hsize]
+    rw [hdegree_some, Option.getD_some]
+    apply le_antisymm
+    · apply Polynomial.natDegree_le_iff_coeff_eq_zero.mpr
+      intro N hN
+      rw [coeff_toMathlibPolynomial,
+        Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
+    · apply Polynomial.le_natDegree_of_ne_zero
+      rw [coeff_toMathlibPolynomial]
+      intro hzero
+      apply Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
+      apply (HexModArithMathlib.ZMod64.equiv (p := p)).injective
+      rw [HexModArithMathlib.ZMod64.equiv_apply,
+        HexModArithMathlib.ZMod64.equiv_apply]
+      exact hzero.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
+
+/-- The executable leading coefficient transports through `toZMod` to
+Mathlib's leading coefficient. -/
+@[simp, grind =]
+theorem leadingCoeff_toMathlibPolynomial (f : Hex.FpPoly p) :
+    (toMathlibPolynomial f).leadingCoeff =
+      HexModArithMathlib.ZMod64.toZMod f.leadingCoeff := by
+  rw [Polynomial.leadingCoeff, natDegree_toMathlibPolynomial,
+    coeff_toMathlibPolynomial]
+  by_cases hsize : f.size = 0
+  · have hf_zero : f = 0 := by
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      rw [Hex.DensePoly.coeff_zero]
+      exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    rw [hf_zero, Hex.DensePoly.leadingCoeff_zero, Hex.DensePoly.coeff_zero]
+  · have hpos : 0 < f.size := Nat.pos_of_ne_zero hsize
+    rw [Hex.DensePoly.degree?_eq_some_of_pos_size f hpos, Option.getD_some,
+      Hex.DensePoly.leadingCoeff_eq_coeff_last f hpos]
 
 /-! # Ring operations across the correspondence
 
@@ -304,6 +375,21 @@ theorem toMathlibPolynomial_sub (f g : Hex.FpPoly p) :
     coeff_toMathlibPolynomial, Hex.DensePoly.coeff_sub_ring,
     HexModArithMathlib.ZMod64.toZMod_sub]
 
+/-- Negation commutes with the finite-field polynomial transport. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_neg (f : Hex.FpPoly p) :
+    toMathlibPolynomial (-f) = -toMathlibPolynomial f := by
+  apply Polynomial.ext
+  intro n
+  rw [Polynomial.coeff_neg, coeff_toMathlibPolynomial, coeff_toMathlibPolynomial,
+    Hex.DensePoly.coeff_neg f n (by show (0 : Hex.ZMod64 p) - 0 = 0; grind),
+    HexModArithMathlib.ZMod64.toZMod_sub]
+  calc HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) -
+        HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n)
+      = 0 - HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := by
+        rw [HexModArithMathlib.ZMod64.toZMod_zero]
+    _ = -HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := zero_sub _
+
 /-- The constant executable polynomial transports to the Mathlib constant. -/
 theorem toMathlibPolynomial_C (c : Hex.ZMod64 p) :
     toMathlibPolynomial (Hex.DensePoly.C c) =
@@ -315,16 +401,27 @@ theorem toMathlibPolynomial_C (c : Hex.ZMod64 p) :
   · subst hn; rw [if_pos rfl, if_pos rfl]
   · rw [if_neg hn, if_neg hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
 
+/-- An executable monomial transports to the corresponding Mathlib monomial. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_monomial (m : Nat) (c : Hex.ZMod64 p) :
+    toMathlibPolynomial (Hex.DensePoly.monomial m c) =
+      Polynomial.monomial m (HexModArithMathlib.ZMod64.toZMod c) := by
+  apply Polynomial.ext
+  intro n
+  rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_monomial,
+    Polynomial.coeff_monomial]
+  by_cases hn : n = m
+  · subst hn
+    simp
+  · rw [ite_eq_right hn, ite_eq_right (fun h : m = n => hn h.symm)]
+    exact HexModArithMathlib.ZMod64.toZMod_zero
+
 /-- The monic monomial `X^m` transports to `X^m` over `ZMod p`. -/
 theorem toMathlibPolynomial_monomial_one (m : Nat) :
     toMathlibPolynomial (Hex.DensePoly.monomial m (1 : Hex.ZMod64 p)) =
       (Polynomial.X : Polynomial (ZMod p)) ^ m := by
-  apply Polynomial.ext
-  intro n
-  rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_monomial, Polynomial.coeff_X_pow]
-  by_cases hn : n = m
-  · rw [if_pos hn, if_pos hn]; exact HexModArithMathlib.ZMod64.toZMod_one
-  · rw [if_neg hn, if_neg hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
+  rw [toMathlibPolynomial_monomial, HexModArithMathlib.ZMod64.toZMod_one,
+    Polynomial.monomial_one_right_eq_X_pow]
 
 /-- The executable indeterminate transports to Mathlib's `X`. -/
 theorem toMathlibPolynomial_X :
@@ -341,6 +438,30 @@ theorem toMathlibPolynomial_dvd {f g : Hex.FpPoly p} (h : f ∣ g) :
     toMathlibPolynomial f ∣ toMathlibPolynomial g := by
   obtain ⟨r, hr⟩ := h
   exact ⟨toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩
+
+/-- Executable finite-field polynomials divide one another exactly when their
+Mathlib images do. -/
+theorem toMathlibPolynomial_dvd_iff {f g : Hex.FpPoly p} :
+    toMathlibPolynomial f ∣ toMathlibPolynomial g ↔ f ∣ g := by
+  constructor
+  · rintro ⟨R, hR⟩
+    refine ⟨fpPolyEquiv.symm R, ?_⟩
+    apply fpPolyEquiv.injective
+    rw [map_mul, fpPolyEquiv.apply_symm_apply]
+    exact hR
+  · exact toMathlibPolynomial_dvd
+
+/-- Evaluation of a transported polynomial is its degree-indexed coefficient
+sum after transporting each executable coefficient through `toZMod`. -/
+theorem eval₂_toMathlibPolynomial {S : Type*} [Semiring S]
+    (h : ZMod p →+* S) (f : Hex.FpPoly p) (x : S) :
+    (toMathlibPolynomial f).eval₂ h x =
+      ∑ i ∈ Finset.range f.size,
+        h (HexModArithMathlib.ZMod64.toZMod (f.coeff i)) * x ^ i := by
+  change (fpPolyToPolynomial f).eval₂ h x = _
+  unfold fpPolyToPolynomial
+  rw [Polynomial.eval₂_finsetSum]
+  exact Finset.sum_congr rfl fun i _ => Polynomial.eval₂_monomial h x
 
 /-- The Mathlib primality fact yields the executable prime-modulus witness, so
 executable field-dependent lemmas (gcd/Bezout, modular division) become
@@ -383,6 +504,156 @@ instance commRing : CommRing (Hex.FpPoly p) :=
     sub := fun a b => Hex.DensePoly.sub a b
     neg := fun a => Hex.DensePoly.neg a
     sub_eq_add_neg := Hex.FpPoly.sub_eq_add_neg }
+
+/-! # Inverse transport and composition
+
+The executable polynomial ring instance makes the standard `RingEquiv.symm`
+operation lemmas available on the inverse map. The coefficient and monomial
+lemmas remain explicit so callers never need to unfold either representation.
+-/
+
+/-- The inverse transport sends Mathlib's zero polynomial to executable zero. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_zero :
+    polynomialToFpPoly (0 : Polynomial (ZMod p)) = 0 := by
+  change fpPolyEquiv.symm 0 = 0
+  exact map_zero fpPolyEquiv.symm
+
+/-- The inverse transport sends Mathlib's one polynomial to executable one. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_one :
+    polynomialToFpPoly (1 : Polynomial (ZMod p)) = 1 := by
+  change fpPolyEquiv.symm 1 = 1
+  exact map_one fpPolyEquiv.symm
+
+/-- The inverse transport sends a Mathlib constant to the corresponding
+executable constant. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_C (c : ZMod p) :
+    polynomialToFpPoly (Polynomial.C c) =
+      Hex.DensePoly.C (HexModArithMathlib.ZMod64.ofZMod c) := by
+  apply Hex.DensePoly.ext_coeff
+  intro n
+  rw [coeff_polynomialToFpPoly, Polynomial.coeff_C, Hex.DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · subst hn
+    simp
+  · rw [ite_eq_right hn, ite_eq_right hn,
+      HexModArithMathlib.ZMod64.ofZMod_zero]
+    rfl
+
+/-- The inverse transport commutes with polynomial negation. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_neg (f : Polynomial (ZMod p)) :
+    polynomialToFpPoly (-f) = -polynomialToFpPoly f := by
+  change fpPolyEquiv.symm (-f) = -fpPolyEquiv.symm f
+  exact map_neg fpPolyEquiv.symm f
+
+/-- The inverse transport commutes with polynomial subtraction. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_sub (f g : Polynomial (ZMod p)) :
+    polynomialToFpPoly (f - g) =
+      polynomialToFpPoly f - polynomialToFpPoly g := by
+  change fpPolyEquiv.symm (f - g) = fpPolyEquiv.symm f - fpPolyEquiv.symm g
+  exact map_sub fpPolyEquiv.symm f g
+
+/-- The inverse transport commutes with polynomial addition. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_add (f g : Polynomial (ZMod p)) :
+    polynomialToFpPoly (f + g) =
+      polynomialToFpPoly f + polynomialToFpPoly g := by
+  change fpPolyEquiv.symm (f + g) = fpPolyEquiv.symm f + fpPolyEquiv.symm g
+  exact map_add fpPolyEquiv.symm f g
+
+/-- The inverse transport sends a Mathlib monomial to the corresponding
+executable monomial. -/
+@[simp, grind =]
+theorem polynomialToFpPoly_monomial (n : Nat) (c : ZMod p) :
+    polynomialToFpPoly (Polynomial.monomial n c) =
+      Hex.DensePoly.monomial n (HexModArithMathlib.ZMod64.ofZMod c) := by
+  apply Hex.DensePoly.ext_coeff
+  intro i
+  rw [coeff_polynomialToFpPoly, Polynomial.coeff_monomial,
+    Hex.DensePoly.coeff_monomial]
+  by_cases hi : i = n
+  · subst hi
+    simp
+  · rw [ite_eq_right hi, ite_eq_right (fun h : n = i => hi h.symm),
+      HexModArithMathlib.ZMod64.ofZMod_zero]
+    rfl
+
+/-- The Horner polynomial obtained by transporting a low-to-high executable
+coefficient list to `ZMod p`. -/
+private def fpHornerList (l : List (Hex.ZMod64 p)) : Polynomial (ZMod p) :=
+  l.foldr (fun c acc =>
+    Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) + Polynomial.X * acc) 0
+
+private theorem coeff_fpHornerList : ∀ (l : List (Hex.ZMod64 p)) (n : Nat),
+    (fpHornerList l).coeff n =
+      HexModArithMathlib.ZMod64.toZMod (l.getD n (Zero.zero : Hex.ZMod64 p))
+  | [], n => by
+      simp [fpHornerList]
+      exact HexModArithMathlib.ZMod64.toZMod_zero.symm
+  | c :: cs, n => by
+      show (Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) +
+          Polynomial.X * fpHornerList cs).coeff n = _
+      cases n with
+      | zero => simp
+      | succ m =>
+          rw [Polynomial.coeff_add, Polynomial.coeff_C,
+            ite_eq_right (Nat.succ_ne_zero m), Polynomial.coeff_X_mul,
+            coeff_fpHornerList cs m, zero_add, List.getD_cons_succ]
+
+private theorem fpHornerList_comp (M : Polynomial (ZMod p)) :
+    ∀ l : List (Hex.ZMod64 p),
+      (fpHornerList l).comp M =
+        l.foldr (fun c acc =>
+          Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) + M * acc) 0
+  | [] => by simp [fpHornerList]
+  | c :: cs => by
+      show (Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) +
+          Polynomial.X * fpHornerList cs).comp M = _
+      rw [Polynomial.add_comp, Polynomial.C_comp, Polynomial.mul_comp,
+        Polynomial.X_comp, fpHornerList_comp M cs]
+      rfl
+
+private theorem fpPoly_toList_getD (f : Hex.FpPoly p) (n : Nat) :
+    f.toList.getD n (Zero.zero : Hex.ZMod64 p) = f.coeff n := by
+  rw [Hex.DensePoly.toList, List.getD_eq_getElem?_getD, Array.getElem?_toList]
+  have h := Hex.DensePoly.toArray_getD f n
+  rw [Array.getD_eq_getD_getElem?] at h
+  exact h
+
+private theorem toMathlibPolynomial_eq_fpHornerList (f : Hex.FpPoly p) :
+    toMathlibPolynomial f = fpHornerList f.toList := by
+  apply Polynomial.ext
+  intro n
+  rw [coeff_toMathlibPolynomial, coeff_fpHornerList, fpPoly_toList_getD]
+
+/-- The finite-field transport intertwines executable Horner composition with
+Mathlib polynomial composition. -/
+@[simp, grind =]
+theorem toMathlibPolynomial_compose (f g : Hex.FpPoly p) :
+    toMathlibPolynomial (Hex.DensePoly.compose f g) =
+      (toMathlibPolynomial f).comp (toMathlibPolynomial g) := by
+  have hlist : ∀ l : List (Hex.ZMod64 p),
+      toMathlibPolynomial (Hex.DensePoly.composeCoeffList l g) =
+        l.foldr (fun c acc =>
+          Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) +
+            toMathlibPolynomial g * acc) 0 := by
+    intro l
+    induction l with
+    | nil =>
+        change toMathlibPolynomial (0 : Hex.FpPoly p) = 0
+        exact map_zero fpPolyEquiv
+    | cons c cs ih =>
+        show toMathlibPolynomial
+            (Hex.DensePoly.composeCoeffList cs g * g + Hex.DensePoly.C c) = _
+        rw [toMathlibPolynomial_add, toMathlibPolynomial_mul,
+          toMathlibPolynomial_C, ih, List.foldr_cons, mul_comm, add_comm]
+  show toMathlibPolynomial (Hex.DensePoly.composeCoeffList f.toList g) = _
+  rw [hlist, toMathlibPolynomial_eq_fpHornerList f,
+    fpHornerList_comp]
 
 /-- The executable linear power is Mathlib's monoid power. `HexPolyFp` defines
 `linearPow` by structural recursion for kernel reduction; the `CommRing` above

--- a/HexPolyFpMathlib/README.md
+++ b/HexPolyFpMathlib/README.md
@@ -8,8 +8,8 @@ The Mathlib correspondence layer for
 [`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp). It relates the
 executable prime-field polynomials `Hex.FpPoly p` to Mathlib's
 `Polynomial (ZMod p)` through a ring equivalence, and transports
-coefficients, monicity, arithmetic, derivatives, and divisibility across
-it. It builds on
+coefficients, degree, leading coefficients, arithmetic, evaluation,
+composition, and divisibility in both directions. It builds on
 [`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib) and
 [`hex-mod-arith-mathlib`](https://github.com/leanprover/hex-mod-arith-mathlib).
 
@@ -37,10 +37,13 @@ polynomials and Mathlib's:
 
 - `fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p)`, with
   `toMathlibPolynomial` as the forward map named for use in statements.
-- Coefficient and monicity transport (`coeff_toMathlibPolynomial`,
-  `toMathlibPolynomial_monic`).
-- Transport lemmas for addition, multiplication, subtraction, derivatives,
-  constants, `X`, monomials, and divisibility.
+- Coefficient transport in both directions, plus monicity, natural degree,
+  and leading-coefficient correspondence.
+- Forward transport for arithmetic, derivatives, constants, `X`, general
+  monomials, evaluation, and composition.
+- Inverse transport for zero, one, constants, addition, subtraction,
+  negation, and monomials, together with preservation and reflection of
+  divisibility.
 - A `CommRing (Hex.FpPoly p)` instance whose operations are the executable
   ones, proved from the ring laws `HexPolyFp` establishes.
 

--- a/HexPolyFpMathlib/README.md
+++ b/HexPolyFpMathlib/README.md
@@ -8,8 +8,9 @@ The Mathlib correspondence layer for
 [`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp). It relates the
 executable prime-field polynomials `Hex.FpPoly p` to Mathlib's
 `Polynomial (ZMod p)` through a ring equivalence, and transports
-coefficients, degree, leading coefficients, arithmetic, evaluation,
-composition, and divisibility in both directions. It builds on
+coefficients and ring operations in both directions. It also identifies
+degree, leading coefficients, Mathlib's coefficient-sum evaluation,
+composition, and divisibility across the equivalence. It builds on
 [`hex-poly-mathlib`](https://github.com/leanprover/hex-poly-mathlib) and
 [`hex-mod-arith-mathlib`](https://github.com/leanprover/hex-mod-arith-mathlib).
 
@@ -40,10 +41,10 @@ polynomials and Mathlib's:
 - Coefficient transport in both directions, plus monicity, natural degree,
   and leading-coefficient correspondence.
 - Forward transport for arithmetic, derivatives, constants, `X`, general
-  monomials, evaluation, and composition.
+  monomials, coefficient-sum evaluation, and composition.
 - Inverse transport for zero, one, constants, addition, subtraction,
-  negation, and monomials, together with preservation and reflection of
-  divisibility.
+  negation, multiplication, and monomials, together with preservation and
+  reflection of divisibility.
 - A `CommRing (Hex.FpPoly p)` instance whose operations are the executable
   ones, proved from the ring laws `HexPolyFp` establishes.
 

--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -10,10 +10,16 @@ Mathlib's own polynomial type.
 - `fpPolyEquiv : FpPoly p ≃+* Polynomial (ZMod p)`, the ring equivalence they
   assemble into.
 - `toMathlibPolynomial`, the forward map named for use in statements, with its
-  coefficient, monicity, and `simp` lemmas.
+  coefficient, monicity, natural-degree, leading-coefficient, and `simp`
+  lemmas; `coeff_polynomialToFpPoly` supplies the inverse coefficient rule.
 - Transport lemmas naming the forward map for the operations a caller reaches
   for directly rather than through a `RingEquiv` composition: `derivative`,
-  `mul`, `add`, `sub`, `C`, the monic monomial `monomial m 1`, `X`, and `dvd`.
+  `mul`, `add`, `sub`, `neg`, `C`, general monomials, `X`, evaluation, and
+  composition. The inverse family covers zero, one, constants, negation,
+  subtraction, addition, and monomials.
+- `toMathlibPolynomial_dvd_iff`, which both preserves executable divisibility
+  and reflects a Mathlib divisibility witness back to the executable
+  representation.
 - `commRing : CommRing (FpPoly p)`, built from the ring laws hex-poly-fp proves
   rather than transported along `fpPolyEquiv`, so that the Mathlib operations
   are the executable ones and `sub` and `neg` are the executable ones too.
@@ -118,14 +124,15 @@ the library name suggests.
 **hex-poly** owns the dense ring surface. `+`, `-`, `neg`, `*`, `derivative`,
 `C` and `monomial` on `FpPoly p` are hex-poly's `DensePoly` operations at the
 `ZMod64 p` coefficient ring, and the transport lemmas name them as such:
-`toMathlibPolynomial_{add, sub, mul, derivative, C, monomial_one}` are stated
+`toMathlibPolynomial_{add, sub, neg, mul, derivative, C, monomial}` are stated
 about `Hex.DensePoly.*`, and `toMathlibPolynomial_X` about `Hex.FpPoly.X`,
-which is `DensePoly.monomial 1 1`. `toMathlibPolynomial_dvd` belongs here too:
-it is proved from a multiplication witness and `toMathlibPolynomial_mul`, not
-from any division or gcd. So does `commRing`, whose `sub` and `neg` fields are
-pinned to the executable `DensePoly` operations. The relevant multiplication is
-the generic schoolbook convolution; hex-poly-fp's packed `mulPacked` is an
-optional value-equal kernel, not the registered implementation of `*`.
+which is `DensePoly.monomial 1 1`. `toMathlibPolynomial_dvd_iff` belongs here
+too: both directions transport a multiplication witness and use the ring
+equivalence, not division or gcd. So does `commRing`, whose `sub` and `neg`
+fields are pinned to the executable `DensePoly` operations. The relevant
+multiplication is the generic schoolbook convolution; hex-poly-fp's packed
+`mulPacked` is an optional value-equal kernel, not the registered
+implementation of `*`.
 
 **hex-poly-fp** owns the prime-field surface above it: `linearPow`, and the
 Frobenius, modular-composition, quotient-ring, square-free and monic-gcd

--- a/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
+++ b/HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md
@@ -14,9 +14,9 @@ Mathlib's own polynomial type.
   lemmas; `coeff_polynomialToFpPoly` supplies the inverse coefficient rule.
 - Transport lemmas naming the forward map for the operations a caller reaches
   for directly rather than through a `RingEquiv` composition: `derivative`,
-  `mul`, `add`, `sub`, `neg`, `C`, general monomials, `X`, evaluation, and
-  composition. The inverse family covers zero, one, constants, negation,
-  subtraction, addition, and monomials.
+  `mul`, `add`, `sub`, `neg`, `C`, general monomials, `X`, coefficient-sum
+  evaluation, and composition. The inverse family covers zero, one, constants,
+  negation, subtraction, addition, multiplication, and monomials.
 - `toMathlibPolynomial_dvd_iff`, which both preserves executable divisibility
   and reflects a Mathlib divisibility witness back to the executable
   representation.
@@ -132,7 +132,10 @@ equivalence, not division or gcd. So does `commRing`, whose `sub` and `neg`
 fields are pinned to the executable `DensePoly` operations. The relevant
 multiplication is the generic schoolbook convolution; hex-poly-fp's packed
 `mulPacked` is an optional value-equal kernel, not the registered
-implementation of `*`.
+implementation of `*`. Unreduced Horner composition is likewise hex-poly's
+`DensePoly.compose`; this layer only proves its representation correspondence.
+The `eval₂` coefficient-sum formula is proof-side normalization and introduces
+no executable kernel to benchmark.
 
 **hex-poly-fp** owns the prime-field surface above it: `linearPow`, and the
 Frobenius, modular-composition, quotient-ring, square-free and monic-gcd

--- a/HexPolyFpMathlib/SquareFree.lean
+++ b/HexPolyFpMathlib/SquareFree.lean
@@ -75,15 +75,6 @@ theorem weightedProduct_eq_prod (factors : List (Hex.FpPoly.SquareFreeFactor p))
   simp only [pow_eq_pow]
   rw [List.prod_eq_foldl, List.foldl_map]
 
-/-- The unit executable polynomial transports to the unit Mathlib polynomial. -/
-theorem toMathlibPolynomial_one : toMathlibPolynomial (1 : Hex.FpPoly p) = 1 :=
-  map_one fpPolyEquiv
-
-/-- Powers commute with the finite-field polynomial transport. -/
-theorem toMathlibPolynomial_pow (f : Hex.FpPoly p) (n : Nat) :
-    toMathlibPolynomial (f ^ n) = toMathlibPolynomial f ^ n :=
-  map_pow fpPolyEquiv f n
-
 /-- The weighted factor product transports to the Mathlib list product of the
 transported factors raised to their multiplicities. -/
 theorem toMathlibPolynomial_weightedProduct

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -87,7 +87,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
-- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and the two-way transport of coefficients, degree, leading coefficients, ring operations, evaluation, composition, and divisibility
+- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and transport of coefficients, degree, leading coefficients, ring operations, coefficient-sum evaluation, composition, and divisibility
 - **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`; the `Polynomial (ZMod p)` extension for `factor_poly` / `irreducibility`
 - **hex-hensel-mathlib**: Hensel correctness, uniqueness, `coprime_mod_p_lifts`
 - **hex-lll-mathlib**: lattice = `Submodule ℤ`, short vector bound

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -87,7 +87,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
-- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and the transport of coefficients, monicity, and ring operations across it
+- **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and the two-way transport of coefficients, degree, leading coefficients, ring operations, evaluation, composition, and divisibility
 - **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`; the `Polynomial (ZMod p)` extension for `factor_poly` / `irreducibility`
 - **hex-hensel-mathlib**: Hensel correctness, uniqueness, `coprime_mod_p_lifts`
 - **hex-lll-mathlib**: lattice = `Submodule ℤ`, short vector bound


### PR DESCRIPTION
Closes #9370.
Closes #9371.

## Summary

- complete the `FpPoly` correspondence with inverse coefficient and constructor/ring transport lemmas, general monomial and negation transport, evaluation, composition, and divisibility reflection
- move natural-degree and leading-coefficient correspondence into `HexPolyFpMathlib`, then simplify Berlekamp and Berlekamp–Zassenhaus consumers
- replace downstream representation-level proofs with the shared transport API and document the complete surface

`ZMod64` remains Mathlib-instance-free; the new proofs use its existing equivalence with `ZMod p`.

## Verification

- `lake build HexPolyFpMathlib.Basic`
- `lake build HexBerlekampMathlib.FactorPoly`
- `lake build HexGFqMathlib.Subfield HexBerlekampZassenhausMathlib`
- `lake build HexManual`
- post-rebase targeted build of `HexPolyFpMathlib`, both changed Berlekamp–Zassenhaus modules, `HexGFqMathlib.Subfield`, and `HexManual.Chapters.HexPolyFp`