### PR TITLE
Connect Kronecker verdict soundness

### DIFF
--- a/HexMvFactor/Irred.lean
+++ b/HexMvFactor/Irred.lean
@@ -192,7 +192,15 @@ theorem kronDecide_irreducible {n : Nat}
     (h : kronDecide g = .irreducible cert)
     (ho : ∀ F ∈ obligations g cert, MvHensel.Irred F) :
     MvHensel.Irred g := by
-  sorry
+  rcases kronDecide_checks hprim hnonconst h with
+    ⟨scalar, uni, hcert, hcheck⟩
+  cases hcert
+  refine checkIrred_sound (cert := .kronecker scalar uni) ?_ ?_
+  · have heq : checkIrred g (.kronecker scalar uni) =
+        checkKronecker g scalar uni := by
+        cases n <;> rfl
+    exact heq.trans hcheck
+  · exact ho
 
 /-- Reducible verdicts retain the exact divisor found by the sweep. -/
 theorem kronDecide_reducible {n : Nat}


### PR DESCRIPTION
Eliminates the remaining verdict-dispatch `sorry` in `HexMvFactor.Irred` by projecting the established `kronDecide` irreducibility and reducible-split soundness theorems in the corresponding branches.

Validation:
- `lake build HexMvFactor`
- all factor tests build; the separate clean-build kernel replay repair is #9563
- `git diff origin/main...HEAD --check`