### PR TITLE
feat(interval): authenticate per-node literal powers

### DIFF
--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -117,7 +117,7 @@ runtime and proof registries, regenerates bounded deterministic offer
 snapshots, and iterates a replaceable policy over the sealed tree/session
 bundle. Its explicit `Controller.Package` conformance route still uses toy
 fact-event callbacks and autonomous application generators. Concrete built-in
-arithmetic is instead supplied by `HexIntervalMathlib.RuntimeRule`: its twelve
+arithmetic is instead supplied by `HexIntervalMathlib.RuntimeRule`: its eleven
 exact handlers generate runtime-owned applications and offers, execute under
 `HexInterval.RuntimeController`, and are jointly sealed against the `Rule`
 schemas by `RuntimeProof`. Raw `(role, schema, body)` quotations remain inert
@@ -125,8 +125,9 @@ until that proof adapter resolves and replays them. `Controller.Executable`
 remains a separate supported fact-only adapter and is not the public tactic's
 typed path.
 
-The first concrete supported theorem registry is the Mathlib arithmetic package for one
-configured constant and natural exponent plus public negation, addition,
+The first concrete supported theorem registry is the Mathlib arithmetic package
+with value-agnostic dyadic and natural literal rows, binary natural power, plus
+public negation, addition,
 subtraction, multiplication, power, absolute-value, min/max, reciprocal,
 division, and regularization operations. `RuntimeProof` supports exact fact,
 equality, transport, and instance correlation, and `RuntimeController`

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -35,24 +35,24 @@ namespace Hex.Interval.Frontend
 
 open Proof
 
-/-- Function-generic arithmetic syntax. One package-configured constant,
-natural exponent, and precision keep semantic identity in `Rule.Config`, not
-in an untrusted term payload. -/
+/-- Function-generic arithmetic syntax. Literal values and power exponents are
+explicit authenticated rows rather than package-global configuration. -/
 inductive Term where
   | source (index : Nat)
-  | constant
+  | dyadic (value : Dyadic)
+  | natural (value : Nat)
   | neg (input : Term)
   | add (left right : Term)
   | sub (left right : Term)
   | mul (left right : Term)
-  | pow (input : Term)
+  | pow (input : Term) (exponent : Nat)
   | abs (input : Term)
   | min (left right : Term)
   | max (left right : Term)
   | inv (input : Term)
   | div (left right : Term)
   | regularize (input : Term)
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
 /-- Reification caps are independent of interval arithmetic and proof replay
 caps. `maxSources` also bounds caller fact-array traversal. `maxOperations`
@@ -78,12 +78,12 @@ structure Config where
 structure Entry where
   term : Term
   node : NodeId
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
 structure State where
   nodes : Array Node := #[]
   entries : Array Entry := #[]
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
 structure Result where
   program : Program
@@ -91,7 +91,7 @@ structure Result where
   term : Term
   entries : Array Entry
   sourceCount : Nat
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
 /-- One node-indexed version-zero fact selection. `none` means that the row
 starts at domain top; `some fact` is caller-selected data whose semantic
@@ -119,6 +119,7 @@ inductive Error where
   | malformedResult
   | wrongInitialCount
   | malformedInitial
+  | literalResource (node : NodeId)
   | wrongSourceCount
   | missingSource (index : Nat)
   | rule (error : Rule.BuildError)
@@ -130,12 +131,13 @@ def State.find? (state : State) (term : Term) : Option NodeId :=
 
 def operationKey : Term → OpKey
   | .source _ => Rule.sourceOp.key
-  | .constant => Rule.constantOp.key
+  | .dyadic _ => Rule.dyadicLiteralOp.key
+  | .natural _ => Rule.natLiteralOp.key
   | .neg _ => Rule.negOp.key
   | .add _ _ => Rule.addOp.key
   | .sub _ _ => Rule.subOp.key
   | .mul _ _ => Rule.mulOp.key
-  | .pow _ => Rule.powOp.key
+  | .pow _ _ => Rule.powOp.key
   | .abs _ => Rule.absOp.key
   | .min _ _ => Rule.minOp.key
   | .max _ _ => Rule.maxOp.key
@@ -152,18 +154,24 @@ protected def Term.opIndex : Term → Nat
   | .add _ _ => 2
   | .sub _ _ => 3
   | .mul _ _ => 4
-  | .pow _ => 5
+  | .pow _ _ => 5
   | .abs _ => 6
   | .min _ _ => 7
   | .max _ _ => 8
-  | .constant => 9
+  | .dyadic _ => 9
   | .inv _ => 10
   | .div _ _ => 11
   | .regularize _ => 12
+  | .natural _ => 13
+
+protected def Term.domain : Term → DomainId
+  | .natural _ => Rule.natDomain
+  | _ => Rule.realDomain
 
 protected def Term.inputs : Term → List Term
-  | .source _ | .constant => []
-  | .neg input | .pow input | .abs input | .inv input | .regularize input => [input]
+  | .source _ | .dyadic _ | .natural _ => []
+  | .neg input | .abs input | .inv input | .regularize input => [input]
+  | .pow input exponent => [input, .natural exponent]
   | .add left right | .sub left right | .mul left right | .div left right |
       .min left right | .max left right => [left, right]
 
@@ -177,9 +185,9 @@ root-at-depth-zero convention while constructing them. A successful check may
 visit the whole already-constructed tree; depth is not a constructor-count
 cap. -/
 protected def Term.depthWithin : Nat → Term → Bool
-  | _, .source _ | _, .constant => true
+  | _, .source _ | _, .dyadic _ | _, .natural _ => true
   | 0, _ => false
-  | depth + 1, .neg input | depth + 1, .pow input | depth + 1, .abs input |
+  | depth + 1, .neg input | depth + 1, .pow input _ | depth + 1, .abs input |
       depth + 1, .inv input | depth + 1, .regularize input =>
       input.depthWithin depth
   | depth + 1, .add left right | depth + 1, .sub left right |
@@ -187,16 +195,16 @@ protected def Term.depthWithin : Nat → Term → Bool
       depth + 1, .min left right | depth + 1, .max left right =>
       left.depthWithin depth && right.depthWithin depth
 
-/-- Real evaluation of a frontend term under exact caller source values and
-the package-owned constant and natural exponent. -/
+/-- Real evaluation of a frontend term under exact caller source values. -/
 noncomputable def Term.eval (config : Rule.Config) (sources : Nat → ℝ) : Term → ℝ
   | .source index => sources index
-  | .constant => toReal config.constant
+  | .dyadic value => toReal value
+  | .natural value => (value : ℝ)
   | .neg input => -(input.eval config sources)
   | .add left right => left.eval config sources + right.eval config sources
   | .sub left right => left.eval config sources - right.eval config sources
   | .mul left right => left.eval config sources * right.eval config sources
-  | .pow input => input.eval config sources ^ config.exponent
+  | .pow input exponent => input.eval config sources ^ exponent
   | .abs input => |input.eval config sources|
   | .min left right => if left.eval config sources ≤ right.eval config sources then
       left.eval config sources else right.eval config sources
@@ -209,12 +217,13 @@ noncomputable def Term.eval (config : Rule.Config) (sources : Nat → ℝ) : Ter
 /-- Exact built-in semantic meaning selected by a frontend term. -/
 protected def Term.meaning (config : Rule.Config) : Term → Program.Meaning ℝ
   | .source _ => Rule.sourceMeaning
-  | .constant => Rule.constantMeaning config.constant
+  | .dyadic _ => Rule.dyadicLiteralMeaning
+  | .natural _ => Rule.natLiteralMeaning
   | .neg _ => Rule.negMeaning
   | .add _ _ => Rule.addMeaning
   | .sub _ _ => Rule.subMeaning
   | .mul _ _ => Rule.mulMeaning
-  | .pow _ => Rule.powMeaning config.exponent
+  | .pow _ _ => Rule.powMeaning
   | .abs _ => Rule.absMeaning
   | .min _ _ => Rule.minMeaning
   | .max _ _ => Rule.maxMeaning
@@ -234,8 +243,8 @@ theorem Term.related (config : Rule.Config) (sources : Nat → ℝ) (term : Term
   cases term <;>
     simp [Term.inputs, Term.eval, Term.meaning, Rule.sourceMeaning, Rule.negMeaning,
       Rule.addMeaning, Rule.subMeaning, Rule.mulMeaning, Rule.powMeaning, Rule.absMeaning,
-      Rule.minMeaning, Rule.maxMeaning, Rule.constantMeaning, Rule.invMeaning,
-      Rule.divMeaning, Rule.regularizeMeaning, min_def, max_def]
+      Rule.minMeaning, Rule.maxMeaning, Rule.dyadicLiteralMeaning, Rule.natLiteralMeaning,
+      Rule.invMeaning, Rule.divMeaning, Rule.regularizeMeaning, min_def, max_def]
 
 def install (config : Config) (term : Term) (reified : List NodeId)
     (state : State) : Except Error (NodeId × State) := do
@@ -250,7 +259,7 @@ def install (config : Config) (term : Term) (reified : List NodeId)
   if signature.inputs.length != reified.length then throw .malformedProgram
   let node : NodeId := { index := state.nodes.size }
   let instruction : Node :=
-    { domain := Rule.realDomain, op := operation, args := reified }
+    { domain := term.domain, op := operation, args := reified }
   pure (node,
     { nodes := state.nodes.push instruction
       entries := state.entries.push { term, node } })
@@ -263,8 +272,16 @@ def reifyTerm (config : Config) (sourceCount depth : Nat)
   | .source index =>
       if sourceCount ≤ index then throw (.sourceIndex index)
       install config term [] state
-  | .constant => install config term [] state
-  | .neg input | .pow input | .abs input | .inv input | .regularize input =>
+  | .dyadic _ | .natural _ => install config term [] state
+  | .pow input exponent =>
+      let (inputNode, state) ← reifyTerm config sourceCount (depth + 1) input state
+      if config.reify.maxDepth < depth + 1 then throw .depthLimit
+      let exponentTerm := .natural exponent
+      let (exponentNode, state) ← match state.find? exponentTerm with
+        | some node => pure (node, state)
+        | none => install config exponentTerm [] state
+      install config term [inputNode, exponentNode] state
+  | .neg input | .abs input | .inv input | .regularize input =>
       let (node, state) ← reifyTerm config sourceCount (depth + 1) input state
       install config term [node] state
   | .add left right | .sub left right | .mul left right | .div left right |
@@ -407,6 +424,45 @@ def Result.sourceInitial (result : Result)
   { rows := result.entries.map fun entry =>
       { node := entry.node
         fact := entry.term.source?.bind fun index => sources[index]? } }
+
+/-- Checked mixed initial context. Source rows use caller facts; literal rows
+use exact singletons; every arithmetic row stays at domain top. Literal
+construction failure is transactional. -/
+def Result.seedInitialWithin (config : Rule.Config) (result : Result)
+    (sources : Array Hex.Interval) : Except Error InitialContext := do
+  let mut rows : Array InitialRow := #[]
+  for entry in result.entries do
+    let fact ← match entry.term with
+      | .source index => pure sources[index]?
+      | .dyadic value =>
+          match Rule.ready? (singletonWithin config.endpoint value) with
+          | some fact => pure (some fact)
+          | none => throw (.literalResource entry.node)
+      | .natural value =>
+          match Rule.ready? (singletonWithin config.endpoint (Dyadic.ofInt value)) with
+          | some fact => pure (some fact)
+          | none => throw (.literalResource entry.node)
+      | _ => pure none
+    rows := rows.push { node := entry.node, fact }
+  pure { rows }
+
+theorem whole_contains (value : ℝ) : Hex.Interval.whole.Contains value := by
+  change Raw.Contains Hex.Interval.whole.view value
+  rw [Hex.Interval.view_whole]
+  exact ⟨trivial, trivial⟩
+
+theorem dyadic_contains {config : Rule.Config} {values : Nat → ℝ} {value : Dyadic}
+    {fact : Hex.Interval} (checked : Rule.ready?
+      (singletonWithin config.endpoint value) = some fact) :
+    fact.Contains ((Term.dyadic value).eval config values) := by
+  simpa [Term.eval] using Rule.constant_mem (Rule.ready?_eq checked)
+
+theorem natural_contains {config : Rule.Config} {values : Nat → ℝ} {value : Nat}
+    {fact : Hex.Interval} (checked : Rule.ready?
+      (singletonWithin config.endpoint (Dyadic.ofInt value)) = some fact) :
+    fact.Contains ((Term.natural value).eval config values) := by
+  have member := Rule.constant_mem (Rule.ready?_eq checked)
+  simpa [Term.eval, Rule.toReal_ofInt] using member
 
 /-- Exact version-zero fact array determined by the retained node/term rows. -/
 def Result.facts (result : Result) (sources : Array Hex.Interval) : Array Hex.Interval :=

--- a/HexIntervalMathlib/Frontend.lean
+++ b/HexIntervalMathlib/Frontend.lean
@@ -275,7 +275,6 @@ def reifyTerm (config : Config) (sourceCount depth : Nat)
   | .dyadic _ | .natural _ => install config term [] state
   | .pow input exponent =>
       let (inputNode, state) ← reifyTerm config sourceCount (depth + 1) input state
-      if config.reify.maxDepth < depth + 1 then throw .depthLimit
       let exponentTerm := .natural exponent
       let (exponentNode, state) ← match state.find? exponentTerm with
         | some node => pure (node, state)

--- a/HexIntervalMathlib/Rule.lean
+++ b/HexIntervalMathlib/Rule.lean
@@ -23,12 +23,10 @@ public import HexIntervalMathlib.Regularize
 # Built-in arithmetic proof rules
 
 This is the first supported arithmetic package for the generic proof replay
-boundary. A package fixes its endpoint, power, and precision resources, one
-natural exponent, and one dyadic constant. Every built-in power node in that
-package therefore uses the same exponent, and every built-in constant node
-uses the same value. Duplicate package registration and operation keys are
-rejected, so a second copy cannot supply another exponent or constant under
-the same stable keys.
+boundary. A package fixes its endpoint, power, and precision resources.
+Dyadic and natural literals are value-agnostic program rows whose exact values
+are authenticated by node-indexed initial facts. Power consumes both a real
+base and a natural-domain exponent row.
 Runtime search may propose facts and recipe bodies, but the package schemas
 recompute the public checked interval operation and prove its one-way real
 enclosure.
@@ -43,21 +41,18 @@ namespace Hex.Interval.Rule
 
 open Proof
 
-/-- Resources and the single natural exponent and dyadic constant owned by one
-immutable arithmetic package. The built-in power and constant operation keys
-cannot express multiple such parameters in the same registry. -/
+/-- Resources owned by one immutable arithmetic package. -/
 structure Config where
   endpoint : EndpointLimit
   powerWork : Arithmetic.PowLimits
-  exponent : Nat
   precisionLimits : Arithmetic.PrecisionLimits
   precision : Precision
-  constant : Dyadic
   /-- Authenticated meanings owned by independently assembled packages. They
   follow the stable built-in prefix and have no built-in rule authority. -/
   extraMeanings : Array (Program.Meaning ℝ) := #[]
 
 def realDomain : DomainId := { index := 0 }
+def natDomain : DomainId := { index := 1 }
 
 def sourceOp : Operation :=
   { key := { name := "hex.interval.source" }, inputs := [], output := realDomain }
@@ -70,26 +65,31 @@ def subOp : Operation :=
 def mulOp : Operation :=
   { key := { name := "hex.interval.mul" }, inputs := [realDomain, realDomain], output := realDomain }
 def powOp : Operation :=
-  { key := { name := "hex.interval.pow.nat" }, inputs := [realDomain], output := realDomain }
+  { key := { name := "hex.interval.pow.nat", version := 2 },
+    inputs := [realDomain, natDomain], output := realDomain }
 def absOp : Operation :=
   { key := { name := "hex.interval.abs" }, inputs := [realDomain], output := realDomain }
 def minOp : Operation :=
   { key := { name := "hex.interval.min" }, inputs := [realDomain, realDomain], output := realDomain }
 def maxOp : Operation :=
   { key := { name := "hex.interval.max" }, inputs := [realDomain, realDomain], output := realDomain }
-def constantOp : Operation :=
-  { key := { name := "hex.interval.constant" }, inputs := [], output := realDomain }
+def dyadicLiteralOp : Operation :=
+  { key := { name := "hex.interval.literal.dyadic", version := 1 },
+    inputs := [], output := realDomain }
 def invOp : Operation :=
   { key := { name := "hex.interval.inv" }, inputs := [realDomain], output := realDomain }
 def divOp : Operation :=
   { key := { name := "hex.interval.div" }, inputs := [realDomain, realDomain], output := realDomain }
 def regularizeOp : Operation :=
   { key := { name := "hex.interval.regularize" }, inputs := [realDomain], output := realDomain }
+def natLiteralOp : Operation :=
+  { key := { name := "hex.interval.literal.nat", version := 1 },
+    inputs := [], output := natDomain }
 
 /-- Exact operation order owned by the built-in package. -/
 def operations : Array Operation :=
-  #[sourceOp, negOp, addOp, subOp, mulOp, powOp, absOp, minOp, maxOp, constantOp,
-    invOp, divOp, regularizeOp]
+  #[sourceOp, negOp, addOp, subOp, mulOp, powOp, absOp, minOp, maxOp, dyadicLiteralOp,
+    invOp, divOp, regularizeOp, natLiteralOp]
 
 def sourceMeaning : Program.Meaning ℝ := { operation := sourceOp, relation := fun _ _ => True }
 def negMeaning : Program.Meaning ℝ :=
@@ -100,27 +100,31 @@ def subMeaning : Program.Meaning ℝ :=
   { operation := subOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x - y }
 def mulMeaning : Program.Meaning ℝ :=
   { operation := mulOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x * y }
-def powMeaning (exponent : Nat) : Program.Meaning ℝ :=
-  { operation := powOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x ^ exponent }
+def powMeaning : Program.Meaning ℝ :=
+  { operation := powOp
+    relation := fun xs z => ∃ base : ℝ, ∃ exponent : Nat,
+      xs = [base, (exponent : ℝ)] ∧ z = base ^ exponent }
 def absMeaning : Program.Meaning ℝ :=
   { operation := absOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = |x| }
 def minMeaning : Program.Meaning ℝ :=
   { operation := minOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = min x y }
 def maxMeaning : Program.Meaning ℝ :=
   { operation := maxOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = max x y }
-def constantMeaning (value : Dyadic) : Program.Meaning ℝ :=
-  { operation := constantOp, relation := fun xs z => xs = [] ∧ z = toReal value }
+def dyadicLiteralMeaning : Program.Meaning ℝ :=
+  { operation := dyadicLiteralOp, relation := fun xs _ => xs = [] }
 def invMeaning : Program.Meaning ℝ :=
   { operation := invOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x⁻¹ }
 def divMeaning : Program.Meaning ℝ :=
   { operation := divOp, relation := fun xs z => ∃ x y, xs = [x, y] ∧ z = x / y }
 def regularizeMeaning : Program.Meaning ℝ :=
   { operation := regularizeOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x }
+def natLiteralMeaning : Program.Meaning ℝ :=
+  { operation := natLiteralOp, relation := fun xs _ => xs = [] }
 
 def builtinMeanings (config : Config) : Array (Program.Meaning ℝ) :=
   #[sourceMeaning, negMeaning, addMeaning, subMeaning, mulMeaning,
-    powMeaning config.exponent, absMeaning, minMeaning, maxMeaning,
-    constantMeaning config.constant, invMeaning, divMeaning, regularizeMeaning]
+    powMeaning, absMeaning, minMeaning, maxMeaning, dyadicLiteralMeaning,
+    invMeaning, divMeaning, regularizeMeaning, natLiteralMeaning]
 
 def meanings (config : Config) : Array (Program.Meaning ℝ) :=
   builtinMeanings config ++ config.extraMeanings
@@ -184,7 +188,6 @@ def powKey : RuleKey := { name := "hex.interval.rule.pow.nat" }
 def absKey : RuleKey := { name := "hex.interval.rule.abs" }
 def minKey : RuleKey := { name := "hex.interval.rule.min" }
 def maxKey : RuleKey := { name := "hex.interval.rule.max" }
-def constantKey : RuleKey := { name := "hex.interval.rule.constant" }
 def invKey : RuleKey := { name := "hex.interval.rule.inv" }
 def divKey : RuleKey := { name := "hex.interval.rule.div" }
 def regularizeKey : RuleKey := { name := "hex.interval.rule.regularize" }
@@ -204,12 +207,10 @@ def registrations : Array Registration :=
     binaryRegistration addKey addOp,
     binaryRegistration subKey subOp,
     binaryRegistration mulKey mulOp,
-    unaryRegistration powKey powOp,
+    binaryRegistration powKey powOp,
     unaryRegistration absKey absOp,
     binaryRegistration minKey minOp,
     binaryRegistration maxKey maxOp,
-    { key := constantKey, head := constantOp.key, kind := .forward,
-      watches := [], writes := [.result] },
     unaryRegistration invKey invOp,
     binaryRegistration divKey divOp,
     unaryRegistration regularizeKey regularizeOp]
@@ -251,15 +252,24 @@ theorem binaryRelation (config : Config) {valuation : NodeId → ℝ}
     subst meaning <;>
     simpa [addMeaning, subMeaning, mulMeaning, minMeaning, maxMeaning] using related
 
-theorem powRelation (config : Config) {valuation : NodeId → ℝ} {node input : NodeId}
+theorem powRelation (config : Config) {valuation : NodeId → ℝ}
+    {node base exponentNode : NodeId}
     (meaning : Program.MeaningAt (meanings config) valuation node
-      { domain := realDomain, op := { index := 5 }, args := [input] }) :
-    valuation node = valuation input ^ config.exponent := by
+      { domain := realDomain, op := { index := 5 }, args := [base, exponentNode] }) :
+    ∃ exponent : Nat, valuation exponentNode = (exponent : ℝ) ∧
+      valuation node = valuation base ^ exponent := by
   rcases meaning with ⟨meaning, found, related⟩
   rw [prefixMeaning config (index := 5) (by simp [builtinMeanings])] at found
   simp [builtinMeanings] at found
   subst meaning
-  simpa [powMeaning] using related
+  change ∃ input : ℝ, ∃ exponent : Nat,
+    [valuation base, valuation exponentNode] = [input, (exponent : ℝ)] ∧
+      valuation node = input ^ exponent at related
+  rcases related with ⟨input, exponent, arguments, output⟩
+  have baseEq : valuation base = input := (List.cons.inj arguments).1
+  have exponentEq : valuation exponentNode = (exponent : ℝ) :=
+    (List.cons.inj (List.cons.inj arguments).2).1
+  exact ⟨exponent, exponentEq, output.trans (congrArg (fun x => x ^ exponent) baseEq.symm)⟩
 
 theorem absRelation (config : Config) {valuation : NodeId → ℝ} {node input : NodeId}
     (meaning : Program.MeaningAt (meanings config) valuation node
@@ -270,16 +280,6 @@ theorem absRelation (config : Config) {valuation : NodeId → ℝ} {node input :
   simp [builtinMeanings] at found
   subst meaning
   simpa [absMeaning] using related
-
-theorem constantRelation (config : Config) {valuation : NodeId → ℝ} {node : NodeId}
-    (meaning : Program.MeaningAt (meanings config) valuation node
-      { domain := realDomain, op := { index := 9 }, args := [] }) :
-    valuation node = toReal config.constant := by
-  rcases meaning with ⟨meaning, found, related⟩
-  rw [prefixMeaning config (index := 9) (by simp [builtinMeanings])] at found
-  simp [builtinMeanings] at found
-  subst meaning
-  simpa [constantMeaning] using related
 
 theorem invRelation (config : Config) {valuation : NodeId → ℝ}
     {node input : NodeId}
@@ -323,6 +323,67 @@ theorem constant_mem {limit : EndpointLimit} {value : Dyadic} {result : Hex.Inte
   change result.view.Contains (toReal value)
   rw [view_singletonWithin_ready checked, contains_normalize]
   exact And.intro le_rfl le_rfl
+
+theorem toReal_ofInt (value : Int) :
+    toReal (Dyadic.ofInt value) = (value : ℝ) := by
+  change (((Dyadic.ofInt value).toRat : Rat) : ℝ) = (value : ℝ)
+  rw [show Dyadic.ofInt value = (value : Dyadic) by rfl, Dyadic.toRat_intCast]
+  norm_num
+
+/-- Expose a dyadic's exact rational numerator and denominator to the
+Mathlib-facing quotation layer. -/
+theorem toReal_rat (value : Dyadic) :
+    toReal value = (value.toRat.num : ℝ) / value.toRat.den := by
+  simp [toReal, Rat.cast_def]
+
+theorem eq_of_singletonValue {raw : Raw} {value : Dyadic} {x : ℝ}
+    (shape : raw.singletonValue? = some value) (member : raw.Contains x) :
+    x = toReal value := by
+  cases raw with
+  | empty => simp [Raw.singletonValue?] at shape
+  | bounds lower upper =>
+      cases lower with
+      | unbounded => simp [Raw.singletonValue?] at shape
+      | finite lower lowerStrict =>
+          cases upper with
+          | unbounded => simp [Raw.singletonValue?] at shape
+          | finite upper upperStrict =>
+              cases lowerStrict <;> cases upperStrict <;>
+                simp [Raw.singletonValue?] at shape member
+              rcases shape with ⟨rfl, rfl⟩
+              exact le_antisymm member.2 member.1
+
+/-- Decode exactly a closed singleton containing a nonnegative integer. -/
+def closedNat? (fact : Hex.Interval) : Option Nat := do
+  let value ← fact.view.singletonValue?
+  let rational := value.toRat
+  if rational.den = 1 then
+    if 0 ≤ rational.num then some rational.num.toNat else none
+  else none
+
+theorem closedNat?_sound {fact : Hex.Interval} {value : ℝ} {exponent : Nat}
+    (found : closedNat? fact = some exponent) (member : fact.Contains value) :
+    value = (exponent : ℝ) := by
+  unfold closedNat? at found
+  generalize shape : fact.view.singletonValue? = singleton at found
+  cases singleton with
+  | none => simp at found
+  | some dyadic =>
+      simp only [Option.bind_eq_bind, Option.bind_some] at found
+      split at found
+      · next denEq =>
+        split at found
+        · next numNonnegative =>
+          simp at found
+          subst exponent
+          have exact := eq_of_singletonValue shape member
+          rw [exact]
+          change ((dyadic.toRat : Rat) : ℝ) = ((dyadic.toRat.num.toNat : Nat) : ℝ)
+          rw [← Rat.num_div_den dyadic.toRat]
+          simp only [denEq, Nat.cast_one, div_one]
+          exact_mod_cast (Int.toNat_of_nonneg numNonnegative).symm
+        · simp at found
+      · simp at found
 
 -- Concrete schemas keep each semantic relation and checked public operation
 -- visible; an executable recipe tag alone never selects a theorem.
@@ -418,22 +479,35 @@ def maxSchema (config : Config) :=
 def powSchema (config : Config) : Proof.FactSchema (semantics config) :=
   { key := schemaKey powKey, Certificate := Unit, decode := exactBody 5
     prove := fun c _ => match c.assumptions with
-      | [a] =>
+      | [base, exponentFact] =>
         if hn : c.program.node? c.proposed.node = some
-            { domain := realDomain, op := { index := 5 }, args := [a.node] } then
-          match found : arithmeticReady?
-              (powWithin config.endpoint config.powerWork a.fact config.exponent) with
-          | some result =>
-              if equal : result = c.proposed.fact then
-                some ⟨by
-                  subst result
-                  intro v m hs
-                  have hm := powRelation config (nodeMeaning config m hn)
-                  change c.proposed.fact.Contains (v c.proposed.node)
-                  rw [hm]
-                  exact pow_mem_powWithin (arithmeticReady?_eq found) (by
-                    simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
-              else none
+            { domain := realDomain, op := { index := 5 },
+              args := [base.node, exponentFact.node] } then
+          match exponentFound : closedNat? exponentFact.fact with
+          | some exponent =>
+              match found : arithmeticReady?
+                  (powWithin config.endpoint config.powerWork base.fact exponent) with
+              | some result =>
+                  if equal : result = c.proposed.fact then
+                    some ⟨by
+                      subst result
+                      intro v m hs
+                      have baseMember : base.fact.Contains (v base.node) := by
+                        simpa [semantics, Proof.Semantics.ofMeanings] using hs base (by simp)
+                      have exponentMember : exponentFact.fact.Contains (v exponentFact.node) := by
+                        simpa [semantics, Proof.Semantics.ofMeanings] using
+                          hs exponentFact (by simp)
+                      have exponentValue := closedNat?_sound exponentFound exponentMember
+                      rcases powRelation config (nodeMeaning config m hn) with
+                        ⟨semanticExponent, semanticValue, outputValue⟩
+                      have exponentEq : semanticExponent = exponent := by
+                        apply Nat.cast_injective (R := ℝ)
+                        rw [← semanticValue, exponentValue]
+                      change c.proposed.fact.Contains (v c.proposed.node)
+                      rw [outputValue, exponentEq]
+                      exact pow_mem_powWithin (arithmeticReady?_eq found) baseMember⟩
+                  else none
+              | none => none
           | none => none
         else none
       | _ => none }
@@ -455,27 +529,6 @@ def absSchema (config : Config) : Proof.FactSchema (semantics config) :=
                   rw [hm]
                   exact abs_mem_absWithin (ready?_eq found) (by
                     simpa [semantics, Proof.Semantics.ofMeanings] using hs a (by simp))⟩
-              else none
-          | none => none
-        else none
-      | _ => none }
-
-def constantSchema (config : Config) : Proof.FactSchema (semantics config) :=
-  { key := schemaKey constantKey, Certificate := Unit, decode := exactBody 9
-    prove := fun c _ => match c.assumptions with
-      | [] =>
-        if hn : c.program.node? c.proposed.node = some
-            { domain := realDomain, op := { index := 9 }, args := [] } then
-          match found : ready? (singletonWithin config.endpoint config.constant) with
-          | some result =>
-              if equal : result = c.proposed.fact then
-                some ⟨by
-                  subst result
-                  intro v m _
-                  have hm := constantRelation config (nodeMeaning config m hn)
-                  change c.proposed.fact.Contains (v c.proposed.node)
-                  rw [hm]
-                  exact constant_mem (ready?_eq found)⟩
               else none
           | none => none
         else none
@@ -557,7 +610,7 @@ def package (config : Config) : Proof.Package (semantics config) :=
   { registrations
     facts := #[negSchema config, addSchema config, subSchema config, mulSchema config,
       powSchema config, absSchema config, minSchema config, maxSchema config,
-      constantSchema config, invSchema config, divSchema config,
+      invSchema config, divSchema config,
       regularizeSchema config] }
 
 inductive BuildError where

--- a/HexIntervalMathlib/RuntimeRule.lean
+++ b/HexIntervalMathlib/RuntimeRule.lean
@@ -73,15 +73,10 @@ private def arithmeticValue? : Arithmetic.Result → Option Hex.Interval :=
 private def proposal? (config : Rule.Config) (rule : RuleKey)
     (inputs : List (FactView Hex.Interval)) : Option Hex.Interval :=
   match rule, inputs with
-  | key, [] =>
-      if key == Rule.constantKey then
-        buildValue? (singletonWithin config.endpoint config.constant)
-      else none
+  | _, [] => none
   | key, [input] =>
       if key == Rule.negKey then
         buildValue? (negWithin config.endpoint input.fact)
-      else if key == Rule.powKey then
-        arithmeticValue? (powWithin config.endpoint config.powerWork input.fact config.exponent)
       else if key == Rule.absKey then
         buildValue? (absWithin config.endpoint input.fact)
       else if key == Rule.invKey then
@@ -91,7 +86,12 @@ private def proposal? (config : Rule.Config) (rule : RuleKey)
           (regularizeWithin config.precisionLimits config.precision input.fact)
       else none
   | key, [left, right] =>
-      if key == Rule.addKey then
+      if key == Rule.powKey then
+        match Rule.closedNat? right.fact with
+        | some exponent =>
+            arithmeticValue? (powWithin config.endpoint config.powerWork left.fact exponent)
+        | none => none
+      else if key == Rule.addKey then
         buildValue? (addWithin config.endpoint left.fact right.fact)
       else if key == Rule.subKey then
         buildValue? (subWithin config.endpoint left.fact right.fact)
@@ -162,18 +162,15 @@ opaque package (config : Rule.Config) :
         handler config (Rule.binaryRegistration Rule.addKey Rule.addOp) 2,
         handler config (Rule.binaryRegistration Rule.subKey Rule.subOp) 3,
         handler config (Rule.binaryRegistration Rule.mulKey Rule.mulOp) 4,
-        handler config (Rule.unaryRegistration Rule.powKey Rule.powOp) 5,
+        handler config (Rule.binaryRegistration Rule.powKey Rule.powOp) 5,
         handler config (Rule.unaryRegistration Rule.absKey Rule.absOp) 6,
         handler config (Rule.binaryRegistration Rule.minKey Rule.minOp) 7,
         handler config (Rule.binaryRegistration Rule.maxKey Rule.maxOp) 8,
-        handler config
-          { key := Rule.constantKey, head := Rule.constantOp.key, kind := .forward,
-            watches := [], writes := [.result] } 9,
         handler config (Rule.unaryRegistration Rule.invKey Rule.invOp) 10,
         handler config (Rule.binaryRegistration Rule.divKey Rule.divOp) 11,
         handler config (Rule.unaryRegistration Rule.regularizeKey Rule.regularizeOp) 12]
     measure :=
-      { metadata := { bytes := 12, work := 12 }
+      { metadata := { bytes := 11, work := 11 }
         application := fun _ => { bytes := 1, work := 1 }
         cache := fun cache => { bytes := cache.calls, work := cache.calls }
         result := fun batch => { bytes := batch.events.size, work := batch.events.size } } }

--- a/HexIntervalMathlib/RuntimeRuleEmit.lean
+++ b/HexIntervalMathlib/RuntimeRuleEmit.lean
@@ -18,7 +18,7 @@ public meta import HexInterval.Canonical
 /-!
 # Built-in arithmetic runtime emitters
 
-This elaborator-only companion pairs the twelve built-in arithmetic theorem
+This elaborator-only companion pairs the eleven built-in arithmetic theorem
 schemas with exact `RuntimeEmit` handles. The joint builder constructs the
 executable assembly, theorem registry, and emitter registry in one call.
 Caller-owned meanings need their own emitter packages and are intentionally
@@ -95,8 +95,8 @@ meta def configExpr (config : Rule.Config) : MetaM Expr := do
     throwError "built-in runtime emitter cannot quote caller function meanings"
   mkAppM ``Rule.Config.mk
     #[← endpointExpr config.endpoint, ← powLimitsExpr config.powerWork,
-      mkNatLit config.exponent, ← precisionLimitsExpr config.precisionLimits,
-      mkIntLit config.precision, ← dyadicExpr config.constant, ← emptyMeaningsExpr]
+      ← precisionLimitsExpr config.precisionLimits,
+      mkIntLit config.precision, ← emptyMeaningsExpr]
 
 meta def intervalExpr (limit : EndpointLimit) (interval : Hex.Interval) : MetaM Expr := do
   let raw ← rawExpr interval.view
@@ -130,7 +130,6 @@ meta def emitPackage (config : Rule.Config) :
         Quote.schema config (Rule.schemaKey Rule.absKey) ``Rule.absSchema,
         Quote.schema config (Rule.schemaKey Rule.minKey) ``Rule.minSchema,
         Quote.schema config (Rule.schemaKey Rule.maxKey) ``Rule.maxSchema,
-        Quote.schema config (Rule.schemaKey Rule.constantKey) ``Rule.constantSchema,
         Quote.schema config (Rule.schemaKey Rule.invKey) ``Rule.invSchema,
         Quote.schema config (Rule.schemaKey Rule.divKey) ``Rule.divSchema,
         Quote.schema config (Rule.schemaKey Rule.regularizeKey) ``Rule.regularizeSchema] }

--- a/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
+++ b/HexIntervalMathlib/SPEC/hex-interval-mathlib.md
@@ -35,11 +35,11 @@ fact/equality/transport/instance/refutation steps, immutable typed proof state,
 and exact caller-target closure.
 
 `HexIntervalMathlib.Rule` is the first supported concrete registry. Its
-immutable configuration fixes endpoint limits, natural-power work and one
-exponent, precision resources, and one dyadic constant. It owns stable
+immutable configuration fixes endpoint limits, natural-power work, precision
+resources, and optional extra meanings. It owns stable
 operation and rule keys, exact real meanings, local registrations, and forward
-schemas for that constant, negation, addition, subtraction, multiplication,
-natural power, absolute value, minimum, maximum, reciprocal, division, and
+schemas for negation, addition, subtraction, multiplication, binary natural
+power, absolute value, minimum, maximum, reciprocal, division, and
 regularization. Source nodes obtain their version-zero facts from
 caller hypotheses rather than a rule. Every schema authenticates the exact
 node operation and argument order, source fact versions through the quoted
@@ -72,7 +72,9 @@ every caller-selected source interval exactly once, leaves computed rows at
 domain top, and proves those top seeds automatically. Both constructors share
 one common bounded reifier preflight, so the wrapper preserves its source-error
 precedence without repeating the structural scan. Constants and later
-improvements still enter through package-owned chronology. Successful replay
+improvements still enter through package-owned chronology. Exact dyadic and
+natural-literal singletons are seeded through the checked node-indexed initial
+context. Successful replay
 can be eliminated from either source containment or generalized initial-row
 containment to a target membership theorem, either endpoint inequality, their
 conjunction, or equality for a closed singleton.
@@ -104,7 +106,7 @@ runs bounded repeated policy selection over the sealed tree/session bundle.
 The explicit `Controller.Package` vertical still uses toy fact-event callbacks
 and application generators. Concrete built-in arithmetic has two explicit
 adapters: the fact-only `Controller.Executable` route and the typed-batch
-`RuntimeRule` route. `RuntimeRule` recomputes all twelve supported arithmetic
+`RuntimeRule` route. `RuntimeRule` recomputes all eleven supported arithmetic
 operations from exact executable requests, emits one typed fact batch with the
 matching one-cell format, and seals its assembly against the same-order
 `Rule` theorem registry through `RuntimeProof.Registry`. Paired caller packages
@@ -146,13 +148,15 @@ the same transaction succeeds; failure emits no misleading query result.
 `interval_bound e` elaborates and derives inside `withoutModifyingState`, then
 reports concrete selected lower/upper cuts and the recipe size. Those cuts are
 diagnostics, not tactic syntax: noninteger dyadic endpoints may be displayed,
-while the current goal parser accepts only integer targets, so reported cuts
-are not necessarily pasteable. Programmatic
+while inequality targets currently accept only integer endpoints and equality
+targets accept exact dyadics, so reported cuts are not necessarily pasteable.
+Programmatic
 `Tactic.deriveBound` exposes the exact authenticated forward bundle.
 
-This first vertical deliberately accepts only integer source and target cuts,
-zero, the configured natural exponent, and forward negation, addition,
-subtraction, multiplication, power, absolute value, minimum, maximum,
+This first vertical deliberately accepts only integer source and inequality
+target cuts, exact dyadic literal/equality targets, per-node natural-literal
+exponents, and forward negation, addition, subtraction, multiplication, binary
+power, absolute value, minimum, maximum,
 reciprocal, and division. It appends configured outward regularization after
 each computed arithmetic row, and fails transactionally on precision-resource
 refusal. Its fixed public-tactic precision is `16`, the dyadic grid `2⁻¹⁶`;
@@ -353,7 +357,7 @@ Schema, chronology, body, dependency, and
 expression limits fail without returning a partial expression.
 
 `HexIntervalMathlib.RuntimeRuleEmit` supplies the paired handles and fact
-quoter for exactly the twelve built-in arithmetic schemas. Its convenience
+quoter for exactly the eleven built-in arithmetic schemas. Its convenience
 builder jointly constructs the executable batch assembly, theorem registry,
 and emitter registry. Configurations with caller-owned opaque meanings require
 their own paired emitter packages and are deliberately rejected by this
@@ -431,17 +435,19 @@ rejects that import outside an exact reviewed allowlist, currently empty.
 
 `HexIntervalMathlib.Rule` is the first supported package registry. Its stable
 arithmetic schemas recompute exact checked negation, addition, subtraction,
-multiplication, natural power, absolute value, minimum, maximum, constant,
+multiplication, binary natural power, absolute value, minimum, maximum,
 reciprocal, division, and regularization results before producing evidence.
-Source facts remain caller assumptions. Direct registry assembly bounds the
-retained packages and schemas but does not preempt construction or equality of
-caller program/meaning arrays; decoded callers must first cross `Search`.
+Source facts remain caller assumptions, while exact dyadic and natural literals
+are authenticated node-indexed initial facts and have no callbacks. Direct
+registry assembly bounds the retained packages and schemas but does not preempt
+construction or equality of caller program/meaning arrays; decoded callers
+must first cross `Search`.
 Its `quote` and `quoteSession` functions convert supported branch/session
-causes to proof events without making runtime state evidence. `Config` fixes
-exactly one natural exponent and one dyadic constant: every node at the
-built-in power operation index shares that exponent, and every node at the
-built-in constant index shares that value. Duplicate package registration and
-operation keys cannot add another parameterization. Arbitrary-function package
+causes to proof events without making runtime state evidence. Each power node
+has ordered `[base, natural-exponent]` edges, and literal operation meanings are
+value-agnostic; exact values come only from their separately authenticated
+initial singleton facts. Duplicate package registration and operation keys
+cannot add another parameterization. Arbitrary-function package
 discovery, Mathlib-free runtime packages, split-search tactic integration, and
 default package discovery remain experimental. The
 supported direct-forward reifier and tactic syntax are a narrow client of this
@@ -590,7 +596,7 @@ exact proposed/installed facts, one-cell bodies, semantic schema execution,
 sticky cache refusal and replayability, sealed rule mutation rejection, and a
 paired opaque-operation extension.
 `HexIntervalMathlib.RuntimeEmitConformance` installs target Evidence only from
-the sealed input/evidence pair for all twelve built-in rules, including repeated-input
+the sealed input/evidence pair for all eleven built-in rules, including repeated-input
 binary applications, and separately emits the mixed `sin (-x)` instance,
 equality, fact, and transport chronology. It rejects package-local/global
 coverage errors, cross-package and input transplants, a wrong schema
@@ -623,7 +629,7 @@ proof-frontend closure of the stronger two-sided theorem.
 wrong-source and false-endpoint rejection, the ordinary π-bound axiom surface,
 and generic proof-frontend closure.
 `HexIntervalMathlib.FrontendConformance` reconstructs that shared arithmetic
-DAG recursively, pins exact source and configured-constant node binding,
+DAG recursively, pins exact source and node-indexed literal binding,
 rejects malformed result entries, duplicate stable keys, and one-over
 source/operation/node/depth limits, replays a flat supported chronology, and
 closes fully discharged lower inequality, two-sided conjunction, and equality

--- a/HexIntervalMathlib/Tactic.lean
+++ b/HexIntervalMathlib/Tactic.lean
@@ -1254,7 +1254,7 @@ meta def prepareRuntime (config : Frontend.Config) (reified : Frontend.Result)
 the caller's source proofs. -/
 meta def emitBoundWith (config : Frontend.Config) (expression : Expr)
     (term : Frontend.Term) (parsed : ParseState) (reified : Frontend.Result)
-    (sourceIntervals sourceProofs : Array Expr) (runtime : RuntimeResult config.rule) :
+    (sourceProofs : Array Expr) (runtime : RuntimeResult config.rule) :
     MetaM Bound := do
   let limits := runtimeLimits config
   let emitted : RuntimeEmit.Emitted ←
@@ -1316,7 +1316,6 @@ meta def deriveBound (config : Frontend.Config) (expression : Expr) : MetaM Boun
     | .ok result => pure result
     | .error error => throwError "interval: reification failed: {repr error}"
   let mut sourceFacts : Array Hex.Interval := #[]
-  let mut sourceIntervals : Array Expr := #[]
   let mut sourceProofs : Array Expr := #[]
   for index in [0:parsed.sources.size] do
     let some source := parsed.sources[index]?
@@ -1324,9 +1323,8 @@ meta def deriveBound (config : Frontend.Config) (expression : Expr) : MetaM Boun
     let some _ := reified.sourceNode? index
       | throwError "interval: selected source is absent from the target graph"
     let cuts ← collectCuts source
-    let (interval, intervalExpr, proof) ← sourceProof config source cuts
+    let (interval, _, proof) ← sourceProof config source cuts
     sourceFacts := sourceFacts.push interval
-    sourceIntervals := sourceIntervals.push intervalExpr
     sourceProofs := sourceProofs.push proof
   let initial ← match reified.seedInitialWithin config.rule sourceFacts with
     | .ok initial => pure initial
@@ -1334,7 +1332,7 @@ meta def deriveBound (config : Frontend.Config) (expression : Expr) : MetaM Boun
   match prepareRuntime config reified initial with
   | .error error => throwError "interval: {error}"
   | .ok runtime =>
-      emitBoundWith config expression term parsed reified sourceIntervals sourceProofs runtime
+      emitBoundWith config expression term parsed reified sourceProofs runtime
 
 inductive GoalKind where
   | lower (value : Int) (endpoint : Expr) (strict : Bool)

--- a/HexIntervalMathlib/Tactic.lean
+++ b/HexIntervalMathlib/Tactic.lean
@@ -279,12 +279,6 @@ theorem dyadicLtIntCast {endpoint : Dyadic} {value : Int}
   change ((endpoint.toRat : ℝ) < ((value : Rat) : ℝ))
   exact_mod_cast h
 
-theorem toRealEqIntCast {endpoint : Dyadic} {value : Int}
-    (h : endpoint.toRat = (value : Rat)) :
-    toReal endpoint = (value : ℝ) := by
-  change ((endpoint.toRat : ℝ) = ((value : Rat) : ℝ))
-  exact_mod_cast h
-
 theorem lowerClosedFromClosed {endpoint : Dyadic} {value : Int} {x : ℝ}
     (order : (value : ℝ) ≤ toReal endpoint)
     (bound : (Lower.finite endpoint false).Contains x) : (value : ℝ) ≤ x :=
@@ -350,10 +344,6 @@ theorem castUpperLe {actual x : ℝ} {value : Int}
 theorem castUpperLt {actual x : ℝ} {value : Int}
     (endpoint : actual = (value : ℝ)) :
     (x < actual ↔ x < (value : ℝ)) := by rw [endpoint]
-
-theorem castEquality {actual x : ℝ} {value : Int}
-    (endpoint : actual = (value : ℝ)) :
-    (x = actual ↔ x = (value : ℝ)) := by rw [endpoint]
 
 theorem lowerOfEqRight {actual x : ℝ} (equality : x = actual) : actual ≤ x :=
   equality.ge

--- a/HexIntervalMathlib/Tactic.lean
+++ b/HexIntervalMathlib/Tactic.lean
@@ -25,7 +25,7 @@ settles the retained target lineage, and passes that sealed chronology through
 runtime success is never reflected into proof syntax.
 
 The current production subset is forward arithmetic over real local variables,
-the configured constant, natural power, precision, reciprocal, and division.
+exact dyadic literals, node-indexed natural power, precision, reciprocal, and division.
 Every computed arithmetic row is followed by the package's authenticated
 outward regularization row. The bare tactic uses precision `16`, hence the
 dyadic grid `2⁻¹⁶`; programmatic callers may supply another admitted precision.
@@ -87,20 +87,59 @@ theorem cons {value : ℝ} {source : Hex.Interval} {values : List ℝ}
 
 end Sources
 
+theorem initialNil {config : Rule.Config} {values : Nat → ℝ} : List.Forall₂
+    (fun row : Frontend.InitialRow => fun entry : Frontend.Entry =>
+      row.node = entry.node ∧
+        (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values)) [] [] :=
+  .nil
+
+theorem initialCons {config : Rule.Config} {values : Nat → ℝ}
+    {row : Frontend.InitialRow} {entry : Frontend.Entry}
+    {rows : List Frontend.InitialRow} {entries : List Frontend.Entry}
+    (node : row.node = entry.node)
+    (member : (row.fact.getD Hex.Interval.whole).Contains
+      (entry.term.eval config values))
+    (tail : List.Forall₂
+      (fun row : Frontend.InitialRow => fun entry : Frontend.Entry =>
+        row.node = entry.node ∧
+          (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+      rows entries) :
+    List.Forall₂
+      (fun row : Frontend.InitialRow => fun entry : Frontend.Entry =>
+        row.node = entry.node ∧
+          (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+      (row :: rows) (entry :: entries) :=
+  .cons ⟨node, member⟩ tail
+
+/-- Transport quoted row-by-row authority across the separately checked
+quotation of the frontend result and initial context. -/
+theorem initialCast {initial : Frontend.InitialContext} {config : Rule.Config}
+    {values : Nat → ℝ} {result : Frontend.Result}
+    {rows : List Frontend.InitialRow} {entries : List Frontend.Entry}
+    (rowsEq : initial.rows.toList = rows)
+    (entriesEq : result.entries.toList = entries)
+    (holds : List.Forall₂
+      (fun row : Frontend.InitialRow => fun entry : Frontend.Entry =>
+        row.node = entry.node ∧
+          (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+      rows entries) :
+    initial.Contains config values result := by
+  change List.Forall₂
+    (fun row entry => row.node = entry.node ∧
+      (row.fact.getD Hex.Interval.whole).Contains (entry.term.eval config values))
+    initial.rows.toList result.entries.toList
+  rw [rowsEq, entriesEq]
+  exact holds
+
 namespace Eval
 
 theorem source {config : Rule.Config} {values : Nat → ℝ} {index : Nat} {value : ℝ}
     (equal : values index = value) :
     (Frontend.Term.source index).eval config values = value := equal
 
-theorem constantMk {endpoint : EndpointLimit} {powerWork : Arithmetic.PowLimits}
-    {exponent : Nat} {precisionLimits : Arithmetic.PrecisionLimits}
-    {precision : Precision} {constant : Dyadic}
-    {extraMeanings : Array (Program.Meaning ℝ)} {values : Nat → ℝ} {value : ℝ}
-    (equal : toReal constant = value) :
-    Frontend.Term.constant.eval
-      { endpoint, powerWork, exponent, precisionLimits, precision, constant,
-        extraMeanings } values = value := by
+theorem dyadic {config : Rule.Config} {values : Nat → ℝ} {literal : Dyadic} {value : ℝ}
+    (equal : toReal literal = value) :
+    (Frontend.Term.dyadic literal).eval config values = value := by
   simpa [Frontend.Term.eval] using equal
 
 theorem neg {config : Rule.Config} {values : Nat → ℝ} {input : Frontend.Term}
@@ -127,8 +166,9 @@ theorem mul {config : Rule.Config} {values : Nat → ℝ} {left right : Frontend
   simp [Frontend.Term.eval, leftEq, rightEq]
 
 theorem pow {config : Rule.Config} {values : Nat → ℝ} {input : Frontend.Term}
+    {exponent : Nat}
     {value : ℝ} (equal : input.eval config values = value) :
-    (Frontend.Term.pow input).eval config values = value ^ config.exponent := by
+    (Frontend.Term.pow input exponent).eval config values = value ^ exponent := by
   simp [Frontend.Term.eval, equal]
 
 theorem abs {config : Rule.Config} {values : Nat → ℝ} {input : Frontend.Term}
@@ -286,11 +326,11 @@ theorem upperOpenFromOpen {endpoint : Dyadic} {value : Int} {x : ℝ}
   bound.trans_le order
 
 theorem equalityOfMem {interval : Hex.Interval} {endpoint : Dyadic}
-    {value : Int} {x : ℝ}
+    {value x : ℝ}
     (shape : interval.view =
       .bounds (.finite endpoint false) (.finite endpoint false))
     (member : interval.Contains x)
-    (endpointEq : toReal endpoint = (value : ℝ)) : x = (value : ℝ) := by
+    (endpointEq : toReal endpoint = value) : x = value := by
   have bounds := And.intro
     (lowerOfMem shape member) (upperOfMem shape member)
   exact (le_antisymm bounds.2 bounds.1).trans endpointEq
@@ -388,6 +428,19 @@ meta def listExpr (type : Expr) (items : List Expr) : MetaM Expr := do
 meta def arrayExpr (type : Expr) (items : List Expr) : MetaM Expr := do
   mkAppM ``Array.mk #[← listExpr type items]
 
+meta def initialRowExpr (limit : EndpointLimit) (row : Frontend.InitialRow) : MetaM Expr := do
+  let fact ← match row.fact with
+    | none => pure (mkApp (mkConst ``Option.none [.zero]) (mkConst ``Hex.Interval))
+    | some value =>
+        mkAppM ``Option.some #[← intervalExpr limit value]
+  mkAppM ``Frontend.InitialRow.mk #[← mkAppM ``NodeId.mk #[mkNatLit row.node.index], fact]
+
+meta def initialContextExpr (limit : EndpointLimit)
+    (initial : Frontend.InitialContext) : MetaM Expr := do
+  let rows ← initial.rows.toList.mapM (initialRowExpr limit)
+  mkAppM ``Frontend.InitialContext.mk
+    #[← arrayExpr (mkConst ``Frontend.InitialRow) rows]
+
 meta def proofLimitsExpr (limits : Proof.Limits) : MetaM Expr := do
   mkAppM ``Proof.Limits.mk
     #[mkNatLit limits.maxPackages, mkNatLit limits.maxSchemas,
@@ -406,7 +459,9 @@ meta def frontendConfigExpr (config : Frontend.Config) : MetaM Expr := do
 
 meta def termExpr : Frontend.Term → MetaM Expr
   | .source index => mkAppM ``Frontend.Term.source #[mkNatLit index]
-  | .constant => pure (mkConst ``Frontend.Term.constant)
+  | .dyadic value => do
+      mkAppM ``Frontend.Term.dyadic #[← Rule.Runtime.Quote.dyadicExpr value]
+  | .natural value => mkAppM ``Frontend.Term.natural #[mkNatLit value]
   | .neg input => do mkAppM ``Frontend.Term.neg #[← termExpr input]
   | .add left right => do
       mkAppM ``Frontend.Term.add #[← termExpr left, ← termExpr right]
@@ -414,7 +469,8 @@ meta def termExpr : Frontend.Term → MetaM Expr
       mkAppM ``Frontend.Term.sub #[← termExpr left, ← termExpr right]
   | .mul left right => do
       mkAppM ``Frontend.Term.mul #[← termExpr left, ← termExpr right]
-  | .pow input => do mkAppM ``Frontend.Term.pow #[← termExpr input]
+  | .pow input exponent => do
+      mkAppM ``Frontend.Term.pow #[← termExpr input, mkNatLit exponent]
   | .abs input => do mkAppM ``Frontend.Term.abs #[← termExpr input]
   | .min left right => do
       mkAppM ``Frontend.Term.min #[← termExpr left, ← termExpr right]
@@ -424,6 +480,10 @@ meta def termExpr : Frontend.Term → MetaM Expr
   | .div left right => do
       mkAppM ``Frontend.Term.div #[← termExpr left, ← termExpr right]
   | .regularize input => do mkAppM ``Frontend.Term.regularize #[← termExpr input]
+
+meta def entryExpr (entry : Frontend.Entry) : MetaM Expr := do
+  mkAppM ``Frontend.Entry.mk
+    #[← termExpr entry.term, ← mkAppM ``NodeId.mk #[mkNatLit entry.node.index]]
 
 meta def resultExpr (config : Frontend.Config) (sourceCount : Nat)
     (term : Frontend.Term) : MetaM Expr := do
@@ -447,18 +507,16 @@ meta def defaultConfig : Frontend.Config :=
   { rule :=
       { endpoint := { maxEndpointHeight := 256, maxAlignmentShift := 256 }
         powerWork := { maxExponent := 64 }
-        exponent := 2
         precisionLimits :=
           { endpoint := { maxEndpointHeight := 256, maxAlignmentShift := 256 }
             maxPrecisionMagnitude := 64, maxPrecisionBits := 64
             maxTemporaryBits := 512 }
         -- The default working grid is `2⁻¹⁶`; integer-grid regularization loses
         -- elementary reciprocal facts such as `2⁻¹ + 2⁻¹ = 1`.
-        precision := 16
-        constant := 0 }
-    reify := { maxSources := 32, maxOperations := 13, maxNodes := 256, maxDepth := 32 }
+        precision := 16 }
+    reify := { maxSources := 32, maxOperations := 14, maxNodes := 256, maxDepth := 32 }
     proof :=
-      { maxPackages := 1, maxSchemas := 12, maxBodyCells := 1
+      { maxPackages := 1, maxSchemas := 11, maxBodyCells := 1
         maxDependencies := 2, maxChronology := 256 } }
 
 structure RuntimeLimits where
@@ -477,7 +535,7 @@ meta def runtimeLimits (config : Frontend.Config) : RuntimeLimits :=
   let structural := 64 + 8 * nodes + 16 * chronology
   let state : State.Limits :=
     { maxOperations := config.reify.maxOperations, maxNodes := nodes,
-      maxRules := 12, maxRegistryEntries := nodes + 32, maxReplayFormats := 12,
+      maxRules := 11, maxRegistryEntries := nodes + 32, maxReplayFormats := 11,
       maxArity := 2, maxScopeNodes := 0, maxApplications := nodes,
       maxQueueEntries := nodes, maxActions := chronology,
       maxMatcherVisits := 0, matcherBatchSize := 0,
@@ -514,7 +572,7 @@ meta def runtimeLimits (config : Frontend.Config) : RuntimeLimits :=
       maxTransitions := chronology, maxEvents := chronology,
       maxStructuralCells := structural }
   let emit : RuntimeEmit.Limits :=
-    { proof := config.proof, maxSchemas := 12, maxChronology := chronology,
+    { proof := config.proof, maxSchemas := 11, maxChronology := chronology,
       maxExpressionCells := structural * 1024 }
   { executable, runtime, search, result, envelope, controller, adapter, emit }
 
@@ -591,6 +649,21 @@ meta def binaryArguments? (expression : Expr) (name : Name) : Option (Expr × Ex
   if arguments.size < 2 then none else
   some (arguments[arguments.size - 2]!, arguments[arguments.size - 1]!)
 
+/-- Recognize only closed integer literals and a single literal division whose
+positive denominator is a power of two. This is deliberately not a rational
+projector over arbitrary expressions. -/
+meta def dyadicLiteral? (expression : Expr) : Option Dyadic :=
+  if let some value := intLiteral? expression then some (Dyadic.ofInt value)
+  else do
+    let (numeratorExpr, denominatorExpr) ← binaryArguments? expression ``HDiv.hDiv
+    let numerator ← intLiteral? numeratorExpr
+    let denominatorInt ← intLiteral? denominatorExpr
+    if denominatorInt ≤ 0 then none else
+    let denominator := denominatorInt.toNat
+    let shift := Nat.log2 denominator
+    if 2 ^ shift != denominator then none else
+    some ((Dyadic.ofInt numerator) >>> (shift : Int))
+
 meta def unaryArgument? (expression : Expr) (name : Name) : Option Expr := do
   if expression.getAppFn.constName? != some name then none else
   expression.getAppArgs.back?
@@ -605,11 +678,9 @@ meta def parseTermAux (config : Frontend.Config) (expression : Expr)
   | 0 => throwError "interval: expression exceeded the reification depth limit"
   | fuel + 1 => do
     ensureReal expression
-    if let some value := intLiteral? expression then
-      if Dyadic.ofInt value == config.rule.constant then
-        return state.computed .constant expression
-      else
-        throwError "interval: this real literal is not the configured constant"
+    if let some value := dyadicLiteral? expression then
+      let result := .dyadic value
+      return (result, state.record result expression)
     if let some input := unaryArgument? expression ``Neg.neg then
       let (term, state) ← parseTermAux config input state fuel
       let result := .neg term
@@ -641,10 +712,12 @@ meta def parseTermAux (config : Frontend.Config) (expression : Expr)
     if let some (input, exponent) := binaryArguments? expression ``HPow.hPow then
       let some value := natLiteral? exponent
         | throwError "interval: power exponent is not a natural literal"
-      unless value == config.rule.exponent do
-        throwError "interval: expected configured power {config.rule.exponent}, got {value}"
       let (term, state) ← parseTermAux config input state fuel
-      let result := .pow term
+      let exponentTerm := .natural value
+      let exponentReal ← mkAppOptM ``Nat.cast
+        #[some (mkConst ``Real), none, some (mkNatLit value)]
+      let state := state.record exponentTerm exponentReal
+      let result := .pow term value
       return state.computed result expression
     if let some input := unaryArgument? expression ``abs then
       let (term, state) ← parseTermAux config input state fuel
@@ -759,6 +832,10 @@ meta def realIntCast (value : Int) : MetaM Expr :=
   mkAppOptM ``Int.cast
     #[some (mkConst ``Real), none, some (mkIntLit value)]
 
+meta def realNatCast (value : Nat) : MetaM Expr :=
+  mkAppOptM ``Nat.cast
+    #[some (mkConst ``Real), none, some (mkNatLit value)]
+
 meta def normNumProof (proposition : Expr) : MetaM Expr := do
   let result ← Mathlib.Meta.NormNum.eval proposition
   unless result.expr.isConstOf ``True do
@@ -766,6 +843,15 @@ meta def normNumProof (proposition : Expr) : MetaM Expr := do
   let proof ← mkOfEqTrue (← result.getProof)
   let emitter : Proof.Emitter Expr := { emit := pure }
   Proof.emitChecked emitter proof proposition
+
+meta def dyadicProof (literal : Dyadic) (expression : Expr) : MetaM Expr := do
+  let quotedLiteral ← Rule.Runtime.Quote.dyadicExpr literal
+  let rational := literal.toRat
+  let quotient ← mkAppM ``HDiv.hDiv
+    #[← realIntCast rational.num, ← realNatCast rational.den]
+  let unfold ← mkAppM ``Rule.toReal_rat #[quotedLiteral]
+  let normalized ← normNumProof (← mkAppM ``Eq #[quotient, expression])
+  mkAppM ``Eq.trans #[unfold, normalized]
 
 meta def endpointProof (endpoint : Expr) (value : Int) : MetaM Expr := do
   let proposition ← mkAppM ``Eq #[endpoint, ← realIntCast value]
@@ -857,25 +943,13 @@ private meta def evalProofCached (config : Frontend.Config) (parsed : ParseState
         mkAppOptM ``Eval.source
           #[some ruleConfig, some values, some (mkNatLit index), some source,
             some lookupProof]
-    | .constant => do
-        let some value := intLiteral? expression
-          | throwError "interval: configured constant is not an integer literal"
-        let quotedConstant ← Rule.Runtime.Quote.dyadicExpr config.rule.constant
-        let rationalEq ← mkDecideProof (← mkAppM ``Eq
-          #[toExpr config.rule.constant.toRat, toExpr (value : Rat)])
-        let castEqual ← mkAppOptM ``toRealEqIntCast
-          #[some quotedConstant, some (mkIntLit value), some rationalEq]
-        let realCast ← realIntCast value
-        let literalEqual ← normNumProof (← mkAppM ``Eq #[realCast, expression])
-        let equal ← mkAppM ``Eq.trans #[castEqual, literalEqual]
-        mkAppOptM ``Eval.constantMk
-          #[some (← Rule.Runtime.Quote.endpointExpr config.rule.endpoint),
-            some (← Rule.Runtime.Quote.powLimitsExpr config.rule.powerWork),
-            some (mkNatLit config.rule.exponent),
-            some (← Rule.Runtime.Quote.precisionLimitsExpr config.rule.precisionLimits),
-            some (mkIntLit config.rule.precision), some quotedConstant,
-            some (← Rule.Runtime.Quote.emptyMeaningsExpr), some values, some expression,
-            some equal]
+    | .dyadic literal => do
+        let quotedLiteral ← Rule.Runtime.Quote.dyadicExpr literal
+        let equal ← dyadicProof literal expression
+        mkAppOptM ``Eval.dyadic
+          #[some ruleConfig, some values, some quotedLiteral, some expression, some equal]
+    | .natural _ =>
+        throwError "interval: internal natural row cannot be a real expression root"
     | .neg input => do
         let some inputValue := parsed.expression? input
           | throwError "interval: negated term has no Lean expression"
@@ -930,7 +1004,7 @@ private meta def evalProofCached (config : Frontend.Config) (parsed : ParseState
           #[some ruleConfig, some values, some (← Quote.termExpr left),
             some (← Quote.termExpr right), some leftValue, some rightValue,
             some leftProof, some rightProof]
-    | .pow input => do
+    | .pow input exponent => do
         let some inputValue := parsed.expression? input
           | throwError "interval: powered term has no Lean expression"
         let (inputProof, nextCache) ←
@@ -938,7 +1012,7 @@ private meta def evalProofCached (config : Frontend.Config) (parsed : ParseState
         cache := nextCache
         mkAppOptM ``Eval.pow
           #[some ruleConfig, some values, some (← Quote.termExpr input),
-            some inputValue, some inputProof]
+            some (mkNatLit exponent), some inputValue, some inputProof]
     | .abs input => do
         let some inputValue := parsed.expression? input
           | throwError "interval: absolute-value term has no Lean expression"
@@ -1023,7 +1097,70 @@ meta def evalProof (config : Frontend.Config) (parsed : ParseState)
   let ruleConfig ← Rule.Runtime.Quote.configExpr config.rule
   return (← evalProofCached config parsed values ruleConfig {} term).1
 
-meta def runtimeKey : RuntimeProof.Key := { name := "interval-tactic", version := 1 }
+meta def runtimeKey : RuntimeProof.Key := { name := "interval-tactic", version := 2 }
+
+meta def initialHolds (config : Frontend.Config) (parsed : ParseState)
+    (reified : Frontend.Result) (initial : Frontend.InitialContext)
+    (sourceProofs : Array Expr) : MetaM Expr := do
+  let configExpr ← Rule.Runtime.Quote.configExpr config.rule
+  let valuesList ← Quote.listExpr (mkConst ``Real) parsed.sources.toList
+  let values ← mkAppM ``Frontend.valuesAt #[valuesList]
+  let mut holds ← mkAppOptM ``initialNil #[some configExpr, some values]
+  for index in List.range reified.entries.size |>.reverse do
+    let some entry := reified.entries[index]?
+      | throwError "interval: initial entry escaped the reifier"
+    let some row := initial.rows[index]?
+      | throwError "interval: initial row escaped the reifier"
+    let rowExpr ← Quote.initialRowExpr config.rule.endpoint row
+    let entryExpr ← Quote.entryExpr entry
+    let member ← match entry.term with
+      | .source source =>
+          let some proof := sourceProofs[source]?
+            | throwError "interval: source proof escaped the source table"
+          pure proof
+      | .dyadic value =>
+          let some fact := row.fact
+            | throwError "interval: dyadic literal has no exact initial fact"
+          let factExpr ← Quote.intervalExpr config.rule.endpoint fact
+          let checked ← mkDecideProof (← mkAppM ``Eq
+            #[← mkAppM ``Rule.ready?
+                #[← mkAppM ``singletonWithin
+                  #[← Rule.Runtime.Quote.endpointExpr config.rule.endpoint,
+                    ← Rule.Runtime.Quote.dyadicExpr value]],
+              ← mkAppM ``Option.some #[factExpr]])
+          mkAppOptM ``Frontend.dyadic_contains
+            #[some configExpr, some values, some (← Rule.Runtime.Quote.dyadicExpr value),
+              some factExpr, some checked]
+      | .natural value =>
+          let some fact := row.fact
+            | throwError "interval: natural literal has no exact initial fact"
+          let factExpr ← Quote.intervalExpr config.rule.endpoint fact
+          let dyadic ← mkAppM ``Dyadic.ofInt #[mkIntLit value]
+          let checked ← mkDecideProof (← mkAppM ``Eq
+            #[← mkAppM ``Rule.ready? #[← mkAppM ``singletonWithin
+                #[← Rule.Runtime.Quote.endpointExpr config.rule.endpoint, dyadic]],
+              ← mkAppM ``Option.some #[factExpr]])
+          mkAppOptM ``Frontend.natural_contains
+            #[some configExpr, some values, some (mkNatLit value), some factExpr,
+              some checked]
+      | _ => do
+          let evaluated ← mkAppM ``Frontend.Term.eval
+            #[configExpr, values, ← Quote.termExpr entry.term]
+          mkAppM ``Frontend.whole_contains #[evaluated]
+    let rowNode ← mkAppM ``Frontend.InitialRow.node #[rowExpr]
+    let entryNode ← mkAppM ``Frontend.Entry.node #[entryExpr]
+    let node ← mkDecideProof (← mkAppM ``Eq #[rowNode, entryNode])
+    let rowFact ← mkAppM ``Frontend.InitialRow.fact #[rowExpr]
+    let selected ← mkAppM ``Option.getD #[rowFact, mkConst ``Hex.Interval.whole]
+    let evaluated ← mkAppM ``Frontend.Term.eval
+      #[configExpr, values, ← mkAppM ``Frontend.Entry.term #[entryExpr]]
+    let expectedMember ← mkAppM ``Hex.Interval.Contains #[selected, evaluated]
+    let emitter : Proof.Emitter Expr := { emit := pure }
+    let member ← Proof.emitChecked emitter member expectedMember
+    holds ← mkAppOptM ``initialCons
+      #[some configExpr, some values, some rowExpr, some entryExpr,
+        none, none, some node, some member, some holds]
+  pure holds
 
 meta def checkedValue (checked : Expr) : MetaM (Expr × Expr) := do
   let option ← mkAppM ``Except.toOption #[checked]
@@ -1036,6 +1173,7 @@ structure RuntimeResult (config : Rule.Config) where
     Rule.Runtime.Cause (List Nat)
   output : Hex.Interval
   chronology : Nat
+  initial : Frontend.InitialContext
 
 private meta def liftRuntimeExcept {ε α : Type} : Except ε α → Except ε (ULift.{1, 0} α)
   | .error error => .error error
@@ -1069,18 +1207,21 @@ private meta def stoppedMessage
 /-! Execute and settle the exact typed runtime chronology. Keeping this phase
 in `Except` permits its sealed `Type 1` handles to remain outside `MetaM`. -/
 meta def prepareRuntime (config : Frontend.Config) (reified : Frontend.Result)
-    (sourceFacts : Array Hex.Interval) : Except String (RuntimeResult config.rule) := do
+    (initial : Frontend.InitialContext) : Except String (RuntimeResult config.rule) := do
   let limits := runtimeLimits config
   let registry ← Rule.Runtime.buildEmitWithin limits.executable limits.emit runtimeKey
       config.rule reified.program |>.mapError fun error =>
         s!"runtime registry failed: {repr error}"
-  let facts := reified.facts sourceFacts
+  let scope : Policy.ScopeId := { index := 0 }
+  let preflight := (← liftRuntimeExcept <|
+    (Frontend.inputInitialWithin config scope reified initial Hex.Interval.whole
+      |>.mapError fun error => s!"initial input failed: {repr error}")).down
+  let facts := preflight.facts
   let branch := (← liftRuntimeExcept <|
     (State.Branch.startWithin limits.executable.state reified.program facts
       |>.mapError fun error => s!"runtime branch failed: {repr error}")).down
   let runtime ← Runtime.State.startWithin limits.runtime registry.runtime.assembly branch
     |>.mapError fun error => s!"runtime start failed: {repr error}"
-  let scope : Policy.ScopeId := { index := 0 }
   let tree := (← liftRuntimeExcept <|
     (Search.Result.startWithin limits.result runtimeMeasure scope branch
       |>.mapError fun error => s!"retained tree start failed: {repr error}")).down
@@ -1099,7 +1240,7 @@ meta def prepareRuntime (config : Frontend.Config) (reified : Frontend.Result)
   let some outputInterval := controller.runtime.branch.factAt? seen
     | throw "target fact escaped the runtime branch"
   let input := (← liftRuntimeExcept <|
-    (Frontend.inputWithin config scope reified sourceFacts outputInterval
+    (Frontend.inputInitialWithin config scope reified initial outputInterval
       |>.mapError fun error => s!"input construction failed: {repr error}")).down
   let active ← RuntimeEmit.Active.startWithin registry input controller
     |>.mapError fun error => s!"emitter start failed: {repr error}"
@@ -1107,7 +1248,7 @@ meta def prepareRuntime (config : Frontend.Config) (reified : Frontend.Result)
     |>.mapError fun error => s!"target settlement failed: {repr error}"
   let checked ← RuntimeEmit.Lineage.quoteWithin limits.adapter runtimeMeasure lineage
     |>.mapError fun error => s!"retained quotation failed: {repr error}"
-  pure { checked, output := outputInterval, chronology := plan.length }
+  pure { checked, output := outputInterval, chronology := plan.length, initial }
 
 /-! Emit the checked runtime result and close its exact quoted input against
 the caller's source proofs. -/
@@ -1125,7 +1266,7 @@ meta def emitBoundWith (config : Frontend.Config) (expression : Expr)
   let resultExpr ← Quote.resultExpr config parsed.sources.size term
   let valuesListExpr ← Quote.listExpr (mkConst ``Real) parsed.sources.toList
   let valuesExpr ← mkAppM ``Frontend.valuesAt #[valuesListExpr]
-  let sourceFactsExpr ← Quote.arrayExpr (mkConst ``Hex.Interval) sourceIntervals.toList
+  let initialExpr ← Quote.initialContextExpr config.rule.endpoint runtime.initial
   let modelCheck ← mkAppM ``Frontend.modelWithin #[configExpr, valuesExpr, resultExpr]
   let (_, modelSuccess) ← checkedValue modelCheck
   let model ← mkAppM ``Frontend.modelOfCheck #[modelCheck, modelSuccess]
@@ -1136,19 +1277,28 @@ meta def emitBoundWith (config : Frontend.Config) (expression : Expr)
   let inputTargetNode ← mkAppM ``Proof.NodeFact.node #[inputTarget]
   let resultTarget ← mkAppM ``Frontend.Result.target #[resultExpr]
   let targetEq ← mkDecideProof (← mkAppM ``Eq #[inputTargetNode, resultTarget])
-  let sourceSizeExpr ← mkAppM ``Array.size #[sourceFactsExpr]
-  let resultSourceCount ← mkAppM ``Frontend.Result.sourceCount #[resultExpr]
-  let sourceSize ← mkDecideProof (← mkAppM ``Eq #[sourceSizeExpr, resultSourceCount])
   let inputFacts ← mkAppM ``Proof.Input.facts #[emitted.input]
-  let resultFacts ← mkAppM ``Frontend.Result.facts #[resultExpr, sourceFactsExpr]
-  let factsEq ← mkDecideProof (← mkAppM ``Eq #[inputFacts, resultFacts])
-  let mut holds := mkConst ``Sources.nil
-  for proof in sourceProofs.toList.reverse do
-    holds ← mkAppM ``Sources.cons #[proof, holds]
-  let sourceHolds ← mkAppM ``Frontend.SourcesContain.ofForall₂ #[holds]
-  let candidate ← mkAppM ``Frontend.closeSources
+  let initialFacts ← mkAppM ``Frontend.InitialContext.facts #[initialExpr]
+  let factsEq ← mkDecideProof (← mkAppM ``Eq #[inputFacts, initialFacts])
+  let holds ← initialHolds config parsed reified runtime.initial sourceProofs
+  let ruleConfigExpr ← Rule.Runtime.Quote.configExpr config.rule
+  let rowExprs ← runtime.initial.rows.toList.mapM
+    (Quote.initialRowExpr config.rule.endpoint)
+  let rowsExpr ← Quote.listExpr (mkConst ``Frontend.InitialRow) rowExprs
+  let entryExprs ← reified.entries.toList.mapM Quote.entryExpr
+  let entriesExpr ← Quote.listExpr (mkConst ``Frontend.Entry) entryExprs
+  let initialRows ← mkAppM ``Frontend.InitialContext.rows #[initialExpr]
+  let initialRowsList ← mkAppM ``Array.toList #[initialRows]
+  let rowsEq ← mkDecideProof (← mkAppM ``Eq #[initialRowsList, rowsExpr])
+  let resultEntries ← mkAppM ``Frontend.Result.entries #[resultExpr]
+  let resultEntriesList ← mkAppM ``Array.toList #[resultEntries]
+  let entriesEq ← mkDecideProof (← mkAppM ``Eq #[resultEntriesList, entriesExpr])
+  let initialHolds ← mkAppOptM ``initialCast
+    #[some initialExpr, some ruleConfigExpr, some valuesExpr, some resultExpr,
+      some rowsExpr, some entriesExpr, some rowsEq, some entriesEq, some holds]
+  let candidate ← mkAppM ``Frontend.closeInitial
     #[configExpr, resultExpr, valuesExpr, model, emitted.input, emitted.evidence,
-      programEq, targetEq, sourceFactsExpr, sourceSize, factsEq, sourceHolds]
+      programEq, targetEq, initialExpr, factsEq, initialHolds]
   let candidate ← mkAppM ``Eval.contains #[candidate, ← evalProof config parsed term]
   let canonicalExpr ← Quote.intervalExpr config.rule.endpoint runtime.output
   let canonicalExpected ← mkAppM ``Hex.Interval.Contains #[canonicalExpr, expression]
@@ -1178,7 +1328,10 @@ meta def deriveBound (config : Frontend.Config) (expression : Expr) : MetaM Boun
     sourceFacts := sourceFacts.push interval
     sourceIntervals := sourceIntervals.push intervalExpr
     sourceProofs := sourceProofs.push proof
-  match prepareRuntime config reified sourceFacts with
+  let initial ← match reified.seedInitialWithin config.rule sourceFacts with
+    | .ok initial => pure initial
+    | .error error => throwError "interval: initial facts failed: {repr error}"
+  match prepareRuntime config reified initial with
   | .error error => throwError "interval: {error}"
   | .ok runtime =>
       emitBoundWith config expression term parsed reified sourceIntervals sourceProofs runtime
@@ -1186,7 +1339,7 @@ meta def deriveBound (config : Frontend.Config) (expression : Expr) : MetaM Boun
 inductive GoalKind where
   | lower (value : Int) (endpoint : Expr) (strict : Bool)
   | upper (value : Int) (endpoint : Expr) (strict : Bool)
-  | equality (value : Int) (endpoint : Expr) (flipped : Bool)
+  | equality (value : Dyadic) (endpoint : Expr) (flipped : Bool)
 
 structure Claim where
   expression : Expr
@@ -1214,13 +1367,13 @@ meta def parseClaim (target : Expr) : MetaM Claim := do
     if arguments.size < 2 then throwError "interval: malformed equality target"
     let left := arguments[arguments.size - 2]!
     let right := arguments[arguments.size - 1]!
-    if let some value := intLiteral? right then
+    if let some value := dyadicLiteral? right then
       ensureReal left
       return { expression := left, kind := .equality value right false }
-    if let some value := intLiteral? left then
+    if let some value := dyadicLiteral? left then
       ensureReal right
       return { expression := right, kind := .equality value left true }
-    throwError "interval: equality target needs an integer endpoint"
+    throwError "interval: equality target needs an exact dyadic endpoint"
   throwError "interval: expected a real inequality, equality, or conjunction"
 
 meta def ratIntCast (value : Int) : MetaM Expr :=
@@ -1291,18 +1444,10 @@ meta def closeClaim (config : Frontend.Config) (bound : Bound) (claim : Claim)
         | .finite left false, .finite right false =>
             unless left == right do
               throwError "interval: derived interval is not a singleton"
-            unless left.toRat == (value : Rat) do
+            unless left == value do
               throwError "interval: derived endpoint does not prove the requested target"
-            let equalityRat ← do
-              let proposition ← mkAppM ``Eq #[toExpr left.toRat, toExpr (value : Rat)]
-              mkDecideProof proposition
-            let endpointEq ← mkAppOptM ``toRealEqIntCast
-              #[some (← Quote.dyadicExpr left), some (mkIntLit value), some equalityRat]
-            let integerProof ← mkAppM ``equalityOfMem #[shape, bound.proof, endpointEq]
-            let targetEq ← endpointProof targetEndpoint value
-            let equivalence ← mkAppOptM ``castEquality
-              #[some targetEndpoint, some claim.expression, some (mkIntLit value), some targetEq]
-            let proof ← mkAppM ``Iff.mpr #[equivalence, integerProof]
+            let endpointEq ← dyadicProof left targetEndpoint
+            let proof ← mkAppM ``equalityOfMem #[shape, bound.proof, endpointEq]
             if flipped then mkAppM ``Eq.symm #[proof] else pure proof
         | _, _ => throwError "interval: derived interval is not a closed singleton"
   let emitter : Proof.Emitter Expr := { emit := pure }

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -37,10 +37,12 @@ value, minimum, maximum, constants, reciprocal, division, and regularization.
 Each schema recomputes the fixed-resource public operation before producing
 evidence; source nodes remain caller assumptions. Supported `quote` and
 `quoteSession` convert exact branch/session causes into proof events without
-granting runtime state evidence authority. The current package fixes one
-natural exponent and one dyadic constant, shared respectively by every node at
-the built-in power and constant operation indices; duplicate package
-registration and operation keys cannot provide another such parameterization.
+granting runtime state evidence authority. Power rows instead consume an
+authenticated natural-literal input, and exact dyadic constants occupy their
+own literal rows. Multiple exponents and constants may therefore coexist in
+one checked program, while structural CSE shares equal literals. Duplicate
+package registration and operation keys cannot provide an alternate
+interpretation of those rows.
 The Mathlib-free `Executable.Assembly` now supports explicit stable-key
 arbitrary-operation callback packages, private caches, exact concrete
 application rows, and bounded raw replay formats. Those raw quotations are not

--- a/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
+++ b/conformance/HexIntervalMathlib/ExecutableControllerConformance.lean
@@ -62,11 +62,11 @@ def copyMeaning : Program.Meaning ℝ :=
   { operation := copyOp, relation := fun xs z => ∃ x, xs = [x] ∧ z = x }
 
 def config : Rule.Config :=
-  { endpoint, powerWork := { maxExponent := 8 }, exponent := 2,
+  { endpoint, powerWork := { maxExponent := 8 },
     precisionLimits :=
       { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
         maxTemporaryBits := 128 },
-    precision := 0, constant := d 5, extraMeanings := #[copyMeaning] }
+    precision := 0, extraMeanings := #[copyMeaning] }
 
 def node (op : Nat) (args : List Nat) : Node :=
   { domain := Rule.realDomain, op := { index := op },
@@ -74,7 +74,7 @@ def node (op : Nat) (args : List Nat) : Node :=
 
 def program : Program :=
   { operations := Rule.operations.push copyOp,
-    nodes := #[node 0 [], node 0 [], node 2 [0, 1], node 13 [2], node 13 [3]] }
+    nodes := #[node 0 [], node 0 [], node 2 [0, 1], node 14 [2], node 14 [3]] }
 
 def x : NodeId := { index := 0 }
 def y : NodeId := { index := 1 }
@@ -99,7 +99,7 @@ def copySchemaKey : Proof.Key := { rule := copyKey, role := .fact, bodySchema :=
 
 theorem copyRelation {valuation : NodeId → ℝ} {out input : NodeId}
     (meaning : Program.MeaningAt (Rule.meanings config) valuation out
-      { domain := Rule.realDomain, op := { index := 13 }, args := [input] }) :
+      { domain := Rule.realDomain, op := { index := 14 }, args := [input] }) :
     valuation out = valuation input := by
   rcases meaning with ⟨meaning, found, related⟩
   simp [Rule.meanings, Rule.builtinMeanings, config, copyMeaning] at found
@@ -112,7 +112,7 @@ def copySchema : Proof.FactSchema (Rule.semantics config) :=
     prove := fun context _ => match context.assumptions with
       | [input] =>
         if found : context.program.node? context.proposed.node = some
-            { domain := Rule.realDomain, op := { index := 13 }, args := [input.node] } then
+            { domain := Rule.realDomain, op := { index := 14 }, args := [input.node] } then
           if equal : context.proposed.fact = input.fact then
             some ⟨by
               intro valuation model assumptions
@@ -131,7 +131,7 @@ def copyProofPackage : Proof.Package (Rule.semantics config) :=
   { registrations := #[copyRegistration], facts := #[copySchema] }
 
 def proofLimits : Proof.Limits :=
-  { maxPackages := 2, maxSchemas := 13, maxBodyCells := 1,
+  { maxPackages := 2, maxSchemas := 12, maxBodyCells := 1,
     maxDependencies := 2, maxChronology := 3 }
 
 def proofRegistry? : Option (Proof.Registry (Rule.semantics config)) :=
@@ -216,8 +216,8 @@ def copyPackage : Package Hex.Interval
   { Cache := Nat, cache := 0, operations := #[copyOp], handlers := #[copyHandler], measure }
 
 def stateLimits : State.Limits :=
-  { maxOperations := 14, maxNodes := 5, maxRules := 13,
-    maxRegistryEntries := 42, maxReplayFormats := 13, maxArity := 2,
+  { maxOperations := 15, maxNodes := 5, maxRules := 12,
+    maxRegistryEntries := 42, maxReplayFormats := 12, maxArity := 2,
     maxScopeNodes := 0, maxApplications := 3, maxQueueEntries := 4,
     maxActions := 8, maxMatcherVisits := 0, matcherBatchSize := 0,
     maxAcceptedFacts := 3, maxRetainedSuggestions := 0, maxEffort := 0,
@@ -582,7 +582,7 @@ def applicationsOneOver : Bool :=
   | _ => false
 
 def formatsOneOver : Bool :=
-  let small := { stateLimits with maxReplayFormats := 12 }
+  let small := { stateLimits with maxReplayFormats := 11 }
   match buildRegistry (limits := small) with
   | .error (.resource (.state .replayFormats)) => true
   | _ => false

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -22,7 +22,7 @@ open Hex.Interval
 open Hex.Interval.Proof
 
 def limits : Frontend.Limits :=
-  { maxSources := 2, maxOperations := 13, maxNodes := 5, maxDepth := 3 }
+  { maxSources := 2, maxOperations := 14, maxNodes := 5, maxDepth := 3 }
 def config : Frontend.Config :=
   { rule := RuleConformance.config, reify := limits, proof := RuleConformance.proofLimits }
 
@@ -88,8 +88,8 @@ theorem resultOperations : result.program.operations =
   simp [result, expectedProgram, RuleConformance.program, config, RuleConformance.config,
     Rule.meanings, Rule.builtinMeanings, Rule.operations, Rule.sourceMeaning,
     Rule.negMeaning, Rule.addMeaning, Rule.subMeaning, Rule.mulMeaning, Rule.powMeaning,
-    Rule.absMeaning, Rule.minMeaning, Rule.maxMeaning, Rule.constantMeaning, Rule.invMeaning,
-    Rule.divMeaning, Rule.regularizeMeaning]
+    Rule.absMeaning, Rule.minMeaning, Rule.maxMeaning, Rule.dyadicLiteralMeaning,
+    Rule.invMeaning, Rule.divMeaning, Rule.regularizeMeaning, Rule.natLiteralMeaning]
 
 noncomputable def semanticModel : Frontend.Model config.rule sourceValues result :=
   { checked := resultChecked
@@ -177,7 +177,7 @@ def shallow : Frontend.Config := { config with reify := { limits with maxDepth :
 def fewNodes : Frontend.Config := { config with reify := { limits with maxNodes := 4 } }
 def fewSources : Frontend.Config := { config with reify := { limits with maxSources := 1 } }
 def fewOperations : Frontend.Config :=
-  { config with reify := { limits with maxOperations := 12 } }
+  { config with reify := { limits with maxOperations := 13 } }
 
 def wrongInitialRow : Frontend.InitialContext :=
   { rows := computedInitial.rows.set! 0 { node := RuleConformance.y } }
@@ -272,7 +272,7 @@ def wrongOperations : Frontend.Result :=
       { result.program with operations := result.program.operations.push RuleConformance.opaqueOp } }
 
 def roomy : Frontend.Config :=
-  { config with reify := { limits with maxOperations := 14 } }
+  { config with reify := { limits with maxOperations := 15 } }
 
 #guard
   match Frontend.inputWithin config RuleConformance.scope wrongEntryNode
@@ -335,7 +335,8 @@ def roomy : Frontend.Config :=
   | _ => false
 
 #guard
-  match Frontend.reifyWithin config 1 (.add .constant (.source 0)) with
+  match Frontend.reifyWithin config 1
+      (.add (.dyadic (RuleConformance.d 5)) (.source 0)) with
   | .ok result => result.program.nodes ==
       #[RuleConformance.node 9 [], RuleConformance.node 0 [], RuleConformance.node 2 [0, 1]]
   | .error _ => false
@@ -351,7 +352,7 @@ def roomy : Frontend.Config :=
 
 def duplicateKey : Frontend.Config :=
   { rule := { config.rule with extraMeanings := #[Rule.sourceMeaning] }
-    reify := { limits with maxOperations := 14 }
+    reify := { limits with maxOperations := 15 }
     proof := config.proof }
 
 #guard

--- a/conformance/HexIntervalMathlib/FrontendConformance.lean
+++ b/conformance/HexIntervalMathlib/FrontendConformance.lean
@@ -341,6 +341,18 @@ def roomy : Frontend.Config :=
       #[RuleConformance.node 9 [], RuleConformance.node 0 [], RuleConformance.node 2 [0, 1]]
   | .error _ => false
 
+def literalStarved : Frontend.Config :=
+  { config with rule :=
+      { config.rule with endpoint := { maxEndpointHeight := 0, maxAlignmentShift := 0 } } }
+
+#guard
+  match Frontend.reifyWithin literalStarved 0 (.dyadic (RuleConformance.d 5)) with
+  | .ok result =>
+      match result.seedInitialWithin literalStarved.rule #[] with
+      | .error (.literalResource node) => node == result.target
+      | _ => false
+  | .error _ => false
+
 #guard
   match Frontend.reifyWithin config 2
       (.regularize (.div (.inv (.source 0)) (.source 1))) with

--- a/conformance/HexIntervalMathlib/RuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuleConformance.lean
@@ -32,6 +32,12 @@ def ready (raw : Raw) : Hex.Interval :=
 def singleton (value : Int) : Hex.Interval :=
   ready (.bounds (.finite (d value) false) (.finite (d value) false))
 
+def singletonDyadic (value : Dyadic) : Hex.Interval :=
+  ready (.bounds (.finite value false) (.finite value false))
+
+def closed (lower upper : Dyadic) : Hex.Interval :=
+  ready (.bounds (.finite lower false) (.finite upper false))
+
 def config : Rule.Config :=
   { endpoint, powerWork := { maxExponent := 8 },
     precisionLimits :=
@@ -86,6 +92,13 @@ def quotientFact := singleton 2
 def regularizedFact := singleton 2
 def combinedFact := singleton (-1)
 def finalFact := singleton 0
+def half : Dyadic := .ofIntWithPrec 1 1
+
+#guard closedNat? (singleton 2) == some 2
+#guard closedNat? (closed (d 1) (d 2)) == none
+#guard closedNat? (singletonDyadic half) == none
+#guard closedNat? (singleton (-1)) == none
+
 def initialFacts : Array Hex.Interval :=
   #[xFact, yFact, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
     Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,

--- a/conformance/HexIntervalMathlib/RuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuleConformance.lean
@@ -33,11 +33,11 @@ def singleton (value : Int) : Hex.Interval :=
   ready (.bounds (.finite (d value) false) (.finite (d value) false))
 
 def config : Rule.Config :=
-  { endpoint, powerWork := { maxExponent := 8 }, exponent := 2,
+  { endpoint, powerWork := { maxExponent := 8 },
     precisionLimits :=
       { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
         maxTemporaryBits := 128 },
-    precision := 0, constant := d 5 }
+    precision := 0 }
 
 def node (op : Nat) (args : List Nat) : Node :=
   { domain := realDomain, op := { index := op }, args := args.map fun index => { index } }
@@ -63,6 +63,9 @@ def seen (node : NodeId) (version : Nat := 0) : SeenVersion :=
 
 #guard program.check
 #guard Rule.operations == program.operations
+#guard Rule.operations.size == 14
+#guard Rule.registrations.size == 11
+#guard (Rule.package config).facts.size == 11
 
 def opaqueOp : Operation :=
   { key := { name := "conformance.opaque" }, inputs := [realDomain], output := realDomain }
@@ -109,10 +112,10 @@ def action (serial ruleIndex : Nat) (key : RuleKey) (kind : ActionKind)
 def addAction := action 0 1 addKey .forward sum [seen x, seen y]
 def subAction := action 1 2 subKey .forward difference [seen x, seen y]
 def mulAction := action 2 3 mulKey .forward product [seen sum 1, seen difference 1]
-def invAction := action 3 9 invKey .forward inverse [seen x]
-def divAction := action 4 10 divKey .forward quotient [seen y, seen x]
+def invAction := action 3 8 invKey .forward inverse [seen x]
+def divAction := action 4 9 divKey .forward quotient [seen y, seen x]
 def regularizeAction :=
-  action 5 11 regularizeKey .forward regularized [seen quotient 1]
+  action 5 10 regularizeKey .forward regularized [seen quotient 1]
 def combinedAction := action 6 1 addKey .forward combined [seen product 1, seen regularized 1]
 def finalAction := action 7 1 addKey .forward final [seen combined 1, seen inverse 1]
 
@@ -155,7 +158,7 @@ def branch : State.Branch Hex.Interval Rule.Cause :=
 #guard (Rule.quote branch).length == 8
 
 def proofLimits : Proof.Limits :=
-  { maxPackages := 1, maxSchemas := 12, maxBodyCells := 1,
+  { maxPackages := 1, maxSchemas := 11, maxBodyCells := 1,
     maxDependencies := 2, maxChronology := 8 }
 
 #guard
@@ -379,7 +382,7 @@ def dependencyShort : Proof.Limits := { proofLimits with maxDependencies := 1 }
       | .error .dependencyLimit => true
       | _ => false
 
-def schemaShort : Proof.Limits := { proofLimits with maxSchemas := 11 }
+def schemaShort : Proof.Limits := { proofLimits with maxSchemas := 10 }
 #guard
   match Rule.buildWithin schemaShort config program with
   | .error (.registry .schemaLimit) => true

--- a/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeEmitConformance.lean
@@ -12,7 +12,7 @@ import HexIntervalMathlib.RuntimeProofConformance
 # Typed runtime expression-emission conformance
 
 The theorem canary below is installed only from the expression returned by the
-sealed root-target runtime emitter. Its chronology contains all twelve built-in
+sealed root-target runtime emitter. Its chronology contains all eleven built-in
 arithmetic rules, including binary applications with repeated input nodes.
 The imported runtime-proof conformance owns the constructible action, body,
 proposed/installed fact, event-order, and event-role mutations before a checked
@@ -157,11 +157,11 @@ example : RuntimeEmit.Emitted :=
 end EmittedPrivateConstruction
 
 def emitLimits : RuntimeEmit.Limits :=
-  { proof := RuntimeRuleConformance.proofLimits, maxSchemas := 12, maxChronology := 12,
+  { proof := RuntimeRuleConformance.proofLimits, maxSchemas := 11, maxChronology := 11,
     maxExpressionCells := 1000000 }
 
 def policyLimits : Policy.Limits :=
-  { maxOffers := 12, maxBytes := 4096, maxPairs := 144, maxWork := 4096,
+  { maxOffers := 11, maxBytes := 4096, maxPairs := 144, maxWork := 4096,
     maxScore := 0 }
 
 def traceLimits : Trace.Limit :=
@@ -193,8 +193,14 @@ def quotedWhole : Hex.Interval :=
   Rule.Runtime.Quote.getValue
     (ofRawWithin RuntimeRuleConformance.endpoint (.bounds .unbounded .unbounded)) (by decide)
 
+def quotedTwo : Hex.Interval :=
+  Rule.Runtime.Quote.getValue
+    (ofRawWithin RuntimeRuleConformance.endpoint
+      (.bounds (.finite (RuntimeRuleConformance.d 2) false)
+        (.finite (RuntimeRuleConformance.d 2) false))) (by decide)
+
 def quotedFacts : Array Hex.Interval :=
-  #[quotedPoint, quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole,
+  #[quotedPoint, quotedTwo, quotedWhole, quotedWhole, quotedWhole, quotedWhole,
     quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole, quotedWhole,
     quotedWhole]
 
@@ -355,7 +361,7 @@ elab "runtime_emit_canary" : tactic => do
   goal.assign emitted.evidence
   replaceMainGoal []
 
-/-- All twelve built-in runtime actions are load-bearing in this evidence. -/
+/-- All eleven built-in runtime actions are load-bearing in this evidence. -/
 def allBuiltinsEvidence : Proof.Evidence
     ((Rule.semantics RuntimeRuleConformance.config).Entails input.program
       (Proof.initialBase input) input.target) := by
@@ -487,9 +493,9 @@ elab "runtime_emit_failure_guards" : tactic => do
   expect "schema expression transplant"
     (← emitWith emitLimits (replaceFirst package wrongSchema)) (.handleKey first.key)
   expect "schema count one-under"
-    (← emitWith { emitLimits with maxSchemas := 11 } package) (.resource .schemas)
+    (← emitWith { emitLimits with maxSchemas := 10 } package) (.resource .schemas)
   expect "chronology count one-under"
-    (← emitWith { emitLimits with maxChronology := 11 } package) (.resource .chronology)
+    (← emitWith { emitLimits with maxChronology := 10 } package) (.resource .chronology)
   expect "body count one-under"
     (← emitWith { emitLimits with proof :=
       { RuntimeRuleConformance.proofLimits with maxBodyCells := 0 } } package)

--- a/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
+++ b/conformance/HexIntervalMathlib/RuntimeRuleConformance.lean
@@ -40,25 +40,26 @@ def endpoint : EndpointLimit :=
 def config : Rule.Config :=
   { endpoint
     powerWork := { maxExponent := 8 }
-    exponent := 2
     precisionLimits :=
       { endpoint, maxPrecisionMagnitude := 64, maxPrecisionBits := 64,
         maxTemporaryBits := 128 }
-    precision := 0
-    constant := d 0 }
+    precision := 0 }
 
 def node (op : Nat) (args : List Nat) : Node :=
   { domain := Rule.realDomain, op := { index := op },
     args := args.map fun index => { index } }
+
+def natNode (valueOp : Nat) : Node :=
+  { domain := Rule.natDomain, op := { index := valueOp }, args := [] }
 
 /-- One source followed by one node for every executable built-in rule. Binary
 rows deliberately repeat the source node, exercising valid repeated slots. -/
 def program : Program :=
   { operations := Rule.operations
     nodes :=
-      #[node 0 [], node 1 [0], node 2 [0, 0], node 3 [0, 0], node 4 [0, 0],
-        node 5 [0], node 6 [0], node 7 [0, 0], node 8 [0, 0], node 9 [],
-        node 10 [0], node 11 [0, 0], node 12 [0]] }
+      #[node 0 [], natNode 13, node 1 [0], node 2 [0, 0], node 3 [0, 0],
+        node 4 [0, 0], node 5 [0, 1], node 6 [0], node 7 [0, 0],
+        node 8 [0, 0], node 10 [0], node 11 [0, 0], node 12 [0]] }
 
 def point (value : Int) : Hex.Interval :=
   match singletonWithin endpoint (d value) with
@@ -66,17 +67,17 @@ def point (value : Int) : Hex.Interval :=
   | .resourceLimit _ => Hex.Interval.empty
 
 def facts : Array Hex.Interval :=
-  #[point 1, Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
+  #[point 1, point 2, Hex.Interval.whole, Hex.Interval.whole,
     Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
     Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole,
     Hex.Interval.whole, Hex.Interval.whole, Hex.Interval.whole]
 
 def stateLimits : State.Limits :=
-  { maxOperations := 13, maxNodes := 13, maxRules := 12,
-    maxRegistryEntries := 64, maxReplayFormats := 12, maxArity := 2,
-    maxScopeNodes := 0, maxApplications := 12, maxQueueEntries := 16,
-    maxActions := 12, maxMatcherVisits := 0, matcherBatchSize := 0,
-    maxAcceptedFacts := 12, maxRetainedSuggestions := 0, maxEffort := 0,
+  { maxOperations := 14, maxNodes := 13, maxRules := 11,
+    maxRegistryEntries := 64, maxReplayFormats := 11, maxArity := 2,
+    maxScopeNodes := 0, maxApplications := 11, maxQueueEntries := 16,
+    maxActions := 11, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 11, maxRetainedSuggestions := 0, maxEffort := 0,
     maxObservationValue := 16, maxDiagnosticValue := 16,
     maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0,
     maxProposalItems := 1, maxInstances := 0, maxGeneration := 0,
@@ -85,7 +86,7 @@ def stateLimits : State.Limits :=
 def executableLimits : Executable.Limits :=
   { state := stateLimits, maxPackages := 1,
     maxMetadataBytes := 64, maxMetadataWork := 64,
-    maxCacheBytes := 12, maxCacheWork := 12,
+    maxCacheBytes := 11, maxCacheWork := 11,
     maxResultBytes := 1, maxResultWork := 1,
     maxQuotes := 1, maxQuoteCells := 1, maxAtom := 12, maxSchema := 1 }
 
@@ -93,8 +94,8 @@ def runtimeLimits : Hex.Interval.Runtime.Limits :=
   { executable := executableLimits, maxEvents := 1 }
 
 def proofLimits : Proof.Limits :=
-  { maxPackages := 1, maxSchemas := 12, maxBodyCells := 1,
-    maxDependencies := 2, maxChronology := 12 }
+  { maxPackages := 1, maxSchemas := 11, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 11 }
 
 def key : RuntimeProof.Key := { name := "arithmetic-runtime", version := 1 }
 
@@ -116,22 +117,23 @@ def seen (index version : Nat) : SeenVersion :=
 def action (serial application rule : Nat) (key : RuleKey)
     (inputs : List SeenVersion) : Action :=
   { serial, programVersion := 0, application := { index := application },
-    rule := { index := rule }, key, node := { index := application + 1 },
-    kind := .forward, effort := 0, inputs, writes := [{ index := application + 1 }] }
+    rule := { index := rule }, key, node := { index := application + 2 },
+    kind := .forward, effort := 0, inputs, writes := [{ index := application + 2 }] }
 
 def actions : List Action :=
   [action 0 0 0 Rule.negKey [seen 0 0],
    action 1 1 1 Rule.addKey [seen 0 0, seen 0 0],
    action 2 2 2 Rule.subKey [seen 0 0, seen 0 0],
    action 3 3 3 Rule.mulKey [seen 0 0, seen 0 0],
-   action 4 4 4 Rule.powKey [seen 0 0],
+   action 4 4 4 Rule.powKey [seen 0 0, seen 1 0],
    action 5 5 5 Rule.absKey [seen 0 0],
    action 6 6 6 Rule.minKey [seen 0 0, seen 0 0],
    action 7 7 7 Rule.maxKey [seen 0 0, seen 0 0],
-   action 8 8 8 Rule.constantKey [],
-   action 9 9 9 Rule.invKey [seen 0 0],
-   action 10 10 10 Rule.divKey [seen 0 0, seen 0 0],
-   action 11 11 11 Rule.regularizeKey [seen 0 0]]
+   action 8 8 8 Rule.invKey [seen 0 0],
+   action 9 9 9 Rule.divKey [seen 0 0, seen 0 0],
+   action 10 10 10 Rule.regularizeKey [seen 0 0]]
+
+def actionTags : Array Nat := #[1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12]
 
 private def run
     (state : Hex.Interval.Runtime.State Hex.Interval Rule.Runtime.Cause) :
@@ -146,14 +148,15 @@ private def run
 
 def run? := runtime?.bind fun state => run state actions
 
+
 private def exactFact (index : Nat)
     (transition : Hex.Interval.Runtime.Applied Hex.Interval Rule.Runtime.Cause) : Bool :=
   match transition.events[0]? with
   | some (Hex.Interval.Runtime.Event.fact step) =>
-      step.action == actions[index]? && step.update.node.index == index + 1 &&
-        step.update.previous == seen (index + 1) 0 && step.update.version == 1 &&
+      step.action == actions[index]? && step.update.node.index == index + 2 &&
+        step.update.previous == seen (index + 2) 0 && step.update.version == 1 &&
         step.proposed == step.update.fact && step.quote.role == .fact &&
-        step.quote.schema == 1 && step.quote.body == [index + 1] &&
+        step.quote.schema == 1 && step.quote.body == [actionTags[index]!] &&
         step.update.cause.rule == step.action.key &&
         step.update.cause.body == step.quote.body
   | _ => false
@@ -163,8 +166,8 @@ private def exactFact (index : Nat)
 #guard branch?.isSome
 #guard runtime?.isSome
 #guard run?.any fun (transitions, state) =>
-  transitions.size == 12 && state.serial == 12 &&
-    (List.range 12).all fun index =>
+  transitions.size == 11 && state.serial == 11 &&
+    (List.range 11).all fun index =>
       transitions[index]?.any (exactFact index)
 
 /-! ## Distinct operand order -/
@@ -199,7 +202,7 @@ def distinctAction (serial application rule node : Nat) (key : RuleKey) : Action
 
 def distinctActions : List Action :=
   [distinctAction 0 0 2 2 Rule.subKey,
-   distinctAction 1 1 10 3 Rule.divKey]
+   distinctAction 1 1 9 3 Rule.divKey]
 
 def distinctRun? := distinctRuntime?.bind fun state => run state distinctActions
 
@@ -222,12 +225,12 @@ private def proposedAt (index : Nat)
 /-! ## Retained quotation without a terminal -/
 
 def searchLimits : Search.Limits :=
-  { maxSteps := 13, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
-    maxDepth := 0, maxScopes := 1, leafFuel := 12 }
+  { maxSteps := 12, maxSplits := 0, maxLeaves := 1, maxFrontier := 1,
+    maxDepth := 0, maxScopes := 1, leafFuel := 11 }
 
 def resultLimits : Search.Result.Limits :=
   { search := searchLimits, runtime := runtimeLimits, maxNodes := 1,
-    maxBodyCells := 12, maxBytes := 65536, maxWork := 65536, maxCode := 16 }
+    maxBodyCells := 11, maxBytes := 65536, maxWork := 65536, maxCode := 16 }
 
 def unitCost : Search.Result.Cost := { bytes := 1, work := 1 }
 
@@ -245,8 +248,8 @@ def measure : Search.Result.Measure Hex.Interval Rule.Runtime.Cause (List Nat) P
 
 def adapterLimits : RuntimeProof.Limits :=
   { result := resultLimits, proof := proofLimits,
-    tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 12, maxWork := 32 },
-    maxTransitions := 12, maxEvents := 12, maxStructuralCells := 512 }
+    tree := { maxNodes := 1, maxDepth := 0, maxBodyCells := 11, maxWork := 32 },
+    maxTransitions := 11, maxEvents := 11, maxStructuralCells := 512 }
 
 private def runTree
     (tree : Search.Result.Tree Hex.Interval Rule.Runtime.Cause (List Nat) Proof.Key)
@@ -279,16 +282,16 @@ def bundle? : Option
   | _, _ => none
 
 #guard treeRun?.any fun (tree, _) =>
-  tree.transitions.size == 12 && tree.pending.length == 1
+  tree.transitions.size == 11 && tree.pending.length == 1
 #guard bundle?.any fun bundle =>
   bundle.recipe.events.size == 1 &&
     bundle.recipe.events[0]?.any fun events =>
-      events.length == 12 && (List.range 12).all fun index =>
+      events.length == 11 && (List.range 11).all fun index =>
         match events[index]? with
         | some (Proof.Event.fact step) =>
             actions[index]?.any fun action =>
               step.schema == Rule.schemaKey action.key &&
-                step.body == [index + 1] && step.proposed == step.installed
+                step.body == [actionTags[index]!] && step.proposed == step.installed
         | _ => false
 
 /-! ## Exact target settlement and semantic replay -/
@@ -298,7 +301,7 @@ def input : Proof.Input Hex.Interval :=
     target := { node := { index := 12 }, fact := point 1 } }
 
 def policyLimits : Policy.Limits :=
-  { maxOffers := 12, maxBytes := 4096, maxPairs := 64, maxWork := 64,
+  { maxOffers := 11, maxBytes := 4096, maxPairs := 64, maxWork := 64,
     maxScore := 0 }
 
 def traceLimits : Trace.Limit :=
@@ -360,6 +363,18 @@ def oneCacheRuntime? : Option
           | _ => false
       | _ => false
   | _, _ => false
+
+-- The same application, resubmitted at the current chronology serial, reaches
+-- the callback and is rejected transactionally when its version-zero update
+-- meets the evolved version-one output.
+#guard runtime?.any fun state =>
+  actions[0]?.any fun first =>
+    match state.stepWithin runtimeLimits first with
+    | .ok (_, next) =>
+        match next.stepWithin runtimeLimits { first with serial := 1 } with
+        | .error (.state (.staleVersion node)) => node == { index := 2 }
+        | _ => false
+    | _ => false
 
 #guard runtime?.any fun state =>
   actions[0]?.any fun first =>
@@ -451,18 +466,18 @@ def extendedConfig : Rule.Config :=
   { config with extraMeanings := #[opaqueMeaning] }
 
 def opaqueNode : Node :=
-  { domain := Rule.realDomain, op := { index := 13 }, args := [{ index := 0 }] }
+  { domain := Rule.realDomain, op := { index := 14 }, args := [{ index := 0 }] }
 
 def extendedProgram : Program :=
   { operations := Rule.operations.push opaqueOp,
     nodes := program.nodes.push opaqueNode }
 
 def extendedStateLimits : State.Limits :=
-  { maxOperations := 14, maxNodes := 14, maxRules := 13,
-    maxRegistryEntries := 72, maxReplayFormats := 13, maxArity := 2,
-    maxScopeNodes := 0, maxApplications := 13, maxQueueEntries := 16,
-    maxActions := 13, maxMatcherVisits := 0, matcherBatchSize := 0,
-    maxAcceptedFacts := 13, maxRetainedSuggestions := 0, maxEffort := 0,
+  { maxOperations := 15, maxNodes := 14, maxRules := 12,
+    maxRegistryEntries := 72, maxReplayFormats := 12, maxArity := 2,
+    maxScopeNodes := 0, maxApplications := 12, maxQueueEntries := 16,
+    maxActions := 12, maxMatcherVisits := 0, matcherBatchSize := 0,
+    maxAcceptedFacts := 12, maxRetainedSuggestions := 0, maxEffort := 0,
     maxObservationValue := 16, maxDiagnosticValue := 16,
     maxOutcomeCandidates := 1, maxOutcomeSuggestions := 0,
     maxProposalItems := 1, maxInstances := 0, maxGeneration := 0,
@@ -471,7 +486,7 @@ def extendedStateLimits : State.Limits :=
 def extendedExecutableLimits : Executable.Limits :=
   { state := extendedStateLimits, maxPackages := 2,
     maxMetadataBytes := 72, maxMetadataWork := 72,
-    maxCacheBytes := 13, maxCacheWork := 13,
+    maxCacheBytes := 12, maxCacheWork := 12,
     maxResultBytes := 1, maxResultWork := 1,
     maxQuotes := 1, maxQuoteCells := 1, maxAtom := 13, maxSchema := 1 }
 
@@ -479,8 +494,8 @@ def extendedRuntimeLimits : Hex.Interval.Runtime.Limits :=
   { executable := extendedExecutableLimits, maxEvents := 1 }
 
 def extendedProofLimits : Proof.Limits :=
-  { maxPackages := 2, maxSchemas := 13, maxBodyCells := 1,
-    maxDependencies := 2, maxChronology := 13 }
+  { maxPackages := 2, maxSchemas := 12, maxBodyCells := 1,
+    maxDependencies := 2, maxChronology := 12 }
 
 def extendedRegistry? : Option (Rule.Runtime.Registry extendedConfig) :=
   (Rule.Runtime.buildWithWithin extendedExecutableLimits extendedProofLimits
@@ -499,8 +514,8 @@ def extendedRuntime? : Option
   | _, _ => none
 
 def opaqueAction : Action :=
-  { serial := 0, programVersion := 0, application := { index := 12 },
-    rule := { index := 12 }, key := opaqueKey, node := { index := 13 },
+  { serial := 0, programVersion := 0, application := { index := 11 },
+    rule := { index := 11 }, key := opaqueKey, node := { index := 13 },
     kind := .forward, effort := 0, inputs := [seen 0 0], writes := [{ index := 13 }] }
 
 #guard extendedProgram.check

--- a/conformance/HexIntervalMathlib/TacticConformance.lean
+++ b/conformance/HexIntervalMathlib/TacticConformance.lean
@@ -68,6 +68,13 @@ theorem dyadicPowers :
     ((1 / 2 : ℝ) ^ 2 + (3 / 4 : ℝ) ^ 3) = 43 / 64 := by
   interval
 
+theorem negativeLiteral : (-3 : ℝ) < 0 := by
+  interval
+
+-- `1 / 3` is not a dyadic literal. It falls through to ordinary division.
+theorem ordinaryThird : (1 / 3 : ℝ) ≤ 1 := by
+  interval
+
 example {x : ℝ} (singleton : x = 1) : x = 1 := by
   interval
 
@@ -234,6 +241,12 @@ info: 'Hex.IntervalMathlib.TacticConformance.ordinary' depends on axioms: [prope
 -/
 #guard_msgs in
 #print axioms ordinary
+
+/--
+info: 'Hex.IntervalMathlib.TacticConformance.dyadicPowers' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms dyadicPowers
 
 /--
 info: 'Hex.IntervalMathlib.TacticConformance.reciprocalSum' depends on axioms: [propext, Classical.choice, Quot.sound]

--- a/conformance/HexIntervalMathlib/TacticConformance.lean
+++ b/conformance/HexIntervalMathlib/TacticConformance.lean
@@ -64,6 +64,10 @@ example : (0 : ℝ) = 0 := by
 example : 0 = (0 : ℝ) := by
   interval
 
+theorem dyadicPowers :
+    ((1 / 2 : ℝ) ^ 2 + (3 / 4 : ℝ) ^ 3) = 43 / 64 := by
+  interval
+
 example {x : ℝ} (singleton : x = 1) : x = 1 := by
   interval
 

--- a/progress/20260824T071651Z.md
+++ b/progress/20260824T071651Z.md
@@ -1,0 +1,35 @@
+# Per-node literal and binary-power production migration
+
+## Accomplished
+
+- Removed configured constant/exponent values and replaced them with
+  value-agnostic dyadic and natural literal operations plus binary natural
+  power over ordered base/exponent edges.
+- Added the natural-domain tag, version-two power identity, exact closed
+  natural-singleton decoding and containment theorem, and the eleven-handler / fourteen-operation
+  Rule, runtime, emitter, frontend, and public-tactic stack.
+- Seeded exact literal singleton facts through checked node-indexed
+  `InitialContext` authority and closed emitted evidence through `closeInitial`.
+- Added exact dyadic quotation/correlation and public support for per-node
+  natural powers, including `(1 / 2)^2 + (3 / 4)^3 = 43 / 64`.
+- Migrated conformance counts, indices, mutations, resource limits, opaque
+  extensions, and controller fixtures. Added a direct repeat invocation at the
+  current chronology serial which reaches transactional fact installation and
+  rejects the stale version-zero update against the evolved version-one node.
+- Updated the HexInterval and HexIntervalMathlib SPEC current-state prose.
+- `lake build` completed successfully (9985 jobs). Focused Rule, Frontend,
+  RuntimeRule, RuntimeEmit, executable-controller, and public-tactic
+  conformance targets are green.
+
+## Current frontier
+
+The production per-node literal/power vertical is complete and validated.
+
+## Next step
+
+Review and merge this isolated migration before adding arbitrary rational
+projection, broader target forms, or new tactic syntax.
+
+## Blockers
+
+None.

--- a/progress/20260824T104649Z.md
+++ b/progress/20260824T104649Z.md
@@ -1,0 +1,37 @@
+# Parameter and initial-context compatibility stack
+
+## Accomplished
+
+- Created a clean compatibility branch from public tactic commit `0321a0907`
+  and stacked the two InitialContext commits before the per-node literal-power
+  migration.
+- Resolved the tactic overlap by retaining traversal-local evaluator-proof
+  memoization while adapting power rows to carry their exact per-node exponent.
+- Routed proof closure through the authenticated mixed `InitialContext`, with
+  exact row/entry quotation and row-by-row containment proofs.
+- Preserved `InitialContext.setFact` as a transactional `Except Error` API.
+  Conformance callers distinguish success from malformed slots explicitly;
+  there is no fallback to an unchanged or default context.
+- Removed the obsolete source-interval quotation array from tactic closure now
+  that the complete initial context supplies runtime facts.
+- Built the frontend, rule, runtime-rule, runtime-emitter,
+  executable-controller, and tactic conformance targets. Ran DAG, published
+  trust-surface, forbidden-term, and whitespace checks successfully.
+
+## Current frontier
+
+The compatibility stack is focused-build green. Literal powers retain their
+own exponent through reification, evaluator-proof memoization, runtime replay,
+and emitted proof construction; source and exact literal facts enter through
+the checked mixed initial context.
+
+## Next step
+
+Cherry-pick the final compatibility commit onto the production integration
+branch and repeat the focused conformance build there.
+
+## Blockers
+
+None. The cherry-pick produced one mechanical tactic conflict, but no semantic
+conflict between transactional initial contexts, per-node parameters, and
+proof memoization.

--- a/progress/20260824T112306Z.md
+++ b/progress/20260824T112306Z.md
@@ -1,0 +1,36 @@
+# Parameter-context review polish
+
+## Accomplished
+
+- Updated the library SPEC to describe per-row dyadic literals and
+  authenticated natural exponent inputs instead of the removed single
+  configured constant/exponent model.
+- Added exact `Rule.closedNat?` conformance for an accepted nonnegative integer
+  singleton and refusal of a non-singleton, a noninteger dyadic singleton, and
+  a negative singleton.
+- Added exact frontend conformance showing endpoint-starved literal seeding
+  refuses with `literalResource` at the literal target node.
+- Added public tactic canaries for a negative dyadic literal and ordinary
+  nondyadic `1 / 3` division fallthrough, plus guarded axiom output for the
+  mixed-exponent `dyadicPowers` theorem.
+- Removed the unused `toRealEqIntCast` and `castEquality` tactic lemmas after a
+  repository-wide use search, and removed the power reifier's depth test that
+  duplicated the successful recursive entry check.
+- Built rule, frontend, and tactic conformance targets and ran DAG, published
+  trust-surface, forbidden-term, and whitespace checks successfully.
+
+## Current frontier
+
+The requested review polish is focused-build green. Transactional initial
+contexts, per-node literal parameters, and evaluator-proof memoization remain
+unchanged apart from the redundant/dead-code removals above.
+
+## Next step
+
+Push the polished stacked head and let the existing PR CI validate the complete
+repository target set.
+
+## Blockers
+
+None. The larger `initialHolds` performance refactor was deliberately left out
+of this pass.


### PR DESCRIPTION
## Summary

- replace configured constant/exponent values with value-agnostic dyadic and natural literal operations plus binary natural power over ordered node edges
- seed exact literal singleton facts through the checked node-indexed `InitialContext` and preserve exact per-node exponents across reification, runtime replay, and emitted proof construction
- retain traversal-local evaluator-proof memoization while adapting the public tactic and controller stack to transactional initial-context writes
- migrate the Rule/runtime/frontend/emitter/tactic conformance surface, including stale-update refusal and `(1 / 2)^2 + (3 / 4)^3 = 43 / 64`

## Dependency

Stacked on #9532. This PR deliberately targets upstream `main`; its diff will shrink to the two literal/power commits when #9532 merges.

## Validation

- `lake build HexIntervalMathlib.TacticConformance HexIntervalMathlib.RuntimeEmitConformance` (8,814 jobs) on the exact stacked head
- dependency DAG check
- published trust surface: 503 Lean files, no axioms, sorries, or native_decide
- diff/whitespace checks