### PR TITLE
Prove extended subresultant chain law

### DIFF
--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexResultant.SubresultantMinor
+public import HexDeterminant.Adjugate
 import all HexResultant.SubresultantMinor
 
 public section
@@ -588,6 +589,491 @@ theorem det_setCol_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     grind
   rw [hcol]
   exact h.trans (by grind)
+
+/-! # Bridge to the reusable matrix determinant
+
+The finite-function determinant remains the definition used by the resultant
+development.  This bridge lets later proof-only cofactor arguments reuse the
+row and adjugate algebra of `HexDeterminant` without changing that definition.
+-/
+
+/-- Regard a proof-only square coefficient family as a `Hex.Matrix`. -/
+@[expose]
+def toMatrix {R : Type u} {n : Nat} (M : Square R n) : Matrix R n n :=
+  Matrix.ofFn M
+
+/-- Entries are unchanged by the matrix view. -/
+@[simp, grind =]
+theorem toMatrix_get {R : Type u} {n : Nat} (M : Square R n)
+    (i j : Fin n) : (toMatrix M)[i][j] = M i j := by
+  rw [toMatrix, Matrix.getElem_ofFn]
+
+/-- The local first-row Laplace determinant agrees with the reusable Leibniz
+matrix determinant. -/
+theorem det_toMatrix {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R n) : det M = Matrix.det (toMatrix M) := by
+  induction n with
+  | zero =>
+      rw [det_zero]
+      have h := Matrix.det_principalSubmatrix_zero (toMatrix M)
+      have hmatrix :
+          Matrix.principalSubmatrix (toMatrix M) 0 (Nat.zero_le 0) =
+            toMatrix M := by
+        apply Matrix.ext_getElem
+        intro i
+        exact Fin.elim0 i
+      rw [hmatrix] at h
+      exact h.symm
+  | succ n ih =>
+      let row : Fin (n + 1) := ⟨0, by omega⟩
+      change
+        (List.finRange (n + 1)).foldl
+            (fun acc j =>
+              acc + sign j.val * M row j * det (deleteFirst M j)) 0 =
+          Matrix.det (toMatrix M)
+      rw [Matrix.det_eq_foldl_laplace_row (toMatrix M) row]
+      simp only [toMatrix_get]
+      change
+        (List.finRange (n + 1)).foldl
+            (fun acc j =>
+              acc + sign j.val * M row j * det (deleteFirst M j)) 0 =
+          (List.finRange (n + 1)).foldl
+            (fun acc j =>
+              acc + M row j * Matrix.cofactor (toMatrix M) row j) 0
+      apply foldl_congr
+      · rfl
+      · intro acc j _hj
+        have hminor :
+            Matrix.deleteRowCol (toMatrix M) row j =
+              toMatrix (deleteFirst M j) := by
+          apply Matrix.ext_getElem
+          intro i k
+          rw [Matrix.getElem_deleteRowCol, toMatrix_get, toMatrix_get]
+          rfl
+        have hsign : sign (R := R) j.val =
+            Matrix.cofactorSign (R := R) row j := by
+          unfold sign Matrix.cofactorSign
+          by_cases h : j.val % 2 = 0
+          · rw [if_pos h, if_pos (by simpa [row] using h)]
+          · rw [if_neg h, if_neg (by simpa [row] using h)]
+            grind
+        unfold Matrix.cofactor
+        rw [hminor, ← ih, ← hsign]
+        grind
+
+/-- A local determinant with two equal rows vanishes. -/
+theorem det_eq_zero_of_row_eq {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R n) (src dst : Fin n) (h : src ≠ dst)
+    (hrow : ∀ j, M src j = M dst j) :
+    det M = 0 := by
+  rw [det_toMatrix]
+  apply Matrix.det_eq_zero_of_row_eq (toMatrix M) src dst h
+  apply Vector.ext
+  intro j hj
+  change (toMatrix M)[src][(⟨j, hj⟩ : Fin n)] =
+    (toMatrix M)[dst][(⟨j, hj⟩ : Fin n)]
+  rw [toMatrix_get, toMatrix_get]
+  exact hrow _
+
+/-- A square matrix with nonzero determinant has trivial right kernel over an
+exact-division domain. -/
+theorem vector_eq_zero_of_mul_eq_zero {R : Type u}
+    [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R] {n : Nat}
+    (M : Square R n) (hn : 0 < n) (hdet : det M ≠ 0) (v : Vector R n)
+    (hmul : toMatrix M * v = 0) : ∀ j : Fin n, v[j] = 0 := by
+  cases n with
+  | zero => omega
+  | succ n =>
+      have hassoc := Matrix.mul_assoc_vec
+        (Matrix.adjugate (toMatrix M)) (toMatrix M) v
+      have hscale :
+          ((Matrix.det (toMatrix M)) • Matrix.identity (R := R) (n + 1)) * v =
+            (Matrix.det (toMatrix M)) • v := by
+        apply Vector.ext
+        intro i hi
+        let ii : Fin (n + 1) := ⟨i, hi⟩
+        change
+          (((Matrix.det (toMatrix M)) • Matrix.identity (R := R) (n + 1)) * v)[ii] =
+            ((Matrix.det (toMatrix M)) • v)[ii]
+        rw [Matrix.getElem_mulVec, Matrix.row_smul,
+          Vector.dotProduct_smul_left]
+        have hid := congrArg (fun w : Vector R (n + 1) => w[ii])
+          (Matrix.identity_mulVec v)
+        rw [Matrix.getElem_mulVec] at hid
+        change ((Matrix.identity (R := R) (n + 1)).row ii).dotProduct v =
+          v[ii] at hid
+        have hentry : ((Matrix.det (toMatrix M)) • v)[ii] =
+            Matrix.det (toMatrix M) * v[ii] := by
+          simp only [Fin.getElem_fin, Vector.getElem_smul]
+          rfl
+        rw [hid, hentry]
+      rw [Matrix.adjugate_mul, hscale, hmul, Matrix.mulVec_zero] at hassoc
+      intro j
+      have hj := congrArg (fun w : Vector R (n + 1) => w[j]) hassoc
+      have hsmul : ((Matrix.det (toMatrix M)) • v)[j] =
+          Matrix.det (toMatrix M) * v[j] := by
+        simp only [Fin.getElem_fin, Vector.getElem_smul]
+        rfl
+      have hzero : (0 : Vector R (n + 1))[j] = 0 := by
+        simp only [Fin.getElem_fin, Vector.getElem_zero]
+      rw [hsmul, hzero] at hj
+      rw [← det_toMatrix] at hj
+      apply ExactDivLaws.mul_right_cancel hdet
+      grind
+
+/-- The signed cofactor of a column along the final row. -/
+@[expose]
+def lastCofactor {R : Type u} [Lean.Grind.CommRing R] :
+    {n : Nat} → Square R n → Fin n → R
+  | 0, _, j => Fin.elim0 j
+  | n + 1, M, j => Matrix.cofactor (toMatrix M) (Fin.last n) j
+
+/-- A final-row cofactor is independent of the entries in that final row. -/
+theorem lastCofactor_congr {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M N : Square R n) (j : Fin n)
+    (h : ∀ i k, i.val < n - 1 → M i k = N i k) :
+    lastCofactor M j = lastCofactor N j := by
+  cases n with
+  | zero => exact Fin.elim0 j
+  | succ n =>
+      simp only [lastCofactor]
+      unfold Matrix.cofactor
+      congr 1
+      apply congrArg Matrix.det
+      apply Matrix.ext_getElem
+      intro i k
+      rw [Matrix.getElem_deleteRowCol, Matrix.getElem_deleteRowCol,
+        toMatrix_get, toMatrix_get]
+      apply h
+      simp [Matrix.skipIndex_last]
+
+/-- Laplace expansion along the final row using `lastCofactor`. -/
+theorem det_lastCofactor {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1)) :
+    det M = (List.finRange (n + 1)).foldl
+      (fun acc j => acc + M (Fin.last n) j * lastCofactor M j) 0 := by
+  rw [det_toMatrix, Matrix.det_eq_foldl_laplace_row (toMatrix M) (Fin.last n)]
+  apply foldl_congr
+  · rfl
+  · intro acc j _hj
+    simp only [toMatrix_get, lastCofactor]
+
+/-- Laplace expansion along the final row, stated for an arbitrary positive
+dimension. -/
+theorem det_lastCofactor_of_pos {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R n) (hn : 0 < n) :
+    det M = (List.finRange n).foldl
+      (fun acc j => acc + M ⟨n - 1, by omega⟩ j * lastCofactor M j) 0 := by
+  cases n with
+  | zero => omega
+  | succ n =>
+      rw [det_lastCofactor M]
+      apply foldl_congr
+      · rfl
+      · intro acc j _hj
+        congr 2
+
+/-! # Expansion along the last row
+
+The coefficient row in a generalized Sylvester minor is the last row.  The
+local determinant recurses on the first row, so the following lemmas derive
+the one piece of row algebra needed by the cofactor development solely from
+the column multilinearity above. -/
+
+/-- The column vector supported by one at the final row. -/
+@[expose]
+def lastUnit {R : Type u} [Zero R] [One R] {n : Nat} : Fin (n + 1) → R :=
+  fun i => if i = Fin.last n then 1 else 0
+
+/-- Clear the final entry of one column. -/
+@[expose]
+def clearLast {R : Type u} [Zero R] {n : Nat} (M : Square R (n + 1))
+    (dst : Fin (n + 1)) : Square R (n + 1) :=
+  setCol M dst (fun i => if i = Fin.last n then 0 else M i dst)
+
+/-- Clear the final entries of a list of columns. -/
+@[expose]
+def clearLastCols {R : Type u} [Zero R] {n : Nat} :
+    Square R (n + 1) → List (Fin (n + 1)) → Square R (n + 1)
+  | M, [] => M
+  | M, dst :: cols => clearLastCols (clearLast M dst) cols
+
+/-- The cofactor terms contributed by a list of columns in a final-row
+Laplace expansion. -/
+@[expose]
+def lastRowTerms {R : Type u} [Zero R] [One R] [Add R] [Sub R] [Mul R]
+    {n : Nat} (M : Square R (n + 1)) : List (Fin (n + 1)) → R
+  | [] => 0
+  | dst :: cols =>
+      M (Fin.last n) dst * det (setCol M dst lastUnit) +
+        lastRowTerms M cols
+
+/-- A square family with zero final row has zero determinant. -/
+theorem det_lastRow_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1)) (hzero : ∀ j, M (Fin.last n) j = 0) :
+    det M = 0 := by
+  induction n with
+  | zero =>
+      change 0 + sign 0 * M 0 0 * 1 = 0
+      have hentry : M 0 0 = 0 := by
+        apply hzero
+      rw [hentry]
+      grind
+  | succ n ih =>
+      have hminor (j : Fin (n + 2)) : det (deleteFirst M j) = 0 := by
+        apply ih
+        intro k
+        change M (Fin.last n).succ (skipIndex j k) = 0
+        have hlast : (Fin.last n).succ = Fin.last (n + 1) := by
+          apply Fin.ext
+          simp
+        rw [hlast]
+        exact hzero _
+      change (List.finRange (n + 2)).foldl
+        (fun acc j => acc + sign j.val * M 0 j * det (deleteFirst M j)) 0 = 0
+      apply foldl_add_zero
+      intro j _hj
+      rw [hminor]
+      grind
+
+/-- A positive-dimensional square family with zero final row has zero
+determinant. -/
+theorem det_lastRow_zero_of_pos {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R n) (hn : 0 < n)
+    (hzero : ∀ j, M ⟨n - 1, by omega⟩ j = 0) :
+    det M = 0 := by
+  cases n with
+  | zero => omega
+  | succ n =>
+      apply det_lastRow_zero M
+      intro j
+      have hlast : Fin.last n = ⟨n + 1 - 1, by omega⟩ := by
+        apply Fin.ext
+        simp
+      rw [hlast]
+      exact hzero j
+
+/-- Replacing a column by `lastUnit` makes the determinant independent of
+all other entries in the final row. -/
+theorem det_lastUnit_congr {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M N : Square R (n + 1)) (dst : Fin (n + 1))
+    (hM : ∀ i, M i dst = lastUnit i)
+    (hN : ∀ i, N i dst = lastUnit i)
+    (hoff : ∀ i j, i ≠ Fin.last n → M i j = N i j) :
+    det M = det N := by
+  induction n with
+  | zero =>
+      have hentry : M (Fin.last 0) dst = N (Fin.last 0) dst :=
+        (hM _).trans (hN _).symm
+      have hdst : dst = Fin.last 0 := Fin.ext (by omega)
+      subst dst
+      have hentry' : M (0 : Fin 1) 0 = N 0 0 := by
+        simpa using hentry
+      change 0 + sign 0 * M 0 0 * 1 = 0 + sign 0 * N 0 0 * 1
+      rw [hentry']
+  | succ n ih =>
+      let row : Fin (n + 2) := ⟨0, by omega⟩
+      have hrow : row ≠ Fin.last (n + 1) := by
+        intro h
+        have := congrArg Fin.val h
+        simp [row] at this
+      have hentry (j : Fin (n + 2)) : M row j = N row j :=
+        hoff row j hrow
+      have hterm (j : Fin (n + 2)) :
+          sign j.val * M row j * det (deleteFirst M j) =
+            sign j.val * N row j * det (deleteFirst N j) := by
+        by_cases hj : j = dst
+        · subst j
+          rw [hM row, hN row]
+          have hunit : lastUnit (R := R) row = 0 := by
+            simp [lastUnit, row]
+          rw [hunit]
+          grind
+        · have hdst : dst ≠ j := fun h => hj h.symm
+          let dst' := eraseIndex j dst hdst
+          have hM' (i : Fin (n + 1)) :
+              deleteFirst M j i dst' = lastUnit i := by
+            unfold deleteFirst
+            rw [skipIndex_eraseIndex]
+            rw [hM]
+            unfold lastUnit
+            by_cases hi : i = Fin.last n
+            · subst i
+              simp
+            · have hisucc : i.succ ≠ Fin.last (n + 1) := by
+                intro h
+                apply hi
+                apply Fin.ext
+                have := congrArg Fin.val h
+                simp at this ⊢
+                omega
+              rw [if_neg hi, if_neg hisucc]
+          have hN' (i : Fin (n + 1)) :
+              deleteFirst N j i dst' = lastUnit i := by
+            unfold deleteFirst
+            rw [skipIndex_eraseIndex]
+            rw [hN]
+            unfold lastUnit
+            by_cases hi : i = Fin.last n
+            · subst i
+              simp
+            · have hisucc : i.succ ≠ Fin.last (n + 1) := by
+                intro h
+                apply hi
+                apply Fin.ext
+                have := congrArg Fin.val h
+                simp at this ⊢
+                omega
+              rw [if_neg hi, if_neg hisucc]
+          have hoff' (i k : Fin (n + 1)) (hi : i ≠ Fin.last n) :
+              deleteFirst M j i k = deleteFirst N j i k := by
+            unfold deleteFirst
+            apply hoff
+            intro hlast
+            apply hi
+            apply Fin.ext
+            have := congrArg Fin.val hlast
+            simp at this ⊢
+            omega
+          have hdet := ih (deleteFirst M j) (deleteFirst N j) dst'
+            hM' hN' hoff'
+          rw [hentry, hdet]
+      change (List.finRange (n + 2)).foldl
+          (fun acc j => acc + sign j.val * M 0 j * det (deleteFirst M j)) 0 =
+        (List.finRange (n + 2)).foldl
+          (fun acc j => acc + sign j.val * N 0 j * det (deleteFirst N j)) 0
+      apply foldl_congr
+      · rfl
+      · intro acc j _hj
+        have := hterm j
+        change acc + sign j.val * M row j * det (deleteFirst M j) =
+          acc + sign j.val * N row j * det (deleteFirst N j)
+        exact congrArg (fun x => acc + x) this
+
+/-- Clearing one column splits off its final-row cofactor term. -/
+theorem det_clearLast {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1)) (dst : Fin (n + 1)) :
+    det M = det (clearLast M dst) +
+      M (Fin.last n) dst * det (setCol M dst lastUnit) := by
+  let top : Fin (n + 1) → R :=
+    fun i => if i = Fin.last n then 0 else M i dst
+  let bottom : Fin (n + 1) → R :=
+    fun i => M (Fin.last n) dst * lastUnit i
+  have hcol : (fun i => top i + bottom i) = fun i => M i dst := by
+    funext i
+    by_cases hi : i = Fin.last n
+    · subst i
+      simp [top, bottom, lastUnit]
+      grind
+    · simp [top, bottom, lastUnit, hi]
+      grind
+  have hself : setCol M dst (fun i => top i + bottom i) = M := by
+    rw [hcol, setCol_self]
+  have hadd := det_setCol_add M dst top bottom
+  have htop : setCol M dst top = clearLast M dst := rfl
+  have hbottom := det_setCol_smul M dst (M (Fin.last n) dst) lastUnit
+  rw [hself, htop, hbottom] at hadd
+  exact hadd
+
+/-- Clearing a duplicate-free list of columns expands the determinant into
+the remaining matrix plus the corresponding final-row cofactor terms. -/
+theorem det_clearLastCols {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1)) (cols : List (Fin (n + 1)))
+    (hnodup : cols.Nodup) :
+    det M = det (clearLastCols M cols) + lastRowTerms M cols := by
+  induction cols generalizing M with
+  | nil =>
+      simp [clearLastCols, lastRowTerms]
+      grind
+  | cons dst cols ih =>
+      simp only [List.nodup_cons] at hnodup
+      rw [det_clearLast]
+      rw [ih (clearLast M dst) hnodup.2]
+      have hentry (j : Fin (n + 1)) (hj : j ∈ cols) :
+          clearLast M dst (Fin.last n) j = M (Fin.last n) j := by
+        have hne : j ≠ dst := by
+          intro h
+          subst j
+          exact hnodup.1 hj
+        simp [clearLast, setCol, hne]
+      have hcofactor (j : Fin (n + 1)) (hj : j ∈ cols) :
+          det (setCol (clearLast M dst) j lastUnit) =
+            det (setCol M j lastUnit) := by
+        apply det_lastUnit_congr (dst := j)
+        · intro i
+          simp [setCol]
+        · intro i
+          simp [setCol]
+        · intro i k hi
+          by_cases hkj : k = j
+          · subst k
+            simp [setCol]
+          · by_cases hkd : k = dst
+            · subst k
+              simp [setCol, hkj, clearLast, hi]
+            · simp [setCol, hkj, clearLast, hkd]
+      have hterms : lastRowTerms (clearLast M dst) cols =
+          lastRowTerms M cols := by
+        have terms_congr (A B : Square R (n + 1))
+            (xs : List (Fin (n + 1)))
+            (he : ∀ j, j ∈ xs → A (Fin.last n) j = B (Fin.last n) j)
+            (hc : ∀ j, j ∈ xs →
+              det (setCol A j lastUnit) = det (setCol B j lastUnit)) :
+            lastRowTerms A xs = lastRowTerms B xs := by
+          induction xs with
+          | nil => rfl
+          | cons j js hjs =>
+              simp only [lastRowTerms]
+              rw [he j List.mem_cons_self, hc j List.mem_cons_self]
+              rw [hjs]
+              · intro k hk
+                exact he k (List.mem_cons_of_mem j hk)
+              · intro k hk
+                exact hc k (List.mem_cons_of_mem j hk)
+        exact terms_congr (clearLast M dst) M cols hentry hcofactor
+      rw [hterms]
+      simp only [clearLastCols, lastRowTerms]
+      grind
+
+/-- Laplace expansion of the local determinant along its final row, expressed
+using column replacements by `lastUnit`. -/
+theorem det_lastRow {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1)) :
+    det M = lastRowTerms M (List.finRange (n + 1)) := by
+  have hexpand := det_clearLastCols M (List.finRange (n + 1))
+    (nodup_finRange (n + 1))
+  have hpreserve (N : Square R (n + 1))
+      (cols : List (Fin (n + 1))) (j : Fin (n + 1))
+      (hz : N (Fin.last n) j = 0) :
+      clearLastCols N cols (Fin.last n) j = 0 := by
+    induction cols generalizing N with
+    | nil => exact hz
+    | cons k ks ih =>
+        apply ih
+        by_cases hjk : j = k
+        · subst j
+          simp [clearLast, setCol]
+        · simp [clearLast, setCol, hjk, hz]
+  have hmember (N : Square R (n + 1))
+      (cols : List (Fin (n + 1))) (j : Fin (n + 1))
+      (hj : j ∈ cols) :
+      clearLastCols N cols (Fin.last n) j = 0 := by
+    induction cols generalizing N with
+    | nil => simp at hj
+    | cons k ks ih =>
+        simp only [clearLastCols]
+        rw [List.mem_cons] at hj
+        rcases hj with rfl | hj
+        · apply hpreserve
+          simp [clearLast, setCol]
+        · exact ih (clearLast N k) hj
+  have hclear : ∀ j,
+      clearLastCols M (List.finRange (n + 1)) (Fin.last n) j = 0 := by
+    intro j
+    exact hmember M (List.finRange (n + 1)) j (List.mem_finRange j)
+  have hzero := det_lastRow_zero (clearLastCols M (List.finRange (n + 1))) hclear
+  rw [hzero] at hexpand
+  grind
 
 /-- Scale a consecutive range of columns. -/
 @[expose]

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -89,7 +89,8 @@ def BrownLaw [One R] [Add R] [Sub R] [Mul R] [Div R]
 
 /-- Integral subresultant-family invariant for one recursive Brown state. It
 keeps all accumulated factors cross-multiplied in the coefficient ring. -/
-private def BrownInv [Lean.Grind.CommRing R] [DecidableEq R]
+@[expose]
+def BrownInv [Lean.Grind.CommRing R] [DecidableEq R]
     (f g prev curr : DensePoly R) (hPrev : R) : Prop :=
   prev ≠ 0 ∧ curr ≠ 0 ∧ curr.size < prev.size ∧ hPrev ≠ 0 ∧
     ∀ J, J < curr.size →
@@ -135,7 +136,7 @@ private theorem sign_prem_cancel {S : Type u} [Lean.Grind.CommRing S]
 /-- The invariant identifies the next Brown scale with the leading principal
 coefficient of the original-pair subresultant and proves its exact quotient
 law inside the base ring. -/
-private theorem BrownInv.nextScale {S : Type u}
+theorem BrownInv.nextScale {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g prev curr : DensePoly S) (hPrev : S)
     (hinv : BrownInv f g prev curr hPrev) :
@@ -215,7 +216,7 @@ private theorem BrownInv.nextScale {S : Type u}
 
 /-- The signed first pseudo-remainder establishes the integral invariant for
 the first recursive Brown state. -/
-private theorem brownInv_init {S : Type u}
+theorem brownInv_init {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
     (hp : (pseudoDivMod f g).2 ≠ 0) :
@@ -322,7 +323,7 @@ private theorem brownInv_init {S : Type u}
 
 /-- At a nonterminal invariant state, the pseudo-remainder has the exact Brown
 factor and its quotient is the adjacent original-pair subresultant. -/
-private theorem BrownInv.factor {S : Type u}
+theorem BrownInv.factor {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g prev curr : DensePoly S) (hPrev : S)
     (hinv : BrownInv f g prev curr hPrev)
@@ -417,7 +418,7 @@ private theorem BrownInv.factor {S : Type u}
 
 /-- One nonterminal Brown step preserves the integral original-pair
 subresultant invariant. -/
-private theorem BrownInv.step {S : Type u}
+theorem BrownInv.step {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g prev curr : DensePoly S) (hPrev : S)
     (hinv : BrownInv f g prev curr hPrev)

--- a/HexResultant/SubresultantCofactor.lean
+++ b/HexResultant/SubresultantCofactor.lean
@@ -1,0 +1,968 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.BrownTraub
+import all HexResultant.BrownTraub
+import HexBasic.Fold
+
+public section
+
+/-!
+Determinantal Bezout cofactors for generalized subresultants.
+
+The coefficient minors in `SubresultantMinor` use their final row to select
+one output coefficient.  Replacing a column by the final coordinate vector
+removes that selector row and leaves an integral cofactor independent of the
+selected coefficient.  Grouping the cofactors belonging to the two Sylvester
+blocks gives the two polynomial transformation rows developed here.
+-/
+
+namespace Hex
+
+universe u v
+
+namespace DensePoly
+namespace Subresultant
+
+section Base
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+
+/-- One column cofactor in a generalized coefficient matrix. -/
+@[expose]
+def columnCofactorAt (df dg J : Nat) (f g : DensePoly R)
+    (j : Fin ((df - J) + (dg - J))) : R :=
+  SubresultantMinor.lastCofactor (coeffMatrixAt df dg J 0 f g) j
+
+/-- Accumulate the left-block cofactor monomials over selected columns. -/
+@[expose]
+def cofactorUCols (df dg J : Nat) (f g : DensePoly R) :
+    List (Fin ((df - J) + (dg - J))) → DensePoly R
+  | [] => 0
+  | j :: js =>
+      if j.val < dg - J then
+        monomial (dg - J - 1 - j.val) (columnCofactorAt df dg J f g j) +
+          cofactorUCols df dg J f g js
+      else
+        cofactorUCols df dg J f g js
+
+/-- Accumulate the right-block cofactor monomials over selected columns. -/
+@[expose]
+def cofactorVCols (df dg J : Nat) (f g : DensePoly R) :
+    List (Fin ((df - J) + (dg - J))) → DensePoly R
+  | [] => 0
+  | j :: js =>
+      if dg - J ≤ j.val then
+        monomial (df - J - 1 - (j.val - (dg - J)))
+            (columnCofactorAt df dg J f g j) +
+          cofactorVCols df dg J f g js
+      else
+        cofactorVCols df dg J f g js
+
+/-- Sum the polynomial contribution of each selected Sylvester column. -/
+@[expose]
+def cofactorRowCols (df dg J : Nat) (f g : DensePoly R) :
+    List (Fin ((df - J) + (dg - J))) → DensePoly R
+  | [] => 0
+  | j :: js =>
+      (if j.val < dg - J then
+        monomial (dg - J - 1 - j.val) (columnCofactorAt df dg J f g j) * f
+      else
+        monomial (df - J - 1 - (j.val - (dg - J)))
+          (columnCofactorAt df dg J f g j) * g) +
+        cofactorRowCols df dg J f g js
+
+/-- Scalar final-row Laplace terms over selected Sylvester columns. -/
+@[expose]
+def cofactorScalarCols (df dg J l : Nat) (f g : DensePoly R) :
+    List (Fin ((df - J) + (dg - J))) → R
+  | [] => 0
+  | j :: js =>
+      (if j.val < dg - J then
+        coeffInt f
+            (Int.ofNat l - Int.ofNat (dg - J - 1) + Int.ofNat j.val) *
+          columnCofactorAt df dg J f g j
+      else
+        coeffInt g
+            (Int.ofNat l - Int.ofNat (df - J - 1) +
+              Int.ofNat (j.val - (dg - J))) *
+          columnCofactorAt df dg J f g j) +
+        cofactorScalarCols df dg J l f g js
+
+/-- Reconstruct a bounded polynomial from a selected interval of coefficient
+columns, listed in descending monomial order. -/
+@[expose]
+def blockCols (start count total : Nat) (p : DensePoly R) :
+    List (Fin total) → DensePoly R
+  | [] => 0
+  | j :: js =>
+      (if start ≤ j.val ∧ j.val < start + count then
+        monomial (count - 1 - (j.val - start))
+          (p.coeff (count - 1 - (j.val - start)))
+      else 0) + blockCols start count total p js
+
+/-- Polynomial contribution of bounded left and right coefficient vectors. -/
+@[expose]
+def bezoutCols (df dg J : Nat) (u v f g : DensePoly R) :
+    List (Fin ((df - J) + (dg - J))) → DensePoly R
+  | [] => 0
+  | j :: js =>
+      (if j.val < dg - J then
+        monomial (dg - J - 1 - j.val) (u.coeff (dg - J - 1 - j.val)) * f
+      else
+        monomial (df - J - 1 - (j.val - (dg - J)))
+          (v.coeff (df - J - 1 - (j.val - (dg - J)))) * g) +
+        bezoutCols df dg J u v f g js
+
+/-- The bounded coefficient vector in Sylvester-column order. -/
+@[expose]
+def bezoutVector (df dg J : Nat) (u v : DensePoly R) :
+    Vector R ((df - J) + (dg - J)) :=
+  Vector.ofFn fun j =>
+    if j.val < dg - J then
+      u.coeff (dg - J - 1 - j.val)
+    else
+      v.coeff (df - J - 1 - (j.val - (dg - J)))
+
+/-- The cofactor polynomial contributed by the left (`f`) block at explicit
+formal degrees. -/
+@[expose]
+def cofactorUAt (df dg J : Nat) (f g : DensePoly R) : DensePoly R :=
+  cofactorUCols df dg J f g (List.finRange ((df - J) + (dg - J)))
+
+/-- The cofactor polynomial contributed by the right (`g`) block at explicit
+formal degrees. -/
+@[expose]
+def cofactorVAt (df dg J : Nat) (f g : DensePoly R) : DensePoly R :=
+  cofactorVCols df dg J f g (List.finRange ((df - J) + (dg - J)))
+
+/-- The left Bezout cofactor of the `J`-th generalized subresultant. -/
+@[expose]
+def cofactorU (J : Nat) (f g : DensePoly R) : DensePoly R :=
+  cofactorUAt (formalDegree f) (formalDegree g) J f g
+
+/-- The right Bezout cofactor of the `J`-th generalized subresultant. -/
+@[expose]
+def cofactorV (J : Nat) (f g : DensePoly R) : DensePoly R :=
+  cofactorVAt (formalDegree f) (formalDegree g) J f g
+
+/-- Column cofactors do not depend on the selected output coefficient, since
+that coefficient changes only the deleted final row. -/
+theorem columnCofactorAt_eq (df dg J l : Nat) (f g : DensePoly R)
+    (j : Fin ((df - J) + (dg - J))) :
+    columnCofactorAt df dg J f g j =
+      SubresultantMinor.lastCofactor (coeffMatrixAt df dg J l f g) j := by
+  unfold columnCofactorAt
+  apply SubresultantMinor.lastCofactor_congr
+  intro i k hi
+  unfold coeffMatrixAt
+  have hlast : i.val ≠ (df - J) + (dg - J) - 1 := by omega
+  simp [hlast]
+
+/-- The two accumulated cofactor blocks multiply back to the sum of their
+individual Sylvester-column contributions. -/
+theorem cofactorCols_mul (df dg J : Nat) (f g : DensePoly R)
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    cofactorUCols df dg J f g cols * f +
+        cofactorVCols df dg J f g cols * g =
+      cofactorRowCols df dg J f g cols := by
+  induction cols with
+  | nil =>
+      simp only [cofactorUCols, cofactorVCols, cofactorRowCols]
+      rw [zero_mul, zero_mul, add_zero_poly]
+  | cons j js ih =>
+      by_cases hj : j.val < dg - J
+      · have hj' : ¬dg - J ≤ j.val := by omega
+        simp only [cofactorUCols, cofactorVCols, cofactorRowCols,
+          if_pos hj, if_neg hj']
+        rw [mul_add_left_poly, add_assoc_poly, ih]
+      · have hj' : dg - J ≤ j.val := by omega
+        simp only [cofactorUCols, cofactorVCols, cofactorRowCols,
+          if_neg hj, if_pos hj']
+        rw [mul_add_left_poly]
+        calc
+          cofactorUCols df dg J f g js * f +
+              (monomial (df - J - 1 - (j.val - (dg - J)))
+                (columnCofactorAt df dg J f g j) * g +
+                cofactorVCols df dg J f g js * g) =
+              monomial (df - J - 1 - (j.val - (dg - J)))
+                  (columnCofactorAt df dg J f g j) * g +
+                (cofactorUCols df dg J f g js * f +
+                  cofactorVCols df dg J f g js * g) := by
+                    rw [← add_assoc_poly, add_comm_poly
+                      (cofactorUCols df dg J f g js * f)]
+                    rw [add_assoc_poly]
+          _ = _ := by rw [ih]
+
+/-- Multiplying by a scalar monomial shifts a scalar multiple of the right
+factor. -/
+private theorem monomial_mul_eq_shift (e : Nat) (c : R) (p : DensePoly R) :
+    monomial e c * p = shift e (scale c p) := by
+  have hmono : monomial e c = scale c (monomial e 1) := by
+    apply ext_coeff
+    intro k
+    rw [coeff_monomial, coeff_scale_semiring, coeff_monomial]
+    by_cases hke : k = e
+    · simp [hke]
+      grind
+    · simp [hke]
+      exact (Lean.Grind.Semiring.mul_zero c).symm
+  rw [hmono, ← scale_mul, monomial_one_mul_poly_eq_shift]
+  apply ext_coeff
+  intro k
+  by_cases hke : k < e
+  · simp [hke]
+    exact Lean.Grind.Semiring.mul_zero c
+  · simp [hke]
+
+/-- Coefficient form of scalar-monomial multiplication, using the same
+integer-index convention as a generalized coefficient matrix. -/
+private theorem coeff_monomial_mul (e : Nat) (c : R) (p : DensePoly R)
+    (l : Nat) :
+    (monomial e c * p).coeff l =
+      c * coeffInt p (Int.ofNat l - Int.ofNat e) := by
+  rw [monomial_mul_eq_shift, coeff_shift_scale_semiring]
+  unfold coeffInt
+  by_cases hle : l < e
+  · have hneg : Int.ofNat l - Int.ofNat e < 0 :=
+      Int.sub_neg_of_lt (Int.ofNat_lt.mpr hle)
+    rw [if_pos hle, if_pos hneg, Lean.Grind.Semiring.mul_zero]
+    rfl
+  · have hleInt : Int.ofNat e ≤ Int.ofNat l :=
+      Int.ofNat_le.mpr (Nat.le_of_not_gt hle)
+    have hnneg : ¬Int.ofNat l - Int.ofNat e < 0 :=
+      Int.not_lt.mpr (Int.sub_nonneg_of_le hleInt)
+    rw [if_neg hle, if_neg hnneg]
+    have hnat := Int.toNat_sub l e
+    change (Int.ofNat l - Int.ofNat e).toNat = l - e at hnat
+    rw [hnat]
+
+omit [DecidableEq R] in
+private theorem foldl_add_eq_foldr {A : Type v} (xs : List A) (h : A → R)
+    (a : R) :
+    xs.foldl (fun acc x => acc + h x) a =
+      a + xs.foldr (fun x acc => h x + acc) 0 := by
+  induction xs generalizing a with
+  | nil =>
+      simp only [List.foldl_nil, List.foldr_nil]
+      grind
+  | cons x xs ih =>
+      simp only [List.foldl_cons, List.foldr_cons]
+      rw [ih]
+      grind
+
+private theorem coeff_blockCols (start count total : Nat) (p : DensePoly R)
+    (cols : List (Fin total)) (k : Nat) :
+    (blockCols start count total p cols).coeff k =
+      cols.foldr
+        (fun j acc =>
+          (if start ≤ j.val ∧ j.val < start + count then
+            if k = count - 1 - (j.val - start) then
+              p.coeff (count - 1 - (j.val - start))
+            else 0
+          else 0) + acc)
+        0 := by
+  induction cols with
+  | nil => simp [blockCols]
+  | cons j js ih =>
+      simp only [blockCols, List.foldr_cons]
+      rw [coeff_add_semiring, ih]
+      by_cases hj : start ≤ j.val ∧ j.val < start + count
+      · rw [if_pos hj, if_pos hj, coeff_monomial]
+        by_cases hk : k = count - 1 - (j.val - start)
+        · rw [if_pos hk, if_pos hk]
+        · rw [if_neg hk, if_neg hk]
+          rfl
+      · rw [if_neg hj, if_neg hj, coeff_zero]
+
+/-- A full interval of reversed coefficient columns reconstructs the bounded
+polynomial. -/
+theorem blockCols_finRange (start count total : Nat) (p : DensePoly R)
+    (hfit : start + count ≤ total) (hsize : p.size ≤ count) :
+    blockCols start count total p (List.finRange total) = p := by
+  apply ext_coeff
+  intro k
+  rw [coeff_blockCols]
+  let term : Fin total → R := fun j =>
+    if start ≤ j.val ∧ j.val < start + count then
+      if k = count - 1 - (j.val - start) then
+        p.coeff (count - 1 - (j.val - start))
+      else 0
+    else 0
+  have hfold := foldl_add_eq_foldr (R := R) (List.finRange total) term 0
+  have hfold' :
+      (List.finRange total).foldr (fun j acc => term j + acc) 0 =
+        (List.finRange total).foldl (fun acc j => acc + term j) 0 := by
+    grind
+  change (List.finRange total).foldr (fun j acc => term j + acc) 0 = p.coeff k
+  rw [hfold']
+  by_cases hk : k < count
+  · let q : Fin total := ⟨start + (count - 1 - k), by omega⟩
+    calc
+      (List.finRange total).foldl (fun acc j => acc + term j) 0 =
+          (List.finRange total).foldl
+            (fun acc j => acc + if j = q then p.coeff k else 0) 0 := by
+              apply List.foldl_congr
+              intro acc j _hj
+              congr 1
+              dsimp only [term, q]
+              by_cases hjq : j = ⟨start + (count - 1 - k), by omega⟩
+              · subst j
+                simp only [if_pos rfl]
+                rw [if_pos (by omega), if_pos (by omega)]
+                congr 1
+                omega
+              · rw [if_neg hjq]
+                by_cases hjblock : start ≤ j.val ∧ j.val < start + count
+                · rw [if_pos hjblock]
+                  rw [if_neg]
+                  intro heq
+                  apply hjq
+                  apply Fin.ext
+                  symm
+                  have hdle : j.val - start ≤ count - 1 := by omega
+                  have hsplit : start + (j.val - start) = j.val := by omega
+                  calc
+                    start + (count - 1 - k) =
+                        start + (count - 1 -
+                          (count - 1 - (j.val - start))) := by rw [heq]
+                    _ = start + (j.val - start) := by
+                      rw [Nat.sub_sub_self hdle]
+                    _ = j.val := hsplit
+                · rw [if_neg hjblock]
+      _ = 0 + p.coeff k := by
+        exact List.foldl_add_single (List.finRange total) 0 q
+          (fun _ => p.coeff k) (List.mem_finRange q) (List.nodup_finRange total)
+      _ = p.coeff k := by grind
+  · have hpzero : p.coeff k = 0 :=
+      coeff_eq_zero_of_size_le p (by omega)
+    have hterm : ∀ j, j ∈ List.finRange total → term j = 0 := by
+      intro j _hj
+      dsimp only [term]
+      by_cases hjblock : start ≤ j.val ∧ j.val < start + count
+      · rw [if_pos hjblock, if_neg (by omega)]
+      · rw [if_neg hjblock]
+    rw [List.foldl_add_eq_self _ term 0 hterm, hpzero]
+
+/-- The two reconstructed coefficient blocks multiply to their per-column
+Bezout contributions. -/
+theorem blockCols_mul (df dg J : Nat) (u v f g : DensePoly R)
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    blockCols 0 (dg - J) ((df - J) + (dg - J)) u cols * f +
+        blockCols (dg - J) (df - J) ((df - J) + (dg - J)) v cols * g =
+      bezoutCols df dg J u v f g cols := by
+  induction cols with
+  | nil =>
+      simp only [blockCols, bezoutCols]
+      rw [zero_mul, zero_mul, add_zero_poly]
+  | cons j js ih =>
+      by_cases hj : j.val < dg - J
+      · have hleft : 0 ≤ j.val ∧ j.val < 0 + (dg - J) := by omega
+        have hright : ¬(dg - J ≤ j.val ∧ j.val < dg - J + (df - J)) := by
+          omega
+        simp only [blockCols, bezoutCols, if_pos hj, if_pos hleft,
+          if_neg hright]
+        rw [add_comm_poly (0 : DensePoly R), add_zero_poly]
+        rw [mul_add_left_poly, add_assoc_poly, ih]
+        simp only [Nat.sub_zero]
+      · have hleft : ¬(0 ≤ j.val ∧ j.val < 0 + (dg - J)) := by omega
+        have hright : dg - J ≤ j.val ∧
+            j.val < dg - J + (df - J) := by
+          have hjfin := j.isLt
+          omega
+        simp only [blockCols, bezoutCols, if_neg hj, if_neg hleft,
+          if_pos hright]
+        rw [add_comm_poly (0 : DensePoly R)
+          (blockCols 0 (dg - J) (df - J + (dg - J)) u js), add_zero_poly,
+          mul_add_left_poly]
+        calc
+          blockCols 0 (dg - J) (df - J + (dg - J)) u js * f +
+              (monomial (df - J - 1 - (j.val - (dg - J)))
+                  (v.coeff (df - J - 1 - (j.val - (dg - J)))) * g +
+                blockCols (dg - J) (df - J) (df - J + (dg - J)) v js * g) =
+              monomial (df - J - 1 - (j.val - (dg - J)))
+                    (v.coeff (df - J - 1 - (j.val - (dg - J)))) * g +
+                (blockCols 0 (dg - J) (df - J + (dg - J)) u js * f +
+                  blockCols (dg - J) (df - J) (df - J + (dg - J)) v js * g) := by
+                    rw [← add_assoc_poly, add_comm_poly
+                      (blockCols 0 (dg - J) (df - J + (dg - J)) u js * f)]
+                    rw [add_assoc_poly]
+          _ = _ := by rw [ih]
+
+/-- Full bounded column lists reconstruct the original Bezout polynomial. -/
+theorem bezoutCols_finRange (df dg J : Nat) (u v f g : DensePoly R)
+    (hu : u.size ≤ dg - J) (hv : v.size ≤ df - J) :
+    bezoutCols df dg J u v f g
+        (List.finRange ((df - J) + (dg - J))) =
+      u * f + v * g := by
+  rw [← blockCols_mul]
+  rw [blockCols_finRange 0 (dg - J) ((df - J) + (dg - J)) u
+      (by omega) hu]
+  rw [blockCols_finRange (dg - J) (df - J)
+      ((df - J) + (dg - J)) v (by omega) hv]
+
+/-- Coefficients of bounded Bezout columns are matrix-row products with the
+bounded coefficient vector. -/
+theorem coeff_bezoutCols (df dg J l : Nat) (u v f g : DensePoly R)
+    (hcount : 0 < (df - J) + (dg - J))
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    (bezoutCols df dg J u v f g cols).coeff l =
+      cols.foldr
+        (fun j acc =>
+          coeffMatrixAt df dg J l f g
+              ⟨(df - J) + (dg - J) - 1, by omega⟩ j *
+            (bezoutVector df dg J u v)[j] + acc)
+        0 := by
+  induction cols with
+  | nil => simp [bezoutCols]
+  | cons j js ih =>
+      simp only [bezoutCols, List.foldr_cons]
+      rw [coeff_add_semiring, ih]
+      unfold coeffMatrixAt bezoutVector
+      simp only [Fin.getElem_fin, Vector.getElem_ofFn]
+      by_cases hj : j.val < dg - J
+      · simp only [if_pos hj, if_pos True.intro, coeff_monomial_mul]
+        have hle : j.val ≤ dg - J - 1 := by omega
+        have hcast : Int.ofNat (dg - J - 1 - j.val) =
+            Int.ofNat (dg - J - 1) - Int.ofNat j.val :=
+          Int.ofNat_sub hle
+        rw [hcast]
+        grind
+      · simp only [if_neg hj, if_pos True.intro, coeff_monomial_mul]
+        have hbound : j.val - (dg - J) ≤ df - J - 1 := by
+          have hjfin := j.isLt
+          omega
+        have hcast :
+            Int.ofNat (df - J - 1 - (j.val - (dg - J))) =
+              Int.ofNat (df - J - 1) - Int.ofNat (j.val - (dg - J)) :=
+          Int.ofNat_sub hbound
+        rw [hcast]
+        grind
+
+private theorem coeffMatrixAt_row_eq_last (df dg J ell : Nat)
+    (f g : DensePoly R) (hJ : J < dg)
+    (hcount : 0 < (df - J) + (dg - J))
+    (i : Fin ((df - J) + (dg - J))) :
+    let l := if i.val = (df - J) + (dg - J) - 1 then ell
+      else df + (dg - J) - 1 - i.val
+    ∀ j,
+      coeffMatrixAt df dg J ell f g i j =
+        coeffMatrixAt df dg J l f g
+          ⟨(df - J) + (dg - J) - 1, by omega⟩ j := by
+  let last : Fin ((df - J) + (dg - J)) :=
+    ⟨(df - J) + (dg - J) - 1, by omega⟩
+  by_cases hi : i.val = (df - J) + (dg - J) - 1
+  · have hieq : i = last := Fin.ext hi
+    subst i
+    simp only [if_pos hi]
+    intro j
+    rfl
+  · simp only [if_neg hi]
+    intro j
+    unfold coeffMatrixAt
+    by_cases hj : j.val < dg - J
+    · simp only [if_pos hj, if_neg hi, if_pos True.intro]
+      congr 2
+      have hleft : 0 < dg - J := by omega
+      have hibound : i.val ≤ df + (dg - J) - 1 := by
+        have hiFin := i.isLt
+        omega
+      have hsub : Int.ofNat (df + (dg - J) - 1 - i.val) =
+          Int.ofNat (df + (dg - J) - 1) - Int.ofNat i.val :=
+        Int.ofNat_sub hibound
+      have hsplitNat : df + (dg - J) - 1 = df + (dg - J - 1) := by omega
+      have hsplit := congrArg Int.ofNat hsplitNat
+      have hadd : Int.ofNat (df + (dg - J - 1)) =
+          Int.ofNat df + Int.ofNat (dg - J - 1) := Int.natCast_add _ _
+      rw [hsub, hsplit, hadd]
+      grind
+    · simp only [if_neg hj, if_neg hi, if_pos True.intro]
+      congr 2
+      have hright : 0 < df - J := by
+        have hiFin := j.isLt
+        omega
+      have hiboundLeft : i.val ≤ df + (dg - J) - 1 := by
+        have hiFin := i.isLt
+        omega
+      have hibound : i.val ≤ dg + (df - J) - 1 := by
+        have hiFin := i.isLt
+        omega
+      have hbaseNat : df + (dg - J) - 1 = dg + (df - J) - 1 := by omega
+      have hbase := congrArg Int.ofNat hbaseNat
+      have hleftSub : Int.ofNat (df + (dg - J) - 1 - i.val) =
+          Int.ofNat (df + (dg - J) - 1) - Int.ofNat i.val :=
+        Int.ofNat_sub hiboundLeft
+      have hsplitNat : dg + (df - J) - 1 = dg + (df - J - 1) := by omega
+      have hsplit := congrArg Int.ofNat hsplitNat
+      have hadd : Int.ofNat (dg + (df - J - 1)) =
+          Int.ofNat dg + Int.ofNat (df - J - 1) := Int.natCast_add _ _
+      rw [hleftSub, hbase, hsplit, hadd]
+      grind
+
+/-- A bounded Bezout syzygy gives a kernel vector for every generalized
+coefficient matrix of the same index. -/
+theorem coeffMatrixAt_mul_bezoutVector_eq_zero
+    (df dg J ell : Nat) (u v f g : DensePoly R)
+    (hJ : J < dg)
+    (hcount : 0 < (df - J) + (dg - J))
+    (hu : u.size ≤ dg - J) (hv : v.size ≤ df - J)
+    (hzero : u * f + v * g = 0) :
+    SubresultantMinor.toMatrix (coeffMatrixAt df dg J ell f g) *
+        bezoutVector df dg J u v = 0 := by
+  apply Vector.ext
+  intro i hi
+  let ii : Fin ((df - J) + (dg - J)) := ⟨i, hi⟩
+  let l := if ii.val = (df - J) + (dg - J) - 1 then ell
+    else df + (dg - J) - 1 - ii.val
+  let term : Fin ((df - J) + (dg - J)) → R := fun j =>
+    coeffMatrixAt df dg J ell f g ii j *
+      (bezoutVector df dg J u v)[j]
+  let lastTerm : Fin ((df - J) + (dg - J)) → R := fun j =>
+    coeffMatrixAt df dg J l f g
+        ⟨(df - J) + (dg - J) - 1, by omega⟩ j *
+      (bezoutVector df dg J u v)[j]
+  have hrow := coeffMatrixAt_row_eq_last df dg J ell f g hJ hcount ii
+  have hterm (j : Fin ((df - J) + (dg - J))) : term j = lastTerm j := by
+    dsimp only [term, lastTerm]
+    rw [hrow j]
+  have hcoeff := coeff_bezoutCols df dg J l u v f g hcount
+    (List.finRange ((df - J) + (dg - J)))
+  rw [bezoutCols_finRange df dg J u v f g hu hv, hzero, coeff_zero] at hcoeff
+  have hlastFold :
+      (List.finRange ((df - J) + (dg - J))).foldl
+          (fun acc j => acc + lastTerm j) 0 = 0 := by
+    have hfold := foldl_add_eq_foldr (R := R)
+      (List.finRange ((df - J) + (dg - J))) lastTerm 0
+    change (0 : R) =
+      (List.finRange ((df - J) + (dg - J))).foldr
+        (fun j acc => lastTerm j + acc) 0 at hcoeff
+    grind
+  have hfoldEq :
+      (List.finRange ((df - J) + (dg - J))).foldl
+          (fun acc j => acc + term j) 0 =
+        (List.finRange ((df - J) + (dg - J))).foldl
+          (fun acc j => acc + lastTerm j) 0 := by
+    apply List.foldl_congr
+    intro acc j _hj
+    rw [hterm j]
+  change
+    (SubresultantMinor.toMatrix (coeffMatrixAt df dg J ell f g) *
+      bezoutVector df dg J u v)[ii] = (0 : Vector R ((df - J) + (dg - J)))[ii]
+  rw [Matrix.getElem_mulVec]
+  unfold Vector.dotProduct
+  simp only [Matrix.getElem_row, SubresultantMinor.toMatrix_get]
+  change (List.finRange ((df - J) + (dg - J))).foldl
+      (fun acc j => acc + term j) 0 = _
+  rw [hfoldEq, hlastFold]
+  simp only [Fin.getElem_fin, Vector.getElem_zero]
+
+/-- A nonzero generalized coefficient minor makes bounded Bezout
+representations unique. -/
+theorem bounded_bezout_unique [Div R] [ExactDivLaws R]
+    (df dg J ell : Nat) (f g u v : DensePoly R)
+    (hJ : J < dg) (hdet : coeffMinorAt df dg J ell f g ≠ 0)
+    (hu : u.size ≤ dg - J) (hv : v.size ≤ df - J)
+    (hzero : u * f + v * g = 0) :
+    u = 0 ∧ v = 0 := by
+  have hcount : 0 < (df - J) + (dg - J) := by omega
+  have hmul := coeffMatrixAt_mul_bezoutVector_eq_zero
+    df dg J ell u v f g hJ hcount hu hv hzero
+  have hkernel := SubresultantMinor.vector_eq_zero_of_mul_eq_zero
+    (coeffMatrixAt df dg J ell f g) hcount hdet
+    (bezoutVector df dg J u v) hmul
+  constructor
+  · apply ext_coeff
+    intro k
+    rw [coeff_zero]
+    by_cases hk : k < dg - J
+    · let j : Fin ((df - J) + (dg - J)) :=
+        ⟨dg - J - 1 - k, by omega⟩
+      have hj := hkernel j
+      unfold bezoutVector at hj
+      simp only [Fin.getElem_fin, Vector.getElem_ofFn] at hj
+      rw [if_pos (by dsimp [j]; omega)] at hj
+      have hle : k ≤ dg - J - 1 := by omega
+      have hindex : dg - J - 1 - (dg - J - 1 - k) = k :=
+        Nat.sub_sub_self hle
+      simpa only [j, hindex] using hj
+    · exact coeff_eq_zero_of_size_le u (by omega)
+  · apply ext_coeff
+    intro k
+    rw [coeff_zero]
+    by_cases hk : k < df - J
+    · let j : Fin ((df - J) + (dg - J)) :=
+        ⟨(dg - J) + (df - J - 1 - k), by omega⟩
+      have hj := hkernel j
+      unfold bezoutVector at hj
+      simp only [Fin.getElem_fin, Vector.getElem_ofFn] at hj
+      rw [if_neg (by dsimp [j]; omega)] at hj
+      have hle : k ≤ df - J - 1 := by omega
+      have hindex :
+          df - J - 1 -
+              ((dg - J + (df - J - 1 - k)) - (dg - J)) = k := by
+        rw [Nat.add_sub_cancel_left]
+        exact Nat.sub_sub_self hle
+      simpa only [j, hindex] using hj
+    · exact coeff_eq_zero_of_size_le v (by omega)
+
+private theorem size_le_of_coeff_zero_above (p : DensePoly R) (n : Nat)
+    (hzero : ∀ k, n ≤ k → p.coeff k = 0) : p.size ≤ n := by
+  by_cases hle : p.size ≤ n
+  · exact hle
+  · have hpos : 0 < p.size := by omega
+    have hlast : n ≤ p.size - 1 := by omega
+    exact False.elim
+      ((coeff_last_ne_zero_of_pos_size p hpos) (hzero _ hlast))
+
+theorem size_sub_le_max (p q : DensePoly R) :
+    (p - q).size ≤ Nat.max p.size q.size := by
+  apply size_le_of_coeff_zero_above
+  intro k hk
+  have hp : p.size ≤ k :=
+    Nat.le_trans (Nat.le_max_left _ _) hk
+  have hq : q.size ≤ k :=
+    Nat.le_trans (Nat.le_max_right _ _) hk
+  rw [coeff_sub_ring, coeff_eq_zero_of_size_le p hp,
+    coeff_eq_zero_of_size_le q hq]
+  grind
+
+private theorem cofactorUCols_size_le (df dg J : Nat) (f g : DensePoly R)
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    (cofactorUCols df dg J f g cols).size ≤ dg - J := by
+  apply size_le_of_coeff_zero_above
+  intro k hk
+  induction cols with
+  | nil => rw [cofactorUCols, coeff_zero]
+  | cons j js ih =>
+      simp only [cofactorUCols]
+      by_cases hj : j.val < dg - J
+      · rw [if_pos hj, coeff_add_semiring, coeff_monomial, ih]
+        rw [if_neg (by omega)]
+        have hzero : (Zero.zero : R) = 0 := rfl
+        rw [hzero]
+        grind
+      · rw [if_neg hj]
+        exact ih
+
+private theorem cofactorVCols_size_le (df dg J : Nat) (f g : DensePoly R)
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    (cofactorVCols df dg J f g cols).size ≤ df - J := by
+  apply size_le_of_coeff_zero_above
+  intro k hk
+  induction cols with
+  | nil => rw [cofactorVCols, coeff_zero]
+  | cons j js ih =>
+      simp only [cofactorVCols]
+      by_cases hj : dg - J ≤ j.val
+      · rw [if_pos hj, coeff_add_semiring, coeff_monomial, ih]
+        rw [if_neg (by omega)]
+        have hzero : (Zero.zero : R) = 0 := rfl
+        rw [hzero]
+        grind
+      · rw [if_neg hj]
+        exact ih
+
+/-- Degree bounds for the two determinantal cofactor blocks. -/
+theorem cofactorUAt_size_le (df dg J : Nat) (f g : DensePoly R) :
+    (cofactorUAt df dg J f g).size ≤ dg - J := by
+  exact cofactorUCols_size_le df dg J f g _
+
+theorem cofactorVAt_size_le (df dg J : Nat) (f g : DensePoly R) :
+    (cofactorVAt df dg J f g).size ≤ df - J := by
+  exact cofactorVCols_size_le df dg J f g _
+
+/-- Degree bounds for the canonical cofactors at the actual formal degrees. -/
+theorem cofactorU_size_le (J : Nat) (f g : DensePoly R) :
+    (cofactorU J f g).size ≤ formalDegree g - J := by
+  exact cofactorUAt_size_le _ _ J f g
+
+theorem cofactorV_size_le (J : Nat) (f g : DensePoly R) :
+    (cofactorV J f g).size ≤ formalDegree f - J := by
+  exact cofactorVAt_size_le _ _ J f g
+/-- Each coefficient of the polynomial column sum is its scalar Laplace
+column sum. -/
+theorem coeff_cofactorRowCols (df dg J l : Nat) (f g : DensePoly R)
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    (cofactorRowCols df dg J f g cols).coeff l =
+      cofactorScalarCols df dg J l f g cols := by
+  induction cols with
+  | nil =>
+      simp [cofactorRowCols, cofactorScalarCols]
+  | cons j js ih =>
+      simp only [cofactorRowCols, cofactorScalarCols]
+      rw [coeff_add_semiring, ih]
+      by_cases hj : j.val < dg - J
+      · rw [if_pos hj, if_pos hj, coeff_monomial_mul]
+        have hle : j.val ≤ dg - J - 1 := by omega
+        have hcast : Int.ofNat (dg - J - 1 - j.val) =
+            Int.ofNat (dg - J - 1) - Int.ofNat j.val :=
+          Int.ofNat_sub hle
+        rw [hcast]
+        grind
+      · have hj' : dg - J ≤ j.val := by omega
+        rw [if_neg hj, if_neg hj, coeff_monomial_mul]
+        have hbound : j.val - (dg - J) ≤ df - J - 1 := by
+          have hjfin := j.isLt
+          omega
+        have hcast :
+            Int.ofNat (df - J - 1 - (j.val - (dg - J))) =
+              Int.ofNat (df - J - 1) - Int.ofNat (j.val - (dg - J)) :=
+          Int.ofNat_sub hbound
+        rw [hcast]
+        grind
+
+/-- The scalar cofactor sum is the final-row Laplace sum of the coefficient
+matrix. -/
+theorem cofactorScalarCols_eq_laplace (df dg J l : Nat)
+    (f g : DensePoly R) (hcount : 0 < (df - J) + (dg - J))
+    (cols : List (Fin ((df - J) + (dg - J)))) :
+    cofactorScalarCols df dg J l f g cols =
+      cols.foldr
+        (fun j acc =>
+          coeffMatrixAt df dg J l f g
+              ⟨(df - J) + (dg - J) - 1, by omega⟩ j *
+            SubresultantMinor.lastCofactor
+              (coeffMatrixAt df dg J l f g) j + acc)
+        0 := by
+  induction cols with
+  | nil => rfl
+  | cons j js ih =>
+      simp only [cofactorScalarCols, List.foldr_cons]
+      rw [← ih]
+      rw [← columnCofactorAt_eq df dg J l f g j]
+      unfold coeffMatrixAt
+      by_cases hj : j.val < dg - J
+      · simp only [if_pos hj]
+        rw [if_pos True.intro]
+      · simp only [if_neg hj]
+        rw [if_pos True.intro]
+
+/-- At positive matrix dimension, the full scalar cofactor sum is the
+corresponding generalized coefficient minor. -/
+theorem cofactorScalarCols_finRange (df dg J l : Nat) (f g : DensePoly R)
+    (hcount : 0 < (df - J) + (dg - J)) :
+    cofactorScalarCols df dg J l f g
+        (List.finRange ((df - J) + (dg - J))) =
+      coeffMinorAt df dg J l f g := by
+  have hlap := SubresultantMinor.det_lastCofactor_of_pos
+    (coeffMatrixAt df dg J l f g) hcount
+  rw [cofactorScalarCols_eq_laplace df dg J l f g hcount]
+  unfold coeffMinorAt
+  rw [hlap]
+  symm
+  have hfold := foldl_add_eq_foldr (R := R)
+    (List.finRange ((df - J) + (dg - J)))
+    (fun j =>
+      coeffMatrixAt df dg J l f g
+          ⟨(df - J) + (dg - J) - 1, by omega⟩ j *
+        SubresultantMinor.lastCofactor
+          (coeffMatrixAt df dg J l f g) j)
+    (0 : R)
+  exact hfold.trans (by grind)
+
+/-- The accumulated cofactor products have the generalized determinant as
+every coefficient for which the coefficient matrix has positive dimension. -/
+theorem coeff_cofactorAt_mul (df dg J l : Nat) (f g : DensePoly R)
+    (hcount : 0 < (df - J) + (dg - J)) :
+    (cofactorUAt df dg J f g * f + cofactorVAt df dg J f g * g).coeff l =
+      coeffMinorAt df dg J l f g := by
+  unfold cofactorUAt cofactorVAt
+  rw [cofactorCols_mul, coeff_cofactorRowCols,
+    cofactorScalarCols_finRange df dg J l f g hcount]
+
+private theorem coeffInt_eq_zero_of_size_le (p : DensePoly R) (k : Int)
+    (h : Int.ofNat p.size ≤ k) : coeffInt p k = 0 := by
+  cases k with
+  | ofNat n =>
+      unfold coeffInt
+      by_cases hneg : Int.ofNat n < 0
+      · exact False.elim (Int.not_ofNat_neg n hneg)
+      rw [if_neg hneg]
+      apply coeff_eq_zero_of_size_le
+      exact Int.ofNat_le.mp h
+  | negSucc n =>
+      have hs : 0 ≤ Int.ofNat p.size := Int.ofNat_zero_le _
+      omega
+
+/-- Coefficient minors above the requested subresultant degree vanish: in
+the active range their selector row repeats an earlier Sylvester row, and
+above that range the selector row is zero. -/
+theorem coeffMinorAt_zero_high (df dg J l : Nat) (f g : DensePoly R)
+    (hJ : J < dg) (hdg : dg ≤ df)
+    (hf : f.size ≤ df + 1) (hg : g.size ≤ dg + 1)
+    (hl : J < l) :
+    coeffMinorAt df dg J l f g = 0 := by
+  unfold coeffMinorAt
+  have hcount : 0 < (df - J) + (dg - J) := by omega
+  by_cases hrange : l < df + dg - J
+  · let src : Fin ((df - J) + (dg - J)) :=
+      ⟨df + dg - J - l - 1, by omega⟩
+    let dst : Fin ((df - J) + (dg - J)) :=
+      ⟨(df - J) + (dg - J) - 1, by omega⟩
+    apply SubresultantMinor.det_eq_zero_of_row_eq
+      (coeffMatrixAt df dg J l f g) src dst
+    · intro hsd
+      have hv := congrArg Fin.val hsd
+      dsimp [src, dst] at hv
+      omega
+    · intro j
+      have hsrc : src.val ≠ (df - J) + (dg - J) - 1 := by
+        dsimp [src]
+        omega
+      have hdst : dst.val = (df - J) + (dg - J) - 1 := by rfl
+      unfold coeffMatrixAt
+      by_cases hj : j.val < dg - J
+      · simp only [if_pos hj, if_neg hsrc, if_pos hdst]
+        congr 2
+        dsimp [src, dst]
+        omega
+      · simp only [if_neg hj, if_neg hsrc, if_pos hdst]
+        congr 2
+        dsimp [src, dst]
+        omega
+  · apply SubresultantMinor.det_lastRow_zero_of_pos
+      (coeffMatrixAt df dg J l f g) hcount
+    intro j
+    unfold coeffMatrixAt
+    by_cases hj : j.val < dg - J
+    · simp only [if_pos hj, if_pos True.intro]
+      apply coeffInt_eq_zero_of_size_le
+      have hbase : dg - J - 1 ≤ l := by omega
+      have hnat : f.size ≤ l - (dg - J - 1) + j.val := by omega
+      calc
+        Int.ofNat f.size ≤
+            Int.ofNat (l - (dg - J - 1) + j.val) := Int.ofNat_le.mpr hnat
+        _ = Int.ofNat l - Int.ofNat (dg - J - 1) + Int.ofNat j.val := by
+          have hadd : Int.ofNat (l - (dg - J - 1) + j.val) =
+              Int.ofNat (l - (dg - J - 1)) + Int.ofNat j.val :=
+            Int.natCast_add _ _
+          have hsub : Int.ofNat (l - (dg - J - 1)) =
+              Int.ofNat l - Int.ofNat (dg - J - 1) :=
+            Int.ofNat_sub hbase
+          exact hadd.trans (congrArg (fun z => z + Int.ofNat j.val) hsub)
+    · simp only [if_neg hj, if_pos True.intro]
+      apply coeffInt_eq_zero_of_size_le
+      have hbase : df - J - 1 ≤ l := by omega
+      have hnat : g.size ≤
+          l - (df - J - 1) + (j.val - (dg - J)) := by omega
+      calc
+        Int.ofNat g.size ≤ Int.ofNat
+            (l - (df - J - 1) + (j.val - (dg - J))) := Int.ofNat_le.mpr hnat
+        _ = Int.ofNat l - Int.ofNat (df - J - 1) +
+            Int.ofNat (j.val - (dg - J)) := by
+          have hadd :
+              Int.ofNat (l - (df - J - 1) + (j.val - (dg - J))) =
+                Int.ofNat (l - (df - J - 1)) +
+                  Int.ofNat (j.val - (dg - J)) := Int.natCast_add _ _
+          have hsub : Int.ofNat (l - (df - J - 1)) =
+              Int.ofNat l - Int.ofNat (df - J - 1) :=
+            Int.ofNat_sub hbase
+          exact hadd.trans
+            (congrArg (fun z => z + Int.ofNat (j.val - (dg - J))) hsub)
+
+/-- The determinantal cofactors give an integral Bezout representation of a
+generalized subresultant. -/
+theorem cofactor_bezout (J : Nat) (f g : DensePoly R)
+    (hgf : g.size ≤ f.size) (hJ : J < formalDegree g) :
+    cofactorU J f g * f + cofactorV J f g * g = poly J f g := by
+  apply ext_coeff
+  intro l
+  let df := formalDegree f
+  let dg := formalDegree g
+  have hdg : dg ≤ df := by
+    dsimp only [df, dg, formalDegree]
+    omega
+  have hcount : 0 < (df - J) + (dg - J) := by omega
+  unfold cofactorU cofactorV
+  rw [coeff_cofactorAt_mul df dg J l f g hcount, coeff_poly]
+  by_cases hl : l < J + 1
+  · rw [if_pos hl]
+    rfl
+  · rw [if_neg hl]
+    apply coeffMinorAt_zero_high
+    · exact hJ
+    · exact hdg
+    · dsimp only [df, formalDegree]
+      omega
+    · dsimp only [dg, formalDegree]
+      omega
+    · omega
+
+/-- Any bounded Bezout row for a scalar multiple of a nonzero subresultant is
+that scalar multiple of the determinantal cofactor row. -/
+theorem eq_scaled_cofactor [Div R] [ExactDivLaws R]
+    (J : Nat) (d : R) (f g u v : DensePoly R)
+    (hgf : g.size ≤ f.size) (hJ : J < formalDegree g)
+    (hroot : poly J f g ≠ 0)
+    (hu : u.size ≤ formalDegree g - J)
+    (hv : v.size ≤ formalDegree f - J)
+    (hrepr : u * f + v * g = scale d (poly J f g)) :
+    u = scale d (cofactorU J f g) ∧
+      v = scale d (cofactorV J f g) := by
+  let df := formalDegree f
+  let dg := formalDegree g
+  let ell := (poly J f g).size - 1
+  have hrootPos : 0 < (poly J f g).size := by
+    by_cases hs : 0 < (poly J f g).size
+    · exact hs
+    · exact False.elim
+        (hroot ((size_eq_zero_iff (poly J f g)).mp (by omega)))
+  have hell : ell < J + 1 := by
+    have hs := Subresultant.poly_size_le J f g
+    dsimp only [ell]
+    omega
+  have hminor : coeffMinorAt df dg J ell f g ≠ 0 := by
+    have hc := coeff_last_ne_zero_of_pos_size (poly J f g) hrootPos
+    rw [coeff_poly, if_pos hell] at hc
+    have hzero : (Zero.zero : R) = 0 := rfl
+    change coeffMinorAt df dg J ell f g ≠ (Zero.zero : R)
+    simpa only [df, dg, ell, coeffMinor] using hc
+  let du := u - scale d (cofactorU J f g)
+  let dv := v - scale d (cofactorV J f g)
+  have hscaleU : (scale d (cofactorU J f g)).size ≤ dg - J := by
+    rw [scale_eq_scaleImpl]
+    exact Nat.le_trans (size_scaleImpl_le _ _) (cofactorU_size_le J f g)
+  have hscaleV : (scale d (cofactorV J f g)).size ≤ df - J := by
+    rw [scale_eq_scaleImpl]
+    exact Nat.le_trans (size_scaleImpl_le _ _) (cofactorV_size_le J f g)
+  have hdu : du.size ≤ dg - J := by
+    exact Nat.le_trans (size_sub_le_max _ _)
+      (Nat.max_le.mpr ⟨by simpa only [dg] using hu, hscaleU⟩)
+  have hdv : dv.size ≤ df - J := by
+    exact Nat.le_trans (size_sub_le_max _ _)
+      (Nat.max_le.mpr ⟨by simpa only [df] using hv, hscaleV⟩)
+  have hcanon := cofactor_bezout J f g hgf hJ
+  have hzero : du * f + dv * g = 0 := by
+    dsimp only [du, dv]
+    have hdistU : (u - scale d (cofactorU J f g)) * f =
+        u * f - scale d (cofactorU J f g) * f := by grind
+    have hdistV : (v - scale d (cofactorV J f g)) * g =
+        v * g - scale d (cofactorV J f g) * g := by grind
+    rw [hdistU, hdistV, ← scale_mul, ← scale_mul]
+    have hrearr :
+        u * f - scale d (cofactorU J f g * f) +
+            (v * g - scale d (cofactorV J f g * g)) =
+          (u * f + v * g) -
+            (scale d (cofactorU J f g * f) +
+              scale d (cofactorV J f g * g)) := by grind
+    rw [hrearr, ← scale_add]
+    rw [hcanon, hrepr]
+    grind
+  have huniq := bounded_bezout_unique df dg J ell f g du dv hJ hminor
+    hdu hdv hzero
+  constructor
+  · dsimp only [du] at huniq
+    grind
+  · dsimp only [dv] at huniq
+    grind
+
+end Base
+
+end Subresultant
+end DensePoly
+end Hex

--- a/HexResultant/SubresultantExt.lean
+++ b/HexResultant/SubresultantExt.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexResultant.Subresultant
+public import HexResultant.SubresultantCofactor
 public meta import HexResultant.Subresultant
 
 public section
@@ -278,6 +279,598 @@ def Law [One R] [Add R] [Sub R] [Mul R] [Div R]
   (∀ e, e ∈ chain → e.1 * f + e.2.1 * g = value e) ∧
     ∀ i, 3 ≤ i → i < chain.size → CofactorStep chain i
 
+private theorem getD_push_old {A : Type u} (xs : Array A) (x fallback : A)
+    (i : Nat) (hi : i < xs.size) :
+    (xs.push x).getD i fallback = xs.getD i fallback := by
+  have hi' : i < (xs.push x).size := by
+    rw [Array.size_push]
+    omega
+  rw [← Array.getElem_eq_getD fallback (h := hi'),
+    Array.getElem_push_lt hi, Array.getElem_eq_getD fallback]
+
+private theorem getD_push_last {A : Type u} (xs : Array A) (x fallback : A) :
+    (xs.push x).getD xs.size fallback = x := by
+  have hi : xs.size < (xs.push x).size := by
+    rw [Array.size_push]
+    omega
+  rw [← Array.getElem_eq_getD fallback (h := hi), Array.getElem_push_eq]
+
+/-- Appending an entry does not alter any earlier accumulated Brown scale. -/
+private theorem brownScale_push_old [One R] [Mul R] [Div R]
+    (chain : Array (Entry R)) (x : Entry R) (k : Nat) (hk : k < chain.size) :
+    brownScale (chain.push x) k = brownScale chain k := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+      cases k with
+      | zero =>
+          simp only [brownScale]
+          rw [getD_push_old, getD_push_old] <;> omega
+      | succ i =>
+          simp only [brownScale]
+          rw [getD_push_old, getD_push_old, ih (by omega)] <;> omega
+
+/-- A previously recorded exact cofactor step is unchanged by appending a
+later entry. -/
+private theorem cofactorStep_push_old [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (chain : Array (Entry R)) (x : Entry R) (i : Nat)
+    (hi : i < chain.size) (hstep : CofactorStep chain i) :
+    CofactorStep (chain.push x) i := by
+  unfold CofactorStep at hstep ⊢
+  rw [getD_push_old, getD_push_old, getD_push_old,
+    brownScale_push_old] <;> try omega
+
+/-- Pushing a Bezout entry and its new exact step preserves the chain law. -/
+private theorem Law.push [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g : DensePoly R) (chain : Array (Entry R)) (x : Entry R)
+    (hlaw : Law f g chain) (hbez : x.1 * f + x.2.1 * g = value x)
+    (hstep : 3 ≤ chain.size → CofactorStep (chain.push x) chain.size) :
+    Law f g (chain.push x) := by
+  constructor
+  · intro e he
+    rcases Array.mem_push.mp he with he | rfl
+    · exact hlaw.1 e he
+    · exact hbez
+  · intro i hi hbound
+    rw [Array.size_push] at hbound
+    by_cases hold : i < chain.size
+    · exact cofactorStep_push_old chain x i hold (hlaw.2 i hi hold)
+    · have hieq : i = chain.size := by omega
+      subst i
+      exact hstep hi
+
+/-- The recursive extended worker preserves the chain law from any reachable
+integral Brown state. -/
+private theorem subresultantAuxExt_law {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (F G prev curr : DensePoly S) (hPrev : S)
+    (prevU prevV currU currV : DensePoly S)
+    (chain : Array (Entry S)) (fuel : Nat)
+    (hinv : _root_.Hex.DensePoly.BrownInv F G prev curr hPrev)
+    (hGF : G.size ≤ F.size) (hprevG : prev.size ≤ G.size)
+    (hcurrG : curr.size ≤ G.size)
+    (hlaw : Law F G chain) (hsize : 3 ≤ chain.size)
+    (hprevBez : prevU * F + prevV * G = prev)
+    (hcurrBez : currU * F + currV * G = curr)
+    (hlastPrev : chain.getD (chain.size - 2) (0, 0, 0) =
+      (prevU, prevV, prev))
+    (hlastCurr : chain.getD (chain.size - 1) (0, 0, 0) =
+      (currU, currV, curr))
+    (hscale : brownScale chain (chain.size - 2) = hPrev)
+    (hprevU : prevU.size ≤ Subresultant.formalDegree G - (curr.size - 2))
+    (hprevV : prevV.size ≤ Subresultant.formalDegree F - (curr.size - 2))
+    (hcurrU : currU.size ≤ Subresultant.formalDegree G - (curr.size - 2))
+    (hcurrV : currV.size ≤ Subresultant.formalDegree F - (curr.size - 2))
+    (hcurrUStrong : currU.size ≤ Subresultant.formalDegree G - (prev.size - 2))
+    (hcurrVStrong : currV.size ≤ Subresultant.formalDegree F - (prev.size - 2)) :
+    Law F G
+      (subresultantAuxExt prev curr hPrev prevU prevV currU currV chain fuel) := by
+  induction fuel generalizing prev curr hPrev prevU prevV currU currV chain with
+  | zero => simpa [subresultantAuxExt] using hlaw
+  | succ fuel ih =>
+      unfold _root_.Hex.DensePoly.BrownInv at hinv
+      rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let qr := pseudoDivMod prev curr
+      let q := qr.1
+      let p := qr.2
+      have hinv : _root_.Hex.DensePoly.BrownInv F G prev curr hPrev :=
+        by exact ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      cases hpzero : p.isZero with
+      | true =>
+          simpa [subresultantAuxExt, delta, hCurr, qr, q, p, hpzero] using hlaw
+      | false =>
+          have hp : p ≠ 0 := by
+            intro hz
+            have hz' : p.isZero = true := by rw [hz]; rfl
+            rw [hz'] at hpzero
+            exact Bool.noConfusion hpzero
+          let divisor :=
+            negOnePow (R := S) (delta + 1) * prev.leadingCoeff *
+              powNat hPrev delta
+          let next := divScalar p divisor
+          let nextImpl := divScalarImpl p divisor
+          have hpRaw : (pseudoDivMod prev curr).2 ≠ 0 := by
+            simpa only [p, qr] using hp
+          have hfactorRaw := _root_.Hex.DensePoly.BrownInv.factor F G prev curr hPrev hinv hpRaw
+          rcases hfactorRaw with
+            ⟨hdivRaw, hpScaleRaw, hnextRaw, hnextEqRaw⟩
+          have hdivisor : divisor ≠ 0 := by
+            simpa only [divisor, delta] using hdivRaw
+          have hpScale : p = scale divisor next := by
+            simpa only [p, divisor, next, delta, qr] using hpScaleRaw
+          have hnext : next ≠ 0 := by
+            simpa only [p, divisor, next, delta, qr] using hnextRaw
+          have hnextEq : next = Subresultant.poly (curr.size - 2) F G := by
+            simpa only [p, divisor, next, delta, qr] using hnextEqRaw
+          have hnextImplEq : nextImpl = next := by
+            dsimp only [nextImpl, next]
+            exact (divScalar_eq_divScalarImpl p divisor).symm
+          have hnextImpl : nextImpl ≠ 0 := by
+            rw [hnextImplEq]
+            exact hnext
+          have hnextZero : nextImpl.isZero = false := by
+            cases hz : nextImpl.isZero with
+            | false => rfl
+            | true =>
+                exact False.elim
+                  (hnextImpl ((size_eq_zero_iff nextImpl).mp
+                    ((isZero_eq_true_iff nextImpl).1 hz)))
+          let J := curr.size - 2
+          let a := powNat curr.leadingCoeff (delta + 1)
+          let numU := numerator a q prevU currU
+          let numV := numerator a q prevV currV
+          let nextU := divScalarImpl numU divisor
+          let nextV := divScalarImpl numV divisor
+          have hcurrBig : 2 ≤ curr.size := by
+            have hpSize : p.size < curr.size := by
+              simpa only [p, qr] using pseudoDivMod_remainder_lt prev curr hcurr
+            have hpPos : 0 < p.size := by
+              by_cases hs : 0 < p.size
+              · exact hs
+              · exact False.elim (hp ((size_eq_zero_iff p).mp (by omega)))
+            omega
+          have hJ : J < Subresultant.formalDegree G := by
+            dsimp only [J, Subresultant.formalDegree]
+            have hGpos : 0 < G.size := by omega
+            omega
+          have hnumRepr : numU * F + numV * G = scale divisor next := by
+            have hrec := pseudoDivMod_reconstruct prev curr hcurr
+              (Nat.le_of_lt hlt)
+            have ha : a = curr.leadingCoeff ^ (prev.size - curr.size + 1) := by
+              simp only [a, delta, powNat_eq_pow]
+            have hnum : numU * F + numV * G = p := by
+              dsimp only [numU, numV, numerator]
+              rw [← scale_eq_scaleImpl, ← scale_eq_scaleImpl]
+              have hdistU : (scale a prevU - q * currU) * F =
+                  scale a prevU * F - (q * currU) * F := by grind
+              have hdistV : (scale a prevV - q * currV) * G =
+                  scale a prevV * G - (q * currV) * G := by grind
+              rw [hdistU, hdistV, ← scale_mul, ← scale_mul]
+              have hrearr :
+                  scale a (prevU * F) - (q * currU) * F +
+                      (scale a (prevV * G) - (q * currV) * G) =
+                    scale a (prevU * F + prevV * G) -
+                      q * (currU * F + currV * G) := by
+                rw [scale_add]
+                grind
+              rw [hrearr, hprevBez, hcurrBez, ha]
+              simpa only [q, p, qr] using (show
+                scale (curr.leadingCoeff ^ (prev.size - curr.size + 1)) prev -
+                    (pseudoDivMod prev curr).1 * curr =
+                  (pseudoDivMod prev curr).2 by grind)
+            rw [hnum, hpScale]
+          have hqSize : q.size ≤ prev.size - curr.size + 1 := by
+            simpa only [q, qr] using pseudoDivMod_quotient_size_le prev curr
+          have hGpos : 0 < G.size := by omega
+          have hFpos : 0 < F.size := by omega
+          have hprevBig : 2 ≤ prev.size := by omega
+          have hnumU : numU.size ≤ Subresultant.formalDegree G - J := by
+            dsimp only [numU, numerator]
+            apply Nat.le_trans (Subresultant.size_sub_le_max _ _)
+            apply Nat.max_le.mpr
+            constructor
+            · exact Nat.le_trans (size_scaleImpl_le _ _) hprevU
+            · apply Nat.le_trans (size_mul_le q currU)
+              dsimp only [J, Subresultant.formalDegree] at hcurrUStrong ⊢
+              omega
+          have hnumV : numV.size ≤ Subresultant.formalDegree F - J := by
+            dsimp only [numV, numerator]
+            apply Nat.le_trans (Subresultant.size_sub_le_max _ _)
+            apply Nat.max_le.mpr
+            constructor
+            · exact Nat.le_trans (size_scaleImpl_le _ _) hprevV
+            · apply Nat.le_trans (size_mul_le q currV)
+              dsimp only [J, Subresultant.formalDegree] at hcurrVStrong ⊢
+              omega
+          have hcanonical := Subresultant.eq_scaled_cofactor J divisor F G numU numV
+            hGF hJ (by rw [← hnextEq]; exact hnext) hnumU hnumV
+            (by rw [hnextEq] at hnumRepr; exact hnumRepr)
+          have hnextUEq : nextU = Subresultant.cofactorU J F G := by
+            dsimp only [nextU]
+            rw [← divScalar_eq_divScalarImpl, hcanonical.1,
+              divScalar_scale _ hdivisor]
+          have hnextVEq : nextV = Subresultant.cofactorV J F G := by
+            dsimp only [nextV]
+            rw [← divScalar_eq_divScalarImpl, hcanonical.2,
+              divScalar_scale _ hdivisor]
+          have hnumUExact : numU = scale divisor nextU := by
+            rw [hnextUEq, hcanonical.1]
+          have hnumVExact : numV = scale divisor nextV := by
+            rw [hnextVEq, hcanonical.2]
+          have hnextBez : nextU * F + nextV * G = nextImpl := by
+            rw [hnextUEq, hnextVEq, Subresultant.cofactor_bezout J F G hGF hJ,
+              ← hnextEq, hnextImplEq]
+          have hstep : _root_.Hex.DensePoly.BrownInv F G curr next hCurr := by
+            have hs := _root_.Hex.DensePoly.BrownInv.step F G prev curr hPrev hinv hpRaw
+            simpa only [delta, hCurr, p, divisor, next, qr] using hs
+          have hstepImpl : _root_.Hex.DensePoly.BrownInv F G curr nextImpl hCurr := by
+            rw [hnextImplEq]
+            exact hstep
+          have hnextLt : nextImpl.size < curr.size := hstepImpl.2.2.1
+          let x : Entry S := (nextU, nextV, nextImpl)
+          have hlawPush : Law F G (chain.push x) := by
+            apply Law.push F G chain x hlaw hnextBez
+            intro _hthree
+            unfold CofactorStep
+            rw [getD_push_old, getD_push_old, getD_push_last,
+              brownScale_push_old, hlastPrev, hlastCurr, hscale]
+            · simpa only [x, value, delta, a, q, divisor, numU, numV]
+                using ⟨hnumUExact, hnumVExact⟩
+            all_goals omega
+          have hlastPrev' :
+              (chain.push x).getD ((chain.push x).size - 2) (0, 0, 0) =
+                (currU, currV, curr) := by
+            rw [Array.size_push, show chain.size + 1 - 2 = chain.size - 1 by omega,
+              getD_push_old, hlastCurr] <;> omega
+          have hlastCurr' :
+              (chain.push x).getD ((chain.push x).size - 1) (0, 0, 0) =
+                (nextU, nextV, nextImpl) := by
+            rw [Array.size_push, show chain.size + 1 - 1 = chain.size by omega,
+              getD_push_last]
+          have hscale' :
+              brownScale (chain.push x) ((chain.push x).size - 2) = hCurr := by
+            rw [Array.size_push, show chain.size + 1 - 2 = chain.size - 1 by omega,
+              show chain.size - 1 = (chain.size - 3) + 2 by omega]
+            simp only [brownScale]
+            rw [show chain.size - 3 + 1 = chain.size - 2 by omega,
+              show chain.size - 3 + 2 = chain.size - 1 by omega]
+            rw [getD_push_old, getD_push_old, brownScale_push_old,
+              hlastPrev, hlastCurr, hscale] <;> try omega
+            rfl
+          have hnextUStrong : nextU.size ≤ Subresultant.formalDegree G - J := by
+            rw [hnextUEq]
+            exact Subresultant.cofactorU_size_le J F G
+          have hnextVStrong : nextV.size ≤ Subresultant.formalDegree F - J := by
+            rw [hnextVEq]
+            exact Subresultant.cofactorV_size_le J F G
+          have hcurrU' : currU.size ≤
+              Subresultant.formalDegree G - (nextImpl.size - 2) := by
+            dsimp only [Subresultant.formalDegree] at hcurrU ⊢
+            omega
+          have hcurrV' : currV.size ≤
+              Subresultant.formalDegree F - (nextImpl.size - 2) := by
+            dsimp only [Subresultant.formalDegree] at hcurrV ⊢
+            omega
+          have hnextU' : nextU.size ≤
+              Subresultant.formalDegree G - (nextImpl.size - 2) := by
+            dsimp only [J, Subresultant.formalDegree] at hnextUStrong ⊢
+            omega
+          have hnextV' : nextV.size ≤
+              Subresultant.formalDegree F - (nextImpl.size - 2) := by
+            dsimp only [J, Subresultant.formalDegree] at hnextVStrong ⊢
+            omega
+          have hrec := ih curr nextImpl hCurr currU currV nextU nextV
+            (chain.push x) hstepImpl hcurrG (by omega) hlawPush
+            (by rw [Array.size_push]; omega) hcurrBez hnextBez
+            hlastPrev' hlastCurr' hscale'
+            hcurrU' hcurrV' hnextU' hnextV' hnextUStrong hnextVStrong
+          simpa [subresultantAuxExt, delta, hCurr, qr, q, p, hpzero,
+            divisor, nextImpl, hnextZero, a, numU, numV, nextU, nextV, x]
+            using hrec
+
+/-- The degree-ordered extended worker satisfies the law in ordered input
+coordinates. -/
+private theorem subresultantOrderedExt_law {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    Law f g (subresultantOrderedExt f g 1 0 0 1) := by
+  unfold subresultantOrderedExt
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let qr := pseudoDivMod f g
+  let q := qr.1
+  let p := qr.2
+  let seed : Array (Entry S) := #[(1, 0, f), (0, 1, g)]
+  cases hpzero : p.isZero with
+  | true =>
+      have hseed : Law f g seed := by
+        constructor
+        · intro e he
+          have he' := Array.mem_def.mp he
+          simp only [seed, List.mem_cons, List.not_mem_nil, or_false] at he'
+          rcases he' with rfl | rfl
+          · change (1 : DensePoly S) * f + 0 * g = f
+            grind
+          · change (0 : DensePoly S) * f + 1 * g = g
+            grind
+        · intro i hi hbound
+          simp [seed] at hbound
+          exact False.elim (by omega)
+      simpa [delta, h₂, qr, q, p, seed, hpzero] using hseed
+  | false =>
+      have hp : p ≠ 0 := by
+        intro hz
+        have hz' : p.isZero = true := by rw [hz]; rfl
+        rw [hz'] at hpzero
+        exact Bool.noConfusion hpzero
+      let sign := negOnePow (R := S) (delta + 1)
+      let g₃ := scaleImpl sign p
+      have hgpos : 0 < g.size := by
+        by_cases hs : 0 < g.size
+        · exact hs
+        · exact False.elim (hg ((size_eq_zero_iff g).mp (by omega)))
+      have hglc := leadingCoeff_ne_zero_of_pos_size g hgpos
+      have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hglc
+      have hsign : sign ≠ 0 := negOnePow_ne_zero h1 (delta + 1)
+      have hg₃Eq : g₃ = scale sign p := by
+        exact (scale_eq_scaleImpl sign p).symm
+      have hg₃ : g₃ ≠ 0 := by
+        rw [hg₃Eq]
+        exact scale_ne_zero hsign hp
+      have hg₃Zero : g₃.isZero = false := by
+        cases hz : g₃.isZero with
+        | false => rfl
+        | true =>
+            exact False.elim (hg₃ ((size_eq_zero_iff g₃).mp
+              ((isZero_eq_true_iff g₃).1 hz)))
+      let a := powNat g.leadingCoeff (delta + 1)
+      let g₃U := scaleImpl sign (numerator a q 1 0)
+      let g₃V := scaleImpl sign (numerator a q 0 1)
+      have hgBig : 2 ≤ g.size := by
+        have hpSize : p.size < g.size := by
+          simpa only [p, qr] using pseudoDivMod_remainder_lt f g hg
+        have hpPos : 0 < p.size := by
+          by_cases hs : 0 < p.size
+          · exact hs
+          · exact False.elim (hp ((size_eq_zero_iff p).mp (by omega)))
+        omega
+      let J := g.size - 2
+      have hJ : J < Subresultant.formalDegree g := by
+        dsimp only [J, Subresultant.formalDegree]
+        omega
+      have hroot : Subresultant.poly J f g = g₃ := by
+        have h := Subresultant.poly_prem f g hgBig hgf
+        rw [hg₃Eq]
+        simpa [J, delta, sign, p, qr, negOnePow_eq_sign] using h
+      have hg₃Bez : g₃U * f + g₃V * g = g₃ := by
+        have hrec := pseudoDivMod_reconstruct f g hg hgf
+        dsimp only [g₃U, g₃V, numerator]
+        rw [← scale_eq_scaleImpl, ← scale_eq_scaleImpl,
+          ← scale_eq_scaleImpl, ← scale_eq_scaleImpl]
+        have ha : a = g.leadingCoeff ^ (f.size - g.size + 1) := by
+          simp only [a, delta, powNat_eq_pow]
+        have hinner :
+            (scale a 1 - q * 0) * f + (scale a 0 - q * 1) * g = p := by
+          have hbaseF : (1 : DensePoly S) * f + 0 * g = f := by grind
+          have hbaseG : (0 : DensePoly S) * f + 1 * g = g := by grind
+          have hrearr :
+              (scale a 1 - q * 0) * f + (scale a 0 - q * 1) * g =
+                scale a ((1 : DensePoly S) * f + 0 * g) -
+                  q * ((0 : DensePoly S) * f + 1 * g) := by
+            rw [scale_add, scale_mul, scale_mul]
+            grind
+          rw [hrearr, hbaseF, hbaseG]
+          rw [ha]
+          simpa only [q, p, qr] using (show
+            scale (g.leadingCoeff ^ (f.size - g.size + 1)) f -
+                (pseudoDivMod f g).1 * g = (pseudoDivMod f g).2 by grind)
+        rw [← scale_mul, ← scale_mul]
+        rw [← scale_add, hinner, ← hg₃Eq]
+      have hg₃UStrong : g₃U.size ≤ Subresultant.formalDegree g - J := by
+        dsimp only [g₃U]
+        apply Nat.le_trans (size_scaleImpl_le _ _)
+        dsimp only [numerator]
+        apply Nat.le_trans (Subresultant.size_sub_le_max _ _)
+        apply Nat.max_le.mpr
+        constructor
+        · apply Nat.le_trans (size_scaleImpl_le _ _)
+          rw [size_one h1]
+          dsimp only [J, Subresultant.formalDegree]
+          omega
+        · have hmul : q * (0 : DensePoly S) = 0 := by grind
+          rw [hmul, size_zero]
+          omega
+      have hg₃VStrong : g₃V.size ≤ Subresultant.formalDegree f - J := by
+        dsimp only [g₃V]
+        apply Nat.le_trans (size_scaleImpl_le _ _)
+        dsimp only [numerator]
+        apply Nat.le_trans (Subresultant.size_sub_le_max _ _)
+        apply Nat.max_le.mpr
+        constructor
+        · apply Nat.le_trans (size_scaleImpl_le _ _)
+          rw [size_zero]
+          omega
+        · apply Nat.le_trans (size_mul_le q (1 : DensePoly S))
+          have hqSize := pseudoDivMod_quotient_size_le f g
+          rw [size_one h1]
+          dsimp only [q, qr, J, Subresultant.formalDegree] at hqSize ⊢
+          omega
+      let chain := seed.push (g₃U, g₃V, g₃)
+      have hlaw : Law f g chain := by
+        constructor
+        · intro e he
+          rcases Array.mem_push.mp he with he | rfl
+          · have he' := Array.mem_def.mp he
+            simp only [seed, List.mem_cons, List.not_mem_nil, or_false] at he'
+            rcases he' with rfl | rfl
+            · change (1 : DensePoly S) * f + 0 * g = f
+              grind
+            · change (0 : DensePoly S) * f + 1 * g = g
+              grind
+          · exact hg₃Bez
+        · intro i hi hbound
+          simp [chain, seed] at hbound
+          exact False.elim (by omega)
+      have hinvRaw := brownInv_init f g hg hgf (by simpa only [p, qr] using hp)
+      have hinv : _root_.Hex.DensePoly.BrownInv f g g g₃ h₂ := by
+        rw [hg₃Eq]
+        simpa only [delta, h₂, p, sign, qr] using hinvRaw
+      have hprevU : (0 : DensePoly S).size ≤
+          Subresultant.formalDegree g - (g₃.size - 2) := by
+        rw [size_zero]
+        omega
+      have hprevV : (1 : DensePoly S).size ≤
+          Subresultant.formalDegree f - (g₃.size - 2) := by
+        have hg₃lt := hinv.2.2.1
+        dsimp only [Subresultant.formalDegree]
+        rw [size_one h1]
+        omega
+      have hcurrU : g₃U.size ≤
+          Subresultant.formalDegree g - (g₃.size - 2) := by
+        have hg₃lt := hinv.2.2.1
+        dsimp only [J, Subresultant.formalDegree] at hg₃UStrong ⊢
+        omega
+      have hcurrV : g₃V.size ≤
+          Subresultant.formalDegree f - (g₃.size - 2) := by
+        have hg₃lt := hinv.2.2.1
+        dsimp only [J, Subresultant.formalDegree] at hg₃VStrong ⊢
+        omega
+      have hprevBez : (0 : DensePoly S) * f + 1 * g = g := by grind
+      have hchainSize : 3 ≤ chain.size := by simp [chain, seed]
+      have hg₃G : g₃.size ≤ g.size := Nat.le_of_lt hinv.2.2.1
+      have haux := subresultantAuxExt_law f g g g₃ h₂ 0 1 g₃U g₃V
+        chain (g.size + 1) hinv hgf (Nat.le_refl _) hg₃G hlaw
+        hchainSize hprevBez hg₃Bez (by rfl) (by rfl)
+        (by rfl)
+        hprevU hprevV hcurrU hcurrV hg₃UStrong hg₃VStrong
+      simpa [delta, h₂, qr, q, p, hpzero, sign, g₃, hg₃Zero, a,
+        g₃U, g₃V, seed, chain] using haux
+
+/-- Exchange the two caller-coordinate cofactors of an extended entry. -/
+@[inline]
+private def swap (e : Entry R) : Entry R := (e.2.1, e.1, e.2.2)
+
+private theorem value_swap (e : Entry R) : value (swap e) = value e := rfl
+
+/-- The recursive worker is equivariant under exchange of its two cofactor
+coordinates. -/
+private theorem subresultantAuxExt_swap [One R] [Add R] [Sub R] [Mul R]
+    [Div R] (prev curr : DensePoly R) (hPrev : R)
+    (prevU prevV currU currV : DensePoly R) (chain : Array (Entry R))
+    (fuel : Nat) :
+    subresultantAuxExt prev curr hPrev prevV prevU currV currU
+        (chain.map swap) fuel =
+      (subresultantAuxExt prev curr hPrev prevU prevV currU currV chain fuel).map
+        swap := by
+  induction fuel generalizing prev curr hPrev prevU prevV currU currV chain with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold subresultantAuxExt
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let qr := pseudoDivMod prev curr
+      let q := qr.1
+      let p := qr.2
+      cases hp : p.isZero with
+      | true => simp [qr, p, hp]
+      | false =>
+          let divisor :=
+            negOnePow (delta + 1) * prev.leadingCoeff * powNat hPrev delta
+          let next := divScalarImpl p divisor
+          cases hnext : next.isZero with
+          | true =>
+              simp [delta, qr, p, hp, divisor, next, hnext]
+          | false =>
+              let a := powNat curr.leadingCoeff (delta + 1)
+              let nextU :=
+                divScalarImpl (numerator a q prevU currU) divisor
+              let nextV :=
+                divScalarImpl (numerator a q prevV currV) divisor
+              have hrec := ih curr next hCurr currU currV nextU nextV
+                (chain.push (nextU, nextV, next))
+              simpa [delta, hCurr, qr, q, p, hp, divisor, next, hnext, a,
+                nextU, nextV, Array.map_push, swap] using hrec
+
+/-- The ordered worker is equivariant under exchange of its two supplied
+cofactor coordinates. -/
+private theorem subresultantOrderedExt_swap [One R] [Add R] [Sub R] [Mul R]
+    [Div R] (f g fU fV gU gV : DensePoly R) :
+    subresultantOrderedExt f g fV fU gV gU =
+      (subresultantOrderedExt f g fU fV gU gV).map swap := by
+  unfold subresultantOrderedExt
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let qr := pseudoDivMod f g
+  let q := qr.1
+  let p := qr.2
+  cases hp : p.isZero with
+  | true => simp [qr, p, hp, swap]
+  | false =>
+      let sign := negOnePow (R := R) (delta + 1)
+      let g₃ := scaleImpl sign p
+      cases hg₃ : g₃.isZero with
+      | true => simp [delta, qr, p, hp, sign, g₃, hg₃, swap]
+      | false =>
+          let a := powNat g.leadingCoeff (delta + 1)
+          let g₃U := scaleImpl sign (numerator a q fU gU)
+          let g₃V := scaleImpl sign (numerator a q fV gV)
+          have haux := subresultantAuxExt_swap g g₃ h₂ gU gV g₃U g₃V
+            (#[(fU, fV, f), (gU, gV, g), (g₃U, g₃V, g₃)]) (g.size + 1)
+          simpa [delta, h₂, qr, q, p, hp, sign, g₃, hg₃, a, g₃U, g₃V,
+            Array.map_push, swap] using haux
+
+private theorem getD_map_swap (chain : Array (Entry R)) (i : Nat) :
+    (chain.map swap).getD i (0, 0, 0) =
+      swap (chain.getD i (0, 0, 0)) := by
+  rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?,
+    Array.getElem?_map]
+  cases chain[i]? <;> rfl
+
+private theorem brownScale_map_swap [One R] [Mul R] [Div R]
+    (chain : Array (Entry R)) (i : Nat) :
+    brownScale (chain.map swap) i = brownScale chain i := by
+  induction i with
+  | zero => rfl
+  | succ i ih =>
+      cases i with
+      | zero =>
+          simp only [brownScale]
+          rw [getD_map_swap, getD_map_swap]
+          rfl
+      | succ i =>
+          simp only [brownScale]
+          rw [getD_map_swap, getD_map_swap, ih]
+          rfl
+
+private theorem CofactorStep.swap [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (chain : Array (Entry R)) (i : Nat) (h : CofactorStep chain i) :
+    CofactorStep (chain.map swap) i := by
+  unfold CofactorStep at h ⊢
+  rw [getD_map_swap, getD_map_swap, getD_map_swap, brownScale_map_swap]
+  exact ⟨h.2, h.1⟩
+
+/-- Exchanging both caller inputs and both cofactor coordinates preserves the
+extended-chain law. -/
+private theorem Law.swap {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    (f g : DensePoly S) (chain : Array (Entry S)) (h : Law f g chain) :
+    Law g f (chain.map swap) := by
+  constructor
+  · intro e he
+    have he' := Array.mem_def.mp he
+    simp only [Array.toList_map] at he'
+    rcases List.mem_map.mp he' with ⟨x, hx, rfl⟩
+    have hx' : x ∈ chain := Array.mem_def.mpr hx
+    have hbez := h.1 x hx'
+    change x.2.1 * g + x.1 * f = value x
+    rw [add_comm_poly (x.2.1 * g) (x.1 * f)]
+    exact hbez
+  · intro i hi hbound
+    have hbound' : i < chain.size := by simpa using hbound
+    exact (h.2 i hi hbound').swap
+
 end SubresultantExt
 
 /-- The extended Brown recurrence has exact transformation rows and every
@@ -286,7 +879,62 @@ theorem subresultantChainExt_law {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) :
     SubresultantExt.Law f g (subresultantChainExt f g) := by
-  sorry
+  unfold subresultantChainExt
+  cases hf : f.isZero with
+  | true =>
+      cases hg : g.isZero with
+      | true =>
+          simp [SubresultantExt.Law]
+      | false =>
+          have hsingle : SubresultantExt.Law f g #[(0, 1, g)] := by
+            constructor
+            · intro e he
+              have he' := Array.mem_def.mp he
+              simp only [List.mem_cons, List.not_mem_nil, or_false] at he'
+              rcases he' with rfl
+              change (0 : DensePoly S) * f + 1 * g = g
+              grind
+            · intro i hi hbound
+              simp at hbound
+              exact False.elim (by omega)
+          simpa [hf, hg] using hsingle
+  | false =>
+      have hf0 : f ≠ 0 := by
+        intro hz
+        have : f.isZero = true := by rw [hz]; rfl
+        rw [this] at hf
+        exact Bool.noConfusion hf
+      cases hg : g.isZero with
+      | true =>
+          have hsingle : SubresultantExt.Law f g #[(1, 0, f)] := by
+            constructor
+            · intro e he
+              have he' := Array.mem_def.mp he
+              simp only [List.mem_cons, List.not_mem_nil, or_false] at he'
+              rcases he' with rfl
+              change (1 : DensePoly S) * f + 0 * g = f
+              grind
+            · intro i hi hbound
+              simp at hbound
+              exact False.elim (by omega)
+          simpa [hf, hg] using hsingle
+      | false =>
+          have hg0 : g ≠ 0 := by
+            intro hz
+            have : g.isZero = true := by rw [hz]; rfl
+            rw [this] at hg
+            exact Bool.noConfusion hg
+          by_cases hfg : f.size < g.size
+          · have hord := SubresultantExt.subresultantOrderedExt_law g f hf0
+                (Nat.le_of_lt hfg)
+            have hswap := SubresultantExt.Law.swap g f
+              (subresultantOrderedExt g f 1 0 0 1) hord
+            rw [← SubresultantExt.subresultantOrderedExt_swap g f
+              (1 : DensePoly S) 0 0 1] at hswap
+            simpa [hf, hg, hfg] using hswap
+          · have hgf : g.size ≤ f.size := by omega
+            have hord := SubresultantExt.subresultantOrderedExt_law f g hg0 hgf
+            simpa [hf, hg, hfg] using hord
 
 /-- Every extended-chain entry reconstructs from the two caller inputs. -/
 theorem subresultantChainExt_bezout {S : Type u}

--- a/HexResultantMathlib/Sylvester.lean
+++ b/HexResultantMathlib/Sylvester.lean
@@ -37,7 +37,7 @@ theorem sign_eq_pow [CommRing R] (j : Nat) :
 with Mathlib's determinant on the same finite square matrix. -/
 theorem det_eq_matrixDet [CommRing R] {n : Nat}
     (M : Hex.SubresultantMinor.Square R n) :
-    Hex.SubresultantMinor.det M = Matrix.det (Matrix.of M) := by
+    Hex.SubresultantMinor.det M = _root_.Matrix.det (_root_.Matrix.of M) := by
   induction n with
   | zero => simp [Hex.SubresultantMinor.det]
   | succ n ih =>
@@ -64,10 +64,10 @@ theorem det_eq_matrixDet [CommRing R] {n : Nat}
       rw [Hex.SubresultantMinor.det]
       change (List.finRange (n + 1)).foldl (fun a j => a + term j) 0 = _
       rw [hfold0]
-      rw [Matrix.det_succ_row_zero]
+      rw [_root_.Matrix.det_succ_row_zero]
       apply Finset.sum_congr rfl
       intro j _
-      simp only [term, Matrix.of_apply]
+      simp only [term, _root_.Matrix.of_apply]
       rw [sign_eq_pow, ih]
       congr 3
 
@@ -78,8 +78,8 @@ namespace Subresultant
 
 /-- A value-indexed presentation of Mathlib's Sylvester matrix. -/
 private def sylvesterByVal [CommRing R] (f g : Polynomial R) (df dg : Nat) :
-    Matrix (Fin (df + dg)) (Fin (df + dg)) R :=
-  Matrix.of fun i j =>
+    _root_.Matrix (Fin (df + dg)) (Fin (df + dg)) R :=
+  _root_.Matrix.of fun i j =>
     if _ : j.val < df then
       if j.val ≤ i.val ∧ i.val ≤ j.val + dg then
         g.coeff (i.val - j.val)
@@ -132,15 +132,15 @@ Sylvester matrix with both axes reversed. -/
 private theorem coeffMatrixAt_zero_eq_sylvester [CommRing R] [DecidableEq R]
     (df dg : Nat) (f g : DensePoly R) (hf : f.size ≤ df + 1)
     (hg : g.size ≤ dg + 1) :
-    Matrix.of (coeffMatrixAt df dg 0 0 f g) =
+    _root_.Matrix.of (coeffMatrixAt df dg 0 0 f g) =
       (Polynomial.sylvester (HexPolyMathlib.toPolynomial f)
         (HexPolyMathlib.toPolynomial g) df dg).submatrix
           Fin.revPerm Fin.revPerm := by
   rw [sylvester_eq_byVal]
   ext i j
-  simp only [Matrix.of_apply, Matrix.submatrix_apply, Fin.revPerm_apply]
+  simp only [_root_.Matrix.of_apply, _root_.Matrix.submatrix_apply, Fin.revPerm_apply]
   unfold coeffMatrixAt sylvesterByVal
-  simp only [Nat.sub_zero, Matrix.of_apply, HexPolyMathlib.coeff_toPolynomial,
+  simp only [Nat.sub_zero, _root_.Matrix.of_apply, HexPolyMathlib.coeff_toPolynomial,
     Int.ofNat_eq_natCast, Int.natCast_zero]
   by_cases hj : j.val < dg
   · rw [if_pos hj]
@@ -223,7 +223,7 @@ theorem coeffMinorAt_zero_eq_resultant [CommRing R] [DecidableEq R]
   unfold coeffMinorAt Polynomial.resultant
   rw [Hex.SubresultantMinor.det_eq_matrixDet]
   rw [coeffMatrixAt_zero_eq_sylvester _ _ f g hf hg]
-  exact Matrix.det_submatrix_equiv_self Fin.revPerm _
+  exact _root_.Matrix.det_submatrix_equiv_self Fin.revPerm _
 
 /-- The zeroth generalized coefficient minor is Mathlib's Sylvester
 determinant at the same formal degrees. -/

--- a/libraries.yml
+++ b/libraries.yml
@@ -634,9 +634,9 @@ libraries:
     done_through: 7
     status: active
   HexResultant:
-    deps: [HexPoly, HexBasic]
+    deps: [HexPoly, HexBasic, HexDeterminant]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:


### PR DESCRIPTION
Closes #9506.

This proves `subresultantChainExt_law` rather than rolling the extended chain back. The proof adds the missing determinantal Bezout-cofactor family, a bounded uniqueness theorem from the Sylvester kernel, exact Brown-step row identification, and caller-coordinate swap equivariance.

It also restores `HexResultant` to `done_through: 5`, records the new `HexDeterminant` dependency, and qualifies Mathlib matrix references affected by the newly public Hex matrix namespace.

Verification:
- `grep -rn sorry HexResultant` (no output)
- `lake build HexResultant HexResultantMathlib`
- `lake build HexResultant.Conformance`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_copyright_headers.py`