### PR TITLE
chore(release): withdraw char-poly and hermite from the manifest until their phases complete

### DIFF
--- a/HexAggregateCheck.lean
+++ b/HexAggregateCheck.lean
@@ -38,12 +38,9 @@ public import HexGFq
 public import HexGFqMathlib
 public import HexDeterminant
 public import HexBareiss
-public import HexHermite
-public import HexCharPoly
 public import HexMatrixMathlib
 public import HexRowReduceMathlib
 public import HexDeterminantMathlib
-public import HexCharPolyMathlib
 public import HexBareissMathlib
 public import HexBerlekampMathlib
 public import HexGramSchmidt

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -115,8 +115,6 @@ contracts and, for mature libraries, supply their proofs.
 
 {include 0 HexManual.Chapters.HexBareiss}
 
-{include 0 HexManual.Chapters.HexCharPoly}
-
 {include 0 HexManual.Chapters.HexGramSchmidt}
 
 {include 0 HexManual.Chapters.HexLLL}
@@ -155,6 +153,8 @@ split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexModular}
+
+{include 2 HexManual.Chapters.HexCharPoly}
 
 {include 2 HexManual.Chapters.HexResultant}
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -645,8 +645,6 @@ lean_lib HexReleaseTests where
     `HexBerlekampZassenhaus.FactorTacticTests,
     `HexBerlekampZassenhausMathlib.FactorPolyTests,
     `HexBerlekampZassenhausMathlib.IrreducibilityTests,
-    `HexCharPoly.CharPolyElabTests,
-    `HexCharPolyMathlib.CharPolyElabTests,
     `HexRealRoots.ReplayTest,
     `HexRealRootsMathlib.IsolateRootsTests,
     `HexRealRootsMathlib.IsolateRootsElabTests,
@@ -694,6 +692,16 @@ lean_lib HexFactorizationModules where
 @[default_target]
 lean_lib HexSparsePolyTests where
   globs := #[`HexSparsePolyMathlib.LintTests]
+
+-- HexCharPoly is not yet a published split repository (its released.yml
+-- entries were withdrawn until the phase pipeline completes), so its
+-- verification-only elaborator regressions stay separate from the
+-- release-manifest-backed target above; they rejoin HexReleaseTests (and
+-- the manifest's test_modules) at publication.
+@[default_target]
+lean_lib HexCharPolyTests where
+  globs := #[`HexCharPoly.CharPolyElabTests,
+    `HexCharPolyMathlib.CharPolyElabTests]
 
 -- HexRCF is not yet a published split repository, so its verification-only
 -- modules stay separate from the release-manifest-backed target above.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1078,5 +1078,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "c513d61bc5722221227dd3f126a96b9cc8a178a1",
     "reason": "Combines current main's registrations with Hermite libraries, conformance, fixture, and benchmark targets; none enters hexbz_factor_service or changes its executable dependency graph or build flags."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "cad4aea1536cb1036d865f540132b84e295bdbbd",
+    "reason": "Moves the CharPoly elaborator regressions out of HexReleaseTests into the monorepo-only HexCharPolyTests target on top of the Hermite registrations, while the char-poly and hermite released.yml entries are withdrawn; no factorization module, executable, or build-flag changes."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -66,6 +66,7 @@ UMBRELLA_BUILD_TARGETS = {
     "HexReleaseTests",
     "HexRCFTests",
     "HexSparsePolyTests",
+    "HexCharPolyTests",
     "HexReleaseExamples",
 }
 

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -38,6 +38,7 @@ BUILD_ONLY_LIBS = {
     "HexReleaseTests",
     "HexRCFTests",
     "HexSparsePolyTests",
+    "HexCharPolyTests",
     "HexReleaseExamples",
 }
 EXTERNAL_IMPORT_ROOTS = {"Mathlib", "Verso"}

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -458,31 +458,6 @@ repos:
     pins: [hex-basic, hex-arith, hex-determinant, hex-matrix]
     lakefile: toml
 
-  - repo: leanprover/hex-hermite
-    component: Hermite normal form
-    lib: HexHermite
-    umbrella: true
-    spec: hex-hermite
-    bench: true
-    conformance: true
-    fixtures: [HexHermite]
-    oracles: [matrix_flint.py, common.py]
-    pins: [hex-basic, hex-arith, hex-matrix, hex-row-reduce, hex-determinant]
-    lakefile: toml
-
-  - repo: leanprover/hex-char-poly
-    component: Characteristic polynomials
-    lib: HexCharPoly
-    test_modules: [HexCharPoly.CharPolyElabTests]
-    umbrella: true
-    spec: hex-char-poly
-    bench: true
-    conformance: true
-    fixtures: [HexCharPoly]
-    oracles: [matrix_flint.py, common.py, flint_bench_driver.py, pari_bench_driver.py]
-    pins: [hex-basic, hex-poly, hex-matrix]
-    lakefile: toml
-
   - repo: leanprover/hex-matrix-mathlib
     lib: HexMatrixMathlib
     umbrella: true
@@ -514,18 +489,6 @@ repos:
     fixtures: []
     oracles: []
     pins: [hex-basic, hex-arith, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-matrix]
-    lakefile: toml
-
-  - repo: leanprover/hex-char-poly-mathlib
-    lib: HexCharPolyMathlib
-    test_modules: [HexCharPolyMathlib.CharPolyElabTests]
-    umbrella: true
-    spec: hex-char-poly-mathlib
-    bench: false
-    conformance: false
-    fixtures: []
-    oracles: []
-    pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-determinant, hex-bareiss, hex-char-poly, hex-poly-mathlib, hex-matrix-mathlib, hex-determinant-mathlib]
     lakefile: toml
 
   - repo: leanprover/hex-bareiss-mathlib
@@ -655,5 +618,5 @@ repos:
   - repo: leanprover/hex
     pins_only: true
     readme_template: scripts/release/hex-README.md
-    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-sparse-poly, hex-poly-mathlib, hex-sparse-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, hex-determinant, hex-bareiss, hex-hermite, hex-char-poly, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-char-poly-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
+    pins: [hex-basic, hex-arith, hex-poly, hex-mv-poly, hex-mod-arith, hex-sparse-poly, hex-poly-mathlib, hex-sparse-poly-mathlib, hex-mv-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-poly-fp-mathlib, hex-gfq-ring, hex-hensel, hex-poly-z-mathlib, hex-hensel-mathlib, hex-roots, hex-real-roots, hex-roots-mathlib, hex-real-roots-mathlib, hex-matrix, hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2, hex-gf2-mathlib, hex-gfq, hex-gfq-mathlib, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-berlekamp-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-berlekamp-zassenhaus, hex-lll-mathlib, hex-berlekamp-zassenhaus-mathlib]
     lakefile: toml


### PR DESCRIPTION
This PR withdraw `leanprover/hex-char-poly`, `leanprover/hex-char-poly-mathlib`, and `leanprover/hex-hermite` from `released.yml`: all three entries landed with their implementation merges, but the libraries sit at `done_through: 0` and none of the released repositories has its Lake skeleton, so every full `sync-released.yml` dispatch fails on the first empty clone and blocks the publication pipeline. The aggregate pins and `HexAggregateCheck` imports are trimmed to match, the char-poly manual chapter moves back to the draft section, and the CharPoly elaborator regressions relocate from `HexReleaseTests` into a monorepo-only `HexCharPolyTests` target with the rejoin-at-publication pattern documented in place. The hermite entry was added mid-flight by the Hermite implementation merge and is withdrawn under the same rule. The forward work stays tracked in https://github.com/kim-em/hex-dev/issues/9523.

🤖 Prepared with Claude Code