### PR TITLE
Complete HexModular Phases 5–7

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -32,6 +32,7 @@ import HexManual.Chapters.HexLLL
 import HexManual.Chapters.HexBerlekampZassenhaus
 import HexManual.Chapters.FactorTactics
 -- Unreleased libraries (dependency order).
+import HexManual.Chapters.HexModular
 import HexManual.Chapters.HexResultant
 import HexManual.Chapters.HexSparsePoly
 import HexManual.Chapters.HexRCF
@@ -148,6 +149,8 @@ These libraries are still incubating in the
 [`hex-dev`](https://github.com/kim-em/hex-dev) monorepo and have not been
 split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
+
+{include 2 HexManual.Chapters.HexModular}
 
 {include 2 HexManual.Chapters.HexResultant}
 

--- a/HexManual/Chapters/HexModular.lean
+++ b/HexManual/Chapters/HexModular.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexModular
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexModular: CRT and rational reconstruction" =>
+%%%
+tag := "hex-modular"
+%%%
+
+# Introduction
+%%%
+tag := "hex-modular-intro"
+%%%
+
+`HexModular` provides executable symmetric residues, incremental Chinese
+remaindering, rational reconstruction, and a bounded multimodular loop.
+The implementation is Mathlib-free and uses `HexArith` for its compiled
+integer extended GCD.
+
+Every search routine checks its output before returning it. Downstream
+algorithms can replay the small public correctness lemmas without unfolding
+the Euclidean search or trusting an external oracle.
+
+# Symmetric representatives
+%%%
+tag := "hex-modular-symmetric"
+%%%
+
+{docstring Hex.Modular.symMod}
+
+The three characterizing theorems say that reduction preserves the ordinary
+residue, lands in the closed half-modulus interval, and is unique away from
+the even-modulus tie.
+
+{docstring Hex.Modular.symMod_emod}
+
+{docstring Hex.Modular.symMod_le}
+
+{docstring Hex.Modular.symMod_unique}
+
+# Incremental Chinese remaindering
+%%%
+tag := "hex-modular-crt"
+%%%
+
+{docstring Hex.Modular.Crt}
+
+{docstring Hex.Modular.Crt.init}
+
+{docstring Hex.Modular.Crt.push}
+
+A successful push multiplies the accumulated modulus, records the new
+residue, and preserves every residue already represented by the state.
+
+{docstring Hex.Modular.Crt.push_modulus}
+
+{docstring Hex.Modular.Crt.push_congr_new}
+
+{docstring Hex.Modular.Crt.push_congr_old}
+
+{docstring Hex.Modular.crt_unique}
+
+For several residue streams sharing the same moduli,
+{name}`Hex.Modular.CrtVec` computes one inverse per push and reuses it across
+all coordinates. Its `push_modulus`, `push_congr_new`, and `push_congr_old`
+theorems have the same shape as the scalar results.
+
+# Rational reconstruction
+%%%
+tag := "hex-modular-reconstruction"
+%%%
+
+{docstring Hex.Modular.Row}
+
+{docstring Hex.Modular.euclidUntil}
+
+{docstring Hex.Modular.ratRecon?}
+
+{docstring Hex.Modular.ratReconWide?}
+
+Successful bounded reconstruction supplies congruence and size facts, and
+the reduced denominator is coprime to the modulus. Under the standard
+strict uniqueness bound, every admissible rational is found.
+
+{docstring Hex.Modular.ratRecon?_congr}
+
+{docstring Hex.Modular.ratRecon?_bounds}
+
+{docstring Hex.Modular.ratRecon?_den_coprime}
+
+{docstring Hex.Modular.ratRecon_unique}
+
+{docstring Hex.Modular.ratRecon?_complete}
+
+{docstring Hex.Modular.ratReconVec?}
+
+The maximal-quotient variant is intentionally heuristic. Its theorem promises
+only the checked modular congruence, not recovery of a preferred rational.
+
+{docstring Hex.Modular.ratReconMaxQuot?}
+
+{docstring Hex.Modular.ratReconMaxQuot?_congr}
+
+# Multimodular loops
+%%%
+tag := "hex-modular-loop"
+%%%
+
+{docstring Hex.Modular.crtLoop}
+
+The loop skips missing images and rejected moduli, tests the caller's exact
+acceptance function only after a successful push, and consumes at most the
+supplied fuel. {name}`Hex.Modular.CrtTrace` records the precise consumed
+prefix.
+
+{docstring Hex.Modular.crtLoop_trace}
+
+{docstring Hex.Modular.crtLoop_of_some}
+
+## Worked example
+%%%
+tag := "hex-modular-worked"
+%%%
+
+The first computation combines `1 mod 3` and `0 mod 2`; the second recovers
+the rational `2/3` from its residue `68 mod 101`.
+
+```lean
+open Hex.Modular
+
+namespace HexModularChapter
+
+def combined : Option (Nat × Int) := do
+  let first ← Crt.init.push 1 3
+  let second ← first.push 0 2
+  pure (second.modulus, second.value)
+
+#guard combined = some (6, -2)
+#guard symMod 17 10 = -3
+#guard
+  ratRecon? 68 101 8 8 =
+    some (Rat.divInt 2 3)
+
+end HexModularChapter
+```
+
+# The Mathlib correspondence
+%%%
+tag := "hex-modular-mathlib"
+%%%
+
+The executable library states congruence using integer remainders and
+`Rat`. The specified `HexModularMathlib` companion transports those results
+to `ZMod` and `ℚ`, including the Chinese-remainder equivalence and rational
+reconstruction predicates. Until that bridge is available, the integer
+congruence lemmas above are the supported proof boundary.
+
+# Cross-references
+%%%
+tag := "hex-modular-cross-references"
+%%%
+
+* {ref "hex-arith"}[`HexArith`] supplies the compiled extended GCD used by
+  CRT accumulation.
+* {ref "hex-mod-arith"}[`HexModArith`] supplies the bundled deterministic
+  modulus stream used by modular algorithms.
+* `HexPolyZGcd`, `HexMvGcd`, and `HexMvHensel` consume this library's CRT,
+  reconstruction, and multimodular-loop APIs.

--- a/HexModular.lean
+++ b/HexModular.lean
@@ -9,7 +9,6 @@ module
 public import HexModular.Crt
 public import HexModular.Euclid
 public import HexModular.Loop
-public import HexModular.LoopTests
 public import HexModular.Recon
 public import HexModular.SymMod
 

--- a/HexModular/README.md
+++ b/HexModular/README.md
@@ -1,0 +1,73 @@
+# hex-modular
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-modular` provides symmetric integer residues, incremental scalar and
+vector CRT, rational reconstruction, and fuel-bounded multimodular loops. It
+depends on [`hex-arith`](https://github.com/leanprover/hex-arith). The
+Mathlib correspondence belongs in
+[`hex-modular-mathlib`](https://github.com/leanprover/hex-modular-mathlib).
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-modular"
+git = "https://github.com/leanprover/hex-modular.git"
+rev = "main"
+```
+
+```lean
+import HexModular
+
+open Hex.Modular
+
+def combined : Option (Nat × Int) := do
+  let first ← Crt.init.push 1 3
+  let second ← first.push 0 2
+  pure (second.modulus, second.value)
+
+#eval combined
+#eval symMod 17 10
+#eval ratRecon? 68 101 8 8
+```
+
+# Functionality
+
+- Symmetric integer reduction with `symMod`.
+- Incremental scalar CRT with `Crt.init` and `Crt.push`.
+- Common-modulus vector CRT with `CrtVec.init` and `CrtVec.push`.
+- Bounded, wide, vector, and maximal-quotient rational reconstruction with
+  `ratRecon?`, `ratReconWide?`, `ratReconVec?`, and `ratReconMaxQuot?`.
+- Fuel-bounded modular image accumulation with `crtLoop` and `CrtTrace`.
+
+# Verification
+
+Successful CRT pushes preserve old congruences, record every new residue,
+and maintain a canonical half-modulus representative. Bounded rational
+reconstruction proves congruence, bounds, denominator coprimality,
+uniqueness, and completeness under the standard strict bound. The
+maximal-quotient heuristic promises congruence only.
+
+```lean
+theorem ratRecon?_complete {a P Q : Int} {m : Nat} {y : Rat}
+    (hm : 2 * P * Q < (m : Int))
+    (hy : (Int.ofNat y.den * a - y.num) % (m : Int) = 0)
+    (hb : (y.num.natAbs : Int) ≤ P ∧ (y.den : Int) ≤ Q) :
+    ratRecon? a m P Q = some y
+```
+
+The executable library is Mathlib-free. Correspondence with `ZMod`,
+Mathlib's Chinese remainder API, and `ℚ` belongs in
+[`hex-modular-mathlib`](https://github.com/leanprover/hex-modular-mathlib).
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want, and
+leave the implementation to the maintainer.

--- a/HexModular/SymMod.lean
+++ b/HexModular/SymMod.lean
@@ -37,7 +37,7 @@ positive modulus. -/
 theorem symMod_emod {a : Int} {m : Nat} (h : 0 < m) :
     (symMod a m) % (m : Int) = a % (m : Int) := by
   unfold symMod
-  rw [if_neg (Nat.ne_of_gt h)]
+  rw [ite_eq_right (Nat.ne_of_gt h)]
   simp only
   split
   · rw [Int.sub_emod, Int.emod_self, Int.sub_zero]
@@ -54,7 +54,7 @@ theorem symMod_le {a : Int} {m : Nat} (h : 0 < m) :
   have hrm : a % (m : Int) < (m : Int) :=
     Int.emod_lt_of_pos _ hm
   unfold symMod
-  rw [if_neg (Nat.ne_of_gt h)]
+  rw [ite_eq_right (Nat.ne_of_gt h)]
   simp only
   split
   · rename_i hlarge

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -640,6 +640,7 @@ lean_lib HexReleaseTests where
 -- must exactly mirror the repositories already present in the release manifest.
 lean_lib HexMvFactorizationTests where
   globs := #[`HexModular.KernelTests,
+    `HexModular.LoopTests,
     `HexPolyZGcd.Kernel,
     `HexMvGcd.KernelTests,
     `HexMvGcd.Kernel,

--- a/libraries.yml
+++ b/libraries.yml
@@ -219,7 +219,7 @@ libraries:
   HexModular:
     deps: [HexArith]
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       comparators:

--- a/libraries.yml
+++ b/libraries.yml
@@ -219,7 +219,7 @@ libraries:
   HexModular:
     deps: [HexArith]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:

--- a/libraries.yml
+++ b/libraries.yml
@@ -219,7 +219,7 @@ libraries:
   HexModular:
     deps: [HexArith]
     mathlib: false
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       comparators:

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -892,5 +892,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "f429150001cdfe913842fd157f5546c8772a0823",
     "reason": "Registers the HexModular benchmark executable and its bench-only support library on top of the sparse-release and conformance registrations; no factorization runtime target, definition, build flag, or dependency changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "2cea1c0addfba1a78d74b905e0297eb1f3441778",
+    "reason": "Moves the existing HexModular.LoopTests module from the public library umbrella into the build-only HexMvFactorizationTests verification target; no factorization runtime definition, executable, build flag, or dependency changes."
   }
 ]


### PR DESCRIPTION
## Summary
- discharge the HexModular Phase 5 proof audit and record the sorry-free boundary
- complete the Phase 6 API, linter, dead-declaration, and public-umbrella polish
- add the Phase 7 manual chapter and split-repository README
- keep the test-only loop module out of the public umbrella while building it explicitly in the aggregate test target

## Verification
- `lake build HexModular HexConformance HexManual.Chapters.HexModular` (10,013 jobs; passed)
- `lake build HexManual` (9,899 jobs; passed before the dependency rebase)
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/release/check_manual_split.py`
- `git diff --check origin/main...HEAD`

This stops before publication. The specified Mathlib correspondence companion is separate follow-on work; the chapter states its present availability accurately.