### PR TITLE
Prove multivariate Hensel modulus laws

### DIFF
--- a/HexMvHensel/Modulus.lean
+++ b/HexMvHensel/Modulus.lean
@@ -87,6 +87,65 @@ private theorem modDiff_add {a b c d : Int} {m : Nat}
   exact Int.dvd_add (Int.dvd_of_emod_eq_zero hab)
     (Int.dvd_of_emod_eq_zero hcd)
 
+private theorem modDiff_mul {a b c d : Int} {m : Nat}
+    (hab : (a - b) % (m : Int) = 0)
+    (hcd : (c - d) % (m : Int) = 0) :
+    (a * c - b * d) % (m : Int) = 0 := by
+  apply Int.emod_eq_zero_of_dvd
+  rw [show a * c - b * d = (a - b) * c + b * (c - d) by grind]
+  exact Int.dvd_add
+    (Int.dvd_mul_of_dvd_left (Int.dvd_of_emod_eq_zero hab))
+    (Int.dvd_mul_of_dvd_right (Int.dvd_of_emod_eq_zero hcd))
+
+private theorem foldlModDiff {A : Type} (xs : List A) (f g : A → Int)
+    {a b : Int} {m : Nat} (hab : (a - b) % (m : Int) = 0)
+    (hfg : ∀ x, x ∈ xs → (f x - g x) % (m : Int) = 0) :
+    (xs.foldl (fun acc x => acc + f x) a -
+      xs.foldl (fun acc x => acc + g x) b) % (m : Int) = 0 := by
+  induction xs generalizing a b with
+  | nil => exact hab
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      apply ih (modDiff_add hab (hfg x (List.mem_cons_self ..)))
+      intro y hy
+      exact hfg y (List.mem_cons_of_mem x hy)
+
+private theorem foldlAdd_le {A : Type} (xs : List A) (f g : A → Nat)
+    {a b : Nat} (hab : a ≤ b) (hfg : ∀ x, x ∈ xs → f x ≤ g x) :
+    xs.foldl (fun acc x => acc + f x) a ≤
+      xs.foldl (fun acc x => acc + g x) b := by
+  induction xs generalizing a b with
+  | nil => exact hab
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      apply ih (Nat.add_le_add hab (hfg x (List.mem_cons_self ..)))
+      intro y hy
+      exact hfg y (List.mem_cons_of_mem x hy)
+
+private theorem nonMainDegree_le_parts (i : Fin (n + 1))
+    {a b u : Mono (n + 1)} (hmul : Mono.mul a b = u) :
+    nonMainDegree i a ≤ nonMainDegree i u ∧
+      nonMainDegree i b ≤ nonMainDegree i u := by
+  have hcoord (j : Fin n) :
+      Mono.degreeOf (remainingVar i j) a ≤
+          Mono.degreeOf (remainingVar i j) u ∧
+        Mono.degreeOf (remainingVar i j) b ≤
+          Mono.degreeOf (remainingVar i j) u := by
+    have hget := congrArg
+      (fun x : Mono (n + 1) => x[remainingVar i j]) hmul
+    simp only [Mono.getElem_mul] at hget
+    change a[remainingVar i j] ≤ u[remainingVar i j] ∧
+      b[remainingVar i j] ≤ u[remainingVar i j]
+    constructor <;> omega
+  unfold nonMainDegree
+  constructor
+  · apply foldlAdd_le _ _ _ (Nat.le_refl 0)
+    intro j _
+    exact (hcoord j).1
+  · apply foldlAdd_le _ _ _ (Nat.le_refl 0)
+    intro j _
+    exact (hcoord j).2
+
 private theorem symMod_zero (m : Nat) : Hex.Modular.symMod 0 m = 0 := by
   unfold Hex.Modular.symMod
   split <;> simp_all
@@ -130,7 +189,14 @@ theorem congrAt_mul {i : Fin (n + 1)} {k m : Nat}
     {p p' q q' : MvPoly (n + 1) Int cmp}
     (hp : CongrAt i k m p p') (hq : CongrAt i k m q q') :
     CongrAt i k m (p * q) (p' * q') := by
-  sorry
+  intro u hu
+  rw [MvPoly.coeff_mul, MvPoly.coeff_mul]
+  apply foldlModDiff _ _ _ (by simp)
+  intro ab hab
+  have hparts := nonMainDegree_le_parts i
+    ((Mono.splits_mem_iff u ab.1 ab.2).mp hab)
+  exact modDiff_mul (hp ab.1 (Nat.le_trans hparts.1 hu))
+    (hq ab.2 (Nat.le_trans hparts.2 hu))
 
 theorem congrAt_reduceMod (i : Fin (n + 1)) (k m : Nat)
     (p : MvPoly (n + 1) Int cmp) :
@@ -177,7 +243,25 @@ theorem boxCongr_mul {i : Fin (n + 1)} {d : Fin n → Nat} {m : Nat}
     {p p' q q' : MvPoly (n + 1) Int cmp}
     (hp : BoxCongr i d m p p') (hq : BoxCongr i d m q q') :
     BoxCongr i d m (p * q) (p' * q') := by
-  sorry
+  intro u hu
+  rw [MvPoly.coeff_mul, MvPoly.coeff_mul]
+  apply foldlModDiff _ _ _ (by simp)
+  intro ab hab
+  have hmul := (Mono.splits_mem_iff u ab.1 ab.2).mp hab
+  have hcoord (j : Fin n) :
+      Mono.degreeOf (remainingVar i j) ab.1 ≤
+          Mono.degreeOf (remainingVar i j) u ∧
+        Mono.degreeOf (remainingVar i j) ab.2 ≤
+          Mono.degreeOf (remainingVar i j) u := by
+    have hget := congrArg
+      (fun x : Mono (n + 1) => x[remainingVar i j]) hmul
+    simp only [Mono.getElem_mul] at hget
+    change ab.1[remainingVar i j] ≤ u[remainingVar i j] ∧
+      ab.2[remainingVar i j] ≤ u[remainingVar i j]
+    constructor <;> omega
+  exact modDiff_mul
+    (hp ab.1 (fun j => Nat.le_trans (hcoord j).1 (hu j)))
+    (hq ab.2 (fun j => Nat.le_trans (hcoord j).2 (hu j)))
 
 theorem boxCongr_reduceMod (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
     (p : MvPoly (n + 1) Int cmp) :
@@ -192,7 +276,7 @@ theorem boxCongr_truncate (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
     (p : MvPoly (n + 1) Int cmp) :
     BoxCongr i d m (truncate i d p) p := by
   intro u hu
-  rw [coeff_truncate, if_pos hu, Int.sub_self, Int.zero_emod]
+  rw [coeff_truncate, Hex.ite_eq_left hu, Int.sub_self, Int.zero_emod]
 
 /-- Total-degree congruence through the sum of the side degrees implies box
 congruence.  The converse is false. -/
@@ -200,18 +284,67 @@ theorem boxCongr_of_congrAt (i : Fin (n + 1)) (d : Fin n → Nat) (m : Nat)
     {p q : MvPoly (n + 1) Int cmp}
     (h : CongrAt i ((List.finRange n).foldl (fun s j => s + d j) 0) m p q) :
     BoxCongr i d m p q := by
-  sorry
+  intro u hu
+  apply h u
+  unfold nonMainDegree
+  exact foldlAdd_le _ _ _ (Nat.le_refl 0) (fun j _ => hu j)
 
 /-- Symmetric reduction lands in the exact canonical interval.  Positivity is
 necessary: at modulus zero the interval `(-m/2,m/2]` is empty. -/
 theorem reduceMod_symCanonical (m : Nat) (hm : 0 < m)
     (p : MvPoly (n + 1) Int cmp) :
     SymCanonical m (reduceMod m p) := by
-  sorry
+  intro u
+  unfold reduceMod
+  rw [MvPoly.coeff_mapCoeffs (symMod_zero m)]
+  let x := Hex.Modular.symMod (MvPoly.coeff u p) m
+  have hbound : 2 * x.natAbs ≤ m := Hex.Modular.symMod_le hm
+  have hbound' : ((2 * x.natAbs : Nat) : Int) ≤ (m : Int) :=
+    Int.ofNat_le.mpr hbound
+  have hlower : -(m : Int) < 2 * x := by
+    unfold x Hex.Modular.symMod
+    rw [Hex.ite_eq_right (Nat.ne_of_gt hm)]
+    simp only
+    have hrem : 0 ≤ MvPoly.coeff u p % (m : Int) :=
+      Int.emod_nonneg _ (by omega)
+    split <;> omega
+  constructor
+  · exact hlower
+  by_cases hx : 0 ≤ x
+  · rw [Int.natCast_mul, Int.ofNat_natAbs_of_nonneg hx] at hbound'
+    exact hbound'
+  · omega
+
+private theorem eq_of_symBounds {a b : Int} {m : Nat}
+    (ha : -(m : Int) < 2 * a ∧ 2 * a ≤ (m : Int))
+    (hb : -(m : Int) < 2 * b ∧ 2 * b ≤ (m : Int))
+    (hab : (a - b) % (m : Int) = 0) : a = b := by
+  have hm : 0 < m := by omega
+  have hdvd : (m : Int) ∣ a - b := Int.dvd_of_emod_eq_zero hab
+  have hlt : (a - b).natAbs < m := by
+    by_cases hnonneg : 0 ≤ a - b
+    · rw [← Int.ofNat_lt, Int.ofNat_natAbs_of_nonneg hnonneg]
+      omega
+    · have hnonpos : a - b ≤ 0 := by omega
+      rw [← Int.ofNat_lt, Int.ofNat_natAbs_of_nonpos hnonpos]
+      omega
+  have hzero : a - b = 0 := by
+    apply Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hdvd
+    simpa using hlt
+  omega
 
 /-- Reducing an already symmetric-canonical polynomial changes nothing. -/
 theorem reduceMod_id (m : Nat) (p : MvPoly (n + 1) Int cmp)
     (h : SymCanonical m p) : reduceMod m p = p := by
-  sorry
+  have hm : 0 < m := by
+    have hz := h Mono.zero
+    omega
+  apply MvPoly.ext
+  intro u
+  have hcanonical := reduceMod_symCanonical m hm p u
+  exact eq_of_symBounds hcanonical (h u) (by
+    unfold reduceMod
+    rw [MvPoly.coeff_mapCoeffs (symMod_zero m)]
+    exact symMod_modDiff _ _)
 
 end Hex.MvHensel


### PR DESCRIPTION
## Summary
- prove multiplicative closure of total-degree and box congruence
- derive box congruence from total non-main degree bounds
- prove symmetric reduction canonicality and fixed-point behavior
- remove every placeholder from HexMvHensel.Modulus

## Validation
- lake build HexMvHensel.Modulus HexMvHensel
- python3 scripts/check_file_line_counts.py
- git diff --check