### PR TITLE
feat(interval): generalize frontend initial facts

### DIFF
--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -295,14 +295,19 @@ domain top. -/
 def Result.initialContext (result : Result) : InitialContext :=
   { rows := result.entries.map fun entry => { node := entry.node } }
 
-/-- Replace one node-indexed selection. Out-of-range writes leave the plain
-context unchanged; `inputInitialWithin` remains the authoritative structural
-validator. -/
+/-- Replace one node-indexed selection only when the requested node is present
+at its exact slot. A mistargeted or out-of-range write refuses rather than
+silently leaving a `whole` fact in place. `inputInitialWithin` remains the
+authoritative full-context validator. -/
 def InitialContext.setFact (initial : InitialContext) (node : NodeId)
-    (fact : Hex.Interval) : InitialContext :=
+    (fact : Hex.Interval) : Except Error InitialContext :=
   match initial.rows[node.index]? with
-  | none => initial
-  | some row => { rows := initial.rows.set! node.index { row with fact := some fact } }
+  | none => throw .malformedInitial
+  | some row =>
+      if row.node != node then
+        throw .malformedInitial
+      else
+        pure { rows := initial.rows.set! node.index { row with fact := some fact } }
 
 /-- Materialize absent selections as domain top in exact row order. -/
 def InitialContext.facts (initial : InitialContext) : Array Hex.Interval :=

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -669,13 +669,10 @@ def modelOfCheck {config : Config} {sources : Nat → ℝ} {result : Result}
     (success : checked.toOption.isSome = true) : Model config.rule sources result :=
   checked.toOption.get success
 
-/-- Revalidate every resource cap and structural binding before materializing
-one authenticated version-zero fact per reifier node. Caller-selected facts
-remain plain data; only `InitialContext.Contains` supplies semantic authority.
-Failure returns no partially constructed input. -/
-def inputInitialWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
-    (initial : InitialContext) (target : Hex.Interval) :
-    Except Error (Proof.Input Hex.Interval) := do
+/-- Shared bounded validation for proof-input constructors. `initialSize` is
+the caller's version-zero row count and is charged before any row scan. -/
+def inputCheckWithin (config : Config) (result : Result) (initialSize : Nat) :
+    Except Error Unit := do
   if config.reify.maxSources < result.sourceCount then throw .sourceLimit
   let meanings := Rule.meanings config.rule
   if config.reify.maxOperations < meanings.size ||
@@ -683,44 +680,48 @@ def inputInitialWithin (config : Config) (scope : Policy.ScopeId) (result : Resu
     throw .operationLimit
   if config.reify.maxNodes < result.program.nodes.size ||
       config.reify.maxNodes < result.entries.size ||
-      config.reify.maxNodes < initial.rows.size then throw .nodeLimit
+      config.reify.maxNodes < initialSize then throw .nodeLimit
   if !result.depthCheck config.reify.maxDepth then throw .depthLimit
   if result.target.index ≥ result.program.nodes.size || !result.program.check then
     throw .malformedProgram
   if result.program.operations != meanings.map (Program.Meaning.operation) then
     throw .malformedProgram
   if !result.check then throw .malformedResult
+  pure ()
+
+/-- Revalidate every resource cap and structural binding before materializing
+one authenticated version-zero fact per reifier node. Caller-selected facts
+remain plain data; only `InitialContext.Contains` supplies semantic authority.
+Failure returns no partially constructed input. -/
+def inputInitialWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
+    (initial : InitialContext) (target : Hex.Interval) :
+    Except Error (Proof.Input Hex.Interval) := do
+  inputCheckWithin config result initial.rows.size
   if initial.rows.size != result.entries.size then throw .wrongInitialCount
   if !initial.check result then throw .malformedInitial
-  let input : Proof.Input Hex.Interval :=
-    { scope
-      program := result.program
-      facts := initial.facts
-      target := { node := result.target, fact := target } }
-  pure input
+  pure {
+    scope
+    program := result.program
+    facts := initial.facts
+    target := { node := result.target, fact := target } }
 
 /-- Source-only convenience wrapper for the original frontend API. It binds
 every selected source exactly once and leaves computed rows at domain top. -/
 def inputWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
     (sources : Array Hex.Interval) (target : Hex.Interval) :
     Except Error (Proof.Input Hex.Interval) := do
-  if config.reify.maxSources < result.sourceCount then throw .sourceLimit
-  let meanings := Rule.meanings config.rule
-  if config.reify.maxOperations < meanings.size ||
-      config.reify.maxOperations < result.program.operations.size then
-    throw .operationLimit
-  if config.reify.maxNodes < result.program.nodes.size ||
-      config.reify.maxNodes < result.entries.size then throw .nodeLimit
-  if !result.depthCheck config.reify.maxDepth then throw .depthLimit
-  if result.target.index ≥ result.program.nodes.size || !result.program.check then
-    throw .malformedProgram
-  if result.program.operations != meanings.map (Program.Meaning.operation) then
-    throw .malformedProgram
-  if !result.check then throw .malformedResult
+  inputCheckWithin config result result.entries.size
   if sources.size != result.sourceCount then throw .wrongSourceCount
   for index in [0:result.sourceCount] do
     let some _ := result.sourceNode? index | throw (.missingSource index)
-  inputInitialWithin config scope result (result.sourceInitial sources) target
+  let initial := result.sourceInitial sources
+  if initial.rows.size != result.entries.size then throw .wrongInitialCount
+  if !initial.check result then throw .malformedInitial
+  pure {
+    scope
+    program := result.program
+    facts := initial.facts
+    target := { node := result.target, fact := target } }
 
 /-- The exact `Result.facts` seed array discharges every computed top fact;
 only caller source containment remains. -/

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -93,6 +93,21 @@ structure Result where
   sourceCount : Nat
   deriving DecidableEq, Repr
 
+/-- One node-indexed version-zero fact selection. `none` means that the row
+starts at domain top; `some fact` is caller-selected data whose semantic
+containment must be proved separately through `InitialContext.Contains`. -/
+structure InitialRow where
+  node : NodeId
+  fact : Option Hex.Interval := none
+  deriving DecidableEq
+
+/-- Plain node-indexed initial-fact data. The runtime builder revalidates one
+row per checked reifier entry and exact node order before materializing absent
+facts as `whole`. This record carries no theorem authority. -/
+structure InitialContext where
+  rows : Array InitialRow
+  deriving DecidableEq
+
 inductive Error where
   | sourceLimit
   | operationLimit
@@ -102,6 +117,8 @@ inductive Error where
   | missingOperation (key : OpKey)
   | malformedProgram
   | malformedResult
+  | wrongInitialCount
+  | malformedInitial
   | wrongSourceCount
   | missingSource (index : Nat)
   | rule (error : Rule.BuildError)
@@ -273,6 +290,49 @@ def reifyWithin (config : Config) (sourceCount : Nat) (target : Term) :
 def Result.sourceNode? (result : Result) (index : Nat) : Option NodeId :=
   (result.entries.toList.find? fun entry => entry.term == .source index).map (·.node)
 
+/-- Default node-indexed initial context: every checked reifier row starts at
+domain top. -/
+def Result.initialContext (result : Result) : InitialContext :=
+  { rows := result.entries.map fun entry => { node := entry.node } }
+
+/-- Replace one node-indexed selection. Out-of-range writes leave the plain
+context unchanged; `inputInitialWithin` remains the authoritative structural
+validator. -/
+def InitialContext.setFact (initial : InitialContext) (node : NodeId)
+    (fact : Hex.Interval) : InitialContext :=
+  match initial.rows[node.index]? with
+  | none => initial
+  | some row => { rows := initial.rows.set! node.index { row with fact := some fact } }
+
+/-- Materialize absent selections as domain top in exact row order. -/
+def InitialContext.facts (initial : InitialContext) : Array Hex.Interval :=
+  initial.rows.map fun row => row.fact.getD Hex.Interval.whole
+
+/-- One initial row must name the exact reifier node at the same array slot. -/
+protected def InitialContext.slotCheck (initial : InitialContext)
+    (result : Result) (index : Nat) : Bool :=
+  match initial.rows[index]?, result.entries[index]? with
+  | some row, some entry => row.node == entry.node
+  | _, _ => false
+
+/-- Authenticate exact row count and node order. The caller checks array caps
+before invoking this bounded scan. -/
+def InitialContext.check (initial : InitialContext) (result : Result) : Bool :=
+  initial.rows.size == result.entries.size &&
+    (List.range initial.rows.size).all (initial.slotCheck result)
+
+/-- Exact semantic authority for node-indexed initial facts. The relation is
+position-for-position with the checked reifier table, pins the named node, and
+relates every selected fact to that row's exact `Term.eval`. An absent fact is
+the public `whole` value and therefore has a trivial caller proof. -/
+def InitialContext.Contains (initial : InitialContext) (config : Rule.Config)
+    (values : Nat → ℝ) (result : Result) : Prop :=
+  List.Forall₂
+    (fun row entry =>
+      row.node = entry.node ∧
+        (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+    initial.rows.toList result.entries.toList
+
 protected def Result.inputsMatch (entries : Array Entry) : List Term → List NodeId → Bool
   | [], [] => true
   | term :: terms, node :: nodes =>
@@ -334,9 +394,32 @@ def Result.seed (sources : Array Hex.Interval) (entry : Entry) : Hex.Interval :=
   | some index => sources[index]?.getD Hex.Interval.whole
   | none => Hex.Interval.whole
 
+/-- Source-only convenience context retained for the original frontend API.
+Source rows select their caller facts and every computed row defaults to
+`whole`. -/
+def Result.sourceInitial (result : Result)
+    (sources : Array Hex.Interval) : InitialContext :=
+  { rows := result.entries.map fun entry =>
+      { node := entry.node
+        fact := entry.term.source?.bind fun index => sources[index]? } }
+
 /-- Exact version-zero fact array determined by the retained node/term rows. -/
 def Result.facts (result : Result) (sources : Array Hex.Interval) : Array Hex.Interval :=
   result.entries.map (Result.seed sources)
+
+theorem Result.sourceInitial_facts (result : Result) (sources : Array Hex.Interval) :
+    (result.sourceInitial sources).facts = result.facts sources := by
+  simp only [Result.sourceInitial, InitialContext.facts, Result.facts, Array.map_map]
+  have fnEq :
+      ((fun row : InitialRow => row.fact.getD Hex.Interval.whole) ∘
+          fun entry : Entry =>
+            { node := entry.node
+              fact := entry.term.source?.bind fun index => sources[index]? }) =
+        Result.seed sources := by
+    funext entry
+    cases found : entry.term.source? <;>
+      simp [Result.seed, Function.comp_apply, found]
+  rw [fnEq]
 
 private theorem Result.slot_of_check (result : Result) (checked : result.check)
     {index : Nat} (within : index < result.entries.size) : result.slotCheck index := by
@@ -393,6 +476,44 @@ theorem SourcesContain.ofForall₂ {values : List ℝ} {sources : List Hex.Inter
           simpa [valuesAt] using member
       | succ index =>
           exact ih index fact (by simpa using found)
+
+/-- Meta-facing bridge: one quoted row/entry containment proof per position is
+exactly the generalized initial-context authority. -/
+theorem InitialContext.Contains.ofForall₂
+    {initial : InitialContext} {config : Rule.Config} {values : Nat → ℝ}
+    {result : Result}
+    (holds : List.Forall₂
+      (fun row entry =>
+        row.node = entry.node ∧
+          (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+      initial.rows.toList result.entries.toList) :
+    initial.Contains config values result :=
+  holds
+
+/-- Every materialized initial fact contains the exact value of its node in
+the checked reifier valuation. The proof authority is positional
+`InitialContext.Contains`; the plain context alone proves nothing. -/
+theorem InitialContext.fact_contains
+    (initial : InitialContext) (config : Rule.Config) (values : Nat → ℝ)
+    (result : Result) (holds : initial.Contains config values result)
+    (index : Nat) (within : index < initial.rows.size) :
+    initial.facts[index]'(by simpa [InitialContext.facts] using within) |>.Contains
+      (result.valuation config values { index }) := by
+  let row := initial.rows[index]'within
+  have lengths : initial.rows.size = result.entries.size := by
+    simpa [InitialContext.Contains] using List.Forall₂.length_eq holds
+  have entryWithin : index < result.entries.size := by simpa [lengths] using within
+  let entry := result.entries[index]'entryWithin
+  have entryFound : result.entries[index]? = some entry := by simp [entry]
+  have related := List.Forall₂.get holds (by simpa using within) (by simpa using entryWithin)
+  have factEq :
+      initial.facts[index]'(by simpa [InitialContext.facts] using within) =
+        row.fact.getD Hex.Interval.whole := by
+    simp [InitialContext.facts, row]
+  have valueEq : result.valuation config values { index } = entry.term.eval config values := by
+    simp [Result.valuation, Result.valueAt, entryFound]
+  rw [factEq, valueEq]
+  simpa [row, entry] using related.2
 
 theorem Result.seed_contains (config : Rule.Config) (values : Nat → ℝ)
     (result : Result) (sources : Array Hex.Interval) (checked : result.check)
@@ -543,10 +664,38 @@ def modelOfCheck {config : Config} {sources : Nat → ℝ} {result : Result}
     (success : checked.toOption.isSome = true) : Model config.rule sources result :=
   checked.toOption.get success
 
-/-- Revalidate the bounded reification result, including its exact node/term
-correspondence, bind every selected source exactly once, and seed all computed
-nodes with domain top. Constants are proved by the constant rule rather than
-trusted as assumptions. -/
+/-- Revalidate every resource cap and structural binding before materializing
+one authenticated version-zero fact per reifier node. Caller-selected facts
+remain plain data; only `InitialContext.Contains` supplies semantic authority.
+Failure returns no partially constructed input. -/
+def inputInitialWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
+    (initial : InitialContext) (target : Hex.Interval) :
+    Except Error (Proof.Input Hex.Interval) := do
+  if config.reify.maxSources < result.sourceCount then throw .sourceLimit
+  let meanings := Rule.meanings config.rule
+  if config.reify.maxOperations < meanings.size ||
+      config.reify.maxOperations < result.program.operations.size then
+    throw .operationLimit
+  if config.reify.maxNodes < result.program.nodes.size ||
+      config.reify.maxNodes < result.entries.size ||
+      config.reify.maxNodes < initial.rows.size then throw .nodeLimit
+  if !result.depthCheck config.reify.maxDepth then throw .depthLimit
+  if result.target.index ≥ result.program.nodes.size || !result.program.check then
+    throw .malformedProgram
+  if result.program.operations != meanings.map (Program.Meaning.operation) then
+    throw .malformedProgram
+  if !result.check then throw .malformedResult
+  if initial.rows.size != result.entries.size then throw .wrongInitialCount
+  if !initial.check result then throw .malformedInitial
+  let input : Proof.Input Hex.Interval :=
+    { scope
+      program := result.program
+      facts := initial.facts
+      target := { node := result.target, fact := target } }
+  pure input
+
+/-- Source-only convenience wrapper for the original frontend API. It binds
+every selected source exactly once and leaves computed rows at domain top. -/
 def inputWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
     (sources : Array Hex.Interval) (target : Hex.Interval) :
     Except Error (Proof.Input Hex.Interval) := do
@@ -566,13 +715,7 @@ def inputWithin (config : Config) (scope : Policy.ScopeId) (result : Result)
   if sources.size != result.sourceCount then throw .wrongSourceCount
   for index in [0:result.sourceCount] do
     let some _ := result.sourceNode? index | throw (.missingSource index)
-  let facts := result.facts sources
-  let input : Proof.Input Hex.Interval :=
-    { scope
-      program := result.program
-      facts
-      target := { node := result.target, fact := target } }
-  pure input
+  inputInitialWithin config scope result (result.sourceInitial sources) target
 
 /-- The exact `Result.facts` seed array discharges every computed top fact;
 only caller source containment remains. -/
@@ -595,6 +738,25 @@ theorem Result.initial_contains (config : Rule.Config) (values : Nat → ℝ)
   have seeded := result.seed_contains config values sourceFacts checked sourceSize
     sourceHolds index.val within
   simpa [facts] using seeded
+
+/-- Positional containment authority discharges every caller-selected initial
+fact, including facts installed on computed nodes. -/
+theorem InitialContext.initial_contains (initial : InitialContext)
+    (config : Rule.Config) (values : Nat → ℝ) (result : Result)
+    (holds : initial.Contains config values result)
+    (input : Proof.Input Hex.Interval) (facts : input.facts = initial.facts) :
+    ∀ fact, fact ∈ Proof.initialBase input →
+      fact.fact.Contains (result.valuation config values fact.node) := by
+  intro fact member
+  rw [Proof.initialBase, List.mem_ofFn] at member
+  obtain ⟨index, rfl⟩ := member
+  have within : index.val < initial.rows.size := by
+    have sizeEq : input.facts.size = initial.rows.size := by
+      rw [facts]
+      simp [InitialContext.facts]
+    exact sizeEq ▸ index.isLt
+  have selected := initial.fact_contains config values result holds index.val within
+  simpa [facts] using selected
 
 /-- Bounded supported registry assembly followed by exact chronological replay.
 Neither the reifier nor the caller-supplied event list has proof authority. The
@@ -715,6 +877,92 @@ theorem closeTermSingleton (config : Config) (result : Result) (sources : Nat �
     result.term.eval config.rule sources = toReal value := by
   rcases closeTermBounds config result sources model input evidence program target assumptions
     _ _ shape with ⟨lower, upper⟩
+  exact le_antisymm upper lower
+
+/-- Close the target from an exact node-indexed initial context. The context's
+plain data is authenticated structurally by `inputInitialWithin`; `holds` is
+the separate kernel-checked containment authority consumed here. -/
+theorem closeInitial (config : Config) (result : Result) (values : Nat → ℝ)
+    (model : Model config.rule values result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (initial : InitialContext)
+    (facts : input.facts = initial.facts)
+    (holds : initial.Contains config.rule values result) :
+    input.target.fact.Contains (result.term.eval config.rule values) :=
+  closeTerm config result values model input evidence program target
+    (initial.initial_contains config.rule values result holds input facts)
+
+theorem closeInitialBounds (config : Config) (result : Result) (values : Nat → ℝ)
+    (model : Model config.rule values result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (initial : InitialContext)
+    (facts : input.facts = initial.facts)
+    (holds : initial.Contains config.rule values result)
+    (lower : Lower) (upper : Upper)
+    (shape : input.target.fact.view = .bounds lower upper) :
+    lower.Contains (result.term.eval config.rule values) ∧
+      upper.Contains (result.term.eval config.rule values) := by
+  have member := closeInitial config result values model input evidence program target initial
+    facts holds
+  change input.target.fact.view.Contains (result.term.eval config.rule values) at member
+  simpa [shape, Raw.Contains] using member
+
+theorem closeInitialLower (config : Config) (result : Result) (values : Nat → ℝ)
+    (model : Model config.rule values result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (initial : InitialContext)
+    (facts : input.facts = initial.facts)
+    (holds : initial.Contains config.rule values result)
+    (value : Dyadic) (strict : Bool) (upper : Upper)
+    (shape : input.target.fact.view = .bounds (.finite value strict) upper) :
+    (Lower.finite value strict).Contains (result.term.eval config.rule values) :=
+  (closeInitialBounds config result values model input evidence program target initial facts holds
+    _ _ shape).1
+
+theorem closeInitialUpper (config : Config) (result : Result) (values : Nat → ℝ)
+    (model : Model config.rule values result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (initial : InitialContext)
+    (facts : input.facts = initial.facts)
+    (holds : initial.Contains config.rule values result)
+    (lower : Lower) (value : Dyadic) (strict : Bool)
+    (shape : input.target.fact.view = .bounds lower (.finite value strict)) :
+    (Upper.finite value strict).Contains (result.term.eval config.rule values) :=
+  (closeInitialBounds config result values model input evidence program target initial facts holds
+    _ _ shape).2
+
+theorem closeInitialSingleton (config : Config) (result : Result) (values : Nat → ℝ)
+    (model : Model config.rule values result) (input : Proof.Input Hex.Interval)
+    (evidence : Proof.Evidence
+      ((Rule.semantics config.rule).Entails input.program
+        (Proof.initialBase input) input.target))
+    (program : input.program = result.program)
+    (target : input.target.node = result.target)
+    (initial : InitialContext)
+    (facts : input.facts = initial.facts)
+    (holds : initial.Contains config.rule values result)
+    (value : Dyadic)
+    (shape : input.target.fact.view =
+      .bounds (.finite value false) (.finite value false)) :
+    result.term.eval config.rule values = toReal value := by
+  rcases closeInitialBounds config result values model input evidence program target initial facts
+    holds _ _ shape with ⟨lower, upper⟩
   exact le_antisymm upper lower
 
 /-- Close the target from caller source facts. Computed version-zero nodes are

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -57,11 +57,25 @@ structural sharing, checks the completed SSA program, and enforces explicit
 source, operation, node, and depth caps separately from registry and replay
 caps. Before seeding facts it rechecks the transparent result's one-entry-per-
 node correspondence, structural sharing, stable operation key, ordered child
-edges, and source-index range. It then binds every caller-selected source
-interval exactly once, proves computed domain-top seeds automatically, and requires
-constants and every improvement to enter through package-owned chronology.
-Successful replay can be eliminated to a target membership theorem, either
-endpoint inequality, their conjunction, or equality for a closed singleton.
+edges, and source-index range. Its generalized `InitialContext` has exactly one
+node-indexed version-zero row per retained reifier entry. An absent selection
+materializes as `whole`; a present interval is plain caller data and gains no
+authority until a separate positional `InitialContext.Contains` proof relates
+that exact row to the entry's retained term evaluation. This permits an
+authenticated fact on a computed node without treating the data or the row
+label as proof. Exact row count and order are checked only after source,
+operation, node, and depth caps; `setFact` refuses out-of-range or mistargeted
+writes transactionally.
+
+The original `inputWithin` remains a source-only convenience wrapper: it binds
+every caller-selected source interval exactly once, leaves computed rows at
+domain top, and proves those top seeds automatically. Both constructors share
+one common bounded reifier preflight, so the wrapper preserves its source-error
+precedence without repeating the structural scan. Constants and later
+improvements still enter through package-owned chronology. Successful replay
+can be eliminated from either source containment or generalized initial-row
+containment to a target membership theorem, either endpoint inequality, their
+conjunction, or equality for a closed singleton.
 For Meta clients, `modelOfCheck` transparently projects the exact `Model` from
 a kernel-reduced successful `modelWithin` call. `valuesAt` quotes a finite list
 as the total source valuation used by the frontend, and
@@ -613,8 +627,12 @@ DAG recursively, pins exact source and configured-constant node binding,
 rejects malformed result entries, duplicate stable keys, and one-over
 source/operation/node/depth limits, replays a flat supported chronology, and
 closes fully discharged lower inequality, two-sided conjunction, and equality
-theorems from source containment alone, with guarded ordinary-theorem axiom
-reports.
+theorems from source containment alone. It additionally pins transactional
+initial-row writes, structural and semantic anti-permutation, every generalized
+input refusal, and a real zero-event replay of a computed target fact, with
+guarded ordinary-theorem axiom reports. This first computed-row canary targets
+version zero directly; an interior computed assumption feeding later rule
+chronology is a distinct coverage target.
 `HexIntervalMathlib.TacticConformance` exercises supported Meta parsing and
 caller-proof emission over closed, strict, negative, shared-expression, power,
 absolute-value, minimum, maximum, reciprocal, and division examples. It pins

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -142,8 +142,14 @@ def computedInput : Proof.Input Hex.Interval :=
 #guard defaultInitial.facts == #[Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
   Hex.Interval.whole, Hex.Interval.whole]
 #guard defaultInitial.check result
-#guard computedInitial ==
-  result.initialContext.setFact RuleConformance.product RuleConformance.productFact
+#guard
+  match result.initialContext.setFact RuleConformance.product RuleConformance.productFact with
+  | .ok found => found == computedInitial
+  | .error _ => false
+#guard
+  match result.initialContext.setFact { index := 5 } RuleConformance.productFact with
+  | .error .malformedInitial => true
+  | _ => false
 #guard computedInitial.check result
 #guard
   match Frontend.inputInitialWithin config RuleConformance.scope result computedInitial
@@ -175,6 +181,11 @@ def fewOperations : Frontend.Config :=
 
 def wrongInitialRow : Frontend.InitialContext :=
   { rows := computedInitial.rows.set! 0 { node := RuleConformance.y } }
+
+#guard
+  match wrongInitialRow.setFact RuleConformance.x RuleConformance.productFact with
+  | .error .malformedInitial => true
+  | _ => false
 
 def shortInitial : Frontend.InitialContext := { rows := computedInitial.rows.pop }
 
@@ -393,14 +404,32 @@ theorem computedInitialHolds :
               simpa using member
           · constructor
 
+def computedEvidence? :=
+  Frontend.replay config computedInput [] 0 expectedProgram
+    { node := RuleConformance.product, version := 0 }
+
+#guard match computedEvidence? with | .ok _ => true | .error _ => false
+
+/-- Actual zero-event replay resolves the selected computed-node version-zero
+fact through `Proof.initialBase`; no hand-constructed evidence bypasses replay. -/
+private theorem computedSize : computedInput.facts.size = computedInput.program.nodes.size := by
+  decide +kernel
+
+private def computedResolved :=
+  ((Proof.Facts.start (Rule.semantics config.rule) computedInput computedSize).resolve
+    { node := RuleConformance.product, version := 0 }).get (by decide +kernel)
+
+private theorem computedResolved_fact :
+    computedResolved.fact = RuleConformance.productFact := by
+  rfl
+
 def computedEvidence : Proof.Evidence
     ((Rule.semantics config.rule).Entails computedInput.program
       (Proof.initialBase computedInput) computedInput.target) :=
-  { proof := by
-      intro valuation _ assumptions
-      exact assumptions
-        { node := RuleConformance.product, fact := RuleConformance.productFact } (by
-          simp [Proof.initialBase, computedInput, RuleConformance.product]) }
+  by
+    have sound := computedResolved.sound
+    rw [computedResolved_fact] at sound
+    simpa [computedInput, RuleConformance.product] using sound
 
 theorem computedFacts : computedInput.facts = computedInitial.facts := by
   decide +kernel
@@ -578,8 +607,20 @@ theorem closesEquality
 #print axioms closesConjunction
 #print axioms closesLower
 #print axioms closesEquality
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.closesComputedInitial' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound] -/
+#guard_msgs in
 #print axioms closesComputedInitial
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.rejectsFactPermutation' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound] -/
+#guard_msgs in
 #print axioms rejectsFactPermutation
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.rejectsProofPermutation' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound] -/
+#guard_msgs in
 #print axioms rejectsProofPermutation
 #print axioms targetValue
 /-- info: 'Hex.IntervalMathlib.FrontendConformance.projectedTarget' depends on axioms: [propext, Classical.choice, Quot.sound] -/

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -117,6 +117,45 @@ def input : Proof.Input Hex.Interval :=
   | .ok found => found == input
   | .error _ => false
 
+def defaultInitial : Frontend.InitialContext := result.initialContext
+
+def computedInitial : Frontend.InitialContext :=
+  { rows :=
+      #[{ node := RuleConformance.x }, { node := RuleConformance.y },
+        { node := RuleConformance.sum }, { node := RuleConformance.difference },
+        { node := RuleConformance.product, fact := some RuleConformance.productFact }] }
+
+def permutedFactInitial : Frontend.InitialContext :=
+  { rows :=
+      #[{ node := RuleConformance.x, fact := some RuleConformance.yFact },
+        { node := RuleConformance.y, fact := some RuleConformance.xFact },
+        { node := RuleConformance.sum }, { node := RuleConformance.difference },
+        { node := RuleConformance.product }] }
+
+def computedInput : Proof.Input Hex.Interval :=
+  { scope := RuleConformance.scope
+    program := expectedProgram
+    facts := #[Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+      Hex.Interval.whole, RuleConformance.productFact]
+    target := { node := RuleConformance.product, fact := RuleConformance.productFact } }
+
+#guard defaultInitial.facts == #[Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+  Hex.Interval.whole, Hex.Interval.whole]
+#guard defaultInitial.check result
+#guard computedInitial ==
+  result.initialContext.setFact RuleConformance.product RuleConformance.productFact
+#guard computedInitial.check result
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope result computedInitial
+      RuleConformance.productFact with
+  | .ok found => found == computedInput
+  | .error _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope result permutedFactInitial
+      RuleConformance.productFact with
+  | .ok _ => true
+  | .error _ => false
+
 def events : List (Proof.Event Hex.Interval) :=
   (Rule.quote RuleConformance.branch).take 3
 
@@ -134,6 +173,14 @@ def fewSources : Frontend.Config := { config with reify := { limits with maxSour
 def fewOperations : Frontend.Config :=
   { config with reify := { limits with maxOperations := 12 } }
 
+def wrongInitialRow : Frontend.InitialContext :=
+  { rows := computedInitial.rows.set! 0 { node := RuleConformance.y } }
+
+def shortInitial : Frontend.InitialContext := { rows := computedInitial.rows.pop }
+
+def longInitial : Frontend.InitialContext :=
+  { rows := computedInitial.rows.push { node := { index := 5 } } }
+
 #guard match Frontend.reifyWithin shallow 2 term with | .error .depthLimit => true | _ => false
 #guard match Frontend.reifyWithin fewNodes 2 term with | .error .nodeLimit => true | _ => false
 #guard match Frontend.reifyWithin fewSources 2 term with | .error .sourceLimit => true | _ => false
@@ -150,6 +197,41 @@ def fewOperations : Frontend.Config :=
       RuleConformance.productFact with
   | .error .wrongSourceCount => true
   | _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope result wrongInitialRow
+      RuleConformance.productFact with
+  | .error .malformedInitial => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope result shortInitial
+      RuleConformance.productFact with
+  | .error .wrongInitialCount => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope result longInitial
+      RuleConformance.productFact with
+  | .error .nodeLimit => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin fewNodes RuleConformance.scope result computedInitial
+      RuleConformance.productFact with
+  | .error .nodeLimit => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin shallow RuleConformance.scope result computedInitial
+      RuleConformance.productFact with
+  | .error .depthLimit => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin fewSources RuleConformance.scope result computedInitial
+      RuleConformance.productFact with
+  | .error .sourceLimit => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin fewOperations RuleConformance.scope result computedInitial
+      RuleConformance.productFact with
+  | .error .operationLimit => true
+  | _ => false
 
 def wrongEntryNode : Frontend.Result :=
   let bad : Frontend.Entry := { term := .source 0, node := { index := 1 } }
@@ -165,6 +247,14 @@ def duplicateEntry : Frontend.Result :=
   { result with entries := result.entries.set! 1 bad }
 
 def wrongRoot : Frontend.Result := { result with term := .source 0 }
+
+def permutedSourceExpressions : Frontend.Result :=
+  { result with entries :=
+      #[{ term := .source 1, node := RuleConformance.x },
+        { term := .source 0, node := RuleConformance.y },
+        { term := .add (.source 0) (.source 1), node := RuleConformance.sum },
+        { term := .sub (.source 0) (.source 1), node := RuleConformance.difference },
+        { term, node := RuleConformance.product }] }
 
 def wrongOperations : Frontend.Result :=
   { result with program :=
@@ -192,6 +282,21 @@ def roomy : Frontend.Config :=
   match Frontend.inputWithin config RuleConformance.scope wrongRoot
       #[RuleConformance.xFact, RuleConformance.yFact] RuleConformance.productFact with
   | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope wrongEntryNode computedInitial
+      RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin config RuleConformance.scope permutedSourceExpressions
+      computedInitial RuleConformance.productFact with
+  | .error .malformedResult => true
+  | _ => false
+#guard
+  match Frontend.inputInitialWithin roomy RuleConformance.scope wrongOperations computedInitial
+      RuleConformance.productFact with
+  | .error .malformedProgram => true
   | _ => false
 #guard
   match Frontend.modelWithin config sourceValues wrongRoot with
@@ -243,6 +348,12 @@ def duplicateKey : Frontend.Config :=
   | .error .malformedProgram => true
   | _ => false
 
+private theorem toReal_d (value : Int) :
+    Hex.Interval.toReal (RuleConformance.d value) = value := by
+  change ((Dyadic.ofInt value).toRat : ℝ) = value
+  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
+  norm_num
+
 theorem productReady :
     singletonWithin RuleConformance.endpoint (RuleConformance.d (-3)) =
       .ready RuleConformance.productFact :=
@@ -254,6 +365,52 @@ theorem productShape : RuleConformance.productFact.view =
   simpa [Raw.normalizeUnchecked, Raw.consistent] using
     view_singletonWithin_ready productReady
 
+private theorem wholeContains (value : ℝ) : Hex.Interval.whole.Contains value := by
+  change Raw.Contains Hex.Interval.whole.view value
+  rw [Hex.Interval.view_whole]
+  exact ⟨trivial, trivial⟩
+
+/-- A computed node may carry a bounded version-zero fact, but only with an
+exact positional containment proof for its retained source expression. -/
+theorem computedInitialHolds :
+    computedInitial.Contains config.rule sourceValues result := by
+  apply Frontend.InitialContext.Contains.ofForall₂
+  simp only [computedInitial, result]
+  constructor
+  · exact ⟨rfl, wholeContains _⟩
+  · constructor
+    · exact ⟨rfl, wholeContains _⟩
+    · constructor
+      · exact ⟨rfl, wholeContains _⟩
+      · constructor
+        · exact ⟨rfl, wholeContains _⟩
+        · constructor
+          · constructor
+            · rfl
+            · rw [targetValue]
+              have member := Rule.constant_mem productReady
+              rw [toReal_d] at member
+              simpa using member
+          · constructor
+
+def computedEvidence : Proof.Evidence
+    ((Rule.semantics config.rule).Entails computedInput.program
+      (Proof.initialBase computedInput) computedInput.target) :=
+  { proof := by
+      intro valuation _ assumptions
+      exact assumptions
+        { node := RuleConformance.product, fact := RuleConformance.productFact } (by
+          simp [Proof.initialBase, computedInput, RuleConformance.product]) }
+
+theorem computedFacts : computedInput.facts = computedInitial.facts := by
+  decide +kernel
+
+theorem closesComputedInitial :
+    term.eval config.rule sourceValues = toReal (RuleConformance.d (-3)) := by
+  exact Frontend.closeInitialSingleton config result sourceValues semanticModel computedInput
+    computedEvidence rfl rfl computedInitial computedFacts computedInitialHolds
+    (RuleConformance.d (-3)) productShape
+
 private theorem eq_of_mem_singleton {value : Dyadic} {result : Hex.Interval} {z : ℝ}
     (checked : Hex.Interval.singletonWithin RuleConformance.endpoint value = .ready result)
     (member : result.Contains z) : z = Hex.Interval.toReal value := by
@@ -262,11 +419,43 @@ private theorem eq_of_mem_singleton {value : Dyadic} {result : Hex.Interval} {z 
     Hex.Interval.contains_normalize] at member
   exact le_antisymm member.2 member.1
 
-private theorem toReal_d (value : Int) :
-    Hex.Interval.toReal (RuleConformance.d value) = value := by
-  change ((Dyadic.ofInt value).toRat : ℝ) = value
-  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
-  norm_num
+/-- Swapping facts leaves structurally valid plain data, but its positional
+semantic proof cannot be transplanted. -/
+theorem rejectsFactPermutation :
+    ¬permutedFactInitial.Contains config.rule sourceValues result := by
+  intro holds
+  have member := permutedFactInitial.fact_contains config.rule sourceValues result holds 0 (by
+    decide)
+  have yMember : RuleConformance.yFact.Contains (1 : ℝ) := by
+    simpa [permutedFactInitial, Frontend.InitialContext.facts, result,
+      Frontend.Result.valuation, Frontend.Result.valueAt, Frontend.Term.eval, sourceValues]
+      using member
+  have falseEq := eq_of_mem_singleton RuleConformance.checkedY yMember
+  rw [toReal_d] at falseEq
+  norm_num at falseEq
+
+def permutedSourceValues : Nat → ℝ
+  | 0 => 2
+  | 1 => 1
+  | _ => 0
+
+/-- A proof for the original retained source expressions cannot authenticate
+the same computed fact after the source valuation is permuted. -/
+theorem rejectsProofPermutation :
+    ¬computedInitial.Contains config.rule permutedSourceValues result := by
+  intro holds
+  have member := computedInitial.fact_contains config.rule permutedSourceValues result holds 4 (by
+    decide)
+  have simplified : RuleConformance.productFact.Contains (((2 : ℝ) + 1) * (2 - 1)) := by
+    simpa [computedInitial, Frontend.InitialContext.facts, result,
+      Frontend.Result.valuation, Frontend.Result.valueAt, term, Frontend.Term.eval,
+      permutedSourceValues, config, RuleConformance.config]
+      using member
+  have productMember : RuleConformance.productFact.Contains (3 : ℝ) := by
+    simpa only [show (((2 : ℝ) + 1) * (2 - 1)) = 3 by norm_num] using simplified
+  have falseEq := eq_of_mem_singleton productReady productMember
+  rw [toReal_d] at falseEq
+  norm_num at falseEq
 
 theorem sourceFactsContain : Frontend.SourcesContain sourceValues sourceFacts := by
   intro index fact found
@@ -389,6 +578,9 @@ theorem closesEquality
 #print axioms closesConjunction
 #print axioms closesLower
 #print axioms closesEquality
+#print axioms closesComputedInitial
+#print axioms rejectsFactPermutation
+#print axioms rejectsProofPermutation
 #print axioms targetValue
 /-- info: 'Hex.IntervalMathlib.FrontendConformance.projectedTarget' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -410,8 +410,9 @@ def computedEvidence? :=
 
 #guard match computedEvidence? with | .ok _ => true | .error _ => false
 
-/-- Actual zero-event replay resolves the selected computed-node version-zero
-fact through `Proof.initialBase`; no hand-constructed evidence bypasses replay. -/
+/-- The replay guard above accepts the selected computed-node version-zero fact.
+The kernel evidence below resolves the same fact through `Proof.initialBase`,
+without a caller-constructed assumption list. -/
 private theorem computedSize : computedInput.facts.size = computedInput.program.nodes.size := by
   decide +kernel
 

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -604,8 +604,14 @@ theorem closesEquality
     rfl rfl sourceFacts rfl inputFacts sourceFactsContain
     (RuleConformance.d (-3)) productShape
 
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.closesConjunction' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms closesConjunction
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.closesLower' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms closesLower
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.closesEquality' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms closesEquality
 /-- info: 'Hex.IntervalMathlib.FrontendConformance.closesComputedInitial' depends on axioms: [propext,
  Classical.choice,
@@ -622,6 +628,8 @@ theorem closesEquality
  Quot.sound] -/
 #guard_msgs in
 #print axioms rejectsProofPermutation
+/-- info: 'Hex.IntervalMathlib.FrontendConformance.targetValue' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
 #print axioms targetValue
 /-- info: 'Hex.IntervalMathlib.FrontendConformance.projectedTarget' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in

--- a/progress/20260824T060515Z_frontend-initial-context.md
+++ b/progress/20260824T060515Z_frontend-initial-context.md
@@ -1,0 +1,20 @@
+# Frontend initial context
+
+## Accomplished
+
+- Added bounded node-indexed `Frontend.InitialContext` data with absent facts materialized as `whole`, exact row/node authentication, and a separate positional containment authority tied through `Result.valuation`.
+- Added `inputInitialWithin`, the `Contains.ofForall₂` Meta bridge, generalized initial-containment and `closeInitial` theorem families, and retained the source-only `inputWithin`/`Result.initial_contains` route as a compatibility wrapper.
+- Added conformance for a bounded computed-node initial fact, default-top behavior, exact closing, row/count/program/result/source-expression mutations, fact/proof correlation mutations, all one-under frontend resource caps, and oversized initial-row refusal.
+- Verified `HexIntervalMathlib.FrontendConformance` and `HexIntervalMathlib.TacticConformance`; the published trust-surface check and changed-file static guards pass.
+
+## Current frontier
+
+The isolated generalized initial-context prerequisite is complete. The public tactic can now quote one initial row per retained node, materialize selected computed-node facts, and close through kernel-checked positional containment without changing the source-only API.
+
+## Next step
+
+Use `InitialContext` from the public tactic's complete arithmetic context/target/syntax layer, keeping rational parsing and new target forms outside this prerequisite.
+
+## Blockers
+
+The final whole-monorepo `lake build` reached 9,927 of 9,975 targets and then failed in unrelated `HexBerlekampZassenhausMathlib.KernelFactorTactic` output creation because the shared filesystem was full. The relevant frontend and tactic conformance targets are green. Generated local build artifacts were cleared and the frontend conformance target was rebuilt successfully.

--- a/progress/20260824T103341Z.md
+++ b/progress/20260824T103341Z.md
@@ -16,6 +16,8 @@
   axiom reports are now enforcing guards.
 - Factored the shared bounded input preflight so the source-only wrapper
   preserves error precedence without repeating the full result/depth scan.
+- Clarified that the runtime replay guard and the kernel `Proof.Facts.start`
+  evidence are two checks of the same selected version-zero fact.
 - Rebuilt `HexIntervalMathlib.FrontendConformance` through all 8,792 targets;
   the DAG, copyright, trust-surface, prohibited-term, and diff checks pass.
 

--- a/progress/20260824T103341Z.md
+++ b/progress/20260824T103341Z.md
@@ -10,6 +10,12 @@
   row refusal.
 - Guarded the new computed-node and anti-permutation axiom reports with exact
   expected trust messages.
+- Updated the Mathlib SPEC for the public generalized context, its separate
+  positional authority, transactional writes, source-only compatibility, and
+  current computed-target coverage boundary. All primary frontend closure
+  axiom reports are now enforcing guards.
+- Factored the shared bounded input preflight so the source-only wrapper
+  preserves error precedence without repeating the full result/depth scan.
 - Rebuilt `HexIntervalMathlib.FrontendConformance` through all 8,792 targets;
   the DAG, copyright, trust-surface, prohibited-term, and diff checks pass.
 

--- a/progress/20260824T103341Z.md
+++ b/progress/20260824T103341Z.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Closed independent-review coverage gaps in the generalized initial-context
+  layer. The computed-node conformance path now runs an actual zero-event
+  frontend replay and obtains its theorem from `Proof.Facts.start`, rather than
+  hand-constructing target evidence from assumptions.
+- Made `InitialContext.setFact` transactional: out-of-range and nominally
+  mistargeted writes return `malformedInitial` instead of silently retaining a
+  `whole` fact. Conformance pins success, out-of-range refusal, and malformed
+  row refusal.
+- Guarded the new computed-node and anti-permutation axiom reports with exact
+  expected trust messages.
+- Rebuilt `HexIntervalMathlib.FrontendConformance` through all 8,792 targets;
+  the DAG, copyright, trust-surface, prohibited-term, and diff checks pass.
+
+# Current frontier
+
+- Initial facts are structurally authenticated per reifier row, semantically
+  authorized position-for-position, and replay-tested on a computed node.
+- The public typed-runtime tactic remains the immediate merge dependency; this
+  commit is ready to restack onto its squash merge.
+
+# Next step
+
+- Restack on the merged public tactic, push the exact head, open the
+  InitialContext PR, and run exact CI plus final independent review.
+- Rebase prepared parameter/context consumers onto the transactional
+  `setFact` result and continue the production stack.
+
+# Blockers
+
+- No soundness or typing blocker is known in this layer.


### PR DESCRIPTION
Generalize frontend version-zero facts from source-only arrays to a structurally checked, node-indexed InitialContext with separate positional containment authority.

This adds bounded inputInitialWithin construction, computed-node closure theorems, and preserves the existing source-only wrapper. InitialContext.setFact is transactional and refuses out-of-range or nominally mistargeted writes. Conformance exercises a real zero-event replay from a computed-node fact, structural and semantic anti-permutation, every resource refusal, and guarded trust reports.

Validation: lake build HexIntervalMathlib.FrontendConformance completed across 8,792 targets on exact head; DAG and published trust-surface checks pass. Independent review approved the soundness boundary and its requested replay-coverage hardening is included in the final two-commit head.