### PR TITLE
Prove gcd certificate payload soundness

### DIFF
--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -597,7 +597,17 @@ theorem checkGcd_sound {n : Nat} {R : Type u}
     {f h : MvPoly n R cmp} {cert : GcdCert n R cmp}
     (hc : checkGcd f h cert = true) :
     CheckedGcdResult f h cert.gcd cert.cofL cert.cofR := by
-  sorry
+  cases n with
+  | zero =>
+      simp only [checkGcd, checkGcdUsing, Bool.and_eq_true,
+        beq_iff_eq] at hc
+      exact ⟨hc.1.1.1.symm, hc.1.1.2.symm, hc.1.2,
+        checkCoprime_sound hc.2⟩
+  | succ n =>
+      simp only [checkGcd, checkGcdUsing, Bool.and_eq_true,
+        beq_iff_eq] at hc
+      exact ⟨hc.1.1.1.symm, hc.1.1.2.symm, hc.1.2,
+        checkCoprime_sound hc.2⟩
 
 /-- Separate gcd-domain cancellation turns checked coprime cofactors into
 maximality. -/


### PR DESCRIPTION
## Summary
- prove that a successful multivariate gcd certificate check reconstructs both inputs
- prove the checked gcd is normalized and its cofactors are coprime
- remove the core certificate payload soundness sorry

## Testing
- lake build HexMvGcd.Cert HexMvGcd.KernelTests