### PR TITLE
Prove Hensel certificate dispatch laws

### DIFF
--- a/HexMvHensel/Cert.lean
+++ b/HexMvHensel/Cert.lean
@@ -128,6 +128,9 @@ def check (inp : Input n cmp cmp') (cert : Cert n cmp) : Bool :=
 /-- The executable checker implies the semantic certificate predicate. -/
 theorem check_sound {inp : Input n cmp cmp'} {cert : Cert n cmp}
     (h : check inp cert = true) : IsLiftOf inp cert.factors := by
-  sorry
+  simp only [check, Bool.and_eq_true, beq_iff_eq, List.all_eq_true,
+    List.mem_range] at h
+  rcases h with ⟨⟨⟨hlen, hproduct⟩, himages⟩, hleading⟩
+  exact ⟨hlen, hproduct, himages, hleading⟩
 
 end Hex.MvHensel

--- a/HexMvHensel/Lift.lean
+++ b/HexMvHensel/Lift.lean
@@ -254,12 +254,36 @@ def liftWith (cfg : Config) (inp : Input n cmp cmp') :
 /-- Every certificate returned by `lift` passes the independent checker. -/
 theorem lift_checks {inp : Input n cmp cmp'} {cert : Cert n cmp}
     (h : lift inp = .ok cert) : check inp cert = true := by
-  sorry
+  unfold lift at h
+  split at h
+  · contradiction
+  · split at h
+    · contradiction
+    · dsimp only at h
+      split at h
+      · cases h
+        assumption
+      · contradiction
 
 /-- Once V1--V6 hold, reconstruction is the only possible failure. -/
 theorem lift_progress {inp : Input n cmp cmp'} (h : valid inp = true) :
     (∃ cert, lift inp = .ok cert) ∨
       (∃ modulus, lift inp = .error (.reconstruct modulus)) := by
-  sorry
+  cases hfailure : failure? inp with
+  | some failure =>
+      simp [valid, hfailure] at h
+  | none =>
+      cases hshift : liftShifted? inp with
+      | none =>
+          exact Or.inr ⟨inp.setup.modulus, by
+            simp [lift, hfailure, hshift]⟩
+      | some shifted =>
+          let cert : Cert n cmp :=
+            { factors := reconstruct inp.setup.main inp.setup.point shifted }
+          by_cases hc : check inp cert = true
+          · exact Or.inl ⟨cert, by
+              simp [lift, hfailure, hshift, cert, hc]⟩
+          · exact Or.inr ⟨inp.setup.modulus, by
+              simp [lift, hfailure, hshift, cert, hc]⟩
 
 end Hex.MvHensel


### PR DESCRIPTION
## Summary

- prove certificate replay soundness for all Hensel certificate constructors
- prove lift-stage checker replay and progress preservation

## Verification

- `lake build HexMvHensel`
- focused Hensel certificate and lift tests