### PR TITLE
Prove HexMvGcd foundational laws

### DIFF
--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -610,7 +610,11 @@ theorem CheckedGcdResult.greatest {n : Nat} {R : Type u}
     {f h g cofL cofR : MvPoly n R cmp}
     (hc : CheckedGcdResult f h g cofL cofR) :
     ∀ d, d ∣ f → d ∣ h → d ∣ g := by
-  sorry
+  intro d hdf hdh
+  rcases hc with ⟨hf, hh, _, hcop⟩
+  rw [hf] at hdf
+  rw [hh] at hdh
+  exact CoprimeCancelLaws.cancel_coprime g cofL cofR d hcop hdf hdh
 
 /-- Full semantic payload of an accepted certificate. -/
 theorem checkGcd_greatest {n : Nat} {R : Type u}

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -263,6 +263,19 @@ implementation detail of Lean's mutual-inductive positivity checker. -/
     ContentCert n R cmp :=
   .mk value (GcdCerts.ofList steps)
 
+@[simp] theorem value_ofSteps (value : MvPoly n R cmp)
+    (steps : List (GcdCert n R cmp)) :
+    (ofSteps value steps).value = value := by
+  rfl
+
+@[simp] theorem steps_ofSteps (value : MvPoly n R cmp)
+    (steps : List (GcdCert n R cmp)) :
+    (ofSteps value steps).steps = steps := by
+  induction steps with
+  | nil => rfl
+  | cons step steps ih =>
+      simp only [ContentCert.steps, GcdCerts.toList, ih]
+
 end ContentCert
 
 /-- Coefficientwise cast from the integer model used by `ratLift`. -/
@@ -296,6 +309,23 @@ structure CheckOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
     (polyNormalize cert.gcd == cert.gcd) &&
     coprime cert.cofL cert.cofR cert.coprime
 
+/-! `checkContentSteps` exposes the accumulator used by content replay.  The
+public checker fixes that accumulator to zero; keeping the general recursion
+named lets producer proofs state the natural induction invariant. -/
+
+@[reducible] def checkContentSteps {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (gcd : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
+    (value acc : MvPoly n R cmp) :
+    List (MvPoly n R cmp) → List (GcdCert n R cmp) → Bool
+  | [], [] => acc == value
+  | q :: qs, step :: steps =>
+      gcd acc q step && checkContentSteps gcd value step.gcd qs steps
+  | _, _ => false
+
 @[reducible] def checkContentUsing {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
@@ -303,12 +333,7 @@ structure CheckOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
     [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
     (gcd : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
     (coeffs : List (MvPoly n R cmp)) (cert : ContentCert n R cmp) : Bool :=
-  let rec go (acc : MvPoly n R cmp) :
-      List (MvPoly n R cmp) → List (GcdCert n R cmp) → Bool
-    | [], [] => acc == cert.value
-    | q :: qs, step :: steps => gcd acc q step && go step.gcd qs steps
-    | _, _ => false
-  go 0 coeffs cert.steps
+  checkContentSteps gcd cert.value 0 coeffs cert.steps
 
 /-! The rational-lift branch contains an embedded coefficient certificate at
 the same arity.  Its replay therefore uses this independent structural

--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -66,7 +66,34 @@ theorem contentCertWith_length {R : Type u}
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
     (coeffs : List (MvPoly n R cmp)) :
     (contentCertWith produce coeffs).steps.length = coeffs.length := by
-  sorry
+  have aux : ∀ (xs : List (MvPoly n R cmp))
+      (state : MvPoly n R cmp × List (GcdCert n R cmp)),
+      (xs.foldl
+          (fun state q =>
+            let step := produce state.1 q
+            (step.gcd, step :: state.2))
+          state).2.length = state.2.length + xs.length := by
+    intro xs
+    induction xs with
+    | nil =>
+        intro state
+        simp
+    | cons q qs ih =>
+        intro state
+        rw [List.foldl_cons, ih]
+        simp only [List.length_cons]
+        omega
+  have ofList_length : ∀ (steps : List (GcdCert n R cmp)),
+      (GcdCerts.ofList steps).toList.length = steps.length := by
+    intro steps
+    induction steps with
+    | nil => rfl
+    | cons step steps ih =>
+        simp only [GcdCerts.toList, List.length_cons, ih]
+  unfold contentCertWith ContentCert.steps ContentCert.ofSteps
+  rw [ofList_length, List.length_reverse]
+  rw [aux]
+  simp
 
 /-- A producer-built fold checks when every supplied gcd certificate checks. -/
 theorem contentCertWith_checks {R : Type u}

--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -59,6 +59,70 @@ def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
     (0, [])
   .ofSteps pair.1 pair.2.reverse
 
+/-- Forward-order specification of the reverse-accumulator content fold. -/
+private def contentTrace {R : Type u} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp) :
+    MvPoly n R cmp → List (MvPoly n R cmp) →
+      MvPoly n R cmp × List (GcdCert n R cmp)
+  | acc, [] => (acc, [])
+  | acc, q :: qs =>
+      let step := produce acc q
+      let tail := contentTrace produce step.gcd qs
+      (tail.1, step :: tail.2)
+
+private theorem contentFold_eq_trace {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (coeffs : List (MvPoly n R cmp)) (acc : MvPoly n R cmp)
+    (done : List (GcdCert n R cmp)) :
+    let pair := coeffs.foldl
+      (fun state q =>
+        let step := produce state.1 q
+        (step.gcd, step :: state.2))
+      (acc, done)
+    (pair.1, pair.2.reverse) =
+      let trace := contentTrace produce acc coeffs
+      (trace.1, done.reverse ++ trace.2) := by
+  induction coeffs generalizing acc done with
+  | nil => simp [contentTrace]
+  | cons q qs ih =>
+      simp only [List.foldl_cons, contentTrace]
+      rw [ih]
+      simp [List.append_assoc]
+
+private theorem contentCertWith_eq_trace {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (coeffs : List (MvPoly n R cmp)) :
+    contentCertWith produce coeffs =
+      let trace := contentTrace produce 0 coeffs
+      ContentCert.ofSteps trace.1 trace.2 := by
+  unfold contentCertWith
+  simpa using congrArg
+    (fun pair => ContentCert.ofSteps pair.1 pair.2)
+    (contentFold_eq_trace produce coeffs 0 [])
+
+private theorem contentTrace_checks {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    (check : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
+    (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
+    (hproduce : ∀ f h, check f h (produce f h) = true)
+    (coeffs : List (MvPoly n R cmp)) (acc : MvPoly n R cmp) :
+    let trace := contentTrace produce acc coeffs
+    checkContentSteps check trace.1 acc coeffs trace.2 = true := by
+  induction coeffs generalizing acc with
+  | nil => simp [contentTrace]
+  | cons q qs ih =>
+      simp only [contentTrace, checkContentSteps]
+      rw [hproduce, Bool.true_and]
+      exact ih (produce acc q).gcd
+
 /-- A producer-built fold has exactly one step per coefficient. -/
 theorem contentCertWith_length {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
@@ -105,7 +169,29 @@ theorem contentCertWith_checks {R : Type u}
     (hproduce : ∀ f h, checkGcd f h (produce f h) = true)
     (coeffs : List (MvPoly n R cmp)) :
     checkContent coeffs (contentCertWith produce coeffs) = true := by
-  sorry
+  rw [contentCertWith_eq_trace]
+  cases n with
+  | zero =>
+      have hp : ∀ f h,
+          checkGcdUsing (baseCheckCoprime (cmp := cmp)) f h
+            (produce f h) = true := by
+        simpa [checkGcd, checkOps] using hproduce
+      simp only [checkContent, checkContentUsing]
+      rw [ContentCert.value_ofSteps, ContentCert.steps_ofSteps]
+      exact contentTrace_checks
+        (checkGcdUsing (baseCheckCoprime (cmp := cmp))) produce hp coeffs
+        (0 : MvPoly 0 R cmp)
+  | succ n =>
+      have hp : ∀ f h,
+          checkGcdUsing (succCheckCoprime (checkOps (R := R) n) (cmp := cmp))
+            f h (produce f h) = true := by
+        simpa [checkGcd, checkOps] using hproduce
+      simp only [checkContent, checkContentUsing]
+      rw [ContentCert.value_ofSteps, ContentCert.steps_ofSteps]
+      exact contentTrace_checks
+        (checkGcdUsing
+          (succCheckCoprime (checkOps (R := R) n) (cmp := cmp)))
+        produce hp coeffs (0 : MvPoly (n + 1) R cmp)
 
 /-- Scalar content and primitive part reconstruct the input. -/
 theorem content_mul_primPart [LawfulGcdOps R] (p : MvPoly n R cmp) :

--- a/HexMvGcd/Gauss.lean
+++ b/HexMvGcd/Gauss.lean
@@ -177,9 +177,15 @@ theorem fractionMap_mul (f g : MvPoly n R cmp) :
   exact mapCoeffs_mul Hex.Fraction.ofCoeff_zero Hex.Fraction.ofCoeff_add
     Hex.Fraction.ofCoeff_mul f g
 
+omit [BEq R] [LawfulBEq R] [Dvd R] in
 theorem fractionMap_injective :
     Function.Injective (fractionMap (n := n) (R := R) (cmp := cmp)) := by
-  sorry
+  intro p q hpq
+  apply ext
+  intro m
+  apply Hex.Fraction.ofCoeff_injective
+  have hcoeff := congrArg (coeff m) hpq
+  simpa [fractionMap, Hex.Fraction.ofCoeff_zero] using hcoeff
 
 /-- Coprimality after embedding the coefficients into the fraction field. -/
 def CoprimeOverFraction (f g : MvPoly n R cmp) : Prop :=

--- a/HexMvGcd/Instances.lean
+++ b/HexMvGcd/Instances.lean
@@ -472,6 +472,215 @@ def normalizedXgcd (f g : @FpPoly p hp) : @FpPoly p hp × @FpPoly p hp :=
   let u := normUnit r.gcd
   (r.left * u, r.right * u)
 
+private theorem coeffOne_ne_zero :
+    (1 : ZMod64 p) ≠ 0 := fun h =>
+  ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h
+
+private theorem one_ne_zero : (1 : FpPoly p) ≠ 0 := by
+  intro h
+  have hcoeff := congrArg (fun f : FpPoly p => f.coeff 0) h
+  change (DensePoly.C (1 : ZMod64 p)).coeff 0 =
+    (0 : FpPoly p).coeff 0 at hcoeff
+  rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
+  exact coeffOne_ne_zero hcoeff
+
+private theorem inv_ne_zero {c : ZMod64 p} (hc : c ≠ 0) : c⁻¹ ≠ 0 := by
+  intro hinv
+  change ZMod64.inv c = 0 at hinv
+  have hone := ZMod64.inv_mul_eq_one_of_ne_zero hc
+  rw [hinv, Lean.Grind.Semiring.zero_mul] at hone
+  exact coeffOne_ne_zero hone.symm
+
+omit [ZMod64.PrimeModulus p] in
+private theorem C_mul_C_eq (a b : ZMod64 p) :
+    (DensePoly.C a * DensePoly.C b : FpPoly p) = DensePoly.C (a * b) := by
+  rw [C_mul_eq_scale]
+  apply DensePoly.ext_coeff
+  intro n
+  have hzero : a * (0 : ZMod64 p) = 0 := Lean.Grind.Semiring.mul_zero a
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_C,
+    DensePoly.coeff_C]
+  cases n <;> rfl
+
+omit [ZMod64.PrimeModulus p] in
+private theorem scale_mul_scale (a b : ZMod64 p) (f g : FpPoly p) :
+    DensePoly.scale a f * DensePoly.scale b g =
+      DensePoly.scale (a * b) (f * g) := by
+  rw [← C_mul_eq_scale, ← C_mul_eq_scale, ← C_mul_eq_scale,
+    ← C_mul_C_eq]
+  calc
+    (DensePoly.C a * f) * (DensePoly.C b * g) =
+        ((DensePoly.C a * f) * DensePoly.C b) * g :=
+      (DensePoly.mul_assoc_poly _ _ _).symm
+    _ = (DensePoly.C a * (f * DensePoly.C b)) * g := by
+      exact congrArg (fun x : FpPoly p => x * g)
+        (DensePoly.mul_assoc_poly _ _ _)
+    _ = (DensePoly.C a * (DensePoly.C b * f)) * g := by
+      exact congrArg (fun x : FpPoly p => x * g)
+        (congrArg (fun x : FpPoly p => DensePoly.C a * x)
+          (DensePoly.mul_comm_poly f (DensePoly.C b)))
+    _ = ((DensePoly.C a * DensePoly.C b) * f) * g := by
+      exact congrArg (fun x : FpPoly p => x * g)
+        (DensePoly.mul_assoc_poly _ _ _).symm
+    _ = (DensePoly.C a * DensePoly.C b) * (f * g) :=
+      DensePoly.mul_assoc_poly _ _ _
+
+omit [ZMod64.PrimeModulus p] in
+private theorem eq_C_of_size_one {f : FpPoly p} (hsize : f.size = 1) :
+    f = DensePoly.C (f.coeff 0) := by
+  apply DensePoly.ext_coeff
+  intro n
+  cases n with
+  | zero =>
+      rw [DensePoly.coeff_C]
+      simp
+  | succ n =>
+      rw [DensePoly.coeff_eq_zero_of_size_le f (by omega),
+        DensePoly.coeff_C]
+      simp
+
+omit [ZMod64.PrimeModulus p] in
+private theorem coeff_zero_ne_zero_of_size_one {f : FpPoly p}
+    (hsize : f.size = 1) : f.coeff 0 ≠ 0 := by
+  have hlast := DensePoly.coeff_last_ne_zero_of_pos_size f (by omega)
+  rwa [hsize] at hlast
+
+omit [ZMod64.PrimeModulus p] in
+private theorem canonical_eq_scale {f : FpPoly p} (hf : f ≠ 0) :
+    f * normUnit f = DensePoly.scale f.leadingCoeff⁻¹ f := by
+  rw [normUnit, Hex.ite_eq_right hf]
+  calc
+    f * DensePoly.C f.leadingCoeff⁻¹ =
+        DensePoly.C f.leadingCoeff⁻¹ * f :=
+      DensePoly.mul_comm_poly _ _
+    _ = DensePoly.scale f.leadingCoeff⁻¹ f :=
+      C_mul_eq_scale _ _
+
+private theorem canonical_monic {f : FpPoly p} (hf : f ≠ 0) :
+    DensePoly.Monic (f * normUnit f) := by
+  rw [canonical_eq_scale hf]
+  have hsize : f.size ≠ 0 := Nat.ne_of_gt (size_pos_of_ne_zero hf)
+  have hlead : f.leadingCoeff ≠ 0 :=
+    DensePoly.leadingCoeff_ne_zero_of_pos_size f (Nat.pos_of_ne_zero hsize)
+  unfold DensePoly.Monic
+  rw [leadingCoeff_scale_of_ne_zero_of_nonzero (inv_ne_zero hlead) f hsize]
+  exact ZMod64.inv_mul_eq_one_of_ne_zero hlead
+
+private theorem canonical_fixed_of_monic {f : FpPoly p}
+    (hf : DensePoly.Monic f) : f * normUnit f = f := by
+  have hf0 : f ≠ 0 := by
+    intro hzero
+    subst f
+    exact coeffOne_ne_zero hf.symm
+  have hinvOne : ZMod64.inv (1 : ZMod64 p) = 1 := by
+    have h := ZMod64.inv_mul_eq_one_of_ne_zero (p := p) coeffOne_ne_zero
+    rw [Lean.Grind.Semiring.mul_one] at h
+    exact h
+  rw [canonical_eq_scale hf0, hf]
+  change DensePoly.scale (ZMod64.inv (1 : ZMod64 p)) f = f
+  rw [hinvOne, scale_one_left]
+
+private theorem canonical_idem (f : FpPoly p) :
+    (f * normUnit f) * normUnit (f * normUnit f) = f * normUnit f := by
+  by_cases hf : f = 0
+  · subst f
+    simp [normUnit]
+  · exact canonical_fixed_of_monic (canonical_monic hf)
+
+private theorem canonical_mul (f g : FpPoly p) :
+    f * g * normUnit (f * g) =
+      (f * normUnit f) * (g * normUnit g) := by
+  by_cases hf : f = 0
+  · subst f
+    simp [normUnit]
+  · by_cases hg : g = 0
+    · subst g
+      simp [normUnit]
+    · have hfg : f * g ≠ 0 := mul_ne_zero_of_ne_zero hf hg
+      rw [canonical_eq_scale hfg, canonical_eq_scale hf,
+        canonical_eq_scale hg, leadingCoeff_mul f g hf hg,
+        Lean.Grind.Field.inv_mul]
+      exact (scale_mul_scale _ _ f g).symm
+
+private theorem canonical_eq_one_of_size_one {f : FpPoly p}
+    (hsize : f.size = 1) : f * normUnit f = 1 := by
+  have hf : f ≠ 0 := by
+    intro hzero
+    rw [hzero] at hsize
+    contradiction
+  have hc : f.coeff 0 ≠ 0 := coeff_zero_ne_zero_of_size_one hsize
+  have hcancel : (f.coeff 0)⁻¹ * f.coeff 0 = 1 := by
+    change ZMod64.inv (f.coeff 0) * f.coeff 0 = 1
+    exact ZMod64.inv_mul_eq_one_of_ne_zero hc
+  rw [canonical_eq_scale hf, eq_C_of_size_one hsize,
+    DensePoly.leadingCoeff_C, ← C_mul_eq_scale, C_mul_C_eq, hcancel]
+  rfl
+
+private theorem normUnit_is_unit (f : FpPoly p) :
+    ∃ g, normUnit f * g = 1 := by
+  by_cases hf : f = 0
+  · exact ⟨1, by simp [normUnit, hf]⟩
+  · have hlead : f.leadingCoeff ≠ 0 :=
+      DensePoly.leadingCoeff_ne_zero_of_pos_size f (size_pos_of_ne_zero hf)
+    have hcancel : f.leadingCoeff⁻¹ * f.leadingCoeff = 1 := by
+      change ZMod64.inv f.leadingCoeff * f.leadingCoeff = 1
+      exact ZMod64.inv_mul_eq_one_of_ne_zero hlead
+    refine ⟨DensePoly.C f.leadingCoeff, ?_⟩
+    rw [normUnit, Hex.ite_eq_right hf, C_mul_C_eq, hcancel]
+    rfl
+
+private theorem canonical_dvd_self (f : FpPoly p) :
+    f * normUnit f ∣ f := by
+  by_cases hf : f = 0
+  · subst f
+    exact ⟨0, by simp [normUnit]⟩
+  · have hlead : f.leadingCoeff ≠ 0 :=
+      DensePoly.leadingCoeff_ne_zero_of_pos_size f (size_pos_of_ne_zero hf)
+    have hcancel : f.leadingCoeff⁻¹ * f.leadingCoeff = 1 := by
+      change ZMod64.inv f.leadingCoeff * f.leadingCoeff = 1
+      exact ZMod64.inv_mul_eq_one_of_ne_zero hlead
+    refine ⟨DensePoly.C f.leadingCoeff, ?_⟩
+    symm
+    calc
+      (f * normUnit f) * DensePoly.C f.leadingCoeff =
+          (f * DensePoly.C f.leadingCoeff⁻¹) *
+            DensePoly.C f.leadingCoeff := by
+              rw [normUnit, Hex.ite_eq_right hf]
+      _ = f * (DensePoly.C f.leadingCoeff⁻¹ *
+            DensePoly.C f.leadingCoeff) :=
+          DensePoly.mul_assoc_poly _ _ _
+      _ = f * DensePoly.C (f.leadingCoeff⁻¹ * f.leadingCoeff) := by
+          rw [C_mul_C_eq]
+      _ = f * DensePoly.C (1 : ZMod64 p) := by rw [hcancel]
+      _ = f := DensePoly.mul_one_right_poly f
+
+omit [ZMod64.PrimeModulus p] in
+private theorem self_dvd_canonical (f : FpPoly p) :
+    f ∣ f * normUnit f := ⟨normUnit f, rfl⟩
+
+omit [ZMod64.PrimeModulus p] in
+private theorem dvd_trans {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨x, hx⟩
+  rcases hbc with ⟨y, hy⟩
+  exact ⟨x * y, hy.trans (hx ▸ DensePoly.mul_assoc_poly a x y)⟩
+
+private theorem size_one_of_mul_eq_one {a b : FpPoly p}
+    (h : a * b = 1) : a.size = 1 ∧ b.size = 1 := by
+  have ha : a ≠ 0 := by
+    intro ha
+    exact one_ne_zero (by rw [← h, ha, FpPoly.zero_mul])
+  have hb : b ≠ 0 := by
+    intro hb
+    exact one_ne_zero (by rw [← h, hb, FpPoly.mul_zero])
+  have hsize := size_mul_eq_add_sub_one a b ha hb
+  have hone : (1 : FpPoly p).size = 1 :=
+    DensePoly.size_one coeffOne_ne_zero
+  rw [h, hone] at hsize
+  have hapos := size_pos_of_ne_zero ha
+  have hbpos := size_pos_of_ne_zero hb
+  omega
+
 end FpPoly
 
 /-- Canonical dense-polynomial ring instance exposed for `FpPoly`. -/
@@ -497,13 +706,109 @@ instance instBezoutOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p] :
 instance instLawfulGcdOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p] :
     @LawfulGcdOps (@FpPoly p hp) instCommRingFpPoly _ _ _ _ instGcdOpsFpPoly := by
-  sorry
+  constructor
+  · intro a b
+    rfl
+  · exact FpPoly.one_ne_zero
+  · intro a b h
+    by_cases ha : a = 0
+    · exact Or.inl ha
+    · by_cases hb : b = 0
+      · exact Or.inr hb
+      · exact False.elim (FpPoly.mul_ne_zero_of_ne_zero ha hb h)
+  · intro a b
+    exact FpPoly.dvd_trans
+      (FpPoly.canonical_dvd_self (DensePoly.gcd a b))
+      (DensePoly.gcd_dvd_left a b)
+  · intro a b
+    exact FpPoly.dvd_trans
+      (FpPoly.canonical_dvd_self (DensePoly.gcd a b))
+      (DensePoly.gcd_dvd_right a b)
+  · intro a b d hda hdb
+    exact FpPoly.dvd_trans (DensePoly.dvd_gcd d a b hda hdb)
+      (FpPoly.self_dvd_canonical (DensePoly.gcd a b))
+  · intro a b
+    exact FpPoly.canonical_idem (DensePoly.gcd a b)
+  · intro a b hb
+    letI : ExactDivLaws (FpPoly p) :=
+      instExactDivLawsDensePoly (R := ZMod64 p)
+    exact ExactDivLaws.mul_div_cancel_right a b hb
+  · intro a
+    change decide (a.size = 1) = true ↔ ∃ b, a * b = 1
+    rw [decide_eq_true_eq]
+    constructor
+    · intro ha
+      refine ⟨FpPoly.normUnit a, ?_⟩
+      exact FpPoly.canonical_eq_one_of_size_one ha
+    · rintro ⟨b, hab⟩
+      exact (FpPoly.size_one_of_mul_eq_one hab).1
+  · exact FpPoly.normUnit_is_unit
+  · exact FpPoly.canonical_mul
+  · exact FpPoly.canonical_idem
+  · intro a ha
+    change decide (a.size = 1) = true at ha
+    rw [decide_eq_true_eq] at ha
+    exact FpPoly.canonical_eq_one_of_size_one ha
 
 instance instLawfulBezoutOpsFpPoly {p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p] :
     @LawfulBezoutOps (@FpPoly p hp) instCommRingFpPoly _ _ _ _ instBezoutOpsFpPoly
       instLawfulGcdOpsFpPoly := by
-  sorry
+  constructor
+  intro f g
+  change
+    let r := DensePoly.xgcd f g
+    let u := FpPoly.normUnit r.gcd
+    (r.left * u) * f + (r.right * u) * g =
+      FpPoly.normalizedGcd f g *
+        FpPoly.normUnit (FpPoly.normalizedGcd f g)
+  dsimp only
+  have hfixed :
+      FpPoly.normalizedGcd f g *
+          FpPoly.normUnit (FpPoly.normalizedGcd f g) =
+        FpPoly.normalizedGcd f g :=
+    FpPoly.canonical_idem (DensePoly.gcd f g)
+  rw [hfixed]
+  change
+    ((DensePoly.xgcd f g).left *
+          FpPoly.normUnit (DensePoly.xgcd f g).gcd) * f +
+        ((DensePoly.xgcd f g).right *
+          FpPoly.normUnit (DensePoly.xgcd f g).gcd) * g =
+      DensePoly.gcd f g * FpPoly.normUnit (DensePoly.gcd f g)
+  let r := DensePoly.xgcd f g
+  let u := FpPoly.normUnit r.gcd
+  have hbez : r.left * f + r.right * g = r.gcd := by
+    dsimp [r]
+    exact DensePoly.xgcd_bezout f g
+  have hleft : (r.left * u) * f = (r.left * f) * u := by
+    calc
+      (r.left * u) * f = r.left * (u * f) :=
+        DensePoly.mul_assoc_poly _ _ _
+      _ = r.left * (f * u) := by
+        exact congrArg (fun x : FpPoly p => r.left * x)
+          (DensePoly.mul_comm_poly u f)
+      _ = (r.left * f) * u :=
+        (DensePoly.mul_assoc_poly _ _ _).symm
+  have hright : (r.right * u) * g = (r.right * g) * u := by
+    calc
+      (r.right * u) * g = r.right * (u * g) :=
+        DensePoly.mul_assoc_poly _ _ _
+      _ = r.right * (g * u) := by
+        exact congrArg (fun x : FpPoly p => r.right * x)
+          (DensePoly.mul_comm_poly u g)
+      _ = (r.right * g) * u :=
+        (DensePoly.mul_assoc_poly _ _ _).symm
+  change (r.left * u) * f + (r.right * u) * g = _
+  calc
+    (r.left * u) * f + (r.right * u) * g =
+        (r.left * f) * u + (r.right * g) * u := by
+      rw [hleft, hright]
+    _ = (r.left * f + r.right * g) * u :=
+      (DensePoly.mul_add_left_poly _ _ _).symm
+    _ = r.gcd * u := by rw [hbez]
+    _ = DensePoly.gcd f g * FpPoly.normUnit (DensePoly.gcd f g) := by
+      dsimp [r, u]
+      rw [DensePoly.xgcd_gcd_eq_gcd]
 
 /-! Instance-graph checks for every base coefficient family. -/
 

--- a/HexMvGcd/Instances.lean
+++ b/HexMvGcd/Instances.lean
@@ -42,15 +42,85 @@ instance instBezoutOpsInt : BezoutOps Int where
     let r := HexArith.Int.extGcd a b
     (r.2.1, r.2.2)
 
+private theorem int_normalize_eq_natAbs (a : Int) :
+    a * (if a < 0 then -1 else 1) = (a.natAbs : Int) := by
+  by_cases h : a < 0
+  · rw [Hex.ite_eq_left h,
+      Int.ofNat_natAbs_of_nonpos (Int.le_of_lt h)]
+    omega
+  · rw [Hex.ite_eq_right h,
+      Int.ofNat_natAbs_of_nonneg (Int.le_of_not_gt h)]
+    omega
+
 instance instLawfulGcdOpsInt : LawfulGcdOps Int := by
-  constructor <;> intros <;> sorry
+  constructor
+  · intro a b
+    rfl
+  · decide
+  · intro a b h
+    exact Int.mul_eq_zero.mp h
+  · intro a b
+    exact Int.gcd_dvd_left a b
+  · intro a b
+    exact Int.gcd_dvd_right a b
+  · intro a b d hda hdb
+    exact Int.dvd_coe_gcd hda hdb
+  · intro a b
+    change
+      (Int.gcd a b : Int) *
+          (if (Int.gcd a b : Int) < 0 then -1 else 1) =
+        (Int.gcd a b : Int)
+    rw [int_normalize_eq_natAbs, Int.natAbs_natCast]
+  · intro a b hb
+    exact Int.mul_ediv_cancel a hb
+  · intro a
+    change decide (a = 1 ∨ a = -1) = true ↔ ∃ b, a * b = 1
+    rw [decide_eq_true_eq]
+    constructor
+    · rintro (rfl | rfl)
+      · exact ⟨1, by decide⟩
+      · exact ⟨-1, by decide⟩
+    · rintro ⟨b, hab⟩
+      have habAbs := congrArg Int.natAbs hab
+      rw [Int.natAbs_mul] at habAbs
+      have haAbs : a.natAbs = 1 :=
+        Nat.eq_one_of_mul_eq_one_right (by simpa using habAbs)
+      exact Int.natAbs_eq_iff.mp haAbs
+  · intro a
+    change ∃ b, (if a < 0 then -1 else 1) * b = 1
+    by_cases h : a < 0
+    · exact ⟨-1, by simp [h]⟩
+    · exact ⟨1, by simp [h]⟩
+  · intro a b
+    change
+      a * b * (if a * b < 0 then -1 else 1) =
+        (a * (if a < 0 then -1 else 1)) *
+          (b * (if b < 0 then -1 else 1))
+    rw [int_normalize_eq_natAbs, int_normalize_eq_natAbs,
+      int_normalize_eq_natAbs, Int.natAbs_mul, Int.natCast_mul]
+  · intro a
+    change
+      (a * (if a < 0 then -1 else 1)) *
+          (if a * (if a < 0 then -1 else 1) < 0 then -1 else 1) =
+        a * (if a < 0 then -1 else 1)
+    rw [int_normalize_eq_natAbs, int_normalize_eq_natAbs,
+      Int.natAbs_natCast]
+  · intro a ha
+    change decide (a = 1 ∨ a = -1) = true at ha
+    rw [decide_eq_true_eq] at ha
+    rcases ha with rfl | rfl <;> decide
 
 instance instLawfulBezoutOpsInt : LawfulBezoutOps Int := by
   constructor
   intro a b
   simp only [BezoutOps.xgcd]
   rw [HexArith.Int.extGcd_bezout_gcd]
-  sorry
+  symm
+  change
+    (Int.gcd a b : Int) *
+        (if (Int.gcd a b : Int) < 0 then -1 else 1) =
+      (Int.gcd a b : Int)
+  rw [int_normalize_eq_natAbs, Int.natAbs_natCast]
 
 /-! # Rationals -/
 

--- a/HexMvGcd/Instances.lean
+++ b/HexMvGcd/Instances.lean
@@ -9,6 +9,7 @@ module
 public import HexArith.ExtGcd
 public import HexMvGcd.Normalize
 public import HexPolyFp.Field
+public import HexPolyFp.PrimeField
 public import HexResultant.ExactDiv
 
 @[expose] public section
@@ -47,7 +48,7 @@ instance instLawfulGcdOpsInt : LawfulGcdOps Int := by
 instance instLawfulBezoutOpsInt : LawfulBezoutOps Int := by
   constructor
   intro a b
-  simp only [BezoutOps.xgcd, instBezoutOpsInt]
+  simp only [BezoutOps.xgcd]
   rw [HexArith.Int.extGcd_bezout_gcd]
   sorry
 
@@ -78,12 +79,108 @@ instance instBezoutOpsRat : BezoutOps Rat where
   xgcd := ratXgcd
 
 instance instLawfulGcdOpsRat : LawfulGcdOps Rat := by
-  constructor <;> intros <;> sorry
+  constructor
+  · intro a b
+    rfl
+  · decide
+  · intro a b h
+    exact Rat.mul_eq_zero.mp h
+  · intro a b
+    change ∃ c, a = (if a = 0 ∧ b = 0 then 0 else 1) * c
+    by_cases h : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [h]⟩
+    · exact ⟨a, by simp [h]⟩
+  · intro a b
+    change ∃ c, b = (if a = 0 ∧ b = 0 then 0 else 1) * c
+    by_cases h : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [h]⟩
+    · exact ⟨b, by simp [h]⟩
+  · intro a b d hda hdb
+    change ∃ c, (if a = 0 ∧ b = 0 then 0 else 1) = d * c
+    by_cases hab : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [hab]⟩
+    · have hd : d ≠ 0 := by
+        intro hd
+        rcases hda with ⟨ca, ha⟩
+        rcases hdb with ⟨cb, hb⟩
+        apply hab
+        simp [hd] at ha hb
+        exact ⟨ha, hb⟩
+      exact ⟨d⁻¹, by rw [Hex.ite_eq_right hab, Rat.mul_inv_cancel d hd]⟩
+  · intro a b
+    change
+      (if a = 0 ∧ b = 0 then 0 else 1) *
+          (if (if a = 0 ∧ b = 0 then 0 else 1) = 0 then 1
+            else (if a = 0 ∧ b = 0 then 0 else 1)⁻¹) =
+        (if a = 0 ∧ b = 0 then 0 else 1)
+    by_cases h : a = 0 ∧ b = 0
+    · simp [h]
+    · simp only [h, ite_false]
+      change (1 : Rat) * (if (1 : Rat) = 0 then 1 else 1⁻¹) = 1
+      rw [Hex.ite_eq_right (by decide)]
+      exact Rat.mul_inv_cancel 1 (by decide)
+  · intro a b hb
+    exact Rat.mul_div_cancel hb
+  · intro a
+    change decide (a ≠ 0) = true ↔ ∃ b, a * b = 1
+    rw [decide_eq_true_eq]
+    constructor
+    · intro ha
+      exact ⟨a⁻¹, Rat.mul_inv_cancel a ha⟩
+    · rintro ⟨b, hab⟩ ha
+      subst a
+      simp at hab
+  · intro a
+    change ∃ b, (if a = 0 then 1 else a⁻¹) * b = 1
+    by_cases ha : a = 0
+    · exact ⟨1, by simp [ha]⟩
+    · exact ⟨a, by rw [Hex.ite_eq_right ha, Rat.inv_mul_cancel a ha]⟩
+  · intro a b
+    change
+      a * b * (if a * b = 0 then 1 else (a * b)⁻¹) =
+        (a * (if a = 0 then 1 else a⁻¹)) *
+          (b * (if b = 0 then 1 else b⁻¹))
+    by_cases ha : a = 0
+    · simp [ha]
+    · by_cases hb : b = 0
+      · simp [hb]
+      · have hab : a * b ≠ 0 := fun h =>
+          ha ((Rat.mul_eq_zero.mp h).resolve_right hb)
+        simp [ha, hb, hab, Rat.mul_inv_cancel]
+  · intro a
+    change
+      (a * (if a = 0 then 1 else a⁻¹)) *
+          (if a * (if a = 0 then 1 else a⁻¹) = 0 then 1
+            else (a * (if a = 0 then 1 else a⁻¹))⁻¹) =
+        a * (if a = 0 then 1 else a⁻¹)
+    by_cases ha : a = 0 <;> simp [ha, Rat.mul_inv_cancel]
+  · intro a ha
+    change a * (if a = 0 then 1 else a⁻¹) = 1
+    change decide (a ≠ 0) = true at ha
+    have hne : a ≠ 0 := by simpa only [decide_eq_true_eq] using ha
+    rw [Hex.ite_eq_right hne, Rat.mul_inv_cancel a hne]
 
 instance instLawfulBezoutOpsRat : LawfulBezoutOps Rat := by
   constructor
   intro a b
-  sorry
+  change
+    let uv := ratXgcd a b
+    uv.1 * a + uv.2 * b =
+      (if a = 0 ∧ b = 0 then 0 else 1) *
+        (if (if a = 0 ∧ b = 0 then 0 else 1) = 0 then 1
+          else (if a = 0 ∧ b = 0 then 0 else 1)⁻¹)
+  have inv_one : (1 : Rat)⁻¹ = 1 := by
+    have h := Rat.mul_inv_cancel (1 : Rat) (by decide)
+    rw [Lean.Grind.Semiring.one_mul] at h
+    exact h
+  by_cases ha : a = 0
+  · by_cases hb : b = 0
+    · simp [ratXgcd, ha, hb]
+      grind
+    · simp [ratXgcd, ha, hb, Rat.inv_mul_cancel, inv_one]
+      grind
+  · simp [ratXgcd, ha, Rat.inv_mul_cancel, inv_one]
+    grind
 
 /-! # Bounded prime fields -/
 
@@ -122,13 +219,167 @@ instance instBezoutOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p] :
 instance instLawfulGcdOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p] :
     @LawfulGcdOps (@ZMod64 p hp) _ _ _ _ instDvdZMod64 instGcdOpsZMod64 := by
-  sorry
+  constructor
+  · intro a b
+    rfl
+  · exact fun h =>
+      ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h
+  · intro a b h
+    exact ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero_of_prime_modulus h
+  · intro a b
+    change ∃ c, a = (if a = 0 ∧ b = 0 then 0 else 1) * c
+    by_cases h : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [h]⟩
+    · exact ⟨a, by simp [h]⟩
+  · intro a b
+    change ∃ c, b = (if a = 0 ∧ b = 0 then 0 else 1) * c
+    by_cases h : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [h]⟩
+    · exact ⟨b, by simp [h]⟩
+  · intro a b d hda hdb
+    change ∃ c, (if a = 0 ∧ b = 0 then 0 else 1) = d * c
+    by_cases hab : a = 0 ∧ b = 0
+    · exact ⟨0, by simp [hab]⟩
+    · have hd : d ≠ 0 := by
+        intro hd
+        rcases hda with ⟨ca, ha⟩
+        rcases hdb with ⟨cb, hb⟩
+        apply hab
+        simp [hd] at ha hb
+        exact ⟨ha, hb⟩
+      exact ⟨d⁻¹, by
+        rw [Hex.ite_eq_right hab]
+        have hdinv : d * d⁻¹ = 1 := by
+          change d * ZMod64.inv d = 1
+          exact ZMod64.mul_inv_eq_one_of_ne_zero hd
+        exact hdinv.symm⟩
+  · intro a b
+    change
+      (if a = 0 ∧ b = 0 then 0 else 1) *
+          (if (if a = 0 ∧ b = 0 then 0 else 1) = 0 then 1
+            else (if a = 0 ∧ b = 0 then 0 else 1)⁻¹) =
+        (if a = 0 ∧ b = 0 then 0 else 1)
+    by_cases h : a = 0 ∧ b = 0
+    · simp [h]
+    · simp only [h, ite_false]
+      change (1 : ZMod64 p) * (if (1 : ZMod64 p) = 0 then 1 else 1⁻¹) = 1
+      have hone : (1 : ZMod64 p) ≠ 0 := fun h =>
+        ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h
+      rw [Hex.ite_eq_right hone]
+      change (1 : ZMod64 p) * ZMod64.inv 1 = 1
+      exact ZMod64.mul_inv_eq_one_of_ne_zero hone
+  · intro a b hb
+    change a * b * b⁻¹ = a
+    have hbinv : b * b⁻¹ = 1 := by
+      change b * ZMod64.inv b = 1
+      exact ZMod64.mul_inv_eq_one_of_ne_zero hb
+    rw [Lean.Grind.Semiring.mul_assoc, hbinv,
+      Lean.Grind.Semiring.mul_one]
+  · intro a
+    change decide (a ≠ 0) = true ↔ ∃ b, a * b = 1
+    rw [decide_eq_true_eq]
+    constructor
+    · intro ha
+      refine ⟨a⁻¹, ?_⟩
+      change a * ZMod64.inv a = 1
+      exact ZMod64.mul_inv_eq_one_of_ne_zero ha
+    · rintro ⟨b, hab⟩ ha
+      subst a
+      rw [Lean.Grind.Semiring.zero_mul] at hab
+      exact ZMod64.one_ne_zero_of_prime
+        (ZMod64.PrimeModulus.prime (p := p)) hab.symm
+  · intro a
+    change ∃ b, (if a = 0 then 1 else a⁻¹) * b = 1
+    by_cases ha : a = 0
+    · exact ⟨1, by simp [ha]⟩
+    · exact ⟨a, by
+        rw [Hex.ite_eq_right ha]
+        change ZMod64.inv a * a = 1
+        exact ZMod64.inv_mul_eq_one_of_ne_zero ha⟩
+  · intro a b
+    change
+      a * b * (if a * b = 0 then 1 else (a * b)⁻¹) =
+        (a * (if a = 0 then 1 else a⁻¹)) *
+          (b * (if b = 0 then 1 else b⁻¹))
+    by_cases ha : a = 0
+    · simp [ha]
+    · by_cases hb : b = 0
+      · simp [hb]
+      · have hab : a * b ≠ 0 := by
+          intro h
+          rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero_of_prime_modulus h with
+            h | h
+          · exact ha h
+          · exact hb h
+        have habInv : a * b * (a * b)⁻¹ = 1 := by
+          change a * b * ZMod64.inv (a * b) = 1
+          exact ZMod64.mul_inv_eq_one_of_ne_zero hab
+        have haInv : a * a⁻¹ = 1 := by
+          change a * ZMod64.inv a = 1
+          exact ZMod64.mul_inv_eq_one_of_ne_zero ha
+        have hbInv : b * b⁻¹ = 1 := by
+          change b * ZMod64.inv b = 1
+          exact ZMod64.mul_inv_eq_one_of_ne_zero hb
+        rw [Hex.ite_eq_right ha, Hex.ite_eq_right hb,
+          Hex.ite_eq_right hab, habInv, haInv, hbInv]
+        exact (Lean.Grind.Semiring.one_mul 1).symm
+  · intro a
+    change
+      (a * (if a = 0 then 1 else a⁻¹)) *
+          (if a * (if a = 0 then 1 else a⁻¹) = 0 then 1
+            else (a * (if a = 0 then 1 else a⁻¹))⁻¹) =
+        a * (if a = 0 then 1 else a⁻¹)
+    by_cases ha : a = 0
+    · simp [ha]
+    · have haInv : a * a⁻¹ = 1 := by
+        change a * ZMod64.inv a = 1
+        exact ZMod64.mul_inv_eq_one_of_ne_zero ha
+      rw [Hex.ite_eq_right ha, haInv]
+      have hone : (1 : ZMod64 p) ≠ 0 := fun h =>
+        ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h
+      have honeInv : (1 : ZMod64 p) * (1 : ZMod64 p)⁻¹ = 1 := by
+        change (1 : ZMod64 p) * ZMod64.inv 1 = 1
+        exact ZMod64.mul_inv_eq_one_of_ne_zero hone
+      rw [Hex.ite_eq_right hone, honeInv]
+  · intro a ha
+    change decide (a ≠ 0) = true at ha
+    have hne : a ≠ 0 := by simpa only [decide_eq_true_eq] using ha
+    change a * (if a = 0 then 1 else a⁻¹) = 1
+    rw [Hex.ite_eq_right hne]
+    change a * ZMod64.inv a = 1
+    exact ZMod64.mul_inv_eq_one_of_ne_zero hne
 
 instance instLawfulBezoutOpsZMod64 {p : Nat} [hp : ZMod64.Bounds p]
     [ZMod64.PrimeModulus p] :
     @LawfulBezoutOps (@ZMod64 p hp) _ _ _ _ instDvdZMod64 instBezoutOpsZMod64
       instLawfulGcdOpsZMod64 := by
-  sorry
+  constructor
+  intro a b
+  change
+    let uv := ZMod64.fieldXgcd a b
+    uv.1 * a + uv.2 * b =
+      (if a = 0 ∧ b = 0 then 0 else 1) *
+        (if (if a = 0 ∧ b = 0 then 0 else 1) = 0 then 1
+          else (if a = 0 ∧ b = 0 then 0 else 1)⁻¹)
+  have one_ne : (1 : ZMod64 p) ≠ 0 := fun h =>
+    ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h
+  have inv_one : (1 : ZMod64 p)⁻¹ = 1 := by
+    have h : (1 : ZMod64 p) * (1 : ZMod64 p)⁻¹ = 1 := by
+      change (1 : ZMod64 p) * ZMod64.inv 1 = 1
+      exact ZMod64.mul_inv_eq_one_of_ne_zero one_ne
+    rw [Lean.Grind.Semiring.one_mul] at h
+    exact h
+  by_cases ha : a = 0
+  · by_cases hb : b = 0
+    · simp [ZMod64.fieldXgcd, ha, hb]
+    · have hbinv : b⁻¹ * b = 1 := by
+        change ZMod64.inv b * b = 1
+        exact ZMod64.inv_mul_eq_one_of_ne_zero hb
+      simp [ZMod64.fieldXgcd, ha, hb, hbinv, inv_one]
+  · have hainv : a⁻¹ * a = 1 := by
+      change ZMod64.inv a * a = 1
+      exact ZMod64.inv_mul_eq_one_of_ne_zero ha
+    simp [ZMod64.fieldXgcd, ha, hainv, inv_one]
 
 /-! # Univariate prime-field polynomials -/
 

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -58,16 +58,19 @@ coefficient rather than relying on an unstated `gcd 0 a` law. -/
   | (_, c) :: terms =>
       normalize (terms.foldl (fun g term => GcdOps.gcd g term.2) c)
 
+omit [Dvd R] in
 /-- The normalization unit at zero is the constant one polynomial. -/
 @[simp] theorem polyNormUnit_zero [IsMonomialOrder cmp] :
     polyNormUnit (0 : MvPoly n R cmp) = 1 := by
-  sorry
+  rfl
 
+omit [Dvd R] in
 /-- Polynomial normalization preserves zero. -/
 @[simp] theorem polyNormalize_zero [IsMonomialOrder cmp] :
     polyNormalize (0 : MvPoly n R cmp) = 0 := by
   rw [polyNormalize, polyNormUnit_zero, Lean.Grind.Semiring.zero_mul]
 
+omit [Dvd R] in
 /-- Scalar content uses the explicit zero convention. -/
 @[simp] theorem scalarContent_zero :
     scalarContent (0 : MvPoly n R cmp) = 0 := by

--- a/HexMvGcd/Prs.lean
+++ b/HexMvGcd/Prs.lean
@@ -53,7 +53,10 @@ theorem quotient_mul_of_dvd {n : Nat} {R : Type u}
     [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
     {f g : MvPoly n R cmp} (hg : g ≠ 0) (hd : g ∣ f) :
     quotient f g * g = f := by
-  sorry
+  rcases hd with ⟨q, hq⟩
+  have hdiv : divExact? f g = some q := (divExact?_eq hg).mpr hq
+  rw [quotient, hdiv]
+  exact hq.symm
 
 /-- Direct computational form used when a producer already has the checked
 division result in hand. -/
@@ -74,13 +77,115 @@ def terminal {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
   let chain := DensePoly.subresultantChainExt f h
   chain.getD (chain.size - 1) (0, 0, 0)
 
+/-- The extended Brown worker only appends to its supplied chain. -/
+private theorem auxExt_size_le {S : Type u} [Lean.Grind.CommRing S]
+    [DecidableEq S] [Div S]
+    (prev curr : DensePoly S) (hPrev : S)
+    (prevU prevV currU currV : DensePoly S)
+    (chain : Array (DensePoly.SubresultantExt.Entry S)) (fuel : Nat) :
+    chain.size ≤
+      (DensePoly.subresultantAuxExt prev curr hPrev prevU prevV currU currV
+        chain fuel).size := by
+  induction fuel generalizing prev curr hPrev prevU prevV currU currV chain with
+  | zero => exact Nat.le_refl _
+  | succ fuel ih =>
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let qr := DensePoly.pseudoDivMod prev curr
+      let q := qr.1
+      let p := qr.2
+      cases hp : p.isZero with
+      | true => simp [DensePoly.subresultantAuxExt, qr, p, hp]
+      | false =>
+          let divisor := DensePoly.negOnePow (delta + 1) *
+            prev.leadingCoeff * powNat hPrev delta
+          let next := DensePoly.divScalarImpl p divisor
+          cases hnext : next.isZero with
+          | true =>
+              simp [DensePoly.subresultantAuxExt, delta, qr, p, hp,
+                divisor, next, hnext]
+          | false =>
+              let a := powNat curr.leadingCoeff (delta + 1)
+              let nextU := DensePoly.divScalarImpl
+                (DensePoly.SubresultantExt.numerator a q prevU currU) divisor
+              let nextV := DensePoly.divScalarImpl
+                (DensePoly.SubresultantExt.numerator a q prevV currV) divisor
+              have hrec := ih curr next hCurr currU currV nextU nextV
+                (chain.push (nextU, nextV, next))
+              have hbound : chain.size ≤
+                  (DensePoly.subresultantAuxExt curr next hCurr currU currV
+                    nextU nextV (chain.push (nextU, nextV, next)) fuel).size :=
+                Nat.le_trans (Nat.le_succ chain.size) (by
+                  simpa only [Array.size_push] using hrec)
+              simpa [DensePoly.subresultantAuxExt, delta, hCurr, qr, q, p, hp,
+                divisor, next, hnext, a, nextU, nextV] using hbound
+
+/-- A degree-ordered extended Brown run retains its two input entries. -/
+private theorem orderedExt_nonempty {S : Type u} [Lean.Grind.CommRing S]
+    [DecidableEq S] [Div S]
+    (f g fU fV gU gV : DensePoly S) :
+    0 < (DensePoly.subresultantOrderedExt f g fU fV gU gV).size := by
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let qr := DensePoly.pseudoDivMod f g
+  let q := qr.1
+  let p := qr.2
+  let seed : Array (DensePoly.SubresultantExt.Entry S) :=
+    #[(fU, fV, f), (gU, gV, g)]
+  cases hp : p.isZero with
+  | true => simp [DensePoly.subresultantOrderedExt, qr, p, hp]
+  | false =>
+      let sign := DensePoly.negOnePow (R := S) (delta + 1)
+      let g₃ := DensePoly.scaleImpl sign p
+      cases hg₃ : g₃.isZero with
+      | true => simp [DensePoly.subresultantOrderedExt, delta, qr, p, hp,
+          sign, g₃, hg₃]
+      | false =>
+          let a := powNat g.leadingCoeff (delta + 1)
+          let g₃U := DensePoly.scaleImpl sign
+            (DensePoly.SubresultantExt.numerator a q fU gU)
+          let g₃V := DensePoly.scaleImpl sign
+            (DensePoly.SubresultantExt.numerator a q fV gV)
+          have h := auxExt_size_le g g₃ h₂ gU gV g₃U g₃V
+            (seed.push (g₃U, g₃V, g₃)) (g.size + 1)
+          have hpos : 0 <
+              (DensePoly.subresultantAuxExt g g₃ h₂ gU gV g₃U g₃V
+                (seed.push (g₃U, g₃V, g₃)) (g.size + 1)).size := by
+            apply Nat.lt_of_lt_of_le (by simp [seed]) h
+          simpa [DensePoly.subresultantOrderedExt, delta, h₂, qr, q, p,
+            seed, hp, sign, g₃, hg₃, a, g₃U, g₃V] using hpos
+
 /-- Nonzero input pairs give a nonempty extended chain, so `terminal` never
 observes its stable default on the PRS route. -/
 theorem chainExt_nonempty {S : Type u} [Lean.Grind.CommRing S]
     [DecidableEq S] [Div S] (f h : DensePoly S)
     (hn : f ≠ 0 ∨ h ≠ 0) :
     0 < (DensePoly.subresultantChainExt f h).size := by
-  sorry
+  rcases hn with hf | hh
+  · have hfz : f.isZero = false := by
+      rw [DensePoly.isZero_eq_false_iff]
+      by_cases hsize : 0 < f.size
+      · exact hsize
+      · exact (hf ((DensePoly.size_eq_zero_iff f).mp (by omega))).elim
+    unfold DensePoly.subresultantChainExt
+    simp only [hfz, Bool.false_eq_true, ↓reduceIte]
+    split
+    · simp
+    · split
+      · exact orderedExt_nonempty h f 0 1 1 0
+      · exact orderedExt_nonempty f h 1 0 0 1
+  · have hhz : h.isZero = false := by
+      rw [DensePoly.isZero_eq_false_iff]
+      by_cases hsize : 0 < h.size
+      · exact hsize
+      · exact (hh ((DensePoly.size_eq_zero_iff h).mp (by omega))).elim
+    unfold DensePoly.subresultantChainExt
+    split
+    · simp [hhz]
+    · simp only [hhz, Bool.false_eq_true, ↓reduceIte]
+      split
+      · exact orderedExt_nonempty h f 0 1 1 0
+      · exact orderedExt_nonempty f h 1 0 0 1
 
 /-- The selected terminal triple is an actual extended-chain entry whenever
 the route's nonzero-input invariant holds. -/
@@ -89,7 +194,13 @@ theorem terminal_mem {S : Type u} [Lean.Grind.CommRing S]
     (hn : f ≠ 0 ∨ h ≠ 0) :
     ∃ k, ∃ hk : k < (DensePoly.subresultantChainExt f h).size,
       terminal f h = (DensePoly.subresultantChainExt f h)[k]'hk := by
-  sorry
+  let chain := DensePoly.subresultantChainExt f h
+  have hpos : 0 < chain.size := chainExt_nonempty f h hn
+  let k := chain.size - 1
+  have hk : k < chain.size := by omega
+  refine ⟨k, hk, ?_⟩
+  simpa [terminal, chain, k] using
+    (Array.getElem_eq_getD (0, 0, 0) (h := hk)).symm
 
 /-- Arity-zero coprimality witness from the base extended gcd. -/
 def baseCoprime {R : Type u}

--- a/HexMvGcd/View.lean
+++ b/HexMvGcd/View.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+import HexBasic.Fold
 public import HexMvGcd.Divide
 public import HexMvPoly.Recursive
 
@@ -38,6 +39,7 @@ def constIn (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
     (c : MvPoly n R cmp') : MvPoly (n + 1) R cmp :=
   ofUnivariate (cmp := cmp) i cmp' (DensePoly.C c)
 
+omit [BEq R] [LawfulBEq R] in
 /-- The recursive view of a constant embedding is a dense constant. -/
 @[simp] theorem toUnivariate_constIn (i : Fin (n + 1))
     (c : MvPoly n R cmp') :
@@ -56,25 +58,212 @@ zero elsewhere. -/
 /-- Constant embedding preserves zero. -/
 @[simp] theorem constIn_zero (i : Fin (n + 1)) :
     constIn (R := R) (cmp := cmp) i cmp' 0 = 0 := by
-  sorry
+  apply MvPoly.ext
+  intro m
+  unfold constIn
+  rw [← insertVar_removeVar i m, ofUnivariate_coeff, DensePoly.coeff_C,
+    insertVar_removeVar]
+  split <;> rw [coeff_zero] <;> rfl
 
 /-- Constant embedding preserves one. -/
 @[simp] theorem constIn_one (i : Fin (n + 1)) :
     constIn (R := R) (cmp := cmp) i cmp' 1 = 1 := by
-  sorry
+  apply MvPoly.ext
+  intro m
+  unfold constIn
+  rw [← insertVar_removeVar i m, ofUnivariate_coeff, DensePoly.coeff_C,
+    insertVar_removeVar]
+  by_cases hdegree : Mono.degreeOf i m = 0
+  · rw [Hex.ite_eq_left hdegree, coeff_one]
+    have hzero : insertVar i 0 (Mono.zero : Mono n) = Mono.zero := by
+      apply Vector.ext
+      intro j hj
+      simp [insertVar, Mono.zero]
+    have hm : m = Mono.zero ↔ removeVar i m = Mono.zero := by
+      constructor
+      · intro h
+        subst m
+        simp [removeVar, Mono.zero]
+      · intro h
+        calc
+          m = insertVar i (Mono.degreeOf i m) (removeVar i m) :=
+            (insertVar_removeVar i m).symm
+          _ = insertVar i 0 Mono.zero := by rw [hdegree, h]
+          _ = Mono.zero := hzero
+    rw [coeff_one]
+    simp only [hm]
+  · rw [Hex.ite_eq_right hdegree]
+    have hm : m ≠ Mono.zero := by
+      intro h
+      subst m
+      exact hdegree (by
+        unfold Mono.degreeOf
+        exact Mono.getElem_zero i)
+    change coeff (removeVar i m) (0 : MvPoly n R cmp') = coeff m 1
+    rw [coeff_zero, coeff_one, Hex.ite_eq_right hm]
 
 /-- Constant embedding preserves addition. -/
 theorem constIn_add (i : Fin (n + 1)) (a b : MvPoly n R cmp') :
     constIn (cmp := cmp) i cmp' (a + b) =
       constIn i cmp' a + constIn i cmp' b := by
-  sorry
+  apply MvPoly.ext
+  intro m
+  unfold constIn
+  rw [← insertVar_removeVar i m, ofUnivariate_coeff, coeff_add,
+    ofUnivariate_coeff, ofUnivariate_coeff, DensePoly.coeff_C,
+    DensePoly.coeff_C, DensePoly.coeff_C]
+  by_cases hdegree : Mono.degreeOf i m = 0
+  · simp only [hdegree, Hex.ite_eq_left, coeff_add]
+  · simp only [hdegree]
+    change coeff (removeVar i m) (0 : MvPoly n R cmp') =
+      coeff (removeVar i m) (0 : MvPoly n R cmp') +
+        coeff (removeVar i m) (0 : MvPoly n R cmp')
+    rw [coeff_zero, Lean.Grind.AddCommMonoid.zero_add]
+
+private theorem degreeOf_mul (i : Fin (n + 1))
+    (a b : Mono (n + 1)) :
+    Mono.degreeOf i (Mono.mul a b) =
+      Mono.degreeOf i a + Mono.degreeOf i b := by
+  unfold Mono.degreeOf
+  exact Mono.getElem_mul a b i
+
+private theorem insertVar_mul_zero (i : Fin (n + 1)) (a b : Mono n) :
+    insertVar i 0 (Mono.mul a b) =
+      Mono.mul (insertVar i 0 a) (insertVar i 0 b) := by
+  apply Vector.ext
+  intro j hj
+  by_cases heq : j = i.val
+  · simp [insertVar, Mono.mul, heq]
+  · by_cases hlt : j < i.val <;>
+      simp [insertVar, Mono.mul, heq, hlt]
+
+private theorem removeVar_mul (i : Fin (n + 1)) (a b : Mono (n + 1)) :
+    removeVar i (Mono.mul a b) =
+      Mono.mul (removeVar i a) (removeVar i b) := by
+  apply Vector.ext
+  intro j hj
+  by_cases hlt : j < i.val <;> simp [removeVar, Mono.mul, hlt]
+
+private theorem splits_insertVar_zero_perm (i : Fin (n + 1)) (m : Mono n) :
+    ((Mono.splits m).map fun ab =>
+      (insertVar i 0 ab.1, insertVar i 0 ab.2)).Perm
+        (Mono.splits (insertVar i 0 m)) := by
+  let lift : Mono n × Mono n → Mono (n + 1) × Mono (n + 1) :=
+    fun ab => (insertVar i 0 ab.1, insertVar i 0 ab.2)
+  have hinj : Function.Injective lift := by
+    rintro ⟨a, b⟩ ⟨c, d⟩ h
+    apply Prod.ext
+    · exact ((insertVar_inj i 0 0 a c).mp (congrArg Prod.fst h)).2
+    · exact ((insertVar_inj i 0 0 b d).mp (congrArg Prod.snd h)).2
+  have hnodup : ((Mono.splits m).map lift).Nodup := by
+    apply (Mono.splits_nodup m).map
+    intro a b hne heq
+    exact hne (hinj heq)
+  apply (List.perm_ext_iff_of_nodup hnodup
+    (Mono.splits_nodup (insertVar i 0 m))).mpr
+  rintro ⟨a, b⟩
+  constructor
+  · intro hmem
+    rcases List.mem_map.mp hmem with ⟨⟨c, d⟩, hcd, hab⟩
+    cases hab
+    apply (Mono.splits_mem_iff ..).mpr
+    rw [← insertVar_mul_zero, (Mono.splits_mem_iff ..).mp hcd]
+  · intro hmem
+    have hmul : Mono.mul a b = insertVar i 0 m :=
+      (Mono.splits_mem_iff ..).mp hmem
+    have hdegree : Mono.degreeOf i a + Mono.degreeOf i b = 0 := by
+      calc
+        Mono.degreeOf i a + Mono.degreeOf i b =
+            Mono.degreeOf i (Mono.mul a b) := (degreeOf_mul i a b).symm
+        _ = Mono.degreeOf i (insertVar i 0 m) := by rw [hmul]
+        _ = 0 := degreeOf_insertVar i 0 m
+    have ha0 : Mono.degreeOf i a = 0 := by omega
+    have hb0 : Mono.degreeOf i b = 0 := by omega
+    have ha : insertVar i 0 (removeVar i a) = a := by
+      rw [← ha0]
+      exact insertVar_removeVar i a
+    have hb : insertVar i 0 (removeVar i b) = b := by
+      rw [← hb0]
+      exact insertVar_removeVar i b
+    apply List.mem_map.mpr
+    refine ⟨(removeVar i a, removeVar i b), ?_, ?_⟩
+    · apply (Mono.splits_mem_iff ..).mpr
+      rw [← removeVar_mul, hmul, removeVar_insertVar]
+    · exact Prod.ext ha hb
 
 /-- Constant embedding preserves multiplication. -/
 theorem constIn_mul (i : Fin (n + 1)) (a b : MvPoly n R cmp') :
     constIn (cmp := cmp) i cmp' (a * b) =
       constIn i cmp' a * constIn i cmp' b := by
-  sorry
+  apply MvPoly.ext
+  intro m
+  unfold constIn
+  rw [← insertVar_removeVar i m, ofUnivariate_coeff, coeff_mul]
+  simp only [DensePoly.coeff_C]
+  split
+  · rename_i hdegree
+    simp only [hdegree, coeff_mul]
+    let term : Mono (n + 1) × Mono (n + 1) → R := fun ab =>
+      coeff ab.1 (ofUnivariate (cmp := cmp) i cmp' (DensePoly.C a)) *
+        coeff ab.2 (ofUnivariate (cmp := cmp) i cmp' (DensePoly.C b))
+    calc
+      (Mono.splits (removeVar i m)).foldl
+          (fun acc ab => acc + coeff ab.1 a * coeff ab.2 b) 0 =
+          ((Mono.splits (removeVar i m)).map fun ab =>
+            (insertVar i 0 ab.1, insertVar i 0 ab.2)).foldl
+              (fun acc ab => acc + term ab) 0 := by
+            rw [List.foldl_map]
+            apply List.foldl_congr
+            intro acc ab hab
+            unfold term
+            rw [ofUnivariate_coeff, ofUnivariate_coeff,
+              DensePoly.coeff_C, DensePoly.coeff_C]
+            simp
+      _ = (Mono.splits (insertVar i 0 (removeVar i m))).foldl
+          (fun acc ab => acc + term ab) 0 :=
+        List.foldl_add_perm term
+          (splits_insertVar_zero_perm i (removeVar i m)) 0
+  · rename_i hdegree
+    change coeff (removeVar i m) (0 : MvPoly n R cmp') = _
+    rw [coeff_zero]
+    symm
+    apply List.foldl_add_eq_self
+    intro ab hab
+    have hmul : Mono.mul ab.1 ab.2 =
+        insertVar i (Mono.degreeOf i m) (removeVar i m) :=
+      (Mono.splits_mem_iff ..).mp hab
+    have hsum : Mono.degreeOf i ab.1 + Mono.degreeOf i ab.2 =
+        Mono.degreeOf i m := by
+      calc
+        Mono.degreeOf i ab.1 + Mono.degreeOf i ab.2 =
+            Mono.degreeOf i (Mono.mul ab.1 ab.2) :=
+          (degreeOf_mul i ab.1 ab.2).symm
+        _ = Mono.degreeOf i
+            (insertVar i (Mono.degreeOf i m) (removeVar i m)) := by rw [hmul]
+        _ = Mono.degreeOf i m := degreeOf_insertVar ..
+    have hnonzero : Mono.degreeOf i ab.1 ≠ 0 ∨
+        Mono.degreeOf i ab.2 ≠ 0 := by
+      by_cases hleft : Mono.degreeOf i ab.1 ≠ 0
+      · exact Or.inl hleft
+      · apply Or.inr
+        intro hright
+        apply hdegree
+        omega
+    rcases hnonzero with hleft | hright
+    · have hz : coeff ab.1
+          (ofUnivariate (cmp := cmp) i cmp' (DensePoly.C a)) = 0 := by
+        rw [← insertVar_removeVar i ab.1, ofUnivariate_coeff,
+          DensePoly.coeff_C, Hex.ite_eq_right hleft]
+        exact coeff_zero _
+      rw [hz, Lean.Grind.Semiring.zero_mul]
+    · have hz : coeff ab.2
+          (ofUnivariate (cmp := cmp) i cmp' (DensePoly.C b)) = 0 := by
+        rw [← insertVar_removeVar i ab.2, ofUnivariate_coeff,
+          DensePoly.coeff_C, Hex.ite_eq_right hright]
+        exact coeff_zero _
+      rw [hz, Lean.Grind.Semiring.mul_zero]
 
+omit [BEq R] [LawfulBEq R] in
 /-- Constant embedding is injective. -/
 theorem constIn_injective (i : Fin (n + 1)) :
     Function.Injective (constIn (R := R) (cmp := cmp) i cmp') := by


### PR DESCRIPTION
Closes the foundational proof obligations in the multivariate gcd stack:

- proves constant embedding and lawful coefficient operations for `Rat`, `ZMod64`, `Int`, and `FpPoly`
- proves content-certificate length and replay correctness
- exposes the content replay accumulator as a reducible helper and proves `ContentCert.ofSteps` projection laws
- proves fraction-map injectivity and checked-result maximality
- proves exact quotient reconstruction and extended Brown-chain terminal selection

The remaining route-level and Gauss/content algebra obligations are deliberately left for follow-up proof slices.

Verification: `lake build HexMvGcd.Prs HexMvGcd.Instances`.