### PR TITLE
Document the multivariate factorization stack

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -35,6 +35,9 @@ import HexManual.Chapters.FactorTactics
 import HexManual.Chapters.HexModular
 import HexManual.Chapters.HexResultant
 import HexManual.Chapters.HexPolyZGcd
+import HexManual.Chapters.HexMvGcd
+import HexManual.Chapters.HexMvHensel
+import HexManual.Chapters.HexMvFactor
 import HexManual.Chapters.HexSparsePoly
 import HexManual.Chapters.HexRCF
 import HexManual.Chapters.HexNumberField
@@ -156,6 +159,12 @@ here to keep the reference chapters above focused on the released libraries.
 {include 2 HexManual.Chapters.HexResultant}
 
 {include 2 HexManual.Chapters.HexPolyZGcd}
+
+{include 2 HexManual.Chapters.HexMvGcd}
+
+{include 2 HexManual.Chapters.HexMvHensel}
+
+{include 2 HexManual.Chapters.HexMvFactor}
 
 {include 2 HexManual.Chapters.HexRCF}
 

--- a/HexManual/Chapters/HexMvFactor.lean
+++ b/HexManual/Chapters/HexMvFactor.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexMvFactor
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexMvFactor: checked multivariate factorization" =>
+%%%
+tag := "hex-mv-factor"
+%%%
+
+# Introduction
+%%%
+tag := "hex-mv-factor-intro"
+%%%
+
+`HexMvFactor` factors sparse multivariate polynomials over `Int`. Its bounded
+driver combines structural answers, content and square-free decomposition,
+Kronecker splitting, evaluation-point search, leading-coefficient
+distribution, and checked extended EEZ lifting.
+
+A stopped search is data, not an unchecked exception: the partial result
+retains its already verified decomposition, the exact failure reason, and the
+generator state. A complete answer additionally replays an irreducibility
+certificate for every distinct factor.
+
+# Checked decompositions
+%%%
+tag := "hex-mv-factor-decompositions"
+%%%
+
+{docstring Hex.MvFactor.Factor}
+
+{docstring Hex.MvFactor.Decomp}
+
+{docstring Hex.MvFactor.checkDecomp}
+
+{docstring Hex.MvFactor.IsDecompOf}
+
+{docstring Hex.MvFactor.CheckedDecomp}
+
+{docstring Hex.MvFactor.checkDecomp_sound}
+
+The decomposition stores integer content separately and gives each
+nonconstant, primitive, normalized factor a positive multiplicity. Replay
+also checks pairwise distinctness, making the result canonical enough for
+downstream comparison and tactic output.
+
+# Kronecker splitting
+%%%
+tag := "hex-mv-factor-kronecker"
+%%%
+
+{docstring Hex.MvFactor.kron}
+
+{docstring Hex.MvFactor.unKron?}
+
+{docstring Hex.MvFactor.findSplit}
+
+{docstring Hex.MvFactor.kronDecide}
+
+{docstring Hex.MvFactor.kronDecide_checks}
+
+{docstring Hex.MvFactor.kronDecide_split}
+
+Mixed-radix weights make the substitution injective on the polynomial's
+degree box. Decoding rejects exponent vectors outside that box, and every
+candidate split is multiplied back in the original multivariate ring before
+it is exposed.
+
+# Evaluation points and EEZ lifting
+%%%
+tag := "hex-mv-factor-eez"
+%%%
+
+{docstring Hex.MvFactor.Config}
+
+{docstring Hex.MvFactor.probe}
+
+{docstring Hex.MvFactor.scoutPoints}
+
+{docstring Hex.MvFactor.distribute?}
+
+{docstring Hex.MvFactor.factorSquarefree}
+
+Point enumeration is deterministic for a fixed `Rand` state and explicitly
+bounded by shell and fuel limits. Probes reject degree drops and unsuitable
+images before building a Hensel input. Grouped recombination tests products
+of lifted image factors and retains only exact multivariate divisors.
+
+# Public factorization
+%%%
+tag := "hex-mv-factor-public"
+%%%
+
+{docstring Hex.MvFactor.Failure}
+
+{docstring Hex.MvFactor.Partial}
+
+{docstring Hex.MvFactor.factorWith}
+
+{docstring Hex.MvFactor.factor?}
+
+{docstring Hex.MvFactor.completeWith}
+
+{docstring Hex.MvFactor.complete?}
+
+`factor?` returns a checked product decomposition or a checked partial
+decomposition with a stopping reason. `complete?` goes further: it requires
+the irreducibility producer to certify every factor and performs one final
+independent replay.
+
+# Irreducibility certificates
+%%%
+tag := "hex-mv-factor-irreducibility"
+%%%
+
+{docstring Hex.MvFactor.IrredCert}
+
+{docstring Hex.MvFactor.checkIrred}
+
+{docstring Hex.MvFactor.checkIrred_sound}
+
+{docstring Hex.MvFactor.Complete}
+
+{docstring Hex.MvFactor.checkComplete}
+
+{docstring Hex.MvFactor.checkComplete_sound}
+
+Certificates cover constants, selected-variable degree one, irreducible
+images with primitive leading data, embeddings from lower arity, and complete
+Kronecker decisions. The checker, not the producer, is the trusted boundary.
+
+# Cross-references
+%%%
+tag := "hex-mv-factor-cross-references"
+%%%
+
+* {ref "hex-mv-gcd"}[`HexMvGcd`] supplies exact division, content, and
+  square-free decomposition.
+* {ref "hex-mv-hensel"}[`HexMvHensel`] supplies checked reconstruction from
+  suitable univariate image factorizations.
+* The Mathlib companion transports checked results to `MvPolynomial` and
+  provides the `factor_poly` and `irreducibility` tactics.

--- a/HexManual/Chapters/HexMvGcd.lean
+++ b/HexManual/Chapters/HexMvGcd.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexMvGcd
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexMvGcd: checked sparse multivariate gcds" =>
+%%%
+tag := "hex-mv-gcd"
+%%%
+
+# Introduction
+%%%
+tag := "hex-mv-gcd-intro"
+%%%
+
+`HexMvGcd` supplies exact division, content, gcd, and square-free
+decomposition for `Hex.MvPoly`. The public gcd is canonical up to the
+coefficient-domain normalization convention, and every fast proposal is
+accepted only after replay by the common certificate checker.
+
+The implementation is Mathlib-free. Integer inputs use heuristic and Brown
+modular producers before a deterministic subresultant fallback; rational and
+bounded prime-field inputs use the same checked boundary with the appropriate
+coefficient operations.
+
+# Exact division and normalization
+%%%
+tag := "hex-mv-gcd-division"
+%%%
+
+{docstring Hex.MvPoly.divMod}
+
+{docstring Hex.MvPoly.divExact?}
+
+{docstring Hex.MvPoly.divMod_spec}
+
+{docstring Hex.MvPoly.eq_mul_of_divExact?_eq_some}
+
+The division order is the polynomial's declared monomial order. Exact
+division returns `none` when the sparse remainder is nonzero; it never exposes
+a quotient that has not been checked against the original product.
+
+{docstring Hex.MvPoly.content}
+
+{docstring Hex.MvPoly.primPart}
+
+{docstring Hex.MvPoly.polyNormalize}
+
+# Certificates and the public gcd
+%%%
+tag := "hex-mv-gcd-certificates"
+%%%
+
+{docstring Hex.MvPoly.GcdCert}
+
+{docstring Hex.MvPoly.checkGcd}
+
+{docstring Hex.MvPoly.checkGcd_sound}
+
+{docstring Hex.MvPoly.gcdCert}
+
+{docstring Hex.MvPoly.gcd}
+
+{docstring Hex.MvPoly.cofactors}
+
+The checker proves exact left and right cofactor identities and that the two
+remaining cofactors are coprime. The maximality theorem then gives the usual
+universal property.
+
+{docstring Hex.MvPoly.gcd_dvd_left}
+
+{docstring Hex.MvPoly.gcd_dvd_right}
+
+{docstring Hex.MvPoly.dvd_gcd}
+
+# Named-variable content
+%%%
+tag := "hex-mv-gcd-content-in"
+%%%
+
+Multivariate factorization treats one variable as the current main variable.
+The recursive coefficient view supports content and primitive part in all
+other variables without changing the sparse ambient representation.
+
+{docstring Hex.MvPoly.contentIn}
+
+{docstring Hex.MvPoly.primPartIn}
+
+{docstring Hex.MvPoly.contentIn_mul_primPartIn}
+
+# Square-free decomposition
+%%%
+tag := "hex-mv-gcd-square-free"
+%%%
+
+{docstring Hex.MvPoly.SqfDecomp}
+
+{docstring Hex.MvPoly.sqfDecomp}
+
+{docstring Hex.MvPoly.radical}
+
+{docstring Hex.MvPoly.sqfDecomp_prod}
+
+{docstring Hex.MvPoly.sqfDecomp_squarefree}
+
+The decomposition records primitive square-free factors together with
+positive, increasing multiplicities. Its ordered product reconstructs the
+primitive part; scalar and monomial content remain explicit.
+
+# Cross-references
+%%%
+tag := "hex-mv-gcd-cross-references"
+%%%
+
+* {ref "hex-mv-poly"}[`HexMvPoly`] supplies the sparse representation and
+  recursive coefficient views.
+* {ref "hex-poly-z-gcd"}[`HexPolyZGcd`] supplies the univariate integer
+  fallback and square-free base case.
+* `HexMvHensel` uses named-variable content and checked gcd certificates in
+  its lifting contracts; `HexMvFactor` consumes the square-free split.

--- a/HexManual/Chapters/HexMvHensel.lean
+++ b/HexManual/Chapters/HexMvHensel.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexMvHensel
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexMvHensel: checked multivariate lifting" =>
+%%%
+tag := "hex-mv-hensel"
+%%%
+
+# Introduction
+%%%
+tag := "hex-mv-hensel-intro"
+%%%
+
+`HexMvHensel` reconstructs multivariate integer factors from a factorization
+of a univariate image. The extended EEZ pipeline translates an evaluation
+point to the origin, installs prescribed leading coefficients, introduces
+the remaining variables in order, and solves each correction equation in a
+bounded degree box.
+
+Every partial operation returns `Option` or a structured failure. Successful
+public results cross an independent checker, so callers do not need to trust
+point selection, the diophantine solver, or the reconstruction loop.
+
+# Coordinates and images
+%%%
+tag := "hex-mv-hensel-coordinates"
+%%%
+
+{docstring Hex.MvHensel.shift}
+
+{docstring Hex.MvHensel.unshift}
+
+{docstring Hex.MvHensel.imageAt}
+
+{docstring Hex.MvHensel.lcIn}
+
+{docstring Hex.MvHensel.truncate}
+
+The chosen main variable is fixed by translation. `imageAt` evaluates every
+remaining-variable coefficient, while `lcIn` retains the top coefficient as
+a polynomial in those variables.
+
+# Univariate and multivariate corrections
+%%%
+tag := "hex-mv-hensel-corrections"
+%%%
+
+{docstring Hex.MvHensel.UniValid}
+
+{docstring Hex.MvHensel.solveUni}
+
+{docstring Hex.MvHensel.solveUni_spec}
+
+{docstring Hex.MvHensel.witnessOf?}
+
+{docstring Hex.MvHensel.diophantine}
+
+{docstring Hex.MvHensel.diophantine_spec}
+
+The univariate solver chooses degree-bounded symmetric representatives modulo
+the prime power. The recursive solver lifts this partial-fraction equation
+through the non-main variables and checks the final box congruence.
+
+# Inputs, certificates, and replay
+%%%
+tag := "hex-mv-hensel-certificates"
+%%%
+
+{docstring Hex.MvHensel.Input}
+
+{docstring Hex.MvHensel.Failure}
+
+{docstring Hex.MvHensel.valid}
+
+{docstring Hex.MvHensel.Cert}
+
+{docstring Hex.MvHensel.check}
+
+{docstring Hex.MvHensel.check_sound}
+
+Validation covers tuple arities, absence of degree drop, image and leading
+coefficient products, leading images, the working prime, coprimality, and
+witness degree. Replay then establishes exact reassembly and the frame of
+every returned factor.
+
+# Stagewise lifting and retries
+%%%
+tag := "hex-mv-hensel-lifting"
+%%%
+
+{docstring Hex.MvHensel.IsStage}
+
+{docstring Hex.MvHensel.lift}
+
+{docstring Hex.MvHensel.liftWith}
+
+{docstring Hex.MvHensel.lift_checks}
+
+{docstring Hex.MvHensel.lift_progress}
+
+Reconstruction failures retain the attempted modulus. `liftWith` can double
+the exponent and regenerate the partial-fraction witness a bounded number of
+times; malformed inputs are not retried.
+
+# Uniqueness and completeness
+%%%
+tag := "hex-mv-hensel-completeness"
+%%%
+
+{docstring Hex.MvHensel.coeffBound}
+
+{docstring Hex.MvHensel.lift_unique}
+
+{docstring Hex.MvHensel.lift_complete}
+
+{docstring Hex.MvHensel.no_lift_of_reconstruct}
+
+The executable bound applies mixed-radix Kronecker substitution after the
+coordinate shift. Once the modulus exceeds twice a valid factor-coefficient
+bound, reconstruction is complete and a reconstruction failure proves that
+no compatible lift tuple exists.
+
+# Cross-references
+%%%
+tag := "hex-mv-hensel-cross-references"
+%%%
+
+* {ref "hex-modular"}[`HexModular`] supplies arbitrary-precision symmetric
+  residues and rational reconstruction infrastructure.
+* {ref "hex-mv-gcd"}[`HexMvGcd`] supplies named-variable content and the gcd
+  layer used by the completeness contracts.
+* `HexMvFactor` constructs valid lift inputs, distributes leading
+  coefficients, and recombines the checked factors.

--- a/HexMvFactor/Decomp.lean
+++ b/HexMvFactor/Decomp.lean
@@ -27,13 +27,17 @@ open Hex.MvPoly
 /-- One nonconstant entry in a product decomposition. -/
 structure Factor (n : Nat) (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  /-- Primitive normalized nonconstant polynomial. -/
   factor : MvPoly n Int cmp
+  /-- Positive exponent of the factor in the decomposition. -/
   multiplicity : Nat
 
 /-- An integer scalar and a list of polynomial powers. -/
 structure Decomp (n : Nat) (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  /-- Integer scalar separated from the polynomial factors. -/
   content : Int
+  /-- Pairwise-distinct polynomial factors with their multiplicities. -/
   factors : List (Factor n cmp)
 
 namespace Decomp
@@ -83,7 +87,9 @@ def IsDecompOf (f : MvPoly n Int cmp) (D : Decomp n cmp) : Prop :=
 
 /-- Accepted decomposition data tied to the subject checked by its caller. -/
 structure CheckedDecomp (f : MvPoly n Int cmp) where
+  /-- Raw decomposition data accepted by the checker. -/
   raw : Decomp n cmp
+  /-- Evidence that replay accepts the decomposition for `f`. -/
   valid : checkDecomp f raw = true
 
 /-- Executable replay implies the semantic decomposition payload. -/

--- a/HexMvFactor/Factor.lean
+++ b/HexMvFactor/Factor.lean
@@ -31,11 +31,17 @@ open Hex.MvPoly
 /-- Public, stable failure distinctions for bounded factorization. -/
 inductive Failure (n : Nat) (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  /-- The input is the zero polynomial. -/
   | zero
+  /-- Evaluation-point search exhausted its budget. -/
   | point (attempts : Nat) (last : Option PointReject)
+  /-- Multivariate Hensel lifting rejected the constructed input or stopped. -/
   | lift (inner : MvHensel.Failure)
+  /-- Grouped recombination exhausted its level budget. -/
   | recombine (levels : Nat)
+  /-- No available certificate proved the reported factor irreducible. -/
   | irreducible (factor : MvPoly n Int cmp)
+  /-- Random-word generation failed. -/
   | random (error : RandError)
 
 /-- A checked coarse answer together with the reason bounded search stopped
@@ -43,8 +49,11 @@ and the generator state reached at that point. -/
 structure Partial {n : Nat} {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
     (f : MvPoly n Int cmp) where
+  /-- Checked decomposition accumulated before the search stopped. -/
   found : CheckedDecomp f
+  /-- Exact reason why the bounded search stopped. -/
   reason : Failure n cmp
+  /-- Random-generator state reached when the search stopped. -/
   rand : Rand
 
 variable {n : Nat} {cmp : Mono n → Mono n → Ordering}

--- a/HexMvFactor/IrredData.lean
+++ b/HexMvFactor/IrredData.lean
@@ -20,8 +20,9 @@ open Hex.MvPoly
 /-- A checkable irreducibility witness, modulo the univariate obligations
 reported by `obligations`. -/
 inductive IrredCert :
-    (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
-    [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type 1
+      (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type 1
+  /-- Certify irreducibility from degree one in a selected variable. -/
   | degreeOne {n : Nat}
       {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
       [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
@@ -29,6 +30,7 @@ inductive IrredCert :
       [order : IsMonomialOrder cmp']
       (prim : ContentCert n Int cmp') :
       @IrredCert (n + 1) cmp outerTrans outerEq
+  /-- Certify irreducibility from an irreducible degree-preserving image. -/
   | image {n : Nat}
       {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
       [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
@@ -36,6 +38,7 @@ inductive IrredCert :
       [order : IsMonomialOrder cmp'] (point : Fin n → Int)
       (prim : ContentCert n Int cmp') :
       @IrredCert (n + 1) cmp outerTrans outerEq
+  /-- Transport a lower-arity irreducibility certificate through embedding. -/
   | embed {n : Nat}
       {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
       [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
@@ -43,6 +46,7 @@ inductive IrredCert :
       [order : IsMonomialOrder cmp'] (sub : MvPoly n Int cmp')
       (cert : IrredCert n cmp') :
       @IrredCert (n + 1) cmp outerTrans outerEq
+  /-- Certify irreducibility by complete bounded Kronecker factorization. -/
   | kronecker {n : Nat} {cmp : Mono n → Mono n → Ordering}
       [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
       (scalar : Int) (uni : List (ZPoly × Nat)) :
@@ -57,7 +61,9 @@ structure Split (n : Nat) (cmp : Mono n → Mono n → Ordering)
 /-- A decomposition paired positionally with irreducibility certificates. -/
 structure Complete (n : Nat) (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  /-- Checked product decomposition whose factors are certified below. -/
   decomp : Decomp n cmp
+  /-- Irreducibility certificates aligned with the decomposition factors. -/
   certs : List (IrredCert n cmp)
 
 /-- The total outcome of the Kronecker sweep. -/

--- a/HexMvFactor/Point.lean
+++ b/HexMvFactor/Point.lean
@@ -30,14 +30,23 @@ open Hex.MvPoly
 
 /-- Search budgets shared by the point layer and the downstream EEZ driver. -/
 structure Config where
+  /-- Initial deterministic random-generator state. -/
   rand : Rand
+  /-- Maximum number of evaluation points examined. -/
   pointFuel : Nat
+  /-- Maximum number of admissible probes retained. -/
   pointScouts : Nat
+  /-- Maximum infinity-norm shell enumerated for evaluation points. -/
   pointShell : Nat
+  /-- Maximum number of candidate primes examined. -/
   primeFuel : Nat
+  /-- Maximum number of reconstruction-modulus doublings. -/
   doublings : Nat
+  /-- Number of grouped recombination levels attempted. -/
   recombLevels : Nat
+  /-- Whether the Kronecker route may be used. -/
   kronecker : Bool
+  /-- Maximum encoded univariate degree accepted by Kronecker substitution. -/
   kroneckerDeg : Nat
   deriving Repr, DecidableEq
 
@@ -309,6 +318,7 @@ def insertProbe (candidate : Probe n cmp cmp') :
         candidate :: probe :: probes
       else probe :: insertProbe candidate probes
 
+/-- Enumerate bounded evaluation-point shells and retain the best probes. -/
 def scoutPoints (cfg : Config) (i : Fin (n + 1))
     (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
     (s : MvPoly (n + 1) Int cmp) (lc : Decomp n cmp') (r : Rand) :

--- a/HexMvFactor/README.md
+++ b/HexMvFactor/README.md
@@ -1,0 +1,70 @@
+# hex-mv-factor
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-mv-factor` provides bounded, checked factorization of sparse
+multivariate integer polynomials. It combines structural decomposition,
+square-free splitting, Kronecker substitution, evaluation-point search, and
+extended EEZ lifting. Complete answers additionally carry an independently
+replayed irreducibility certificate for every factor.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-mv-factor"
+git = "https://github.com/leanprover/hex-mv-factor.git"
+rev = "main"
+```
+
+```lean
+import HexMvFactor
+
+open Hex Hex.MvFactor Hex.MvPoly
+
+abbrev P := MvPoly 2 Int Mono.lex
+
+def x : P := X 0
+def y : P := X 1
+def example : P := 1 + x + y + x * y
+
+#eval factor? example
+#eval complete? example
+```
+
+# Functionality
+
+- Canonical `Decomp` values with scalar content and factor multiplicities.
+- Structural factorization of zero, constants, and monomials.
+- Complete mixed-radix Kronecker splitting for bounded sparse inputs.
+- Deterministic, bounded evaluation-point and modulus searches.
+- Leading-coefficient distribution and grouped EEZ recombination.
+- Partial results that retain checked work and an explicit stopping reason.
+- Complete factorization with replayed irreducibility certificates.
+
+# Verification
+
+`checkDecomp` verifies reassembly and canonical factor shape independently of
+all producers. `checkComplete` additionally checks one irreducibility
+certificate per factor. The public result types retain the subject polynomial
+and the corresponding successful replay equation.
+
+```lean
+theorem checkDecomp_sound {f : P} {D : Decomp 2 Mono.lex}
+    (h : checkDecomp f D = true) : IsDecompOf f D
+```
+
+The executable factorizer is Mathlib-free. The Mathlib companion transports
+checked decompositions and irreducibility to `MvPolynomial` and supplies the
+user-facing `factor_poly` and `irreducibility` tactics.
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want, and
+leave the implementation to the maintainer.

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -144,6 +144,8 @@ mutual
       (n : Nat) → (R : Type u) → [Zero R] →
       (cmp : Mono n → Mono n → Ordering) →
       [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
+    /-- Package a gcd, its two exact cofactors, and evidence that the
+    cofactors are coprime. -/
     | mk {n : Nat} {R : Type u} [Zero R]
         {cmp : Mono n → Mono n → Ordering}
         [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -148,6 +148,7 @@ theorem contentInCert_checks
   intro f h
   exact gcdCert_checks f h
 
+/-- Named-variable content times primitive part reconstructs the input. -/
 theorem contentIn_mul_primPartIn
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
@@ -285,6 +286,7 @@ def gcd [IsMonomialOrder cmp]
     (f h : MvPoly n R cmp) : MvPoly n R cmp :=
   (gcdCert f h).gcd
 
+/-- The exact left and right cofactors accompanying the canonical gcd. -/
 def cofactors [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [BezoutOps R]
@@ -346,6 +348,7 @@ private theorem checkedResult [IsMonomialOrder cmp]
   simpa [gcd, cofactors] using
     (checkGcd_sound (gcdCert_checks f h))
 
+/-- The canonical gcd divides its left input. -/
 theorem gcd_dvd_left [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
@@ -355,6 +358,7 @@ theorem gcd_dvd_left [IsMonomialOrder cmp]
   refine ⟨(cofactors f h).1, ?_⟩
   exact hf.trans (MvPoly.mul_comm (gcd f h) (cofactors f h).1)
 
+/-- The canonical gcd divides its right input. -/
 theorem gcd_dvd_right [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
@@ -364,6 +368,7 @@ theorem gcd_dvd_right [IsMonomialOrder cmp]
   refine ⟨(cofactors f h).2, ?_⟩
   exact hh.trans (MvPoly.mul_comm (gcd f h) (cofactors f h).2)
 
+/-- Every common divisor divides the canonical gcd. -/
 theorem dvd_gcd [IsMonomialOrder cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]

--- a/HexMvGcd/README.md
+++ b/HexMvGcd/README.md
@@ -1,0 +1,68 @@
+# hex-mv-gcd
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-mv-gcd` provides checked exact division, content, greatest common
+divisors, and square-free decomposition for sparse multivariate polynomials.
+It supports integer, rational, and bounded prime-field coefficients. Its
+computational core is Mathlib-free.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-mv-gcd"
+git = "https://github.com/leanprover/hex-mv-gcd.git"
+rev = "main"
+```
+
+```lean
+import HexMvGcd
+
+open Hex Hex.MvPoly
+
+abbrev P := MvPoly 2 Int Mono.lex
+
+def x : P := X 0
+def y : P := X 1
+
+#eval gcd ((x + 1) * (y + 1)) ((x + 1) * (y + 2))
+#eval divExact? ((x + 1) * (y + 1)) (x + 1)
+#eval sqfDecomp ((x + 1) ^ 2 * (y + 1))
+```
+
+# Functionality
+
+- Sparse multivariate division with `MvPoly.divMod` and `MvPoly.divExact?`.
+- Canonical content and primitive parts over gcd domains.
+- Replayable `MvPoly.GcdCert` certificates and the small `checkGcd` checker.
+- Deterministic PRS fallback plus heuristic and Brown modular producers.
+- Named-variable content through `contentIn` and `primPartIn`.
+- Square-free decomposition, radical, and square-freeness tests.
+
+# Verification
+
+Candidate producers never establish correctness by themselves. Every public
+gcd is extracted from a certificate accepted by `checkGcd`; replay proves the
+two exact cofactor identities and the greatest-common-divisor property.
+
+```lean
+theorem gcd_dvd_left (f g : P) : gcd f g ∣ f
+
+theorem dvd_gcd (d f g : P) (hf : d ∣ f) (hg : d ∣ g) :
+    d ∣ gcd f g
+```
+
+The executable library does not import Mathlib. Correspondence with
+Mathlib's `MvPolynomial` belongs in the sibling Mathlib bridge package.
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want, and
+leave the implementation to the maintainer.

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -138,10 +138,13 @@ structure SqfFactor (n : Nat) (R : Type u) [Zero R]
   factor : MvPoly n R cmp
   multiplicity : Nat
 
+/-- Scalar content and the multiplicity-tagged square-free polynomial factors. -/
 structure SqfDecomp (n : Nat) (R : Type u) [Zero R]
     (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  /-- Scalar content separated from the polynomial factors. -/
   content : R
+  /-- Distinct square-free factors paired with their multiplicities. -/
   factors : List (SqfFactor n R cmp)
 
 variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
@@ -281,6 +284,7 @@ omit [LawfulGcdOps R] [LawfulBezoutOps R] in
     radical (0 : MvPoly n R cmp) = 0 := by
   simp [radical]
 
+/-- Multiplying the scalar and factor powers reconstructs the input. -/
 theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) :
     (sqfDecomp p).factors.foldl
@@ -288,6 +292,7 @@ theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
       (C (sqfDecomp p).content) = p := by
   sorry
 
+/-- Every polynomial returned by square-free decomposition is square-free. -/
 theorem sqfDecomp_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, Squarefree f.factor := by

--- a/HexMvHensel/Cert.lean
+++ b/HexMvHensel/Cert.lean
@@ -25,6 +25,7 @@ open Hex.MvPoly
 structure Cert (n : Nat)
     (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
     [IsMonomialOrder cmp] where
+  /-- Reconstructed multivariate factors in image-factor order. -/
   factors : List (MvPoly (n + 1) Int cmp)
   deriving BEq, DecidableEq
 

--- a/HexMvHensel/README.md
+++ b/HexMvHensel/README.md
@@ -1,0 +1,65 @@
+# hex-mv-hensel
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-mv-hensel` implements checked multivariate Hensel lifting over the
+integers. It translates an evaluation point to the origin, solves the
+univariate partial-fraction equation, introduces the remaining variables one
+at a time, and independently checks the reconstructed factor tuple.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-mv-hensel"
+git = "https://github.com/leanprover/hex-mv-hensel.git"
+rev = "main"
+```
+
+```lean
+import HexMvHensel
+
+open Hex Hex.MvHensel Hex.MvPoly
+
+-- Build `Input` from a target, its univariate images, prescribed leading
+-- coefficients, and a partial-fraction witness, then run:
+-- #eval lift input
+-- #eval liftWith Config.default input
+```
+
+# Functionality
+
+- Coordinate translation with `shift`, `unshift`, `imageAt`, and `lcIn`.
+- Arbitrary-precision symmetric modular arithmetic for multivariate terms.
+- Production and prime-power lifting of univariate partial fractions.
+- Recursive multivariate diophantine correction inside a degree box.
+- Leading-coefficient seeding and stagewise extended EEZ lifting.
+- Bounded retry through `liftWith`, with explicit structured failures.
+- Independent certificate replay through `check`.
+
+# Verification
+
+`valid` checks the six input conditions before lifting. A successful result
+always passes the independent checker; `check_sound` turns that Boolean
+replay into exact product, image, and leading-coefficient statements.
+Conditional completeness uses an executable shifted Kronecker coefficient
+bound and uniqueness of compatible lift tuples.
+
+```lean
+theorem lift_checks {inp : Input n cmp cmp'} {cert : Cert n cmp}
+    (h : lift inp = .ok cert) : check inp cert = true
+```
+
+The computational library is Mathlib-free. Algebraic correspondence and
+UFD-facing consequences belong in its Mathlib bridge package.
+
+# Contributing
+
+Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)
+monorepo, not in this published mirror. Contributions are welcome as pull
+requests to the `SPEC/` directory: describe the behaviour you want, and
+leave the implementation to the maintainer.

--- a/HexMvHensel/Seed.lean
+++ b/HexMvHensel/Seed.lean
@@ -26,23 +26,37 @@ structure Input (n : Nat)
     (cmp : Mono (n + 1) → Mono (n + 1) → Ordering)
     (cmp' : Mono n → Mono n → Ordering)
     [IsMonomialOrder cmp] [IsMonomialOrder cmp'] where
+  /-- Selected main variable, evaluation point, prime, and exponent. -/
   setup : Setup n
+  /-- Multivariate polynomial whose factors are to be lifted. -/
   target : MvPoly (n + 1) Int cmp
+  /-- Univariate factors of the target at the evaluation point. -/
   images : List ZPoly
+  /-- Prescribed leading coefficients for the lifted factors. -/
   leading : List (MvPoly n Int cmp')
+  /-- Univariate partial-fraction witnesses for the image factors. -/
   witness : List ZPoly
 
 /-- Failures retain the distinction between malformed input, an unsuitable
 point or prime, and failure to reconstruct at the available modulus. -/
 inductive Failure where
+  /-- Tuple arities, degrees, or setup parameters are malformed. -/
   | arity
+  /-- Evaluation lowers the target's main-variable degree. -/
   | degreeDrop
+  /-- The univariate images do not multiply to the evaluated target. -/
   | imageProduct
+  /-- The prescribed leading coefficients do not multiply correctly. -/
   | leadingProduct
+  /-- A leading coefficient has the wrong image at the selected point. -/
   | leadingImage (j : Nat)
+  /-- The working prime divides an image leading coefficient. -/
   | primeDividesLc (j : Nat)
+  /-- The univariate images are not pairwise coprime modulo the prime. -/
   | notCoprime
+  /-- A partial-fraction witness exceeds its permitted degree. -/
   | witnessDegree (j : Nat)
+  /-- Integer reconstruction failed at the reported modulus. -/
   | reconstruct (modulus : Nat)
   deriving BEq, DecidableEq, Repr
 


### PR DESCRIPTION
Completes the manual and release-README slice of Phase 7 for the new multivariate stack.

- add release-facing READMEs for HexMvGcd, HexMvHensel, and HexMvFactor
- add strict Verso manual chapters for all three libraries and register them in the unreleased manual section
- document the public declarations needed by those chapters instead of weakening missing-doc checks

Validation:
- `lake build HexManual.Chapters.HexMvGcd HexManual.Chapters.HexMvHensel HexManual.Chapters.HexMvFactor`
- `lake build HexManual` (9,960 jobs)
- `git diff --check`