### PR TITLE
Prove HexMvGcd normalization and content foundations

### DIFF
--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -196,7 +196,33 @@ theorem contentCertWith_checks {R : Type u}
 /-- Scalar content and primitive part reconstruct the input. -/
 theorem content_mul_primPart [LawfulGcdOps R] (p : MvPoly n R cmp) :
     C (content p) * primPart p = p := by
-  sorry
+  by_cases hc : content p = 0
+  · have hp : p = 0 := by
+      apply ext
+      intro m
+      have hdiv := scalarContent_dvd_coeff p m
+      rw [← content, hc] at hdiv
+      rcases (LawfulGcdOps.dvd_iff 0 (coeff m p)).mp hdiv with ⟨q, hq⟩
+      rw [hq, Lean.Grind.Semiring.zero_mul, coeff_zero]
+    subst p
+    have hcontent : content (0 : MvPoly n R cmp) = 0 := rfl
+    rw [hcontent, primPart, hcontent, Hex.ite_eq_left rfl]
+    rw [C_zero]
+    exact zero_mul _
+  · apply ext
+    intro m
+    have hzero : GcdOps.exactDiv (0 : R) (content p) = 0 := by
+      simpa only [Lean.Grind.Semiring.zero_mul] using
+        LawfulGcdOps.exactDiv_cancel (0 : R) (content p) hc
+    rw [coeff_C_mul, primPart, Hex.ite_eq_right hc,
+      coeff_mapCoeffs hzero]
+    have hdiv := scalarContent_dvd_coeff p m
+    rw [← content] at hdiv
+    rcases (LawfulGcdOps.dvd_iff (content p) (coeff m p)).mp hdiv with
+      ⟨q, hq⟩
+    rw [hq, Lean.Grind.CommSemiring.mul_comm (content p) q,
+      LawfulGcdOps.exactDiv_cancel q (content p) hc,
+      Lean.Grind.CommSemiring.mul_comm]
 
 @[simp] theorem content_zero : content (0 : MvPoly n R cmp) = 0 := by
   rfl

--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -224,15 +224,58 @@ theorem content_mul_primPart [LawfulGcdOps R] (p : MvPoly n R cmp) :
       LawfulGcdOps.exactDiv_cancel q (content p) hc,
       Lean.Grind.CommSemiring.mul_comm]
 
+omit [Dvd R] in
 @[simp] theorem content_zero : content (0 : MvPoly n R cmp) = 0 := by
   rfl
 
+omit [Dvd R] in
 @[simp] theorem primPart_zero : primPart (0 : MvPoly n R cmp) = 0 := by
   simp [primPart, content]
 
 theorem content_primPart [LawfulGcdOps R] {p : MvPoly n R cmp} (hp : p ≠ 0) :
     content (primPart p) = 1 := by
-  sorry
+  let c := content p
+  let q := primPart p
+  let d := content q
+  have hc : c ≠ 0 := by
+    intro hc
+    apply hp
+    rw [← content_mul_primPart p]
+    change C c * q = 0
+    rw [hc, C_zero, zero_mul]
+  have hcoeff : ∀ m, coeff m p = c * coeff m q := by
+    intro m
+    rw [← content_mul_primPart p]
+    exact coeff_C_mul c q m
+  have hcd : c * d ∣ c := by
+    have hcommon : ∀ m, c * d ∣ coeff m p := by
+      intro m
+      have hd := scalarContent_dvd_coeff q m
+      change d ∣ coeff m q at hd
+      rcases (LawfulGcdOps.dvd_iff d (coeff m q)).mp hd with ⟨a, ha⟩
+      apply (LawfulGcdOps.dvd_iff (c * d) (coeff m p)).mpr
+      refine ⟨a, ?_⟩
+      rw [hcoeff, ha, Lean.Grind.Semiring.mul_assoc]
+    have := dvd_scalarContent p (c * d) hcommon
+    change c * d ∣ c at this
+    exact this
+  rcases (LawfulGcdOps.dvd_iff (c * d) c).mp hcd with ⟨u, hu⟩
+  have hunit : d * u = 1 := by
+    have hzero : c * (1 - d * u) = 0 := by
+      calc
+        c * (1 - d * u) = c - (c * d) * u := by grind
+        _ = 0 := by rw [← hu]; grind
+    rcases LawfulGcdOps.no_zero_div c (1 - d * u) hzero with hczero | hrest
+    · exact False.elim (hc hczero)
+    · grind
+  have hisUnit : GcdOps.isUnit d = true :=
+    (LawfulGcdOps.isUnit_iff d).mpr ⟨u, hunit⟩
+  have hnorm : normalize d = d := by
+    exact normalize_scalarContent q
+  calc
+    content (primPart p) = d := rfl
+    _ = normalize d := hnorm.symm
+    _ = 1 := LawfulGcdOps.normalize_unit d hisUnit
 
 theorem content_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
     content (p * q) = content p * content q := by

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -76,6 +76,126 @@ omit [Dvd R] in
     scalarContent (0 : MvPoly n R cmp) = 0 := by
   rfl
 
+private theorem dvdRefl [LawfulGcdOps R] (a : R) : a ∣ a := by
+  apply (LawfulGcdOps.dvd_iff a a).mpr
+  exact ⟨1, (Lean.Grind.Semiring.mul_one a).symm⟩
+
+private theorem dvdTrans [LawfulGcdOps R] {a b c : R}
+    (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  rcases (LawfulGcdOps.dvd_iff a b).mp hab with ⟨x, rfl⟩
+  rcases (LawfulGcdOps.dvd_iff (a * x) c).mp hbc with ⟨y, rfl⟩
+  apply (LawfulGcdOps.dvd_iff a ((a * x) * y)).mpr
+  exact ⟨x * y, Lean.Grind.Semiring.mul_assoc a x y⟩
+
+private theorem normalize_dvd [LawfulGcdOps R] (a : R) : normalize a ∣ a := by
+  rcases LawfulGcdOps.normUnit_unit a with ⟨u, hu⟩
+  apply (LawfulGcdOps.dvd_iff (normalize a) a).mpr
+  refine ⟨u, ?_⟩
+  calc
+    a = a * 1 := (Lean.Grind.Semiring.mul_one a).symm
+    _ = a * (GcdOps.normUnit a * u) := by rw [hu]
+    _ = normalize a * u := (Lean.Grind.Semiring.mul_assoc ..).symm
+
+private theorem dvd_normalize [LawfulGcdOps R] (a : R) : a ∣ normalize a := by
+  apply (LawfulGcdOps.dvd_iff a (normalize a)).mpr
+  exact ⟨GcdOps.normUnit a, rfl⟩
+
+private theorem foldGcd_dvd_acc [LawfulGcdOps R]
+    (terms : List (Mono n × R)) (acc : R) :
+    terms.foldl (fun g term => GcdOps.gcd g term.2) acc ∣ acc := by
+  induction terms generalizing acc with
+  | nil => exact dvdRefl acc
+  | cons term terms ih =>
+      exact dvdTrans (ih (GcdOps.gcd acc term.2))
+        (LawfulGcdOps.gcd_dvd_left acc term.2)
+
+private theorem foldGcd_dvd_term [LawfulGcdOps R]
+    (terms : List (Mono n × R)) (acc : R) {term : Mono n × R}
+    (hterm : term ∈ terms) :
+    terms.foldl (fun g term => GcdOps.gcd g term.2) acc ∣ term.2 := by
+  induction terms generalizing acc with
+  | nil => simp at hterm
+  | cons head terms ih =>
+      rcases List.mem_cons.mp hterm with rfl | hterm
+      · exact dvdTrans (foldGcd_dvd_acc terms (GcdOps.gcd acc term.2))
+          (LawfulGcdOps.gcd_dvd_right acc term.2)
+      · exact ih (GcdOps.gcd acc head.2) hterm
+
+private theorem dvd_foldGcd [LawfulGcdOps R]
+    (terms : List (Mono n × R)) (acc d : R)
+    (hacc : d ∣ acc) (hterms : ∀ term ∈ terms, d ∣ term.2) :
+    d ∣ terms.foldl (fun g term => GcdOps.gcd g term.2) acc := by
+  induction terms generalizing acc with
+  | nil => exact hacc
+  | cons term terms ih =>
+      apply ih (GcdOps.gcd acc term.2)
+      · exact LawfulGcdOps.dvd_gcd acc term.2 d hacc
+          (hterms term (List.mem_cons_self ..))
+      · intro tail htail
+        exact hterms tail (List.mem_cons_of_mem term htail)
+
+/-- Scalar content divides every coefficient, including the implicit zeros
+outside the support. -/
+theorem scalarContent_dvd_coeff [LawfulGcdOps R]
+    (p : MvPoly n R cmp) (m : Mono n) :
+    scalarContent p ∣ coeff m p := by
+  cases hterms : p.termsList with
+  | nil =>
+      have hm : m ∉ p.monomials := by simp [monomials, hterms]
+      rw [coeff_eq_zero_of_not_mem m p hm]
+      apply (LawfulGcdOps.dvd_iff (scalarContent p) 0).mpr
+      exact ⟨0, (Lean.Grind.Semiring.mul_zero _).symm⟩
+  | cons head terms =>
+      rcases head with ⟨headMono, headCoeff⟩
+      by_cases hm : m ∈ p.monomials
+      · rcases List.mem_map.mp hm with ⟨term, hterm, hmono⟩
+        rcases term with ⟨termMono, termCoeff⟩
+        simp only at hmono
+        subst termMono
+        rw [coeff_eq_of_mem_terms p hterm]
+        unfold scalarContent
+        rw [hterms]
+        simp only
+        apply dvdTrans (normalize_dvd _)
+        rw [hterms] at hterm
+        rcases List.mem_cons.mp hterm with hhead | htail
+        · cases hhead
+          exact foldGcd_dvd_acc terms headCoeff
+        · exact foldGcd_dvd_term terms headCoeff htail
+      · rw [coeff_eq_zero_of_not_mem m p hm]
+        apply (LawfulGcdOps.dvd_iff (scalarContent p) 0).mpr
+        exact ⟨0, (Lean.Grind.Semiring.mul_zero _).symm⟩
+
+/-- Scalar content is divisible by every common scalar divisor of the
+coefficients. -/
+theorem dvd_scalarContent [LawfulGcdOps R]
+    (p : MvPoly n R cmp) (d : R)
+    (hd : ∀ m, d ∣ coeff m p) : d ∣ scalarContent p := by
+  cases hterms : p.termsList with
+  | nil =>
+      unfold scalarContent
+      rw [hterms]
+      apply (LawfulGcdOps.dvd_iff d 0).mpr
+      exact ⟨0, (Lean.Grind.Semiring.mul_zero _).symm⟩
+  | cons head terms =>
+      rcases head with ⟨headMono, headCoeff⟩
+      unfold scalarContent
+      rw [hterms]
+      simp only
+      apply dvdTrans _ (dvd_normalize _)
+      apply dvd_foldGcd terms headCoeff d
+      · have hcoeff : coeff headMono p = headCoeff :=
+          coeff_eq_of_mem_terms p (hterms ▸ List.mem_cons_self)
+        rw [← hcoeff]
+        exact hd headMono
+      · intro term hterm
+        rcases term with ⟨termMono, termCoeff⟩
+        have hcoeff : coeff termMono p = termCoeff :=
+          coeff_eq_of_mem_terms p
+            (hterms ▸ List.mem_cons_of_mem _ hterm)
+        rw [← hcoeff]
+        exact hd termMono
+
 /-- Unit recognition is sound and complete under the coefficient gcd laws. -/
 theorem polyIsUnit_iff [LawfulGcdOps R] (p : MvPoly n R cmp) :
     polyIsUnit p = true ↔ ∃ q, p * q = 1 := by

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+import HexBasic.Fold
 public import HexMvGcd.View
 
 @[expose] public section
@@ -196,10 +197,270 @@ theorem dvd_scalarContent [LawfulGcdOps R]
         rw [← hcoeff]
         exact hd termMono
 
+/-- Scalar content is already in the coefficient ring's canonical
+normalization. -/
+theorem normalize_scalarContent [LawfulGcdOps R] (p : MvPoly n R cmp) :
+    normalize (scalarContent p) = scalarContent p := by
+  cases hterms : p.termsList with
+  | nil =>
+      unfold scalarContent
+      rw [hterms]
+      exact Lean.Grind.Semiring.zero_mul _
+  | cons head terms =>
+      unfold scalarContent
+      rw [hterms]
+      simp only
+      exact LawfulGcdOps.normalize_idem _
+
+omit [Std.LawfulEqCmp cmp] in
+private theorem mul_isLE [IsMonomialOrder cmp]
+    {a b c d : Mono n} (hab : (cmp a b).isLE) (hcd : (cmp c d).isLE) :
+    (cmp (Mono.mul a c) (Mono.mul b d)).isLE := by
+  have hleft : (cmp (Mono.mul a c) (Mono.mul b c)).isLE := by
+    rw [← IsMonomialOrder.mul_mono (cmp := cmp) a b c]
+    exact hab
+  have hright : (cmp (Mono.mul b c) (Mono.mul b d)).isLE := by
+    rw [Mono.mul_comm b c, Mono.mul_comm b d,
+      ← IsMonomialOrder.mul_mono (cmp := cmp) c d b]
+    exact hcd
+  exact Std.TransCmp.isLE_trans hleft hright
+
+private theorem left_eq_of_mul_eq [IsMonomialOrder cmp]
+    {a b c d : Mono n} (hab : (cmp a b).isLE) (hcd : (cmp c d).isLE)
+    (hmul : Mono.mul a c = Mono.mul b d) : a = b := by
+  cases hcmp : cmp a b with
+  | lt =>
+      have hleft : cmp (Mono.mul a c) (Mono.mul b c) = .lt := by
+        rw [← IsMonomialOrder.mul_mono (cmp := cmp) a b c]
+        exact hcmp
+      have hright : (cmp (Mono.mul b c) (Mono.mul b d)).isLE := by
+        rw [Mono.mul_comm b c, Mono.mul_comm b d,
+          ← IsMonomialOrder.mul_mono (cmp := cmp) c d b]
+        exact hcd
+      have hlt := Std.TransCmp.lt_of_lt_of_isLE hleft hright
+      rw [hmul] at hlt
+      have hself : cmp (Mono.mul b d) (Mono.mul b d) = .eq :=
+        Std.ReflCmp.compare_self
+      rw [hself] at hlt
+      contradiction
+  | eq => exact Std.LawfulEqCmp.eq_of_compare hcmp
+  | gt => simp [hcmp] at hab
+
+private theorem mul_left_cancel {a b c : Mono n}
+    (h : Mono.mul a b = Mono.mul a c) : b = c := by
+  apply Vector.ext
+  intro i hi
+  let j : Fin n := ⟨i, hi⟩
+  have hj := congrArg (fun m : Mono n => m[j]) h
+  simp only [Mono.getElem_mul] at hj
+  exact Nat.add_left_cancel hj
+
+private theorem eq_zero_of_mul_eq_zero {a b : Mono n}
+    (h : Mono.mul a b = Mono.zero) : a = Mono.zero := by
+  apply Vector.ext
+  intro i hi
+  let j : Fin n := ⟨i, hi⟩
+  have hj := congrArg (fun m : Mono n => m[j]) h
+  have hj' : a[j] + b[j] = 0 := by
+    calc
+      a[j] + b[j] = (Mono.mul a b)[j] := (Mono.getElem_mul a b j).symm
+      _ = Mono.zero[j] := hj
+      _ = 0 := Mono.getElem_zero j
+  change a[j] = Mono.zero[j]
+  rw [Mono.getElem_zero]
+  exact (Nat.eq_zero_of_add_eq_zero hj').1
+
+private theorem eq_zero_of_isLE [IsMonomialOrder cmp] {m : Mono n}
+    (h : (cmp m Mono.zero).isLE) : m = Mono.zero := by
+  cases hcmp : cmp m Mono.zero with
+  | lt =>
+      have hgt : cmp Mono.zero m = .gt :=
+        (Std.OrientedCmp.gt_iff_lt (cmp := cmp)).mpr hcmp
+      exact False.elim (IsMonomialOrder.zero_le m hgt)
+  | eq => exact Std.LawfulEqCmp.eq_of_compare hcmp
+  | gt => simp [hcmp] at h
+
+/-- The leading term of a product is the product of the leading terms over a
+coefficient domain. -/
+theorem leadingTerm_mul [IsMonomialOrder cmp] [LawfulGcdOps R]
+    {p q : MvPoly n R cmp} {mp mq : Mono n} {cp cq : R}
+    (hp : p.leadingTerm = some (mp, cp))
+    (hq : q.leadingTerm = some (mq, cq)) :
+    (p * q).leadingTerm = some (Mono.mul mp mq, cp * cq) := by
+  have hpc := (leadingTerm_eq_some_iff p mp cp).mp hp |>.1
+  have hqc := (leadingTerm_eq_some_iff q mq cq).mp hq |>.1
+  have hcp : cp ≠ 0 := by
+    intro hzero
+    exact p.coeff?_ne_zero mp (hpc.trans (congrArg some hzero))
+  have hcq : cq ≠ 0 := by
+    intro hzero
+    exact q.coeff?_ne_zero mq (hqc.trans (congrArg some hzero))
+  have hprod : cp * cq ≠ 0 := by
+    intro hzero
+    rcases LawfulGcdOps.no_zero_div cp cq hzero with hzero | hzero
+    · exact hcp hzero
+    · exact hcq hzero
+  have hcoeff : coeff (Mono.mul mp mq) (p * q) = cp * cq := by
+    rw [coeff_mul]
+    have hmem : (mp, mq) ∈ Mono.splits (Mono.mul mp mq) :=
+      (Mono.splits_mem_iff ..).mpr rfl
+    calc
+      (Mono.splits (Mono.mul mp mq)).foldl
+          (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) 0 =
+          (Mono.splits (Mono.mul mp mq)).foldl
+            (fun acc ab => acc + if ab = (mp, mq) then cp * cq else 0) 0 := by
+              apply List.foldl_congr
+              intro acc ab hab
+              by_cases hpq : ab = (mp, mq)
+              · subst ab
+                rw [Hex.ite_eq_left rfl, coeff_eq_of_leadingTerm hp,
+                  coeff_eq_of_leadingTerm hq]
+              · rw [Hex.ite_eq_right hpq]
+                by_cases hpa : coeff ab.1 p = 0
+                · rw [hpa, Lean.Grind.Semiring.zero_mul]
+                · by_cases hqb : coeff ab.2 q = 0
+                  · rw [hqb, Lean.Grind.Semiring.mul_zero]
+                  · have hma : ab.1 ∈ p.monomials :=
+                      (mem_monomials_iff ab.1 p).mpr hpa
+                    have hmb : ab.2 ∈ q.monomials :=
+                      (mem_monomials_iff ab.2 q).mpr hqb
+                    have ha := le_leadingTerm hp ab.1 hma
+                    have hb := le_leadingTerm hq ab.2 hmb
+                    have hmul := (Mono.splits_mem_iff ..).mp hab
+                    have heqa : ab.1 = mp :=
+                      left_eq_of_mul_eq ha hb hmul
+                    have heqb : ab.2 = mq := by
+                      have hmul' : Mono.mul mp ab.2 = Mono.mul mp mq := by
+                        exact (congrArg (fun a => Mono.mul a ab.2) heqa).symm.trans hmul
+                      exact mul_left_cancel hmul'
+                    exact False.elim (hpq (Prod.ext heqa heqb))
+      _ = 0 + cp * cq :=
+        List.foldl_add_single _ _ _ _ hmem
+          (Mono.splits_nodup (Mono.mul mp mq))
+      _ = cp * cq := by grind
+  apply (leadingTerm_eq_some_iff (p * q) (Mono.mul mp mq) (cp * cq)).mpr
+  constructor
+  · cases hopt : (p * q).coeff? (Mono.mul mp mq) with
+    | none =>
+        have : coeff (Mono.mul mp mq) (p * q) = 0 := by
+          unfold coeff
+          rw [hopt]
+          rfl
+        exact False.elim (hprod (hcoeff.symm.trans this))
+    | some c =>
+        have hc : c = cp * cq := by
+          have : coeff (Mono.mul mp mq) (p * q) = c := by
+            unfold coeff
+            rw [hopt]
+            rfl
+          exact this.symm.trans hcoeff
+        exact congrArg some hc
+  · intro m hm
+    rcases exists_mul_of_mem hm with ⟨a, ha, b, hb, rfl⟩
+    exact mul_isLE (le_leadingTerm hp a ha) (le_leadingTerm hq b hb)
+
 /-- Unit recognition is sound and complete under the coefficient gcd laws. -/
-theorem polyIsUnit_iff [LawfulGcdOps R] (p : MvPoly n R cmp) :
+theorem polyIsUnit_iff [IsMonomialOrder cmp] [LawfulGcdOps R]
+    (p : MvPoly n R cmp) :
     polyIsUnit p = true ↔ ∃ q, p * q = 1 := by
-  sorry
+  constructor
+  · intro hunit
+    cases hterms : p.termsList with
+    | nil => simp [polyIsUnit, hterms] at hunit
+    | cons term terms =>
+        cases terms with
+        | nil =>
+            rcases term with ⟨m, c⟩
+            rw [polyIsUnit, hterms] at hunit
+            simp only at hunit
+            change (decide (m = Mono.zero) && GcdOps.isUnit c) = true at hunit
+            rcases Bool.and_eq_true_iff.mp hunit with ⟨hm, hc⟩
+            have hmzero : m = Mono.zero := by
+              simpa only [decide_eq_true_eq] using hm
+            subst m
+            rcases (LawfulGcdOps.isUnit_iff c).mp hc with ⟨d, hd⟩
+            have hcne : c ≠ 0 := by
+              intro hzero
+              rw [hzero, Lean.Grind.Semiring.zero_mul] at hd
+              exact LawfulGcdOps.one_ne_zero hd.symm
+            have hpC : p = C c := by
+              apply termsList_inj
+              rw [hterms, termsList_C, Hex.ite_eq_right hcne]
+            refine ⟨C d, ?_⟩
+            rw [hpC]
+            change monomial Mono.zero c * monomial Mono.zero d = 1
+            rw [monomial_mul_monomial, Mono.zero_mul, hd]
+            rfl
+        | cons next rest => simp [polyIsUnit, hterms] at hunit
+  · rintro ⟨q, hpq⟩
+    have hpzero : p ≠ 0 := by
+      intro hp
+      subst p
+      rw [zero_mul] at hpq
+      have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq
+      rw [coeff_zero, coeff_one, Hex.ite_eq_left rfl] at hcoeff
+      exact LawfulGcdOps.one_ne_zero hcoeff.symm
+    have hqzero : q ≠ 0 := by
+      intro hq
+      subst q
+      rw [mul_zero] at hpq
+      have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq
+      rw [coeff_zero, coeff_one, Hex.ite_eq_left rfl] at hcoeff
+      exact LawfulGcdOps.one_ne_zero hcoeff.symm
+    cases hpLead : p.leadingTerm with
+    | none => exact False.elim (hpzero ((leadingTerm_eq_none_iff p).mp hpLead))
+    | some pterm =>
+        rcases pterm with ⟨mp, cp⟩
+        cases hqLead : q.leadingTerm with
+        | none => exact False.elim (hqzero ((leadingTerm_eq_none_iff q).mp hqLead))
+        | some qterm =>
+            rcases qterm with ⟨mq, cq⟩
+            have hlead := leadingTerm_mul hpLead hqLead
+            have hcoeff := coeff_eq_of_leadingTerm hlead
+            rw [hpq, coeff_one] at hcoeff
+            have hcp : cp ≠ 0 := by
+              intro hzero
+              have hopt := (leadingTerm_eq_some_iff p mp cp).mp hpLead |>.1
+              exact p.coeff?_ne_zero mp
+                (hopt.trans (congrArg some hzero))
+            have hcq : cq ≠ 0 := by
+              intro hzero
+              have hopt := (leadingTerm_eq_some_iff q mq cq).mp hqLead |>.1
+              exact q.coeff?_ne_zero mq
+                (hopt.trans (congrArg some hzero))
+            have hcprod : cp * cq ≠ 0 := by
+              intro hzero
+              rcases LawfulGcdOps.no_zero_div cp cq hzero with hzero | hzero
+              · exact hcp hzero
+              · exact hcq hzero
+            have hmono : Mono.mul mp mq = Mono.zero := by
+              by_cases hmono : Mono.mul mp mq = Mono.zero
+              · exact hmono
+              · rw [Hex.ite_eq_right hmono] at hcoeff
+                exact False.elim (hcprod hcoeff.symm)
+            have hcoeffUnit : cp * cq = 1 := by
+              rw [Hex.ite_eq_left hmono] at hcoeff
+              exact hcoeff.symm
+            have hmp : mp = Mono.zero := eq_zero_of_mul_eq_zero hmono
+            have hpC : p = C cp := by
+              apply ext
+              intro m
+              rw [coeff_C]
+              by_cases hm : m = Mono.zero
+              · subst m
+                rw [← hmp, coeff_eq_of_leadingTerm hpLead]
+                simp
+              · rw [Hex.ite_eq_right hm]
+                apply coeff_eq_zero_of_not_mem m p
+                intro hmem
+                have hle := le_leadingTerm hpLead m hmem
+                rw [hmp] at hle
+                exact hm (eq_zero_of_isLE hle)
+            have hisUnit : GcdOps.isUnit cp = true :=
+              (LawfulGcdOps.isUnit_iff cp).mpr ⟨cq, hcoeffUnit⟩
+            rw [hpC]
+            rw [polyIsUnit, termsList_C, Hex.ite_eq_right hcp]
+            simp [hisUnit]
 
 /-- The chosen normalization multiplier is a polynomial unit. -/
 theorem polyNormUnit_isUnit [IsMonomialOrder cmp] [LawfulGcdOps R]

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -33,7 +33,7 @@ variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
 zero. -/
 @[reducible] def polyNormUnit [IsMonomialOrder cmp]
     (p : MvPoly n R cmp) : MvPoly n R cmp :=
-  match p.termsList.getLast? with
+  match p.leadingTerm with
   | none => 1
   | some (_, c) => C (GcdOps.normUnit c)
 
@@ -63,7 +63,7 @@ omit [Dvd R] in
 /-- The normalization unit at zero is the constant one polynomial. -/
 @[simp] theorem polyNormUnit_zero [IsMonomialOrder cmp] :
     polyNormUnit (0 : MvPoly n R cmp) = 1 := by
-  rfl
+  rw [polyNormUnit, leadingTerm_zero]
 
 omit [Dvd R] in
 /-- Polynomial normalization preserves zero. -/
@@ -466,12 +466,75 @@ theorem polyIsUnit_iff [IsMonomialOrder cmp] [LawfulGcdOps R]
 theorem polyNormUnit_isUnit [IsMonomialOrder cmp] [LawfulGcdOps R]
     (p : MvPoly n R cmp) :
     polyIsUnit (polyNormUnit p) = true := by
-  sorry
+  rw [polyIsUnit_iff]
+  unfold polyNormUnit
+  cases hlead : p.leadingTerm with
+  | none =>
+      refine ⟨1, ?_⟩
+      exact one_mul _
+  | some term =>
+      rcases term with ⟨m, c⟩
+      rcases LawfulGcdOps.normUnit_unit c with ⟨d, hd⟩
+      refine ⟨C d, ?_⟩
+      change monomial Mono.zero (GcdOps.normUnit c) *
+          monomial Mono.zero d = 1
+      rw [monomial_mul_monomial, Mono.zero_mul, hd]
+      rfl
 
 /-- Polynomial normalization is idempotent. -/
 theorem polyNormalize_idem [IsMonomialOrder cmp] [LawfulGcdOps R]
     (p : MvPoly n R cmp) :
     polyNormalize (polyNormalize p) = polyNormalize p := by
-  sorry
+  cases hlead : p.leadingTerm with
+  | none =>
+      have hpzero : p = 0 := (leadingTerm_eq_none_iff p).mp hlead
+      subst p
+      simp
+  | some term =>
+      rcases term with ⟨m, c⟩
+      have hc : c ≠ 0 := by
+        intro hzero
+        have hcoeff := (leadingTerm_eq_some_iff p m c).mp hlead |>.1
+        exact p.coeff?_ne_zero m (hcoeff.trans (congrArg some hzero))
+      rcases LawfulGcdOps.normUnit_unit c with ⟨d, hd⟩
+      have hu : GcdOps.normUnit c ≠ 0 := by
+        intro hzero
+        rw [hzero, Lean.Grind.Semiring.zero_mul] at hd
+        exact LawfulGcdOps.one_ne_zero hd.symm
+      have hunitLead :
+          (C (GcdOps.normUnit c) : MvPoly n R cmp).leadingTerm =
+            some (Mono.zero, GcdOps.normUnit c) :=
+        leadingTerm_C hu
+      have hnormLead : (polyNormalize p).leadingTerm =
+          some (m, normalize c) := by
+        unfold polyNormalize polyNormUnit
+        rw [hlead]
+        simpa [normalize] using leadingTerm_mul hlead hunitLead
+      have hnormNe : normalize c ≠ 0 := by
+        intro hzero
+        unfold normalize at hzero
+        rcases LawfulGcdOps.no_zero_div c (GcdOps.normUnit c) hzero with
+          hczero | huzero
+        · exact hc hczero
+        · exact hu huzero
+      have hnext : GcdOps.normUnit (normalize c) = 1 := by
+        have hzero :
+            normalize c * (GcdOps.normUnit (normalize c) - 1) = 0 := by
+          calc
+            normalize c * (GcdOps.normUnit (normalize c) - 1) =
+                normalize (normalize c) - normalize c := by
+                  unfold normalize
+                  grind
+            _ = 0 := by rw [LawfulGcdOps.normalize_idem]; grind
+        rcases LawfulGcdOps.no_zero_div (normalize c)
+            (GcdOps.normUnit (normalize c) - 1) hzero with hzero | hrest
+        · exact False.elim (hnormNe hzero)
+        · grind
+      change polyNormalize p * polyNormUnit (polyNormalize p) = polyNormalize p
+      unfold polyNormUnit
+      rw [hnormLead]
+      simp only
+      rw [hnext]
+      exact mul_one _
 
 end Hex.MvPoly

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -39,7 +39,10 @@ instance instNatNoZeroInt : NatNoZero Int := by
 instance instNatNoZeroRat : NatNoZero Rat := by
   constructor
   intro m hm
-  sorry
+  change ((m : Int) : Rat) ≠ 0
+  intro h
+  have : (m : Int) = 0 := Rat.intCast_eq_zero_iff.mp h
+  omega
 
 instance instFractionNonzeroOneInt : Hex.Fraction.NonzeroOne Int :=
   ⟨by decide⟩
@@ -75,13 +78,19 @@ instance instPerfectFracInt : PerfectFrac Int := by
   constructor
   left
   intro m hm
-  sorry
+  change Hex.Fraction.ofCoeff (m : Int) ≠ 0
+  intro h
+  have : (m : Int) = 0 := (Hex.Fraction.ofCoeff_eq_zero_iff _).mp h
+  omega
 
 instance instPerfectFracRat : PerfectFrac Rat := by
   constructor
   left
   intro m hm
-  sorry
+  change Hex.Fraction.ofCoeff (m : Rat) ≠ 0
+  intro h
+  have hrat : (m : Rat) = 0 := (Hex.Fraction.ofCoeff_eq_zero_iff _).mp h
+  exact NatNoZero.natCast_ne_zero m hm hrat
 
 /-- The fraction field of a bounded prime field is perfect.  Every fraction is
 represented by a coefficient because its denominator is invertible, and
@@ -267,9 +276,10 @@ theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) : radical p ∣ p := by
   sorry
 
+omit [LawfulGcdOps R] [LawfulBezoutOps R] in
 @[simp] theorem radical_zero [IsMonomialOrder cmp] [NatCast R] [NatNoZero R] :
     radical (0 : MvPoly n R cmp) = 0 := by
-  sorry
+  simp [radical]
 
 theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) :

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -56,6 +56,19 @@ variable [Zero R]
 def termsList (p : MvPoly n R cmp) : List (Mono n × R) :=
   p.termsInternal.toList
 
+/-- The canonical term list determines a polynomial. -/
+theorem termsList_inj {p q : MvPoly n R cmp}
+    (h : p.termsList = q.termsList) : p = q := by
+  have ht : p.termsInternal = q.termsInternal :=
+    Std.ExtTreeMap.toList_inj.mp h
+  cases p with
+  | mk pt hp =>
+      cases q with
+      | mk qt hq =>
+          simp only at ht
+          subst qt
+          rfl
+
 /-- Compatibility spelling for consumers that iterate over all terms. -/
 def toList (p : MvPoly n R cmp) : List (Mono n × R) :=
   termsList p
@@ -366,6 +379,51 @@ theorem coeff_C [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
   intro m
   rw [coeff_C, coeff_zero]
   split <;> rfl
+
+/-- A nonzero monomial polynomial has exactly its defining stored term. -/
+theorem termsList_monomial [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (m : Mono n) (c : R) :
+    (monomial m c : MvPoly n R cmp).termsList =
+      if c = 0 then [] else [(m, c)] := by
+  by_cases hc : c = 0
+  · rw [Hex.ite_eq_left hc, monomial, Hex.dite_eq_left hc]
+    rfl
+  · rw [Hex.ite_eq_right hc, monomial, Hex.dite_eq_right hc]
+    change ((∅ : Std.ExtTreeMap (Mono n) R cmp).insert m c).toList = [(m, c)]
+    apply List.Perm.eq_singleton
+    have hnodup :
+        ((∅ : Std.ExtTreeMap (Mono n) R cmp).insert m c).toList.Nodup := by
+      have hkeys := Std.ExtTreeMap.distinct_keys_toList
+        (t := (∅ : Std.ExtTreeMap (Mono n) R cmp).insert m c)
+      exact hkeys.imp fun hcmp hab => by
+        cases hab
+        simp at hcmp
+    rw [List.perm_ext_iff_of_nodup hnodup (by simp)]
+    intro term
+    rcases term with ⟨k, v⟩
+    rw [Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some]
+    constructor
+    · intro hget
+      rw [Std.ExtTreeMap.getElem?_insert,
+        Std.ExtTreeMap.getElem?_empty] at hget
+      split at hget
+      · rename_i hcmp
+        have hmk : m = k := Std.LawfulEqCmp.eq_of_compare hcmp
+        subst k
+        simp at hget
+        subst v
+        simp
+      · contradiction
+    · intro hmem
+      simp only [List.mem_singleton] at hmem
+      cases hmem
+      exact Std.ExtTreeMap.getElem?_insert_self
+
+/-- A nonzero constant polynomial has one stored term at the zero monomial. -/
+theorem termsList_C [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R] (c : R) :
+    (C c : MvPoly n R cmp).termsList =
+      if c = 0 then [] else [(Mono.zero, c)] := by
+  exact termsList_monomial Mono.zero c
 
 /-- A variable polynomial is supported at its unit monomial. -/
 theorem coeff_X [Zero R] [One R] [BEq R] [LawfulBEq R] [DecidableEq R]

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -359,6 +359,14 @@ theorem coeff_C [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
       if m = Mono.zero then c else 0 := by
   simp [C, coeff_monomial]
 
+/-- The constant polynomial with zero coefficient is the zero polynomial. -/
+@[simp] theorem C_zero [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R] :
+    C (0 : R) = (0 : MvPoly n R cmp) := by
+  apply ext
+  intro m
+  rw [coeff_C, coeff_zero]
+  split <;> rfl
+
 /-- A variable polynomial is supported at its unit monomial. -/
 theorem coeff_X [Zero R] [One R] [BEq R] [LawfulBEq R] [DecidableEq R]
     (m : Mono n) (i : Fin n) :

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -355,6 +355,37 @@ theorem coeff_mul [Lean.Grind.Semiring R] [DecidableEq R]
       (Mono.splits m).foldl (fun acc ab => acc + value ab) 0
   rw [hkeyFilter, List.foldl_add_perm value hactivePerm 0, hsplitFilter]
 
+/-- Every monomial occurring in a product is a product of monomials from the
+two input supports. Cancellation may make the converse false. -/
+theorem exists_mul_of_mem [Lean.Grind.Semiring R] [DecidableEq R]
+    {p q : MvPoly n R cmp} {m : Mono n} (hm : m ∈ (p * q).monomials) :
+    ∃ a ∈ p.monomials, ∃ b ∈ q.monomials, Mono.mul a b = m := by
+  letI : Decidable (∃ a ∈ p.monomials, ∃ b ∈ q.monomials,
+      Mono.mul a b = m) := Classical.propDecidable _
+  by_cases hexists : ∃ a ∈ p.monomials, ∃ b ∈ q.monomials,
+      Mono.mul a b = m
+  · exact hexists
+  · have hzero : coeff m (p * q) = 0 := by
+      rw [coeff_mul]
+      calc
+        (Mono.splits m).foldl
+            (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) 0 =
+            (Mono.splits m).foldl (fun acc _ => acc + 0) 0 := by
+              apply List.foldl_congr
+              intro acc ab hab
+              by_cases ha : ab.1 ∈ p.monomials
+              · have hb : ab.2 ∉ q.monomials := by
+                  intro hb
+                  apply hexists
+                  exact ⟨ab.1, ha, ab.2, hb,
+                    (Mono.splits_mem_iff ..).mp hab⟩
+                rw [coeff_eq_zero_of_not_mem ab.2 q hb,
+                  Lean.Grind.Semiring.mul_zero]
+              · rw [coeff_eq_zero_of_not_mem ab.1 p ha,
+                  Lean.Grind.Semiring.zero_mul]
+        _ = 0 := List.foldl_add_zero _ _
+    exact False.elim (((mem_monomials_iff m (p * q)).mp hm) hzero)
+
 /-- Zero is absorbing on the right for polynomial multiplication. -/
 theorem mul_zero [Lean.Grind.Semiring R] [DecidableEq R]
     (p : MvPoly n R cmp) : p * 0 = 0 := by

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -593,6 +593,41 @@ theorem one_mul [Lean.Grind.Semiring R] [DecidableEq R]
       List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
     _ = coeff m p := by grind
 
+/-- Multiplication by a constant polynomial scales every coefficient. -/
+theorem coeff_C_mul [Lean.Grind.Semiring R] [DecidableEq R]
+    (c : R) (p : MvPoly n R cmp) (m : Mono n) :
+    coeff m (C c * p) = c * coeff m p := by
+  rw [coeff_mul]
+  simp only [coeff_C]
+  have hmem : (Mono.zero, m) ∈ Mono.splits m :=
+    (Mono.splits_mem_iff ..).mpr (Mono.zero_mul m)
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab =>
+          acc + (if ab.1 = Mono.zero then c else 0) * coeff ab.2 p)
+        0 =
+        (Mono.splits m).foldl
+          (fun acc ab =>
+            acc + if ab = (Mono.zero, m) then c * coeff ab.2 p else 0)
+          0 := by
+            apply List.foldl_congr
+            intro acc ab hab
+            have hmul := (Mono.splits_mem_iff ..).mp hab
+            by_cases ha : ab.1 = Mono.zero
+            · have hb : ab.2 = m := by
+                rw [ha, Mono.zero_mul] at hmul
+                exact hmul
+              have hab' : ab = (Mono.zero, m) := Prod.ext ha hb
+              rw [Hex.ite_eq_left ha, Hex.ite_eq_left hab', hb]
+            · have hab' : ab ≠ (Mono.zero, m) := by
+                intro h
+                exact ha (congrArg Prod.fst h)
+              rw [Hex.ite_eq_right ha, Lean.Grind.Semiring.zero_mul,
+                Hex.ite_eq_right hab']
+    _ = 0 + c * coeff m p :=
+      List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
+    _ = c * coeff m p := by grind
+
 /-- A three-factor monomial split. -/
 private abbrev MonoTriple (n : Nat) :=
   Mono n × (Mono n × Mono n)

--- a/HexMvPoly/Query.lean
+++ b/HexMvPoly/Query.lean
@@ -175,6 +175,39 @@ theorem leadingCoeff_eq [Zero R] [IsMonomialOrder cmp]
   unfold leadingCoeff
   cases p.leadingTerm <;> rfl
 
+/-- A polynomial has no leading term exactly when it is zero. -/
+@[simp] theorem leadingTerm_eq_none_iff [Zero R] [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) : p.leadingTerm = none ↔ p = 0 := by
+  constructor
+  · intro hnone
+    unfold leadingTerm maxTerm? at hnone
+    cases hmax : p.termsInternal.maxKey? with
+    | none =>
+        have hempty : p.termsInternal = ∅ :=
+          Std.ExtTreeMap.maxKey?_eq_none_iff.mp hmax
+        apply ext
+        intro m
+        rw [coeff_zero]
+        unfold coeff coeff?
+        rw [hempty]
+        simp
+    | some m =>
+        have hmem : m ∈ p.termsInternal :=
+          (Std.ExtTreeMap.maxKey?_eq_some_iff_mem_and_forall.mp hmax).1
+        have hisSome : p.termsInternal[m]?.isSome := by
+          rw [← Std.ExtTreeMap.mem_iff_isSome_getElem?]
+          exact hmem
+        cases hcoeff : p.termsInternal[m]? with
+        | none => simp [hcoeff] at hisSome
+        | some c => simp [hmax, hcoeff] at hnone
+  · rintro rfl
+    unfold leadingTerm maxTerm?
+    change
+      ((∅ : Std.ExtTreeMap (Mono n) R cmp).maxKey?.bind fun m =>
+        (∅ : Std.ExtTreeMap (Mono n) R cmp)[m]?.map fun c => (m, c)) = none
+    rw [Std.ExtTreeMap.maxKey?_empty]
+    rfl
+
 /-- Retain exactly the terms whose monomials satisfy `keep`. -/
 @[expose] def restrictBy [Zero R]
     (keep : Mono n → Bool) (p : MvPoly n R cmp) : MvPoly n R cmp where

--- a/HexMvPoly/Query.lean
+++ b/HexMvPoly/Query.lean
@@ -175,6 +175,24 @@ theorem leadingCoeff_eq [Zero R] [IsMonomialOrder cmp]
   unfold leadingCoeff
   cases p.leadingTerm <;> rfl
 
+/-- A nonzero constant has its defining coefficient as leading term. -/
+theorem leadingTerm_C [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    [IsMonomialOrder cmp] {c : R} (hc : c ≠ 0) :
+    leadingTerm (C c : MvPoly n R cmp) = some (Mono.zero, c) := by
+  apply (leadingTerm_eq_some_iff (C c : MvPoly n R cmp) Mono.zero c).mpr
+  constructor
+  · unfold coeff? C monomial
+    rw [Hex.dite_eq_right hc, Std.ExtTreeMap.getElem?_insert_self]
+  · intro m hm
+    have hcoeff := (mem_monomials_iff m (C c : MvPoly n R cmp)).mp hm
+    rw [coeff_C] at hcoeff
+    by_cases hmzero : m = Mono.zero
+    · subst m
+      rw [show cmp Mono.zero Mono.zero = .eq from Std.ReflCmp.compare_self]
+      trivial
+    · rw [Hex.ite_eq_right hmzero] at hcoeff
+      contradiction
+
 /-- A polynomial has no leading term exactly when it is zero. -/
 @[simp] theorem leadingTerm_eq_none_iff [Zero R] [IsMonomialOrder cmp]
     (p : MvPoly n R cmp) : p.leadingTerm = none ↔ p = 0 := by


### PR DESCRIPTION
## Summary

- prove characteristic, radical, and constant-coefficient helper laws used by multivariate gcd replay
- prove product-support and product-leading-term laws for distributed multivariate polynomials
- prove scalar-content divisibility, reconstruction, normalization, and nonzero primitive-part content
- prove sound and complete polynomial unit recognition and idempotence of polynomial normalization
- select the normalization unit through the logarithmic leading-term query instead of materializing the whole term list

## Verification

- `lake build HexMvGcd`
- `git diff --check`

This follows merged PR #9528 and removes all remaining `sorry`s from `HexMvGcd/Normalize.lean` while establishing the content lemmas needed by the Gauss layer.
