### PR TITLE
Prove structural factor decompositions

### DIFF
--- a/HexMvFactor/Decomp.lean
+++ b/HexMvFactor/Decomp.lean
@@ -111,6 +111,43 @@ monomial content still needs a residual factorization and is handled by the
 driver rather than hidden behind a partial division here.
 -/
 
+/-- Each nonzero variable power is a canonical decomposition entry. -/
+private theorem checkFactor_X (i : Fin n) {e : Nat} (he : e ≠ 0) :
+    checkFactor (⟨X i, e⟩ : Factor n cmp) = true := by
+  have hvars : (X i : MvPoly n Int cmp).vars ≠ [] := by
+    intro hnil
+    have hi : i ∈ (X i : MvPoly n Int cmp).vars := by
+      rw [mem_vars_iff]
+      change degreeOf i
+        (monomial (Mono.unit i) (1 : Int) : MvPoly n Int cmp) ≠ 0
+      rw [degreeOf_monomial]
+      rw [ite_eq_right (by decide)]
+      rw [Mono.getElem_unit]
+      simp
+    rw [hnil] at hi
+    contradiction
+  have hlead : (X i : MvPoly n Int cmp).leadingTerm =
+      some (Mono.unit i, 1) := by
+    exact leadingTerm_monomial (by decide)
+  have hnorm : polyNormalize (X i : MvPoly n Int cmp) = X i := by
+    rw [polyNormalize, polyNormUnit, hlead]
+    change X i * (1 : MvPoly n Int cmp) = X i
+    exact MvPoly.mul_one _
+  have hcontent : content (X i : MvPoly n Int cmp) = 1 := by
+    unfold content scalarContent
+    change ((match
+      (monomial (Mono.unit i) (1 : Int) : MvPoly n Int cmp).termsList with
+      | [] => (0 : Int)
+      | (_, c) :: terms =>
+          normalize (terms.foldl (fun g term => GcdOps.gcd g term.2) c)) :
+        Int) = (1 : Int)
+    rw [termsList_monomial]
+    simp [normalize]
+    rfl
+  simp only [checkFactor, Bool.and_eq_true, decide_eq_true_eq,
+    beq_iff_eq]
+  exact ⟨⟨⟨Nat.pos_iff_ne_zero.mpr he, hvars⟩, hnorm⟩, hcontent⟩
+
 /-- The variable factors of a monomial, in increasing variable order. -/
 def monomialFactors (m : Mono n) : List (Factor n cmp) :=
   (List.finRange n).filterMap fun i =>
@@ -120,6 +157,152 @@ def monomialFactors (m : Mono n) : List (Factor n cmp) :=
 /-- Canonical decomposition of one coefficient-monomial pair. -/
 def monomialDecomp (coefficient : Int) (m : Mono n) : Decomp n cmp :=
   ⟨coefficient, monomialFactors m⟩
+
+/-- Filtering zero exponents does not change the variable-power product. -/
+private theorem fold_monomialFactors (m : Mono n)
+    (initial : MvPoly n Int cmp) :
+    (monomialFactors m).foldl
+        (fun acc entry => acc * entry.factor ^ entry.multiplicity) initial =
+      (List.finRange n).foldl
+        (fun acc i => acc * X i ^ m[i]) initial := by
+  unfold monomialFactors
+  generalize hxs : List.finRange n = xs
+  clear hxs
+  induction xs generalizing initial with
+  | nil => rfl
+  | cons i xs ih =>
+      simp only [List.filterMap_cons, List.foldl_cons]
+      by_cases he : Mono.degreeOf i m = 0
+      ·
+        simp only [ite_eq_left he]
+        rw [show m[i] = 0 from he]
+        rw [Lean.Grind.Semiring.pow_zero, MvPoly.mul_one]
+        exact ih initial
+      ·
+        simp only [ite_eq_right he, List.foldl_cons]
+        exact ih (initial * X i ^ m[i])
+
+/-- A fold of variable powers is the corresponding monomial polynomial. -/
+private theorem fold_variablePowers (m : Mono n) :
+    ∀ (xs : List (Fin n)) (a : Mono n) (c : Int),
+      xs.foldl (fun acc i => acc * X i ^ m[i])
+          (monomial a c : MvPoly n Int cmp) =
+        (monomial
+          (xs.foldl
+            (fun acc i => Mono.mul acc (Mono.scale m[i] (Mono.unit i))) a)
+          c : MvPoly n Int cmp)
+  | [], _, _ => rfl
+  | i :: xs, a, c => by
+      simp only [List.foldl_cons]
+      have hpower : (X i : MvPoly n Int cmp) ^ m[i] =
+          monomial (Mono.scale m[i] (Mono.unit i)) 1 := by
+        rw [← Mono.powBySq_eq_pow, X, powBySq_monomial,
+          Mono.powBySq_eq_pow]
+        rw [Lean.Grind.Semiring.one_pow]
+      rw [hpower, monomial_mul_monomial]
+      simpa using fold_variablePowers m xs
+        (Mono.mul a (Mono.scale m[i] (Mono.unit i))) c
+
+/-- The canonical monomial decomposition reconstructs its one-term input. -/
+private theorem monomialDecomp_product (coefficient : Int) (m : Mono n) :
+    (monomialDecomp (cmp := cmp) coefficient m).product =
+      monomial m coefficient := by
+  unfold Decomp.product monomialDecomp
+  change (monomialFactors m).foldl
+      (fun acc entry => acc * entry.factor ^ entry.multiplicity)
+      (C coefficient : MvPoly n Int cmp) =
+    (monomial m coefficient : MvPoly n Int cmp)
+  rw [fold_monomialFactors]
+  change (List.finRange n).foldl (fun acc i => acc * X i ^ m[i])
+      (monomial Mono.zero coefficient) = monomial m coefficient
+  rw [fold_variablePowers (cmp := cmp), Mono.mul_units]
+
+/-- Every emitted variable power satisfies the local factor checker. -/
+private theorem monomialFactors_all (m : Mono n) :
+    (monomialFactors (cmp := cmp) m).all checkFactor = true := by
+  rw [List.all_eq_true]
+  intro entry hentry
+  unfold monomialFactors at hentry
+  rcases List.mem_filterMap.mp hentry with ⟨i, _, hi⟩
+  dsimp only at hi
+  by_cases he : Mono.degreeOf i m = 0
+  · rw [ite_eq_left he] at hi
+    contradiction
+  · rw [ite_eq_right he] at hi
+    simp only [Option.some.injEq] at hi
+    subst entry
+    exact checkFactor_X i he
+
+/-- Distinct variables denote distinct one-term polynomials. -/
+private theorem X_injective : Function.Injective
+    (fun i : Fin n => (X i : MvPoly n Int cmp)) := by
+  intro i j h
+  change (monomial (Mono.unit i) 1 : MvPoly n Int cmp) =
+    monomial (Mono.unit j) 1 at h
+  have hterms := congrArg MvPoly.termsList h
+  rw [termsList_monomial, termsList_monomial] at hterms
+  have hunit : Mono.unit i = Mono.unit j := by
+    simpa using hterms
+  by_cases hij : i = j
+  · exact hij
+  · have hget := congrArg (fun m : Mono n => m[i]) hunit
+    rw [Mono.getElem_unit, Mono.getElem_unit] at hget
+    rw [ite_eq_left rfl, ite_eq_right hij] at hget
+    omega
+
+/-- Filtering a duplicate-free index list preserves distinct variable keys. -/
+private theorem factorList_pairwise (m : Mono n) :
+    ∀ {xs : List (Fin n)}, xs.Nodup →
+      (xs.filterMap fun i =>
+        let exponent := Mono.degreeOf i m
+        if exponent = 0 then none else some (⟨X i, exponent⟩ : Factor n cmp)
+      ).Pairwise fun left right => left.factor ≠ right.factor
+  | [], _ => .nil
+  | i :: xs, hnodup => by
+      rw [List.nodup_cons] at hnodup
+      simp only [List.filterMap_cons]
+      by_cases he : Mono.degreeOf i m = 0
+      · rw [ite_eq_left he]
+        exact factorList_pairwise m hnodup.2
+      · rw [ite_eq_right he]
+        apply List.Pairwise.cons
+        · intro entry hentry
+          rcases List.mem_filterMap.mp hentry with ⟨j, hj, hout⟩
+          by_cases hjzero : Mono.degreeOf j m = 0
+          · rw [ite_eq_left hjzero] at hout
+            contradiction
+          · rw [ite_eq_right hjzero] at hout
+            simp only [Option.some.injEq] at hout
+            subst entry
+            intro hfactor
+            apply hnodup.1
+            exact X_injective hfactor ▸ hj
+        · exact factorList_pairwise m hnodup.2
+
+/-- Pairwise-distinct factor keys pass the structural Boolean replay. -/
+private theorem distinctFactors_of_pairwise :
+    ∀ {factors : List (Factor n cmp)},
+      factors.Pairwise (fun left right => left.factor ≠ right.factor) →
+      distinctFactors factors = true
+  | [], _ => rfl
+  | _ :: _, .cons head tail => by
+      simp only [distinctFactors, Bool.and_eq_true, List.all_eq_true,
+        decide_eq_true_eq]
+      exact ⟨head, distinctFactors_of_pairwise tail⟩
+
+/-- The increasing variable-factor list passes distinctness replay. -/
+private theorem monomialFactors_distinct (m : Mono n) :
+    distinctFactors (monomialFactors (cmp := cmp) m) = true := by
+  apply distinctFactors_of_pairwise
+  exact factorList_pairwise m (List.nodup_finRange n)
+
+/-- Every canonical monomial decomposition passes full replay. -/
+private theorem monomialDecomp_checks (coefficient : Int) (m : Mono n) :
+    checkDecomp (monomial m coefficient : MvPoly n Int cmp)
+      (monomialDecomp coefficient m) = true := by
+  simp only [checkDecomp, Bool.and_eq_true, beq_iff_eq]
+  exact ⟨⟨monomialDecomp_product coefficient m, monomialFactors_all m⟩,
+    monomialFactors_distinct m⟩
 
 /-- Recognize the no-search structural cases. -/
 def structural? (f : MvPoly n Int cmp) : Option (Decomp n cmp) :=
@@ -131,6 +314,40 @@ def structural? (f : MvPoly n Int cmp) : Option (Decomp n cmp) :=
 /-- Every structural answer passes the decomposition checker. -/
 theorem structural_checks {f : MvPoly n Int cmp} {D : Decomp n cmp}
     (h : structural? f = some D) : checkDecomp f D = true := by
-  sorry
+  unfold structural? at h
+  cases hterms : f.termsList with
+  | nil =>
+      simp only [hterms, Option.some.injEq] at h
+      subst D
+      have hf : f = 0 := by
+        apply termsList_inj
+        rw [hterms]
+        rfl
+      subst f
+      rfl
+  | cons head tail =>
+      cases tail with
+      | nil =>
+          rcases head with ⟨m, coefficient⟩
+          simp only [hterms, Option.some.injEq] at h
+          subst D
+          have hmem : (m, coefficient) ∈ f.termsList := by
+            rw [hterms]
+            exact List.mem_cons_self
+          unfold MvPoly.termsList at hmem
+          have hget :=
+            Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some.mp hmem
+          have hc : coefficient ≠ 0 := by
+            intro hc
+            subst coefficient
+            exact f.nonzeroInternal m hget
+          have hf : f = monomial m coefficient := by
+            apply termsList_inj
+            rw [hterms, termsList_monomial, ite_eq_right hc]
+          subst f
+          exact monomialDecomp_checks coefficient m
+      | cons second rest =>
+          simp only [hterms] at h
+          contradiction
 
 end Hex.MvFactor

--- a/HexMvPoly/Query.lean
+++ b/HexMvPoly/Query.lean
@@ -43,6 +43,19 @@ theorem degreeOf_eq [Zero R] (i : Fin n) (p : MvPoly n R cmp) :
       p.foldTerms (fun d m _ => max d (Mono.degreeOf i m)) 0 := by
   rfl
 
+/-- A one-term polynomial carries its monomial exponent when its coefficient
+is nonzero. -/
+theorem degreeOf_monomial [Zero R] [BEq R] [LawfulBEq R]
+    [DecidableEq R] (i : Fin n) (m : Mono n) (c : R) :
+    degreeOf i (monomial m c : MvPoly n R cmp) =
+      if c = 0 then 0 else m[i] := by
+  unfold degreeOf foldTerms
+  rw [Std.ExtTreeMap.foldl_eq_foldl_toList]
+  change (monomial m c : MvPoly n R cmp).termsList.foldl
+      (fun d term => max d (Mono.degreeOf i term.1)) 0 = _
+  rw [termsList_monomial]
+  by_cases hc : c = 0 <;> simp [hc, Mono.degreeOf]
+
 /-- Coordinatewise maximum of all supported exponent vectors. -/
 def degrees [Zero R] (p : MvPoly n R cmp) : Mono n :=
   p.foldTerms (fun d m _ => Mono.lcm d m) Mono.zero
@@ -191,6 +204,27 @@ theorem leadingTerm_C [Zero R] [BEq R] [LawfulBEq R] [DecidableEq R]
       rw [show cmp Mono.zero Mono.zero = .eq from Std.ReflCmp.compare_self]
       trivial
     · rw [Hex.ite_eq_right hmzero] at hcoeff
+      contradiction
+
+/-- A nonzero one-term polynomial has its defining term as leading term. -/
+theorem leadingTerm_monomial [Zero R] [BEq R] [LawfulBEq R]
+    [DecidableEq R] [IsMonomialOrder cmp] {m : Mono n} {c : R}
+    (hc : c ≠ 0) :
+    leadingTerm (monomial m c : MvPoly n R cmp) = some (m, c) := by
+  apply (leadingTerm_eq_some_iff
+    (monomial m c : MvPoly n R cmp) m c).mpr
+  constructor
+  · unfold coeff? monomial
+    rw [Hex.dite_eq_right hc, Std.ExtTreeMap.getElem?_insert_self]
+  · intro k hk
+    have hcoeff :=
+      (mem_monomials_iff k (monomial m c : MvPoly n R cmp)).mp hk
+    rw [coeff_monomial] at hcoeff
+    by_cases hkm : k = m
+    · subst k
+      rw [show cmp m m = .eq from Std.ReflCmp.compare_self]
+      trivial
+    · rw [Hex.ite_eq_right hkm] at hcoeff
       contradiction
 
 /-- A polynomial has no leading term exactly when it is zero. -/

--- a/HexMvPoly/SPEC/hex-mv-poly.md
+++ b/HexMvPoly/SPEC/hex-mv-poly.md
@@ -488,6 +488,10 @@ theorem coeff_zero      : coeff m 0 = 0
 theorem coeff_C         : coeff m (C c) = if m = Mono.zero then c else 0
 theorem coeff_X         : coeff m (X i) = if m = Mono.unit i then 1 else 0
 theorem coeff_monomial  : coeff m (monomial m' c) = if m = m' then c else 0
+theorem degreeOf_monomial : degreeOf i (monomial m c) =
+    if c = 0 then 0 else m[i]
+theorem leadingTerm_monomial (hc : c ≠ 0) :
+    leadingTerm (monomial m c) = some (m, c)
 theorem coeff_one       : coeff m 1 = if m = Mono.zero then 1 else 0
 theorem coeff_ofTerms   : coeff m (ofTerms ts) =
     ((ts.filter fun t => t.1 == m).map fun t => t.2).sum


### PR DESCRIPTION
## Summary

- prove product and normalization laws for monomial and constant decompositions
- prove `checkDecomp_sound` from the executable replay
- connect structural factor assembly to its semantic decomposition contract

## Dependency

Stacked on #9568 (and transitively #9567). This PR targets upstream `main`; its tree diff will shrink as those dependencies merge. Auto-merge remains disabled until #9568 lands.

## Verification

- `lake build HexMvFactor`
- `git diff origin/main...HEAD --check`