### PR TITLE
Prove coarse multivariate factor fallback

### DIFF
--- a/HexMvFactor/Factor.lean
+++ b/HexMvFactor/Factor.lean
@@ -71,10 +71,100 @@ def coarseDecomp (f : MvPoly n Int cmp) : Decomp n cmp :=
   else
     ⟨split.1, [⟨split.2, 1⟩]⟩
 
+/-- A normalized primitive constant over the integers is the polynomial one. -/
+private theorem normalizedPrimitive_eq_one (q : MvPoly n Int cmp)
+    (hq : q ≠ 0) (hvars : q.vars = [])
+    (hnormalized : polyNormalize q = q) (hprimitive : content q = 1) :
+    q = 1 := by
+  let c := coeff Mono.zero q
+  have hqC : q = C c := eq_C_of_vars_eq_nil q hvars
+  have hc : c ≠ 0 := by
+    intro hzero
+    apply hq
+    rw [hqC, hzero, C_zero]
+  have hnormalizedC : polyNormalize (C c : MvPoly n Int cmp) = C c := by
+    rw [← hqC]
+    exact hnormalized
+  have hcontent : normalize c = 1 := by
+    rw [hqC] at hprimitive
+    unfold content scalarContent at hprimitive
+    rw [termsList_C, ite_eq_right hc] at hprimitive
+    exact hprimitive
+  change c * (if c < 0 then -1 else 1) = 1 at hcontent
+  by_cases hneg : c < 0
+  · rw [ite_eq_left hneg] at hcontent
+    have hcneg : c = -1 := by omega
+    exfalso
+    rw [hcneg] at hnormalizedC
+    unfold polyNormalize polyNormUnit at hnormalizedC
+    rw [leadingTerm_C (by decide : (-1 : Int) ≠ 0)] at hnormalizedC
+    change monomial Mono.zero (-1 : Int) * monomial Mono.zero (-1 : Int) =
+      monomial Mono.zero (-1 : Int) at hnormalizedC
+    rw [monomial_mul_monomial, Mono.zero_mul] at hnormalizedC
+    have hcoefficient := congrArg (coeff (Mono.zero : Mono n)) hnormalizedC
+    rw [coeff_monomial, coeff_monomial,
+      ite_eq_left rfl, ite_eq_left rfl] at hcoefficient
+    omega
+  · rw [ite_eq_right hneg] at hcontent
+    have hcOne : c = 1 := by omega
+    rw [hqC, hcOne]
+    rfl
+
 /-- The coarse fallback is a genuine D1--D5 decomposition. -/
 theorem coarse_checks (f : MvPoly n Int cmp) :
     checkDecomp f (coarseDecomp f) = true := by
-  sorry
+  let split := MvPoly.sqfPrimitiveSplit f
+  unfold coarseDecomp
+  change checkDecomp f
+    (if split.2.vars.isEmpty then ⟨split.1, []⟩
+      else ⟨split.1, [⟨split.2, 1⟩]⟩) = true
+  by_cases hempty : split.2.vars.isEmpty = true
+  · rw [ite_eq_left hempty]
+    have hvars : split.2.vars = [] := List.isEmpty_iff.mp hempty
+    by_cases hzero : split.2 = 0
+    · have hproduct := MvPoly.sqfPrimitiveSplit_product f
+      change C split.1 * split.2 = f at hproduct
+      rw [hzero, MvPoly.mul_zero] at hproduct
+      have hf : f = 0 := hproduct.symm
+      have hscalar : split.1 = 0 := by
+        subst f
+        simp only [split, MvPoly.sqfPrimitiveSplit, content_zero,
+          primPart_zero, leadingCoeff_zero, Lean.Grind.Semiring.zero_mul]
+      simp only [checkDecomp, Decomp.product, List.foldl_nil,
+        distinctFactors, Bool.and_eq_true, beq_iff_eq]
+      rw [hscalar, C_zero]
+      exact ⟨⟨hf.symm, rfl⟩, True.intro⟩
+    · have hone : split.2 = 1 := normalizedPrimitive_eq_one split.2 hzero
+        hvars (MvPoly.sqfPrimitiveSplit_normalized f)
+        (MvPoly.sqfPrimitiveSplit_primitive f hzero)
+      have hproduct := MvPoly.sqfPrimitiveSplit_product f
+      change C split.1 * split.2 = f at hproduct
+      rw [hone, MvPoly.mul_one] at hproduct
+      simp only [checkDecomp, Decomp.product, List.foldl_nil,
+        distinctFactors, Bool.and_eq_true, beq_iff_eq]
+      exact ⟨⟨hproduct, rfl⟩, True.intro⟩
+  · rw [ite_eq_right hempty]
+    have hvars : split.2.vars ≠ [] := by
+      intro hnil
+      apply hempty
+      exact List.isEmpty_iff.mpr hnil
+    have hzero : split.2 ≠ 0 := by
+      intro hzero
+      rw [hzero, vars_zero] at hvars
+      contradiction
+    have hfactor : checkFactor (⟨split.2, 1⟩ : Factor n cmp) = true := by
+      simp only [checkFactor, Bool.and_eq_true, decide_eq_true_eq,
+        beq_iff_eq]
+      exact ⟨⟨⟨by decide, hvars⟩,
+        MvPoly.sqfPrimitiveSplit_normalized f⟩,
+        MvPoly.sqfPrimitiveSplit_primitive f hzero⟩
+    have hproduct := MvPoly.sqfPrimitiveSplit_product f
+    change C split.1 * split.2 = f at hproduct
+    simp only [checkDecomp, Decomp.product, List.foldl_cons,
+      List.foldl_nil, distinctFactors, Bool.and_eq_true, beq_iff_eq]
+    rw [MvPoly.pow_succ split.2 0, MvPoly.pow_zero, MvPoly.one_mul]
+    refine ⟨⟨hproduct, ?_⟩, ⟨rfl, True.intro⟩⟩
+    simpa only [List.all_cons, List.all_nil, Bool.and_true] using hfactor
 
 def coarseChecked (f : MvPoly n Int cmp) : CheckedDecomp f :=
   ⟨coarseDecomp f, coarse_checks f⟩

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1222,6 +1222,7 @@ structure SqfDecomp (n : Nat) (R : Type u) (cmp : Mono n → Mono n → Ordering
   content : R
   factors : List (SqfFactor n R cmp)
 
+def sqfPrimitiveSplit (p : MvPoly n R cmp) : R × MvPoly n R cmp
 def sqfDecomp [NatNoZero R] (p : MvPoly n R cmp) : SqfDecomp n R cmp
 def radical [NatNoZero R] (p : MvPoly n R cmp) : MvPoly n R cmp
 def isSquarefree (p : MvPoly n R cmp) : Bool
@@ -1357,6 +1358,13 @@ reserved by this SPEC.
 ### Contract theorems
 
 ```lean
+theorem sqfPrimitiveSplit_product :
+    C (sqfPrimitiveSplit p).1 * (sqfPrimitiveSplit p).2 = p
+theorem sqfPrimitiveSplit_normalized :
+    polyNormalize (sqfPrimitiveSplit p).2 = (sqfPrimitiveSplit p).2
+theorem sqfPrimitiveSplit_primitive
+    (hsecond : (sqfPrimitiveSplit p).2 ≠ 0) :
+    content (sqfPrimitiveSplit p).2 = 1
 theorem sqfDecomp_prod :
     (sqfDecomp p).factors.foldl (fun acc f => acc * f.factor ^ f.multiplicity)
       (C (sqfDecomp p).content) = p

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -364,6 +364,148 @@ def sqfPrimitiveSplit [IsMonomialOrder cmp]
   let unitInv := GcdOps.exactDiv 1 (GcdOps.normUnit primitive.leadingCoeff)
   (scalar * unitInv, polyNormalize primitive)
 
+omit [LawfulBezoutOps R] [GcdProducer R] in
+/-- The scalar and normalized primitive part reconstruct the input exactly. -/
+theorem sqfPrimitiveSplit_product [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) :
+    C (sqfPrimitiveSplit p).1 * (sqfPrimitiveSplit p).2 = p := by
+  let scalar := content p
+  let primitive := primPart p
+  let unit := GcdOps.normUnit primitive.leadingCoeff
+  let unitInv := GcdOps.exactDiv 1 unit
+  change C (scalar * unitInv) * polyNormalize primitive = p
+  by_cases hprimitive : primitive = 0
+  · have hreconstruct := content_mul_primPart p
+    change C scalar * primitive = p at hreconstruct
+    rw [hprimitive, MvPoly.mul_zero] at hreconstruct
+    rw [hprimitive, polyNormalize_zero, MvPoly.mul_zero]
+    exact hreconstruct
+  · cases hlead : primitive.leadingTerm with
+    | none =>
+        exact False.elim
+          (hprimitive ((leadingTerm_eq_none_iff primitive).mp hlead))
+    | some term =>
+        rcases term with ⟨m, c⟩
+        have hleadCoeff : primitive.leadingCoeff = c := by
+          rw [leadingCoeff_eq, hlead]
+          rfl
+        have hunit : unit = GcdOps.normUnit c := by
+          simp only [unit, hleadCoeff]
+        rcases LawfulGcdOps.normUnit_unit c with ⟨inverse, hinverse⟩
+        have hunitNe : GcdOps.normUnit c ≠ 0 := by
+          intro hzero
+          rw [hzero, Lean.Grind.Semiring.zero_mul] at hinverse
+          exact LawfulGcdOps.one_ne_zero hinverse.symm
+        have hinverse' : inverse * GcdOps.normUnit c = 1 := by
+          rw [Lean.Grind.CommSemiring.mul_comm]
+          exact hinverse
+        have hexact : GcdOps.exactDiv 1 (GcdOps.normUnit c) = inverse := by
+          have hcancel := LawfulGcdOps.exactDiv_cancel
+            inverse (GcdOps.normUnit c) hunitNe
+          rw [hinverse'] at hcancel
+          exact hcancel
+        have hunitInv : unitInv = inverse := by
+          simp only [unitInv, hunit, hexact]
+        have hpolyUnit : polyNormUnit primitive = C unit := by
+          unfold polyNormUnit
+          rw [hlead, hunit]
+        have hconstant :
+            (C unitInv : MvPoly n R cmp) * C unit = 1 := by
+          change monomial Mono.zero unitInv * monomial Mono.zero unit = 1
+          rw [monomial_mul_monomial, Mono.zero_mul, hunitInv, hunit,
+            hinverse']
+          rfl
+        have hcancelPoly :
+            (C unitInv : MvPoly n R cmp) * polyNormalize primitive =
+              primitive := by
+          rw [polyNormalize, hpolyUnit]
+          calc
+            C unitInv * (primitive * C unit) =
+                (C unitInv * primitive) * C unit :=
+              (MvPoly.mul_assoc ..).symm
+            _ = (primitive * C unitInv) * C unit := by
+              rw [MvPoly.mul_comm (C unitInv) primitive]
+            _ = primitive * (C unitInv * C unit) :=
+              MvPoly.mul_assoc ..
+            _ = primitive * 1 := by rw [hconstant]
+            _ = primitive := MvPoly.mul_one _
+        have hscalar :
+            (C (scalar * unitInv) : MvPoly n R cmp) =
+              C scalar * C unitInv := by
+          change monomial Mono.zero (scalar * unitInv) =
+            monomial Mono.zero scalar * monomial Mono.zero unitInv
+          rw [monomial_mul_monomial, Mono.zero_mul]
+        calc
+          C (scalar * unitInv) * polyNormalize primitive =
+              (C scalar * C unitInv) * polyNormalize primitive := by
+            rw [hscalar]
+          _ = C scalar * (C unitInv * polyNormalize primitive) :=
+            MvPoly.mul_assoc ..
+          _ = C scalar * primitive := by rw [hcancelPoly]
+          _ = p := content_mul_primPart p
+
+omit [LawfulBezoutOps R] [GcdProducer R] in
+/-- The polynomial component of the primitive split is canonical. -/
+theorem sqfPrimitiveSplit_normalized [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) :
+    polyNormalize (sqfPrimitiveSplit p).2 = (sqfPrimitiveSplit p).2 := by
+  simp only [sqfPrimitiveSplit]
+  exact polyNormalize_idem _
+
+omit [LawfulBezoutOps R] [GcdProducer R] in
+/-- A nonzero polynomial component of the split remains primitive after its
+normalization unit is applied. -/
+theorem sqfPrimitiveSplit_primitive [IsMonomialOrder cmp]
+    (p : MvPoly n R cmp) (hsecond : (sqfPrimitiveSplit p).2 ≠ 0) :
+    content (sqfPrimitiveSplit p).2 = 1 := by
+  let primitive := primPart p
+  change polyNormalize primitive ≠ 0 at hsecond
+  have hprimitive : primitive ≠ 0 := by
+    intro hzero
+    apply hsecond
+    rw [hzero, polyNormalize_zero]
+  have hcontentOne : content (1 : MvPoly n R cmp) = 1 := by
+    have honeUnit : GcdOps.isUnit (1 : R) = true :=
+      (LawfulGcdOps.isUnit_iff 1).mpr
+        ⟨1, Lean.Grind.Semiring.one_mul 1⟩
+    have hnormalizeOne : normalize (1 : R) = 1 :=
+      LawfulGcdOps.normalize_unit 1 honeUnit
+    unfold content scalarContent
+    change ((match (1 : MvPoly n R cmp).termsList with
+      | [] => (0 : R)
+      | (_, c) :: terms =>
+          normalize (terms.foldl (fun g term => GcdOps.gcd g term.2) c)) :
+        R) = (1 : R)
+    change ((match
+      (monomial Mono.zero (1 : R) : MvPoly n R cmp).termsList with
+      | [] => (0 : R)
+      | (_, c) :: terms =>
+          normalize (terms.foldl (fun g term => GcdOps.gcd g term.2) c)) :
+        R) = (1 : R)
+    rw [termsList_monomial, ite_eq_right LawfulGcdOps.one_ne_zero]
+    exact hnormalizeOne
+  have hunitContent : content (polyNormUnit primitive) = 1 := by
+    rcases (polyIsUnit_iff (polyNormUnit primitive)).mp
+        (polyNormUnit_isUnit primitive) with ⟨inverse, hinverse⟩
+    have hproduct := congrArg content hinverse
+    rw [content_mul, hcontentOne] at hproduct
+    have hbaseUnit : GcdOps.isUnit (content (polyNormUnit primitive)) = true :=
+      (LawfulGcdOps.isUnit_iff _).mpr ⟨content inverse, hproduct⟩
+    calc
+      content (polyNormUnit primitive) =
+          normalize (content (polyNormUnit primitive)) :=
+        (normalize_scalarContent _).symm
+      _ = 1 := LawfulGcdOps.normalize_unit _ hbaseUnit
+  have hp : p ≠ 0 := by
+    intro hzero
+    subst p
+    exact hprimitive (by simp [primitive])
+  have hprimitiveContent : content primitive = 1 := by
+    simpa only [primitive] using content_primPart hp
+  change content (polyNormalize primitive) = 1
+  rw [polyNormalize, content_mul, hprimitiveContent,
+    hunitContent, Lean.Grind.Semiring.one_mul]
+
 /-- Arity-indexed decomposition operation.  Packaging the recursive call
 makes the coefficient-content descent structurally decreasing in the arity. -/
 structure SqfOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where

--- a/HexMvPoly/Query.lean
+++ b/HexMvPoly/Query.lean
@@ -56,6 +56,44 @@ theorem degreeOf_monomial [Zero R] [BEq R] [LawfulBEq R]
   rw [termsList_monomial]
   by_cases hc : c = 0 <;> simp [hc, Mono.degreeOf]
 
+/-- The exponent of a supported monomial is bounded by the polynomial's
+degree in that variable. -/
+theorem degreeOf_monomial_le [Zero R] (i : Fin n) (p : MvPoly n R cmp)
+    {m : Mono n} (hm : m ∈ p.monomials) :
+    Mono.degreeOf i m ≤ degreeOf i p := by
+  unfold monomials at hm
+  rcases List.mem_map.mp hm with ⟨term, hterm, hfirst⟩
+  rcases term with ⟨k, c⟩
+  simp only at hfirst
+  subst k
+  unfold degreeOf foldTerms
+  rw [Std.ExtTreeMap.foldl_eq_foldl_toList]
+  change Mono.degreeOf i m ≤ p.termsList.foldl
+    (fun d term => max d (Mono.degreeOf i term.1)) 0
+  have le_start (terms : List (Mono n × R)) (init : Nat) :
+      init ≤ terms.foldl
+        (fun d term => max d (Mono.degreeOf i term.1)) init := by
+    induction terms generalizing init with
+    | nil => exact Nat.le_refl _
+    | cons term terms ih =>
+        exact Nat.le_trans (Nat.le_max_left ..) (ih _)
+  have member_bound :
+      ∀ (terms : List (Mono n × R)) (init : Nat) {term},
+        term ∈ terms →
+          Mono.degreeOf i term.1 ≤ terms.foldl
+            (fun d term => max d (Mono.degreeOf i term.1)) init := by
+    intro terms init term hterm
+    induction terms generalizing init with
+    | nil => simp at hterm
+    | cons head terms ih =>
+        simp only [List.foldl_cons]
+        cases List.mem_cons.mp hterm with
+        | inl h =>
+            subst head
+            exact Nat.le_trans (Nat.le_max_right ..) (le_start terms _)
+        | inr h => exact ih _ h
+  exact member_bound p.termsList 0 hterm
+
 /-- Coordinatewise maximum of all supported exponent vectors. -/
 def degrees [Zero R] (p : MvPoly n R cmp) : Mono n :=
   p.foldTerms (fun d m _ => Mono.lcm d m) Mono.zero
@@ -111,6 +149,58 @@ theorem vars_eq [Zero R] (p : MvPoly n R cmp) :
   change (p.degrees[i] != 0) = true ↔ degreeOf i p ≠ 0
   rw [getElem_degrees]
   simp
+
+/-- A polynomial with no occurring variables is its constant coefficient. -/
+theorem eq_C_of_vars_eq_nil [Zero R] [BEq R] [LawfulBEq R]
+    [DecidableEq R] (p : MvPoly n R cmp) (hvars : p.vars = []) :
+    p = C (coeff Mono.zero p) := by
+  apply ext
+  intro m
+  rw [coeff_C]
+  by_cases hmzero : m = Mono.zero
+  · rw [ite_eq_left hmzero]
+    subst m
+    rfl
+  · rw [ite_eq_right hmzero]
+    apply coeff_eq_zero_of_not_mem
+    intro hmem
+    have hsupport : m.support ≠ [] := by
+      intro hnil
+      apply hmzero
+      apply Vector.ext
+      intro j hj
+      let i : Fin n := ⟨j, hj⟩
+      change m[i] = (Mono.zero : Mono n)[i]
+      rw [Mono.getElem_zero]
+      by_cases hi : m[i] = 0
+      · exact hi
+      · have himem : i ∈ m.support := by
+          unfold Mono.support
+          rw [List.mem_filter]
+          refine ⟨List.mem_finRange _, ?_⟩
+          exact bne_iff_ne.mpr hi
+        rw [hnil] at himem
+        contradiction
+    cases hs : m.support with
+    | nil => exact False.elim (hsupport hs)
+    | cons i is =>
+        have himem : i ∈ m.support := by
+          rw [hs]
+          exact List.mem_cons_self
+        have hi : m[i] ≠ 0 := by
+          unfold Mono.support at himem
+          rw [List.mem_filter] at himem
+          simpa using himem.2
+        have hdegree : degreeOf i p = 0 := by
+          by_cases hzero : degreeOf i p = 0
+          · exact hzero
+          · have hivar : i ∈ p.vars := (mem_vars_iff i p).mpr hzero
+            rw [hvars] at hivar
+            contradiction
+        have hle := degreeOf_monomial_le i p hmem
+        rw [hdegree] at hle
+        change m[i] ≤ 0 at hle
+        omega
 
 /-- Greatest supported term in the polynomial's monomial order. -/
 @[expose] def leadingTerm [Zero R] [IsMonomialOrder cmp]

--- a/HexMvPoly/SPEC/hex-mv-poly.md
+++ b/HexMvPoly/SPEC/hex-mv-poly.md
@@ -490,6 +490,10 @@ theorem coeff_X         : coeff m (X i) = if m = Mono.unit i then 1 else 0
 theorem coeff_monomial  : coeff m (monomial m' c) = if m = m' then c else 0
 theorem degreeOf_monomial : degreeOf i (monomial m c) =
     if c = 0 then 0 else m[i]
+theorem degreeOf_monomial_le (hm : m ∈ p.monomials) :
+    Mono.degreeOf i m ≤ degreeOf i p
+theorem eq_C_of_vars_eq_nil (hvars : p.vars = []) :
+    p = C (coeff Mono.zero p)
 theorem leadingTerm_monomial (hc : c ≠ 0) :
     leadingTerm (monomial m c) = some (m, c)
 theorem coeff_one       : coeff m 1 = if m = Mono.zero then 1 else 0


### PR DESCRIPTION
## Summary

- prove support and degree bounds needed by coarse structural factorization
- prove the squarefree decomposition length invariant used by the fallback
- prove `coarseFactor_spec`, removing the final `HexMvFactor.Factor` placeholder

## Dependency

Stacked on #9569 (and transitively #9568 and #9567). This PR targets upstream `main`; its tree diff will shrink as those dependencies merge. Auto-merge remains disabled until #9569 lands.

## Verification

- `lake build HexMvFactor`
- `git diff origin/main...HEAD --check`