### PR TITLE
Complete HexPolyZGcd through Phase 7

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -34,6 +34,7 @@ import HexManual.Chapters.FactorTactics
 -- Unreleased libraries (dependency order).
 import HexManual.Chapters.HexModular
 import HexManual.Chapters.HexResultant
+import HexManual.Chapters.HexPolyZGcd
 import HexManual.Chapters.HexSparsePoly
 import HexManual.Chapters.HexRCF
 import HexManual.Chapters.HexNumberField
@@ -153,6 +154,8 @@ here to keep the reference chapters above focused on the released libraries.
 {include 2 HexManual.Chapters.HexModular}
 
 {include 2 HexManual.Chapters.HexResultant}
+
+{include 2 HexManual.Chapters.HexPolyZGcd}
 
 {include 2 HexManual.Chapters.HexRCF}
 

--- a/HexManual/Chapters/HexPolyZGcd.lean
+++ b/HexManual/Chapters/HexPolyZGcd.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexPolyZGcd
+import HexPolyZGcdMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexPolyZGcd: checked integer-polynomial gcds" =>
+%%%
+tag := "hex-poly-z-gcd"
+%%%
+
+# Introduction
+%%%
+tag := "hex-poly-z-gcd-intro"
+%%%
+
+`HexPolyZGcd` computes greatest common divisors in `ℤ[x]` together with
+exact cofactors and replayable coprimality evidence. Its fast routes use
+modular images, heuristic reconstruction, and subresultant chains. Every
+route passes through the same small checker before its answer becomes public.
+
+The executable library is Mathlib-free. It builds on `HexPolyZ`,
+`HexModular`, and `HexResultant`, and it supplies the square-free
+decomposition used by integer-polynomial factorization.
+
+# Certificates and exact division
+%%%
+tag := "hex-poly-z-gcd-certificates"
+%%%
+
+{docstring Hex.ZPoly.CoprimeWitness}
+
+{docstring Hex.ZPoly.GcdCert}
+
+{docstring Hex.ZPoly.checkGcd}
+
+{docstring Hex.ZPoly.checkGcd_sound}
+
+The checker verifies two exact product identities, the normalization
+convention, coprime cofactor contents, and one modular or integral Bezout
+witness. Candidate production is separate from certificate replay.
+
+{docstring Hex.ZPoly.divExact?}
+
+{docstring Hex.ZPoly.divExact?_product}
+
+# Gcd operations
+%%%
+tag := "hex-poly-z-gcd-operations"
+%%%
+
+{docstring Hex.ZPoly.gcdCert}
+
+{docstring Hex.ZPoly.gcd}
+
+{docstring Hex.ZPoly.cofactors}
+
+{docstring Hex.ZPoly.gcdList}
+
+{docstring Hex.ZPoly.lcm}
+
+The usual divisibility laws hold for the checked result, including the
+greatestness direction that downstream factorization algorithms need.
+
+{docstring Hex.ZPoly.gcd_dvd_left}
+
+{docstring Hex.ZPoly.gcd_dvd_right}
+
+{docstring Hex.ZPoly.dvd_gcd}
+
+## Worked example
+%%%
+tag := "hex-poly-z-gcd-worked"
+%%%
+
+```lean
+open Hex
+
+namespace HexPolyZGcdChapter
+
+def x1 : ZPoly := DensePoly.ofList [1, 1]
+def x2 : ZPoly := DensePoly.ofList [2, 1]
+def left : ZPoly := x1 * x1 * x2
+def right : ZPoly := x1 * x2 * x2
+
+#guard ZPoly.gcd left right == x1 * x2
+
+end HexPolyZGcdChapter
+```
+
+# Fast square-free decomposition
+%%%
+tag := "hex-poly-z-gcd-square-free"
+%%%
+
+{docstring Hex.ZPoly.sqfDecomp}
+
+{docstring Hex.ZPoly.sqfDecomp_reassembly_signed}
+
+{docstring Hex.ZPoly.sqfDecomp_squareFreeCore}
+
+The implementation uses the checked integer gcd of a primitive polynomial
+and its derivative. Its proof compares the repeated factor with the rational
+reference decomposition, then cancels that factor from their signed
+reassembly laws.
+
+# The Mathlib correspondence
+%%%
+tag := "hex-poly-z-gcd-mathlib"
+%%%
+
+`HexPolyZGcdMathlib` transports the divisibility and maximality results
+through the ring equivalence from `ZPoly` to Mathlib's `Polynomial ℤ`.
+
+{docstring HexPolyZGcdMathlib.gcd_dvd_left}
+
+{docstring HexPolyZGcdMathlib.dvd_gcd}
+
+{docstring HexPolyZGcdMathlib.divExact?_eq_dvd}
+
+The exact-division correspondence records a nonzero-divisor condition.
+This distinguishes the executable operation, which rejects division by zero,
+from the proposition `0 ∣ 0`, which is true.

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -579,6 +579,11 @@ private theorem rat_scale_size_of_ne_zero {u : Rat} (hu : u ≠ 0) (p : DensePol
         exact hscaled_zero
       exact (Rat.mul_eq_zero.mp hmul_zero).resolve_left hu
 
+/-- Scaling a rational polynomial by a nonzero scalar preserves its size. -/
+theorem rat_size_scale {u : Rat} (hu : u ≠ 0) (p : DensePoly Rat) :
+    (DensePoly.scale u p).size = p.size :=
+  rat_scale_size_of_ne_zero hu p
+
 /-- `rat_scale_mulCoeffStep`: scaling the factors by `u` and `v` pulls the
 `u * v` factor out through one `mulCoeffStep` term of the coefficient
 convolution. -/
@@ -1087,6 +1092,22 @@ private theorem rat_product_size_gt_top
   rcases Nat.lt_or_ge (f.size - 1 + (g.size - 1)) (f * g).size with hlt | hle
   · exact hlt
   · exact False.elim (hcoeff_ne (DensePoly.coeff_eq_zero_of_size_le (f * g) hle))
+
+/-- The size of a product of nonzero rational polynomials is one less than
+the sum of their sizes. -/
+theorem rat_size_mul (f g : DensePoly Rat) (hf : f ≠ 0) (hg : g ≠ 0) :
+    (f * g).size = f.size + g.size - 1 := by
+  have hfPos : 0 < f.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hf (rat_eq_zero_of_size_zero f hzero)
+  have hgPos : 0 < g.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hg (rat_eq_zero_of_size_zero g hzero)
+  have hlower := rat_product_size_gt_top f g hfPos hgPos
+  have hupper := DensePoly.size_mul_le f g
+  omega
 
 /-- A nonzero rational polynomial divisor has size at most the size of the
 nonzero polynomial it divides. -/

--- a/HexPolyZGcd/Brown.lean
+++ b/HexPolyZGcd/Brown.lean
@@ -268,6 +268,112 @@ def brownCert? (f h : ZPoly) : Option GcdCert :=
         let nextStart := 2 ^ 31 - 1
         brownBatches f h (budget - brownBundledSupply.size) nextStart state
 
+/-- A certificate returned by one Brown supply traversal has passed the
+shared candidate checker. -/
+private theorem brownLoop_checks (f h : ZPoly)
+    (supply : Array ZMod64.Prime) (index fuel : Nat)
+    (state : Option BrownState) {cert : GcdCert}
+    (hfound : brownLoop f h supply index fuel state = .found cert) :
+    checkGcd f h cert = true := by
+  unfold brownLoop at hfound
+  by_cases hfuel : fuel = 0
+  · rw [if_pos hfuel] at hfound
+    contradiction
+  · rw [if_neg hfuel] at hfound
+    by_cases hi : index < supply.size
+    · rw [dif_pos hi] at hfound
+      dsimp only at hfound
+      generalize hoffer : brownOffer f h state supply[index] = offer at hfound
+      cases offer with
+      | bad =>
+          exact brownLoop_checks f h supply (index + 1) (fuel - 1) state hfound
+      | unlucky =>
+          exact brownLoop_checks f h supply (index + 1) (fuel - 1) state hfound
+      | restarted next =>
+          simp only at hfound
+          generalize hcand : checkedCandidate? f h (next.candidate f h) =
+            candidate? at hfound
+          cases candidate? with
+          | some candidate =>
+              cases hfound
+              exact checkedCandidate?_checks hcand
+          | none =>
+              exact brownLoop_checks f h supply (index + 1) (fuel - 1)
+                (some next) hfound
+      | accumulated next =>
+          simp only at hfound
+          generalize hcand : checkedCandidate? f h (next.candidate f h) =
+            candidate? at hfound
+          cases candidate? with
+          | some candidate =>
+              cases hfound
+              exact checkedCandidate?_checks hcand
+          | none =>
+              exact brownLoop_checks f h supply (index + 1) (fuel - 1)
+                (some next) hfound
+    · rw [dif_neg hi] at hfound
+      contradiction
+termination_by fuel
+decreasing_by all_goals omega
+
+/-- A certificate returned by the dynamically generated Brown batches has
+passed the shared checker. -/
+private theorem brownBatches_checks (f h : ZPoly) (remaining start : Nat)
+    (state : Option BrownState) {cert : GcdCert}
+    (hcert : brownBatches f h remaining start state = some cert) :
+    checkGcd f h cert = true := by
+  unfold brownBatches at hcert
+  by_cases hremaining : remaining = 0
+  · rw [if_pos hremaining] at hcert
+    contradiction
+  · rw [if_neg hremaining] at hcert
+    dsimp only at hcert
+    let supply := (ZMod64.primesBelow start (min brownBatchSize remaining)).filter
+      (fun p => 2 ^ 30 < p.m)
+    change (match brownLoop f h supply 0 supply.size state with
+      | .found found => some found
+      | .pending next =>
+          brownBatches f h (remaining - min brownBatchSize remaining)
+            (supply.back?.map (fun p => p.m - 1) |>.getD 0) next) =
+        some cert at hcert
+    generalize hloop : brownLoop f h supply 0 supply.size state = progress at hcert
+    cases progress with
+    | found found =>
+        cases hcert
+        exact brownLoop_checks f h supply 0 supply.size state hloop
+    | pending next =>
+        exact brownBatches_checks f h (remaining - min brownBatchSize remaining)
+          (supply.back?.map (fun p => p.m - 1) |>.getD 0) next hcert
+termination_by remaining
+decreasing_by
+  have hcount : 0 < min brownBatchSize remaining := by
+    simp [brownBatchSize]
+    omega
+  exact Nat.sub_lt (Nat.zero_lt_of_ne_zero hremaining) hcount
+
+/-- Every certificate returned by Brown reconstruction has passed the full
+checker. -/
+theorem brownCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : brownCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold brownCert? at hcert
+  generalize hloop : brownLoop f h brownBundledSupply 0
+      brownBundledSupply.size none = progress at hcert
+  cases progress with
+  | found found =>
+      cases hcert
+      exact brownLoop_checks f h brownBundledSupply 0
+        brownBundledSupply.size none hloop
+  | pending state =>
+      dsimp only at hcert
+      by_cases hbudget : brownPrimeBudget f h ≤ brownBundledSupply.size
+      · rw [if_pos hbudget] at hcert
+        contradiction
+      · rw [if_neg hbudget] at hcert
+        exact brownBatches_checks f h
+          (brownPrimeBudget f h - brownBundledSupply.size) (2 ^ 31 - 1)
+          state hcert
+
 /-! Route-level executable pins for the three easy-to-miss Brown rules. -/
 
 -- Every small witness probe is unlucky when the constant offset is the

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -78,6 +78,142 @@ def mulEqPacked (p q target : ZPoly) : Bool :=
           constPack b bias slots ==
         packAux b (fun i => target.coeff i + bias) 0 slots)
 
+/-- Packing a target with the Kronecker bias is the same integer that the
+ordinary Kronecker product kernel would unpack for `target * 1`. -/
+private theorem packTarget (target : ZPoly) (b slots : Nat)
+    (hsize : target.size ≤ slots) :
+    let bias : Int := ((2 ^ (b - 1) : Nat) : Int)
+    packAux b (fun i => target.coeff i + bias) 0 slots =
+      packAux b target.coeff 0 target.size *
+          packAux b (1 : ZPoly).coeff 0 (1 : ZPoly).size +
+        constPack b bias slots := by
+  dsimp only
+  rw [packAux_eq, packAux_eq, packAux_eq, constPack_eq]
+  simp only [Nat.zero_add]
+  rw [packSpec_add_fun, packSpec_eq_eval b target slots hsize,
+    packSpec_eq_eval b target target.size (Nat.le_refl _),
+    packSpec_eq_eval b (1 : ZPoly) (1 : ZPoly).size (Nat.le_refl _)]
+  have hone : DensePoly.eval (1 : ZPoly) ((2 : Int) ^ b) = 1 := by
+    change DensePoly.eval (DensePoly.C (1 : Int)) ((2 : Int) ^ b) = 1
+    exact DensePoly.eval_C_semiring 1 ((2 : Int) ^ b)
+  rw [hone, Int.mul_one]
+
+/-- A successful packed multiplication comparison is an exact polynomial
+identity. -/
+theorem mulEqPacked_sound {p q target : ZPoly}
+    (hcheck : mulEqPacked p q target = true) :
+    p * q = target := by
+  unfold mulEqPacked at hcheck
+  by_cases hz : p.isZero || q.isZero
+  · rw [if_pos hz] at hcheck
+    have htarget : target = 0 := by
+      simpa [beq_iff_eq] using hcheck
+    have hz' : p.isZero = true ∨ q.isZero = true := by
+      simpa only [Bool.or_eq_true] using hz
+    rcases hz' with hp | hq
+    · have hp0 : p = 0 :=
+        (DensePoly.size_eq_zero_iff p).mp ((DensePoly.isZero_eq_true_iff p).mp hp)
+      rw [hp0, htarget]
+      exact DensePoly.zero_mul q
+    · have hq0 : q = 0 :=
+        (DensePoly.size_eq_zero_iff q).mp ((DensePoly.isZero_eq_true_iff q).mp hq)
+      rw [hq0, htarget, DensePoly.mul_comm_poly]
+      exact DensePoly.zero_mul p
+  · rw [if_neg hz] at hcheck
+    dsimp only at hcheck
+    have hparts :
+        target.size ≤ p.size + q.size - 1 ∧
+          packAux
+                (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                    ceilLog2 (min p.size q.size) + 1)
+                p.coeff 0 p.size *
+              packAux
+                (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                    ceilLog2 (min p.size q.size) + 1)
+                q.coeff 0 q.size +
+              constPack
+                (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                    ceilLog2 (min p.size q.size) + 1)
+                (Int.ofNat
+                  (2 ^ (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                    ceilLog2 (min p.size q.size) + 1 - 1)))
+                (p.size + q.size - 1) =
+            packAux
+              (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                  ceilLog2 (min p.size q.size) + 1)
+              (fun i => target.coeff i +
+                Int.ofNat
+                  (2 ^ (2 * bitLen (max (max (maxAbs p) (maxAbs q)) (maxAbs target)) +
+                    ceilLog2 (min p.size q.size) + 1 - 1)))
+              0 (p.size + q.size - 1) := by
+      simpa [Bool.and_eq_true, beq_iff_eq] using hcheck
+    let A := max (max (maxAbs p) (maxAbs q)) (maxAbs target)
+    let width := bitLen A
+    let b := 2 * width + ceilLog2 (min p.size q.size) + 1
+    let slots := p.size + q.size - 1
+    have hsize : target.size ≤ slots := by
+      simpa [slots] using hparts.1
+    have hpack :
+        packAux b p.coeff 0 p.size * packAux b q.coeff 0 q.size +
+            constPack b (((2 ^ (b - 1) : Nat) : Int)) slots =
+          packAux b (fun i => target.coeff i + ((2 ^ (b - 1) : Nat) : Int)) 0 slots := by
+      simpa [A, width, b, slots] using hparts.2
+    have hb : 0 < b := by
+      simp only [b]
+      omega
+    have hpBound : ∀ i, (p.coeff i).natAbs ≤ A := fun i =>
+      Nat.le_trans (natAbs_coeff_le_maxAbs p i)
+        (Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_left _ _))
+    have hqBound : ∀ i, (q.coeff i).natAbs ≤ A := fun i =>
+      Nat.le_trans (natAbs_coeff_le_maxAbs q i)
+        (Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_left _ _))
+    have hproductBudget : ∀ n, ((p * q).coeff n).natAbs < 2 ^ (b - 1) := by
+      intro n
+      have hle := natAbs_coeff_mul_le_min p q A hpBound hqBound n
+      have hpow : (2 : Nat) ^ (b - 1) =
+          2 ^ ceilLog2 (min p.size q.size) * (2 ^ width * 2 ^ width) := by
+        rw [show b - 1 = ceilLog2 (min p.size q.size) + (width + width) by
+          simp only [b]
+          omega, Nat.pow_add, Nat.pow_add]
+      have hA : A < 2 ^ width := by
+        simpa only [width] using lt_two_pow_bitLen A
+      have hxpos : 0 < 2 ^ width := Nat.two_pow_pos _
+      have haa : A * A < 2 ^ width * 2 ^ width := by
+        have h1 : A * A ≤ A * 2 ^ width :=
+          Nat.mul_le_mul_left _ (Nat.le_of_lt hA)
+        have h2 : A * 2 ^ width < 2 ^ width * 2 ^ width :=
+          (Nat.mul_lt_mul_right hxpos).mpr hA
+        omega
+      have hMpos : 0 < 2 ^ ceilLog2 (min p.size q.size) := Nat.two_pow_pos _
+      have h3 : min p.size q.size * (A * A) ≤
+          2 ^ ceilLog2 (min p.size q.size) * (A * A) :=
+        Nat.mul_le_mul_right _ (le_two_pow_ceilLog2 _)
+      have h4 : 2 ^ ceilLog2 (min p.size q.size) * (A * A) <
+          2 ^ ceilLog2 (min p.size q.size) * (2 ^ width * 2 ^ width) :=
+        (Nat.mul_lt_mul_left hMpos).mpr haa
+      omega
+    have htargetBudget : ∀ n, (target.coeff n).natAbs < 2 ^ (b - 1) := by
+      intro n
+      have hcoeff : (target.coeff n).natAbs ≤ A :=
+        Nat.le_trans (natAbs_coeff_le_maxAbs target n) (Nat.le_max_right _ _)
+      have hA : A < 2 ^ width := by
+        simpa only [width] using lt_two_pow_bitLen A
+      have hexp : width ≤ b - 1 := by
+        simp only [b]
+        omega
+      exact Nat.lt_of_le_of_lt hcoeff <|
+        Nat.lt_of_lt_of_le hA (Nat.pow_le_pow_right (by decide : 0 < 2) hexp)
+    have hproduct := kronecker_identity p q b slots hb
+      (by simpa only [slots] using DensePoly.size_mul_le p q) hproductBudget
+    have htarget := kronecker_identity target (1 : ZPoly) b slots hb
+      (by simpa only [DensePoly.mul_one_right_poly] using hsize)
+      (by
+        intro n
+        simpa only [DensePoly.mul_one_right_poly] using htargetBudget n)
+    rw [hpack, packTarget target b slots hsize] at hproduct
+    rw [DensePoly.mul_one_right_poly] at htarget
+    exact hproduct.symm.trans htarget
+
 /-- Replay the coprimality half of a gcd certificate. -/
 @[expose]
 def checkCoprime (f h : ZPoly) : CoprimeWitness → Bool

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -156,9 +156,13 @@ inductive CoprimeWitness
 
 /-- A gcd candidate, its two exact cofactors, and checked coprimality data. -/
 structure GcdCert where
+  /-- The proposed normalized greatest common divisor. -/
   gcd : ZPoly
+  /-- The exact cofactor of the left input. -/
   cofL : ZPoly
+  /-- The exact cofactor of the right input. -/
   cofR : ZPoly
+  /-- Replayable evidence that the two cofactors have no common nonunit. -/
   coprime : CoprimeWitness
 
 /-- The normalization convention for integer gcds.  Zero is admitted for the

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -326,6 +326,70 @@ theorem mulEqPacked_sound {p q target : ZPoly}
     rw [DensePoly.mul_one_right_poly] at htarget
     exact hproduct.symm.trans htarget
 
+/-- Every exact polynomial product passes the packed multiplication checker. -/
+theorem mulEqPacked_complete {p q target : ZPoly}
+    (hproduct : p * q = target) :
+    mulEqPacked p q target = true := by
+  unfold mulEqPacked
+  by_cases hz : p.isZero || q.isZero
+  · rw [if_pos hz]
+    rw [beq_iff_eq]
+    rw [← hproduct]
+    have hz' : p.isZero = true ∨ q.isZero = true := by
+      simpa only [Bool.or_eq_true] using hz
+    rcases hz' with hp | hq
+    · have hp0 : p = 0 :=
+        (DensePoly.size_eq_zero_iff p).mp
+          ((DensePoly.isZero_eq_true_iff p).mp hp)
+      rw [hp0]
+      exact DensePoly.zero_mul q
+    · have hq0 : q = 0 :=
+        (DensePoly.size_eq_zero_iff q).mp
+          ((DensePoly.isZero_eq_true_iff q).mp hq)
+      rw [hq0, DensePoly.mul_comm_poly]
+      exact DensePoly.zero_mul p
+  · rw [if_neg hz]
+    dsimp only
+    rw [Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+    let A := max (max (maxAbs p) (maxAbs q)) (maxAbs target)
+    let width := bitLen A
+    let b := 2 * width + ceilLog2 (min p.size q.size) + 1
+    let slots := p.size + q.size - 1
+    have hsize : target.size ≤ slots := by
+      rw [← hproduct]
+      simpa only [slots] using DensePoly.size_mul_le p q
+    refine ⟨by simpa only [slots] using hsize, ?_⟩
+    have hpPack :
+        packAux b p.coeff 0 p.size = DensePoly.eval p ((2 : Int) ^ b) := by
+      rw [packAux_eq]
+      simpa using packSpec_eq_eval b p p.size (Nat.le_refl _)
+    have hqPack :
+        packAux b q.coeff 0 q.size = DensePoly.eval q ((2 : Int) ^ b) := by
+      rw [packAux_eq]
+      simpa using packSpec_eq_eval b q q.size (Nat.le_refl _)
+    have htPack :
+        packAux b target.coeff 0 target.size =
+          DensePoly.eval target ((2 : Int) ^ b) := by
+      rw [packAux_eq]
+      simpa using packSpec_eq_eval b target target.size (Nat.le_refl _)
+    have hOnePack :
+        packAux b (1 : ZPoly).coeff 0 (1 : ZPoly).size = 1 := by
+      rw [packAux_eq]
+      simp only [Nat.zero_add]
+      have heval := packSpec_eq_eval b (1 : ZPoly) (1 : ZPoly).size
+        (Nat.le_refl _)
+      rw [heval]
+      exact DensePoly.eval_C_semiring 1 ((2 : Int) ^ b)
+    have hpacked :
+        packAux b p.coeff 0 p.size * packAux b q.coeff 0 q.size +
+            constPack b (((2 ^ (b - 1) : Nat) : Int)) slots =
+          packAux b (fun i => target.coeff i +
+            ((2 ^ (b - 1) : Nat) : Int)) 0 slots := by
+      rw [packTarget target b slots hsize]
+      rw [hpPack, hqPack, htPack, hOnePack, Int.mul_one,
+        ← DensePoly.eval_mul_commring, hproduct]
+    simpa only [A, width, b, slots, Int.ofNat_eq_natCast] using hpacked
+
 /-- A common divisor of two polynomials with coprime contents is primitive. -/
 private theorem primitiveCommon {f h d : ZPoly}
     (hcontent : Int.gcd (content f) (content h) = 1)

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -680,6 +680,7 @@ def checkGcd (f h : ZPoly) (c : GcdCert) : Bool :=
 
 /-- The cofactor identities together with absence of a common nonunit
 cofactor. -/
+@[expose]
 def CoprimeCofactors (f h g : ZPoly) : Prop :=
   ∃ f' h', f = g * f' ∧ h = g * h' ∧
     ∀ d : ZPoly, d ∣ f' → d ∣ h' → IsUnit d

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -34,6 +34,118 @@ def reduceModP (p : Nat) [ZMod64.Bounds p] (f : ZPoly) : FpPoly p :=
   DensePoly.ofList <|
     (List.range f.size).map (fun i => ZMod64.intCast p (f.coeff i))
 
+/-- Coefficientwise specification of reduction modulo `p`. -/
+@[simp]
+theorem coeff_reduceModP (p : Nat) [ZMod64.Bounds p] (f : ZPoly) (i : Nat) :
+    (reduceModP p f).coeff i = ZMod64.intCast p (f.coeff i) := by
+  unfold reduceModP
+  rw [DensePoly.coeff_ofList]
+  by_cases hi : i < f.size
+  · simp [hi]
+  · have hcoeff : f.coeff i = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
+    rw [List.getD_eq_getElem?_getD,
+      List.getElem?_eq_none (by simp; omega), hcoeff]
+    change (0 : ZMod64 p) = ZMod64.intCast p 0
+    rfl
+
+/-- Reduction can only trim high zero residues. -/
+theorem size_reduceModP_le (p : Nat) [ZMod64.Bounds p] (f : ZPoly) :
+    (reduceModP p f).size ≤ f.size := by
+  unfold reduceModP
+  exact Nat.le_trans (DensePoly.size_ofList_le _)
+    (by simp)
+
+private theorem intCast_add (p : Nat) [ZMod64.Bounds p] (a b : Int) :
+    ZMod64.intCast p (a + b) = ZMod64.intCast p a + ZMod64.intCast p b := by
+  exact Lean.Grind.Ring.intCast_add a b
+
+private theorem intCast_mul (p : Nat) [ZMod64.Bounds p] (a b : Int) :
+    ZMod64.intCast p (a * b) = ZMod64.intCast p a * ZMod64.intCast p b := by
+  exact Lean.Grind.Ring.intCast_mul a b
+
+private theorem intCast_diagonal (p : Nat) [ZMod64.Bounds p]
+    (f g : ZPoly) (n i : Nat) :
+    ZMod64.intCast p (DensePoly.diagonalMulCoeffTerm f g n i) =
+      DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i := by
+  unfold DensePoly.diagonalMulCoeffTerm
+  by_cases hn : n < i
+  · simp [hn]
+    rfl
+  · simp only [hn, ↓reduceIte, coeff_reduceModP]
+    exact intCast_mul p (f.coeff i) (g.coeff (n - i))
+
+private theorem intCast_foldDiagonal (p : Nat) [ZMod64.Bounds p]
+    (f g : ZPoly) (n : Nat) :
+    ∀ (xs : List Nat) (acc : Int),
+      ZMod64.intCast p
+          (xs.foldl (fun c i => c + DensePoly.diagonalMulCoeffTerm f g n i) acc) =
+        xs.foldl
+          (fun c i => c +
+            DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i)
+          (ZMod64.intCast p acc) := by
+  intro xs
+  induction xs with
+  | nil => intro acc; rfl
+  | cons i xs ih =>
+      intro acc
+      simp only [List.foldl_cons]
+      rw [ih, intCast_add, intCast_diagonal]
+
+private theorem foldDiagonal_extend (p : Nat) [ZMod64.Bounds p]
+    (f g : ZPoly) (n d : Nat) :
+    (List.range ((reduceModP p f).size + d)).foldl
+        (fun c i => c +
+          DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i) 0 =
+      (List.range (reduceModP p f).size).foldl
+        (fun c i => c +
+          DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i) 0 := by
+  induction d with
+  | zero => simp
+  | succ d ih =>
+      rw [Nat.add_succ, List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil, ih]
+      have hcoeff : (reduceModP p f).coeff ((reduceModP p f).size + d) = 0 :=
+        DensePoly.coeff_eq_zero_of_size_le _ (by omega)
+      by_cases hn : n < (reduceModP p f).size + d
+      · have hterm : DensePoly.diagonalMulCoeffTerm
+            (reduceModP p f) (reduceModP p g) n ((reduceModP p f).size + d) = 0 := by
+          unfold DensePoly.diagonalMulCoeffTerm
+          rw [if_pos hn]
+          rfl
+        rw [hterm]
+        exact Lean.Grind.Semiring.add_zero _
+      · have hterm : DensePoly.diagonalMulCoeffTerm
+            (reduceModP p f) (reduceModP p g) n ((reduceModP p f).size + d) = 0 := by
+          unfold DensePoly.diagonalMulCoeffTerm
+          rw [if_neg hn, hcoeff]
+          exact Lean.Grind.Semiring.zero_mul _
+        rw [hterm]
+        exact Lean.Grind.Semiring.add_zero _
+
+/-- Coefficientwise reduction is multiplicative. -/
+theorem reduceModP_mul (p : Nat) [ZMod64.Bounds p] (f g : ZPoly) :
+    reduceModP p (f * g) = reduceModP p f * reduceModP p g := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_reduceModP, DensePoly.coeff_mul, DensePoly.coeff_mul,
+    DensePoly.mulCoeffSum_eq_diagonal f g n, intCast_foldDiagonal]
+  have hzero : ZMod64.intCast p 0 = (0 : ZMod64 p) := rfl
+  rw [hzero]
+  have hle := size_reduceModP_le p f
+  have hsum : (reduceModP p f).size + (f.size - (reduceModP p f).size) = f.size := by
+    omega
+  calc
+    (List.range f.size).foldl
+          (fun c i => c +
+            DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i) 0 =
+        (List.range (reduceModP p f).size).foldl
+          (fun c i => c +
+            DensePoly.diagonalMulCoeffTerm (reduceModP p f) (reduceModP p g) n i) 0 := by
+      rw [← hsum, foldDiagonal_extend]
+    _ = DensePoly.mulCoeffSum (reduceModP p f) (reduceModP p g) n :=
+      (DensePoly.mulCoeffSum_eq_diagonal (reduceModP p f) (reduceModP p g) n).symm
+
 /-- Evidence that the two cofactors have no common nonunit factor. -/
 inductive CoprimeWitness
   /-- A degree-preserving reduction and a Bezout identity over a prime field. -/
@@ -214,6 +326,270 @@ theorem mulEqPacked_sound {p q target : ZPoly}
     rw [DensePoly.mul_one_right_poly] at htarget
     exact hproduct.symm.trans htarget
 
+/-- A common divisor of two polynomials with coprime contents is primitive. -/
+private theorem primitiveCommon {f h d : ZPoly}
+    (hcontent : Int.gcd (content f) (content h) = 1)
+    (hdf : d ∣ f) (hdh : d ∣ h) :
+    Primitive d := by
+  rcases hdf with ⟨a, ha⟩
+  rcases hdh with ⟨b, hb⟩
+  have hdcf : content d ∣ content f := by
+    refine ⟨content a, ?_⟩
+    rw [ha, content_mul]
+  have hdch : content d ∣ content h := by
+    refine ⟨content b, ?_⟩
+    rw [hb, content_mul]
+  rw [Int.gcd_eq_one_iff] at hcontent
+  have hdone : content d ∣ (1 : Int) := hcontent (content d) hdcf hdch
+  have hnat : DensePoly.contentNat d ∣ (1 : Nat) := by
+    apply Int.ofNat_dvd.mp
+    simpa [content, DensePoly.content] using hdone
+  show content d = 1
+  rw [content, DensePoly.content, Nat.eq_one_of_dvd_one hnat]
+  rfl
+
+/-- A primitive integer polynomial of size at most one is a unit. -/
+private theorem unitOfPrimitive {d : ZPoly}
+    (hprimitive : Primitive d) (hsize : d.size ≤ 1) :
+    IsUnit d := by
+  have hpos : 0 < d.size := by
+    rcases Nat.eq_zero_or_pos d.size with hzero | hpos
+    · have hdzero : d = 0 := (DensePoly.size_eq_zero_iff d).mp hzero
+      subst d
+      change content (0 : ZPoly) = 1 at hprimitive
+      have hczero : content (0 : ZPoly) = 0 := by rfl
+      rw [hczero] at hprimitive
+      omega
+    · exact hpos
+  have hsizeOne : d.size = 1 := by omega
+  have hdC : d = DensePoly.C (d.coeff 0) := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_C]
+    cases n with
+    | zero => simp
+    | succ n =>
+        rw [DensePoly.coeff_eq_zero_of_size_le d (by omega)]
+        rfl
+  have habsCast : ((d.coeff 0).natAbs : Int) = 1 := by
+    have hp := hprimitive
+    rw [hdC] at hp
+    simpa [Primitive, content] using hp
+  have habs : (d.coeff 0).natAbs = 1 := by
+    exact_mod_cast habsCast
+  rcases Int.natAbs_eq (d.coeff 0) with hc | hc
+  · left
+    rw [hdC, hc, habs]
+    rfl
+  · right
+    rw [hdC, hc, habs]
+    rfl
+
+/-- A primitive integer polynomial is nonzero. -/
+private theorem neZeroOfPrimitive {d : ZPoly} (hprimitive : Primitive d) :
+    d ≠ 0 := by
+  intro hzero
+  subst d
+  change content (0 : ZPoly) = 1 at hprimitive
+  have hczero : content (0 : ZPoly) = 0 := by rfl
+  rw [hczero] at hprimitive
+  omega
+
+/-- An exact nonzero constant Bezout combination forces every common divisor
+to have size at most one. -/
+private theorem sizeCommonConstant {f h d u v : ZPoly} {k : Int}
+    (hk : k ≠ 0) (hbez : u * f + v * h = DensePoly.C k)
+    (hprimitive : Primitive d) (hdf : d ∣ f) (hdh : d ∣ h) :
+    d.size ≤ 1 := by
+  rcases hdf with ⟨a, ha⟩
+  rcases hdh with ⟨b, hb⟩
+  have hu : u * (d * a) = d * (u * a) := by
+    calc
+      u * (d * a) = (u * d) * a := (DensePoly.mul_assoc_poly u d a).symm
+      _ = (d * u) * a := by rw [DensePoly.mul_comm_poly u d]
+      _ = d * (u * a) := DensePoly.mul_assoc_poly d u a
+  have hv : v * (d * b) = d * (v * b) := by
+    calc
+      v * (d * b) = (v * d) * b := (DensePoly.mul_assoc_poly v d b).symm
+      _ = (d * v) * b := by rw [DensePoly.mul_comm_poly v d]
+      _ = d * (v * b) := DensePoly.mul_assoc_poly d v b
+  have hdvd : d ∣ DensePoly.C k := by
+    refine ⟨u * a + v * b, ?_⟩
+    calc
+      DensePoly.C k = u * f + v * h := hbez.symm
+      _ = u * (d * a) + v * (d * b) := by rw [ha, hb]
+      _ = d * (u * a) + d * (v * b) := by rw [hu, hv]
+      _ = d * (u * a + v * b) := (DensePoly.mul_add_right_poly d (u * a) (v * b)).symm
+  have hCne : DensePoly.C k ≠ (0 : ZPoly) := by
+    intro hzero
+    have hcoeff := congrArg (fun p : ZPoly => p.coeff 0) hzero
+    rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
+    simp only [↓reduceIte] at hcoeff
+    exact hk hcoeff
+  exact Nat.le_trans
+    (size_le_of_dvd_nonzero (neZeroOfPrimitive hprimitive) hCne hdvd)
+    (DensePoly.size_C_le_one k)
+
+/-- A degree-preserving prime-field Bezout witness forces every primitive
+common divisor to have size at most one. -/
+private theorem sizeCommonModular
+    (prime : ZMod64.Prime)
+    (f h d : ZPoly) (alpha beta : @FpPoly prime.m prime.bounds)
+    (hfsize : (@reduceModP prime.m prime.bounds f).size = f.size)
+    (hhsize : (@reduceModP prime.m prime.bounds h).size = h.size)
+    (hbez : alpha * @reduceModP prime.m prime.bounds f +
+        beta * @reduceModP prime.m prime.bounds h = 1)
+    (hprimitive : Primitive d) (hdf : d ∣ f) (hdh : d ∣ h) :
+    d.size ≤ 1 := by
+  letI : ZMod64.Bounds prime.m := prime.bounds
+  letI : ZMod64.PrimeModulus prime.m := ZMod64.primeModulusOfPrime prime.prime
+  let fd := reduceModP prime.m f
+  let hd := reduceModP prime.m h
+  let dd := reduceModP prime.m d
+  have hbez' : alpha * fd + beta * hd = 1 := by
+    simpa only [fd, hd] using hbez
+  rcases hdf with ⟨a, ha⟩
+  rcases hdh with ⟨b, hb⟩
+  let ad := reduceModP prime.m a
+  let bd := reduceModP prime.m b
+  have hfa : fd = dd * ad := by
+    dsimp only [fd, dd, ad]
+    rw [ha, reduceModP_mul]
+  have hhb : hd = dd * bd := by
+    dsimp only [hd, dd, bd]
+    rw [hb, reduceModP_mul]
+  have halpha : alpha * (dd * ad) = dd * (alpha * ad) := by
+    calc
+      alpha * (dd * ad) = (alpha * dd) * ad :=
+        (DensePoly.mul_assoc_poly alpha dd ad).symm
+      _ = (dd * alpha) * ad :=
+        congrArg (fun x => x * ad) (DensePoly.mul_comm_poly alpha dd)
+      _ = dd * (alpha * ad) := DensePoly.mul_assoc_poly dd alpha ad
+  have hbeta : beta * (dd * bd) = dd * (beta * bd) := by
+    calc
+      beta * (dd * bd) = (beta * dd) * bd :=
+        (DensePoly.mul_assoc_poly beta dd bd).symm
+      _ = (dd * beta) * bd :=
+        congrArg (fun x => x * bd) (DensePoly.mul_comm_poly beta dd)
+      _ = dd * (beta * bd) := DensePoly.mul_assoc_poly dd beta bd
+  have hddvd : dd ∣ (1 : FpPoly prime.m) := by
+    refine ⟨alpha * ad + beta * bd, ?_⟩
+    calc
+      (1 : FpPoly prime.m) = alpha * fd + beta * hd := hbez'.symm
+      _ = alpha * (dd * ad) + beta * (dd * bd) := by rw [hfa, hhb]
+      _ = dd * (alpha * ad) + dd * (beta * bd) := by rw [halpha, hbeta]
+      _ = dd * (alpha * ad + beta * bd) :=
+        (DensePoly.mul_add_right_poly dd (alpha * ad) (beta * bd)).symm
+  rcases hddvd with ⟨e, he⟩
+  have hcoeffOne : (1 : ZMod64 prime.m) ≠ 0 :=
+    ZMod64.one_ne_zero_of_prime prime.prime
+  have honeSize : (1 : FpPoly prime.m).size = 1 :=
+    DensePoly.size_C_of_ne_zero hcoeffOne
+  have honeNe : (1 : FpPoly prime.m) ≠ 0 := by
+    intro hzero
+    have hsizeZero : (1 : FpPoly prime.m).size = 0 := by rw [hzero]; rfl
+    omega
+  have hddNe : dd ≠ 0 := by
+    intro hzero
+    apply honeNe
+    rw [he, hzero]
+    exact DensePoly.zero_mul e
+  have heNe : e ≠ 0 := by
+    intro hzero
+    apply honeNe
+    rw [he, hzero]
+    exact (DensePoly.mul_comm_poly dd 0).trans (DensePoly.zero_mul dd)
+  have hddSize : dd.size ≤ 1 := by
+    have hmul := FpPoly.size_mul_eq_add_sub_one dd e hddNe heNe
+    rw [← he] at hmul
+    have hddPos := FpPoly.size_pos_of_ne_zero hddNe
+    have hePos := FpPoly.size_pos_of_ne_zero heNe
+    omega
+  have hnonzero : fd ≠ 0 ∨ hd ≠ 0 := by
+    by_cases hfd : fd = 0
+    · right
+      intro hhd
+      rw [hfd, hhd] at hbez'
+      have ha0 : alpha * (0 : FpPoly prime.m) = 0 :=
+        (DensePoly.mul_comm_poly alpha 0).trans (DensePoly.zero_mul alpha)
+      have hb0 : beta * (0 : FpPoly prime.m) = 0 :=
+        (DensePoly.mul_comm_poly beta 0).trans (DensePoly.zero_mul beta)
+      have hsumZero : (0 : FpPoly prime.m) + 0 = 0 := DensePoly.zero_add 0
+      rw [ha0, hb0, hsumZero] at hbez'
+      exact honeNe hbez'.symm
+    · exact Or.inl hfd
+  rcases hnonzero with hfdNe | hhdNe
+  · have hfNe : f ≠ 0 := by
+      intro hfzero
+      have hfSizeZero : f.size = 0 := by rw [hfzero]; rfl
+      have hsizeZero : fd.size = 0 := by
+        dsimp only [fd]
+        exact hfsize.trans hfSizeZero
+      exact hfdNe ((DensePoly.size_eq_zero_iff fd).mp hsizeZero)
+    have haNe : a ≠ 0 := by
+      intro hazero
+      apply hfNe
+      rw [ha, hazero, DensePoly.mul_comm_poly]
+      exact DensePoly.zero_mul d
+    have hadNe : ad ≠ 0 := by
+      intro hadzero
+      apply hfdNe
+      rw [hfa, hadzero]
+      exact (DensePoly.mul_comm_poly dd 0).trans (DensePoly.zero_mul dd)
+    have himage := FpPoly.size_mul_eq_add_sub_one dd ad hddNe hadNe
+    rw [← hfa] at himage
+    have hfdSize : fd.size = f.size := by simpa only [fd] using hfsize
+    have hdPos : 0 < d.size := by
+      apply Nat.pos_of_ne_zero
+      intro hsizeZero
+      exact neZeroOfPrimitive hprimitive ((DensePoly.size_eq_zero_iff d).mp hsizeZero)
+    have haPos : 0 < a.size := by
+      apply Nat.pos_of_ne_zero
+      intro hsizeZero
+      exact haNe ((DensePoly.size_eq_zero_iff a).mp hsizeZero)
+    have hinteger := mul_size_eq_top_succ_of_nonzero d a hdPos haPos
+    rw [← ha] at hinteger
+    rw [hfdSize, hinteger] at himage
+    have hadSize := size_reduceModP_le prime.m a
+    dsimp only [ad] at himage hadSize
+    dsimp only [dd] at himage hddSize
+    omega
+  · have hhNe : h ≠ 0 := by
+      intro hhzero
+      have hhSizeZero : h.size = 0 := by rw [hhzero]; rfl
+      have hsizeZero : hd.size = 0 := by
+        dsimp only [hd]
+        exact hhsize.trans hhSizeZero
+      exact hhdNe ((DensePoly.size_eq_zero_iff hd).mp hsizeZero)
+    have hbNe : b ≠ 0 := by
+      intro hbzero
+      apply hhNe
+      rw [hb, hbzero, DensePoly.mul_comm_poly]
+      exact DensePoly.zero_mul d
+    have hbdNe : bd ≠ 0 := by
+      intro hbdzero
+      apply hhdNe
+      rw [hhb, hbdzero]
+      exact (DensePoly.mul_comm_poly dd 0).trans (DensePoly.zero_mul dd)
+    have himage := FpPoly.size_mul_eq_add_sub_one dd bd hddNe hbdNe
+    rw [← hhb] at himage
+    have hhdSize : hd.size = h.size := by simpa only [hd] using hhsize
+    have hdPos : 0 < d.size := by
+      apply Nat.pos_of_ne_zero
+      intro hsizeZero
+      exact neZeroOfPrimitive hprimitive ((DensePoly.size_eq_zero_iff d).mp hsizeZero)
+    have hbPos : 0 < b.size := by
+      apply Nat.pos_of_ne_zero
+      intro hsizeZero
+      exact hbNe ((DensePoly.size_eq_zero_iff b).mp hsizeZero)
+    have hinteger := mul_size_eq_top_succ_of_nonzero d b hdPos hbPos
+    rw [← hb] at hinteger
+    rw [hhdSize, hinteger] at himage
+    have hbdSize := size_reduceModP_le prime.m b
+    dsimp only [bd] at himage hbdSize
+    dsimp only [dd] at himage hddSize
+    omega
+
 /-- Replay the coprimality half of a gcd certificate. -/
 @[expose]
 def checkCoprime (f h : ZPoly) : CoprimeWitness → Bool
@@ -250,7 +626,42 @@ theorem checkGcd_sound {f h : ZPoly} {c : GcdCert}
     (hc : checkGcd f h c = true) :
     f = c.gcd * c.cofL ∧ h = c.gcd * c.cofR ∧
       ∀ d : ZPoly, d ∣ c.cofL → d ∣ c.cofR → IsUnit d := by
-  sorry
+  have hparts :
+      (((mulEqPacked c.gcd c.cofL f = true ∧
+          mulEqPacked c.gcd c.cofR h = true) ∧
+          NormalizedGcd c.gcd = true) ∧
+          Int.gcd (content c.cofL) (content c.cofR) = 1) ∧
+        checkCoprime c.cofL c.cofR c.coprime = true := by
+    simpa [checkGcd, Bool.and_eq_true, decide_eq_true_eq] using hc
+  refine ⟨(mulEqPacked_sound hparts.1.1.1.1).symm,
+    (mulEqPacked_sound hparts.1.1.1.2).symm, ?_⟩
+  intro d hdl hdr
+  have hprimitive := primitiveCommon hparts.1.2 hdl hdr
+  have hcop := hparts.2
+  cases hw : c.coprime with
+  | constant u v k =>
+      rw [hw] at hcop
+      have hconstant : k ≠ 0 ∧
+          u * c.cofL + v * c.cofR = DensePoly.C k := by
+        simpa [checkCoprime, Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+          using hcop
+      exact unitOfPrimitive hprimitive
+        (sizeCommonConstant hconstant.1 hconstant.2 hprimitive hdl hdr)
+  | modular prime alpha beta =>
+      rw [hw] at hcop
+      letI : ZMod64.Bounds prime.m := prime.bounds
+      letI : ZMod64.PrimeModulus prime.m :=
+        ZMod64.primeModulusOfPrime prime.prime
+      have hmodular :
+          ((reduceModP prime.m c.cofL).size = c.cofL.size ∧
+            (reduceModP prime.m c.cofR).size = c.cofR.size) ∧
+            alpha * reduceModP prime.m c.cofL +
+                beta * reduceModP prime.m c.cofR = 1 := by
+        simpa [checkCoprime, Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+          using hcop
+      exact unitOfPrimitive hprimitive <|
+        sizeCommonModular prime c.cofL c.cofR d alpha beta
+          hmodular.1.1 hmodular.1.2 hmodular.2 hprimitive hdl hdr
 
 /-- Checker soundness packaged in the public cofactor predicate. -/
 theorem coprimeCofactors_of_checkGcd {f h : ZPoly} {c : GcdCert}

--- a/HexPolyZGcd/Fast.lean
+++ b/HexPolyZGcd/Fast.lean
@@ -158,6 +158,51 @@ def checkedCandidate? (f h candidate : ZPoly) : Option GcdCert := do
   let cert : GcdCert := { gcd := candidate, cofL, cofR, coprime := witness }
   if checkGcd f h cert then some cert else none
 
+/-- Every certificate returned by the difference route passed the full
+checker. -/
+theorem differenceCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hc : differenceCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold differenceCert? at hc
+  simp only [bind, Option.bind] at hc
+  split at hc
+  · contradiction
+  · split at hc
+    · contradiction
+    · split at hc
+      · split at hc
+        · rename_i hcheck
+          cases hc
+          exact hcheck
+        · contradiction
+      · split at hc
+        · rename_i hcheck
+          cases hc
+          exact hcheck
+        · contradiction
+
+/-- Every arbitrary candidate exposed by the shared acceptance gate passed
+the full checker. -/
+theorem checkedCandidate?_checks {f h candidate : ZPoly} {cert : GcdCert}
+    (hc : checkedCandidate? f h candidate = some cert) :
+    checkGcd f h cert = true := by
+  unfold checkedCandidate? at hc
+  simp only [bind, Option.bind] at hc
+  split at hc
+  · contradiction
+  · generalize hw : candidateWitness
+        (DensePoly.divMod f candidate).1 (DensePoly.divMod h candidate).1 =
+      witness? at hc
+    cases witness? with
+    | none => simp at hc
+    | some witness =>
+        simp only at hc
+        split at hc
+        · rename_i hcheck
+          cases hc
+          exact hcheck
+        · contradiction
+
 /-- Every certificate returned by the coprime fast route was accepted by the
 full checker. -/
 theorem coprimeCert?_checks {f h : ZPoly} {cert : GcdCert}

--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -200,6 +200,31 @@ def rationalGcdCandidate (f h : ZPoly) : ZPoly :=
   let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
   normalizePrimitiveSign (DensePoly.scale commonContent primitive)
 
+/-- On a primitive left input, rational candidate construction is exactly the
+positive primitive representative of the rational gcd. -/
+theorem rationalGcdCandidate_of_primitive {f h : ZPoly} (hf : Primitive f) :
+    rationalGcdCandidate f h =
+      ratPolyPrimitivePart (DensePoly.gcd (toRatPoly f) (toRatPoly h)) := by
+  let primitive :=
+    ratPolyPrimitivePart (DensePoly.gcd (toRatPoly f) (toRatPoly h))
+  have hscaleOne : DensePoly.scale (1 : Int) primitive = primitive := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_scale_semiring, Int.one_mul]
+  unfold rationalGcdCandidate
+  rw [show Int.gcd (content f) (content h) = 1 by
+    rw [show content f = 1 from hf]
+    exact Nat.gcd_eq_left_iff_dvd.mpr (Nat.one_dvd _)]
+  change normalizePrimitiveSign (DensePoly.scale (1 : Int) primitive) = primitive
+  rw [hscaleOne]
+  unfold normalizePrimitiveSign
+  rw [if_neg (by
+    have hlead := leadingCoeff_ratPolyPrimitivePart_nonneg
+      (DensePoly.gcd (toRatPoly f) (toRatPoly h))
+    have hleadPrimitive : 0 ≤ DensePoly.leadingCoeff primitive := by
+      simpa only [primitive] using hlead
+    omega)]
+
 /-- A nontrivial input pair has a nonzero rational gcd. -/
 private theorem ratGcdNe {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
     DensePoly.gcd (toRatPoly f) (toRatPoly h) ≠ 0 := by
@@ -947,6 +972,14 @@ private theorem divModProduct {f g : ZPoly} (hg : g ≠ 0) (hdvd : g ∣ f) :
   rw [hquot]
   exact hq.symm
 
+/-- Long division by the nonzero rational candidate reconstructs the left
+input exactly. -/
+theorem rationalGcdCandidate_mul_quotient {f h : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0) :
+    rationalGcdCandidate f h *
+        (DensePoly.divMod f (rationalGcdCandidate f h)).1 = f :=
+  divModProduct (rationalGcdCandidate_ne_zero hnz) candidateDvdLeft
+
 /-- Deterministic rational fallback certificate.
 
 The cofactors are the concrete long-division quotients.  Their exactness is
@@ -1018,6 +1051,17 @@ theorem rationalGcdCert_checks (f h : ZPoly) :
       simpa only [g] using candidateNormalized hnz
     rw [hnorm]
     simp [hcontents, hcop]
+
+/-- The nondegenerate rational fallback stores the canonical rational gcd
+candidate in its gcd field. -/
+theorem rationalGcdCert_gcd {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    (rationalGcdCert f h).gcd = rationalGcdCandidate f h := by
+  unfold rationalGcdCert
+  rw [if_neg (by
+    intro hzero
+    rcases hnz with hf | hh
+    · exact hf hzero.1
+    · exact hh hzero.2)]
 
 /-- Scan the low coefficients for the exponent of the first nonzero term. -/
 private def xOrder.go (f : ZPoly) : Nat → Nat → Nat

--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -7,10 +7,12 @@ Authors: Kim Morrison
 module
 
 public meta import HexPolyZ.Kronecker
+public meta import HexPolyZ.Decomposition
 public meta import HexPolyZGcd.Brown
 public meta import HexPolyZGcd.Heu
 public meta import HexPolyZGcd.Prs
 public import HexPolyZ.Kronecker
+public import HexPolyZ.Decomposition
 public import HexPolyZGcd.Brown
 public import HexPolyZGcd.Heu
 public import HexPolyZGcd.Prs
@@ -31,6 +33,165 @@ namespace Hex
 
 namespace ZPoly
 
+/-- Vanishing integer content characterizes the zero polynomial. -/
+private theorem eqZeroOfContent {f : ZPoly} (hcontent : content f = 0) :
+    f = 0 := by
+  have hreconstruct := content_mul_primitivePart f
+  rw [hcontent] at hreconstruct
+  simpa using hreconstruct.symm
+
+/-- Coefficientwise rationalization is injective. -/
+private theorem toRatInjective {p q : ZPoly} (h : toRatPoly p = toRatPoly q) :
+    p = q := by
+  apply DensePoly.ext_coeff
+  intro n
+  have hcoeff := congrArg (fun r : DensePoly Rat => r.coeff n) h
+  rw [coeff_toRatPoly, coeff_toRatPoly] at hcoeff
+  exact_mod_cast hcoeff
+
+/-- Coefficientwise rationalization preserves polynomial addition. -/
+private theorem toRatAdd (p q : ZPoly) :
+    toRatPoly (p + q) = toRatPoly p + toRatPoly q := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_toRatPoly,
+    DensePoly.coeff_add (R := Int) (hzero := by rfl),
+    DensePoly.coeff_add (R := Rat) (hzero := by exact Rat.zero_add 0),
+    coeff_toRatPoly, coeff_toRatPoly]
+  exact Rat.intCast_add _ _
+
+/-- A polynomial of size at most one is its constant coefficient. -/
+private theorem eqCOfSizeLe {p : DensePoly Rat} (hsize : p.size ≤ 1) :
+    p = DensePoly.C (p.coeff 0) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C]
+  cases n with
+  | zero => simp
+  | succ n =>
+      rw [DensePoly.coeff_eq_zero_of_size_le p (by omega)]
+      rfl
+
+/-- Cancel a nonzero rational scalar from a polynomial equality. -/
+private theorem ratUnscale {c : Rat} (hc : c ≠ 0) {p q : DensePoly Rat}
+    (hscale : DensePoly.scale c p = q) :
+    p = DensePoly.scale c⁻¹ q := by
+  apply DensePoly.ext_coeff
+  intro n
+  have hcoeff := congrArg (fun r : DensePoly Rat => r.coeff n) hscale
+  rw [DensePoly.coeff_scale_semiring] at hcoeff ⊢
+  rw [← hcoeff, ← Rat.mul_assoc, Rat.inv_mul_cancel c hc, Rat.one_mul]
+
+/-- Sign normalization changes a polynomial only by the unit `-1`, so it
+preserves divisibility into any target. -/
+private theorem normalizeDvd {p f : ZPoly} (hpf : p ∣ f) :
+    normalizePrimitiveSign p ∣ f := by
+  unfold normalizePrimitiveSign
+  split
+  · rcases hpf with ⟨q, hq⟩
+    refine ⟨DensePoly.scale (-1 : Int) q, ?_⟩
+    rw [hq]
+    symm
+    calc
+      DensePoly.scale (-1 : Int) p * DensePoly.scale (-1 : Int) q =
+          DensePoly.scale (-1 : Int)
+            (DensePoly.scale (-1 : Int) p * q) :=
+        (DensePoly.mul_scale (-1 : Int) (DensePoly.scale (-1 : Int) p) q).symm
+      _ = DensePoly.scale (-1 : Int)
+          (DensePoly.scale (-1 : Int) (p * q)) := by
+        exact congrArg (DensePoly.scale (-1 : Int))
+          (DensePoly.scale_mul (-1 : Int) p q).symm
+      _ = DensePoly.scale ((-1 : Int) * (-1 : Int)) (p * q) :=
+        DensePoly.scale_scale (-1 : Int) (-1 : Int) (p * q)
+      _ = p * q := by
+        apply DensePoly.ext_coeff
+        intro n
+        rw [DensePoly.coeff_scale_semiring]
+        omega
+  · exact hpf
+
+/-- A scalar divisor of the integer content, multiplied by the primitive
+integer representative of a rational divisor, divides the original input. -/
+private theorem scaledPrimitiveDvd {f : ZPoly} {rg : DensePoly Rat} {c : Int}
+    (hrg : rg ∣ toRatPoly f) (hc : c ∣ content f) :
+    DensePoly.scale c (ratPolyPrimitivePart rg) ∣ f := by
+  by_cases hf : f = 0
+  · subst f
+    refine ⟨0, ?_⟩
+    exact ((DensePoly.mul_comm_poly _ 0).trans (DensePoly.zero_mul _)).symm
+  · let r := ratPolyPrimitivePart rg
+    have hrgNe : rg ≠ 0 := by
+      intro hzero
+      rcases hrg with ⟨q, hq⟩
+      apply toRatPoly_ne_zero_of_ne_zero f hf
+      rw [hzero, DensePoly.zero_mul] at hq
+      exact hq
+    have hrNe : r ≠ 0 := by
+      rcases ratPolyPrimitivePart_rational_associate rg with ⟨u, hu⟩
+      intro hzero
+      apply hrgNe
+      dsimp only [r] at hzero
+      rw [hu, hzero, toRatPoly_zero]
+      exact DensePoly.scale_zero_right u
+    have hrPrimitive : Primitive r := by
+      apply ratPolyPrimitivePart_primitive
+      intro hcontent
+      exact hrNe (eqZeroOfContent hcontent)
+    have hrRatF : toRatPoly r ∣ toRatPoly f := by
+      rcases hrg with ⟨a, ha⟩
+      rcases ratPolyPrimitivePart_rational_associate rg with ⟨u, hu⟩
+      have hu' : rg = DensePoly.scale u (toRatPoly r) := by
+        simpa only [r] using hu
+      refine ⟨DensePoly.scale u a, ?_⟩
+      calc
+        toRatPoly f = rg * a := ha
+        _ = DensePoly.scale u (toRatPoly r) * a := by rw [hu']
+        _ = DensePoly.scale u (toRatPoly r * a) :=
+          (DensePoly.scale_mul u (toRatPoly r) a).symm
+        _ = toRatPoly r * DensePoly.scale u a :=
+          DensePoly.mul_scale u (toRatPoly r) a
+    have hcontentNe : content f ≠ 0 := by
+      intro hzero
+      exact hf (eqZeroOfContent hzero)
+    have hcontentRatNe : ((content f : Int) : Rat) ≠ 0 := by
+      exact_mod_cast hcontentNe
+    have hrRatPrimitive : toRatPoly r ∣ toRatPoly (primitivePart f) := by
+      rcases hrRatF with ⟨q, hq⟩
+      have hscaled :
+          DensePoly.scale ((content f : Int) : Rat)
+              (toRatPoly (primitivePart f)) = toRatPoly r * q := by
+        rw [← toRatPoly_scale_int, content_mul_primitivePart]
+        exact hq
+      refine ⟨DensePoly.scale (((content f : Int) : Rat)⁻¹) q, ?_⟩
+      calc
+        toRatPoly (primitivePart f) =
+            DensePoly.scale (((content f : Int) : Rat)⁻¹) (toRatPoly r * q) :=
+          ratUnscale hcontentRatNe hscaled
+        _ = toRatPoly r *
+            DensePoly.scale (((content f : Int) : Rat)⁻¹) q :=
+          DensePoly.mul_scale _ _ _
+    have hrDvd : r ∣ primitivePart f :=
+      dvd_of_toRatPoly_dvd_of_primitive hrPrimitive hrRatPrimitive
+    rcases hrDvd with ⟨s, hs⟩
+    rcases hc with ⟨k, hk⟩
+    refine ⟨DensePoly.scale k s, ?_⟩
+    calc
+      f = DensePoly.scale (content f) (primitivePart f) :=
+        (content_mul_primitivePart f).symm
+      _ = DensePoly.scale (c * k) (r * s) := by rw [hk, hs]
+      _ = DensePoly.scale c r * DensePoly.scale k s := by
+        symm
+        calc
+          DensePoly.scale c r * DensePoly.scale k s =
+              DensePoly.scale k (DensePoly.scale c r * s) :=
+            (DensePoly.mul_scale k (DensePoly.scale c r) s).symm
+          _ = DensePoly.scale k (DensePoly.scale c (r * s)) := by
+            exact congrArg (DensePoly.scale k)
+              (DensePoly.scale_mul c r s).symm
+          _ = DensePoly.scale (k * c) (r * s) :=
+            DensePoly.scale_scale k c (r * s)
+          _ = DensePoly.scale (c * k) (r * s) := by rw [Int.mul_comm]
+
 /-- The canonical integer candidate obtained from the rational gcd, with the
 common integer content restored. -/
 def rationalGcdCandidate (f h : ZPoly) : ZPoly :=
@@ -39,18 +200,340 @@ def rationalGcdCandidate (f h : ZPoly) : ZPoly :=
   let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
   normalizePrimitiveSign (DensePoly.scale commonContent primitive)
 
+/-- A nontrivial input pair has a nonzero rational gcd. -/
+private theorem ratGcdNe {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    DensePoly.gcd (toRatPoly f) (toRatPoly h) ≠ 0 := by
+  rcases hnz with hf | hh
+  · intro hzero
+    rcases DensePoly.gcd_dvd_left (toRatPoly f) (toRatPoly h) with ⟨a, ha⟩
+    apply toRatPoly_ne_zero_of_ne_zero f hf
+    rw [hzero, DensePoly.zero_mul] at ha
+    exact ha
+  · intro hzero
+    rcases DensePoly.gcd_dvd_right (toRatPoly f) (toRatPoly h) with ⟨a, ha⟩
+    apply toRatPoly_ne_zero_of_ne_zero h hh
+    rw [hzero, DensePoly.zero_mul] at ha
+    exact ha
+
+/-- Clearing and primitive normalization preserve a nonzero rational gcd. -/
+private theorem ratPrimitiveNe {rg : DensePoly Rat} (hrg : rg ≠ 0) :
+    ratPolyPrimitivePart rg ≠ 0 := by
+  rcases ratPolyPrimitivePart_rational_associate rg with ⟨u, hu⟩
+  intro hzero
+  apply hrg
+  rw [hu, hzero, toRatPoly_zero]
+  exact DensePoly.scale_zero_right u
+
+/-- The integer representative of a nonzero rational polynomial is primitive. -/
+private theorem ratPrimitive {rg : DensePoly Rat} (hrg : rg ≠ 0) :
+    Primitive (ratPolyPrimitivePart rg) := by
+  apply ratPolyPrimitivePart_primitive
+  intro hcontent
+  exact ratPrimitiveNe hrg (eqZeroOfContent hcontent)
+
+/-- A nontrivial pair has positive common integer content. -/
+private theorem commonContentNe {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    Int.gcd (content f) (content h) ≠ 0 := by
+  intro hzero
+  rcases Int.gcd_eq_zero_iff.mp hzero with ⟨hf, hh⟩
+  rcases hnz with hnz | hnz
+  · exact hnz (eqZeroOfContent hf)
+  · exact hnz (eqZeroOfContent hh)
+
+/-- The candidate contains exactly the gcd of the two input contents. -/
+private theorem candidateContent {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    content (rationalGcdCandidate f h) =
+      Int.ofNat (Int.gcd (content f) (content h)) := by
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  let r := ratPolyPrimitivePart rg
+  let c : Int := Int.ofNat (Int.gcd (content f) (content h))
+  have hrgNe : rg ≠ 0 := by simpa only [rg] using ratGcdNe hnz
+  have hrPrimitive : Primitive r := by simpa only [r] using ratPrimitive hrgNe
+  have hrContent : DensePoly.content r = 1 := by
+    simpa [Primitive, content] using hrPrimitive
+  change content (normalizePrimitiveSign (DensePoly.scale c r)) = c
+  unfold normalizePrimitiveSign
+  split
+  · change DensePoly.content (DensePoly.scale (-1 : Int) (DensePoly.scale c r)) = c
+    rw [DensePoly.content_scale_neg_one, DensePoly.content_scale_int, hrContent]
+    simp only [Int.mul_one]
+    dsimp only [c]
+    simp
+  · change DensePoly.content (DensePoly.scale c r) = c
+    rw [DensePoly.content_scale_int, hrContent]
+    simp only [Int.mul_one]
+    dsimp only [c]
+    simp
+
 /-- The candidate is nonzero unless both inputs are zero. -/
 theorem rationalGcdCandidate_ne_zero {f h : ZPoly}
     (hnz : f ≠ 0 ∨ h ≠ 0) :
     rationalGcdCandidate f h ≠ 0 := by
-  sorry
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  let primitive := ratPolyPrimitivePart rg
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  have hrgNe : rg ≠ 0 := by
+    rcases hnz with hf | hh
+    · intro hzero
+      dsimp only [rg] at hzero
+      rcases DensePoly.gcd_dvd_left (toRatPoly f) (toRatPoly h) with ⟨a, ha⟩
+      apply toRatPoly_ne_zero_of_ne_zero f hf
+      rw [hzero, DensePoly.zero_mul] at ha
+      exact ha
+    · intro hzero
+      dsimp only [rg] at hzero
+      rcases DensePoly.gcd_dvd_right (toRatPoly f) (toRatPoly h) with ⟨a, ha⟩
+      apply toRatPoly_ne_zero_of_ne_zero h hh
+      rw [hzero, DensePoly.zero_mul] at ha
+      exact ha
+  have hprimitiveNe : primitive ≠ 0 := by
+    rcases ratPolyPrimitivePart_rational_associate rg with ⟨u, hu⟩
+    intro hzero
+    dsimp only [primitive] at hzero
+    apply hrgNe
+    rw [hu, hzero, toRatPoly_zero]
+    exact DensePoly.scale_zero_right u
+  have hcommonNat : Int.gcd (content f) (content h) ≠ 0 := by
+    intro hzero
+    rcases Int.gcd_eq_zero_iff.mp hzero with ⟨hf, hh⟩
+    rcases hnz with hnz | hnz
+    · exact hnz (eqZeroOfContent hf)
+    · exact hnz (eqZeroOfContent hh)
+  have hcommonNe : commonContent ≠ 0 := by
+    change Int.ofNat (Int.gcd (content f) (content h)) ≠ 0
+    exact Int.ofNat_ne_zero.mpr hcommonNat
+  have hscaledNe : DensePoly.scale commonContent primitive ≠ 0 := by
+    intro hzero
+    have hsize : primitive.size = 0 := by
+      rw [← scale_size_of_ne_zero commonContent primitive hcommonNe, hzero]
+      rfl
+    exact hprimitiveNe ((DensePoly.size_eq_zero_iff primitive).mp hsize)
+  change normalizePrimitiveSign (DensePoly.scale commonContent primitive) ≠ 0
+  intro hzero
+  have hsize : (normalizePrimitiveSign (DensePoly.scale commonContent primitive)).size = 0 := by
+    rw [hzero]
+    rfl
+  rw [size_normalizePrimitiveSign] at hsize
+  exact hscaledNe ((DensePoly.size_eq_zero_iff _).mp hsize)
+
+/-- The rational candidate satisfies the public normalization predicate. -/
+private theorem candidateNormalized {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    NormalizedGcd (rationalGcdCandidate f h) = true := by
+  have hgNe := rationalGcdCandidate_ne_zero hnz
+  have hleadNonneg :
+      0 ≤ DensePoly.leadingCoeff (rationalGcdCandidate f h) := by
+    simpa only [rationalGcdCandidate] using
+      leadingCoeff_normalizePrimitiveSign_nonneg
+        (DensePoly.scale (Int.ofNat (Int.gcd (content f) (content h)))
+          (ratPolyPrimitivePart (DensePoly.gcd (toRatPoly f) (toRatPoly h))))
+  have hleadNe := leadingCoeff_ne_zero_of_ne_zero _ hgNe
+  have hlead : 0 < DensePoly.leadingCoeff (rationalGcdCandidate f h) := by omega
+  have hcontent : 0 < content (rationalGcdCandidate f h) := by
+    rw [candidateContent hnz]
+    have hpos := Nat.pos_of_ne_zero (commonContentNe hnz)
+    exact Int.natCast_pos.mpr hpos
+  simp [NormalizedGcd, hlead, hcontent]
+
+/-- Removing the full common content leaves cofactors with coprime integer
+contents. -/
+private theorem cofactorContents {f h cofL cofR : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0)
+    (hleft : rationalGcdCandidate f h * cofL = f)
+    (hright : rationalGcdCandidate f h * cofR = h) :
+    Int.gcd (content cofL) (content cofR) = 1 := by
+  let common := Int.gcd (content f) (content h)
+  have hcommonPos : 0 < common := Nat.pos_of_ne_zero (commonContentNe hnz)
+  have hgContent : content (rationalGcdCandidate f h) = Int.ofNat common := by
+    simpa only [common] using candidateContent hnz
+  have hfContent : content f =
+      content (rationalGcdCandidate f h) * content cofL := by
+    have h := congrArg content hleft
+    rw [content_mul] at h
+    exact h.symm
+  have hhContent : content h =
+      content (rationalGcdCandidate f h) * content cofR := by
+    have h := congrArg content hright
+    rw [content_mul] at h
+    exact h.symm
+  have hfactor : common = common * Int.gcd (content cofL) (content cofR) := by
+    calc
+      common = Int.gcd (content f) (content h) := rfl
+      _ = Int.gcd
+          (content (rationalGcdCandidate f h) * content cofL)
+          (content (rationalGcdCandidate f h) * content cofR) := by
+        rw [hfContent, hhContent]
+      _ = (content (rationalGcdCandidate f h)).natAbs *
+          Int.gcd (content cofL) (content cofR) :=
+        Int.gcd_mul_left _ _ _
+      _ = common * Int.gcd (content cofL) (content cofR) := by
+        rw [hgContent]
+        simp
+  apply Nat.eq_of_mul_eq_mul_left hcommonPos
+  simpa using hfactor.symm
+
+/-- The rational candidate and the rational gcd have the same polynomial
+size; all intervening transformations are by nonzero scalars or signs. -/
+private theorem candidateSize {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
+    (toRatPoly (rationalGcdCandidate f h)).size =
+      (DensePoly.gcd (toRatPoly f) (toRatPoly h)).size := by
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  let r := ratPolyPrimitivePart rg
+  let c : Int := Int.ofNat (Int.gcd (content f) (content h))
+  have hrgNe : rg ≠ 0 := by simpa only [rg] using ratGcdNe hnz
+  have hcNe : c ≠ 0 := by
+    change Int.ofNat (Int.gcd (content f) (content h)) ≠ 0
+    exact Int.ofNat_ne_zero.mpr (commonContentNe hnz)
+  rcases ratPolyPrimitivePart_rational_associate rg with ⟨u, hu⟩
+  have huNe : u ≠ 0 := by
+    intro hzero
+    apply hrgNe
+    rw [hu, hzero]
+    exact DensePoly.scale_zero_left_semiring (toRatPoly r)
+  calc
+    (toRatPoly (rationalGcdCandidate f h)).size =
+        (rationalGcdCandidate f h).size := size_toRatPoly _
+    _ = (DensePoly.scale c r).size := by
+      simpa only [rationalGcdCandidate, rg, r, c] using
+        size_normalizePrimitiveSign (DensePoly.scale c r)
+    _ = r.size := scale_size_of_ne_zero c r hcNe
+    _ = (toRatPoly r).size := (size_toRatPoly r).symm
+    _ = (DensePoly.scale u (toRatPoly r)).size :=
+      (rat_size_scale huNe (toRatPoly r)).symm
+    _ = rg.size := by rw [← hu]
+    _ = (DensePoly.gcd (toRatPoly f) (toRatPoly h)).size := rfl
+
+/-- Exact cofactors of the rational gcd are coprime over `Rat[x]`; equivalently,
+their rational gcd has size at most one. -/
+private theorem cofactorRatGcdSize {f h cofL cofR : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0)
+    (hleft : rationalGcdCandidate f h * cofL = f)
+    (hright : rationalGcdCandidate f h * cofR = h) :
+    (DensePoly.gcd (toRatPoly cofL) (toRatPoly cofR)).size ≤ 1 := by
+  let g := rationalGcdCandidate f h
+  let gRat := toRatPoly g
+  let d := DensePoly.gcd (toRatPoly cofL) (toRatPoly cofR)
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  have hgNe : gRat ≠ 0 := by
+    dsimp only [gRat, g]
+    exact toRatPoly_ne_zero_of_ne_zero _ (rationalGcdCandidate_ne_zero hnz)
+  have hfRat : toRatPoly f = gRat * toRatPoly cofL := by
+    dsimp only [gRat, g]
+    rw [← toRatPoly_mul, hleft]
+  have hhRat : toRatPoly h = gRat * toRatPoly cofR := by
+    dsimp only [gRat, g]
+    rw [← toRatPoly_mul, hright]
+  have hdNe : d ≠ 0 := by
+    intro hzero
+    have hcofLZero : toRatPoly cofL = 0 := by
+      rcases DensePoly.gcd_dvd_left (toRatPoly cofL) (toRatPoly cofR) with ⟨a, ha⟩
+      dsimp only [d] at hzero
+      rw [hzero, DensePoly.zero_mul] at ha
+      exact ha
+    have hcofRZero : toRatPoly cofR = 0 := by
+      rcases DensePoly.gcd_dvd_right (toRatPoly cofL) (toRatPoly cofR) with ⟨a, ha⟩
+      dsimp only [d] at hzero
+      rw [hzero, DensePoly.zero_mul] at ha
+      exact ha
+    have hfZero : f = 0 := by
+      have hfRatZero : toRatPoly f = 0 := by
+        rw [hfRat, hcofLZero]
+        exact (DensePoly.mul_comm_poly gRat 0).trans (DensePoly.zero_mul gRat)
+      exact (DensePoly.size_eq_zero_iff f).mp (by
+        rw [← size_toRatPoly f, hfRatZero]
+        rfl)
+    have hhZero : h = 0 := by
+      have hhRatZero : toRatPoly h = 0 := by
+        rw [hhRat, hcofRZero]
+        exact (DensePoly.mul_comm_poly gRat 0).trans (DensePoly.zero_mul gRat)
+      exact (DensePoly.size_eq_zero_iff h).mp (by
+        rw [← size_toRatPoly h, hhRatZero]
+        rfl)
+    rcases hnz with hnz | hnz
+    · exact hnz hfZero
+    · exact hnz hhZero
+  have hprodLeft : gRat * d ∣ toRatPoly f := by
+    rcases DensePoly.gcd_dvd_left (toRatPoly cofL) (toRatPoly cofR) with ⟨a, ha⟩
+    have ha' : toRatPoly cofL = d * a := by simpa only [d] using ha
+    refine ⟨a, ?_⟩
+    calc
+      toRatPoly f = gRat * toRatPoly cofL := hfRat
+      _ = gRat * (d * a) := by rw [ha']
+      _ = (gRat * d) * a := (DensePoly.mul_assoc_poly gRat d a).symm
+  have hprodRight : gRat * d ∣ toRatPoly h := by
+    rcases DensePoly.gcd_dvd_right (toRatPoly cofL) (toRatPoly cofR) with ⟨a, ha⟩
+    have ha' : toRatPoly cofR = d * a := by simpa only [d] using ha
+    refine ⟨a, ?_⟩
+    calc
+      toRatPoly h = gRat * toRatPoly cofR := hhRat
+      _ = gRat * (d * a) := by rw [ha']
+      _ = (gRat * d) * a := (DensePoly.mul_assoc_poly gRat d a).symm
+  have hprodDvd : gRat * d ∣ rg := by
+    dsimp only [rg]
+    exact DensePoly.dvd_gcd (gRat * d) (toRatPoly f) (toRatPoly h)
+      hprodLeft hprodRight
+  have hgPos : 0 < gRat.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hgNe ((DensePoly.size_eq_zero_iff gRat).mp hzero)
+  have hdPos : 0 < d.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hdNe ((DensePoly.size_eq_zero_iff d).mp hzero)
+  have hprodSize := rat_size_mul gRat d hgNe hdNe
+  have hprodPos : 0 < (gRat * d).size := by omega
+  have hrgNe : rg ≠ 0 := by simpa only [rg] using ratGcdNe hnz
+  have hrgPos : 0 < rg.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hrgNe ((DensePoly.size_eq_zero_iff rg).mp hzero)
+  have hsizeLe := rat_size_le_of_dvd_nonzero
+    (Nat.ne_of_gt hprodPos) (Nat.ne_of_gt hrgPos) hprodDvd
+  have hsame : gRat.size = rg.size := by
+    simpa only [gRat, g, rg] using candidateSize hnz
+  have hsumLe : gRat.size + d.size - 1 ≤ rg.size := by
+    rw [← hprodSize]
+    exact hsizeLe
+  rw [hsame] at hsumLe
+  have hrearrange : rg.size + d.size - 1 = rg.size + (d.size - 1) := by omega
+  rw [hrearrange] at hsumLe
+  have hsubLe : d.size - 1 ≤ 0 := by
+    apply Nat.le_of_add_le_add_left (a := rg.size)
+    simpa using hsumLe
+  dsimp only [d] at hdPos hsubLe ⊢
+  omega
+
+/-- The rational gcd candidate divides the left integer input. -/
+private theorem candidateDvdLeft {f h : ZPoly} :
+    rationalGcdCandidate f h ∣ f := by
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  have hleftBase :
+      DensePoly.scale commonContent (ratPolyPrimitivePart rg) ∣ f := by
+    apply scaledPrimitiveDvd (DensePoly.gcd_dvd_left (toRatPoly f) (toRatPoly h))
+    exact Int.gcd_dvd_left (content f) (content h)
+  simpa only [rationalGcdCandidate, rg, commonContent] using
+    normalizeDvd hleftBase
+
+/-- The rational gcd candidate divides the right integer input. -/
+private theorem candidateDvdRight {f h : ZPoly} :
+    rationalGcdCandidate f h ∣ h := by
+  let rg := DensePoly.gcd (toRatPoly f) (toRatPoly h)
+  let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+  have hrightBase :
+      DensePoly.scale commonContent (ratPolyPrimitivePart rg) ∣ h := by
+    apply scaledPrimitiveDvd (DensePoly.gcd_dvd_right (toRatPoly f) (toRatPoly h))
+    exact Int.gcd_dvd_right (content f) (content h)
+  simpa only [rationalGcdCandidate, rg, commonContent] using
+    normalizeDvd hrightBase
 
 /-- The rational gcd candidate exactly divides both integer inputs. -/
 theorem rationalGcdCandidate_divisions {f h : ZPoly}
     (hnz : f ≠ 0 ∨ h ≠ 0) :
     (divExact? f (rationalGcdCandidate f h)).isSome = true ∧
       (divExact? h (rationalGcdCandidate f h)).isSome = true := by
-  sorry
+  have hcandidateNe := rationalGcdCandidate_ne_zero hnz
+  exact ⟨divExact?_isSome_of_dvd hcandidateNe candidateDvdLeft,
+    divExact?_isSome_of_dvd hcandidateNe candidateDvdRight⟩
 
 /-- Least common denominator of the stored coefficients of a rational
 polynomial. -/
@@ -65,6 +548,109 @@ private def clearRat (den : Nat) (f : DensePoly Rat) : ZPoly :=
       let q := f.coeff i
       q.num * Int.ofNat (den / q.den)
 
+/-- Divisibility by the initial accumulator is preserved by an lcm fold. -/
+private theorem dvdFoldLcm (coeffs : List Rat) {d acc : Nat} (hacc : d ∣ acc) :
+    d ∣ coeffs.foldl (fun n q => Nat.lcm n q.den) acc := by
+  induction coeffs generalizing acc with
+  | nil => exact hacc
+  | cons q coeffs ih =>
+      simp only [List.foldl_cons]
+      exact ih (Nat.dvd_trans hacc (Nat.dvd_lcm_left acc q.den))
+
+/-- Every member denominator divides the result of the lcm fold. -/
+private theorem denDvdFoldLcm (coeffs : List Rat) {q : Rat} {acc : Nat}
+    (hq : q ∈ coeffs) :
+    q.den ∣ coeffs.foldl (fun n q => Nat.lcm n q.den) acc := by
+  induction coeffs generalizing acc with
+  | nil => cases hq
+  | cons head coeffs ih =>
+      simp only [List.foldl_cons, List.mem_cons] at hq ⊢
+      rcases hq with hhead | htail
+      · subst head
+        exact dvdFoldLcm coeffs (Nat.dvd_lcm_right acc q.den)
+      · exact ih htail
+
+/-- Every coefficient denominator divides `ratDen`. -/
+private theorem coeffDenDvdRatDen (f : DensePoly Rat) (i : Nat) :
+    (f.coeff i).den ∣ ratDen f := by
+  by_cases hi : i < f.size
+  · unfold ratDen
+    rw [← Array.foldl_toList]
+    apply denDvdFoldLcm
+    unfold DensePoly.coeff DensePoly.toArray Array.getD
+    simp [show i < f.coeffs.size by simpa [DensePoly.size] using hi]
+  · have hcoeff : f.coeff i = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
+    rw [hcoeff]
+    exact Nat.one_dvd _
+
+/-- The lcm denominator fold is positive. -/
+private theorem ratDenPos (f : DensePoly Rat) : 0 < ratDen f := by
+  unfold ratDen
+  rw [← Array.foldl_toList]
+  have go : ∀ (coeffs : List Rat) (acc : Nat), 0 < acc →
+      0 < coeffs.foldl (fun d q => Nat.lcm d q.den) acc := by
+    intro coeffs
+    induction coeffs with
+    | nil => intro acc hpos; exact hpos
+    | cons q coeffs ih =>
+        intro acc hpos
+        simp only [List.foldl_cons]
+        exact ih (Nat.lcm acc q.den) (Nat.lcm_pos hpos q.den_pos)
+  exact go f.toArray.toList 1 (by decide)
+
+/-- Clearing one rational coefficient against a multiple of its denominator
+recovers scalar multiplication after casting back to `Rat`. -/
+private theorem clearCoeffCast (den : Nat) (q : Rat) (hden : q.den ∣ den) :
+    (((q.num * Int.ofNat (den / q.den) : Int) : Rat)) = (den : Rat) * q := by
+  rcases hden with ⟨k, rfl⟩
+  rw [Nat.mul_div_right _ q.den_pos]
+  have hdenNe : ((q.den : Nat) : Rat) ≠ 0 := by simp [q.den_nz]
+  have hq : ((q.num : Rat) / (q.den : Rat)) = q := by
+    simpa [Rat.divInt_eq_div, Rat.intCast_natCast] using q.num_divInt_den
+  calc
+    ((q.num * Int.ofNat k : Int) : Rat) =
+        (q.num : Rat) * (k : Rat) := by
+      rw [Rat.intCast_mul, Int.ofNat_eq_natCast, Rat.intCast_natCast]
+    _ = ((q.num : Rat) * (k : Rat) * (q.den : Rat)) / (q.den : Rat) := by
+      exact (Rat.mul_div_cancel hdenNe).symm
+    _ = ((q.den * k : Nat) : Rat) * ((q.num : Rat) / (q.den : Rat)) := by
+      grind [Rat.div_def, Rat.mul_assoc, Rat.mul_comm]
+    _ = ((q.den * k : Nat) : Rat) * q := by rw [hq]
+
+/-- Clearing all coefficients against a common denominator is scalar
+multiplication after rationalization. -/
+private theorem toRatPoly_clearRat (den : Nat) (f : DensePoly Rat)
+    (hden : ∀ i, (f.coeff i).den ∣ den) :
+    toRatPoly (clearRat den f) = DensePoly.scale (den : Rat) f := by
+  apply DensePoly.ext_coeff
+  intro i
+  rw [coeff_toRatPoly]
+  unfold clearRat
+  rw [DensePoly.coeff_ofList]
+  by_cases hi : i < f.size
+  · have hget :
+        ((List.range f.size).map fun j =>
+            (f.coeff j).num * Int.ofNat (den / (f.coeff j).den)).getD i 0 =
+          (f.coeff i).num * Int.ofNat (den / (f.coeff i).den) := by
+      simp [hi]
+    change (((((List.range f.size).map fun j =>
+        (f.coeff j).num * Int.ofNat (den / (f.coeff j).den)).getD i 0 : Int) : Rat)) =
+      (DensePoly.scale (den : Rat) f).coeff i
+    rw [hget, DensePoly.coeff_scale_semiring]
+    exact clearCoeffCast den (f.coeff i) (hden i)
+  · have hcoeff : f.coeff i = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
+    have hget :
+        ((List.range f.size).map fun j =>
+            (f.coeff j).num * Int.ofNat (den / (f.coeff j).den)).getD i 0 = 0 := by
+      simp [hi]
+    change (((((List.range f.size).map fun j =>
+        (f.coeff j).num * Int.ofNat (den / (f.coeff j).den)).getD i 0 : Int) : Rat)) =
+      (DensePoly.scale (den : Rat) f).coeff i
+    rw [hget, DensePoly.coeff_scale_semiring, hcoeff]
+    exact (Rat.mul_zero (den : Rat)).symm
+
 /-- Clear the extended rational gcd identity into an integral combination.
 For coprime cofactors the rational gcd is a nonzero constant, so the returned
 `k` is nonzero and the checker verifies the identity directly. -/
@@ -76,6 +662,98 @@ def rationalCoprimeWitness (f h : ZPoly) : CoprimeWitness :=
   let v := clearRat den xg.right
   let k := scalar.num * Int.ofNat (den / scalar.den)
   .constant u v k
+
+set_option maxHeartbeats 1600000 in
+/-- Clearing the extended-gcd identity for rationally coprime integer
+polynomials produces a certificate accepted by the integer checker. -/
+private theorem rationalCoprimeWitness_checks {f h : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0)
+    (hsize : (DensePoly.gcd (toRatPoly f) (toRatPoly h)).size ≤ 1) :
+    checkCoprime f h (rationalCoprimeWitness f h) = true := by
+  let xg := DensePoly.xgcd (toRatPoly f) (toRatPoly h)
+  let scalar := xg.gcd.coeff 0
+  let den := Nat.lcm (ratDen xg.left)
+    (Nat.lcm (ratDen xg.right) scalar.den)
+  let u := clearRat den xg.left
+  let v := clearRat den xg.right
+  let k := scalar.num * Int.ofNat (den / scalar.den)
+  have hxgSize : xg.gcd.size ≤ 1 := by
+    rw [DensePoly.xgcd_gcd_eq_gcd]
+    exact hsize
+  have hxgNe : xg.gcd ≠ 0 := by
+    rw [DensePoly.xgcd_gcd_eq_gcd]
+    exact ratGcdNe hnz
+  have hxgC : xg.gcd = DensePoly.C scalar := by
+    simpa only [scalar] using eqCOfSizeLe hxgSize
+  have hscalarNe : scalar ≠ 0 := by
+    intro hzero
+    apply hxgNe
+    rw [hxgC, hzero]
+    rfl
+  have hleftDen : ∀ i, (xg.left.coeff i).den ∣ den := by
+    intro i
+    exact Nat.dvd_trans (coeffDenDvdRatDen xg.left i)
+      (Nat.dvd_lcm_left _ _)
+  have hrightDen : ∀ i, (xg.right.coeff i).den ∣ den := by
+    intro i
+    exact Nat.dvd_trans (coeffDenDvdRatDen xg.right i)
+      (Nat.dvd_trans (Nat.dvd_lcm_left _ _)
+        (Nat.dvd_lcm_right _ _))
+  have hscalarDen : scalar.den ∣ den :=
+    Nat.dvd_trans (Nat.dvd_lcm_right _ _)
+      (Nat.dvd_lcm_right _ _)
+  have hdenPos : 0 < den := by
+    exact Nat.lcm_pos (ratDenPos xg.left)
+      (Nat.lcm_pos (ratDenPos xg.right) scalar.den_pos)
+  have huRat : toRatPoly u = DensePoly.scale (den : Rat) xg.left := by
+    simpa only [u] using toRatPoly_clearRat den xg.left hleftDen
+  have hvRat : toRatPoly v = DensePoly.scale (den : Rat) xg.right := by
+    simpa only [v] using toRatPoly_clearRat den xg.right hrightDen
+  have hkRat : ((k : Int) : Rat) = (den : Rat) * scalar := by
+    simpa only [k] using clearCoeffCast den scalar hscalarDen
+  have hkNe : k ≠ 0 := by
+    intro hzero
+    have hcastZero : ((k : Int) : Rat) = 0 := by rw [hzero]; rfl
+    rw [hkRat] at hcastZero
+    rcases Rat.mul_eq_zero.mp hcastZero with hdenZero | hscalarZero
+    · have : den = 0 := by exact_mod_cast hdenZero
+      omega
+    · exact hscalarNe hscalarZero
+  have hbezRat :
+      xg.left * toRatPoly f + xg.right * toRatPoly h = xg.gcd := by
+    simpa only [xg] using DensePoly.xgcd_bezout (toRatPoly f) (toRatPoly h)
+  have hscaleC :
+      DensePoly.scale (den : Rat) (DensePoly.C scalar) =
+        DensePoly.C ((k : Int) : Rat) := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_scale_semiring, DensePoly.coeff_C,
+      DensePoly.coeff_C]
+    by_cases hn : n = 0
+    · simp only [hn, ↓reduceIte]
+      exact hkRat.symm
+    · simp only [hn, ↓reduceIte]
+      exact Rat.mul_zero (den : Rat)
+  have hbezInt : u * f + v * h = DensePoly.C k := by
+    apply toRatInjective
+    rw [toRatAdd, toRatPoly_mul, toRatPoly_mul, huRat, hvRat]
+    calc
+      DensePoly.scale (den : Rat) xg.left * toRatPoly f +
+            DensePoly.scale (den : Rat) xg.right * toRatPoly h =
+          DensePoly.scale (den : Rat) (xg.left * toRatPoly f) +
+            DensePoly.scale (den : Rat) (xg.right * toRatPoly h) := by
+        rw [DensePoly.scale_mul, DensePoly.scale_mul]
+      _ = DensePoly.scale (den : Rat)
+            (xg.left * toRatPoly f + xg.right * toRatPoly h) :=
+        (DensePoly.scale_add _ _ _).symm
+      _ = DensePoly.scale (den : Rat) xg.gcd := by rw [hbezRat]
+      _ = DensePoly.scale (den : Rat) (DensePoly.C scalar) := by rw [hxgC]
+      _ = DensePoly.C ((k : Int) : Rat) := hscaleC
+      _ = toRatPoly (DensePoly.C k) := (toRatPoly_C k).symm
+  rw [show rationalCoprimeWitness f h = .constant u v k by rfl]
+  unfold checkCoprime
+  rw [Bool.and_eq_true]
+  exact ⟨by simpa only [decide_eq_true_eq], by simpa only [beq_iff_eq]⟩
 
 /-- The canonical certificate for the doubly-zero input.  Unit cofactors keep
 the coprimality obligation meaningful even though the gcd itself is zero. -/
@@ -154,6 +832,20 @@ private def structuralGcdCert? (f h : ZPoly) : Option GcdCert :=
   else
     none
 
+/-- Long division by a nonzero divisor returns the exact cofactor whenever
+the divisor is known to divide the input. -/
+private theorem divModProduct {f g : ZPoly} (hg : g ≠ 0) (hdvd : g ∣ f) :
+    g * (DensePoly.divMod f g).1 = f := by
+  rcases hdvd with ⟨q, hq⟩
+  have hqmul : q * g = f := by
+    rw [DensePoly.mul_comm_poly q g]
+    exact hq.symm
+  have hdiv := divMod_eq_mul_of_ne_zero f g q hg hqmul
+  have hquot : (DensePoly.divMod f g).1 = q := by
+    rw [hdiv]
+  rw [hquot]
+  exact hq.symm
+
 /-- Deterministic rational fallback certificate.
 
 The cofactors are the concrete long-division quotients.  Their exactness is
@@ -177,7 +869,54 @@ def rationalGcdCert (f h : ZPoly) : GcdCert :=
 proof obligation while the executable certificate remains fully concrete. -/
 theorem rationalGcdCert_checks (f h : ZPoly) :
     checkGcd f h (rationalGcdCert f h) = true := by
-  sorry
+  by_cases hzero : f = 0 ∧ h = 0
+  · rcases hzero with ⟨rfl, rfl⟩
+    decide
+  · have hnz : f ≠ 0 ∨ h ≠ 0 := by
+      by_cases hf : f = 0
+      · exact Or.inr (fun hh => hzero ⟨hf, hh⟩)
+      · exact Or.inl hf
+    let g := rationalGcdCandidate f h
+    let cofL := (DensePoly.divMod f g).1
+    let cofR := (DensePoly.divMod h g).1
+    have hgNe : g ≠ 0 := by
+      simpa only [g] using rationalGcdCandidate_ne_zero hnz
+    have hleft : g * cofL = f := by
+      simpa only [g, cofL] using divModProduct hgNe candidateDvdLeft
+    have hright : g * cofR = h := by
+      simpa only [g, cofR] using divModProduct hgNe candidateDvdRight
+    have hcofNz : cofL ≠ 0 ∨ cofR ≠ 0 := by
+      rcases hnz with hf | hh
+      · left
+        intro hcof
+        apply hf
+        have hmulZero : g * (0 : ZPoly) = 0 :=
+          (DensePoly.mul_comm_poly g 0).trans (DensePoly.zero_mul g)
+        exact hleft.symm.trans (by simpa only [hcof] using hmulZero)
+      · right
+        intro hcof
+        apply hh
+        have hmulZero : g * (0 : ZPoly) = 0 :=
+          (DensePoly.mul_comm_poly g 0).trans (DensePoly.zero_mul g)
+        exact hright.symm.trans (by simpa only [hcof] using hmulZero)
+    have hcontents : Int.gcd (content cofL) (content cofR) = 1 := by
+      simpa only [g] using cofactorContents hnz hleft hright
+    have hcopSize :
+        (DensePoly.gcd (toRatPoly cofL) (toRatPoly cofR)).size ≤ 1 := by
+      simpa only [g] using cofactorRatGcdSize hnz hleft hright
+    have hcop :
+        checkCoprime cofL cofR (rationalCoprimeWitness cofL cofR) = true :=
+      rationalCoprimeWitness_checks hcofNz hcopSize
+    rw [rationalGcdCert, if_neg hzero]
+    change checkGcd f h
+      { gcd := g, cofL := cofL, cofR := cofR,
+        coprime := rationalCoprimeWitness cofL cofR } = true
+    unfold checkGcd
+    rw [mulEqPacked_complete hleft, mulEqPacked_complete hright]
+    have hnorm : NormalizedGcd g = true := by
+      simpa only [g] using candidateNormalized hnz
+    rw [hnorm]
+    simp [hcontents, hcop]
 
 /-- Scan the low coefficients for the exponent of the first nonzero term. -/
 private def xOrder.go (f : ZPoly) : Nat → Nat → Nat

--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -832,6 +832,107 @@ private def structuralGcdCert? (f h : ZPoly) : Option GcdCert :=
   else
     none
 
+/-- The structural acceptance gate exposes only certificates that passed the
+checker. -/
+private theorem acceptStructural?_checks {f h : ZPoly} {offered cert : GcdCert}
+    (hcert : acceptStructural? f h offered = some cert) :
+    checkGcd f h cert = true := by
+  unfold acceptStructural? at hcert
+  split at hcert
+  · rename_i hcheck
+    cases hcert
+    exact hcheck
+  · contradiction
+
+private theorem zeroLeftCert?_checks {h : ZPoly} {cert : GcdCert}
+    (hcert : zeroLeftCert? h = some cert) :
+    checkGcd 0 h cert = true := by
+  unfold zeroLeftCert? at hcert
+  dsimp only at hcert
+  generalize hdiv : divExact? h (normalizePrimitiveSign h) = quotient? at hcert
+  cases quotient? with
+  | none => simp at hcert
+  | some quotient =>
+      exact acceptStructural?_checks hcert
+
+private theorem zeroRightCert?_checks {f : ZPoly} {cert : GcdCert}
+    (hcert : zeroRightCert? f = some cert) :
+    checkGcd f 0 cert = true := by
+  unfold zeroRightCert? at hcert
+  dsimp only at hcert
+  generalize hdiv : divExact? f (normalizePrimitiveSign f) = quotient? at hcert
+  cases quotient? with
+  | none => simp at hcert
+  | some quotient =>
+      exact acceptStructural?_checks hcert
+
+private theorem constantLeftCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : constantLeftCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold constantLeftCert? at hcert
+  dsimp only at hcert
+  generalize hleft : divExact? f
+      (DensePoly.C (Int.ofNat (Int.gcd (f.coeff 0) (content h)))) = left? at hcert
+  cases left? with
+  | none => simp at hcert
+  | some left =>
+      generalize hright : divExact? h
+          (DensePoly.C (Int.ofNat (Int.gcd (f.coeff 0) (content h)))) =
+        right? at hcert
+      cases right? with
+      | none => simp at hcert
+      | some right => exact acceptStructural?_checks hcert
+
+private theorem constantRightCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : constantRightCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold constantRightCert? at hcert
+  dsimp only at hcert
+  generalize hleft : divExact? f
+      (DensePoly.C (Int.ofNat (Int.gcd (content f) (h.coeff 0)))) = left? at hcert
+  cases left? with
+  | none => simp at hcert
+  | some left =>
+      generalize hright : divExact? h
+          (DensePoly.C (Int.ofNat (Int.gcd (content f) (h.coeff 0)))) =
+        right? at hcert
+      cases right? with
+      | none => simp at hcert
+      | some right => exact acceptStructural?_checks hcert
+
+/-- Every certificate returned by the mandatory zero/constant prepass passed
+the checker. -/
+private theorem structuralGcdCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : structuralGcdCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold structuralGcdCert? at hcert
+  split at hcert
+  · rename_i hfzero
+    have hf : f = 0 :=
+      (DensePoly.size_eq_zero_iff f).mp
+        ((DensePoly.isZero_eq_true_iff f).mp hfzero)
+    subst f
+    split at hcert
+    · rename_i hhzero
+      have hh : h = 0 :=
+        (DensePoly.size_eq_zero_iff h).mp
+          ((DensePoly.isZero_eq_true_iff h).mp hhzero)
+      subst h
+      exact acceptStructural?_checks hcert
+    · exact zeroLeftCert?_checks hcert
+  · split at hcert
+    · rename_i hhzero
+      have hh : h = 0 :=
+        (DensePoly.size_eq_zero_iff h).mp
+          ((DensePoly.isZero_eq_true_iff h).mp hhzero)
+      subst h
+      exact zeroRightCert?_checks hcert
+    · split at hcert
+      · exact constantLeftCert?_checks hcert
+      · split at hcert
+        · exact constantRightCert?_checks hcert
+        · contradiction
+
 /-- Long division by a nonzero divisor returns the exact cofactor whenever
 the divisor is known to divide the input. -/
 private theorem divModProduct {f g : ZPoly} (hg : g ≠ 0) (hdvd : g ∣ f) :
@@ -947,6 +1048,16 @@ private def fallbackGcdCert (f h : ZPoly) : GcdCert :=
   | some cert => cert
   | none => rationalGcdCert f h
 
+/-- The deterministic PRS route and its rational contingency both return
+accepted certificates. -/
+private theorem fallbackGcdCert_checks (f h : ZPoly) :
+    checkGcd f h (fallbackGcdCert f h) = true := by
+  unfold fallbackGcdCert
+  generalize hprs : prsCert? f h = cert?
+  cases cert? with
+  | some cert => exact prsCert_checks hprs
+  | none => exact rationalGcdCert_checks f h
+
 /-- Route 0: extract the common integer content and common power of `x`.
 Both divisions are explicit checked operations, so a representation or
 division regression declines instead of inventing a reduced input. -/
@@ -959,6 +1070,36 @@ def structuralReduction? (f h : ZPoly) : Option StructuralReduction := do
   let right ← divExact? h factor
   pure { factor, left, right }
 
+/-- A successful structural reduction records exact products for both
+inputs. -/
+private theorem structuralReduction?_products {f h : ZPoly}
+    {reduced : StructuralReduction}
+    (hresult : structuralReduction? f h = some reduced) :
+    reduced.factor * reduced.left = f ∧
+      reduced.factor * reduced.right = h := by
+  unfold structuralReduction? at hresult
+  dsimp only at hresult
+  by_cases hzero : f.isZero || h.isZero
+  · rw [if_pos hzero] at hresult
+    contradiction
+  · rw [if_neg hzero] at hresult
+    let commonPower := min (xOrder f) (xOrder h)
+    let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
+    let factor := DensePoly.scale commonContent (xPower commonPower)
+    generalize hleft : divExact? f factor = left? at hresult
+    cases left? with
+    | none => simp at hresult
+    | some left =>
+        generalize hright : divExact? h factor = right? at hresult
+        cases right? with
+        | none => simp at hresult
+        | some right =>
+            cases hresult
+            have hleftProduct := divExact?_product hleft
+            have hrightProduct := divExact?_product hright
+            exact ⟨(DensePoly.mul_comm_poly factor left).trans hleftProduct,
+              (DensePoly.mul_comm_poly factor right).trans hrightProduct⟩
+
 /-- Restore route 0's common factor around a certificate for the reduced
 pair.  The public checker is the only acceptance gate. -/
 def restoreStructural? (f h : ZPoly) (reduced : StructuralReduction)
@@ -969,6 +1110,19 @@ def restoreStructural? (f h : ZPoly) (reduced : StructuralReduction)
       cofR := cert.cofR
       coprime := cert.coprime }
   if checkGcd f h restored then some restored else none
+
+/-- Structural restoration exposes only the checker-approved result. -/
+private theorem restoreStructural?_checks {f h : ZPoly}
+    {reduced : StructuralReduction} {cert restored : GcdCert}
+    (hresult : restoreStructural? f h reduced cert = some restored) :
+    checkGcd f h restored = true := by
+  unfold restoreStructural? at hresult
+  dsimp only at hresult
+  split at hresult
+  · rename_i hcheck
+    cases hresult
+    exact hcheck
+  · contradiction
 
 /-- Largest reduced input size at which the evaluation heuristic runs before
 Brown reconstruction. Above this point dense evaluation builds integers whose
@@ -987,6 +1141,14 @@ private def brownOrFallback (f h : ZPoly) : GcdCert :=
   | some cert => cert
   | none => fallbackGcdCert f h
 
+private theorem brownOrFallback_checks (f h : ZPoly) :
+    checkGcd f h (brownOrFallback f h) = true := by
+  unfold brownOrFallback
+  generalize hbrown : brownCert? f h = cert?
+  cases cert? with
+  | some cert => exact brownCert?_checks hbrown
+  | none => exact fallbackGcdCert_checks f h
+
 private def afterCoprime (f h : ZPoly) : GcdCert :=
   if max f.size h.size <= heuSizeLimit then
     match heuCert? f h with
@@ -994,6 +1156,18 @@ private def afterCoprime (f h : ZPoly) : GcdCert :=
     | none => brownOrFallback f h
   else
     brownOrFallback f h
+
+private theorem afterCoprime_checks (f h : ZPoly) :
+    checkGcd f h (afterCoprime f h) = true := by
+  unfold afterCoprime
+  by_cases hsmall : max f.size h.size ≤ heuSizeLimit
+  · rw [if_pos hsmall]
+    generalize hheu : heuCert? f h = cert?
+    cases cert? with
+    | some cert => exact heuCert?_checks hheu
+    | none => exact brownOrFallback_checks f h
+  · rw [if_neg hsmall]
+    exact brownOrFallback_checks f h
 
 /-- Routes 1--4 on inputs after structural content and `x`-power removal. -/
 def reducedGcdCert (f h : ZPoly) : GcdCert :=
@@ -1007,6 +1181,25 @@ def reducedGcdCert (f h : ZPoly) : GcdCert :=
         match coprimeCert? f h with
         | some cert => cert
         | none => afterCoprime f h
+
+/-- Every nonstructural route either returns a checked fast certificate or
+the checked deterministic fallback. -/
+private theorem reducedGcdCert_checks (f h : ZPoly) :
+    checkGcd f h (reducedGcdCert f h) = true := by
+  unfold reducedGcdCert
+  dsimp only
+  generalize hdiff : differenceCert? f h = difference?
+  cases difference? with
+  | some cert => exact differenceCert?_checks hdiff
+  | none =>
+      by_cases hbits : brownBitCutoff < max (maxAbs f).log2 (maxAbs h).log2
+      · rw [if_pos hbits]
+        exact brownOrFallback_checks f h
+      · rw [if_neg hbits]
+        generalize hcop : coprimeCert? f h = coprime?
+        cases coprime? with
+        | some cert => exact coprimeCert?_checks hcop
+        | none => exact afterCoprime_checks f h
 
 /-- Internal route tag used by executable dispatch guards. -/
 private inductive GcdRoute where
@@ -1046,7 +1239,44 @@ def gcdCert (f h : ZPoly) : GcdCert :=
 /-- Every public certificate has passed the checker. -/
 theorem gcdCert_checks (f h : ZPoly) :
     checkGcd f h (gcdCert f h) = true := by
-  sorry
+  unfold gcdCert dispatchGcdCert
+  generalize hstruct : structuralGcdCert? f h = structural?
+  cases structural? with
+  | some cert =>
+      exact structuralGcdCert?_checks hstruct
+  | none =>
+      simp only
+      generalize hreduction : structuralReduction? f h = reduction?
+      cases reduction? with
+      | none =>
+          exact fallbackGcdCert_checks f h
+      | some reduced =>
+          simp only
+          let cert := reducedGcdCert reduced.left reduced.right
+          by_cases hfactor : reduced.factor == 1
+          · rw [if_pos hfactor]
+            have hfactorEq : reduced.factor = 1 := by
+              simpa only [beq_iff_eq] using hfactor
+            have hproducts := structuralReduction?_products hreduction
+            have hleft : reduced.left = f := by
+              rw [hfactorEq] at hproducts
+              rw [DensePoly.mul_comm_poly (1 : ZPoly) reduced.left,
+                DensePoly.mul_one_right_poly] at hproducts
+              exact hproducts.1
+            have hright : reduced.right = h := by
+              rw [hfactorEq] at hproducts
+              rw [DensePoly.mul_comm_poly (1 : ZPoly) reduced.right,
+                DensePoly.mul_one_right_poly] at hproducts
+              exact hproducts.2
+            simpa only [cert, hleft, hright] using
+              reducedGcdCert_checks reduced.left reduced.right
+          · rw [if_neg hfactor]
+            generalize hrestore : restoreStructural? f h reduced cert = restored?
+            cases restored? with
+            | some restored =>
+                exact restoreStructural?_checks hrestore
+            | none =>
+                exact fallbackGcdCert_checks f h
 
 /-- Canonically normalized gcd of two integer polynomials.  Exposure is
 limited to the projection equation `gcd_eq_cert`; `gcdCert` and its route

--- a/HexPolyZGcd/Heu.lean
+++ b/HexPolyZGcd/Heu.lean
@@ -96,6 +96,42 @@ def heuCert? (f h : ZPoly) : Option GcdCert :=
   let base := max 3 (2 * norm + 1)
   heuLoop f h base 4096 (by omega)
 
+/-- Every certificate produced by the bounded heuristic loop passed the
+shared checker. -/
+private theorem heuLoop_checks (f h : ZPoly) (base remainingBits : Nat)
+    (hbase : 1 < base) {cert : GcdCert}
+    (hcert : heuLoop f h base remainingBits hbase = some cert) :
+    checkGcd f h cert = true := by
+  unfold heuLoop at hcert
+  dsimp only at hcert
+  by_cases hcost : projectedBits f h base > remainingBits
+  · rw [if_pos hcost] at hcert
+    contradiction
+  · rw [if_neg hcost] at hcert
+    generalize hcand : checkedCandidate? f h
+        (heuCandidateAt f h base hbase) = candidate? at hcert
+    cases candidate? with
+    | some candidate =>
+        cases hcert
+        exact checkedCandidate?_checks hcand
+    | none =>
+        exact heuLoop_checks f h (2 * base + 1)
+          (remainingBits - projectedBits f h base) (by omega) hcert
+termination_by remainingBits
+decreasing_by
+  have hcostOne : 1 ≤ projectedBits f h base := by
+    unfold projectedBits
+    exact Nat.le_max_left 1 _
+  omega
+
+/-- Every certificate returned by the public heuristic route passed the full
+checker. -/
+theorem heuCert?_checks {f h : ZPoly} {cert : GcdCert}
+    (hcert : heuCert? f h = some cert) :
+    checkGcd f h cert = true := by
+  unfold heuCert? at hcert
+  exact heuLoop_checks f h _ 4096 (by omega) hcert
+
 /-! Route-level pins: one genuine hit and one accidental evaluated factor. -/
 
 #guard

--- a/HexPolyZGcd/Maximal.lean
+++ b/HexPolyZGcd/Maximal.lean
@@ -425,6 +425,101 @@ theorem dvd_gcd (d f h : ZPoly) (hf : d ∣ f) (hh : d ∣ h) :
     d ∣ gcd f h :=
   dvd_gcd_of_coprimeCofactors (gcdCert_coprimeCofactors f h) d hf hh
 
+/-- Two mutually dividing gcd candidates satisfying the public normalization
+convention are equal. -/
+theorem eq_of_normalized_of_dvd_dvd {p q : ZPoly}
+    (hpNorm : NormalizedGcd p = true) (hqNorm : NormalizedGcd q = true)
+    (hpq : p ∣ q) (hqp : q ∣ p) : p = q := by
+  have hpCases : p = 0 ∨
+      (0 < DensePoly.leadingCoeff p ∧ 0 < content p) := by
+    simpa [NormalizedGcd, Bool.or_eq_true, Bool.and_eq_true,
+      decide_eq_true_eq, beq_iff_eq] using hpNorm
+  have hqCases : q = 0 ∨
+      (0 < DensePoly.leadingCoeff q ∧ 0 < content q) := by
+    simpa [NormalizedGcd, Bool.or_eq_true, Bool.and_eq_true,
+      decide_eq_true_eq, beq_iff_eq] using hqNorm
+  rcases hpCases with hpZero | hpPos
+  · rcases hpq with ⟨a, ha⟩
+    rw [hpZero, DensePoly.zero_mul] at ha
+    exact hpZero.trans ha.symm
+  · have hpNe : p ≠ 0 := by
+      intro hpZero
+      subst p
+      have hleadZero : DensePoly.leadingCoeff (0 : ZPoly) = 0 := rfl
+      omega
+    rcases hqCases with hqZero | hqPos
+    · subst q
+      rcases hqp with ⟨a, ha⟩
+      rw [DensePoly.zero_mul] at ha
+      exact False.elim (hpNe ha)
+    · have hqNe : q ≠ 0 := by
+        intro hqZero'
+        subst q
+        have hleadZero : DensePoly.leadingCoeff (0 : ZPoly) = 0 := rfl
+        omega
+      rcases hpq with ⟨a, ha⟩
+      rcases hqp with ⟨b, hb⟩
+      have haNe : a ≠ 0 := by
+        intro haZero
+        apply hqNe
+        rw [ha, haZero]
+        exact (DensePoly.mul_comm_poly p 0).trans (DensePoly.zero_mul p)
+      have hbNe : b ≠ 0 := by
+        intro hbZero
+        apply hpNe
+        rw [hb, hbZero]
+        exact (DensePoly.mul_comm_poly q 0).trans (DensePoly.zero_mul q)
+      have hpab : p = p * (a * b) := by
+        calc
+          p = q * b := hb
+          _ = (p * a) * b := by rw [ha]
+          _ = p * (a * b) := DensePoly.mul_assoc_poly p a b
+      have hab : a * b = 1 := by
+        apply mul_right_cancel_of_ne_zero hpNe
+        calc
+          (a * b) * p = p * (a * b) := DensePoly.mul_comm_poly _ _
+          _ = p := hpab.symm
+          _ = 1 * p := by
+            rw [DensePoly.mul_comm_poly (1 : ZPoly) p,
+              DensePoly.mul_one_right_poly]
+      have haSizePos : 0 < a.size := size_pos_of_ne_zero a haNe
+      have hbSizePos : 0 < b.size := size_pos_of_ne_zero b hbNe
+      have hsize := mul_size_eq_top_succ_of_nonzero a b haSizePos hbSizePos
+      have habSize : (a * b).size = 1 := by rw [hab]; rfl
+      have hsizeEq : 1 = a.size + b.size - 1 := habSize.symm.trans hsize
+      have haSize : a.size = 1 := by omega
+      have haC : a = DensePoly.C (a.coeff 0) := by
+        apply DensePoly.ext_coeff
+        intro n
+        rw [DensePoly.coeff_C]
+        cases n with
+        | zero => simp
+        | succ n =>
+            rw [DensePoly.coeff_eq_zero_of_size_le a (by omega)]
+            rfl
+      have hleadA : 0 < DensePoly.leadingCoeff a := by
+        have hlead := leadingCoeff_mul_of_nonzero p a hpNe haNe
+        rw [← ha] at hlead
+        have hprodPos :
+            0 < DensePoly.leadingCoeff p * DensePoly.leadingCoeff a := by
+          rw [← hlead]
+          exact hqPos.1
+        exact Int.pos_of_mul_pos_right hprodPos hpPos.1
+      have hleadAB := leadingCoeff_mul_of_nonzero a b haNe hbNe
+      rw [hab] at hleadAB
+      have hleadOne : DensePoly.leadingCoeff (1 : ZPoly) = 1 := by rfl
+      rw [hleadOne] at hleadAB
+      have hleadAOne : DensePoly.leadingCoeff a = 1 :=
+        Int.eq_one_of_mul_eq_one_right (Int.le_of_lt hleadA) hleadAB.symm
+      have hcoeffA : a.coeff 0 = 1 := by
+        rw [DensePoly.leadingCoeff_eq_coeff_last a haSizePos,
+          haSize] at hleadAOne
+        exact hleadAOne
+      have haOne : a = 1 := by
+        rw [haC, hcoeffA]
+        rfl
+      rw [ha, haOne, DensePoly.mul_one_right_poly]
+
 end ZPoly
 
 end Hex

--- a/HexPolyZGcd/Maximal.lean
+++ b/HexPolyZGcd/Maximal.lean
@@ -20,6 +20,157 @@ namespace Hex
 
 namespace ZPoly
 
+private theorem dvdTrans {a b c : ZPoly} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨q, hq⟩
+  rcases hbc with ⟨r, hr⟩
+  refine ⟨q * r, ?_⟩
+  calc
+    c = b * r := hr
+    _ = (a * q) * r := by rw [hq]
+    _ = a * (q * r) := DensePoly.mul_assoc_poly a q r
+
+private theorem toRatDvd {a b : ZPoly} (h : a ∣ b) :
+    toRatPoly a ∣ toRatPoly b := by
+  rcases h with ⟨q, hq⟩
+  refine ⟨toRatPoly q, ?_⟩
+  rw [← toRatPoly_mul, ← hq]
+
+private theorem ratDvdTrans {a b c : DensePoly Rat}
+    (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  rcases hab with ⟨q, hq⟩
+  rcases hbc with ⟨r, hr⟩
+  refine ⟨q * r, ?_⟩
+  calc
+    c = b * r := hr
+    _ = (a * q) * r := by rw [hq]
+    _ = a * (q * r) := DensePoly.mul_assoc_poly a q r
+
+private theorem ratDvdMulLeft {d p : DensePoly Rat} (q : DensePoly Rat)
+    (h : d ∣ p) : d ∣ q * p := by
+  rcases h with ⟨a, ha⟩
+  refine ⟨q * a, ?_⟩
+  calc
+    q * p = q * (d * a) := by rw [ha]
+    _ = (q * d) * a := (DensePoly.mul_assoc_poly q d a).symm
+    _ = (d * q) * a := by rw [DensePoly.mul_comm_poly q d]
+    _ = d * (q * a) := DensePoly.mul_assoc_poly d q a
+
+private theorem ratDvdAdd {d p q : DensePoly Rat}
+    (hp : d ∣ p) (hq : d ∣ q) : d ∣ p + q := by
+  rcases hp with ⟨a, ha⟩
+  rcases hq with ⟨b, hb⟩
+  refine ⟨a + b, ?_⟩
+  rw [ha, hb, DensePoly.mul_add_right_poly]
+
+private theorem ratEqCOfSizeLe {p : DensePoly Rat} (hsize : p.size ≤ 1) :
+    p = DensePoly.C (p.coeff 0) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C]
+  cases n with
+  | zero => simp
+  | succ n =>
+      rw [DensePoly.coeff_eq_zero_of_size_le p (by omega)]
+      rfl
+
+private theorem contentDvdOfDvd {a b : ZPoly} (h : a ∣ b) :
+    content a ∣ content b := by
+  rcases h with ⟨q, hq⟩
+  refine ⟨content q, ?_⟩
+  rw [hq, content_mul]
+
+/-- A scalar dividing the content divides the whole integer polynomial. -/
+private theorem C_dvd_of_dvd_content {p : ZPoly} {c : Int}
+    (hc : c ∣ content p) : DensePoly.C c ∣ p := by
+  rcases hc with ⟨k, hk⟩
+  refine ⟨DensePoly.scale k (primitivePart p), ?_⟩
+  calc
+    p = DensePoly.scale (content p) (primitivePart p) :=
+      (content_mul_primitivePart p).symm
+    _ = DensePoly.scale (c * k) (primitivePart p) := by rw [hk]
+    _ = DensePoly.scale c (DensePoly.scale k (primitivePart p)) :=
+      (DensePoly.scale_scale c k (primitivePart p)).symm
+    _ = DensePoly.C c * DensePoly.scale k (primitivePart p) :=
+      (C_mul_eq_scale c _).symm
+
+/-- Cofactors with no common nonunit have coprime integer contents. -/
+private theorem coprimeContents {a b : ZPoly}
+    (hcop : ∀ d : ZPoly, d ∣ a → d ∣ b → IsUnit d) :
+    Int.gcd (content a) (content b) = 1 := by
+  rw [Int.gcd_eq_one_iff]
+  intro c hca hcb
+  have hunit := hcop (DensePoly.C c)
+    (C_dvd_of_dvd_content hca) (C_dvd_of_dvd_content hcb)
+  rcases hunit with hpos | hneg
+  · have hc : c = 1 := by
+      have hcoeff := congrArg (fun p : ZPoly => p.coeff 0) hpos
+      simpa using hcoeff
+    rw [hc]
+    exact ⟨1, by omega⟩
+  · have hc : c = -1 := by
+      have hcoeff := congrArg (fun p : ZPoly => p.coeff 0) hneg
+      simpa using hcoeff
+    rw [hc]
+    exact ⟨-1, by omega⟩
+
+/-- Absence of a common integer-polynomial nonunit forces the rational gcd of
+the cofactors to be constant. -/
+private theorem ratGcdSizeLeOne {a b : ZPoly}
+    (hcop : ∀ d : ZPoly, d ∣ a → d ∣ b → IsUnit d) :
+    (DensePoly.gcd (toRatPoly a) (toRatPoly b)).size ≤ 1 := by
+  let cg := DensePoly.gcd (toRatPoly a) (toRatPoly b)
+  by_cases hcgZero : cg = 0
+  · change cg.size ≤ 1
+    rw [hcgZero]
+    exact Nat.zero_le 1
+  · let r := ratPolyPrimitivePart cg
+    rcases ratPolyPrimitivePart_rational_associate cg with ⟨u, hu⟩
+    have hrNe : r ≠ 0 := by
+      intro hrZero
+      apply hcgZero
+      change ratPolyPrimitivePart cg = 0 at hrZero
+      rw [hu, hrZero, toRatPoly_zero]
+      exact DensePoly.scale_zero_right u
+    have hrContentNe : content r ≠ 0 := by
+      intro hcontent
+      apply hrNe
+      have hreconstruct := content_mul_primitivePart r
+      rw [hcontent] at hreconstruct
+      exact hreconstruct.symm.trans
+        (DensePoly.scale_zero_left_semiring (primitivePart r))
+    have hrPrimitive : Primitive r :=
+      ratPolyPrimitivePart_primitive cg hrContentNe
+    have hrDvdCg : toRatPoly r ∣ cg := by
+      refine ⟨DensePoly.scale u (1 : DensePoly Rat), ?_⟩
+      calc
+        cg = DensePoly.scale u (toRatPoly r) := hu
+        _ = DensePoly.scale u (toRatPoly r * 1) := by
+          rw [DensePoly.mul_one_right_poly]
+        _ = toRatPoly r * DensePoly.scale u 1 :=
+          DensePoly.mul_scale u (toRatPoly r) 1
+    have hrDvdA : r ∣ a := by
+      apply dvd_of_toRatPoly_dvd_of_primitive hrPrimitive
+      exact ratDvdTrans hrDvdCg (DensePoly.gcd_dvd_left _ _)
+    have hrDvdB : r ∣ b := by
+      apply dvd_of_toRatPoly_dvd_of_primitive hrPrimitive
+      exact ratDvdTrans hrDvdCg (DensePoly.gcd_dvd_right _ _)
+    have hrUnit := hcop r hrDvdA hrDvdB
+    have huNe : u ≠ 0 := by
+      intro huZero
+      apply hcgZero
+      rw [hu, huZero]
+      exact DensePoly.scale_zero_left_semiring (toRatPoly r)
+    rw [show DensePoly.gcd (toRatPoly a) (toRatPoly b) = cg by rfl,
+      hu, rat_size_scale huNe, size_toRatPoly]
+    change r.size ≤ 1
+    rcases hrUnit with hr | hr
+    · rw [hr]
+      exact Nat.le_refl _
+    · rw [hr]
+      exact Nat.le_refl _
+
+set_option maxHeartbeats 1600000 in
 /-- In one variable over the integers, exact coprime cofactors make their
 common factor maximal.  The proof rationalizes a primitive part of `d`, uses
 the field gcd laws over `Rat[x]`, and descends with
@@ -27,7 +178,220 @@ the field gcd laws over `Rat[x]`, and descends with
 theorem dvd_gcd_of_coprimeCofactors {f h g : ZPoly}
     (hc : CoprimeCofactors f h g) (d : ZPoly)
     (hf : d ∣ f) (hh : d ∣ h) : d ∣ g := by
-  sorry
+  unfold CoprimeCofactors at hc
+  rcases hc with ⟨a, b, hfa, hhb, hcop⟩
+  have zeroNotUnit : ¬ IsUnit (0 : ZPoly) := by decide
+  by_cases hd : d = 0
+  · subst d
+    rcases hf with ⟨q, hq⟩
+    rcases hh with ⟨r, hr⟩
+    have hfZero : f = 0 := by
+      rw [DensePoly.zero_mul] at hq
+      exact hq
+    have hhZero : h = 0 := by
+      rw [DensePoly.zero_mul] at hr
+      exact hr
+    have hgZero : g = 0 := by
+      apply Classical.byContradiction
+      intro hg
+      have haZero : a = 0 := by
+        apply Classical.byContradiction
+        intro ha
+        have hprod := mul_ne_zero_of_ne_zero g a hg ha
+        exact hprod (hfa.symm.trans hfZero)
+      have hbZero : b = 0 := by
+        apply Classical.byContradiction
+        intro hb
+        have hprod := mul_ne_zero_of_ne_zero g b hg hb
+        exact hprod (hhb.symm.trans hhZero)
+      have hunit := hcop 0
+        ⟨1, by rw [haZero]; exact (DensePoly.zero_mul 1).symm⟩
+        ⟨1, by rw [hbZero]; exact (DensePoly.zero_mul 1).symm⟩
+      exact zeroNotUnit hunit
+    refine ⟨0, ?_⟩
+    rw [hgZero]
+    exact (DensePoly.zero_mul 0).symm
+  · have hdContent : content d ≠ 0 := by
+      intro hcontent
+      apply hd
+      have hreconstruct := content_mul_primitivePart d
+      rw [hcontent] at hreconstruct
+      exact hreconstruct.symm.trans
+        (DensePoly.scale_zero_left_semiring (primitivePart d))
+    let primitive := primitivePart d
+    have hprimitive : Primitive primitive :=
+      primitivePart_primitive d hdContent
+    have hprimitiveDvdD : primitive ∣ d := by
+      refine ⟨DensePoly.C (content d), ?_⟩
+      calc
+        d = DensePoly.scale (content d) primitive :=
+          (content_mul_primitivePart d).symm
+        _ = DensePoly.C (content d) * primitive :=
+          (C_mul_eq_scale (content d) primitive).symm
+        _ = primitive * DensePoly.C (content d) :=
+          DensePoly.mul_comm_poly _ _
+    have hprimitiveDvdF : primitive ∣ f := dvdTrans hprimitiveDvdD hf
+    have hprimitiveDvdH : primitive ∣ h := dvdTrans hprimitiveDvdD hh
+    have hcofactorGcdSize := ratGcdSizeLeOne hcop
+    have habNe : a ≠ 0 ∨ b ≠ 0 := by
+      by_cases ha : a = 0
+      · right
+        intro hb
+        have hunit := hcop 0
+          ⟨1, by rw [ha]; exact (DensePoly.zero_mul 1).symm⟩
+          ⟨1, by rw [hb]; exact (DensePoly.zero_mul 1).symm⟩
+        exact zeroNotUnit hunit
+      · exact Or.inl ha
+    let xg := DensePoly.xgcd (toRatPoly a) (toRatPoly b)
+    let scalar := xg.gcd.coeff 0
+    have hxgSize : xg.gcd.size ≤ 1 := by
+      rw [DensePoly.xgcd_gcd_eq_gcd]
+      exact hcofactorGcdSize
+    have hxgNe : xg.gcd ≠ 0 := by
+      rw [DensePoly.xgcd_gcd_eq_gcd]
+      intro hzero
+      rcases habNe with ha | hb
+      · apply toRatPoly_ne_zero_of_ne_zero a ha
+        rcases DensePoly.gcd_dvd_left (toRatPoly a) (toRatPoly b) with ⟨q, hq⟩
+        rw [hzero, DensePoly.zero_mul] at hq
+        exact hq
+      · apply toRatPoly_ne_zero_of_ne_zero b hb
+        rcases DensePoly.gcd_dvd_right (toRatPoly a) (toRatPoly b) with ⟨q, hq⟩
+        rw [hzero, DensePoly.zero_mul] at hq
+        exact hq
+    have hxgC : xg.gcd = DensePoly.C scalar := by
+      simpa only [scalar] using ratEqCOfSizeLe hxgSize
+    have hscalarNe : scalar ≠ 0 := by
+      intro hzero
+      apply hxgNe
+      rw [hxgC, hzero]
+      rfl
+    let alpha := DensePoly.scale scalar⁻¹ xg.left
+    let beta := DensePoly.scale scalar⁻¹ xg.right
+    have hbez : xg.left * toRatPoly a + xg.right * toRatPoly b = xg.gcd := by
+      simpa only [xg] using DensePoly.xgcd_bezout (toRatPoly a) (toRatPoly b)
+    have hscaleC :
+        DensePoly.scale scalar⁻¹ (DensePoly.C scalar) =
+          (1 : DensePoly Rat) := by
+      change DensePoly.scale scalar⁻¹ (DensePoly.C scalar) = DensePoly.C 1
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_scale_semiring, DensePoly.coeff_C,
+        DensePoly.coeff_C]
+      by_cases hn : n = 0
+      · simp only [hn, ↓reduceIte]
+        exact Rat.inv_mul_cancel scalar hscalarNe
+      · simp only [hn, ↓reduceIte]
+        exact Rat.mul_zero scalar⁻¹
+    have hbezOne :
+        alpha * toRatPoly a + beta * toRatPoly b = 1 := by
+      calc
+        alpha * toRatPoly a + beta * toRatPoly b =
+            DensePoly.scale scalar⁻¹ (xg.left * toRatPoly a) +
+              DensePoly.scale scalar⁻¹ (xg.right * toRatPoly b) := by
+          simp only [alpha, beta, DensePoly.scale_mul]
+        _ = DensePoly.scale scalar⁻¹
+              (xg.left * toRatPoly a + xg.right * toRatPoly b) :=
+          (DensePoly.scale_add _ _ _).symm
+        _ = DensePoly.scale scalar⁻¹ xg.gcd := by rw [hbez]
+        _ = DensePoly.scale scalar⁻¹ (DensePoly.C scalar) := by rw [hxgC]
+        _ = 1 := hscaleC
+    have hfRat : toRatPoly f = toRatPoly g * toRatPoly a := by
+      rw [← toRatPoly_mul, hfa]
+    have hhRat : toRatPoly h = toRatPoly g * toRatPoly b := by
+      rw [← toRatPoly_mul, hhb]
+    have hcomb :
+        alpha * toRatPoly f + beta * toRatPoly h = toRatPoly g := by
+      rw [hfRat, hhRat]
+      have halpha :
+          alpha * (toRatPoly g * toRatPoly a) =
+            toRatPoly g * (alpha * toRatPoly a) := by
+        calc
+          alpha * (toRatPoly g * toRatPoly a) =
+              (alpha * toRatPoly g) * toRatPoly a :=
+            (DensePoly.mul_assoc_poly _ _ _).symm
+          _ = (toRatPoly g * alpha) * toRatPoly a := by
+            rw [DensePoly.mul_comm_poly alpha (toRatPoly g)]
+          _ = toRatPoly g * (alpha * toRatPoly a) :=
+            DensePoly.mul_assoc_poly _ _ _
+      have hbeta :
+          beta * (toRatPoly g * toRatPoly b) =
+            toRatPoly g * (beta * toRatPoly b) := by
+        calc
+          beta * (toRatPoly g * toRatPoly b) =
+              (beta * toRatPoly g) * toRatPoly b :=
+            (DensePoly.mul_assoc_poly _ _ _).symm
+          _ = (toRatPoly g * beta) * toRatPoly b := by
+            rw [DensePoly.mul_comm_poly beta (toRatPoly g)]
+          _ = toRatPoly g * (beta * toRatPoly b) :=
+            DensePoly.mul_assoc_poly _ _ _
+      calc
+        alpha * (toRatPoly g * toRatPoly a) +
+              beta * (toRatPoly g * toRatPoly b) =
+            toRatPoly g * (alpha * toRatPoly a) +
+              toRatPoly g * (beta * toRatPoly b) := by
+          exact (congrArg
+            (fun p : DensePoly Rat => p + beta * (toRatPoly g * toRatPoly b))
+            halpha).trans (congrArg
+              (fun p : DensePoly Rat => toRatPoly g * (alpha * toRatPoly a) + p)
+              hbeta)
+        _ = toRatPoly g *
+              (alpha * toRatPoly a + beta * toRatPoly b) :=
+          (DensePoly.mul_add_right_poly _ _ _).symm
+        _ = toRatPoly g * 1 :=
+          congrArg (fun p : DensePoly Rat => toRatPoly g * p) hbezOne
+        _ = toRatPoly g := DensePoly.mul_one_right_poly _
+    have hprimitiveDvdGRat : toRatPoly primitive ∣ toRatPoly g := by
+      have hsum := ratDvdAdd
+        (ratDvdMulLeft alpha (toRatDvd hprimitiveDvdF))
+        (ratDvdMulLeft beta (toRatDvd hprimitiveDvdH))
+      rw [hcomb] at hsum
+      exact hsum
+    have hprimitiveDvdG : primitive ∣ g :=
+      dvd_of_toRatPoly_dvd_of_primitive hprimitive hprimitiveDvdGRat
+    have hcontents := coprimeContents hcop
+    have hcontentDvdF := contentDvdOfDvd hf
+    have hcontentDvdH := contentDvdOfDvd hh
+    have hfContent : content f = content g * content a := by
+      have hcontent := congrArg content hfa
+      rw [content_mul] at hcontent
+      exact hcontent
+    have hhContent : content h = content g * content b := by
+      have hcontent := congrArg content hhb
+      rw [content_mul] at hcontent
+      exact hcontent
+    have hcontentNatDvd :
+        DensePoly.contentNat d ∣ Int.gcd (content f) (content h) := by
+      apply Int.dvd_gcd
+      · simpa [content, DensePoly.content] using hcontentDvdF
+      · simpa [content, DensePoly.content] using hcontentDvdH
+    have hcontentNatDvd' := hcontentNatDvd
+    rw [hfContent, hhContent, Int.gcd_mul_left, hcontents, Nat.mul_one]
+      at hcontentNatDvd'
+    have hcontentDvdG : content d ∣ content g := by
+      simpa [content, DensePoly.content] using
+        (Int.ofNat_dvd_left.mpr hcontentNatDvd')
+    rcases hprimitiveDvdG with ⟨s, hs⟩
+    have hsContent : content s = content g := by
+      have hcontent := congrArg content hs
+      rw [content_mul, show content primitive = 1 from hprimitive,
+        Int.one_mul] at hcontent
+      exact hcontent.symm
+    have hcontentDvdS : content d ∣ content s := by
+      rw [hsContent]
+      exact hcontentDvdG
+    rcases C_dvd_of_dvd_content hcontentDvdS with ⟨t, ht⟩
+    refine ⟨t, ?_⟩
+    calc
+      g = primitive * s := hs
+      _ = primitive * (DensePoly.C (content d) * t) := by rw [ht]
+      _ = (primitive * DensePoly.C (content d)) * t :=
+        (DensePoly.mul_assoc_poly _ _ _).symm
+      _ = (DensePoly.C (content d) * primitive) * t := by
+        rw [DensePoly.mul_comm_poly primitive (DensePoly.C (content d))]
+      _ = DensePoly.scale (content d) primitive * t := by
+        rw [C_mul_eq_scale]
+      _ = d * t := by rw [content_mul_primitivePart]
 
 /-- The public checked certificate packages coprime cofactors. -/
 theorem gcdCert_coprimeCofactors (f h : ZPoly) :

--- a/HexPolyZGcd/Maximal.lean
+++ b/HexPolyZGcd/Maximal.lean
@@ -427,7 +427,7 @@ theorem dvd_gcd (d f h : ZPoly) (hf : d ∣ f) (hh : d ∣ h) :
 
 /-- Two mutually dividing gcd candidates satisfying the public normalization
 convention are equal. -/
-theorem eq_of_normalized_of_dvd_dvd {p q : ZPoly}
+theorem eq_of_normalized_dvd {p q : ZPoly}
     (hpNorm : NormalizedGcd p = true) (hqNorm : NormalizedGcd q = true)
     (hpq : p ∣ q) (hqp : q ∣ p) : p = q := by
   have hpCases : p = 0 ∨

--- a/HexPolyZGcd/Prs.lean
+++ b/HexPolyZGcd/Prs.lean
@@ -63,16 +63,48 @@ def prsCert? (f h : ZPoly) : Option GcdCert :=
     let cofL := (DensePoly.divMod f candidate).1
     let cofR := (DensePoly.divMod h candidate).1
     let coprime ← prsCoprimeWitness? cofL cofR
-    pure
+    let cert : GcdCert :=
       { gcd := candidate
         cofL := cofL
         cofR := cofR
         coprime := coprime }
+    if checkGcd f h cert then some cert else none
 
 /-- Completeness of the deterministic extended-subresultant fallback. -/
 theorem prsCert_checks {f h : ZPoly} {cert : GcdCert}
     (hcert : prsCert? f h = some cert) : checkGcd f h cert = true := by
-  sorry
+  unfold prsCert? at hcert
+  by_cases hzero : f.isZero && h.isZero
+  · simp only [hzero, ite_true] at hcert
+    cases hcert
+    have hzero' : f.isZero = true ∧ h.isZero = true := by
+      simpa using hzero
+    have hfzero : f = 0 :=
+      (DensePoly.size_eq_zero_iff f).1 <|
+        (DensePoly.isZero_eq_true_iff f).1 hzero'.1
+    have hhzero : h = 0 :=
+      (DensePoly.size_eq_zero_iff h).1 <|
+        (DensePoly.isZero_eq_true_iff h).1 hzero'.2
+    subst f
+    subst h
+    decide
+  · simp only [hzero, Bool.false_eq_true, ite_false] at hcert
+    generalize hcandidate : prsCandidate? f h = candidate? at hcert
+    cases candidate? with
+    | none => simp [bind, Option.bind] at hcert
+    | some candidate =>
+        simp only [bind, Option.bind] at hcert
+        generalize hwitness :
+          prsCoprimeWitness? (DensePoly.divMod f candidate).1
+            (DensePoly.divMod h candidate).1 = witness? at hcert
+        cases witness? with
+        | none => simp at hcert
+        | some witness =>
+            simp only [] at hcert
+            split at hcert
+            · cases hcert
+              assumption
+            · contradiction
 
 /-! Executable pin for the extended-chain route, including rationally
 nonmonic cofactors. -/

--- a/HexPolyZGcd/README.md
+++ b/HexPolyZGcd/README.md
@@ -1,0 +1,74 @@
+# hex-poly-z-gcd
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-poly-z-gcd` provides checked modular gcds, exact cofactors, coprimality
+witnesses, and fast square-free decomposition for dense polynomials in
+`ℤ[x]`. It depends on `hex-poly-z`, `hex-poly-fp`, `hex-modular`, and
+`hex-resultant`. Its Mathlib correspondence is
+[`hex-poly-z-gcd-mathlib`](https://github.com/leanprover/hex-poly-z-gcd-mathlib).
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-poly-z-gcd"
+git = "https://github.com/leanprover/hex-poly-z-gcd.git"
+rev = "main"
+```
+
+```lean
+import HexPolyZGcd
+
+open Hex
+
+def x1 : ZPoly := DensePoly.ofList [1, 1]
+def x2 : ZPoly := DensePoly.ofList [2, 1]
+def left : ZPoly := x1 * x1 * x2
+def right : ZPoly := x1 * x2 * x2
+
+#eval ZPoly.gcd left right
+#eval ZPoly.cofactors left right
+#eval ZPoly.sqfDecomp left
+```
+
+# Functionality
+
+- Checked exact division with `ZPoly.divExact?` and decidable divisibility.
+- Certificate production and replay with `ZPoly.GcdCert`, `ZPoly.gcdCert`,
+  and `ZPoly.checkGcd`.
+- Modular, heuristic, and subresultant gcd routes behind `ZPoly.gcd`.
+- Exact paired cofactors with `ZPoly.cofactors`, plus `ZPoly.gcdList` and
+  `ZPoly.lcm`.
+- Fast primitive square-free decomposition with `ZPoly.sqfDecomp`.
+
+# Verification
+
+Every public gcd result comes from a certificate accepted by `checkGcd`.
+The checker proves both cofactor identities and absence of a common nonunit
+cofactor. The maximality layer proves the usual greatest-common-divisor
+universal property. The fast square-free decomposition proves signed
+reassembly and square-freeness of every nonzero core.
+
+```lean
+theorem dvd_gcd (d f h : ZPoly) (hf : d ∣ f) (hh : d ∣ h) :
+    d ∣ gcd f h
+
+theorem sqfDecomp_squareFreeCore (f : ZPoly)
+    (hcore : (sqfDecomp f).squareFreeCore ≠ 0) :
+    SquareFreeRat (sqfDecomp f).squareFreeCore
+```
+
+The executable library is Mathlib-free. The sibling Mathlib package
+transports divisibility and maximality to `Polynomial ℤ`.
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want and leave
+the implementation to the maintainer.

--- a/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
+++ b/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
@@ -680,7 +680,8 @@ theorem dvd_gcd (d) : d ∣ e f → d ∣ e h → d ∣ e (gcd f h)
 theorem coprimeCofactors_greatest (hc : CoprimeCofactors f h g) (d) :
     d ∣ e f → d ∣ e h → d ∣ e g
 
-theorem divExact?_eq_dvd : (divExact? f g).isSome = true ↔ e g ∣ e f
+theorem divExact?_eq_dvd :
+    (divExact? f g).isSome = true ↔ g ≠ 0 ∧ e g ∣ e f
 
 instance : Decidable (a ∣ b)          -- Polynomial ℤ
 instance : DecidableEq (Polynomial ℤ) -- through the equivalence, for the above

--- a/HexPolyZGcd/SquareFree.lean
+++ b/HexPolyZGcd/SquareFree.lean
@@ -6,8 +6,8 @@ Authors: Kim Morrison
 
 module
 
-public meta import HexPolyZGcd.Gcd
-public import HexPolyZGcd.Gcd
+public meta import HexPolyZGcd.Maximal
+public import HexPolyZGcd.Maximal
 
 public section
 
@@ -18,6 +18,37 @@ Fast primitive square-free normalization driven by the checked integer gcd.
 namespace Hex
 
 namespace ZPoly
+
+/-- The gcd component of an accepted certificate satisfies the public
+normalization convention. -/
+private theorem normalizedOfCheck {f h : ZPoly} {cert : GcdCert}
+    (hcheck : checkGcd f h cert = true) :
+    NormalizedGcd cert.gcd = true := by
+  unfold checkGcd at hcheck
+  simp only [Bool.and_eq_true] at hcheck
+  exact hcheck.1.1.2
+
+/-- Scaling an integer polynomial by one leaves it unchanged. -/
+private theorem scaleOne (p : ZPoly) :
+    DensePoly.scale (1 : Int) p = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_scale_semiring, Int.one_mul]
+
+/-- Sign normalization differs from its input by a unit of `Int`. -/
+private theorem scaleNormalize (p : ZPoly) :
+    ∃ ε : Int, (ε = 1 ∨ ε = -1) ∧
+      DensePoly.scale ε (normalizePrimitiveSign p) = p := by
+  unfold normalizePrimitiveSign
+  by_cases hnegative : p.leadingCoeff < 0
+  · rw [if_pos hnegative]
+    refine ⟨-1, Or.inr rfl, ?_⟩
+    rw [DensePoly.scale_scale]
+    have hunit : (-1 : Int) * -1 = 1 := by omega
+    rw [hunit]
+    exact scaleOne p
+  · rw [if_neg hnegative]
+    exact ⟨1, Or.inl rfl, scaleOne p⟩
 
 /-- Integer-gcd replacement for `primitiveSquareFreeDecomposition`'s rational
 Euclidean bottleneck.  The return type and normalization convention are shared
@@ -48,6 +79,46 @@ def sqfDecomp (f : ZPoly) : PrimitiveSquareFreeDecomposition :=
         squareFreeCore := normalizePrimitiveSign cert.cofL
         repeatedPart := cert.gcd }
 
+/-- The public checked gcd agrees with the canonical rational fallback on
+every nonzero input pair. -/
+private theorem gcd_eq_rationalCandidate {f h : ZPoly}
+    (hnz : f ≠ 0 ∨ h ≠ 0) :
+    gcd f h = rationalGcdCandidate f h := by
+  let reference := rationalGcdCert f h
+  have hreference := rationalGcdCert_checks f h
+  have hreferenceGcd : reference.gcd = rationalGcdCandidate f h := by
+    simpa only [reference] using rationalGcdCert_gcd hnz
+  have hreferenceCop : CoprimeCofactors f h reference.gcd :=
+    coprimeCofactors_of_checkGcd hreference
+  have hreferenceSound := checkGcd_sound hreference
+  have hreferenceDvdLeft : reference.gcd ∣ f :=
+    ⟨reference.cofL, hreferenceSound.1⟩
+  have hreferenceDvdRight : reference.gcd ∣ h :=
+    ⟨reference.cofR, hreferenceSound.2.1⟩
+  have hpublicDvdReference : gcd f h ∣ reference.gcd :=
+    dvd_gcd_of_coprimeCofactors hreferenceCop (gcd f h)
+      (gcd_dvd_left f h) (gcd_dvd_right f h)
+  have hreferenceDvdPublic : reference.gcd ∣ gcd f h :=
+    dvd_gcd reference.gcd f h hreferenceDvdLeft hreferenceDvdRight
+  have hpublicNorm : NormalizedGcd (gcd f h) = true := by
+    rw [gcd_eq_cert]
+    exact normalizedOfCheck (gcdCert_checks f h)
+  have heq : reference.gcd = gcd f h :=
+    eq_of_normalized_of_dvd_dvd (normalizedOfCheck hreference) hpublicNorm
+      hreferenceDvdPublic hpublicDvdReference
+  exact heq.symm.trans hreferenceGcd
+
+/-- Casting coefficients from `Int` to `Rat` commutes with formal
+differentiation. -/
+private theorem toRatPoly_derivative (p : ZPoly) :
+    toRatPoly (DensePoly.derivative p) =
+      DensePoly.derivative (toRatPoly p) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_toRatPoly, DensePoly.coeff_derivative_semiring,
+    DensePoly.coeff_derivative_semiring, coeff_toRatPoly]
+  rw [Rat.intCast_mul, Rat.intCast_natCast]
+
 /-- The fast decomposition's repeated part is the checked gcd of the primitive
 input and its derivative in the nondegenerate branch. -/
 theorem sqfDecomp_repeatedPart (f : ZPoly)
@@ -55,7 +126,135 @@ theorem sqfDecomp_repeatedPart (f : ZPoly)
     (hd : (DensePoly.derivative (primitivePart f)).isZero = false) :
     (sqfDecomp f).repeatedPart =
       gcd (primitivePart f) (DensePoly.derivative (primitivePart f)) := by
-  sorry
+  let p := primitivePart f
+  let derivative := DensePoly.derivative p
+  have hpNot : ¬p.isZero = true := by
+    intro hpTrue
+    change (primitivePart f).isZero = true at hpTrue
+    rw [hp] at hpTrue
+    contradiction
+  have hpNe : p ≠ 0 := by
+    intro hpZero
+    have hpTrue : p.isZero = true := by rw [hpZero]; rfl
+    exact hpNot hpTrue
+  unfold sqfDecomp
+  rw [if_neg (by simpa only [p] using hpNot)]
+  rw [if_neg (by
+    intro hdTrue
+    rw [hd] at hdTrue
+    contradiction)]
+  by_cases hsmall : p.size ≤ 8
+  · rw [if_pos hsmall]
+    exact (gcd_eq_rationalCandidate (Or.inl hpNe)).symm
+  · rw [if_neg hsmall]
+    exact (gcd_eq_cert p derivative).symm
+
+/-- The fast and rational reference decompositions choose the same repeated
+factor whenever the primitive input and its derivative are nonzero. -/
+private theorem repeatedPart_eq_reference (f : ZPoly)
+    (hp : (primitivePart f).isZero = false)
+    (hd : (DensePoly.derivative (primitivePart f)).isZero = false) :
+    (sqfDecomp f).repeatedPart =
+      (primitiveSquareFreeDecomposition f).repeatedPart := by
+  let p := primitivePart f
+  let derivative := DensePoly.derivative p
+  have hpNe : p ≠ 0 := by
+    intro hpZero
+    have hpTrue : p.isZero = true := by rw [hpZero]; rfl
+    change (primitivePart f).isZero = true at hpTrue
+    rw [hp] at hpTrue
+    contradiction
+  have hcontentNe : content f ≠ 0 := by
+    intro hcontent
+    apply hpNe
+    simpa only [p, primitivePart] using
+      DensePoly.primitivePart_eq_zero_of_content_eq_zero f
+        (by simpa only [content] using hcontent)
+  have hpPrimitive : Primitive p := by
+    simpa only [p] using primitivePart_primitive f hcontentNe
+  have hderivativeNe : derivative ≠ 0 := by
+    intro hzero
+    have htrue : derivative.isZero = true := by rw [hzero]; rfl
+    change (DensePoly.derivative (primitivePart f)).isZero = true at htrue
+    rw [hd] at htrue
+    contradiction
+  have hratDerivativeNe : DensePoly.derivative (toRatPoly p) ≠ 0 := by
+    rw [← toRatPoly_derivative]
+    exact toRatPoly_ne_zero_of_ne_zero derivative hderivativeNe
+  have hpNot : ¬p.isZero = true := by
+    intro htrue
+    change (primitivePart f).isZero = true at htrue
+    rw [hp] at htrue
+    contradiction
+  have hratNot : ¬(DensePoly.derivative (toRatPoly p)).isZero = true := by
+    intro htrue
+    apply hratDerivativeNe
+    exact (DensePoly.size_eq_zero_iff _).mp
+      ((DensePoly.isZero_eq_true_iff _).mp htrue)
+  rw [sqfDecomp_repeatedPart f hp hd]
+  rw [gcd_eq_rationalCandidate (Or.inl hpNe)]
+  rw [rationalGcdCandidate_of_primitive hpPrimitive]
+  unfold primitiveSquareFreeDecomposition
+  rw [if_neg (by simpa only [p] using hpNot)]
+  rw [if_neg (by simpa only [p] using hratNot)]
+  rw [toRatPoly_derivative]
+
+/-- The repeated factors also agree in the derivative-zero branch. -/
+private theorem repeatedPart_eq_reference_of_nonzero (f : ZPoly)
+    (hp : (primitivePart f).isZero = false) :
+    (sqfDecomp f).repeatedPart =
+      (primitiveSquareFreeDecomposition f).repeatedPart := by
+  by_cases hd : (DensePoly.derivative (primitivePart f)).isZero = true
+  · have hpNot : ¬(primitivePart f).isZero = true := by
+      intro htrue
+      rw [hp] at htrue
+      contradiction
+    have hderivativeZero : DensePoly.derivative (primitivePart f) = 0 :=
+      (DensePoly.size_eq_zero_iff _).mp
+        ((DensePoly.isZero_eq_true_iff _).mp hd)
+    have hratDerivativeZero :
+        DensePoly.derivative (toRatPoly (primitivePart f)) = 0 := by
+      rw [← toRatPoly_derivative, hderivativeZero, toRatPoly_zero]
+    have hratTrue :
+        (DensePoly.derivative (toRatPoly (primitivePart f))).isZero = true := by
+      rw [hratDerivativeZero]
+      rfl
+    unfold sqfDecomp primitiveSquareFreeDecomposition
+    rw [if_neg hpNot, if_pos hd, if_neg hpNot, if_pos hratTrue]
+  · have hdFalse :
+        (DensePoly.derivative (primitivePart f)).isZero = false := by
+      cases hvalue : (DensePoly.derivative (primitivePart f)).isZero with
+      | false => rfl
+      | true => exact (hd hvalue).elim
+    exact repeatedPart_eq_reference f hp hdFalse
+
+/-- The fast decomposition retains the input's primitive part verbatim. -/
+private theorem sqfDecomp_primitive (f : ZPoly) :
+    (sqfDecomp f).primitive = primitivePart f := by
+  let p := primitivePart f
+  unfold sqfDecomp
+  by_cases hp : p.isZero = true
+  · rw [if_pos (by simpa only [p] using hp)]
+  · rw [if_neg (by simpa only [p] using hp)]
+    by_cases hd : (DensePoly.derivative p).isZero = true
+    · rw [if_pos (by simpa only [p] using hd)]
+    · rw [if_neg (by simpa only [p] using hd)]
+      split <;> rfl
+
+/-- Scaling twice by `-1` is the identity on integer polynomials. -/
+private theorem scaleNegInvolutive (p : ZPoly) :
+    DensePoly.scale (-1 : Int) (DensePoly.scale (-1 : Int) p) = p := by
+  rw [DensePoly.scale_scale]
+  have hunit : (-1 : Int) * -1 = 1 := by omega
+  rw [hunit]
+  exact scaleOne p
+
+/-- Scaling by `-1` is injective on integer polynomials. -/
+private theorem scaleNegInjective {p q : ZPoly}
+    (h : DensePoly.scale (-1 : Int) p = DensePoly.scale (-1 : Int) q) :
+    p = q := by
+  have hscaled := congrArg (DensePoly.scale (-1 : Int)) h
+  simpa only [scaleNegInvolutive] using hscaled
 
 /-- The fast square-free core and repeated part reassemble the primitive input
 up to the normalization sign. -/
@@ -63,13 +262,134 @@ theorem sqfDecomp_reassembly_signed (f : ZPoly) :
     let d := sqfDecomp f
     ∃ ε : Int, (ε = 1 ∨ ε = -1) ∧
       DensePoly.scale ε (d.squareFreeCore * d.repeatedPart) = d.primitive := by
-  sorry
+  dsimp only
+  let p := primitivePart f
+  have hpDef : primitivePart f = p := rfl
+  unfold sqfDecomp
+  by_cases hp : p.isZero = true
+  · rw [if_pos (by simpa only [p] using hp)]
+    have hpZero : p = 0 :=
+      (DensePoly.size_eq_zero_iff p).mp
+        ((DensePoly.isZero_eq_true_iff p).mp hp)
+    refine ⟨1, Or.inl rfl, ?_⟩
+    rw [DensePoly.zero_mul, DensePoly.scale_zero_right]
+    change 0 = primitivePart f
+    rw [hpDef, hpZero]
+  · rw [if_neg (by simpa only [p] using hp)]
+    let derivative := DensePoly.derivative p
+    by_cases hd : derivative.isZero = true
+    · rw [if_pos (by simpa only [derivative, p] using hd)]
+      rcases scaleNormalize p with ⟨ε, hε, hscale⟩
+      refine ⟨ε, hε, ?_⟩
+      rw [DensePoly.mul_one_right_poly]
+      exact hscale
+    · rw [if_neg (by simpa only [derivative, p] using hd)]
+      have hpNe : p ≠ 0 := by
+        intro hpZero
+        apply hp
+        rw [hpZero]
+        rfl
+      by_cases hsmall : p.size ≤ 8
+      · rw [if_pos (by simpa only [p] using hsmall)]
+        let repeated := rationalGcdCandidate p derivative
+        let quotient := (DensePoly.divMod p repeated).1
+        rcases scaleNormalize quotient with ⟨ε, hε, hscale⟩
+        refine ⟨ε, hε, ?_⟩
+        have hproduct : repeated * quotient = p := by
+          simpa only [repeated, quotient] using
+            rationalGcdCandidate_mul_quotient (f := p) (h := derivative)
+              (Or.inl hpNe)
+        rw [DensePoly.scale_mul, hscale]
+        rw [DensePoly.mul_comm_poly quotient repeated]
+        exact hproduct
+      · rw [if_neg (by simpa only [p] using hsmall)]
+        let cert := gcdCert p derivative
+        rcases scaleNormalize cert.cofL with ⟨ε, hε, hscale⟩
+        refine ⟨ε, hε, ?_⟩
+        have hproduct : cert.gcd * cert.cofL = p := by
+          exact (checkGcd_sound (gcdCert_checks p derivative)).1.symm
+        rw [DensePoly.scale_mul, hscale]
+        rw [DensePoly.mul_comm_poly cert.cofL cert.gcd]
+        exact hproduct
 
 /-- Every nonzero fast square-free core is square-free over `Rat[x]`. -/
 theorem sqfDecomp_squareFreeCore (f : ZPoly)
     (hcore : (sqfDecomp f).squareFreeCore ≠ 0) :
     SquareFreeRat (sqfDecomp f).squareFreeCore := by
-  sorry
+  let fast := sqfDecomp f
+  let reference := primitiveSquareFreeDecomposition f
+  have hfastCore : fast.squareFreeCore ≠ 0 := by
+    simpa only [fast] using hcore
+  have hpNe : primitivePart f ≠ 0 := by
+    intro hpZero
+    apply hfastCore
+    have hpTrue : (primitivePart f).isZero = true := by
+      rw [hpZero]
+      rfl
+    simp only [fast, sqfDecomp, hpTrue, if_pos]
+  have hfNe : f ≠ 0 := by
+    intro hfZero
+    subst f
+    apply hpNe
+    rfl
+  have hpFalse : (primitivePart f).isZero = false := by
+    cases hp : (primitivePart f).isZero with
+    | false => rfl
+    | true =>
+        exfalso
+        apply hpNe
+        exact (DensePoly.size_eq_zero_iff _).mp
+          ((DensePoly.isZero_eq_true_iff _).mp hp)
+  have hrepeated : fast.repeatedPart = reference.repeatedPart := by
+    simpa only [fast, reference] using
+      repeatedPart_eq_reference_of_nonzero f hpFalse
+  rcases sqfDecomp_reassembly_signed f with ⟨ε, hε, hfastProduct⟩
+  have hfastProduct' :
+      DensePoly.scale ε (fast.squareFreeCore * fast.repeatedPart) =
+        primitivePart f := by
+    simpa only [fast, sqfDecomp_primitive] using hfastProduct
+  have hfastRepeated : fast.repeatedPart ≠ 0 := by
+    intro hrepeatedZero
+    apply hpNe
+    rw [hrepeatedZero, DensePoly.mul_comm_poly fast.squareFreeCore 0,
+      DensePoly.zero_mul, DensePoly.scale_zero_right] at hfastProduct'
+    exact hfastProduct'.symm
+  rcases primitiveSquareFreeDecomposition_reassembly_signed f hfNe with
+    ⟨δ, hδ, hreferenceProduct⟩
+  have hreferenceCore : reference.squareFreeCore ≠ 0 := by
+    intro hreferenceZero
+    apply hpNe
+    change DensePoly.scale δ
+      (reference.squareFreeCore * reference.repeatedPart) = primitivePart f at hreferenceProduct
+    rw [hreferenceZero, DensePoly.zero_mul, DensePoly.scale_zero_right] at hreferenceProduct
+    exact hreferenceProduct.symm
+  have hreferenceSquareFree : SquareFreeRat reference.squareFreeCore := by
+    exact primitiveSquareFreeDecomposition_squareFreeCore f (by
+      simpa only [reference] using hreferenceCore)
+  have hproducts :
+      DensePoly.scale ε (fast.squareFreeCore * fast.repeatedPart) =
+        DensePoly.scale δ (reference.squareFreeCore * reference.repeatedPart) := by
+    exact hfastProduct'.trans hreferenceProduct.symm
+  rw [DensePoly.scale_mul, DensePoly.scale_mul, ← hrepeated] at hproducts
+  have hcores :
+      DensePoly.scale ε fast.squareFreeCore =
+        DensePoly.scale δ reference.squareFreeCore :=
+    mul_right_cancel_of_ne_zero hfastRepeated hproducts
+  rcases hε with rfl | rfl <;> rcases hδ with rfl | rfl
+  · rw [scaleOne, scaleOne] at hcores
+    rw [hcores]
+    exact hreferenceSquareFree
+  · rw [scaleOne] at hcores
+    rw [hcores]
+    exact squareFreeRat_scale_neg_one reference.squareFreeCore hreferenceSquareFree
+  · rw [scaleOne] at hcores
+    have hcores' := congrArg (DensePoly.scale (-1 : Int)) hcores
+    rw [scaleNegInvolutive] at hcores'
+    rw [hcores']
+    exact squareFreeRat_scale_neg_one reference.squareFreeCore hreferenceSquareFree
+  · have hcores' := scaleNegInjective hcores
+    rw [hcores']
+    exact hreferenceSquareFree
 
 #guard
   let x1 : ZPoly := DensePoly.ofList [1, 1]

--- a/HexPolyZGcd/SquareFree.lean
+++ b/HexPolyZGcd/SquareFree.lean
@@ -104,7 +104,7 @@ private theorem gcd_eq_rationalCandidate {f h : ZPoly}
     rw [gcd_eq_cert]
     exact normalizedOfCheck (gcdCert_checks f h)
   have heq : reference.gcd = gcd f h :=
-    eq_of_normalized_of_dvd_dvd (normalizedOfCheck hreference) hpublicNorm
+    eq_of_normalized_dvd (normalizedOfCheck hreference) hpublicNorm
       hreferenceDvdPublic hpublicDvdReference
   exact heq.symm.trans hreferenceGcd
 
@@ -149,9 +149,11 @@ theorem sqfDecomp_repeatedPart (f : ZPoly)
   · rw [if_neg hsmall]
     exact (gcd_eq_cert p derivative).symm
 
+namespace Repeated
+
 /-- The fast and rational reference decompositions choose the same repeated
 factor whenever the primitive input and its derivative are nonzero. -/
-private theorem repeatedPart_eq_reference (f : ZPoly)
+private theorem nondegenerate (f : ZPoly)
     (hp : (primitivePart f).isZero = false)
     (hd : (DensePoly.derivative (primitivePart f)).isZero = false) :
     (sqfDecomp f).repeatedPart =
@@ -200,7 +202,7 @@ private theorem repeatedPart_eq_reference (f : ZPoly)
   rw [toRatPoly_derivative]
 
 /-- The repeated factors also agree in the derivative-zero branch. -/
-private theorem repeatedPart_eq_reference_of_nonzero (f : ZPoly)
+private theorem eqReference (f : ZPoly)
     (hp : (primitivePart f).isZero = false) :
     (sqfDecomp f).repeatedPart =
       (primitiveSquareFreeDecomposition f).repeatedPart := by
@@ -226,7 +228,9 @@ private theorem repeatedPart_eq_reference_of_nonzero (f : ZPoly)
       cases hvalue : (DensePoly.derivative (primitivePart f)).isZero with
       | false => rfl
       | true => exact (hd hvalue).elim
-    exact repeatedPart_eq_reference f hp hdFalse
+    exact nondegenerate f hp hdFalse
+
+end Repeated
 
 /-- The fast decomposition retains the input's primitive part verbatim. -/
 private theorem sqfDecomp_primitive (f : ZPoly) :
@@ -342,7 +346,7 @@ theorem sqfDecomp_squareFreeCore (f : ZPoly)
           ((DensePoly.isZero_eq_true_iff _).mp hp)
   have hrepeated : fast.repeatedPart = reference.repeatedPart := by
     simpa only [fast, reference] using
-      repeatedPart_eq_reference_of_nonzero f hpFalse
+      Repeated.eqReference f hpFalse
   rcases sqfDecomp_reassembly_signed f with ⟨ε, hε, hfastProduct⟩
   have hfastProduct' :
       DensePoly.scale ε (fast.squareFreeCore * fast.repeatedPart) =

--- a/HexPolyZGcdMathlib.lean
+++ b/HexPolyZGcdMathlib.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcdMathlib.Gcd
+
+public section
+
+/-!
+`HexPolyZGcdMathlib` transports the verified executable integer-polynomial gcd
+surface to Mathlib's `Polynomial ℤ` representation.
+-/

--- a/HexPolyZGcdMathlib/Gcd.lean
+++ b/HexPolyZGcdMathlib/Gcd.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZGcd.Maximal
+public import HexPolyZMathlib.PolynomialEquivalence
+
+public section
+
+/-!
+Transport of the checked integer-polynomial gcd API to Mathlib's
+`Polynomial ℤ` representation.
+-/
+
+namespace HexPolyZGcdMathlib
+
+open Hex
+
+noncomputable section
+
+/-- The transported checked gcd divides the left input. -/
+theorem gcd_dvd_left (f h : ZPoly) :
+    HexPolyZMathlib.equiv (ZPoly.gcd f h) ∣ HexPolyZMathlib.equiv f := by
+  simpa only [HexPolyZMathlib.equiv_apply] using
+    HexPolyMathlib.toPolynomial_dvd (ZPoly.gcd_dvd_left f h)
+
+/-- The transported checked gcd divides the right input. -/
+theorem gcd_dvd_right (f h : ZPoly) :
+    HexPolyZMathlib.equiv (ZPoly.gcd f h) ∣ HexPolyZMathlib.equiv h := by
+  simpa only [HexPolyZMathlib.equiv_apply] using
+    HexPolyMathlib.toPolynomial_dvd (ZPoly.gcd_dvd_right f h)
+
+/-- Every common executable divisor divides the transported checked gcd. -/
+theorem dvd_gcd (d f h : ZPoly)
+    (hdf : HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv f)
+    (hdh : HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv h) :
+    HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv (ZPoly.gcd f h) := by
+  have hdf' : d ∣ f := by
+    exact HexPolyMathlib.toPolynomial_dvd_iff.mp (by
+      simpa only [HexPolyZMathlib.equiv_apply] using hdf)
+  have hdh' : d ∣ h := by
+    exact HexPolyMathlib.toPolynomial_dvd_iff.mp (by
+      simpa only [HexPolyZMathlib.equiv_apply] using hdh)
+  simpa only [HexPolyZMathlib.equiv_apply] using
+    HexPolyMathlib.toPolynomial_dvd (ZPoly.dvd_gcd d f h hdf' hdh')
+
+/-- Checked coprime cofactors establish greatestness after transport to
+Mathlib polynomials. -/
+theorem coprimeCofactors_greatest {f h g : ZPoly}
+    (hc : ZPoly.CoprimeCofactors f h g) (d : ZPoly)
+    (hdf : HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv f)
+    (hdh : HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv h) :
+    HexPolyZMathlib.equiv d ∣ HexPolyZMathlib.equiv g := by
+  have hdf' : d ∣ f := HexPolyMathlib.toPolynomial_dvd_iff.mp (by
+    simpa only [HexPolyZMathlib.equiv_apply] using hdf)
+  have hdh' : d ∣ h := HexPolyMathlib.toPolynomial_dvd_iff.mp (by
+    simpa only [HexPolyZMathlib.equiv_apply] using hdh)
+  simpa only [HexPolyZMathlib.equiv_apply] using
+    HexPolyMathlib.toPolynomial_dvd
+      (ZPoly.dvd_gcd_of_coprimeCofactors hc d hdf' hdh')
+
+/-- Checked exact division succeeds precisely for a nonzero divisor that
+divides after transport to Mathlib polynomials. -/
+theorem divExact?_eq_dvd (f g : ZPoly) :
+    (ZPoly.divExact? f g).isSome = true ↔
+      g ≠ 0 ∧ HexPolyZMathlib.equiv g ∣ HexPolyZMathlib.equiv f := by
+  constructor
+  · intro hsome
+    cases hq : ZPoly.divExact? f g with
+    | none => simp [hq] at hsome
+    | some q =>
+        refine ⟨?_, ?_⟩
+        · intro hg
+          subst g
+          rw [ZPoly.divExact?_zero_right] at hq
+          contradiction
+        · apply HexPolyMathlib.toPolynomial_dvd
+          refine ⟨q, ?_⟩
+          rw [DensePoly.mul_comm_poly]
+          exact (ZPoly.divExact?_product hq).symm
+  · rintro ⟨hg, hdvd⟩
+    have hdvd' : g ∣ f := HexPolyMathlib.toPolynomial_dvd_iff.mp (by
+      simpa only [HexPolyZMathlib.equiv_apply] using hdvd)
+    exact ZPoly.divExact?_isSome_of_dvd hg hdvd'
+
+end
+
+end HexPolyZGcdMathlib

--- a/HexPolyZGcdMathlib/README.md
+++ b/HexPolyZGcdMathlib/README.md
@@ -1,0 +1,58 @@
+# hex-poly-z-gcd-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-poly-z-gcd-mathlib` transports the verified gcd API from
+[`hex-poly-z-gcd`](https://github.com/leanprover/hex-poly-z-gcd) to Mathlib's
+`Polynomial ℤ`. It depends on `hex-poly-z-gcd`, `hex-poly-z-mathlib`, and
+`hex-poly-mathlib`; executable computation remains in the Mathlib-free
+package.
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-poly-z-gcd-mathlib"
+git = "https://github.com/leanprover/hex-poly-z-gcd-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexPolyZGcdMathlib
+
+open Hex
+
+example (f h : ZPoly) :
+    HexPolyZMathlib.equiv (ZPoly.gcd f h) ∣
+      HexPolyZMathlib.equiv f :=
+  HexPolyZGcdMathlib.gcd_dvd_left f h
+```
+
+# Functionality
+
+- Left and right divisibility of the transported checked gcd.
+- The greatest-common-divisor universal property in `Polynomial ℤ`.
+- Transported greatestness for an arbitrary accepted
+  `ZPoly.CoprimeCofactors` witness.
+- Exact-division success characterized by nonzero polynomial divisibility.
+
+# Verification
+
+This package contains correspondence proofs and no new executable gcd
+algorithm. Its theorems transport the Mathlib-free certificate and maximality
+results through `HexPolyZMathlib.equiv`.
+
+```lean
+theorem divExact?_eq_dvd (f g : ZPoly) :
+    (ZPoly.divExact? f g).isSome = true ↔
+      g ≠ 0 ∧ HexPolyZMathlib.equiv g ∣ HexPolyZMathlib.equiv f
+```
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want and leave
+the implementation to the maintainer.

--- a/HexPolyZGcdMathlib/SPEC/hex-poly-z-gcd-mathlib.md
+++ b/HexPolyZGcdMathlib/SPEC/hex-poly-z-gcd-mathlib.md
@@ -1,0 +1,37 @@
+# hex-poly-z-gcd-mathlib
+
+## Purpose
+
+This library transports the verified executable integer-polynomial gcd API
+from `hex-poly-z-gcd` across `HexPolyZMathlib.equiv` to Mathlib's
+`Polynomial ℤ`. It contains proof-facing correspondence results and no gcd
+implementation of its own.
+
+## API
+
+For `f h d g : Hex.ZPoly`:
+
+```lean
+theorem gcd_dvd_left (f h) : e (gcd f h) ∣ e f
+theorem gcd_dvd_right (f h) : e (gcd f h) ∣ e h
+
+theorem dvd_gcd (d f h) :
+    e d ∣ e f → e d ∣ e h → e d ∣ e (gcd f h)
+
+theorem coprimeCofactors_greatest
+    (hc : CoprimeCofactors f h g) (d) :
+    e d ∣ e f → e d ∣ e h → e d ∣ e g
+
+theorem divExact?_eq_dvd (f g) :
+    (divExact? f g).isSome = true ↔ g ≠ 0 ∧ e g ∣ e f
+```
+
+The nonzero condition in the final statement is necessary: executable exact
+division rejects a zero divisor, while Mathlib divisibility admits `0 ∣ 0`.
+
+## Proof boundary
+
+The computational package proves exact cofactor identities, cofactor
+coprimality, normalization, and maximality without importing Mathlib. This
+companion uses the existing dense-polynomial ring equivalence and its
+divisibility correspondence to restate those results over `Polynomial ℤ`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -162,6 +162,9 @@ lean_lib HexModArithMathlib where
 lean_lib HexPolyZMathlib where
 
 @[default_target]
+lean_lib HexPolyZGcdMathlib where
+
+@[default_target]
 lean_lib HexRootsMathlib where
 
 @[default_target]

--- a/libraries.yml
+++ b/libraries.yml
@@ -336,7 +336,7 @@ libraries:
   HexPolyZGcd:
     deps: [HexPolyZ, HexPolyFp, HexPoly, HexModular, HexModArith, HexArith, HexResultant]
     mathlib: false
-    done_through: 4
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -609,6 +609,11 @@ libraries:
     deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
     done_through: 6
+    status: active
+  HexPolyZGcdMathlib:
+    deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib]
+    mathlib: true
+    done_through: 7
     status: active
   HexLLLMathlib:
     deps: [HexLLL, HexGramSchmidtMathlib, HexRowReduceMathlib]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -952,5 +952,17 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "ce28c059fd9412e7f82e0dd5a482911ccd29b0ef",
     "reason": "Combines current main's build-only, conformance, fixture, benchmark, and proof-side interval registrations with the HexMvGcd conformance executables; none changes a factorization runtime target, definition, build flag, or dependency."
+  },
+  {
+    "path": "HexPolyZ/Rational.lean",
+    "baseline_blob": "ba568b38f9482f906439858ac72b823d2b933be7",
+    "current_blob": "5495375e8339591996f2607e4a858f48e09a80b2",
+    "reason": "Exports two already-proved rational-polynomial size laws for proof reuse by HexPolyZGcd; no executable definition or factorization runtime call path changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "63a35adbd5c123b4fccd97b7a53e0316abad5fee",
+    "reason": "Combines current main's build-only, conformance, fixture, benchmark, and proof-side interval registrations with the HexPolyZGcd benchmark executable and proof-only HexPolyZGcdMathlib library; neither enters the factorization service target or changes its runtime dependency graph."
   }
 ]


### PR DESCRIPTION
Completes the integer-polynomial gcd stack from Phase 5 through Phase 7.

- proves all certificate, dispatch, maximality, and fast square-free obligations without `sorry`
- adds the `HexPolyZGcdMathlib` divisibility/maximality correspondence
- corrects the exact-division correspondence to record the necessary nonzero-divisor condition
- adds the Verso manual chapter and release READMEs
- records both the computational library and Mathlib companion at Phase 7

This PR is stacked on #9524. Merge #9524 first; after its squash merge this branch will be rebased onto `main` so the final diff contains only Phase 5-7 work.

Verification:
- `lake build HexPolyZGcd`
- `lake build HexPolyZGcdMathlib`
- `lake build HexManual.Chapters.HexPolyZGcd`
- `python3 scripts/check_phase7.py`
- no `sorry`, `axiom`, or `native_decide` in either library