### PR TITLE
Prove named content reconstruction

### DIFF
--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -148,18 +148,6 @@ theorem contentInCert_checks
   intro f h
   exact gcdCert_checks f h
 
-/-- Named-variable content times primitive part reconstructs the input. -/
-theorem contentIn_mul_primPartIn
-    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
-    [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
-    [GcdProducer R]
-    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
-    constIn i cmp' (contentIn i cmp' p) * primPartIn i cmp' p = p := by
-  sorry
-
 theorem contentIn_dvd_coeff
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
@@ -231,6 +219,31 @@ theorem dvd_contentIn
     exact hcoeff.trans (MvPoly.zero_mul 0).symm
   rcases dvd_contentIn i cmp' 0 0 hd with ⟨q, hq⟩
   exact hq.trans (MvPoly.mul_zero q)
+
+/-- Named-variable content times primitive part reconstructs the input. -/
+theorem contentIn_mul_primPartIn
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
+    [GcdProducer R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [IsMonomialOrder cmp'] (p : MvPoly (n + 1) R cmp) :
+    constIn i cmp' (contentIn i cmp' p) * primPartIn i cmp' p = p := by
+  have hd : constIn i cmp' (contentIn i cmp' p) ∣ p :=
+    constIn_dvd i (contentIn i cmp' p) p (contentIn_dvd_coeff i cmp' p)
+  by_cases hp : p = 0
+  · subst p
+    rw [contentIn_zero, constIn_zero, MvPoly.zero_mul]
+  · have hc :
+        constIn (cmp := cmp) i cmp' (contentIn i cmp' p) ≠
+          (0 : MvPoly (n + 1) R cmp) := by
+      intro hc
+      rcases hd with ⟨q, hq⟩
+      rw [hc, MvPoly.mul_zero] at hq
+      exact hp hq
+    rw [MvPoly.mul_comm]
+    exact quotient_mul_of_dvd hc hd
 
 @[simp] theorem primPartIn_zero
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}

--- a/HexMvGcd/View.lean
+++ b/HexMvGcd/View.lean
@@ -127,15 +127,21 @@ private theorem degreeOf_mul (i : Fin (n + 1))
   unfold Mono.degreeOf
   exact Mono.getElem_mul a b i
 
-private theorem insertVar_mul_zero (i : Fin (n + 1)) (a b : Mono n) :
-    insertVar i 0 (Mono.mul a b) =
-      Mono.mul (insertVar i 0 a) (insertVar i 0 b) := by
+private theorem insertVar_mul (i : Fin (n + 1)) (ea eb : Nat)
+    (a b : Mono n) :
+    insertVar i (ea + eb) (Mono.mul a b) =
+      Mono.mul (insertVar i ea a) (insertVar i eb b) := by
   apply Vector.ext
   intro j hj
   by_cases heq : j = i.val
   · simp [insertVar, Mono.mul, heq]
   · by_cases hlt : j < i.val <;>
       simp [insertVar, Mono.mul, heq, hlt]
+
+private theorem insertVar_mul_zero (i : Fin (n + 1)) (a b : Mono n) :
+    insertVar i 0 (Mono.mul a b) =
+      Mono.mul (insertVar i 0 a) (insertVar i 0 b) := by
+  simpa using insertVar_mul i 0 0 a b
 
 private theorem removeVar_mul (i : Fin (n + 1)) (a b : Mono (n + 1)) :
     removeVar i (Mono.mul a b) =
@@ -190,6 +196,175 @@ private theorem splits_insertVar_zero_perm (i : Fin (n + 1)) (m : Mono n) :
     · apply (Mono.splits_mem_iff ..).mpr
       rw [← removeVar_mul, hmul, removeVar_insertVar]
     · exact Prod.ext ha hb
+
+/-- The full coefficient of a constant embedding is supported exactly on
+monomials having selected-variable degree zero. -/
+theorem coeff_constIn_term (i : Fin (n + 1))
+    (c : MvPoly n R cmp') (m : Mono (n + 1)) :
+    coeff m (constIn (cmp := cmp) i cmp' c) =
+      if Mono.degreeOf i m = 0 then coeff (removeVar i m) c else 0 := by
+  by_cases hdegree : Mono.degreeOf i m = 0
+  · rw [Hex.ite_eq_left hdegree]
+    calc
+      coeff m (constIn (cmp := cmp) i cmp' c) =
+          coeff (insertVar i (Mono.degreeOf i m) (removeVar i m))
+            (constIn (cmp := cmp) i cmp' c) := by
+        rw [insertVar_removeVar]
+      _ = coeff (removeVar i m) c := by
+        unfold constIn
+        rw [ofUnivariate_coeff, DensePoly.coeff_C, hdegree,
+          Hex.ite_eq_left rfl]
+  · rw [Hex.ite_eq_right hdegree]
+    calc
+      coeff m (constIn (cmp := cmp) i cmp' c) =
+          coeff (insertVar i (Mono.degreeOf i m) (removeVar i m))
+            (constIn (cmp := cmp) i cmp' c) := by
+        rw [insertVar_removeVar]
+      _ = 0 := by
+        unfold constIn
+        rw [ofUnivariate_coeff, DensePoly.coeff_C,
+          Hex.ite_eq_right hdegree]
+        change coeff (removeVar i m) (0 : MvPoly n R cmp') = 0
+        rw [coeff_zero]
+
+private theorem splits_const_perm (i : Fin (n + 1)) (e : Nat)
+    (m : Mono n) :
+    ((Mono.splits m).map fun ab =>
+      (insertVar i 0 ab.1, insertVar i e ab.2)).Perm
+        ((Mono.splits (insertVar i e m)).filter fun ab =>
+          decide (Mono.degreeOf i ab.1 = 0)) := by
+  let lift : Mono n × Mono n → Mono (n + 1) × Mono (n + 1) :=
+    fun ab => (insertVar i 0 ab.1, insertVar i e ab.2)
+  have hinj : Function.Injective lift := by
+    rintro ⟨a, b⟩ ⟨c, d⟩ h
+    apply Prod.ext
+    · exact ((insertVar_inj i 0 0 a c).mp (congrArg Prod.fst h)).2
+    · exact ((insertVar_inj i e e b d).mp (congrArg Prod.snd h)).2
+  have hleft : ((Mono.splits m).map lift).Nodup := by
+    apply (Mono.splits_nodup m).map
+    intro a b hne heq
+    exact hne (hinj heq)
+  have hright :
+      ((Mono.splits (insertVar i e m)).filter fun ab =>
+        decide (Mono.degreeOf i ab.1 = 0)).Nodup :=
+    (Mono.splits_nodup (insertVar i e m)).filter _
+  apply (List.perm_ext_iff_of_nodup hleft hright).mpr
+  rintro ⟨a, b⟩
+  constructor
+  · intro hmem
+    rcases List.mem_map.mp hmem with ⟨⟨c, d⟩, hcd, hab⟩
+    cases hab
+    rw [List.mem_filter]
+    constructor
+    · apply (Mono.splits_mem_iff ..).mpr
+      rw [← insertVar_mul i 0 e, (Mono.splits_mem_iff ..).mp hcd]
+      simp
+    · simp
+  · intro hmem
+    rw [List.mem_filter] at hmem
+    have hmul : Mono.mul a b = insertVar i e m :=
+      (Mono.splits_mem_iff ..).mp hmem.1
+    have ha0 : Mono.degreeOf i a = 0 := by simpa using hmem.2
+    have hsum := congrArg (Mono.degreeOf i) hmul
+    rw [degreeOf_mul, degreeOf_insertVar, ha0, Nat.zero_add] at hsum
+    have ha : insertVar i 0 (removeVar i a) = a := by
+      rw [← ha0]
+      exact insertVar_removeVar i a
+    have hb : insertVar i e (removeVar i b) = b := by
+      rw [← hsum]
+      exact insertVar_removeVar i b
+    apply List.mem_map.mpr
+    refine ⟨(removeVar i a, removeVar i b), ?_, Prod.ext ha hb⟩
+    apply (Mono.splits_mem_iff ..).mpr
+    rw [← removeVar_mul, hmul, removeVar_insertVar]
+
+/-- Multiplication by a constant embedding acts coefficientwise in the
+selected-variable recursive view. -/
+theorem coeff_constIn_mul (i : Fin (n + 1))
+    (c : MvPoly n R cmp') (p : MvPoly (n + 1) R cmp) (e : Nat) :
+    (toUnivariate i cmp' (constIn i cmp' c * p)).coeff e =
+      c * (toUnivariate i cmp' p).coeff e := by
+  apply MvPoly.ext
+  intro m
+  rw [toUnivariate_coeff, coeff_mul, coeff_mul]
+  let fullTerm : Mono (n + 1) × Mono (n + 1) → R := fun ab =>
+    coeff ab.1 (constIn (cmp := cmp) i cmp' c) * coeff ab.2 p
+  let lowerTerm : Mono n × Mono n → R := fun ab =>
+    coeff ab.1 c * coeff ab.2 ((toUnivariate i cmp' p).coeff e)
+  calc
+    (Mono.splits (insertVar i e m)).foldl
+        (fun acc ab => acc + fullTerm ab) 0 =
+        ((Mono.splits (insertVar i e m)).filter fun ab =>
+          decide (Mono.degreeOf i ab.1 = 0)).foldl
+            (fun acc ab => acc + fullTerm ab) 0 := by
+      symm
+      rw [List.foldl_filter]
+      apply List.foldl_congr
+      intro acc ab _
+      by_cases hdegree : Mono.degreeOf i ab.1 = 0
+      · simp [hdegree]
+      · unfold fullTerm
+        rw [coeff_constIn_term, Hex.ite_eq_right hdegree]
+        rw [Lean.Grind.Semiring.zero_mul,
+          Lean.Grind.AddCommMonoid.add_zero]
+        simp [hdegree]
+    _ = ((Mono.splits m).map fun ab =>
+          (insertVar i 0 ab.1, insertVar i e ab.2)).foldl
+            (fun acc ab => acc + fullTerm ab) 0 :=
+      List.foldl_add_perm fullTerm (splits_const_perm i e m).symm 0
+    _ = (Mono.splits m).foldl
+          (fun acc ab => acc + lowerTerm ab) 0 := by
+      rw [List.foldl_map]
+      apply List.foldl_congr
+      intro acc ab _
+      unfold fullTerm lowerTerm
+      rw [coeff_constIn_term, degreeOf_insertVar, Hex.ite_eq_left rfl,
+        removeVar_insertVar,
+        ← toUnivariate_coeff (cmp' := cmp') i p e ab.2]
+
+/-- A polynomial in the remaining variables divides a polynomial in the full
+ring when it divides every coefficient of the selected-variable view. -/
+theorem constIn_dvd (i : Fin (n + 1)) (d : MvPoly n R cmp')
+    (p : MvPoly (n + 1) R cmp)
+    (h : ∀ k, d ∣ (toUnivariate i cmp' p).coeff k) :
+    constIn (cmp := cmp) i cmp' d ∣ p := by
+  classical
+  let view := toUnivariate i cmp' p
+  let qs : Nat → MvPoly n R cmp' := fun k => Classical.choose (h k)
+  have hqs (k : Nat) : view.coeff k = qs k * d := by
+    exact Classical.choose_spec (h k)
+  let qView : DensePoly (MvPoly n R cmp') :=
+    DensePoly.ofCoeffs (Array.ofFn (n := view.size) fun k => qs k)
+  let q := ofUnivariate (cmp := cmp) i cmp' qView
+  have hqView : toUnivariate i cmp' q = qView := by
+    unfold q
+    exact toUnivariate_ofUnivariate i qView
+  refine ⟨q, ?_⟩
+  apply MvPoly.ext
+  intro m
+  rw [← insertVar_removeVar i m]
+  rw [← toUnivariate_coeff (cmp' := cmp') i p,
+    ← toUnivariate_coeff (cmp' := cmp') i (q * constIn i cmp' d)]
+  rw [MvPoly.mul_comm q (constIn i cmp' d), coeff_constIn_mul]
+  rw [hqView]
+  apply congrArg (coeff (removeVar i m))
+  change view.coeff (Mono.degreeOf i m) = d * qView.coeff (Mono.degreeOf i m)
+  let e := Mono.degreeOf i m
+  change view.coeff e = d * qView.coeff e
+  unfold qView
+  rw [DensePoly.coeff_ofCoeffs]
+  by_cases he : e < view.size
+  · rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn,
+      Hex.dite_eq_left he]
+    simp only [Option.getD_some]
+    rw [hqs]
+    exact Lean.Grind.CommSemiring.mul_comm _ _
+  · rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn,
+      Hex.dite_eq_right he]
+    simp only [Option.getD_none]
+    rw [DensePoly.coeff_eq_zero_of_size_le view (Nat.le_of_not_gt he)]
+    change (0 : MvPoly n R cmp') = d * 0
+    exact (MvPoly.mul_zero d).symm
 
 /-- Constant embedding preserves multiplication. -/
 theorem constIn_mul (i : Fin (n + 1)) (a b : MvPoly n R cmp') :


### PR DESCRIPTION
Adds the missing bridge between the recursive univariate view and the full multivariable ring:

- prove coefficient behavior for constant embeddings
- prove constant embeddings divide a polynomial when they divide every recursive coefficient
- prove named-variable content times primitive part reconstructs the input

This removes one `sorry` from `HexMvGcd.Gcd`.

Depends on #9571; rebase and auto-merge will be enabled after that PR lands.

Validation: `lake build HexMvGcd.Squarefree`