### PR TITLE
feat(interval): emit correlated typed runtime evidence

### DIFF
--- a/HexIntervalMathlib.lean
+++ b/HexIntervalMathlib.lean
@@ -25,6 +25,8 @@ public import HexIntervalMathlib.Proof
 public import HexIntervalMathlib.RuntimeProof
 public import HexIntervalMathlib.RuntimeTerminal
 public import HexIntervalMathlib.RuntimeRule
+public import HexIntervalMathlib.RuntimeEmit
+public import HexIntervalMathlib.RuntimeRuleEmit
 public import HexIntervalMathlib.Rule
 public import HexIntervalMathlib.Frontend
 public import HexIntervalMathlib.Tactic
@@ -45,6 +47,12 @@ transition chains into those proof events without trusting raw quotations.
 the same sealed runtime/search lineage, theorem registry, and immutable proof
 input; general split settlement remains blocked by the runtime/proof child
 equality-arena mismatch documented by that module.
+`HexIntervalMathlib.RuntimeEmit` quotes only a sealed one-node target lineage
+into an exactly checked `Proof.Evidence` expression through package-owned
+transparent theorem handles. `HexIntervalMathlib.RuntimeRuleEmit` jointly
+assembles those handles with the executable and theorem views of the twelve
+built-in arithmetic rules. Refutation and split expression emission are not
+supported.
 `HexIntervalMathlib.Rule` supplies a checked built-in arithmetic package whose
 schemas recompute checked public operations before producing proof evidence.
 `HexIntervalMathlib.RuntimeRule` supplies the aligned executable half: its

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -370,6 +370,30 @@ version-zero facts constructed by `Result.facts`. -/
 def SourcesContain (values : Nat → ℝ) (sources : Array Hex.Interval) : Prop :=
   ∀ index (fact : Hex.Interval), sources[index]? = some fact → fact.Contains (values index)
 
+/-- Total lookup used when a Meta caller quotes a finite source-expression
+list. Indices outside the list are irrelevant to `SourcesContain`. -/
+def valuesAt (values : List ℝ) (index : Nat) : ℝ :=
+  values[index]?.getD 0
+
+/-- Convert one membership proof per quoted source into the frontend's exact
+array-indexed source obligation. -/
+theorem SourcesContain.ofForall₂ {values : List ℝ} {sources : List Hex.Interval}
+    (holds : List.Forall₂ (fun value source => source.Contains value) values sources) :
+    SourcesContain (valuesAt values) sources.toArray := by
+  induction holds with
+  | nil =>
+      intro index fact found
+      simp at found
+  | @cons value source values sources member _ ih =>
+      intro index fact found
+      cases index with
+      | zero =>
+          simp at found
+          subst fact
+          simpa [valuesAt] using member
+      | succ index =>
+          exact ih index fact (by simpa using found)
+
 theorem Result.seed_contains (config : Rule.Config) (values : Nat → ℝ)
     (result : Result) (sources : Array Hex.Interval) (checked : result.check)
     (sourceSize : sources.size = result.sourceCount)
@@ -510,6 +534,14 @@ def modelWithin (config : Config) (sources : Nat → ℝ) (result : Result) :
         target := result.target_eval config.rule sources checked }
     else throw .malformedResult
   else throw .malformedProgram
+
+/-- Project the exact semantic model from a transparently successful checked
+frontend result. Meta callers construct `success` by kernel reduction of the
+quoted configuration and reifier data. -/
+def modelOfCheck {config : Config} {sources : Nat → ℝ} {result : Result}
+    (checked : Except Error (Model config.rule sources result))
+    (success : checked.toOption.isSome = true) : Model config.rule sources result :=
+  checked.toOption.get success
 
 /-- Revalidate the bounded reification result, including its exact node/term
 correspondence, bind every selected source exactly once, and seed all computed

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -481,6 +481,68 @@ def acceptsAction (registry : Registry semantics Plan) (program : Program)
 
 end Registry
 
+/-! ## Transparent schema resolution
+
+`Registry` remains the sealed runtime theorem authority. `Resolver` is the
+plain proof-syntax view used by an elaborator after a separate sealed bridge
+has authenticated exact package-local coverage. Constructing a resolver does
+not authorize a runtime action: every schema still returns an ordinary proof,
+and transparent replay rechecks the complete quoted action and chronology. -/
+
+structure Resolver (semantics : Semantics Fact) where
+  registrations : Array Registration
+  facts : Array (FactSchema semantics)
+  equalities : Array (EqualitySchema semantics)
+  instances : Array (InstanceSchema semantics)
+
+namespace Resolver
+
+def fact? (resolver : Resolver semantics) (key : Key) : Option (FactSchema semantics) :=
+  resolver.facts.toList.find? fun schema => schema.key == key
+
+def equality? (resolver : Resolver semantics) (key : Key) :
+    Option (EqualitySchema semantics) :=
+  resolver.equalities.toList.find? fun schema => schema.key == key
+
+def instance? (resolver : Resolver semantics) (key : Key) :
+    Option (InstanceSchema semantics) :=
+  resolver.instances.toList.find? fun schema => schema.key == key
+
+/-- Independently authenticate the structural portion of a quoted action.
+This is deliberately identical to `Registry.acceptsAction`; the syntax replay
+must not inherit authorization from the compiled runtime check. -/
+def acceptsAction (resolver : Resolver semantics) (program : Program)
+    (action : Action) (inputs : List NodeId) : Bool :=
+  match resolver.registrations[action.rule.index]?, program.node? action.node with
+  | some registration, some anchor =>
+      let common := registration.key == action.key && registration.kind == action.kind &&
+        (program.operation? anchor.op).any (fun operation => operation.key == registration.head) &&
+        action.inputs.map (fun seen => seen.node) == inputs &&
+        match registration.matchWatch with
+        | .none => action.structuralInputs.isEmpty && action.matcherEpoch.isNone
+        | .network => !action.structuralInputs.isEmpty && action.matcherEpoch.isSome
+      common && match registration.binding with
+      | .local =>
+          Slot.resolveAll? action.node anchor registration.watches == some inputs &&
+            Slot.resolveAll? action.node anchor registration.writes == some action.writes
+      | .scoped =>
+          registration.watches.isEmpty && registration.writes.isEmpty &&
+            allDistinct inputs && allDistinct action.writes &&
+            inputs.all (fun node => (program.node? node).isSome) &&
+            action.writes.all (fun node => (program.node? node).isSome)
+      | .global =>
+          registration.watches.isEmpty && registration.writes.isEmpty &&
+            inputs.isEmpty && action.writes.isEmpty
+  | _, _ => false
+
+end Resolver
+
+def Registry.resolver (registry : Registry semantics Plan) : Resolver semantics :=
+  { registrations := registry.registrations
+    facts := registry.facts
+    equalities := registry.equalities
+    instances := registry.instances }
+
 /-! ## Plain replay quotations -/
 
 structure FactStep (Fact : Type) where
@@ -919,7 +981,7 @@ def dependenciesCheck (limits : Limits) (dependencies : List SeenVersion) :
     Except Error Unit :=
   if limits.maxDependencies < dependencies.length then throw .dependencyLimit else pure ()
 
-def replayFact (limits : Limits) (registry : Registry semantics Plan)
+def replayFactWith (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (input : Input Fact)
     (checked : State semantics input assumptions)
     (step : FactStep Fact) : Except Error (State semantics input assumptions) := do
@@ -941,9 +1003,9 @@ def replayFact (limits : Limits) (registry : Registry semantics Plan)
     | throw (.missingDependency step.previous)
   let some resolvedInputs := resolveInputs checked.facts step.assumptions
     | throw (.missingDependency (step.assumptions.head?.getD step.previous))
-  if !registry.acceptsAction checked.program step.action
+  if !resolver.acceptsAction checked.program step.action
       (resolvedInputs.facts.map fun fact => fact.node) then throw .wrongAction
-  let some schema := registry.fact? step.schema | throw .missingSchema
+  let some schema := resolver.fact? step.schema | throw .missingSchema
   let some certificate := schema.decode step.body | throw .malformedBody
   let context : FactContext semantics :=
     { scope := step.scope
@@ -966,7 +1028,13 @@ def replayFact (limits : Limits) (registry : Registry semantics Plan)
   let pushed := checked.facts.push current step.installed currentWithin sound
   pure { checked with facts := pushed }
 
-def replayEquality (limits : Limits) (registry : Registry semantics Plan)
+def replayFact (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (input : Input Fact)
+    (checked : State semantics input assumptions)
+    (step : FactStep Fact) : Except Error (State semantics input assumptions) :=
+  replayFactWith limits registry.resolver domain input checked step
+
+def replayEqualityWith (limits : Limits) (resolver : Resolver semantics)
     (input : Input Fact) (checked : State semantics input assumptions)
     (step : EqualityStep) : Except Error (State semantics input assumptions) := do
   bodyCheck limits step.schema .equality step.body
@@ -983,9 +1051,9 @@ def replayEquality (limits : Limits) (registry : Registry semantics Plan)
   let some resolvedInputs := resolveInputs checked.facts step.assumptions
     | throw (.missingDependency (step.assumptions.head?.getD
         { node := step.left, version := 0 }))
-  if !registry.acceptsAction checked.program step.action
+  if !resolver.acceptsAction checked.program step.action
       (resolvedInputs.facts.map fun fact => fact.node) then throw .wrongAction
-  let some schema := registry.equality? step.schema | throw .missingSchema
+  let some schema := resolver.equality? step.schema | throw .missingSchema
   let some certificate := schema.decode step.body | throw .malformedBody
   let context : EqualityContext semantics :=
     { scope := step.scope, programVersion := checked.version, program := checked.program
@@ -1002,6 +1070,11 @@ def replayEquality (limits : Limits) (registry : Registry semantics Plan)
   let proof : EqualityProof semantics checked.program (replayBase input assumptions) :=
     { equality := step.equality, left := step.left, right := step.right, sound }
   pure { checked with equalities := checked.equalities.push proof }
+
+def replayEquality (limits : Limits) (registry : Registry semantics Plan)
+    (input : Input Fact) (checked : State semantics input assumptions)
+    (step : EqualityStep) : Except Error (State semantics input assumptions) :=
+  replayEqualityWith limits registry.resolver input checked step
 
 def replayTransport (_limits : Limits) (domain : Domain semantics)
     (laws : Laws semantics) (input : Input Fact)
@@ -1153,7 +1226,7 @@ theorem composeStable (left : Stable semantics first middle)
           (Nat.lt_of_lt_of_le within left.appendOnly.nodeSize) middleModel newModel
           (fun _ _ => rfl)) }
 
-def replayInstance (limits : Limits) (registry : Registry semantics Plan)
+def replayInstanceWith (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (input : Input Fact)
     (checked : State semantics input assumptions)
     (step : InstanceStep) : Except Error (State semantics input assumptions) := do
@@ -1163,13 +1236,13 @@ def replayInstance (limits : Limits) (registry : Registry semantics Plan)
     throw .wrongProgramVersion
   if step.action.programVersion != checked.version || step.action.key != step.schema.rule then
     throw .wrongAction
-  if !registry.acceptsAction checked.program step.action [] then throw .wrongAction
+  if !resolver.acceptsAction checked.program step.action [] then throw .wrongAction
   if !step.after.check || !Hex.Interval.State.programPrefix checked.program step.after then
     throw .wrongInstance
   let expected := (List.range (step.after.nodes.size - checked.program.nodes.size)).map
     fun offset => { index := checked.program.nodes.size + offset : NodeId }
   if step.newNodes != expected then throw .wrongInstance
-  let some schema := registry.instance? step.schema | throw .missingSchema
+  let some schema := resolver.instance? step.schema | throw .missingSchema
   let some certificate := schema.decode step.body | throw .malformedBody
   let context : InstanceContext semantics :=
     { scope := step.scope, beforeVersion := checked.version,
@@ -1197,23 +1270,41 @@ def replayInstance (limits : Limits) (registry : Registry semantics Plan)
       facts := checked.facts.lift proof.stable currentBaseWithin domain
       equalities := checked.equalities.lift proof.stable currentBaseWithin }
 
-def replayEvent (limits : Limits) (registry : Registry semantics Plan)
+def replayInstance (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (input : Input Fact)
+    (checked : State semantics input assumptions)
+    (step : InstanceStep) : Except Error (State semantics input assumptions) :=
+  replayInstanceWith limits registry.resolver domain input checked step
+
+def replayEventWith (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
     State semantics input assumptions → Event Fact →
       Except Error (State semantics input assumptions)
-  | checked, .fact step => replayFact limits registry domain input checked step
-  | checked, .equality step => replayEquality limits registry input checked step
+  | checked, .fact step => replayFactWith limits resolver domain input checked step
+  | checked, .equality step => replayEqualityWith limits resolver input checked step
   | checked, .transport step => replayTransport limits domain laws input checked step
-  | checked, .instance step => replayInstance limits registry domain input checked step
+  | checked, .instance step => replayInstanceWith limits resolver domain input checked step
 
-def replayEvents (limits : Limits) (registry : Registry semantics Plan)
+def replayEvent (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
+    State semantics input assumptions → Event Fact →
+      Except Error (State semantics input assumptions) :=
+  replayEventWith limits registry.resolver domain laws input
+
+def replayEventsWith (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
     List (Event Fact) → State semantics input assumptions →
       Except Error (State semantics input assumptions)
   | [], state => pure state
   | event :: events, state => do
-      let next ← replayEvent limits registry domain laws input state event
-      replayEvents limits registry domain laws input events next
+      let next ← replayEventWith limits resolver domain laws input state event
+      replayEventsWith limits resolver domain laws input events next
+
+def replayEvents (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact) :
+    List (Event Fact) → State semantics input assumptions →
+      Except Error (State semantics input assumptions) :=
+  replayEventsWith limits registry.resolver domain laws input
 
 /-- A successfully replayed chronology retains its checked proof state. It is
 the only input accepted by later target, refutation, split, and child-seed
@@ -1226,18 +1317,25 @@ structure Replay (semantics : Semantics Fact) (input : Input Fact)
 /-- Replay from an already authenticated proof state and require the exact
 final program version and structural program. Failure returns no partial
 state. -/
-def replayFrom (limits : Limits) (registry : Registry semantics Plan)
+def replayFromWith (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
     (start : State semantics input assumptions) (events : List (Event Fact))
     (finalVersion : Nat) (finalProgram : Program) :
     Except Error (Replay semantics input assumptions start) := do
   if limits.maxChronology < events.length then throw .chronologyLimit
-  let checked ← replayEvents limits registry domain laws input events start
+  let checked ← replayEventsWith limits resolver domain laws input events start
   if checked.version != finalVersion then throw .wrongProgramVersion
   if checked.program != finalProgram then throw .wrongFinalProgram
   let originEq : Evidence (checked.origin = start.origin) ←
     if h : checked.origin = start.origin then pure ⟨h⟩ else throw .wrongFinalProgram
   pure { state := checked, originEq := originEq.proof }
+
+def replayFrom (limits : Limits) (registry : Registry semantics Plan)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
+    (start : State semantics input assumptions) (events : List (Event Fact))
+    (finalVersion : Nat) (finalProgram : Program) :
+    Except Error (Replay semantics input assumptions start) :=
+  replayFromWith limits registry.resolver domain laws input start events finalVersion finalProgram
 
 /-- Close a proof in the node's possibly extended program back to the exact
 program at entry to that node. Independent child extensions therefore meet at
@@ -1261,7 +1359,7 @@ def closeOrigin (checked : State semantics input assumptions) (target : NodeFact
         originModel finalModel agreement).mpr finalTarget }
 
 /-- Replay exact chronology and close the exact target/version. -/
-def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
+def replayWith [DecidableEq Fact] (limits : Limits) (resolver : Resolver semantics)
     (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
     (events : List (Event Fact)) (finalVersion : Nat) (finalProgram : Program)
     (result : SeenVersion) :
@@ -1271,7 +1369,7 @@ def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
     if h : input.facts.size = input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
   let targetWithin : Evidence (input.target.node.index < input.program.nodes.size) ←
     if h : input.target.node.index < input.program.nodes.size then pure ⟨h⟩ else throw .invalidInput
-  let replayed ← replayFrom limits registry domain laws input
+  let replayed ← replayFromWith limits resolver domain laws input
     (State.start semantics input size.proof) events finalVersion finalProgram
   let checked := replayed.state
   let nodeEq : Evidence (result.node = input.target.node) ←
@@ -1296,6 +1394,13 @@ def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
           simpa [nodeEq.proof, factEq.proof] using finalResult
         exact (checked.stable.holdsOld valuation extended input.target targetWithin.proof
           baseModel finalModel agreement).mpr finalTarget }
+
+def replay [DecidableEq Fact] (limits : Limits) (registry : Registry semantics)
+    (domain : Domain semantics) (laws : Laws semantics) (input : Input Fact)
+    (events : List (Event Fact)) (finalVersion : Nat) (finalProgram : Program)
+    (result : SeenVersion) :
+    Except Error (Evidence (semantics.Entails input.program (initialBase input) input.target)) :=
+  replayWith limits registry.resolver domain laws input events finalVersion finalProgram result
 
 /-- Replay one exact established impossible fact. Runtime contradiction state
 is not an argument. -/

--- a/HexIntervalMathlib/Proof.lean
+++ b/HexIntervalMathlib/Proof.lean
@@ -17,8 +17,11 @@ public import Mathlib.Lean.Elab.Tactic.Basic
 This module is the supported proof authority for interval search. Search state,
 callback replies, payload arenas, and diagnostic traces are decoded data only.
 The replay cursor starts from the caller's exact program and fact array and can
-advance only through package-owned theorem schemas whose complete address,
-owner, body, action, scope, versions, dependencies, and chronology all match.
+advance only through theorem schemas whose complete address, body, action,
+scope, versions, dependencies, and chronology all match. The sealed `Registry`
+authenticates package ownership before producing its resolver; the public
+`Resolver` replay surface is caller-owned and does not independently enforce
+that provenance.
 Binary splits additionally require a package-owned cover theorem. Each child
 adds exactly one assumption; inherited facts are rebased as derived evidence.
 A bounded fold checks an exact retained `Search.Result.Tree`, rejects unknown
@@ -484,10 +487,12 @@ end Registry
 /-! ## Transparent schema resolution
 
 `Registry` remains the sealed runtime theorem authority. `Resolver` is the
-plain proof-syntax view used by an elaborator after a separate sealed bridge
-has authenticated exact package-local coverage. Constructing a resolver does
-not authorize a runtime action: every schema still returns an ordinary proof,
-and transparent replay rechecks the complete quoted action and chronology. -/
+public plain proof-syntax view used by an elaborator after a separate sealed
+bridge has authenticated exact package-local coverage. Direct callers may also
+construct one without that provenance; `replayWith` checks its registrations,
+schema keys, actions, and chronology, but does not establish package ownership.
+Every accepted schema still returns an ordinary proof checked at the exact
+claim. -/
 
 structure Resolver (semantics : Semantics Fact) where
   registrations : Array Registration

--- a/HexIntervalMathlib/RuntimeEmit.lean
+++ b/HexIntervalMathlib/RuntimeEmit.lean
@@ -76,6 +76,7 @@ inductive Error where
   | extraHandle (key : Proof.Key)
   | duplicateHandle (key : Proof.Key)
   | wrongRole (key : Proof.Key)
+  | handleKey (key : Proof.Key)
   | proof (error : Proof.Error)
   | malformed
   | emitter
@@ -139,6 +140,24 @@ private def checkPackages (packages : Array (Package semantics Plan)) : Except E
         if seen.contains handle.key then throw (.duplicateHandle handle.key)
         seen := handle.key :: seen
 
+private def schemaCount (packages : Array (Package semantics Plan)) : Nat :=
+  packages.foldl (init := 0) fun count package =>
+    count + package.facts.size + package.equalities.size + package.instances.size
+
+private def qRuleKey (value : RuleKey) : MetaM Lean.Expr :=
+  mkAppM ``RuleKey.mk #[toExpr value.name, mkNatLit value.schema]
+
+private def qRole : Proof.Role → Lean.Expr
+  | .fact => mkConst ``Proof.Role.fact
+  | .equality => mkConst ``Proof.Role.equality
+  | .instance => mkConst ``Proof.Role.instance
+  | .refute => mkConst ``Proof.Role.refute
+  | .split => mkConst ``Proof.Role.split
+
+private def qProofKey (value : Proof.Key) : MetaM Lean.Expr := do
+  mkAppM ``Proof.Key.mk
+    #[← qRuleKey value.rule, qRole value.role, mkNatLit value.bodySchema]
+
 /-- Deterministic syntax-tree size used by `Limits.maxExpressionCells`. -/
 def expressionCells : Lean.Expr → Nat
   | .bvar _ | .fvar _ | .mvar _ | .sort _ | .const _ _ | .lit _ => 1
@@ -162,6 +181,13 @@ private def schemaType (role : Proof.Role) (semanticsExpr : Lean.Expr) : MetaM L
   | .instance => mkAppM ``Proof.InstanceSchema #[semanticsExpr]
   | .refute | .split => throwError "runtime emitter has no terminal schema role"
 
+private def schemaKey (role : Proof.Role) (schema : Lean.Expr) : MetaM Lean.Expr :=
+  match role with
+  | .fact => mkAppM ``Proof.FactSchema.key #[schema]
+  | .equality => mkAppM ``Proof.EqualitySchema.key #[schema]
+  | .instance => mkAppM ``Proof.InstanceSchema.key #[schema]
+  | .refute | .split => throwError "runtime emitter has no terminal schema role"
+
 private def prepareHandles (limits : Limits) (semanticsExpr : Lean.Expr)
     (packages : Array (Package semantics Plan)) (role : Proof.Role) :
     MetaM (Except Error (Array Entry)) := do
@@ -169,13 +195,18 @@ private def prepareHandles (limits : Limits) (semanticsExpr : Lean.Expr)
   let mut entries := #[]
   for package in packages do
     for handle in handles package role do
-      if limits.maxSchemas ≤ entries.size then return .error (.resource .schemas)
       let prepared ← prepare handle.schema expected
       match prepared with
       | .error error => return .error error
       | .ok expr =>
           if limits.maxExpressionCells < expressionCells expr then
             return .error (.resource .expression)
+          let actualKey ← try
+            schemaKey role expr
+          catch _ =>
+            return .error .emitter
+          unless ← isDefEq actualKey (← qProofKey handle.key) do
+            return .error (.handleKey handle.key)
           entries := entries.push { key := handle.key, expr }
   return .ok entries
 
@@ -205,6 +236,8 @@ private def prepareRegistry (limits : Limits)
     MetaM (Except Error (Prepared Fact)) := do
   let quoter := registry.quoter
   let packages := registry.packages
+  if limits.maxSchemas < schemaCount packages then
+    return .error (.resource .schemas)
   let factType ← match ← prepare quoter.factType (mkSort (.succ .zero)) with
     | .error error => return .error error
     | .ok expr => pure expr
@@ -320,9 +353,6 @@ private def qOpId (value : OpId) : MetaM Lean.Expr :=
 private def qNodeId (value : NodeId) : MetaM Lean.Expr :=
   mkAppM ``NodeId.mk #[mkNatLit value.index]
 
-private def qRuleKey (value : RuleKey) : MetaM Lean.Expr :=
-  mkAppM ``RuleKey.mk #[toExpr value.name, mkNatLit value.schema]
-
 private def qRuleId (value : RuleId) : MetaM Lean.Expr :=
   mkAppM ``RuleId.mk #[mkNatLit value.index]
 
@@ -385,17 +415,6 @@ private def qAction (value : Action) : MetaM Lean.Expr := do
       mkNatLit value.generation, ← listExpr seenType (← value.inputs.mapM qSeen),
       ← listExpr nodeType (← value.writes.mapM qNodeId),
       ← listExpr structuralType (← value.structuralInputs.mapM qStructuralInput), epoch]
-
-private def qRole : Proof.Role → Lean.Expr
-  | .fact => mkConst ``Proof.Role.fact
-  | .equality => mkConst ``Proof.Role.equality
-  | .instance => mkConst ``Proof.Role.instance
-  | .refute => mkConst ``Proof.Role.refute
-  | .split => mkConst ``Proof.Role.split
-
-private def qProofKey (value : Proof.Key) : MetaM Lean.Expr := do
-  mkAppM ``Proof.Key.mk
-    #[← qRuleKey value.rule, qRole value.role, mkNatLit value.bodySchema]
 
 private def qNodeFact (registry : Prepared Fact)
     (value : Proof.NodeFact Fact) : MetaM Lean.Expr := do

--- a/HexIntervalMathlib/RuntimeEmit.lean
+++ b/HexIntervalMathlib/RuntimeEmit.lean
@@ -1,0 +1,583 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.RuntimeTerminal
+public meta import HexIntervalMathlib.RuntimeTerminal
+
+@[expose] public section
+
+/-!
+# Kernel-facing quotation of a sealed typed runtime target
+
+This module is the elaborator bridge for the root-target subset of the typed
+runtime. Executable callbacks and compiled `Proof.Evidence` values are never
+converted into syntax. Instead, packages contribute Meta handles for their
+ordinary theorem schemas. A sealed registry checks those handles against the
+same package-local schemas used to build `RuntimeProof.Registry`; a checked
+root chronology is then quoted as plain `Proof.Event` data and transparently
+replayed by `Proof.replayWith`.
+
+There is deliberately no refutation or split emitter here. `Checked.emitWithin`
+accepts only a one-node target-terminal tree. Emitter callbacks and quotation
+of arbitrary caller facts are pure Lean/Meta callbacks and are not preempted by
+these structural limits. Their results are nevertheless rolled back, checked,
+and bounded before any expression escapes.
+-/
+
+namespace Hex.Interval.RuntimeEmit
+
+open Lean Meta
+
+variable {Fact Cause Plan : Type} {semantics : Proof.Semantics Fact}
+
+/-- One package-owned expression handle for an exact proof schema address. -/
+structure Handle where
+  key : Proof.Key
+  schema : Proof.Emitter Unit
+
+/-- Handles paired with the exact proof package which owns their keys. -/
+structure Package (semantics : Proof.Semantics Fact) (Plan : Type := List Nat) where
+  proof : Proof.Package semantics Plan
+  facts : Array Handle := #[]
+  equalities : Array Handle := #[]
+  instances : Array Handle := #[]
+
+/-- Registry-wide quotation of the indexed fact domain and its proof laws. -/
+structure Quoter (Fact : Type) (semantics : Proof.Semantics Fact) where
+  factType : Proof.Emitter Unit
+  fact : Proof.Emitter Fact
+  semantics : Proof.Emitter Unit
+  domain : Proof.Emitter Unit
+  laws : Proof.Emitter Unit
+
+structure Limits where
+  proof : Proof.Limits
+  maxSchemas : Nat
+  maxChronology : Nat
+  maxExpressionCells : Nat
+  deriving DecidableEq, Repr
+
+inductive Resource where
+  | schemas
+  | chronology
+  | expression
+  deriving DecidableEq, Repr
+
+inductive Error where
+  | proofBuild (error : Proof.BuildError)
+  | runtimeProof (error : RuntimeProof.Error)
+  | terminal (error : RuntimeTerminal.Error)
+  | missingHandle (key : Proof.Key)
+  | extraHandle (key : Proof.Key)
+  | duplicateHandle (key : Proof.Key)
+  | wrongRole (key : Proof.Key)
+  | proof (error : Proof.Error)
+  | malformed
+  | emitter
+  | replay
+  | resource (resource : Resource)
+  deriving DecidableEq, Repr
+
+private structure Entry where
+  key : Proof.Key
+  expr : Lean.Expr
+
+/-- Exact executable/proof/emitter assembly. The private constructor ensures
+the emitter view cannot be attached after a runtime registry was built. -/
+structure Registry (Fact : Type) (semantics : Proof.Semantics Fact)
+    (Cause Plan : Type := List Nat) where
+  private mk ::
+  runtime : RuntimeProof.Registry Fact semantics Cause Plan
+  quoter : Quoter Fact semantics
+  packages : Array (Package semantics Plan)
+
+private structure Prepared (Fact : Type) where
+  quoteFact : Proof.Emitter Fact
+  factType : Lean.Expr
+  semanticsExpr : Lean.Expr
+  domainExpr : Lean.Expr
+  lawsExpr : Lean.Expr
+  facts : Array Entry
+  equalities : Array Entry
+  instances : Array Entry
+
+private def packageKeys (package : Package semantics Plan) (role : Proof.Role) : List Proof.Key :=
+  match role with
+  | .fact => package.proof.facts.toList.map (·.key)
+  | .equality => package.proof.equalities.toList.map (·.key)
+  | .instance => package.proof.instances.toList.map (·.key)
+  | .refute | .split => []
+
+private def handles (package : Package semantics Plan) (role : Proof.Role) : Array Handle :=
+  match role with
+  | .fact => package.facts
+  | .equality => package.equalities
+  | .instance => package.instances
+  | .refute | .split => #[]
+
+private def checkPackage (package : Package semantics Plan) (role : Proof.Role) : Except Error Unit := do
+  let expected := packageKeys package role
+  let actual := (handles package role).toList.map (·.key)
+  for handle in handles package role do
+    if handle.key.role != role then throw (.wrongRole handle.key)
+    if 1 < actual.count handle.key then throw (.duplicateHandle handle.key)
+    if !expected.contains handle.key then throw (.extraHandle handle.key)
+  for key in expected do
+    if !actual.contains key then throw (.missingHandle key)
+
+private def checkPackages (packages : Array (Package semantics Plan)) : Except Error Unit := do
+  let mut seen : List Proof.Key := []
+  for package in packages do
+    for role in [Proof.Role.fact, .equality, .instance] do
+      checkPackage package role
+      for handle in handles package role do
+        if seen.contains handle.key then throw (.duplicateHandle handle.key)
+        seen := handle.key :: seen
+
+/-- Deterministic syntax-tree size used by `Limits.maxExpressionCells`. -/
+def expressionCells : Lean.Expr → Nat
+  | .bvar _ | .fvar _ | .mvar _ | .sort _ | .const _ _ | .lit _ => 1
+  | .app f a => 1 + expressionCells f + expressionCells a
+  | .lam _ type body _ | .forallE _ type body _ =>
+      1 + expressionCells type + expressionCells body
+  | .letE _ type value body _ =>
+      1 + expressionCells type + expressionCells value + expressionCells body
+  | .mdata _ body | .proj _ _ body => 1 + expressionCells body
+
+private def prepare (emitter : Proof.Emitter Unit) (expected : Lean.Expr) : MetaM (Except Error Lean.Expr) :=
+  try
+    return .ok (← Proof.emitChecked emitter () expected)
+  catch _ =>
+    return .error .emitter
+
+private def schemaType (role : Proof.Role) (semanticsExpr : Lean.Expr) : MetaM Lean.Expr :=
+  match role with
+  | .fact => mkAppM ``Proof.FactSchema #[semanticsExpr]
+  | .equality => mkAppM ``Proof.EqualitySchema #[semanticsExpr]
+  | .instance => mkAppM ``Proof.InstanceSchema #[semanticsExpr]
+  | .refute | .split => throwError "runtime emitter has no terminal schema role"
+
+private def prepareHandles (limits : Limits) (semanticsExpr : Lean.Expr)
+    (packages : Array (Package semantics Plan)) (role : Proof.Role) :
+    MetaM (Except Error (Array Entry)) := do
+  let expected ← schemaType role semanticsExpr
+  let mut entries := #[]
+  for package in packages do
+    for handle in handles package role do
+      if limits.maxSchemas ≤ entries.size then return .error (.resource .schemas)
+      let prepared ← prepare handle.schema expected
+      match prepared with
+      | .error error => return .error error
+      | .ok expr =>
+          if limits.maxExpressionCells < expressionCells expr then
+            return .error (.resource .expression)
+          entries := entries.push { key := handle.key, expr }
+  return .ok entries
+
+/-- Jointly assemble the exact theorem registry and its package-local syntax
+handles. The `RuntimeProof.Registry` is created inside this function; no
+prebuilt registry or compatibility key can be spliced onto emitter handles.
+Meta callbacks are checked transactionally only when `emitWithin` runs because
+the existential theorem registry lives one universe above `MetaM` results. -/
+opaque Registry.buildWithin (executableLimits : Executable.Limits)
+    (limits : Limits) (key : RuntimeProof.Key)
+    (assembly : RuntimeProof.Assembly Fact Cause)
+    (quoter : Quoter Fact semantics)
+    (packages : Array (Package semantics Plan)) :
+    Except Error (Registry Fact semantics Cause Plan) := do
+  let _ : ULift.{1} Unit ← match checkPackages packages with
+    | .error error => throw error
+    | .ok value => pure ⟨value⟩
+  let proofPackages := packages.map (·.proof)
+  let proof ← Proof.Registry.buildWithin limits.proof assembly.program proofPackages
+    |>.mapError Error.proofBuild
+  let runtime ← RuntimeProof.Registry.buildWithin executableLimits key assembly proof
+    |>.mapError Error.runtimeProof
+  pure { runtime := runtime, quoter := quoter, packages := packages }
+
+private def prepareRegistry (limits : Limits)
+    (registry : Registry Fact semantics Cause Plan) :
+    MetaM (Except Error (Prepared Fact)) := do
+  let quoter := registry.quoter
+  let packages := registry.packages
+  let factType ← match ← prepare quoter.factType (mkSort (.succ .zero)) with
+    | .error error => return .error error
+    | .ok expr => pure expr
+  let semanticsType ← mkAppM ``Proof.Semantics #[factType]
+  let semanticsExpr ← match ← prepare quoter.semantics semanticsType with
+    | .error error => return .error error
+    | .ok expr => pure expr
+  let domainType ← mkAppM ``Proof.Domain #[semanticsExpr]
+  let domainExpr ← match ← prepare quoter.domain domainType with
+    | .error error => return .error error
+    | .ok expr => pure expr
+  let lawsType ← mkAppM ``Proof.Laws #[semanticsExpr]
+  let lawsExpr ← match ← prepare quoter.laws lawsType with
+    | .error error => return .error error
+    | .ok expr => pure expr
+  let facts ← match ← prepareHandles limits semanticsExpr packages .fact with
+    | .error error => return .error error
+    | .ok entries => pure entries
+  let equalities ← match ← prepareHandles limits semanticsExpr packages .equality with
+    | .error error => return .error error
+    | .ok entries => pure entries
+  let instances ← match ← prepareHandles limits semanticsExpr packages .instance with
+    | .error error => return .error error
+    | .ok entries => pure entries
+  return .ok
+    { quoteFact := quoter.fact
+      factType := factType
+      semanticsExpr := semanticsExpr
+      domainExpr := domainExpr
+      lawsExpr := lawsExpr
+      facts := facts
+      equalities := equalities
+      instances := instances }
+
+/-! ## Sealed root-target lineage -/
+
+structure Active (Fact : Type) (semantics : Proof.Semantics Fact) (Cause Plan : Type) where
+  private mk ::
+  registry : Registry Fact semantics Cause Plan
+  terminal : RuntimeTerminal.Active Fact semantics Cause Plan
+
+structure Lineage (Fact : Type) (semantics : Proof.Semantics Fact) (Cause Plan : Type) where
+  private mk ::
+  registry : Registry Fact semantics Cause Plan
+  terminal : RuntimeTerminal.Lineage Fact semantics Cause Plan
+
+structure Checked (Fact : Type) (semantics : Proof.Semantics Fact) (Cause Plan : Type) where
+  private mk ::
+  registry : Registry Fact semantics Cause Plan
+  terminal : RuntimeTerminal.Checked Fact semantics Cause Plan
+
+opaque Active.startWithin [DecidableEq Fact] [DecidableEq Cause]
+    (registry : Registry Fact semantics Cause Plan) (input : Proof.Input Fact)
+    (controller : Runtime.Controller.State Fact Cause Plan Proof.Key) :
+    Except Error (Active Fact semantics Cause Plan) :=
+  RuntimeTerminal.Active.startWithin registry.runtime input controller
+    |>.map (fun terminal => { registry, terminal })
+    |>.mapError Error.terminal
+
+opaque Active.targetWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Search.Result.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (active : Active Fact semantics Cause Plan) (seen : SeenVersion) :
+    Except Error (Lineage Fact semantics Cause Plan) :=
+  RuntimeTerminal.Active.targetWithin limits measure active.terminal seen
+    |>.map (fun terminal => { registry := active.registry, terminal })
+    |>.mapError Error.terminal
+
+opaque Lineage.quoteWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : RuntimeProof.Limits)
+    (measure : Search.Result.Measure Fact Cause Plan Proof.Key)
+    (lineage : Lineage Fact semantics Cause Plan) :
+    Except Error (Checked Fact semantics Cause Plan) :=
+  RuntimeTerminal.Lineage.quoteWithin limits measure lineage.terminal
+    |>.map (fun terminal => { registry := lineage.registry, terminal })
+    |>.mapError Error.terminal
+
+/-! ## Plain quotation helpers -/
+
+private def levelOf (type : Lean.Expr) : MetaM Lean.Level := do
+  let sort ← whnf (← inferType type)
+  match sort with
+  | .sort (.succ level) => pure level
+  | .sort .zero => pure .zero
+  | _ => throwError "runtime emitter expected a type"
+
+private def listExpr (type : Lean.Expr) (items : List Lean.Expr) : MetaM Lean.Expr := do
+  let level ← levelOf type
+  let nil := mkApp (mkConst ``List.nil [level]) type
+  return items.foldr (fun item tail =>
+    mkAppN (mkConst ``List.cons [level]) #[type, item, tail]) nil
+
+private def arrayExpr (type : Lean.Expr) (items : Array Lean.Expr) : MetaM Lean.Expr := do
+  let level ← levelOf type
+  let list ← listExpr type items.toList
+  return mkAppN (mkConst ``Array.mk [level]) #[type, list]
+
+private def optionExpr (type : Lean.Expr) (item : Option Lean.Expr) : MetaM Lean.Expr := do
+  let level ← levelOf type
+  match item with
+  | none => return mkApp (mkConst ``Option.none [level]) type
+  | some item => return mkAppN (mkConst ``Option.some [level]) #[type, item]
+
+private def qDomain (value : DomainId) : MetaM Lean.Expr :=
+  mkAppM ``DomainId.mk #[mkNatLit value.index]
+
+private def qOpKey (value : OpKey) : MetaM Lean.Expr :=
+  mkAppM ``OpKey.mk #[toExpr value.name, mkNatLit value.version]
+
+private def qOpId (value : OpId) : MetaM Lean.Expr :=
+  mkAppM ``OpId.mk #[mkNatLit value.index]
+
+private def qNodeId (value : NodeId) : MetaM Lean.Expr :=
+  mkAppM ``NodeId.mk #[mkNatLit value.index]
+
+private def qRuleKey (value : RuleKey) : MetaM Lean.Expr :=
+  mkAppM ``RuleKey.mk #[toExpr value.name, mkNatLit value.schema]
+
+private def qRuleId (value : RuleId) : MetaM Lean.Expr :=
+  mkAppM ``RuleId.mk #[mkNatLit value.index]
+
+private def qApplicationId (value : ApplicationId) : MetaM Lean.Expr :=
+  mkAppM ``ApplicationId.mk #[mkNatLit value.index]
+
+private def qEqualityId (value : EqualityId) : MetaM Lean.Expr :=
+  mkAppM ``EqualityId.mk #[mkNatLit value.index]
+
+private def qScope (value : Policy.ScopeId) : MetaM Lean.Expr :=
+  mkAppM ``Policy.ScopeId.mk #[mkNatLit value.index]
+
+private def qSeen (value : SeenVersion) : MetaM Lean.Expr := do
+  mkAppM ``SeenVersion.mk #[← qNodeId value.node, mkNatLit value.version]
+
+private def qOperation (value : Operation) : MetaM Lean.Expr := do
+  let domainType := mkConst ``DomainId
+  mkAppM ``Operation.mk #[← qOpKey value.key,
+    ← listExpr domainType (← value.inputs.mapM qDomain), ← qDomain value.output]
+
+private def qNode (value : Node) : MetaM Lean.Expr := do
+  let nodeType := mkConst ``NodeId
+  mkAppM ``Node.mk #[← qDomain value.domain, ← qOpId value.op,
+    ← listExpr nodeType (← value.args.mapM qNodeId)]
+
+private def qProgram (value : Program) : MetaM Lean.Expr := do
+  mkAppM ``Program.mk
+    #[← arrayExpr (mkConst ``Operation) (← value.operations.mapM qOperation),
+      ← arrayExpr (mkConst ``Node) (← value.nodes.mapM qNode)]
+
+private def qActionKind : ActionKind → Lean.Expr
+  | .forward => mkConst ``ActionKind.forward
+  | .backward => mkConst ``ActionKind.backward
+  | .improve => mkConst ``ActionKind.improve
+  | .shave => mkConst ``ActionKind.shave
+  | .instantiate => mkConst ``ActionKind.instantiate
+  | .rewrite => mkConst ``ActionKind.rewrite
+  | .regularize => mkConst ``ActionKind.regularize
+  | .split => mkConst ``ActionKind.split
+
+private def qStructuralKey : StructuralKey → MetaM Lean.Expr
+  | .node node => do mkAppM ``StructuralKey.node #[← qNodeId node]
+  | .equality equality => do mkAppM ``StructuralKey.equality #[← qEqualityId equality]
+  | .application application => do
+      mkAppM ``StructuralKey.application #[← qApplicationId application]
+
+private def qStructuralInput (value : StructuralInput) : MetaM Lean.Expr := do
+  mkAppM ``StructuralInput.mk #[← qStructuralKey value.key, mkNatLit value.generation]
+
+private def qAction (value : Action) : MetaM Lean.Expr := do
+  let seenType := mkConst ``SeenVersion
+  let nodeType := mkConst ``NodeId
+  let structuralType := mkConst ``StructuralInput
+  let natType := mkConst ``Nat
+  let epoch ← optionExpr natType (value.matcherEpoch.map mkNatLit)
+  mkAppM ``Action.mk
+    #[mkNatLit value.serial, mkNatLit value.programVersion,
+      ← qApplicationId value.application, ← qRuleId value.rule, ← qRuleKey value.key,
+      ← qNodeId value.node, qActionKind value.kind, mkNatLit value.effort,
+      mkNatLit value.generation, ← listExpr seenType (← value.inputs.mapM qSeen),
+      ← listExpr nodeType (← value.writes.mapM qNodeId),
+      ← listExpr structuralType (← value.structuralInputs.mapM qStructuralInput), epoch]
+
+private def qRole : Proof.Role → Lean.Expr
+  | .fact => mkConst ``Proof.Role.fact
+  | .equality => mkConst ``Proof.Role.equality
+  | .instance => mkConst ``Proof.Role.instance
+  | .refute => mkConst ``Proof.Role.refute
+  | .split => mkConst ``Proof.Role.split
+
+private def qProofKey (value : Proof.Key) : MetaM Lean.Expr := do
+  mkAppM ``Proof.Key.mk
+    #[← qRuleKey value.rule, qRole value.role, mkNatLit value.bodySchema]
+
+private def qNodeFact (registry : Prepared Fact)
+    (value : Proof.NodeFact Fact) : MetaM Lean.Expr := do
+  let fact ← Proof.emitChecked registry.quoteFact value.fact registry.factType
+  mkAppM ``Proof.NodeFact.mk #[← qNodeId value.node, fact]
+
+private def qInput (registry : Prepared Fact)
+    (value : Proof.Input Fact) : MetaM Lean.Expr := do
+  let mut facts := #[]
+  for fact in value.facts do
+    facts := facts.push (← Proof.emitChecked registry.quoteFact fact registry.factType)
+  mkAppM ``Proof.Input.mk
+    #[← qScope value.scope, ← qProgram value.program,
+      ← arrayExpr registry.factType facts, ← qNodeFact registry value.target]
+
+private def qFactStep (registry : Prepared Fact)
+    (value : Proof.FactStep Fact) : MetaM Lean.Expr := do
+  let fact ← Proof.emitChecked registry.quoteFact value.proposed registry.factType
+  let installed ← Proof.emitChecked registry.quoteFact value.installed registry.factType
+  mkAppM ``Proof.FactStep.mk
+    #[← qScope value.scope, mkNatLit value.programVersion, ← qAction value.action,
+      ← qNodeId value.node, ← qSeen value.previous, mkNatLit value.version,
+      fact, installed, ← listExpr (mkConst ``SeenVersion) (← value.assumptions.mapM qSeen),
+      ← qProofKey value.schema,
+      ← listExpr (mkConst ``Nat) (value.body.map mkNatLit)]
+
+private def qEqualityStep (value : Proof.EqualityStep) : MetaM Lean.Expr := do
+  mkAppM ``Proof.EqualityStep.mk
+    #[← qScope value.scope, mkNatLit value.programVersion, ← qAction value.action,
+      ← qEqualityId value.equality, ← qNodeId value.left, ← qNodeId value.right,
+      ← listExpr (mkConst ``SeenVersion) (← value.assumptions.mapM qSeen),
+      ← qProofKey value.schema,
+      ← listExpr (mkConst ``Nat) (value.body.map mkNatLit)]
+
+private def qTransportStep (registry : Prepared Fact)
+    (value : Proof.TransportStep Fact) : MetaM Lean.Expr := do
+  let installed ← Proof.emitChecked registry.quoteFact value.installed registry.factType
+  mkAppM ``Proof.TransportStep.mk
+    #[← qScope value.scope, mkNatLit value.programVersion, ← qNodeId value.node,
+      ← qSeen value.previous, mkNatLit value.version, ← qEqualityId value.equality,
+      ← qSeen value.source, installed]
+
+private def qInstanceStep (value : Proof.InstanceStep) : MetaM Lean.Expr := do
+  mkAppM ``Proof.InstanceStep.mk
+    #[← qScope value.scope, mkNatLit value.beforeVersion, mkNatLit value.afterVersion,
+      ← qAction value.action, ← qProgram value.after,
+      ← listExpr (mkConst ``NodeId) (← value.newNodes.mapM qNodeId),
+      ← qProofKey value.schema,
+      ← listExpr (mkConst ``Nat) (value.body.map mkNatLit)]
+
+private def qEvent (registry : Prepared Fact) :
+    Proof.Event Fact → MetaM Lean.Expr
+  | .fact step => do
+      pure (mkAppN (mkConst ``Proof.Event.fact)
+        #[registry.factType, ← qFactStep registry step])
+  | .equality step => do
+      pure (mkAppN (mkConst ``Proof.Event.equality)
+        #[registry.factType, ← qEqualityStep step])
+  | .transport step => do
+      pure (mkAppN (mkConst ``Proof.Event.transport)
+        #[registry.factType, ← qTransportStep registry step])
+  | .instance step => do
+      pure (mkAppN (mkConst ``Proof.Event.instance)
+        #[registry.factType, ← qInstanceStep step])
+
+private def qRegistration (value : Registration) : MetaM Lean.Expr := do
+  let qSlot : Slot → MetaM Lean.Expr
+    | .result => pure (mkConst ``Slot.result)
+    | .argument index => mkAppM ``Slot.argument #[mkNatLit index]
+  let qBinding : BindingKind → Lean.Expr
+    | .local => mkConst ``BindingKind.local
+    | .scoped => mkConst ``BindingKind.scoped
+    | .global => mkConst ``BindingKind.global
+  let qWatch : MatchWatch → Lean.Expr
+    | .none => mkConst ``MatchWatch.none
+    | .network => mkConst ``MatchWatch.network
+  mkAppM ``Registration.mk
+    #[← qRuleKey value.key, ← qOpKey value.head, qActionKind value.kind,
+      ← listExpr (mkConst ``Slot) (← value.watches.mapM qSlot),
+      ← listExpr (mkConst ``Slot) (← value.writes.mapM qSlot),
+      qBinding value.binding, toExpr value.watchesProgram, qWatch value.matchWatch,
+      mkNatLit value.initialEffort]
+
+private def qEntries (type : Lean.Expr) (entries : Array Entry) : MetaM Lean.Expr :=
+  arrayExpr type (entries.map (·.expr))
+
+private def qResolver (runtime : RuntimeProof.Registry Fact semantics Cause Plan)
+    (registry : Prepared Fact) : MetaM Lean.Expr := do
+  let registrations ← arrayExpr (mkConst ``Registration)
+    (← runtime.proof.registrations.mapM qRegistration)
+  let factType ← mkAppM ``Proof.FactSchema #[registry.semanticsExpr]
+  let equalityType ← mkAppM ``Proof.EqualitySchema #[registry.semanticsExpr]
+  let instanceType ← mkAppM ``Proof.InstanceSchema #[registry.semanticsExpr]
+  mkAppM ``Proof.Resolver.mk
+    #[registrations, ← qEntries factType registry.facts,
+      ← qEntries equalityType registry.equalities,
+      ← qEntries instanceType registry.instances]
+
+private def qLimits (value : Proof.Limits) : MetaM Lean.Expr :=
+  mkAppM ``Proof.Limits.mk
+    #[mkNatLit value.maxPackages, mkNatLit value.maxSchemas,
+      mkNatLit value.maxBodyCells, mkNatLit value.maxDependencies,
+      mkNatLit value.maxChronology]
+
+/-- Extract the ordinary Evidence term from a transparently successful replay.
+The success proof is generated and kernel-checked from the quoted plain data. -/
+def evidenceOfReplay {claim : Prop} (result : Except Proof.Error (Proof.Evidence claim))
+    (success : result.toOption.isSome = true) : Proof.Evidence claim :=
+  result.toOption.get success
+
+private def eventWithin (limits : Limits) : Proof.Event Fact → Except Error Unit
+  | .fact step => do
+      Proof.bodyCheck limits.proof step.schema .fact step.body |>.mapError Error.proof
+      Proof.dependenciesCheck limits.proof step.assumptions |>.mapError Error.proof
+  | .equality step => do
+      Proof.bodyCheck limits.proof step.schema .equality step.body |>.mapError Error.proof
+      Proof.dependenciesCheck limits.proof step.assumptions |>.mapError Error.proof
+  | .transport _ => pure ()
+  | .instance step =>
+      Proof.bodyCheck limits.proof step.schema .instance step.body |>.mapError Error.proof
+
+private def restoreClean (saved : Lean.Meta.SavedState) : MetaM Unit := do
+  saved.restore
+  Lean.Meta.resetCache
+  modifyThe Lean.Core.State fun state => { state with cache := {} }
+
+/-- Emit one exact Evidence expression from a sealed one-node target lineage.
+No expression is returned until every callback, resource check, transparent
+reduction, `Meta.check`, and exact type comparison has succeeded. -/
+opaque Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (checked : Checked Fact semantics Cause Plan) :
+    MetaM (Except Error Lean.Expr) := do
+  let tree := checked.terminal.bundle.tree
+  let recipe := checked.terminal.bundle.recipe
+  if tree.nodes.size != 1 || recipe.events.size != 1 || recipe.edges.size != 1 then
+    return .error .malformed
+  let some node := tree.nodes[0]? | return .error .malformed
+  let some events := recipe.events[0]? | return .error .malformed
+  let some edge := recipe.edges[0]? | return .error .malformed
+  if edge.parent.isSome || edge.side.isSome || edge.seed.isSome then return .error .malformed
+  let (source, result) ← match node with
+    | .terminal source (.target target) => pure (source, target.seen)
+    | .pending _ | .terminal _ (.unknown _) | .terminal _ (.refute _) | .split .. =>
+        return .error .malformed
+  if limits.maxChronology < events.length then return .error (.resource .chronology)
+  for event in events do
+    match eventWithin limits event with
+    | .error error => return .error error
+    | .ok _ => pure ()
+  let run (_ : Unit) : MetaM (Except Error Lean.Expr) := do
+    let prepared ← match ← prepareRegistry limits checked.registry with
+      | .error error => return .error error
+      | .ok prepared => pure prepared
+    let inputExpr ← qInput prepared checked.terminal.input
+    let resolverExpr ← qResolver checked.registry.runtime prepared
+    let mut eventExprs := []
+    for event in events do eventExprs := eventExprs.concat (← qEvent prepared event)
+    let eventsExpr ← listExpr (← mkAppM ``Proof.Event #[prepared.factType]) eventExprs
+    let replay ← mkAppM ``Proof.replayWith
+      #[← qLimits limits.proof, resolverExpr, prepared.domainExpr,
+        prepared.lawsExpr, inputExpr, eventsExpr,
+        mkNatLit source.branch.programVersion, ← qProgram source.branch.program, ← qSeen result]
+    let option ← mkAppM ``Except.toOption #[replay]
+    let ready ← mkAppM ``Option.isSome #[option]
+    let success ← mkDecideProof (← mkAppM ``Eq #[ready, toExpr true])
+    let candidate ← mkAppM ``evidenceOfReplay #[replay, success]
+    if limits.maxExpressionCells < expressionCells candidate then
+      return .error (.resource .expression)
+    let program ← mkAppM ``Proof.Input.program #[inputExpr]
+    let base ← mkAppM ``Proof.initialBase #[inputExpr]
+    let target ← mkAppM ``Proof.Input.target #[inputExpr]
+    let claim ← mkAppM ``Proof.Semantics.Entails
+      #[prepared.semanticsExpr, program, base, target]
+    let expected ← mkAppM ``Proof.Evidence #[claim]
+    let emitter : Proof.Emitter Lean.Expr := { emit := pure }
+    return .ok (← Proof.emitChecked emitter candidate expected)
+  let saved ← Lean.Meta.saveState
+  let result ← try
+    run ()
+  catch _ =>
+    pure (.error .replay)
+  restoreClean saved
+  return result
+
+end Hex.Interval.RuntimeEmit

--- a/HexIntervalMathlib/RuntimeEmit.lean
+++ b/HexIntervalMathlib/RuntimeEmit.lean
@@ -541,12 +541,20 @@ private def restoreClean (saved : Lean.Meta.SavedState) : MetaM Unit := do
   Lean.Meta.resetCache
   modifyThe Lean.Core.State fun state => { state with cache := {} }
 
-/-- Emit one exact Evidence expression from a sealed one-node target lineage.
-No expression is returned until every callback, resource check, transparent
-reduction, `Meta.check`, and exact type comparison has succeeded. -/
-opaque Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
+/-- The exact quoted proof input and its correlated evidence expression. The
+private constructor prevents callers from pairing independently emitted terms. -/
+structure Emitted where
+  private mk ::
+  input : Lean.Expr
+  evidence : Lean.Expr
+
+/-- Emit one exact input/evidence pair from a sealed one-node target lineage.
+Neither expression is returned until every callback, resource check,
+transparent reduction, `Meta.check`, and exact type comparison has succeeded.
+Both expressions are bounded independently by `maxExpressionCells`. -/
+opaque Checked.emitResultWithin [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (checked : Checked Fact semantics Cause Plan) :
-    MetaM (Except Error Lean.Expr) := do
+    MetaM (Except Error Emitted) := do
   let tree := checked.terminal.bundle.tree
   let recipe := checked.terminal.bundle.recipe
   if tree.nodes.size != 1 || recipe.events.size != 1 || recipe.edges.size != 1 then
@@ -564,11 +572,16 @@ opaque Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
     match eventWithin limits event with
     | .error error => return .error error
     | .ok _ => pure ()
-  let run (_ : Unit) : MetaM (Except Error Lean.Expr) := do
+  let run (_ : Unit) : MetaM (Except Error Emitted) := do
     let prepared ← match ← prepareRegistry limits checked.registry with
       | .error error => return .error error
       | .ok prepared => pure prepared
     let inputExpr ← qInput prepared checked.terminal.input
+    if limits.maxExpressionCells < expressionCells inputExpr then
+      return .error (.resource .expression)
+    let inputType ← mkAppM ``Proof.Input #[prepared.factType]
+    let emitter : Proof.Emitter Lean.Expr := { emit := pure }
+    let inputExpr ← Proof.emitChecked emitter inputExpr inputType
     let resolverExpr ← qResolver checked.registry.runtime prepared
     let mut eventExprs := []
     for event in events do eventExprs := eventExprs.concat (← qEvent prepared event)
@@ -589,8 +602,8 @@ opaque Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
     let claim ← mkAppM ``Proof.Semantics.Entails
       #[prepared.semanticsExpr, program, base, target]
     let expected ← mkAppM ``Proof.Evidence #[claim]
-    let emitter : Proof.Emitter Lean.Expr := { emit := pure }
-    return .ok (← Proof.emitChecked emitter candidate expected)
+    let evidence ← Proof.emitChecked emitter candidate expected
+    return .ok { input := inputExpr, evidence }
   let saved ← Lean.Meta.saveState
   let result ← try
     run ()
@@ -598,5 +611,13 @@ opaque Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
     pure (.error .replay)
   restoreClean saved
   return result
+
+/-- Compatibility projection for callers which need only the evidence term. -/
+def Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
+    (limits : Limits) (checked : Checked Fact semantics Cause Plan) :
+    MetaM (Except Error Lean.Expr) := do
+  match ← checked.emitResultWithin limits with
+  | .error error => return .error error
+  | .ok emitted => return .ok emitted.evidence
 
 end Hex.Interval.RuntimeEmit

--- a/HexIntervalMathlib/RuntimeEmit.lean
+++ b/HexIntervalMathlib/RuntimeEmit.lean
@@ -321,7 +321,7 @@ private def levelOf (type : Lean.Expr) : MetaM Lean.Level := do
   let sort ← whnf (← inferType type)
   match sort with
   | .sort (.succ level) => pure level
-  | .sort .zero => pure .zero
+  | .sort .zero => throwError "runtime emitter expected a type, not Prop"
   | _ => throwError "runtime emitter expected a type"
 
 private def listExpr (type : Lean.Expr) (items : List Lean.Expr) : MetaM Lean.Expr := do
@@ -612,7 +612,12 @@ opaque Checked.emitResultWithin [DecidableEq Fact] [DecidableEq Cause]
   restoreClean saved
   return result
 
-/-- Compatibility projection for callers which need only the evidence term. -/
+/-- Compatibility projection for callers which need only the evidence term.
+Unlike `emitResultWithin`, this discards the quoted input which indexes that
+term. A caller using the result to discharge a pre-existing claim must pin its
+claim input first (for example by exact definitional comparison with
+`emitResultWithin.input`); successful emission alone authenticates only the
+claim indexed by the quoter-produced input term. -/
 def Checked.emitWithin [DecidableEq Fact] [DecidableEq Cause]
     (limits : Limits) (checked : Checked Fact semantics Cause Plan) :
     MetaM (Except Error Lean.Expr) := do

--- a/HexIntervalMathlib/RuntimeRuleEmit.lean
+++ b/HexIntervalMathlib/RuntimeRuleEmit.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntervalMathlib.RuntimeEmit
+public import HexIntervalMathlib.RuntimeRule
+public meta import HexIntervalMathlib.RuntimeEmit
+public meta import HexIntervalMathlib.RuntimeRule
+public meta import HexIntervalMathlib.Rule
+public meta import HexInterval.Canonical
+
+@[expose] public section
+
+/-!
+# Built-in arithmetic runtime emitters
+
+This elaborator-only companion pairs the twelve built-in arithmetic theorem
+schemas with exact `RuntimeEmit` handles. The joint builder constructs the
+executable assembly, theorem registry, and emitter registry in one call.
+Caller-owned meanings need their own emitter packages and are intentionally
+outside the convenience builder.
+-/
+
+namespace Hex.Interval.Rule.Runtime
+
+open Lean Meta
+
+abbrev EmitRegistry (config : Rule.Config) (Plan : Type := List Nat) :=
+  RuntimeEmit.Registry Hex.Interval (Rule.semantics config) Cause Plan
+
+inductive EmitError where
+  | runtime (error : Error)
+  | emit (error : RuntimeEmit.Error)
+  | unsupportedMeanings
+  deriving Repr
+
+namespace Quote
+
+def isReady (result : BuildResult) : Bool :=
+  match result with
+  | .ready _ => true
+  | .resourceLimit _ => false
+
+def getValue (result : BuildResult) (success : isReady result = true) :
+    Hex.Interval :=
+  match result with
+  | .ready interval => interval
+  | .resourceLimit _ => False.elim (by simp [isReady] at success)
+
+meta def dyadicExpr (value : Dyadic) : MetaM Expr := do
+  let rational := value.toRat
+  let base ← mkAppM ``Dyadic.ofInt #[mkIntLit rational.num]
+  if rational.den = 1 then return base
+  mkAppM ``HShiftRight.hShiftRight
+    #[base, mkIntLit (Int.ofNat rational.den.log2)]
+
+meta def lowerExpr : Lower → MetaM Expr
+  | .unbounded => pure (mkConst ``Lower.unbounded)
+  | .finite value strict => do
+      mkAppM ``Lower.finite #[← dyadicExpr value, toExpr strict]
+
+meta def upperExpr : Upper → MetaM Expr
+  | .unbounded => pure (mkConst ``Upper.unbounded)
+  | .finite value strict => do
+      mkAppM ``Upper.finite #[← dyadicExpr value, toExpr strict]
+
+meta def rawExpr : Raw → MetaM Expr
+  | .empty => pure (mkConst ``Raw.empty)
+  | .bounds lower upper => do
+      mkAppM ``Raw.bounds #[← lowerExpr lower, ← upperExpr upper]
+
+meta def endpointExpr (limit : EndpointLimit) : MetaM Expr :=
+  mkAppM ``EndpointLimit.mk
+    #[mkNatLit limit.maxEndpointHeight, mkNatLit limit.maxAlignmentShift]
+
+meta def powLimitsExpr (limits : Arithmetic.PowLimits) : MetaM Expr :=
+  mkAppM ``Arithmetic.PowLimits.mk #[mkNatLit limits.maxExponent]
+
+meta def precisionLimitsExpr (limits : Arithmetic.PrecisionLimits) : MetaM Expr := do
+  mkAppM ``Arithmetic.PrecisionLimits.mk
+    #[← endpointExpr limits.endpoint, mkNatLit limits.maxPrecisionMagnitude,
+      mkNatLit limits.maxPrecisionBits, mkNatLit limits.maxTemporaryBits]
+
+meta def emptyMeaningsExpr : MetaM Expr := do
+  let meaningType ← mkAppM ``Program.Meaning #[mkConst ``Real]
+  let emptyList := Lean.mkApp (mkConst ``List.nil [.zero]) meaningType
+  pure (Lean.mkAppN (mkConst ``Array.mk [.zero]) #[meaningType, emptyList])
+
+meta def configExpr (config : Rule.Config) : MetaM Expr := do
+  unless config.extraMeanings.isEmpty do
+    throwError "built-in runtime emitter cannot quote caller function meanings"
+  mkAppM ``Rule.Config.mk
+    #[← endpointExpr config.endpoint, ← powLimitsExpr config.powerWork,
+      mkNatLit config.exponent, ← precisionLimitsExpr config.precisionLimits,
+      mkIntLit config.precision, ← dyadicExpr config.constant, ← emptyMeaningsExpr]
+
+meta def intervalExpr (limit : EndpointLimit) (interval : Hex.Interval) : MetaM Expr := do
+  let raw ← rawExpr interval.view
+  let build ← mkAppM ``ofRawWithin #[← endpointExpr limit, raw]
+  let ready ← mkAppM ``isReady #[build]
+  let success ← mkDecideProof (← mkAppM ``Eq #[ready, toExpr true])
+  match ofRawWithin limit interval.view with
+  | .ready rebuilt =>
+      unless rebuilt == interval do
+        throwError "runtime emitter changed a canonical interval"
+      mkAppM ``getValue #[build, success]
+  | .resourceLimit _ =>
+      throwError "runtime emitter interval exceeded its endpoint envelope"
+
+meta def schema (config : Rule.Config) (key : Proof.Key) (name : Name) :
+    RuntimeEmit.Handle :=
+  { key
+    schema := { emit := fun _ => do mkAppM name #[← configExpr config] } }
+
+end Quote
+
+meta def emitPackage (config : Rule.Config) :
+    RuntimeEmit.Package (Rule.semantics config) :=
+  { proof := Rule.package config
+    facts :=
+      #[Quote.schema config (Rule.schemaKey Rule.negKey) ``Rule.negSchema,
+        Quote.schema config (Rule.schemaKey Rule.addKey) ``Rule.addSchema,
+        Quote.schema config (Rule.schemaKey Rule.subKey) ``Rule.subSchema,
+        Quote.schema config (Rule.schemaKey Rule.mulKey) ``Rule.mulSchema,
+        Quote.schema config (Rule.schemaKey Rule.powKey) ``Rule.powSchema,
+        Quote.schema config (Rule.schemaKey Rule.absKey) ``Rule.absSchema,
+        Quote.schema config (Rule.schemaKey Rule.minKey) ``Rule.minSchema,
+        Quote.schema config (Rule.schemaKey Rule.maxKey) ``Rule.maxSchema,
+        Quote.schema config (Rule.schemaKey Rule.constantKey) ``Rule.constantSchema,
+        Quote.schema config (Rule.schemaKey Rule.invKey) ``Rule.invSchema,
+        Quote.schema config (Rule.schemaKey Rule.divKey) ``Rule.divSchema,
+        Quote.schema config (Rule.schemaKey Rule.regularizeKey) ``Rule.regularizeSchema] }
+
+meta def quoter (config : Rule.Config) :
+    RuntimeEmit.Quoter Hex.Interval (Rule.semantics config) :=
+  { factType := { emit := fun _ => pure (Lean.mkConst ``Hex.Interval) }
+    fact := { emit := Quote.intervalExpr config.endpoint }
+    semantics := { emit := fun _ => do
+      Lean.Meta.mkAppM ``Rule.semantics #[← Quote.configExpr config] }
+    domain := { emit := fun _ => do
+      Lean.Meta.mkAppM ``Rule.domain #[← Quote.configExpr config] }
+    laws := { emit := fun _ => do
+      Lean.Meta.mkAppM ``Rule.laws #[← Quote.configExpr config] } }
+
+/-- Joint built-in executable/proof/emitter registry for the root-target Meta
+bridge. -/
+meta def buildEmitWithin (executableLimits : Executable.Limits)
+    (emitLimits : RuntimeEmit.Limits) (key : RuntimeProof.Key)
+    (config : Rule.Config) (program : Program) :
+    Except EmitError (EmitRegistry config) := do
+  if !config.extraMeanings.isEmpty then throw .unsupportedMeanings
+  let assembly ← assemblyWithin executableLimits config program |>.mapError EmitError.runtime
+  RuntimeEmit.Registry.buildWithin executableLimits emitLimits key assembly
+    (quoter config) #[emitPackage config]
+    |>.mapError EmitError.emit
+
+end Hex.Interval.Rule.Runtime

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -280,11 +280,12 @@ tree resources remain transactional at bundle quotation.
 sealed root-target lineage to kernel syntax. Emitter packages pair exact
 `Proof.Key`s with transparent theorem-schema expressions. One joint builder
 checks package-local and global missing, extra, duplicate, and wrong-role
-coverage, builds the `Proof.Registry` and `RuntimeProof.Registry` from the same
-package array, and seals those registries with the emitter table; there is no
-post-hoc compatibility-key attachment. `Active`, `Lineage`, and `Checked`
-retain this unified registry alongside the corresponding private
-`RuntimeTerminal` token.
+coverage. Preparation also projects each emitted schema's key and requires it
+to be definitionally equal to the handle's declared key. The builder constructs
+the `Proof.Registry` and `RuntimeProof.Registry` from the same package array and
+seals those registries with the emitter table; there is no post-hoc
+compatibility-key attachment. `Active`, `Lineage`, and `Checked` retain this
+unified registry alongside the corresponding private `RuntimeTerminal` token.
 
 `RuntimeEmit.Checked.emitWithin` supports only a one-node root target. It
 quotes the already authenticated program, input, registrations, and exact
@@ -295,6 +296,11 @@ exact `Proof.Evidence` term. Every fact and schema callback crosses
 checked with `Meta.check`, compared with the exact Evidence type, and rejected
 for metavariables, synthetic placeholders, temporary declarations, or retained
 Meta-state leakage. There is no refutation or split expression emitter.
+`Quoter` and `Handle` callbacks are trusted reflection code: the kernel checks
+the theorem in the world they quote, but a generic registry cannot prove that a
+caller callback faithfully reifies an arbitrary runtime `Fact`. Supported
+public builders must therefore own those callbacks and compare the emitted
+claim with the caller's exact goal before installation.
 
 For `S` emitter handles, `C` retained events, `B` total body cells, `D` total
 dependency cells, and `X` cells in a checked expression, registry coverage is

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -62,6 +62,12 @@ interval exactly once, proves computed domain-top seeds automatically, and requi
 constants and every improvement to enter through package-owned chronology.
 Successful replay can be eliminated to a target membership theorem, either
 endpoint inequality, their conjunction, or equality for a closed singleton.
+For Meta clients, `modelOfCheck` transparently projects the exact `Model` from
+a kernel-reduced successful `modelWithin` call. `valuesAt` quotes a finite list
+as the total source valuation used by the frontend, and
+`SourcesContain.ofForall₂` converts one membership proof per list entry into
+the exact array-indexed source obligation; indices beyond the list are never
+observed. These helpers add no proof schema and do not replay chronology.
 These are ordinary theorem combinators over a flat caller-supplied event
 chronology: the module does not turn a generic search tree into proof recipes,
 parse Lean expressions or hypotheses, or contain tactic syntax. The caps run
@@ -287,15 +293,20 @@ seals those registries with the emitter table; there is no post-hoc
 compatibility-key attachment. `Active`, `Lineage`, and `Checked` retain this
 unified registry alongside the corresponding private `RuntimeTerminal` token.
 
-`RuntimeEmit.Checked.emitWithin` supports only a one-node root target. It
+`RuntimeEmit.Checked.emitResultWithin` supports only a one-node root target. It
 quotes the already authenticated program, input, registrations, and exact
 fact/equality/transport/instance chronology as ordinary data and applies the
-transparent `Proof.replayWith` fold. A decidable success proof projects the
-exact `Proof.Evidence` term. Every fact and schema callback crosses
-`Proof.emitChecked`; the final candidate is transactionally rolled back,
-checked with `Meta.check`, compared with the exact Evidence type, and rejected
-for metavariables, synthetic placeholders, temporary declarations, or retained
-Meta-state leakage. There is no refutation or split expression emitter.
+transparent `Proof.replayWith` fold. A decidable success proof projects an
+exact `Proof.Evidence` term. The sealed result contains both the quoted
+`Proof.Input` expression and Evidence whose claim projects that same expression;
+its private constructor prevents callers from pairing independently emitted
+terms. Every fact and schema callback crosses `Proof.emitChecked`, and the input
+and final evidence separately cross it against their exact types. Both are
+independently charged against the expression cap in the same saved-state
+transaction before rollback; metavariables, synthetic placeholders, temporary
+declarations, or retained Meta-state leakage therefore cannot escape.
+`Checked.emitWithin` remains the evidence-only compatibility projection of that
+operation. There is no refutation or split expression emitter.
 `Quoter` and `Handle` callbacks are trusted reflection code: the kernel checks
 the theorem in the world they quote, but a generic registry cannot prove that a
 caller callback faithfully reifies an arbitrary runtime `Fact`. Supported
@@ -310,8 +321,9 @@ one `O(X)` syntax traversal per returned schema expression. Chronology
 prechecking and quotation are `O(C + B + D)` apart from fact callbacks and
 construction of quoted program/action data; the transparent replay then pays
 the existing proof fold and package theorem callbacks, which are arbitrary
-pure Lean code and are not preemptible. The final expression cap performs one
-additional `O(X)` traversal. Schema, chronology, body, dependency, and
+pure Lean code and are not preemptible. The two final expression caps perform
+one `O(X)` traversal for the quoted input and one for its correlated evidence.
+Schema, chronology, body, dependency, and
 expression limits fail without returning a partial expression.
 
 `HexIntervalMathlib.RuntimeRuleEmit` supplies the paired handles and fact
@@ -551,13 +563,16 @@ exact proposed/installed facts, one-cell bodies, semantic schema execution,
 sticky cache refusal and replayability, sealed rule mutation rejection, and a
 paired opaque-operation extension.
 `HexIntervalMathlib.RuntimeEmitConformance` installs target Evidence only from
-the emitted expression for all twelve built-in rules, including repeated-input
+the sealed input/evidence pair for all twelve built-in rules, including repeated-input
 binary applications, and separately emits the mixed `sin (-x)` instance,
 equality, fact, and transport chronology. It rejects package-local/global
 coverage errors, cross-package and input transplants, a wrong schema
 expression, ill-typed/open/placeholder/temporary emitters, Meta-state leakage,
-and exact one-under schema, chronology, body, dependency, and expression
-resources while guarding every private constructor.
+and exact one-under schema, chronology, body, dependency, input-expression, and
+evidence-expression resources while guarding every private constructor and the
+ordinary theorem axiom surface. `FrontendConformance` additionally pins
+transparent model projection and conversion from per-source list membership to
+the indexed containment obligation.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -276,6 +276,45 @@ replay independently proves it again. Search/result and proof body resources
 are checked at settlement, while complete transition/event/structural/proof-
 tree resources remain transactional at bundle quotation.
 
+`HexIntervalMathlib.RuntimeEmit` is the supported Meta boundary from that
+sealed root-target lineage to kernel syntax. Emitter packages pair exact
+`Proof.Key`s with transparent theorem-schema expressions. One joint builder
+checks package-local and global missing, extra, duplicate, and wrong-role
+coverage, builds the `Proof.Registry` and `RuntimeProof.Registry` from the same
+package array, and seals those registries with the emitter table; there is no
+post-hoc compatibility-key attachment. `Active`, `Lineage`, and `Checked`
+retain this unified registry alongside the corresponding private
+`RuntimeTerminal` token.
+
+`RuntimeEmit.Checked.emitWithin` supports only a one-node root target. It
+quotes the already authenticated program, input, registrations, and exact
+fact/equality/transport/instance chronology as ordinary data and applies the
+transparent `Proof.replayWith` fold. A decidable success proof projects the
+exact `Proof.Evidence` term. Every fact and schema callback crosses
+`Proof.emitChecked`; the final candidate is transactionally rolled back,
+checked with `Meta.check`, compared with the exact Evidence type, and rejected
+for metavariables, synthetic placeholders, temporary declarations, or retained
+Meta-state leakage. There is no refutation or split expression emitter.
+
+For `S` emitter handles, `C` retained events, `B` total body cells, `D` total
+dependency cells, and `X` cells in a checked expression, registry coverage is
+quadratic in the worst case because list membership/count checks scan the
+package and global key tables. Preparation is `O(S)` callback invocations plus
+one `O(X)` syntax traversal per returned schema expression. Chronology
+prechecking and quotation are `O(C + B + D)` apart from fact callbacks and
+construction of quoted program/action data; the transparent replay then pays
+the existing proof fold and package theorem callbacks, which are arbitrary
+pure Lean code and are not preemptible. The final expression cap performs one
+additional `O(X)` traversal. Schema, chronology, body, dependency, and
+expression limits fail without returning a partial expression.
+
+`HexIntervalMathlib.RuntimeRuleEmit` supplies the paired handles and fact
+quoter for exactly the twelve built-in arithmetic schemas. Its convenience
+builder jointly constructs the executable batch assembly, theorem registry,
+and emitter registry. Configurations with caller-owned opaque meanings require
+their own paired emitter packages and are deliberately rejected by this
+built-in-only builder.
+
 A general split terminal adapter is intentionally absent. `Proof.seedChild`
 inherits the parent proof equality table and compact identities, whereas
 `Runtime.State.startWithin` restarts a child with an empty equality arena and
@@ -505,6 +544,14 @@ over the complete retained chronology without a fallback theorem. It checks
 exact proposed/installed facts, one-cell bodies, semantic schema execution,
 sticky cache refusal and replayability, sealed rule mutation rejection, and a
 paired opaque-operation extension.
+`HexIntervalMathlib.RuntimeEmitConformance` installs target Evidence only from
+the emitted expression for all twelve built-in rules, including repeated-input
+binary applications, and separately emits the mixed `sin (-x)` instance,
+equality, fact, and transport chronology. It rejects package-local/global
+coverage errors, cross-package and input transplants, a wrong schema
+expression, ill-typed/open/placeholder/temporary emitters, Meta-state leakage,
+and exact one-under schema, chronology, body, dependency, and expression
+resources while guarding every private constructor.
 `HexIntervalMathlib.RuleConformance` replays a shared arithmetic DAG through
 the supported state quote and proof registry. Its ordinary theorem makes both
 source assumptions load-bearing through add/sub/mul and checked

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -64,6 +64,16 @@ def sourceValues : Nat → ℝ
 def model? := Frontend.modelWithin config sourceValues result
 
 #guard match model? with | .ok _ => true | .error _ => false
+
+theorem modelReady : model?.toOption.isSome = true := by decide +kernel
+
+noncomputable def projectedModel : Frontend.Model config.rule sourceValues result :=
+  Frontend.modelOfCheck model? modelReady
+
+theorem projectedTarget :
+    result.valuation config.rule sourceValues result.target =
+      result.term.eval config.rule sourceValues :=
+  projectedModel.target
 #guard
   match result? with
   | .ok found => found.program == result.program && found.target == result.target &&
@@ -277,6 +287,24 @@ theorem sourceFactsContain : Frontend.SourcesContain sourceValues sourceFacts :=
           simpa [sourceValues] using member
       | succ index => simp [sourceFacts] at found
 
+theorem sourceListHolds : List.Forall₂
+    (fun value source => source.Contains value)
+    ([1, 2] : List ℝ) [RuleConformance.xFact, RuleConformance.yFact] := by
+  constructor
+  · have member := Rule.constant_mem RuleConformance.checkedX
+    rw [toReal_d] at member
+    simpa using member
+  · constructor
+    · have member := Rule.constant_mem RuleConformance.checkedY
+      rw [toReal_d] at member
+      simpa using member
+    · constructor
+
+theorem sourceListContains : Frontend.SourcesContain
+    (Frontend.valuesAt ([1, 2] : List ℝ))
+    [RuleConformance.xFact, RuleConformance.yFact].toArray :=
+  Frontend.SourcesContain.ofForall₂ sourceListHolds
+
 theorem inputFacts : input.facts = result.facts sourceFacts := by
   simp [input, result, sourceFacts, Frontend.Result.facts, Frontend.Result.seed,
     Frontend.Term.source?, term]
@@ -362,5 +390,12 @@ theorem closesEquality
 #print axioms closesLower
 #print axioms closesEquality
 #print axioms targetValue
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.projectedTarget' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms projectedTarget
+
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.sourceListContains' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms sourceListContains
 
 end Hex.IntervalMathlib.FrontendConformance

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -44,6 +44,10 @@ open Hex.Interval.Rule.Runtime
 #guard_msgs in
 #check RuntimeEmit.Checked.mk
 
+/-- error: Unknown constant `Hex.Interval.RuntimeEmit.Emitted.mk` -/
+#guard_msgs in
+#check RuntimeEmit.Emitted.mk
+
 def emitLimits : RuntimeEmit.Limits :=
   { proof := RuntimeRuleConformance.proofLimits, maxSchemas := 12, maxChronology := 12,
     maxExpressionCells := 1000000 }
@@ -90,6 +94,9 @@ def input : Proof.Input Hex.Interval :=
   { scope := { index := 0 }, program := RuntimeRuleConformance.program,
     facts := quotedFacts,
     target := { node := { index := 12 }, fact := quotedPoint } }
+
+def changedInput : Proof.Input Hex.Interval :=
+  { input with target := { input.target with node := { index := 11 } } }
 
 private def liftOption {α : Type} : Option α → Option (ULift.{1, 0} α)
   | some value => some ⟨value⟩
@@ -148,10 +155,10 @@ meta def registryError
       | .error error => some error
       | .ok _ => none
 
-meta def emitWith (limits : RuntimeEmit.Limits)
+meta def emitResultWith (limits : RuntimeEmit.Limits)
     (package : RuntimeEmit.Package
       (Rule.semantics RuntimeRuleConformance.config) (List Nat)) :
-    MetaM (Except RuntimeEmit.Error Expr) :=
+    MetaM (Except RuntimeEmit.Error RuntimeEmit.Emitted) :=
   match Rule.Runtime.assemblyWithin RuntimeRuleConformance.executableLimits
       RuntimeRuleConformance.config RuntimeRuleConformance.program with
   | .error _ => pure (.error .malformed)
@@ -162,7 +169,15 @@ meta def emitWith (limits : RuntimeEmit.Limits)
       | .error error => pure (.error error)
       | .ok registry => match checkedFor registry with
         | .error error => pure (.error error)
-        | .ok checked => RuntimeEmit.Checked.emitWithin limits checked
+        | .ok checked => RuntimeEmit.Checked.emitResultWithin limits checked
+
+meta def emitWith (limits : RuntimeEmit.Limits)
+    (package : RuntimeEmit.Package
+      (Rule.semantics RuntimeRuleConformance.config) (List Nat)) :
+    MetaM (Except RuntimeEmit.Error Expr) := do
+  match ← emitResultWith limits package with
+  | .error error => return .error error
+  | .ok emitted => return .ok emitted.evidence
 
 meta def activeError (changed : Proof.Input Hex.Interval) : Option RuntimeEmit.Error :=
   match Rule.Runtime.buildEmitWithin RuntimeRuleConformance.executableLimits
@@ -204,15 +219,32 @@ elab "runtime_emit_canary" : tactic => do
     | .error error => throwError "unified runtime emitter registry failed: {repr error}"
     | .ok registry => match checkedFor registry with
       | .error error => throwError "runtime emitter lineage failed: {repr error}"
-      | .ok checked => RuntimeEmit.Checked.emitWithin emitLimits checked
-  let candidate ← match emitted with
+      | .ok checked => RuntimeEmit.Checked.emitResultWithin emitLimits checked
+  let emitted ← match emitted with
     | .error error => throwError "runtime expression emission failed: {repr error}"
-    | .ok candidate => pure candidate
+    | .ok emitted => pure emitted
+  let inputType ← mkAppM ``Proof.Input #[mkConst ``Hex.Interval]
+  unless ← isDefEq (← inferType emitted.input) inputType do
+    throwError "runtime emitter returned an ill-typed proof input"
+  unless ← isDefEq emitted.input (mkConst ``input) do
+    throwError "runtime emitter input differs from its sealed input"
+  let semantics ← mkAppM ``Rule.semantics
+    #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config]
+  let evidenceType (input : Expr) : MetaM Expr := do
+    let program ← mkAppM ``Proof.Input.program #[input]
+    let base ← mkAppM ``Proof.initialBase #[input]
+    let target ← mkAppM ``Proof.Input.target #[input]
+    let claim ← mkAppM ``Proof.Semantics.Entails #[semantics, program, base, target]
+    mkAppM ``Proof.Evidence #[claim]
+  let actual ← inferType emitted.evidence
+  unless ← isDefEq actual (← evidenceType emitted.input) do
+    throwError "runtime emitter evidence is not correlated with its emitted input"
+  if ← isDefEq actual (← evidenceType (mkConst ``changedInput)) then
+    throwError "runtime emitter evidence admitted a changed input"
   let expected ← goal.getType
-  let actual ← inferType candidate
   unless ← isDefEq actual expected do
     throwError "runtime emitter returned the wrong theorem type\nactual: {actual}\nexpected: {expected}"
-  goal.assign candidate
+  goal.assign emitted.evidence
   replaceMainGoal []
 
 /-- All twelve built-in runtime actions are load-bearing in this evidence. -/
@@ -358,14 +390,21 @@ elab "runtime_emit_failure_guards" : tactic => do
     (← emitWith { emitLimits with proof :=
       { RuntimeRuleConformance.proofLimits with maxDependencies := 1 } } package)
     (.proof .dependencyLimit)
-  let accepted ← emitWith emitLimits package
-  let expression ← match accepted with
+  let accepted ← emitResultWith emitLimits package
+  let emitted ← match accepted with
     | .error error => throwError "expression-size baseline failed: {repr error}"
-    | .ok expression => pure expression
-  let cells := RuntimeEmit.expressionCells expression
-  if cells == 0 then throwError "runtime emitter reported a zero-sized expression"
-  expect "expression count one-under"
-    (← emitWith { emitLimits with maxExpressionCells := cells - 1 } package)
+    | .ok emitted => pure emitted
+  let inputCells := RuntimeEmit.expressionCells emitted.input
+  let evidenceCells := RuntimeEmit.expressionCells emitted.evidence
+  if inputCells == 0 || evidenceCells == 0 then
+    throwError "runtime emitter reported a zero-sized expression"
+  expect "input expression count one-under"
+    (← emitWith { emitLimits with maxExpressionCells := inputCells - 1 } package)
+    (.resource .expression)
+  if evidenceCells ≤ inputCells then
+    throwError "evidence-size guard did not reach the second emitted expression"
+  expect "evidence expression count one-under"
+    (← emitWith { emitLimits with maxExpressionCells := evidenceCells - 1 } package)
     (.resource .expression)
   let goal ← getMainGoal
   goal.assign (mkConst ``True.intro)

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -1,0 +1,492 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexIntervalMathlib.RuntimeRuleEmit
+import HexIntervalMathlib.RuntimeRuleConformance
+import HexIntervalMathlib.RuntimeProofConformance
+
+/-!
+# Typed runtime expression-emission conformance
+
+The theorem canary below is installed only from the expression returned by the
+sealed root-target runtime emitter. Its chronology contains all twelve built-in
+arithmetic rules, including binary applications with repeated input nodes.
+The imported runtime-proof conformance owns the constructible action, body,
+proposed/installed fact, event-order, and event-role mutations before a checked
+token exists. This module adds emitter-schema and whole-input transplants;
+private checked chronology fields cannot be mutated by an ordinary importer.
+-/
+
+namespace Hex.IntervalMathlib.RuntimeEmitConformance
+
+open Lean Meta Elab Tactic
+open Hex.Interval
+open Hex.Interval.Executable
+open Hex.Interval.Rule
+open Hex.Interval.Rule.Runtime
+
+/-- error: Unknown constant `Hex.Interval.RuntimeEmit.Registry.mk` -/
+#guard_msgs in
+#check RuntimeEmit.Registry.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeEmit.Active.mk` -/
+#guard_msgs in
+#check RuntimeEmit.Active.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeEmit.Lineage.mk` -/
+#guard_msgs in
+#check RuntimeEmit.Lineage.mk
+
+/-- error: Unknown constant `Hex.Interval.RuntimeEmit.Checked.mk` -/
+#guard_msgs in
+#check RuntimeEmit.Checked.mk
+
+def emitLimits : RuntimeEmit.Limits :=
+  { proof := RuntimeRuleConformance.proofLimits, maxSchemas := 12, maxChronology := 12,
+    maxExpressionCells := 1000000 }
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 12, maxBytes := 4096, maxPairs := 144, maxWork := 4096,
+    maxScore := 0 }
+
+def traceLimits : Trace.Limit :=
+  { maxEvents := 0, maxBytes := 0, maxWork := 0, maxCode := 8 }
+
+def terminalSearchLimits : Search.Limits :=
+  { RuntimeRuleConformance.searchLimits with maxSteps := 13, leafFuel := 13 }
+
+def envelope : Search.Envelope :=
+  { state := RuntimeRuleConformance.stateLimits, policy := policyLimits, trace := traceLimits,
+    search := terminalSearchLimits }
+
+def terminalResultLimits : Search.Result.Limits :=
+  { RuntimeRuleConformance.resultLimits with search := terminalSearchLimits }
+
+def terminalAdapterLimits : RuntimeProof.Limits :=
+  { RuntimeRuleConformance.adapterLimits with result := terminalResultLimits }
+
+def controllerLimits : Runtime.Controller.Limits :=
+  { maxChoices := 0, result := terminalResultLimits }
+
+def quotedPoint : Hex.Interval :=
+  Rule.Runtime.Quote.getValue
+    (ofRawWithin RuntimeRuleConformance.endpoint
+      (.bounds (.finite (RuntimeRuleConformance.d 1) false)
+        (.finite (RuntimeRuleConformance.d 1) false))) (by decide)
+
+def quotedWhole : Hex.Interval :=
+  Rule.Runtime.Quote.getValue
+    (ofRawWithin RuntimeRuleConformance.endpoint (.bounds .unbounded .unbounded)) (by decide)
+
+def quotedFacts : Array Hex.Interval :=
+  #[quotedPoint, quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole,
+    quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole,
+    quotedWhole]
+
+def input : Proof.Input Hex.Interval :=
+  { scope := { index := 0 }, program := RuntimeRuleConformance.program,
+    facts := quotedFacts,
+    target := { node := { index := 12 }, fact := quotedPoint } }
+
+private def liftOption {α : Type} : Option α → Option (ULift.{1, 0} α)
+  | some value => some ⟨value⟩
+  | none => none
+
+private def runTree
+    (tree : Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key)
+    (state : Runtime.State Hex.Interval Rule.Runtime.Cause) :
+    List Action → Option
+      (Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key ×
+        Runtime.State Hex.Interval Rule.Runtime.Cause)
+  | [] => some (tree, state)
+  | next :: rest => do
+      let (transition, state) ← (state.stepWithin RuntimeRuleConformance.runtimeLimits next).toOption
+      let tree := (← liftOption
+        (Search.Result.advanceRuntimeWithin RuntimeRuleConformance.resultLimits
+          RuntimeRuleConformance.measure tree transition).toOption).down
+      runTree tree state rest
+
+private def controllerFor
+    (assembly : RuntimeProof.Assembly Hex.Interval Rule.Runtime.Cause) :
+    Option (Runtime.Controller.State Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key) := do
+  let branch := (← liftOption RuntimeRuleConformance.branch?).down
+  let runtime ← (Runtime.State.startWithin RuntimeRuleConformance.runtimeLimits assembly branch).toOption
+  let tree := (← liftOption ((Search.Result.startWithin RuntimeRuleConformance.resultLimits
+    RuntimeRuleConformance.measure
+    { index := 0 } branch).toOption)).down
+  let (tree, runtime) ← runTree tree runtime RuntimeRuleConformance.actions
+  (Runtime.Controller.State.startWithin controllerLimits envelope
+    RuntimeRuleConformance.measure runtime tree).toOption
+
+meta def checkedFor
+    (registry : RuntimeEmit.Registry Hex.Interval
+      (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat)) :
+    Except RuntimeEmit.Error
+      (RuntimeEmit.Checked Hex.Interval (Rule.semantics RuntimeRuleConformance.config)
+        Rule.Runtime.Cause (List Nat)) := do
+  let some controller := controllerFor registry.runtime.assembly
+    | throw .malformed
+  let active ← RuntimeEmit.Active.startWithin registry input controller
+  let lineage ← active.targetWithin terminalResultLimits
+    RuntimeRuleConformance.measure { node := { index := 12 }, version := 1 }
+  lineage.quoteWithin terminalAdapterLimits RuntimeRuleConformance.measure
+
+meta def registryError
+    (packages : Array
+      (RuntimeEmit.Package (Rule.semantics RuntimeRuleConformance.config) (List Nat))) :
+    Option RuntimeEmit.Error :=
+  match Rule.Runtime.assemblyWithin RuntimeRuleConformance.executableLimits
+      RuntimeRuleConformance.config RuntimeRuleConformance.program with
+  | .error _ => some .malformed
+  | .ok assembly =>
+      match RuntimeEmit.Registry.buildWithin RuntimeRuleConformance.executableLimits
+          emitLimits RuntimeRuleConformance.key assembly
+          (Rule.Runtime.quoter RuntimeRuleConformance.config) packages with
+      | .error error => some error
+      | .ok _ => none
+
+meta def emitWith (limits : RuntimeEmit.Limits)
+    (package : RuntimeEmit.Package
+      (Rule.semantics RuntimeRuleConformance.config) (List Nat)) :
+    MetaM (Except RuntimeEmit.Error Expr) :=
+  match Rule.Runtime.assemblyWithin RuntimeRuleConformance.executableLimits
+      RuntimeRuleConformance.config RuntimeRuleConformance.program with
+  | .error _ => pure (.error .malformed)
+  | .ok assembly =>
+      match RuntimeEmit.Registry.buildWithin RuntimeRuleConformance.executableLimits
+          limits RuntimeRuleConformance.key assembly
+          (Rule.Runtime.quoter RuntimeRuleConformance.config) #[package] with
+      | .error error => pure (.error error)
+      | .ok registry => match checkedFor registry with
+        | .error error => pure (.error error)
+        | .ok checked => RuntimeEmit.Checked.emitWithin limits checked
+
+meta def activeError (changed : Proof.Input Hex.Interval) : Option RuntimeEmit.Error :=
+  match Rule.Runtime.buildEmitWithin RuntimeRuleConformance.executableLimits
+      emitLimits RuntimeRuleConformance.key RuntimeRuleConformance.config
+      RuntimeRuleConformance.program with
+  | .error _ => some .malformed
+  | .ok registry => match controllerFor registry.runtime.assembly with
+    | none => some .malformed
+    | some controller => match RuntimeEmit.Active.startWithin registry changed controller with
+      | .error error => some error
+      | .ok _ => none
+
+meta def targetError (changed : Proof.Input Hex.Interval) : Option RuntimeEmit.Error :=
+  match Rule.Runtime.buildEmitWithin RuntimeRuleConformance.executableLimits
+      emitLimits RuntimeRuleConformance.key RuntimeRuleConformance.config
+      RuntimeRuleConformance.program with
+  | .error _ => some .malformed
+  | .ok registry => match controllerFor registry.runtime.assembly with
+    | none => some .malformed
+    | some controller => match RuntimeEmit.Active.startWithin registry changed controller with
+      | .error error => some error
+      | .ok active => match active.targetWithin terminalResultLimits
+          RuntimeRuleConformance.measure { node := { index := 12 }, version := 1 } with
+        | .error error => some error
+        | .ok _ => none
+
+meta def replaceFirst
+    (package : RuntimeEmit.Package
+      (Rule.semantics RuntimeRuleConformance.config) (List Nat))
+    (handle : RuntimeEmit.Handle) :
+    RuntimeEmit.Package (Rule.semantics RuntimeRuleConformance.config) (List Nat) :=
+  { package with facts := package.facts.set! 0 handle }
+
+elab "runtime_emit_canary" : tactic => do
+  let goal ← getMainGoal
+  let emitted ← match Rule.Runtime.buildEmitWithin RuntimeRuleConformance.executableLimits
+      emitLimits RuntimeRuleConformance.key RuntimeRuleConformance.config
+      RuntimeRuleConformance.program with
+    | .error error => throwError "unified runtime emitter registry failed: {repr error}"
+    | .ok registry => match checkedFor registry with
+      | .error error => throwError "runtime emitter lineage failed: {repr error}"
+      | .ok checked => RuntimeEmit.Checked.emitWithin emitLimits checked
+  let candidate ← match emitted with
+    | .error error => throwError "runtime expression emission failed: {repr error}"
+    | .ok candidate => pure candidate
+  let expected ← goal.getType
+  let actual ← inferType candidate
+  unless ← isDefEq actual expected do
+    throwError "runtime emitter returned the wrong theorem type\nactual: {actual}\nexpected: {expected}"
+  goal.assign candidate
+  replaceMainGoal []
+
+/-- All twelve built-in runtime actions are load-bearing in this evidence. -/
+def allBuiltinsEvidence : Proof.Evidence
+    ((Rule.semantics RuntimeRuleConformance.config).Entails input.program
+      (Proof.initialBase input) input.target) := by
+  runtime_emit_canary
+
+theorem allBuiltins :
+    (Rule.semantics RuntimeRuleConformance.config).Entails input.program
+      (Proof.initialBase input) input.target := by
+  exact allBuiltinsEvidence.proof
+
+#print axioms allBuiltins
+
+elab "runtime_emit_registry_guards" : tactic => do
+  let package := Rule.Runtime.emitPackage RuntimeRuleConformance.config
+  let first := package.facts[0]'(by decide)
+  let second := package.facts[1]'(by decide)
+  let expect (label : String) (actual expected : Option RuntimeEmit.Error) := do
+    unless actual == expected do
+      throwError "{label}: expected {repr expected}, got {repr actual}"
+  expect "missing package handle"
+    (registryError #[{ package with facts := package.facts.eraseIdx 0 }])
+    (some (.missingHandle first.key))
+  let extraKey : Proof.Key :=
+    { rule := { name := "conformance.runtime.emit.extra" }, role := .fact,
+      bodySchema := 1 }
+  expect "extra package handle"
+    (registryError #[{ package with facts := package.facts.push { first with key := extraKey } }])
+    (some (.extraHandle extraKey))
+  expect "duplicate package handle"
+    (registryError #[{ package with facts := package.facts.push first }])
+    (some (.duplicateHandle first.key))
+  let wrongRoleKey := { first.key with role := Proof.Role.equality }
+  expect "wrong-role handle"
+    (registryError #[replaceFirst package { first with key := wrongRoleKey }])
+    (some (.wrongRole wrongRoleKey))
+  let negProof : Proof.Package (Rule.semantics RuntimeRuleConformance.config) (List Nat) :=
+    { registrations := #[], facts := #[Rule.negSchema RuntimeRuleConformance.config] }
+  let addProof : Proof.Package (Rule.semantics RuntimeRuleConformance.config) (List Nat) :=
+    { registrations := #[], facts := #[Rule.addSchema RuntimeRuleConformance.config] }
+  let negPackage : RuntimeEmit.Package
+      (Rule.semantics RuntimeRuleConformance.config) (List Nat) :=
+    { proof := negProof, facts := #[first] }
+  let addPackage : RuntimeEmit.Package
+      (Rule.semantics RuntimeRuleConformance.config) (List Nat) :=
+    { proof := addProof, facts := #[second] }
+  expect "global duplicate handle"
+    (registryError #[negPackage, negPackage])
+    (some (.duplicateHandle first.key))
+  expect "cross-package handle transplant"
+    (registryError #[{ negPackage with facts := #[second] },
+      { addPackage with facts := #[first] }])
+    (some (.extraHandle second.key))
+  expect "fact-input transplant"
+    (activeError { input with facts := input.facts.set! 0 Hex.Interval.empty })
+    (some (.terminal .mismatch))
+  expect "target-input transplant"
+    (targetError { input with target := { input.target with node := { index := 11 } } })
+    (some (.terminal .mismatch))
+  expect "scope-input transplant"
+    (activeError { input with scope := { index := 1 } })
+    (some (.terminal .mismatch))
+  let goal ← getMainGoal
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by runtime_emit_registry_guards
+
+elab "runtime_emit_failure_guards" : tactic => do
+  let package := Rule.Runtime.emitPackage RuntimeRuleConformance.config
+  let first := package.facts[0]'(by decide)
+  let expect (label : String) (actual : Except RuntimeEmit.Error Expr)
+      (expected : RuntimeEmit.Error) := do
+    match actual with
+    | .error error => unless error == expected do
+        throwError "{label}: expected {repr expected}, got {repr error}"
+    | .ok _ => throwError "{label}: malformed emission was accepted"
+  let wrongType : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => pure (mkNatLit 0) } }
+  expect "wrong emitter type" (← emitWith emitLimits (replaceFirst package wrongType)) .emitter
+  let openMVar : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => do
+        let semantics ← mkAppM ``Rule.semantics
+          #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config]
+        let expected ← mkAppM ``Proof.FactSchema #[semantics]
+        mkFreshExprMVar expected } }
+  expect "open emitter metavariable"
+    (← emitWith emitLimits (replaceFirst package openMVar)) .emitter
+  let placeholder : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => do
+        let semantics ← mkAppM ``Rule.semantics
+          #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config]
+        let expected ← mkAppM ``Proof.FactSchema #[semantics]
+        mkSorry expected true } }
+  expect "synthetic emitter placeholder"
+    (← emitWith emitLimits (replaceFirst package placeholder)) .emitter
+  let transientName :=
+    `Hex.IntervalMathlib.RuntimeEmitConformance.transientEmitterSchema
+  let temporary : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => do
+        let value ← mkAppM ``Rule.negSchema
+          #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config]
+        let type ← inferType value
+        addDecl <| .defnDecl
+          { name := transientName, levelParams := [], type, value,
+            hints := .abbrev, safety := .safe }
+        pure (mkConst transientName) } }
+  expect "temporary emitter declaration"
+    (← emitWith emitLimits (replaceFirst package temporary)) .emitter
+  if (← getEnv).contains transientName then
+    throwError "failed runtime emitter leaked a temporary declaration"
+  let scratch ← mkFreshExprMVar (mkConst ``Nat)
+  let scratchId := scratch.mvarId!
+  let assigning : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => do
+        scratchId.assign (mkNatLit 0)
+        mkAppM ``Rule.negSchema
+          #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config] } }
+  match ← emitWith emitLimits (replaceFirst package assigning) with
+  | .error error => throwError "assigning emitter baseline failed: {repr error}"
+  | .ok _ => pure ()
+  if ← scratchId.isAssigned then
+    throwError "successful runtime emitter leaked a Meta assignment"
+  let wrongSchema : RuntimeEmit.Handle :=
+    { first with schema := { emit := fun _ => do
+        mkAppM ``Rule.addSchema
+          #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config] } }
+  expect "schema expression transplant"
+    (← emitWith emitLimits (replaceFirst package wrongSchema)) .replay
+  expect "schema count one-under"
+    (← emitWith { emitLimits with maxSchemas := 11 } package) (.resource .schemas)
+  expect "chronology count one-under"
+    (← emitWith { emitLimits with maxChronology := 11 } package) (.resource .chronology)
+  expect "body count one-under"
+    (← emitWith { emitLimits with proof :=
+      { RuntimeRuleConformance.proofLimits with maxBodyCells := 0 } } package)
+    (.proof .bodyLimit)
+  expect "dependency count one-under"
+    (← emitWith { emitLimits with proof :=
+      { RuntimeRuleConformance.proofLimits with maxDependencies := 1 } } package)
+    (.proof .dependencyLimit)
+  let accepted ← emitWith emitLimits package
+  let expression ← match accepted with
+    | .error error => throwError "expression-size baseline failed: {repr error}"
+    | .ok expression => pure expression
+  let cells := RuntimeEmit.expressionCells expression
+  if cells == 0 then throwError "runtime emitter reported a zero-sized expression"
+  expect "expression count one-under"
+    (← emitWith { emitLimits with maxExpressionCells := cells - 1 } package)
+    (.resource .expression)
+  let goal ← getMainGoal
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by runtime_emit_failure_guards
+
+/-! ## Mixed instance/equality/fact/transport chronology -/
+
+namespace Mixed
+
+open Hex.Interval.Experiment.SineSign
+def emitLimits : RuntimeEmit.Limits :=
+  { proof := RuntimeProofConformance.proofLimits, maxSchemas := 4, maxChronology := 4,
+    maxExpressionCells := 1000000 }
+
+def policyLimits : Policy.Limits :=
+  { maxOffers := 8, maxBytes := 4096, maxPairs := 64, maxWork := 4096,
+    maxScore := 0 }
+
+def traceLimits : Trace.Limit :=
+  { maxEvents := 0, maxBytes := 0, maxWork := 0, maxCode := 8 }
+
+def envelope : Search.Envelope :=
+  { state := RuntimeProofConformance.stateLimits, policy := policyLimits, trace := traceLimits,
+    search := RuntimeProofConformance.searchLimits }
+
+def controllerLimits : Runtime.Controller.Limits :=
+  { maxChoices := 0, result := RuntimeProofConformance.resultLimits }
+
+meta def factExpr : Range → MetaM Expr
+  | .all => pure (mkConst ``Range.all)
+  | .unit => pure (mkConst ``Range.unit)
+  | .nonnegative => pure (mkConst ``Range.nonnegative)
+  | .nonpositive => pure (mkConst ``Range.nonpositive)
+  | .zero => pure (mkConst ``Range.zero)
+  | .empty => pure (mkConst ``Range.empty)
+
+meta def factHandle : RuntimeEmit.Handle :=
+  { key := RuntimeProofConformance.factProofKey
+    schema := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.factSchema) } }
+
+meta def equalityHandle : RuntimeEmit.Handle :=
+  { key := RuntimeProofConformance.equalityProofKey
+    schema := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.equalitySchema) } }
+
+meta def instanceHandle : RuntimeEmit.Handle :=
+  { key := RuntimeProofConformance.instanceProofKey
+    schema := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.instanceSchema) } }
+
+meta def package : RuntimeEmit.Package RuntimeProofConformance.semantics Nat :=
+  { proof := RuntimeProofConformance.proofPackage
+    facts := #[factHandle]
+    equalities := #[equalityHandle]
+    instances := #[instanceHandle] }
+
+meta def quoter : RuntimeEmit.Quoter Range RuntimeProofConformance.semantics :=
+  { factType := { emit := fun _ => pure (mkConst ``Range) }
+    fact := { emit := factExpr }
+    semantics := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.semantics) }
+    domain := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.domain) }
+    laws := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.laws) } }
+
+private def advance
+    (tree : Search.Result.Tree Range Nat Nat Proof.Key)
+    (runtime : Runtime.State Range Nat) : List Action →
+    Option (Search.Result.Tree Range Nat Nat Proof.Key × Runtime.State Range Nat)
+  | [] => some (tree, runtime)
+  | action :: rest => do
+      let (transition, runtime) ← (runtime.stepWithin RuntimeProofConformance.runtimeLimits action).toOption
+      let tree := (← liftOption
+        (Search.Result.advanceRuntimeWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure tree transition).toOption).down
+      advance tree runtime rest
+
+private def controllerFor (assembly : RuntimeProof.Assembly Range Nat) :
+    Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
+  let branch := (← liftOption RuntimeProofConformance.branch?).down
+  let runtime ← (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits assembly branch).toOption
+  let tree := (← liftOption ((Search.Result.startWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure
+    RuntimeProofConformance.scope branch).toOption)).down
+  let (tree, runtime) ← advance tree runtime
+    [RuntimeProofConformance.instanceAction, RuntimeProofConformance.equalityAction, RuntimeProofConformance.factAction, RuntimeProofConformance.transportAction]
+  (Runtime.Controller.State.startWithin controllerLimits envelope RuntimeProofConformance.measure runtime tree).toOption
+
+elab "runtime_emit_mixed_canary" : tactic => do
+  let goal ← getMainGoal
+  let emitted ← match RuntimeProofConformance.assembly? with
+    | none => throwError "mixed runtime emitter assembly failed"
+    | some assembly =>
+      match RuntimeEmit.Registry.buildWithin RuntimeProofConformance.executableLimits emitLimits RuntimeProofConformance.adapterKey
+          assembly quoter #[package] with
+      | .error error => throwError "mixed runtime emitter registry failed: {repr error}"
+      | .ok registry => match controllerFor registry.runtime.assembly with
+        | none => throwError "mixed runtime emitter controller failed"
+        | some controller =>
+          match RuntimeEmit.Active.startWithin registry RuntimeProofConformance.input controller with
+          | .error error => throwError "mixed runtime emitter start failed: {repr error}"
+          | .ok active => match (RuntimeEmit.Active.targetWithin
+              RuntimeProofConformance.resultLimits RuntimeProofConformance.measure active
+              { node := node 2, version := 1 }) with
+            | .error error => throwError "mixed runtime target failed: {repr error}"
+            | .ok lineage => match lineage.quoteWithin RuntimeProofConformance.adapterLimits RuntimeProofConformance.measure with
+              | .error error => throwError "mixed runtime quotation failed: {repr error}"
+              | .ok checked => RuntimeEmit.Checked.emitWithin emitLimits checked
+  let candidate ← match emitted with
+    | .error error => throwError "mixed runtime expression failed: {repr error}"
+    | .ok candidate => pure candidate
+  let expected ← goal.getType
+  unless ← isDefEq (← inferType candidate) expected do
+    throwError "mixed runtime emitter returned the wrong Evidence type"
+  goal.assign candidate
+  replaceMainGoal []
+
+def evidence : Proof.Evidence
+    (RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target) := by
+  runtime_emit_mixed_canary
+
+theorem target :
+    RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target :=
+  evidence.proof
+
+#print axioms target
+
+end Mixed
+
+end Hex.IntervalMathlib.RuntimeEmitConformance

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -226,6 +226,8 @@ theorem allBuiltins :
       (Proof.initialBase input) input.target := by
   exact allBuiltinsEvidence.proof
 
+/-- info: 'Hex.IntervalMathlib.RuntimeEmitConformance.allBuiltins' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms allBuiltins
 
 elab "runtime_emit_registry_guards" : tactic => do
@@ -343,7 +345,7 @@ elab "runtime_emit_failure_guards" : tactic => do
         mkAppM ``Rule.addSchema
           #[← Rule.Runtime.Quote.configExpr RuntimeRuleConformance.config] } }
   expect "schema expression transplant"
-    (← emitWith emitLimits (replaceFirst package wrongSchema)) .replay
+    (← emitWith emitLimits (replaceFirst package wrongSchema)) (.handleKey first.key)
   expect "schema count one-under"
     (← emitWith { emitLimits with maxSchemas := 11 } package) (.resource .schemas)
   expect "chronology count one-under"
@@ -448,26 +450,31 @@ private def controllerFor (assembly : RuntimeProof.Assembly Range Nat) :
     [RuntimeProofConformance.instanceAction, RuntimeProofConformance.equalityAction, RuntimeProofConformance.factAction, RuntimeProofConformance.transportAction]
   (Runtime.Controller.State.startWithin controllerLimits envelope RuntimeProofConformance.measure runtime tree).toOption
 
-elab "runtime_emit_mixed_canary" : tactic => do
-  let goal ← getMainGoal
-  let emitted ← match RuntimeProofConformance.assembly? with
-    | none => throwError "mixed runtime emitter assembly failed"
-    | some assembly =>
-      match RuntimeEmit.Registry.buildWithin RuntimeProofConformance.executableLimits emitLimits RuntimeProofConformance.adapterKey
-          assembly quoter #[package] with
-      | .error error => throwError "mixed runtime emitter registry failed: {repr error}"
+meta def emitWith (limits : RuntimeEmit.Limits) :
+    MetaM (Except RuntimeEmit.Error Expr) :=
+  match RuntimeProofConformance.assembly? with
+  | none => pure (.error .malformed)
+  | some assembly =>
+      match RuntimeEmit.Registry.buildWithin RuntimeProofConformance.executableLimits limits
+          RuntimeProofConformance.adapterKey assembly quoter #[package] with
+      | .error error => pure (.error error)
       | .ok registry => match controllerFor registry.runtime.assembly with
-        | none => throwError "mixed runtime emitter controller failed"
+        | none => pure (.error .malformed)
         | some controller =>
           match RuntimeEmit.Active.startWithin registry RuntimeProofConformance.input controller with
-          | .error error => throwError "mixed runtime emitter start failed: {repr error}"
+          | .error error => pure (.error error)
           | .ok active => match (RuntimeEmit.Active.targetWithin
               RuntimeProofConformance.resultLimits RuntimeProofConformance.measure active
               { node := node 2, version := 1 }) with
-            | .error error => throwError "mixed runtime target failed: {repr error}"
-            | .ok lineage => match lineage.quoteWithin RuntimeProofConformance.adapterLimits RuntimeProofConformance.measure with
-              | .error error => throwError "mixed runtime quotation failed: {repr error}"
-              | .ok checked => RuntimeEmit.Checked.emitWithin emitLimits checked
+            | .error error => pure (.error error)
+            | .ok lineage => match lineage.quoteWithin RuntimeProofConformance.adapterLimits
+                RuntimeProofConformance.measure with
+              | .error error => pure (.error error)
+              | .ok checked => RuntimeEmit.Checked.emitWithin limits checked
+
+elab "runtime_emit_mixed_canary" : tactic => do
+  let goal ← getMainGoal
+  let emitted ← emitWith emitLimits
   let candidate ← match emitted with
     | .error error => throwError "mixed runtime expression failed: {repr error}"
     | .ok candidate => pure candidate
@@ -477,6 +484,19 @@ elab "runtime_emit_mixed_canary" : tactic => do
   goal.assign candidate
   replaceMainGoal []
 
+elab "runtime_emit_mixed_guards" : tactic => do
+  match ← emitWith { emitLimits with maxSchemas := 2 } with
+  | .error (.resource .schemas) => pure ()
+  | .error error =>
+      throwError "mixed schema limit returned the wrong error: {repr error}"
+  | .ok _ =>
+      throwError "mixed fact/equality/instance handles exceeded the global schema limit"
+  let goal ← getMainGoal
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+example : True := by runtime_emit_mixed_guards
+
 def evidence : Proof.Evidence
     (RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target) := by
   runtime_emit_mixed_canary
@@ -485,6 +505,8 @@ theorem target :
     RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target :=
   evidence.proof
 
+/-- info: 'Hex.IntervalMathlib.RuntimeEmitConformance.Mixed.target' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms target
 
 end Mixed

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -16,7 +16,8 @@ sealed root-target runtime emitter. Its chronology contains all twelve built-in
 arithmetic rules, including binary applications with repeated input nodes.
 The imported runtime-proof conformance owns the constructible action, body,
 proposed/installed fact, event-order, and event-role mutations before a checked
-token exists. This module adds emitter-schema and whole-input transplants;
+token exists. This module adds emitter-schema and whole-input transplants plus
+a self-consistent wrong fact quoter rejected at exact caller-input correlation;
 private checked chronology fields cannot be mutated by an ordinary importer.
 -/
 
@@ -47,6 +48,92 @@ open Hex.Interval.Rule.Runtime
 /-- error: Unknown constant `Hex.Interval.RuntimeEmit.Emitted.mk` -/
 #guard_msgs in
 #check RuntimeEmit.Emitted.mk
+
+section SealedPrivateConstruction
+
+variable
+  (registry : RuntimeEmit.Registry Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat))
+  (active : RuntimeEmit.Active Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat))
+  (lineage : RuntimeEmit.Lineage Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat))
+  (checked : RuntimeEmit.Checked Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat))
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Registry` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Registry Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { runtime := registry.runtime, quoter := registry.quoter, packages := registry.packages }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeEmit.Registry` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Registry Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  ⟨registry.runtime, registry.quoter, registry.packages⟩
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Registry` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Registry Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { registry with packages := registry.packages }
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Active` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Active Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { registry := active.registry, terminal := active.terminal }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeEmit.Active` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Active Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  ⟨active.registry, active.terminal⟩
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Active` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Active Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { active with terminal := active.terminal }
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Lineage` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Lineage Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { registry := lineage.registry, terminal := lineage.terminal }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeEmit.Lineage` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Lineage Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  ⟨lineage.registry, lineage.terminal⟩
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Lineage` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Lineage Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { lineage with terminal := lineage.terminal }
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Checked` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Checked Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { registry := checked.registry, terminal := checked.terminal }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeEmit.Checked` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Checked Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  ⟨checked.registry, checked.terminal⟩
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Checked` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Checked Hex.Interval
+    (Rule.semantics RuntimeRuleConformance.config) Rule.Runtime.Cause (List Nat) :=
+  { checked with terminal := checked.terminal }
+
+end SealedPrivateConstruction
 
 section EmittedPrivateConstruction
 
@@ -489,6 +576,20 @@ meta def quoter : RuntimeEmit.Quoter Range RuntimeProofConformance.semantics :=
     domain := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.domain) }
     laws := { emit := fun _ => pure (mkConst ``RuntimeProofConformance.laws) } }
 
+/-- Deliberately misquote one uniquely marked, unused seed fact as the strictly
+smaller zero fact. Replay remains internally valid while the emitted input
+differs from the caller's claim. -/
+meta def shiftedQuoter : RuntimeEmit.Quoter Range RuntimeProofConformance.semantics :=
+  { quoter with fact := { emit := fun
+      | .nonnegative => pure (mkConst ``Range.zero)
+      | fact => factExpr fact } }
+
+def correlationInput : Proof.Input Range :=
+  { RuntimeProofConformance.input with facts := #[.unit, .nonnegative, .all] }
+
+def shiftedInput : Proof.Input Range :=
+  { RuntimeProofConformance.input with facts := #[.unit, .zero, .all] }
+
 private def advance
     (tree : Search.Result.Tree Range Nat Nat Proof.Key)
     (runtime : Runtime.State Range Nat) : List Action →
@@ -500,9 +601,10 @@ private def advance
         (Search.Result.advanceRuntimeWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure tree transition).toOption).down
       advance tree runtime rest
 
-private def controllerFor (assembly : RuntimeProof.Assembly Range Nat) :
+private def controllerFor (assembly : RuntimeProof.Assembly Range Nat)
+    (facts : Array Range) :
     Option (Runtime.Controller.State Range Nat Nat Proof.Key) := do
-  let branch := (← liftOption RuntimeProofConformance.branch?).down
+  let branch := (← liftOption (RuntimeProofConformance.branchWith? facts)).down
   let runtime ← (Runtime.State.startWithin RuntimeProofConformance.runtimeLimits assembly branch).toOption
   let tree := (← liftOption ((Search.Result.startWithin RuntimeProofConformance.resultLimits RuntimeProofConformance.measure
     RuntimeProofConformance.scope branch).toOption)).down
@@ -510,18 +612,20 @@ private def controllerFor (assembly : RuntimeProof.Assembly Range Nat) :
     [RuntimeProofConformance.instanceAction, RuntimeProofConformance.equalityAction, RuntimeProofConformance.factAction, RuntimeProofConformance.transportAction]
   (Runtime.Controller.State.startWithin controllerLimits envelope RuntimeProofConformance.measure runtime tree).toOption
 
-meta def emitWith (limits : RuntimeEmit.Limits) :
-    MetaM (Except RuntimeEmit.Error Expr) :=
+meta def emitResultWith (limits : RuntimeEmit.Limits)
+    (selectedQuoter : RuntimeEmit.Quoter Range RuntimeProofConformance.semantics)
+    (sealedInput : Proof.Input Range) :
+    MetaM (Except RuntimeEmit.Error RuntimeEmit.Emitted) :=
   match RuntimeProofConformance.assembly? with
   | none => pure (.error .malformed)
   | some assembly =>
       match RuntimeEmit.Registry.buildWithin RuntimeProofConformance.executableLimits limits
-          RuntimeProofConformance.adapterKey assembly quoter #[package] with
+          RuntimeProofConformance.adapterKey assembly selectedQuoter #[package] with
       | .error error => pure (.error error)
-      | .ok registry => match controllerFor registry.runtime.assembly with
+      | .ok registry => match controllerFor registry.runtime.assembly sealedInput.facts with
         | none => pure (.error .malformed)
         | some controller =>
-          match RuntimeEmit.Active.startWithin registry RuntimeProofConformance.input controller with
+          match RuntimeEmit.Active.startWithin registry sealedInput controller with
           | .error error => pure (.error error)
           | .ok active => match (RuntimeEmit.Active.targetWithin
               RuntimeProofConformance.resultLimits RuntimeProofConformance.measure active
@@ -530,7 +634,13 @@ meta def emitWith (limits : RuntimeEmit.Limits) :
             | .ok lineage => match lineage.quoteWithin RuntimeProofConformance.adapterLimits
                 RuntimeProofConformance.measure with
               | .error error => pure (.error error)
-              | .ok checked => RuntimeEmit.Checked.emitWithin limits checked
+              | .ok checked => RuntimeEmit.Checked.emitResultWithin limits checked
+
+meta def emitWith (limits : RuntimeEmit.Limits) :
+    MetaM (Except RuntimeEmit.Error Expr) := do
+  match ← emitResultWith limits quoter RuntimeProofConformance.input with
+  | .error error => return .error error
+  | .ok emitted => return .ok emitted.evidence
 
 elab "runtime_emit_mixed_canary" : tactic => do
   let goal ← getMainGoal
@@ -556,6 +666,34 @@ elab "runtime_emit_mixed_guards" : tactic => do
   replaceMainGoal []
 
 example : True := by runtime_emit_mixed_guards
+
+elab "runtime_emit_input_correlation_guards" : tactic => do
+  let emitted ← match ← emitResultWith emitLimits shiftedQuoter correlationInput with
+    | .error error => throwError "shifted fact quoter failed to emit: {repr error}"
+    | .ok emitted => pure emitted
+  unless ← isDefEq emitted.input (mkConst ``shiftedInput) do
+    throwError "shifted fact quoter did not produce the deliberately shifted input"
+  if ← isDefEq emitted.input (mkConst ``correlationInput) then
+    throwError "exact input correlation accepted a shifted fact quoter"
+  let evidenceType (quotedInput : Expr) : MetaM Expr := do
+    let program ← mkAppM ``Proof.Input.program #[quotedInput]
+    let base ← mkAppM ``Proof.initialBase #[quotedInput]
+    let target ← mkAppM ``Proof.Input.target #[quotedInput]
+    let claim ← mkAppM ``Proof.Semantics.Entails
+      #[mkConst ``RuntimeProofConformance.semantics, program, base, target]
+    mkAppM ``Proof.Evidence #[claim]
+  let actual ← inferType emitted.evidence
+  unless ← isDefEq actual (← evidenceType emitted.input) do
+    throwError "shifted evidence lost correlation with its emitted input"
+  if ← isDefEq actual (← evidenceType (mkConst ``correlationInput)) then
+    throwError "shifted evidence was mistaken for the expected exact-input claim"
+  let goal ← getMainGoal
+  goal.assign (mkConst ``True.intro)
+  replaceMainGoal []
+
+/-- A self-consistent wrong quoter can emit, but exact claim-input correlation
+rejects both its quoted input and its evidence type. -/
+example : True := by runtime_emit_input_correlation_guards
 
 def evidence : Proof.Evidence
     (RuntimeProofConformance.semantics.Entails RuntimeProofConformance.input.program (Proof.initialBase RuntimeProofConformance.input) RuntimeProofConformance.input.target) := by

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -48,6 +48,27 @@ open Hex.Interval.Rule.Runtime
 #guard_msgs in
 #check RuntimeEmit.Emitted.mk
 
+section EmittedPrivateConstruction
+
+variable (input evidence : Expr) (emitted : RuntimeEmit.Emitted)
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Emitted` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Emitted :=
+  { input := input, evidence := evidence }
+
+/-- error: Invalid `⟨...⟩` notation: Constructor for `Hex.Interval.RuntimeEmit.Emitted` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Emitted :=
+  ⟨input, evidence⟩
+
+/-- error: invalid {...} notation, constructor for `RuntimeEmit.Emitted` is marked as private -/
+#guard_msgs in
+example : RuntimeEmit.Emitted :=
+  { emitted with input }
+
+end EmittedPrivateConstruction
+
 def emitLimits : RuntimeEmit.Limits :=
   { proof := RuntimeRuleConformance.proofLimits, maxSchemas := 12, maxChronology := 12,
     maxExpressionCells := 1000000 }

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -579,6 +579,7 @@ lean_lib HexConformance where
       `HexIntervalMathlib.RuntimeProofConformance,
       `HexIntervalMathlib.RuntimeTerminalConformance,
       `HexIntervalMathlib.RuntimeRuleConformance,
+      `HexIntervalMathlib.RuntimeEmitConformance,
       `HexIntervalMathlib.ProgramProofConformance,
       `HexIntervalMathlib.DriverConformance,
       `HexIntervalMathlib.ControllerConformance,

--- a/progress/2026-08-24T02-40-02Z.md
+++ b/progress/2026-08-24T02-40-02Z.md
@@ -1,0 +1,31 @@
+# Typed runtime emitter hardening
+
+## Accomplished
+
+- Enforced `RuntimeEmit.Limits.maxSchemas` across the combined fact, equality,
+  and instance handle table rather than independently per role.
+- Correlated every prepared schema expression with its declared handle by
+  projecting and checking the exact `Proof.Key` before retaining the expression.
+- Added a mixed-role one-under schema-limit canary, an explicit schema-key
+  transplant error, and exact guarded axiom canaries for both emitted theorems.
+- Documented the trusted-reflection obligation for generic quoter and handle
+  callbacks.
+- Built `HexIntervalMathlib.RuntimeEmitConformance` successfully and passed the
+  DAG checker, its unit test, and diff hygiene on the stacked branch.
+
+## Current frontier
+
+The RuntimeEmit bridge is implemented and the independent audit findings are
+closed on this branch. It remains stacked on the pre-Lean-4.34 RuntimeRule and
+RuntimeTerminal commits.
+
+## Next step
+
+Cherry-pick this hardening commit with the original RuntimeEmit commits onto the
+fresh terminal-based RuntimeRule branch, resolve additive umbrella/SPEC/test
+conflicts, and rerun the focused build under Lean 4.34 before opening its PR.
+
+## Blockers
+
+None in the emitter implementation. Publication waits for the terminal and
+RuntimeRule dependency layers to merge.

--- a/progress/2026-08-24T03-38-09Z.md
+++ b/progress/2026-08-24T03-38-09Z.md
@@ -1,0 +1,30 @@
+# Typed runtime emitter restack
+
+## Accomplished
+
+- Restacked the production typed runtime emitter onto the current terminal and
+  built-in RuntimeRule layers while preserving both conformance registrations.
+- Retained the hardened global schema budget, declared-key correlation checks,
+  mixed-role cap canary, and exact emitted-expression trust checks.
+- Rebuilt `HexIntervalMathlib.RuntimeEmitConformance` and
+  `HexIntervalMathlib` successfully from a cold cache across all 8,818 jobs.
+- Added the exact proof-only factor-sweep exemption for the combined terminal,
+  RuntimeRule, and RuntimeEmit conformance glob registration.
+- Re-ran freshness, DAG/unit, published trust-surface, source hygiene, and diff
+  checks successfully.
+
+## Current frontier
+
+The RuntimeEmit layer is locally green atop the open RuntimeRule PR stack. Its
+registry produces evidence only through typed terminal replay and checks the
+emitted input/evidence types transactionally.
+
+## Next step
+
+After RuntimeRule merges, rebase RuntimeEmit onto the squash commit, restack the
+exact input/evidence expression bridge, obtain exact-head review and CI, and
+open the production emitter PR.
+
+## Blockers
+
+Publication depends on the RuntimeRule PR merging first.

--- a/progress/2026-08-24T06-35-21Z.md
+++ b/progress/2026-08-24T06-35-21Z.md
@@ -1,0 +1,33 @@
+# Runtime emitter hardening
+
+## Accomplished
+
+- Made runtime expression collection helpers reject `Prop` instead of treating
+  it as a level-zero data type.
+- Clarified the public `Resolver` ownership boundary and documented that
+  `Checked.emitWithin` callers must pin the quoter-produced input before using
+  its evidence for a pre-existing claim.
+- Added private-constructor record-literal, angle-bracket, and record-update
+  canaries for `RuntimeEmit.Registry`, `Active`, `Lineage`, and `Checked`.
+- Added a mixed-runtime conformance in which a wrong fact quoter produces a
+  self-consistent shifted input and evidence, while exact input and claim-type
+  correlation reject the caller's expected input.
+- Built `HexIntervalMathlib.RuntimeEmitConformance` and ran DAG, line-count,
+  trust-surface, copyright, diff, and added-prohibited-token checks successfully.
+
+## Current frontier
+
+The scoped emitter-hardening changes are complete and committed-ready. The
+existing emitter remains intentionally restricted to one-node target trees.
+
+## Next step
+
+Review or integrate this commit before opening the dependent PR. If a public
+refutation or split emitter is introduced later, add a reachable `.malformed`
+canary at that new boundary.
+
+## Blockers
+
+None. A refutation or multi-node `.malformed` canary was not added because no
+ordinary importer can construct either shape: `RuntimeEmit` exposes no refute
+or split wrapper and all `Checked` constructors are private.

--- a/progress/20260822T102321Z_typed-runtime-public-audit.md
+++ b/progress/20260822T102321Z_typed-runtime-public-audit.md
@@ -1,0 +1,43 @@
+# Typed runtime public tactic audit
+
+## Accomplished
+
+- Stacked the repeated-slot scheduler, built-in `RuntimeRule`, and
+  `RuntimeTerminal` commits on current `origin/main` in an isolated worktree.
+- Resolved the umbrella, SPEC, and Lake target overlap by retaining both the
+  runtime-rule and runtime-terminal layers.
+- Audited the public tactic from reification through proof installation and
+  checked the typed controller/target/replay route against the existing
+  experimental proof-emission design.
+- Built `RuntimeRule`, `RuntimeTerminal`, and both conformance targets from a
+  fresh dependency checkout; all 8,712 transitive jobs passed.
+
+## Current frontier
+
+The forward controller and exact target terminal are sufficient for the
+current public arithmetic tactic without a split adapter. The remaining
+blocker is proof syntax: `RuntimeTerminal.Checked.replayWithin` returns a
+compiled `Proof.Evidence` value, while a tactic must install a `Lean.Expr`.
+No supported quotation maps the sealed runtime bundle and package schemas to
+a transparent replay expression. The current tactic instead reconstructs an
+independent arithmetic theorem expression, which cannot be retained under the
+requested load-bearing typed path.
+
+## Next step
+
+Promote the narrow root-only portion of `Experiment.ProofEmitter` and
+`Experiment.ProofRegistry`: package-local emitter handles paired exactly with
+the runtime proof schema keys, transparent fact/instance/equality/transport
+composition over the plain chronology extracted from a sealed checked token,
+and a transactional Meta boundary returning an exactly checked Evidence
+expression. Then the tactic can eliminate that expression with
+`Frontend.closeSources` and use the existing endpoint closures.
+
+## Blockers
+
+- Runtime proof values contain erased proposition proofs and cannot be turned
+  into syntax by `ToExpr`.
+- `RuntimeProof.Registry` contains executable formats and runtime theorem
+  callbacks but no elaborator emitter handles or transparent quotation API.
+- General split emission remains out of scope; the public forward route only
+  needs a one-node target-terminal tree.

--- a/progress/20260822T110711Z_runtime-emit-bridge.md
+++ b/progress/20260822T110711Z_runtime-emit-bridge.md
@@ -1,0 +1,38 @@
+# Typed runtime expression bridge
+
+## Accomplished
+
+- Added a transparent resolver/replay view whose existing sealed `Proof.Registry`
+  wrappers preserve the prior compiled API.
+- Added the production root-target `RuntimeEmit` bridge with jointly assembled
+  executable, theorem, and package-owned emitter registries; sealed lineage
+  tokens; plain-data quotation for every runtime event role; exact Evidence
+  emission; full Meta rollback; and explicit structural/syntax resources.
+- Added the paired twelve-schema built-in arithmetic emitter package and unified
+  `Rule.Runtime` convenience builder.
+- Added conformance proving all twelve arithmetic schemas, repeated input slots,
+  and the mixed instance/equality/fact/transport `sin (-x)` chronology are
+  load-bearing, together with registry, mutation, hygiene, resource, and seal
+  refusals.
+- Documented the supported root-target boundary, unsupported refutation/split
+  emission, resource behavior, and asymptotic costs.
+- Verified the focused emitter conformance, `HexIntervalMathlib`, and the full
+  9,635-job `HexConformance` graph, plus DAG/unit, copyright, line-count,
+  trust-surface, and whitespace gates.
+
+## Current frontier
+
+The production bridge returns an exactly checked `Proof.Evidence` expression
+from a sealed root-target runtime lineage. Public tactic integration can now
+construct the unified built-in registry and project the returned evidence proof.
+
+## Next step
+
+Replace the public tactic's flat proof-expression route with the typed runtime
+controller, target settlement, `RuntimeEmit`, and final evidence projection.
+
+## Blockers
+
+- General split emission remains blocked by the documented child equality-arena
+  mismatch.
+- Refutation expression emission is deliberately outside this root-target API.

--- a/progress/20260824T025950Z_runtime-expression-bridge.md
+++ b/progress/20260824T025950Z_runtime-expression-bridge.md
@@ -1,0 +1,38 @@
+# Runtime expression bridge
+
+## Accomplished
+
+- Added a sealed `RuntimeEmit.Emitted` result and
+  `Checked.emitResultWithin`, which return the exact quoted `Proof.Input`
+  expression with its correlated Evidence expression from one saved-state
+  transaction. Both expressions receive independent size and exact-type checks;
+  `Checked.emitWithin` remains the evidence-only compatibility projection.
+- Added transparent frontend helpers for projecting a successful checked
+  `Model` and converting finite source-list membership proofs into
+  `SourcesContain`.
+- Extended focused frontend and runtime-emitter conformance with private
+  constructor, exact input/evidence correlation, changed-input refusal,
+  model/source projection, rollback, exact resource one-under, and guarded
+  ordinary-axiom checks.
+- Updated the current library contract and verified the focused conformance
+  targets, dependency DAG and unit test, published trust surface, copyright
+  headers, line limits, and clean diff formatting.
+
+## Current frontier
+
+The expression-level bridge needed by a typed-runtime public tactic is now
+available. The public tactic itself is deliberately unchanged in this branch.
+
+## Next step
+
+Route `HexIntervalMathlib.Tactic` through the checked frontend model, typed
+runtime rule/controller and target-terminal lineage, then install only the
+pair returned by `RuntimeEmit.Checked.emitResultWithin`, correlating its input
+and evidence with the current facts and goal before assignment.
+
+## Blockers
+
+None in the expression bridge. Its input remains the exact runtime-admitted
+`Proof.Input`, so the tactic integration must quote the same source valuation
+and use the new frontend membership conversion; it cannot substitute a
+separately reconstructed input or Evidence claim.

--- a/progress/20260824T030521Z_runtime-emitted-construction-guards.md
+++ b/progress/20260824T030521Z_runtime-emitted-construction-guards.md
@@ -1,0 +1,22 @@
+# Runtime emitted construction guards
+
+## Accomplished
+
+- Extended `RuntimeEmitConformance` with exact guarded diagnostics rejecting
+  direct record construction, angle-bracket construction, and record update of
+  `RuntimeEmit.Emitted` from caller-owned `Expr` values.
+- Rebuilt `HexIntervalMathlib.RuntimeEmitConformance` successfully and checked
+  diff formatting.
+
+## Current frontier
+
+The sealed expression result now has conformance coverage for every ordinary
+structure-construction spelling used by the terminal guards.
+
+## Next step
+
+Integrate the committed expression bridge into the public tactic stack.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -940,5 +940,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "b6feee43b834c71a5531fd02fb527756bd4a7a3d",
     "reason": "Combines current main's build-only verification, conformance, fixture, benchmark, and truncated-series registrations with the proof-side HexIntervalMathlib.RuntimeRuleConformance registration; none enters hexbz_factor_service or changes a factorization runtime library, executable definition, or build flag."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "d7a6b7f5c4576d3435ffa5f39cb8bee459abd555",
+    "reason": "Combines current main's build-only registrations with the proof-side HexIntervalMathlib.RuntimeRuleConformance and RuntimeEmitConformance registrations; none enters hexbz_factor_service or changes a factorization runtime library, executable definition, or build flag."
   }
 ]


### PR DESCRIPTION
## Summary

- add a sealed typed RuntimeEmit registry and exact input/evidence correlation
- bridge retained runtime expressions through checked lineage into proof emission
- harden private construction, Prop rejection, rollback, and wrong-quoter canaries

## Validation

- lake build HexIntervalMathlib.RuntimeEmitConformance (8811 jobs)
- factor sweep freshness guard
- published trust-surface guard (503 Lean files)
- copyright, line-count, dependency-DAG, unit, and diff checks

RuntimeEmit and the exact-expression bridge are intentionally shipped atomically: the emitted claim pins both the original input expression and checked runtime evidence.