### PR TITLE
fix(release): pin hex-poly-fp for the sparse-poly bench sidecar

### DIFF
--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -331,19 +331,21 @@ def main() -> int:
             for dependency in closure[lib]
             if dependency in repo_by_library
         }
-        # A repo's conformance project may import libraries its published
-        # library does not (declared per entry as `conformance_pins`); the
-        # SPEC of the owning library records why. These are sanctioned
-        # additions to the closure, never replacements.
-        conformance_extra = set(entry.get("conformance_pins", []))
-        undeclared = conformance_extra & expected
-        if undeclared:
-            fail(
-                f"{entry['repo']}: conformance_pins {sorted(undeclared)} are "
-                "already in the library dependency closure; list only the "
-                "conformance-only additions"
-            )
-        expected |= conformance_extra
+        # A repo's conformance or bench sidecar may import libraries its
+        # published library does not (declared per entry as
+        # `conformance_pins` / `bench_pins`); the SPEC of the owning library
+        # records why. These are sanctioned additions to the closure, never
+        # replacements.
+        for field in ("conformance_pins", "bench_pins"):
+            extra = set(entry.get(field, []))
+            undeclared = extra & expected
+            if undeclared:
+                fail(
+                    f"{entry['repo']}: {field} {sorted(undeclared)} are "
+                    "already in the library dependency closure; list only "
+                    "the sidecar-only additions"
+                )
+            expected |= extra
         actual = set(entry["pins"])
         if actual != expected:
             fail(

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -135,21 +135,6 @@ repos:
     pins: [hex-arith]
     lakefile: lean
 
-  - repo: leanprover/hex-sparse-poly
-    component: Sparse univariate polynomials
-    lib: HexSparsePoly
-    test_modules: [HexSparsePoly.KernelTests]
-    umbrella: true
-    spec: hex-sparse-poly
-    bench: true
-    conformance: true
-    conformance_files: [HexSparsePolyFixtures.lean]
-    fixtures: [HexSparsePoly]
-    oracles: [sparsepoly_sympy.py, common.py]
-    pins: [hex-basic, hex-poly, hex-arith, hex-mod-arith]
-    conformance_pins: [hex-arith, hex-mod-arith]
-    lakefile: toml
-
   - repo: leanprover/hex-poly-mathlib
     lib: HexPolyMathlib
     umbrella: true
@@ -159,17 +144,6 @@ repos:
     fixtures: []
     oracles: []
     pins: [hex-poly]
-    lakefile: toml
-
-  - repo: leanprover/hex-sparse-poly-mathlib
-    lib: HexSparsePolyMathlib
-    umbrella: true
-    spec: hex-sparse-poly-mathlib
-    bench: false
-    conformance: true
-    fixtures: []
-    oracles: []
-    pins: [hex-basic, hex-poly, hex-sparse-poly, hex-poly-mathlib]
     lakefile: toml
 
   - repo: leanprover/hex-mv-poly-mathlib
@@ -193,6 +167,33 @@ repos:
     fixtures: [HexPolyFp]
     oracles: [polyfp_flint.py, common.py]
     pins: [hex-arith, hex-poly, hex-mod-arith]
+    lakefile: toml
+
+  - repo: leanprover/hex-sparse-poly
+    component: Sparse univariate polynomials
+    lib: HexSparsePoly
+    test_modules: [HexSparsePoly.KernelTests]
+    umbrella: true
+    spec: hex-sparse-poly
+    bench: true
+    conformance: true
+    conformance_files: [HexSparsePolyFixtures.lean]
+    fixtures: [HexSparsePoly]
+    oracles: [sparsepoly_sympy.py, common.py]
+    pins: [hex-basic, hex-poly, hex-arith, hex-mod-arith, hex-poly-fp]
+    conformance_pins: [hex-arith, hex-mod-arith]
+    bench_pins: [hex-poly-fp]
+    lakefile: toml
+
+  - repo: leanprover/hex-sparse-poly-mathlib
+    lib: HexSparsePolyMathlib
+    umbrella: true
+    spec: hex-sparse-poly-mathlib
+    bench: false
+    conformance: true
+    fixtures: []
+    oracles: []
+    pins: [hex-basic, hex-poly, hex-sparse-poly, hex-poly-mathlib]
     lakefile: toml
 
   - repo: leanprover/hex-poly-z


### PR DESCRIPTION
This PR add the missing `hex-poly-fp` pin to the `leanprover/hex-sparse-poly` manifest entry: the bench driver runs its convert-gcd family over `ZMod64` with field division supplied by `HexPolyFp`, so the released bench sidecar requires it (caught by the post-publish fresh-clone validation, which the monorepo build cannot catch because everything builds together there). The addition is declared through a new `bench_pins` field symmetric to `conformance_pins`, validated by `check_released_manifest.py`, and the sparse-poly pair moves after `hex-poly-fp` to keep the manifest topological.

🤖 Prepared with Claude Code