### PR TITLE
chore: record the first wave libraries at done_through 7

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -598,7 +598,7 @@ libraries:
   HexRootsMathlib:
     deps: [HexRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 7
     status: active
   HexResultant:
     deps: [HexPoly, HexBasic]
@@ -644,7 +644,7 @@ libraries:
   HexResultantMathlib:
     deps: [HexResultant, HexPolyMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 7
     status: active
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
@@ -694,7 +694,7 @@ libraries:
   HexRCF:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 7
     status: active
     proof_probes: [bench/HexRCF/ProofProbe]
     phase4:

--- a/progress/2026-08-24T05-10-00Z.md
+++ b/progress/2026-08-24T05-10-00Z.md
@@ -1,0 +1,33 @@
+# First wave libraries to done_through 7
+
+## Accomplished
+
+- Advanced HexRootsMathlib 4 -> 7, HexRCF 5 -> 7, and
+  HexResultantMathlib 5 -> 7, the wave's first fully-done libraries.
+  Per-library evidence: Phase 5 held on the merits throughout
+  (sorry-free, CI-green); Phase 6 passes merged as #9416 (RootsMathlib,
+  closing #9384), #9426 (RCF, with the build-enforced docBlame/
+  docBlameThm' linters and the backfilled scaffolding token), and
+  #9408 (the resultant pair's polish); Phase 7 artifacts merged as
+  #9396/#9505 (correspondence headings and sections), #9505 (READMEs),
+  and #9375 (the integrated-library check_phase7 fix HexRCF needs).
+  check_phase7 passes with all three at 7; no tutorials anchor to
+  these libraries.
+- HexResultantMathlib completes at 7 while its computational partner
+  sits rolled back at 4 (#9506); phases 5-7 are local per the
+  Conventions coupling table, so the companion's record is honest.
+
+## Current frontier
+
+- Remaining to 7: Berlekamp chain (measurement campaigns B7/B8 then
+  Phase 6/7), NumberField cluster (C16 measurements then 5/6/7),
+  HexResultant (parked on #9506, assigned externally).
+
+## Next step
+
+- Drain 9424/9432/9504; run the serialized measurement campaigns;
+  TowerMathlib docstring pass.
+
+## Blockers
+
+- HexResultant's return to 5+ waits on #9506.


### PR DESCRIPTION
This PR advance HexRootsMathlib (4 to 7), HexRCF (5 to 7), and HexResultantMathlib (5 to 7), the release wave's first fully-done libraries. Phase 5 held on the merits throughout (sorry-free, CI-green); the Phase-6 passes merged as #9416 (closing #9384), #9426 (with build-enforced docBlame/docBlameThm' linting and the backfilled scaffolding token), and #9408; the Phase-7 artifacts merged as #9396 and #9505 (correspondence headings, sections, and READMEs) with #9375 supplying the integrated-library checker semantics HexRCF needs. `check_phase7.py` passes with all three at 7, and no tutorials anchor to these libraries. HexResultantMathlib completes while its computational partner sits rolled back at 4 on #9506; phases 5 through 7 are local per the Conventions coupling table, so the companion's record is honest.

🤖 Prepared with Claude Code