### PR TITLE
fix(release): route publishing tokens by the receive-pack write handshake

### DIFF
--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -22,7 +22,7 @@ Auth (non-dry-run): tokens from --token (repeatable) or the environment
 `x-access-token` basic-auth credentials for clone and push. A fine-grained
 token caps its selected-repository list, so the published set is split across
 more than one token; for each target repository the preflight probes the
-tokens in order until one can see it, and routes that repository's clone and
+tokens in order until one can push to it, and routes that repository's clone and
 push through that token. Dry-run clones over public https and never pushes.
 
 Usage:
@@ -32,6 +32,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import re
@@ -65,10 +66,11 @@ TOOLCHAIN = REPO_ROOT / "lean-toolchain"
 # of a token with room. The second part needs an organization owner's
 # approval, so start it before the release rather than discovering it
 # mid-publish. The sync does not care which token carries which repository; it
-# routes per repository to the first token that can see it.
+# routes per repository to the first token that can push to it.
 TOKEN_HELP = (
-    "Follow the per-token reasons above: a repository reported as not selected\n"
-    "must be added to the selected repositories of one of the tokens behind the\n"
+    "Follow the per-token reasons above: a repository reported without a\n"
+    "write grant must be added to the selected repositories of one of the\n"
+    "tokens behind the\n"
     "RELEASED_SYNC_PAT / RELEASED_SYNC_PAT_2 secrets (Contents: Read and write);\n"
     "a missing repository must be created first; an indeterminate reason (rate\n"
     "limit, network, credentials) calls for a retry or a token repair, not a\n"
@@ -212,39 +214,61 @@ def _api_repo(repo: str, token: str | None) -> dict | int:
         return exc.code
 
 
+def _receive_pack_status(repo: str, token: str) -> int:
+    """HTTP status of the smart-HTTP receive-pack advertisement.
+
+    `GET <repo>.git/info/refs?service=git-receive-pack` is the handshake `git
+    push` performs before sending anything, so it is authorized exactly like a
+    push (`Contents: write`) and has no side effects: 200 means this token can
+    push, 401/403 mean it cannot, 404 means the repository is not there.
+    """
+    auth = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    request = urllib.request.Request(
+        f"https://github.com/{repo}.git/info/refs?service=git-receive-pack",
+        headers={"Authorization": f"Basic {auth}",
+                 "User-Agent": "hex-dev-release-sync"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
 def selection_check(repo: str, token: str) -> str | None:
-    """None if `repo` is in the token's selected repositories, else why not.
+    """None if `token` can push to `repo`, else why not.
 
-    This is a *selection* check, not an authorization check. `GET /repos` needs
-    only `Metadata: read`, and the `permissions` it reports describe the
-    authenticated user's role on the repository, not the grants of this
-    particular token, so a token holding only `Contents: read` on a selected
-    repository still reports `push: true`. What it does catch, and what has
-    actually bitten a release, is a repository missing from the token's
-    selection: a fine-grained token cannot see one at all, so it answers 404.
+    Probes the receive-pack advertisement rather than `GET /repos`: a
+    fine-grained token reads any *public* repository whether or not it is in
+    the token's selection, so a metadata probe routes a repository to the
+    first token even when only a later token holds the write grant, and the
+    failure then surfaces at push time, after earlier repositories were
+    already published (this has actually bitten a first publish). The
+    receive-pack handshake is authorized exactly like the push itself.
 
-    A repository that does not exist answers 404 too, so an anonymous probe
-    separates the two; released repositories are public and are created by hand
-    before they enter the manifest (see scripts/release/BOOTSTRAP.md). Any other
-    status is reported as indeterminate rather than guessed at, so a rate limit
-    or an outage never reads as a missing repository.
+    A repository that does not exist answers 404; an anonymous metadata probe
+    separates "missing" from anything odder. Any other status is reported as
+    indeterminate rather than guessed at, so a rate limit or an outage never
+    reads as a missing grant.
     """
     try:
-        result = _api_repo(repo, token)
+        status = _receive_pack_status(repo, token)
     except (urllib.error.URLError, OSError, ValueError) as exc:
         return f"could not be checked ({exc})"
-    if not isinstance(result, int):
+    if status == 200:
         return None
-    if result in (403, 429):
-        return f"could not be checked (HTTP {result}; rate limited or forbidden)"
-    if result != 404:
-        return f"could not be checked (HTTP {result})"
+    if status in (401, 403):
+        return ("not granted Contents: write (repository unselected on this "
+                "token, or selected read-only)")
+    if status == 429:
+        return f"could not be checked (HTTP {status}; rate limited)"
+    if status != 404:
+        return f"could not be checked (HTTP {status})"
     try:
         anonymous = _api_repo(repo, None)
     except (urllib.error.URLError, OSError, ValueError) as exc:
         return f"HTTP 404, and could not be checked anonymously ({exc})"
     if not isinstance(anonymous, int):
-        return "not in the token's selected repositories"
+        return "HTTP 404 with the token yet publicly visible; undetermined"
     if anonymous == 404:
         return "no such repository (create it before publishing)"
     return (f"HTTP 404, and anonymously HTTP {anonymous}, so whether it is "
@@ -262,8 +286,8 @@ def route_tokens(entries: list[dict], tokens: list[str]) -> tuple[dict[str, str]
     it, and every later clone and push uses the token routed here. A library
     released here
     but on no token's list would otherwise fail partway through, after earlier
-    repos were already published. This proves selection, not write access; see
-    `selection_check`.
+    repos were already published. The probe authorizes like the push itself;
+    see `selection_check`.
     """
     routed: dict[str, str] = {}
     blocked: list[str] = []
@@ -857,7 +881,7 @@ def main() -> int:
             f"token {index + 1}: {sum(1 for t in repo_token.values() if t == token)}"
             for index, token in enumerate(tokens))
         print(f"token preflight: all {len(targets)} target repositories are covered "
-              f"({per_slot}; this does not prove write access, see selection_check)")
+              f"({per_slot}; the probe authorizes like the push itself, see selection_check)")
 
     failed_repo: str | None = None
     current_repo = "<manifest>"

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -350,47 +350,56 @@ class TokenPreflightTests(unittest.TestCase):
             self.assertEqual(sync_released.main(), 0)
         self.assertEqual(seen_tokens, [None])
 
-    def _check(self, responses: list) -> str | None:
-        """Run selection_check with `_api_repo` answering from `responses`,
-        in call order: authenticated first, then the anonymous probe."""
-        with patch.object(sync_released, "_api_repo", side_effect=responses):
+    def _check(self, advertisement, anonymous: list | None = None) -> str | None:
+        """Run selection_check with the receive-pack advertisement answering
+        `advertisement` and, when reached, the anonymous `_api_repo` probe
+        answering from `anonymous`."""
+        with (
+            patch.object(sync_released, "_receive_pack_status",
+                         side_effect=[advertisement]),
+            patch.object(sync_released, "_api_repo",
+                         side_effect=anonymous or []),
+        ):
             return sync_released.selection_check("leanprover/hex-arith", "t")
 
-    def test_visible_repo_passes(self) -> None:
-        self.assertIsNone(self._check([{"permissions": {"push": True}}]))
-
-    def test_visible_but_read_only_role_still_passes(self) -> None:
-        # `permissions` reports the *user's* role, not the token's grants, so it
-        # is deliberately not treated as evidence either way.
-        self.assertIsNone(self._check([{"permissions": {"push": False}}]))
+    def test_write_capable_repo_passes(self) -> None:
+        self.assertIsNone(self._check(200))
 
     def test_unselected_repo_is_named_as_such(self) -> None:
-        reason = self._check([404, {"name": "hex-arith"}])
-        self.assertIn("not in the token's selected repositories", reason)
+        # A public repository is readable by any fine-grained token whether or
+        # not it is selected, so only the write handshake separates the tokens:
+        # unauthorized receive-pack means no Contents: write grant here.
+        for status in (401, 403):
+            with self.subTest(status=status):
+                reason = self._check(status)
+                self.assertIn("not granted Contents: write", reason)
 
     def test_absent_repo_says_create_it(self) -> None:
-        reason = self._check([404, 404])
+        reason = self._check(404, [404])
         self.assertIn("no such repository", reason)
 
     def test_rate_limit_is_indeterminate_not_a_missing_repo(self) -> None:
-        for status in (403, 429):
-            with self.subTest(status=status):
-                reason = self._check([status])
-                self.assertIn("could not be checked", reason)
-                self.assertNotIn("no such repository", reason)
+        reason = self._check(429)
+        self.assertIn("could not be checked", reason)
+        self.assertNotIn("no such repository", reason)
 
     def test_server_error_is_indeterminate(self) -> None:
-        reason = self._check([503])
+        reason = self._check(503)
         self.assertIn("could not be checked", reason)
 
     def test_anonymous_probe_failure_does_not_claim_the_repo_is_missing(self) -> None:
-        reason = self._check([404, 429])
+        reason = self._check(404, [429])
+        self.assertIn("undetermined", reason)
+        self.assertNotIn("no such repository", reason)
+
+    def test_hidden_but_public_repo_is_undetermined(self) -> None:
+        reason = self._check(404, [{"name": "hex-arith"}])
         self.assertIn("undetermined", reason)
         self.assertNotIn("no such repository", reason)
 
     def test_network_failure_is_indeterminate(self) -> None:
         import urllib.error
-        reason = self._check([urllib.error.URLError("dns")])
+        reason = self._check(urllib.error.URLError("dns"))
         self.assertIn("could not be checked", reason)
 
     def test_misspelled_only_fails_instead_of_publishing_nothing(self) -> None:


### PR DESCRIPTION
This PR fix the release-sync token router for repositories carried by the second publishing token. A fine-grained token can read any public repository whether or not it is in the token's selection, so the `GET /repos` selection probe routed every repository to the first token, and a repository whose write grant lives only on a later token failed at push time (bitten by the hex-sparse-poly first publish). The preflight now probes the smart-HTTP receive-pack advertisement, which is authorized exactly like the push itself and has no side effects: 200 proves the Contents: write grant, 401/403 rejects the token, and 404 still separates a genuinely missing repository through the anonymous metadata probe. The preflight tests are updated to the write-probe contract, including the public-but-unselected case the old probe could not express.

🤖 Prepared with Claude Code