### PR TITLE
docs: specify fast polynomial arithmetic

### DIFF
--- a/HexBerlekamp/SPEC/hex-berlekamp.md
+++ b/HexBerlekamp/SPEC/hex-berlekamp.md
@@ -138,6 +138,21 @@ The emitted term contains:
 `hex-berlekamp-mathlib` adds the same syntax for
 `Polynomial (ZMod p)`.
 
+## Fast-arithmetic adoption
+
+After [hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md), the Fp production
+plan is audited in the repeated Frobenius reductions, distinct-degree gcd
+chain, Rabin powers, and Berlekamp splits. Fast division and half-gcd must
+agree exactly with the existing `DensePoly` operations, so certificate shapes
+and checker theorems do not change.
+
+Adoption is decided by the complete operation benchmark, not by a standalone
+NTT or half-gcd microbenchmark. Small degrees retain packed multiplication and
+the current Euclidean gcd; larger cells may select direct or CRT-NTT,
+reciprocal division, and half-gcd. Every selected cell is recorded beside its
+retained baseline, including prime, degree, and whether a transform plan was
+reused.
+
 ## Mathematical companion
 
 `hex-berlekamp-mathlib` uses the ring equivalence

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -51,6 +51,22 @@ polynomial factors. Integer content is not split into constant prime
 polynomials. A power of `X` is stored as one factor with its
 multiplicity.
 
+## Fast-arithmetic adoption
+
+The implementation audit required by
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) covers modular-image
+products, Hensel product trees, subset trial products, exact quotient checks,
+and final integer reassembly. Integer multiplication uses `ZPoly.mulFast` only
+where its schoolbook/KS1/KS2/KS3/KS4/CRT-NTT dispatcher improves the complete
+factorization cell; finite-field stages use the corresponding `FpPoly` plan.
+
+No fast result is treated as certificate evidence. The existing product,
+divisibility, and irreducibility checks replay against unchanged schoolbook
+semantics, and every decline/fallback remains available. Benchmarks separate
+classical and lattice recombination, balanced and skewed degree patterns, and
+small/large coefficient regimes so a win in reassembly cannot hide a loss in
+prime selection or lifting.
+
 ## Normalization
 
 Every factorization method uses the same normalization:

--- a/HexGFqRing/SPEC/hex-gfq-ring.md
+++ b/HexGFqRing/SPEC/hex-gfq-ring.md
@@ -62,6 +62,21 @@ supports a field structure; that extension belongs to hex-gfq-field.
 - `reduceMod f (a * b) = reduceMod f (reduceMod f a * reduceMod f b)`
 - Ring axioms for `PolyQuotient p f hf`
 
+## Fast-arithmetic adoption
+
+After [hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md), a quotient context
+may cache an `FpPoly` multiplication plan and a `DivPlan` for its fixed
+modulus. Multiplication, square-and-multiply exponentiation, and repeated
+reduction then use the cached plans above their measured crossover. The
+canonical representative and every `reduceMod` theorem remain unchanged
+because the fast operations agree exactly with the current multiplication and
+division.
+
+Benchmarks report context construction separately from warm quotient
+operations. Production adopts the cached route only where repeated operations
+recover its construction cost; one-shot and small-degree calls retain the
+current path.
+
 ## External comparators
 
 No external comparator is required.

--- a/HexHensel/SPEC/hex-hensel.md
+++ b/HexHensel/SPEC/hex-hensel.md
@@ -139,6 +139,21 @@ degree, list-shape, and invariant-preservation statements.
 The later Berlekamp-Zassenhaus companion proves the correspondence
 between subsets of lifted factors and irreducible integer factors.
 
+## Fast-arithmetic adoption
+
+After [hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md), the quadratic
+multifactor tree reuses its balanced product-tree shape and the `ZPoly`/`FpPoly`
+lawful multiplication plans. Complementary-product gcd and Bezout setup use
+the fast full or one-sided extended gcd, and repeated division by a fixed node
+may cache a `DivPlan`.
+
+This is a benchmark-gated implementation change, not a change to any lifting
+invariant. The audit measures complete two-factor and multifactor lifts over
+degree, factor-count, coefficient-width, and lift-exponent ladders. A node
+uses the fast entry point only where the end-to-end lift improves; small nodes
+retain the existing kernels. Product congruence, factor ordering, canonical
+coefficient ranges, and exact-division checks remain the public semantics.
+
 ## Verification
 
 Changes must pass:

--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -212,21 +212,54 @@ allocating Lean carry pairs in polynomial coefficient loops. The runtime and
 logical bodies agree for the full word-modulus range, including operands near
 `UInt64`'s upper limit.
 
+## Reusable number-theoretic transforms
+
+This library owns the radix-2 transform used by
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md), because the transform
+is an operation on `ZMod64` vectors and is useful independently of any
+polynomial representation.
+
+`ZMod64.NttPlan p n` packages a power-of-two length, a root of exact order
+`n`, its inverse, the inverse of `n`, and reusable forward/inverse twiddle
+tables with Shoup preconditioners. `NttPlan.build?` validates the length and
+root conditions; fixed auxiliary primes provide pre-verified plans for every
+supported smaller length. Plan construction and transform execution are
+separate benchmark operations, and callers pass plans explicitly rather than
+consulting a mutable global cache.
+
+Forward butterflies use Harvey's redundant interval `[0, 2p)` and inverse
+butterflies use `[0, 4p)`. The raw words are bounded internal structures, not
+a second modular type and not a ring instance. The existing `p < 2^31` bound
+proves the intermediate additions fit in `UInt64`; multiplication by a
+twiddle uses the existing high-word primitive and a precomputed Shoup
+constant. Canonical normalization occurs only at transform boundaries.
+
+Required theorems identify each butterfly modulo `p`, prove its raw output
+bound, identify the whole forward transform with the DFT, and prove inverse
+after forward is the identity. Pointwise multiplication between transforms
+then gives cyclic convolution; a primitive `2n`th root gives negacyclic
+convolution. No new `@[extern]` is introduced for the first implementation.
+
+The fixed `NttPrime` catalogue records a prime below `2^31`, a maximum
+power-of-two length, and a root of that exact order. It is finite by design;
+failure to supply a requested transform is reported as `none` so polynomial
+dispatchers can select a different verified kernel.
+
 ## External comparators
 
 No external comparator is required.
 
-**Justification:** `implementation-is-extern` per
-`SPEC/benchmarking.md §"Comparator naming"`. HexModArith's modular
-operations route through GMP (for general `Nat`/`Int` arithmetic)
-or through dedicated word-arithmetic C externs (for `ZMod64`).
-The Phase-4 surface is GMP / native arithmetic; there is no
-algorithmically distinct reference implementation to compare
-against externally.
+**Justification:** scalar operations are `implementation-is-extern` per
+`SPEC/benchmarking.md §"Comparator naming"`: they route through GMP or the
+dedicated word-arithmetic C externs, leaving no algorithmically distinct
+external implementation. The NTT surface is an internal building block rather
+than a user-facing result type; FLINT comparison belongs to the `FpPoly` and
+`ZPoly` convolution consumers where inputs and outputs match.
 
-The architecturally important within-Lean comparison — Barrett
-versus Montgomery modular multiplication — is registered as a
-`compare` group in `HexModArith/Bench.lean` (per
-`SPEC/benchmarking.md §"Within-Lean comparisons"`). That
-comparison is the right shape for this library; an external tool
+The architecturally important within-Lean comparisons — Barrett versus
+Montgomery modular multiplication, and canonical versus redundant-residue
+butterflies — are registered as
+`compare` groups in `HexModArith/Bench.lean` (per
+`SPEC/benchmarking.md §"Within-Lean comparisons"`). Those
+comparisons are the right shape for this library; an external tool
 would just be wrapping the same underlying word-level operations.

--- a/HexModular/SPEC/hex-modular.md
+++ b/HexModular/SPEC/hex-modular.md
@@ -81,6 +81,7 @@ work, and would trade one library for one reopened phase.
 
 In scope: symmetric representatives modulo `m`; incremental Chinese
 remaindering for a scalar and for a vector of residues sharing a modulus;
+balanced batch CRT for many fixed moduli and many coefficient lanes;
 rational reconstruction with explicit bounds, with symmetric bounds, and
 with the maximal-quotient heuristic; the vector form with a common
 denominator; the modulus supply and its runtime primality test; and the
@@ -220,6 +221,49 @@ family of algorithms gets its answer. Nothing above it needs a theorem
 about the Chinese remainder *isomorphism*: the executable statement is
 that a small enough integer is determined by its residues, and the
 isomorphism is the companion's business.
+
+### Balanced batch CRT
+
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) introduces a consumer that reconstructs
+every coefficient of a convolution from the same fixed auxiliary primes. The
+incremental API remains right for algorithms that test after every new image,
+but it is the wrong shape when all moduli are known before any reconstruction:
+it repeatedly multiplies through a growing accumulated modulus and makes the
+large-integer work quadratic in the number of primes.
+
+```lean
+/-- A validated balanced product tree of pairwise-coprime moduli greater than
+one. -/
+structure CrtPlan where
+  moduli : Array Nat
+  ...
+
+def CrtPlan.build? (moduli : Array Nat) : Option CrtPlan
+
+/-- Reconstruct one residue for every modulus. -/
+def CrtPlan.reconstruct? (plan : CrtPlan)
+    (residues : Array Int) : Option Int
+
+/-- Reconstruct `k` lanes sharing the plan, amortising all modulus-only work. -/
+def CrtPlan.reconstructVec? (plan : CrtPlan)
+    (residues : Array (Vector Int k)) : Option (Vector Int k)
+```
+
+`build?` succeeds exactly when the moduli are all greater than one and
+pairwise coprime. It stores the balanced modulus-product tree and the inverses
+needed to combine sibling results. Reconstruction rejects a residue-count
+mismatch and returns the symmetric representative modulo the root product.
+
+Soundness states congruence to every input lane at every modulus. The root
+product and symmetric bound are observations of the result, so a consumer
+with `2 * |x| < product` obtains exact recovery from `symMod_unique`. The
+vector form computes the tree's inverses once and applies each combination to
+all lanes; mapping the scalar form and repeating extended gcd per coefficient
+is forbidden.
+
+The target cost is quasi-linear in the total modulus bit length up to tree
+logarithms, plus linear work per residue lane. Incremental `Crt` is not
+rewritten in terms of this operation and retains its early-stopping behavior.
 
 ## Rational reconstruction
 
@@ -626,7 +670,7 @@ carries its own rejection rules.
 ## Complexity
 
 `k` moduli of `w` bits, an accumulated modulus of `M = k·w` bits, a
-vector of `n` residues.
+vector of `n` residues, and `I(t)` the cost of multiplying `t`-bit integers.
 
 Write `D(M)` for the bit cost of one balanced `M`-bit division and `S(M)`
 for integer square root. On the GMP operand range exercised below, the native
@@ -640,6 +684,8 @@ algorithm.
 | `Crt.push` | one `extGcd` on two words, one multiply-add at size `M` | `O(w²)` plus `O(M)` |
 | `CrtVec.push` | one `extGcd`, `n` multiply-adds | `O(w²)` plus `O(n·M)` |
 | `k` pushes, cumulative | quadratic in the number of moduli | `O(k²·w²)` word ops |
+| `CrtPlan.build?` | balanced product/inverse tree | `O(I(M) log k)` |
+| `CrtPlan.reconstructVec?` | balanced tree over `n` lanes | `O(n·I(M) log k)` |
 | `euclidUntil` | truncated Euclidean run at size `M` | `O(M²)` word ops |
 | `ratRecon?` | `euclidUntil` plus checks | `O(M²)` |
 | `ratReconWide?` on an early-success input | integer square root plus bounded checks | `O(S(M))`; native proxy `O(M√M)` |
@@ -647,13 +693,11 @@ algorithm.
 | `ratReconVec?` | one run plus `n` multiplications, on average | `O(M²) + O(n·M)` |
 | `ratReconMaxQuot?` | complete Euclidean quotient scan | `O(M²)` |
 
-The cumulative `O(k²w²)` for a full multi-modular run is the entry that
-matters, and it is what a product-tree (fast) CRT would improve to
-`O(M(M) log k)`. That is a later milestone: at `k = 400` and `w = 31` the
-incremental cost is under a millisecond of word operations, which is far
-below the `O(n³)` per-image cost that motivates the whole technique. The
-crossover is a measurement, and the benchmark family below is designed to
-find it rather than to assume it.
+The cumulative `O(k²w²)` incremental cost remains the right price when a
+consumer may stop after any image. `CrtPlan` supplies the product-tree route
+when every modulus is known in advance, as in auxiliary-prime convolution.
+The crossover is measured independently for one lane and for vectors; neither
+API silently dispatches to the other because their stopping behavior differs.
 
 ## Kernel exposure
 
@@ -743,10 +787,12 @@ operations a downstream certificate replay pays for.
 
 Families:
 
-- **Incremental CRT**, `k` from 4 to 8192 moduli of 31 bits. The declared
-  complexity is `k²`, and the family exists to find the point where a
-  product tree would pay.
-- **Vector CRT**, `k` from 4 to 8192 moduli against `n` from 1 to 4096 residues,
+- **Incremental CRT**, `k` from 4 to 4000 moduli of 31 bits. The declared
+  complexity is `k²`, retained because early-stopping consumers need it.
+- **Balanced batch CRT**, the same modulus ladder, forced against incremental
+  reconstruction for one lane and for convolution-sized vectors. This fixes
+  the measured crossover for callers that know all moduli in advance.
+- **Vector CRT**, `k` moduli against `n` from 1 to 4096 residues,
   checking that the extended gcd is amortised across the vector rather
   than repeated.
 - **Rational reconstruction**, moduli from 64 to 262144 bits, over
@@ -862,10 +908,15 @@ argument says should not exist.
    in hex-mod-arith alongside. At the end of this milestone both consumer
    libraries can be written.
 
-4. **Completeness and the heuristic.** `ratRecon?_complete` and
+4. **Balanced batch CRT.** `CrtPlan`, its validation and product tree,
+   scalar/vector reconstruction, congruence and uniqueness corollaries, and
+   the crossover against incremental reconstruction. This milestone unblocks
+   auxiliary-prime polynomial NTTs.
+
+5. **Completeness and the heuristic.** `ratRecon?_complete` and
    `ratReconMaxQuot?`.
 
-5. **The companion.** The `ZMod` correspondence, the `ℚ` restatements,
+6. **The companion.** The `ZMod` correspondence, the `ℚ` restatements,
    and the decidability instances. Begins as soon as milestone 2 is done.
 
 ## File organisation
@@ -874,6 +925,7 @@ argument says should not exist.
 HexModular/
   SymMod.lean       -- symMod and its uniqueness lemma
   Crt.lean          -- Crt, CrtVec, push, crt_unique
+  BatchCrt.lean     -- CrtPlan and balanced scalar/vector reconstruction
   Euclid.lean       -- Row, euclidUntil
   Recon.lean        -- ratRecon?, ratReconWide?, ratReconVec?, ratReconMaxQuot?
   Loop.lean         -- crtLoop
@@ -913,11 +965,6 @@ planned until its correspondence and decidability layer is implemented.
   loop with a stopping predicate would serve both, at the cost of an
   indirection in hex-arith's hottest scalar routine. Measure before
   merging them.
-- **Whether the product-tree CRT is worth having.** The complexity table
-  says the incremental cost is negligible against the images at the sizes
-  the consumers use. The benchmark family exists to find the size where
-  that stops being true, and the answer may be that no consumer reaches
-  it.
 - **Whether `Modulus` should carry the Barrett context.** hex-arith has
   Barrett and Montgomery reduction, and a modulus used for `O(n³)`
   operations wants its reduction context precomputed once. Attaching it

--- a/HexPoly/SPEC/hex-poly.md
+++ b/HexPoly/SPEC/hex-poly.md
@@ -26,7 +26,10 @@ type. As with `ofCoeffs`, trailing zero coefficients are removed.
 - Addition, subtraction, multiplication. `mul` is the schoolbook
   convolution and is the specification at every coefficient type; the
   subquadratic kernel is coefficient-specific and therefore lives
-  downstream (`Hex.ZPoly.mulKronecker` in `hex-poly-z`). A
+  downstream (`Hex.ZPoly.mulKronecker` in `hex-poly-z`). The planned
+  [hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) adds explicit lawful
+  multiplication plans, Karatsuba, clipped products, fast division, and
+  half-gcd without changing this operation or its instance. A
   type-preserving `@[csimp]` swap of `mul` itself is not available: every
   subquadratic scheme needs subtraction (Karatsuba) or an integer
   encoding (Kronecker), and `mul` is defined over `[Add R] [Mul R]`
@@ -93,10 +96,10 @@ hex-gfq-ring, and hex-berlekamp-mathlib (Berlekamp correctness proof).
 FLINT's `fmpz_poly` is the standard reference for univariate
 integer polynomial arithmetic. The comparator is `informational`
 rather than `gating`: FLINT tunes Karatsuba/Toom-Cook/FFT
-crossovers in `fmpz_poly_mul` and uses non-recursive Newton-style
-algorithms for division and GCD; Hex's implementation is
-schoolbook with the Karatsuba crossover named in the algorithm
-table above. The constant-factor gap is structural, not
-algorithmic. The ratio is recorded for orientation rather than as an
+crossovers in `fmpz_poly_mul` and uses Newton-style algorithms for
+division and GCD; this library deliberately supplies only the schoolbook
+semantic foundation. The coefficient-specific and composed algorithms are
+specified downstream in hex-poly-z and hex-poly-fast. The ratio is recorded
+for orientation rather than as an
 acceptance threshold. It is measured through a persistent Python process per
 `SPEC/benchmarking.md §"External comparators" §"Process call"`.

--- a/HexPolyFp/SPEC/hex-poly-fp.md
+++ b/HexPolyFp/SPEC/hex-poly-fp.md
@@ -1,6 +1,8 @@
-# hex-poly-fp (polynomials over F_p, depends on hex-poly + hex-mod-arith)
+# hex-poly-fp (polynomials over F_p)
 
 Specialized polynomial arithmetic over `Z/pZ` using `UInt64` coefficients.
+It depends on hex-poly and hex-mod-arith today. The fast-arithmetic stage adds
+hex-poly-fast and hex-modular, after both planned libraries are active.
 
 **Contents:**
 - `FpPoly p` = `DensePoly (ZMod64 p)` with specialized fast paths
@@ -52,3 +54,39 @@ hex-mod-arith (or hex-matrix as a fast path for matrix operations).
 
 For large p (≥ 2^32), each multiplication must reduce immediately
 (or use 128-bit intermediates), so lazy reduction doesn't apply.
+
+## Fast polynomial arithmetic
+
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) supplies the generic
+lawful-plan interface, Newton division, half-gcd, product trees, multipoint
+operations, and Padé approximation. This library supplies the `FpPoly`
+multiplication plan and keeps `mulPacked` as its small-input baseline.
+
+Three NTT paths are exposed:
+
+- direct ordinary convolution when the target prime contains a root for the
+  padded transform length;
+- direct cyclic or negacyclic convolution when the corresponding root-order
+  condition holds;
+- convolution over the fixed auxiliary NTT-prime catalogue followed by
+  balanced CRT and reduction modulo the target prime.
+
+For operand sizes `r`, `s`, put `k = min r s`. Canonical coefficient lifts
+give the integer bound `B = k * (p - 1)^2`; auxiliary primes are accepted only
+when their product `P` satisfies the strict uniqueness condition `2*B < P`.
+`mulNtt?` and `mulNttCrt?` return `none` when no suitable length or sufficient
+catalogue product is available, and a `some` result is proved equal to
+`DensePoly.mul`. `mulFast` is total: it dispatches among packed schoolbook,
+generic Karatsuba, direct NTT, and CRT-NTT, falling back rather than exposing
+catalogue exhaustion.
+
+The same `FpPoly` plan drives fast division and half-gcd. Square-free
+decomposition, Frobenius/power reduction, modular composition, and quotient-
+ring consumers adopt those operations only at their measured crossover.
+`DensePoly.mul`, `mulPacked`, and every existing theorem remain compatible.
+
+Benchmarks sweep degree, target modulus, transform length, operand ratio,
+cold/warm plan use, and every dispatcher boundary. Conformance forces each
+kernel and checks it against `mulPacked`, schoolbook multiplication, and the
+existing FLINT oracle; an invalid direct root or insufficient CRT product is
+a required fallback case.

--- a/HexPolyZ/SPEC/hex-poly-z.md
+++ b/HexPolyZ/SPEC/hex-poly-z.md
@@ -169,6 +169,42 @@ by index would drop those allocations and the `O(n log n)` element
 copying, which is the largest remaining cost in the kernel (50 µs of
 149 µs at degree 90).
 
+## Multipoint Kronecker and CRT-NTT
+
+The fast-arithmetic stage specified by
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) extends this owner rather
+than moving integer packing into the generic library. Existing
+`mulKronecker`, `mulKroneckerAt`, and their agreement theorems remain
+compatible.
+
+The new forced kernels are KS2 (evaluation at `B` and `-B`), KS3 (forward and
+reciprocal/reversed packing), and KS4 (their combination). They use two or
+four shorter GMP multiplications and prove signed recovery at every slot.
+Runtime bounds use the product of the two operands' separate maximum absolute
+coefficients and the maximum number of contributing terms. The production
+dispatcher measures KS1/KS2/KS3/KS4 across degree, operand ratio, coefficient
+width, and the GMP Karatsuba/Toom/FFT regimes; it does not assume that the
+variant with the most evaluation points wins everywhere.
+
+For larger products, `mulNttCrt?` transforms the integer coefficients modulo
+the fixed auxiliary primes owned by hex-mod-arith and reconstructs them with
+the balanced batch CRT owned by hex-modular. With `k = min p.size q.size`,
+`A = maxAbs p`, and `C = maxAbs q`, it accumulates primes until their product
+`P` satisfies `2 * k * A * C < P`. This strict bound makes symmetric CRT
+reconstruction equal to each true signed coefficient. The operation returns
+`none` if the fixed catalogue cannot cover the transform length or bound.
+
+`ZPoly.mulFast` is total and dispatches among schoolbook, KS1/KS2/KS3/KS4,
+and CRT-NTT, falling back on catalogue exhaustion. Every forced kernel and the
+dispatcher are proved equal to `DensePoly.mul`. The resulting `ZPoly`
+multiplication plan can drive generic product trees and clipped products; no
+new `Mul ZPoly` instance is introduced.
+
+This stage adds dependencies on hex-poly-fast, hex-mod-arith, and hex-modular
+only after those libraries are active. Its conformance extends the current
+signed Kronecker fixtures, and its benchmark extends the current two-
+dimensional grid rather than replacing it with asymptotic-only cases.
+
 ## External comparators
 
 | Comparator | Class | Scope |
@@ -176,8 +212,9 @@ copying, which is the largest remaining cost in the kernel (50 µs of
 | FLINT `fmpz_poly` via python-flint | informational | bench targets exercising arithmetic on `ZPoly` (the integer-polynomial surface inherited from `HexPoly`) |
 
 Same comparator and rationale as `hex-poly` (informational because
-of FLINT's tuned Karatsuba/Toom-Cook/FFT crossovers vs Hex's
-schoolbook-plus-Kronecker implementation). The Mignotte / Hensel-lift
+FLINT and Hex have independently tuned schoolbook/Kronecker/transform
+dispatchers, so one global ratio cannot gate every input cell). The Mignotte /
+Hensel-lift
 data surfaces specific to `hex-poly-z` have no direct FLINT
 analog at the same level of abstraction; those bench targets
 declare absence with the `no-comparable-surface-in-named-comparator`

--- a/HexTruncatedSeries/SPEC/hex-truncated-series.md
+++ b/HexTruncatedSeries/SPEC/hex-truncated-series.md
@@ -10,8 +10,9 @@ each operation with its Mathlib counterpart where one exists.
 This SPEC expands the "Truncated power series" entry of
 [future-work](../../SPEC/future-work.md). It does not specify fast polynomial
 division, fast polynomial remainder, or any conversion to `DensePoly`.
-Those belong to the planned `hex-poly-fast`, which depends on both this
-library and hex-poly. The reason is given under "Placement in the DAG".
+Those belong to the planned [hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md), which depends
+on both this library and hex-poly. The reason is given under "Placement in
+the DAG".
 
 ## Why this library exists
 
@@ -56,7 +57,7 @@ The planned consumer joins this library to hex-poly:
 
 ```text
 hex-poly ─────────────┐
-                      ├── hex-poly-fast  (planned)
+                      ├── hex-poly-fast
 hex-truncated-series ──┘
 ```
 
@@ -254,28 +255,37 @@ of the full-precision cost:
 
 ```lean
 /-- The product, with every coefficient at index `m` or above set to
-zero. Costs `O(m²)` coefficient operations rather than `O(n²)`. -/
+zero. Its logical body is the bounded schoolbook convolution. -/
 def mulUpTo (m : Nat) (a b : TSeries R n) : TSeries R n
+
+/-- The measured schoolbook/Karatsuba implementation of `mulUpTo`. -/
+def mulUpToImpl (m : Nat) (a b : TSeries R n) : TSeries R n
+
+@[csimp] theorem mulUpTo_eq_impl : @mulUpTo = @mulUpToImpl
 
 theorem coeff_mulUpTo (m) (a b) (i) (hi : i < n) :
     (mulUpTo m a b).coeff i = if i < m then (a * b).coeff i else 0
 ```
 
 `mulUpTo n = (· * ·)` up to the propositional equality above, and
-`mulUpTo` is the single place a later fast multiplication goes. That is
+`mulUpTo` is the single place fast multiplication goes. That is
 the reason the iterations are written against it rather than against
 `*`.
 
-**A later fast multiplication lands in this library, not in
+**Fast series multiplication lands in this library, not in
 hex-poly-fast.** `mulUpTo` is a concrete definition here, and a library
 above cannot change what `invOfUnit` calls; saying otherwise would be
-wrong about how Lean works. The point is that no consumer has to change:
-Karatsuba, Toom-Cook, and an NTT on a coefficient `Vector` are
-self-contained array algorithms needing nothing from hex-poly, so they
-belong in `Ring.lean` beside the schoolbook version, behind the same
-signature and the same `coeff_mulUpTo`. hex-poly-fast is about
-polynomial division and reversal, which are facts about `DensePoly`, and
-it consumes this library's series API rather than modifying it.
+wrong about how Lean works. `mulUpToImpl` therefore uses schoolbook below a
+measured cutoff and a clipped Karatsuba recursion above it, with the same
+signature and `coeff_mulUpTo` theorem. The recursion needs only coefficient
+addition, subtraction, and multiplication and so adds no dependency.
+
+[hex-poly-fast](../../SPEC/Libraries/hex-poly-fast.md) owns polynomial reversal and a separate
+plan-driven Newton inverse. That inverse is proved equal to `invOfUnit` after
+conversion, but it does not modify this function or route a coefficient-
+specific NTT/Kronecker plan into this library. This deliberate duplication
+keeps the DAG acyclic and lets this library's own `exp`, `log`, square root,
+and reversion benefit from subquadratic bounded products.
 
 ## Degenerate precisions
 
@@ -445,7 +455,7 @@ The `ZMod64 p` instances are **not**
 here, because `ZMod64` is hex-mod-arith's type and depending on
 hex-mod-arith would add an edge this library does not need. They belong
 in whichever library has both types in scope, which in practice is
-hex-poly-fast or a consumer. The open questions record the alternative.
+hex-poly-fp or another consumer. The open questions record the alternative.
 
 Per-algorithm hypotheses, collected:
 
@@ -664,16 +674,13 @@ commutative, `a` is a unit, and inverses of a unit are unique. It is
 what lets every later theorem say "the inverse" rather than "an
 inverse".
 
-**Against a naive baseline, Newton inversion wins nothing at schoolbook
-multiplication.** The linear recurrence `b_i = -u · Σ_{j<i} a_{i-j} b_j`
-computes the same answer in `O(n²)` coefficient operations, and so does
-this iteration. The Newton form is specified anyway because it is the
-form that becomes `O(M(n))` the moment `mulUpTo` becomes subquadratic,
-and hex-poly-fast is the library that makes it so. The benchmark
-requirement below is therefore "within a small constant of the
-recurrence", not "faster than the recurrence", and a SPEC that promised
-the latter at schoolbook multiplication would be promising something
-false.
+**Against a naive baseline, Newton inversion wins only after the measured
+Karatsuba crossover.** The linear recurrence
+`b_i = -u · Σ_{j<i} a_{i-j} b_j` and schoolbook Newton both use `O(n²)`
+coefficient operations. Above the `mulUpToImpl` crossover, bounded Newton is
+subquadratic. The benchmark therefore requires a bounded constant ratio in
+the schoolbook range and a growing win in the Karatsuba range; a claim that
+Newton wins below the multiplication crossover would still be false.
 
 ## Square root
 
@@ -1046,8 +1053,8 @@ and `1` over `ℤ` for exactly this reason.
 
 ## Complexity
 
-`M(m)` is the cost of `mulUpTo m` in coefficient operations: `O(m²)`
-schoolbook, and whatever hex-poly-fast later installs.
+`M(m)` is the cost of `mulUpToImpl m` in coefficient operations: `O(m²)`
+below the measured schoolbook crossover and `O(m^(log 2 3))` above it.
 
 | operation | algorithm | cost |
 |---|---|---|
@@ -1191,7 +1198,10 @@ what a downstream proof pays.
 Families:
 
 - **Multiplication**, precisions 8 to 4096 over `Int` and `Rat`. The
-  baseline every other family is read against.
+  baseline every other family is read against. It compares forced schoolbook,
+  forced Karatsuba, and production dispatch at cells immediately around the
+  crossover; no selected production cell may lose outside the benchmark
+  protocol's uncertainty band.
 - **Inverse**, the same ladder, Newton against the linear recurrence.
 - **`exp` and `log`**, precisions 8 to 1024 over `Rat`.
 - **Square root**, the same ladder over `Rat`.
@@ -1206,11 +1216,10 @@ Families:
 `fmpq_poly_revert_series`) are `informational`, not `gating`. The
 rationale is structural and is the same one hex-poly records for
 `fmpz_poly`: FLINT's series routines are built on a tuned
-Karatsuba/Toom-Cook/FFT multiplication, and this library multiplies
-schoolbook until hex-poly-fast exists, so the ratio measures the
-multiplication gap rather than anything about the Newton iterations.
-The comparator is reclassified to `gating` when hex-poly-fast lands, and
-the SPEC of that library is where the goal is written.
+Karatsuba/Toom-Cook/FFT multiplication, while this library stops at generic
+Karatsuba and has no coefficient-specific transform. The ratio therefore
+continues to measure a known kernel gap rather than only the Newton iteration,
+so it does not gate.
 
 Two required internal checks, which matter more than the external one:
 
@@ -1397,7 +1406,8 @@ operation.
 ## Milestones
 
 1. **The type and the ring.** `TSeries`, `coeff`, `ofFn`, `ext`,
-   `DecidableEq`, the ring operations, `mulUpTo`, and the
+   `DecidableEq`, the ring operations, `mulUpTo`, its measured
+   schoolbook/Karatsuba `mulUpToImpl`, and the
    `Lean.Grind.CommRing` instance. The `decide +kernel` test lands here,
    because that is when the `Vector` instance choice is still cheap to
    change.
@@ -1459,7 +1469,7 @@ HexTruncatedSeriesMathlib.lean
       comparators:
         - tool: FLINT fmpq_poly truncated series routines via python-flint
           class: informational
-          rationale: "FLINT's series routines run on a tuned Karatsuba/Toom-Cook/FFT multiplication while this library multiplies schoolbook until hex-poly-fast exists, so the measured ratio reports the multiplication gap rather than the Newton iterations. Reclassified to gating when hex-poly-fast lands."
+          rationale: "FLINT's series routines run on tuned Karatsuba/Toom-Cook/FFT multiplication while this library stops at generic Karatsuba, so the measured ratio includes a known coefficient-specific kernel gap."
       input_families:
         - name: multiplication
           description: truncated products at precisions 8 to 4096 over Int and Rat
@@ -1501,7 +1511,7 @@ release time.
   `log`, and `sqrt` useful over a small prime field, and they need
   hex-mod-arith. Adding that dependency would give the series library a
   second edge for the sake of two instances. The alternative is that
-  hex-poly-fast, or a small `hex-truncated-series-modular`, supplies
+  hex-poly-fp, or a small `hex-truncated-series-modular`, supplies
   them. The measurement that settles it is whether any consumer wants
   the modular instances without also wanting hex-poly.
 - **The Horner/Brent-Kung crossover**, and whether Brent-Kung's block

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -11,6 +11,7 @@
 - **hex-mv-hensel**: multivariate Hensel lifting against an evaluation ideal, with the coprimality witness, leading-coefficient contract, and reconstruction that Wang's EEZ factorization needs
 - **hex-mv-factor**: factorization of `Z[x_1, ..., x_n]` by Wang's EEZ algorithm, with a checked product decomposition and a separate irreducibility certificate
 - **hex-truncated-series**: power series truncated at a precision fixed in the type, with Newton inversion, square root, `exp`, `log`, composition, and reversion
+- **hex-poly-fast**: explicit lawful multiplication plans, Karatsuba and clipped products, Newton division, half-gcd, multipoint evaluation/interpolation, and Padé approximation
 - **hex-matrix**: dense matrices, matrix/vector arithmetic, elementary row and column operations, submatrix slicing, the Gram matrix
 - **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
 - **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
@@ -27,9 +28,9 @@
 - **hex-padics**: fixed-precision approximations to `Z_p` and `Q_p`, with the valuation reported as a bound when that is all the data supports, precision-aware arithmetic, partial inversion and division, and exactification by rational reconstruction
 - **hex-modular-matrix**: multi-modular determinant, certified rank, and Dixon p-adic linear solving over `Q`
 - **hex-finite-field**: the Mathlib-free `F_q` interface (characteristic, degree, Frobenius, indexing), the generic `q`-power Frobenius and Frobenius matrix
-- **hex-poly-fp**: polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
+- **hex-poly-fp**: polynomials over `F_p`, Frobenius map, square-free decomposition, packed/NTT/CRT-NTT multiplication, lazy reduction for small p
 - **hex-gf2**: packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
-- **hex-poly-z**: polynomials over `Z`, content/primitive part, Mignotte bound
+- **hex-poly-z**: polynomials over `Z`, content/primitive part, Mignotte bound, multipoint Kronecker and CRT-NTT multiplication
 - **hex-poly-z-gcd**: modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division
 - **hex-cyclotomic**: dense integer cyclotomic polynomials from a checked factorization of the index, the divisor family, and the factorization of `x^n - 1`
 - **hex-roots**: certified complex root isolation for `Z[x]` via dyadic squares, Pellet tests, and speculative Newton iteration
@@ -111,6 +112,7 @@ Each library with its immediate dependencies:
 - **hex-mv-hensel**: hex-mv-gcd, hex-mv-poly, hex-poly, hex-poly-z, hex-poly-fp, hex-mod-arith, hex-modular, hex-arith, hex-basic
 - **hex-mv-factor**: hex-mv-hensel, hex-mv-gcd, hex-mv-poly, hex-berlekamp-zassenhaus, hex-poly, hex-poly-z, hex-poly-z-gcd, hex-poly-fp, hex-mod-arith, hex-modular, hex-arith, hex-basic
 - **hex-truncated-series**: hex-basic
+- **hex-poly-fast**: hex-poly, hex-truncated-series
 - **hex-matrix**: hex-basic
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
@@ -128,8 +130,8 @@ Each library with its immediate dependencies:
 - **hex-finite-field**: hex-arith, hex-mod-arith, hex-poly, hex-poly-fp, hex-matrix, hex-basic
 - **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
 - **hex-lll**: hex-gram-schmidt, hex-matrix, hex-basic
-- **hex-poly-fp**: hex-poly, hex-mod-arith
-- **hex-poly-z**: hex-poly, hex-arith, hex-basic
+- **hex-poly-fp**: hex-poly, hex-mod-arith, hex-poly-fast, hex-modular
+- **hex-poly-z**: hex-poly, hex-arith, hex-basic, hex-poly-fast, hex-mod-arith, hex-modular
 - **hex-poly-z-gcd**: hex-poly-z, hex-poly-fp, hex-poly, hex-modular, hex-mod-arith, hex-arith, hex-resultant
 - **hex-cyclotomic**: hex-poly-z, hex-int-factor, hex-poly
 - **hex-roots**: hex-poly-z
@@ -463,9 +465,24 @@ valid publication order in
 hex-basic ── hex-truncated-series ── hex-truncated-series-mathlib
 
 hex-truncated-series ──┐
-                       ├── hex-poly-fast (planned)
+                       ├── hex-poly-fast
 hex-poly ──────────────┘
 ```
+
+The coefficient-specific fast kernels point back down to the arithmetic
+owners rather than moving those representations into hex-poly-fast:
+
+```text
+hex-arith ── hex-mod-arith ─────────┐
+hex-arith ── hex-modular ───────────┼── hex-poly-fp / hex-poly-z
+hex-poly-fast ───────────────────────┘
+```
+
+hex-mod-arith owns reusable word-modular NTT plans, hex-modular owns balanced
+batch CRT, hex-poly-fp owns direct and auxiliary-prime NTT adapters, and
+hex-poly-z owns multipoint Kronecker and integer CRT-NTT dispatch. The complete
+boundary and staged dependency change are specified in
+[hex-poly-fast](hex-poly-fast.md).
 
 `hex-primality` sits directly on `hex-arith`, which owns the
 `Hex.Nat.Prime` predicate, Fermat's little theorem, and the modular
@@ -588,11 +605,12 @@ for developments whose source-local move has not happened yet.
 - [hex-mv-factor.md](../../HexMvFactor/SPEC/hex-mv-factor.md): factorization of `Z[x_1, ..., x_n]` by Wang's EEZ algorithm, the evaluation-point and leading-coefficient search, the checked product decomposition, and the separate irreducibility certificate (the Mathlib companion is specified in the same file)
 - [hex-truncated-series](../../HexTruncatedSeries/SPEC/hex-truncated-series.md): power series truncated at a precision fixed in the type, Newton inversion, square root, `exp`, `log`, composition, and reversion
 - [hex-truncated-series-mathlib](../../HexTruncatedSeriesMathlib/SPEC/hex-truncated-series-mathlib.md): quotient-by-`X ^ n` equivalence and operation correspondence
-- [hex-poly-fp](../../HexPolyFp/SPEC/hex-poly-fp.md): polynomials over `F_p`, Frobenius, square-free decomposition
+- [hex-poly-fast.md](hex-poly-fast.md): explicit lawful multiplication plans, Karatsuba and clipped products, Newton division, half-gcd, multipoint evaluation/interpolation, and Padé approximation
+- [hex-poly-fp](../../HexPolyFp/SPEC/hex-poly-fp.md): polynomials over `F_p`, Frobenius, square-free decomposition, and packed/direct-NTT/CRT-NTT multiplication
 - [hex-gf2](../../HexGF2/SPEC/hex-gf2.md): packed bitwise polynomials over `F_2`, `GF(2^n)` elements
 - [hex-gf2-mathlib](../../HexGF2Mathlib/SPEC/hex-gf2-mathlib.md): `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
 - [hex-poly-fp-mathlib](../../HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md): `FpPoly p ≃+* Polynomial (ZMod p)`, the crossing point to Mathlib's polynomial type
-- [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound
+- [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound, multipoint Kronecker, and CRT-NTT multiplication
 - [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md): Mignotte bound proof via Mathlib's Mahler measure
 - [hex-poly-z-gcd.md](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md): modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division (the Mathlib companion is specified in the same file)
 - [hex-cyclotomic.md](hex-cyclotomic.md): dense integer cyclotomic polynomials indexed by a checked factorization, the squarefree-kernel and divisor-recursion routes, the divisor family, and the factorization of `x^n - 1` (the Mathlib companion is specified in the same file)

--- a/SPEC/Libraries/hex-poly-fast.md
+++ b/SPEC/Libraries/hex-poly-fast.md
@@ -1,0 +1,737 @@
+# hex-poly-fast (fast dense-polynomial arithmetic)
+
+Fast multiplication, division, gcd, multipoint operations, and Padé
+approximation for `DensePoly`, without changing the deliberately small
+schoolbook interface of hex-poly. Mathlib-free.
+
+This SPEC replaces the "Fast polynomial arithmetic" sketch in
+[future-work](../future-work.md). It depends on both hex-poly and
+[hex-truncated-series](../../HexTruncatedSeries/SPEC/hex-truncated-series.md). Coefficient-specific kernels
+remain in the libraries that own the coefficient representation:
+hex-poly-z owns integer packing and CRT reconstruction, hex-mod-arith owns
+word-modular transforms, hex-modular owns integer CRT, and hex-poly-fp owns
+the `FpPoly` adapters and dispatch.
+
+## Why this library exists
+
+**The current semantic foundation is intentionally quadratic.**
+`DensePoly.mul` is the schoolbook convolution over only `[Add R] [Mul R]`.
+That weak signature is useful: it makes multiplication available over every
+coefficient type that can state it and gives every optimized routine one
+small reference operation to agree with. It cannot itself be replaced by
+Karatsuba, which needs subtraction, or by Kronecker substitution and NTTs,
+which know the coefficient representation.
+
+**Fast division is not a separate optimization.** Newton division reverses
+the divisor, inverts it as a truncated series, and uses short products to
+recover the quotient. Half-gcd then groups many such degree-reducing steps.
+Product trees, remainder trees, interpolation, and Padé approximation use
+the same multiplication, reciprocal, and middle-product machinery. A library
+that supplied only `mulKaratsuba` would leave the important algorithms unable
+to compose.
+
+**The coefficient libraries need one algorithmic consumer interface.**
+`ZPoly` and `FpPoly` are abbreviations of `DensePoly`, not new representations
+that can carry competing `Mul` instances. An explicit multiplication plan
+lets integer Kronecker, direct NTT, and CRT-NTT kernels drive the generic
+division and tree algorithms without instance ambiguity and without making
+this library depend back on either coefficient library.
+
+**The performance work must reach callers.** A fast kernel that no existing
+consumer selects is not a completed optimization. The last milestone audits
+the Hensel, finite-field, GFq, Berlekamp, and Berlekamp-Zassenhaus hot paths
+and changes each call site only when its own benchmark crosses over.
+
+## Placement in the DAG
+
+The generic library has exactly two direct dependencies:
+
+```text
+hex-basic ── hex-truncated-series ──┐
+                                    ├── hex-poly-fast
+hex-poly ────────────────────────────┘
+```
+
+It does not depend on hex-mod-arith, hex-modular, hex-poly-fp, or hex-poly-z.
+Those libraries construct plans above it:
+
+```text
+hex-arith ── hex-mod-arith ─────────┐
+hex-arith ── hex-modular ───────────┼── hex-poly-fp / hex-poly-z
+hex-poly-fast ───────────────────────┘
+```
+
+This direction is essential. Putting `ZMod64` or `Int` dispatch in
+hex-poly-fast would make the generic algorithms drag both arithmetic stacks
+into every consumer. Putting polynomial reversal in hex-truncated-series
+would give that library a hex-poly dependency and destroy the reason its
+fixed-vector representation sits below polynomial arithmetic.
+
+hex-truncated-series keeps its own `mulUpTo` implementation. A library above
+it cannot change what `TSeries.invOfUnit` calls. Its SPEC therefore requires
+a measured generic Karatsuba path for `mulUpTo`, while this library supplies
+a separate plan-driven Newton inverse whose correctness is stated by
+conversion to `TSeries.invOfUnit`. The small duplication is the price of the
+acyclic dependency boundary; the semantic proof is shared.
+
+## Scope
+
+In scope:
+
+- explicit lawful multiplication plans;
+- schoolbook and Karatsuba full products, squaring, unbalanced products, and
+  arbitrary clipped products;
+- cyclic and negacyclic products with positive length;
+- reversal and fixed-precision `TSeries` bridges;
+- Newton reciprocal precomputation and fast monic/field division;
+- half-gcd, gcd, full extended gcd, and one-sided extended gcd;
+- balanced product and remainder trees;
+- reusable multipoint evaluation and interpolation plans;
+- homogeneous Padé approximants and the normalized rational-series form;
+- agreement theorems, conformance fixtures, crossover benchmarks, and the
+  benchmark-gated downstream adoption audit.
+
+Coefficient-specific work specified here but implemented in its owner:
+
+- two- and four-point Kronecker substitution in hex-poly-z;
+- redundant-residue NTT butterflies and reusable transform plans in
+  hex-mod-arith;
+- balanced batch CRT in hex-modular;
+- direct and auxiliary-prime NTT convolution in hex-poly-fp and hex-poly-z.
+
+Out of scope:
+
+- changing `DensePoly.mul`, its `Mul` instance, or its minimal typeclass
+  requirements;
+- a `PolyOps` abstraction over dense and sparse representations;
+- Toom-Cook before a measured gap remains between Karatsuba and the
+  coefficient-specific kernels;
+- a limb-level arbitrary-precision integer middle product;
+- multivariate multiplication, sparse interpolation, or polynomial-matrix
+  approximant bases;
+- a new Mathlib companion.
+
+## The semantic boundary stays schoolbook
+
+Every public optimized operation reduces to a theorem about existing
+`DensePoly` semantics. Dispatch thresholds, cached roots, scratch allocation,
+and the chosen kernel are absent from theorem statements.
+
+There is deliberately no typeclass for the plan. Plans are passed explicitly:
+
+```lean
+namespace Hex.DensePoly
+
+structure MulPlan (R : Type u) [Zero R] [DecidableEq R]
+    [Lean.Grind.CommRing R] where
+  /-- A complete normalized product. -/
+  mul : DensePoly R → DensePoly R → DensePoly R
+  /-- A specialized square; it need not call `mul p p`. -/
+  square : DensePoly R → DensePoly R
+  /-- `len` coefficients beginning at product degree `lo`, shifted down. -/
+  slice : Nat → Nat → DensePoly R → DensePoly R → DensePoly R
+  mul_eq : ∀ a b, mul a b = a * b
+  square_eq : ∀ a, square a = a * a
+  coeff_slice : ∀ lo len a b i,
+    (slice lo len a b).coeff i =
+      if i < len then (a * b).coeff (lo + i) else 0
+
+def schoolbookPlan : MulPlan R
+def karatsubaPlan (cutoff : Nat) : MulPlan R
+
+def mulWith (plan : MulPlan R) (a b : DensePoly R) : DensePoly R :=
+  plan.mul a b
+
+def squareWith (plan : MulPlan R) (a : DensePoly R) : DensePoly R :=
+  plan.square a
+
+def mulLow (plan : MulPlan R) (len : Nat)
+    (a b : DensePoly R) : DensePoly R :=
+  plan.slice 0 len a b
+```
+
+The proof fields are erased. Passing a plan does not move correctness into a
+runtime checker, and using a structure rather than a typeclass prevents a
+global choice of integer or finite-field multiplication from leaking into
+unrelated code.
+
+`slice lo len` is the primitive rather than separate low, high, and middle
+implementations. The named middle-product wrapper selects the standard range:
+for operand sizes `m >= n > 0`, coefficients `n - 1` through `m - 1`, shifted
+down to indices `0` through `m - n`. Callers that already know `m`, `n`, and
+the inequalities take the proof-accepting form; the checked form reorders the
+operands and handles an empty operand by returning zero.
+
+The generic agreement theorems are short projections:
+
+```lean
+theorem mulWith_eq (plan : MulPlan R) (a b : DensePoly R) :
+    mulWith plan a b = a * b
+
+theorem squareWith_eq (plan : MulPlan R) (a : DensePoly R) :
+    squareWith plan a = a * a
+
+theorem coeff_mulLow (plan : MulPlan R) (len i : Nat) (a b : DensePoly R) :
+    (mulLow plan len a b).coeff i =
+      if i < len then (a * b).coeff i else 0
+```
+
+The substantive proofs are the laws of each plan.
+
+## Generic multiplication algorithms
+
+### Schoolbook plan
+
+`schoolbookPlan` delegates full multiplication to `DensePoly.mulImpl` and
+computes a slice without first allocating the full result. For output index
+`k`, it folds exactly the valid pairs `i + j = lo + k`. It is both the base
+case of every recursive plan and the independent executable comparator used
+by conformance tests.
+
+### Karatsuba plan
+
+The Karatsuba plan works over `Lean.Grind.CommRing`, because the cross term
+uses subtraction. For a balanced split `a = a0 + x^k a1` and
+`b = b0 + x^k b1`, it computes
+
+```text
+z0 = a0*b0
+z2 = a1*b1
+z1 = (a0+a1)*(b0+b1) - z0 - z2
+```
+
+and assembles `z0 + x^k z1 + x^(2k) z2`. The recursion:
+
+- stops at an explicit cutoff, including cutoff zero;
+- handles odd sizes without padding an observable trailing zero;
+- normalizes only once at the public `DensePoly` boundary;
+- uses uniquely owned arrays for assembly rather than repeated append;
+- has a specialized square recursion, reusing the two equal halves rather
+  than rediscovering equality inside the generic product;
+- prunes a recursive subproduct when its entire output interval lies outside
+  `slice lo len`.
+
+For operands with sizes `m >> n`, the long operand is split into blocks near
+the shorter size and the block products are accumulated at their offsets.
+Padding both inputs to `max m n` is forbidden: it turns a linear number of
+useful blocks into a balanced product whose unused work can dominate the
+caller. The declared cost is
+`O(ceil(m/n) * M(n))` for `m >= n > 0`, with `M` the balanced plan cost.
+
+Full balanced multiplication and squaring cost
+`O(n^(log₂ 3))`; clipped products have the same asymptotic upper bound and
+must show a constant-factor win over full-product-then-slice in the
+schoolbook/Karatsuba range before their production crossover is enabled.
+
+### Cyclic and negacyclic products
+
+The generic definitions fold an ordinary product modulo `x^n - 1` and
+`x^n + 1`, respectively. A proof-taking API requires `0 < n`; checked forms
+return `none` at `n = 0`. Their theorems identify the result with the
+corresponding polynomial remainder and bound its size by `n`.
+
+hex-poly-fp may compute these operations directly with an NTT plan. The
+generic fold remains the reference and fallback, so the direct path needs no
+new algebraic semantics.
+
+## Reversal and truncated series
+
+For a polynomial `f` and precision `n`, reversal reads the coefficient below
+the leading end first and zero-extends to exactly `n` entries:
+
+```lean
+def reverseSeries (f : DensePoly R) (n : Nat) : TSeries R n
+
+theorem coeff_reverseSeries (f : DensePoly R) (n i : Nat) (hi : i < n) :
+    (reverseSeries f n).coeff i = f.coeff (f.size - 1 - i)
+```
+
+The theorem is accompanied by a range-aware form, because subtraction on
+`Nat` makes the displayed convenience statement useful only while
+`i < f.size`. `polyOfSeries` converts a fixed prefix back through
+`DensePoly.ofCoeffs`; its coefficient theorem, not structural array equality,
+is the bridge used by division proofs.
+
+The plan-driven Newton step computes
+
+```text
+h' = h * (2 - g*h) mod x^k
+```
+
+at doubling precisions, using `MulPlan.slice 0 k`. `reciprocalWith` takes an
+explicit inverse `u` of the constant coefficient. Under
+`g.coeff 0 * u = 1`, its result converts to the same truncated series as
+`TSeries.invOfUnit g u`. This library does not replace or redirect
+`TSeries.invOfUnit`.
+
+## Reusable fast division
+
+A reciprocal is worth caching whenever a fixed modulus divides many values,
+as in a remainder tree or quotient ring:
+
+```lean
+structure DivPlan (R : Type u) [Zero R] [DecidableEq R]
+    [Lean.Grind.CommRing R] where
+  divisor : DensePoly R
+  capacity : Nat
+  reciprocal : TSeries R capacity
+  divisor_ne : divisor ≠ 0
+  reciprocal_spec : ...
+
+def DivPlan.ofMonic (mul : MulPlan R) (q : DensePoly R)
+    (hq : Monic q) (capacity : Nat) : DivPlan R
+
+def DivPlan.ofNonzero [Lean.Grind.Field R] (mul : MulPlan R)
+    (q : DensePoly R) (hq : q ≠ 0) (capacity : Nat) : DivPlan R
+```
+
+`DivPlan.divMod` takes evidence that the requested quotient length is within
+`capacity`. Its quotient is the reversal of a low product with the cached
+reciprocal; the remainder is `p - quotient * divisor`, computed with the
+same multiplication plan. `DivPlan.mod` may omit materialization of a
+quotient that the caller does not retain, but agrees with the second
+component.
+
+The one-shot API is total and preserves existing conventions:
+
+```lean
+def divModWith [Lean.Grind.Field R] (mul : MulPlan R)
+    (p q : DensePoly R) : DensePoly R × DensePoly R
+
+theorem divModWith_eq [Lean.Grind.Field R] (mul : MulPlan R) (p q) :
+    divModWith mul p q = DensePoly.divMod p q
+```
+
+In particular, division by zero returns `(0, p)`, a divisor larger than the
+dividend returns `(0, p)`, and a nonzero constant divisor returns zero
+remainder. `divModMonicWith` supplies the analogous commutative-ring API.
+
+The declared cost for quotient length `k` is `O(M(k))` after a reciprocal of
+precision `k` is available and `O(M(k))` including construction, since the
+doubling steps form a geometric series for every supported multiplication
+plan.
+
+## Half-gcd
+
+The half-gcd implementation uses a dedicated four-polynomial transformation
+record rather than depending on hex-matrix:
+
+```lean
+structure GcdStep (R : Type u) [Zero R] [DecidableEq R] where
+  a00 : DensePoly R
+  a01 : DensePoly R
+  a10 : DensePoly R
+  a11 : DensePoly R
+```
+
+Its invariant states that applying the transformation to the input pair gives
+the current Euclidean pair and that the second component has crossed the
+requested degree boundary. Recursive high-half calls use middle products;
+the finishing steps use `divModWith`.
+
+Expose `gcdWith`, `xgcdWith`, and `xgcdLeftWith`. Their acceptance theorem is
+exact executable agreement with `DensePoly.gcd`, `DensePoly.xgcd`, and
+`DensePoly.xgcdLeft`, including the returned scaling and Bezout coefficients.
+Agreement merely up to multiplication by a unit is insufficient: existing
+callers compare the raw gcd and transport the current `GcdLaws` theorems.
+
+The implementation must therefore preserve the existing Euclidean quotient
+sequence and input order. It may group steps into matrices but may not insert
+monic normalization between them. Zero pairs, one zero input, reversed degree
+order, and constant divisors are explicit base cases. The declared balanced
+cost is `O(M(n) log n)`.
+
+## Product trees and multipoint operations
+
+`ProductTree` is an opaque balanced tree of nonempty levels. Its public
+observations are its leaf sequence, root product, and the product represented
+by each node. Construction accepts general polynomial leaves; a point plan
+uses leaves `x - C point`.
+
+`EvalPlan` stores the point sequence, its product tree, and the reciprocal
+plans needed by the remainder tree. Reusing it for another polynomial does
+not rebuild products or reciprocals:
+
+```lean
+def EvalPlan.build (mul : MulPlan R) (points : Array R) : EvalPlan R
+def EvalPlan.eval (plan : EvalPlan R) (f : DensePoly R) : Array R
+
+theorem EvalPlan.get_eval (plan : EvalPlan R) (f) (i) (hi : i < plan.size) :
+    (plan.eval f)[i] = f.eval plan.points[i]
+```
+
+Evaluation works over a commutative ring because every divisor in the point
+tree is monic. The empty point sequence produces an empty result.
+
+Interpolation needs a field and distinct points. `InterpPlan.build?` returns
+`none` exactly when duplicate points are present. It reuses the point product,
+evaluates its derivative at the points, stores the inverse derivative values,
+and combines the weighted leaves bottom-up. `InterpPlan.interpolate?` returns
+`none` exactly on a value-count mismatch; an empty plan interpolates the empty
+value array to zero.
+
+Soundness states that the result has size at most the point count and evaluates
+to every supplied value. Uniqueness states that any polynomial of smaller
+degree with those values is equal to the result. Both construction and one
+evaluation/interpolation cost `O(M(n) log n)`; the reusable plan cost is
+reported separately.
+
+## Padé approximation
+
+For a series prefix `s` and bounds `m`, `n`, a homogeneous approximant is a
+nonzero pair `(p, q)` satisfying
+
+```text
+degree p <= m
+degree q <= n
+q*s - p = 0 mod x^(m+n+1).
+```
+
+The public result carries those degree, nontriviality, and congruence fields.
+The homogeneous result is total over a field and is computed by the same
+half-gcd engine applied to `x^(m+n+1)` and the polynomial represented by the
+series prefix.
+
+A rational formal-series approximant additionally needs `q.coeff 0 ≠ 0`.
+`pade?` searches the terminal half-gcd candidates, normalizes a successful
+denominator to constant coefficient `1`, and returns `none` exactly when no
+approximant within the bounds has an invertible constant term. This distinction
+is required: for some series and degree pairs a homogeneous approximant exists
+but every admissible denominator has zero constant coefficient.
+
+The declared cost is `O(M(m+n) log (m+n))` and the specification includes the
+zero series, `m = 0`, `n = 0`, and precision zero.
+
+## Integer multiplication: multipoint Kronecker
+
+The existing `Hex.ZPoly.mulKronecker` and `mulKroneckerAt` remain compatible
+and keep their agreement theorems. New named kernels implement:
+
+- **KS2**, evaluation at `B` and `-B`, separating even and odd coefficients;
+- **KS3**, evaluation at `B` and the reciprocal direction represented by
+  reversing the coefficient blocks before packing;
+- **KS4**, the combination, using four integer multiplications of roughly
+  quarter-sized packed operands.
+
+Here `B = 2^b`, and every variant derives `b` from runtime scans of the two
+operands. Bounds use `maxAbs a * maxAbs b`, not the looser square of a shared
+maximum, and include the number of terms contributing to a coefficient.
+Signed coefficients use an explicit bias or symmetric digit recovery whose
+no-overlap and no-borrow obligations are proved for every slot.
+
+The two- and four-point variants trade more GMP multiplications for shorter
+operands. No asymptotic winner is assumed. `ZPoly.mulFast` dispatches among
+schoolbook, KS1, KS2, KS3, KS4, and CRT-NTT using a committed measured table
+over shorter size, operand ratio, and coefficient widths. The existing simple
+cutoff APIs remain available to reproduce the current benchmark.
+
+Every kernel has a theorem equal to `DensePoly.mul`; the dispatcher theorem is
+independent of the table contents.
+
+## Word-modular NTT
+
+The transform lives in hex-mod-arith because it is an operation on vectors of
+`ZMod64`, not on polynomials. A reusable plan records:
+
+```lean
+structure ZMod64.NttPlan (p n : Nat) [ZMod64.Bounds p]
+    [ZMod64.PrimeModulus p] where
+  length_pow_two : exists k, n = 2^k
+  root : ZMod64 p
+  root_order : ...                 -- exact order n
+  invRoot : ZMod64 p
+  invLength : ZMod64 p
+  forwardTwiddles : Array ...
+  inverseTwiddles : Array ...
+```
+
+The actual field layout may package powers and preconditioners together, but
+the public observations above and the exact-order theorem are fixed.
+`build?` validates the requested power-of-two length and returns `none` when
+`n` does not divide `p - 1` or no supplied root witness checks. Fixed
+auxiliary primes carry pre-built proofs and plans for every supported smaller
+length.
+
+Forward butterflies use representatives in `[0, 2p)` and inverse butterflies
+use `[0, 4p)`, following Harvey's modified Shoup algorithms. These raw words
+are internal bounded structures, not a second modular ring and not a public
+`CommRing` instance. The existing `p < 2^31` bound implies `4p < 2^33`, so
+all additions and subtractions fit comfortably in `UInt64`; Shoup products
+use the existing high-word primitive. Normalization to `ZMod64` happens only
+at transform boundaries.
+
+Required theorems:
+
+- each butterfly output has its advertised raw bound and canonical residue;
+- forward transform equals the coefficientwise DFT;
+- inverse after forward is the original vector;
+- pointwise product between the transforms gives cyclic convolution;
+- padding to `nextPowTwo (a.size + b.size - 1)` gives ordinary convolution;
+- a primitive `2n`th root gives negacyclic convolution of length `n`.
+
+No new `@[extern]` is part of this SPEC. The first implementation is Lean over
+the existing verified word primitives. A native transform would require a
+separate SPEC amendment naming its logical fallback, runtime contract, and
+measured reason to cross the FFI boundary.
+
+## CRT-NTT for arbitrary coefficients
+
+hex-mod-arith owns a fixed catalogue of `NttPrime` packages: a prime modulus
+below `2^31`, the maximum supported power-of-two transform length, and a root
+of that exact order. The catalogue is finite and checked in the kernel; a
+failed capacity or length request is normal control flow.
+
+hex-modular adds balanced batch CRT beside incremental `Crt`/`CrtVec`. The
+batch operation validates moduli greater than one and pairwise coprimality,
+builds a product tree, combines residues bottom-up, and returns symmetric
+representatives. Its agreement theorem is coefficientwise congruence to every
+input modulus, and uniqueness uses the existing strict `symMod_unique` bound.
+
+For operands of sizes `r`, `s`, put `k = min r s`.
+
+- For `FpPoly p`, canonical lifts give the absolute coefficient bound
+  `B = k * (p - 1)^2` before reduction modulo `p`.
+- For `ZPoly`, if the operand bounds are `A` and `C`, use
+  `B = k * A * C`.
+
+Auxiliary primes are accumulated until their product `P` satisfies `2*B < P`.
+The strict factor-two bound makes symmetric reconstruction equal to the true
+integer coefficient in both cases. The finite-field path then reduces that
+integer modulo `p`; the integer path returns it directly.
+
+`FpPoly.mulNtt?` uses the target modulus directly when it has a suitable root.
+`FpPoly.mulNttCrt?` and `ZPoly.mulNttCrt?` use the catalogue and return `none`
+when its length or modulus product is insufficient. Their soundness theorem is
+conditional only on returning `some`, not on an unchecked bound supplied by
+the caller. `FpPoly.mulFast` falls back to `mulPacked` or Karatsuba;
+`ZPoly.mulFast` falls back through the Kronecker dispatcher. Both public
+operations are total and equal schoolbook multiplication.
+
+## Complexity contracts
+
+Let `M(n)` be the measured balanced multiplication cost of the selected plan.
+
+| Operation | Required bound |
+|---|---:|
+| schoolbook full product | `O(n^2)` coefficient operations |
+| Karatsuba full/square | `O(n^(log₂ 3))` |
+| unbalanced `m x n`, `m >= n` | `O(ceil(m/n) * M(n))` |
+| radix-2 NTT convolution | `O(n log n)` word operations |
+| reciprocal and division | `O(M(n))` |
+| half-gcd / extended gcd | `O(M(n) log n)` |
+| product/remainder tree | `O(M(n) log n)` |
+| one multipoint evaluation/interpolation | `O(M(n) log n)` |
+| Padé approximation | `O(M(n) log n)` |
+
+These are executable design constraints, not merely analysis. A recursive body
+that repeatedly normalizes whole arrays, recomputes a reciprocal at every
+remainder-tree node, pads an unbalanced product to the longer size, or rebuilds
+an NTT root table inside each transform violates the SPEC even if it returns
+the correct polynomial.
+
+## Kernel exposure and trust
+
+The logical closure consists of schoolbook polynomial operations, the
+coefficientwise `TSeries` API, `Nat`/`Int` arithmetic, and the logical
+`ZMod64` operations already specified by hex-mod-arith. Optimized loops use
+ordinary definitions or proof-backed `@[csimp]` replacements where source and
+target types are identical.
+
+No theorem depends on a benchmark table or on the availability of a native
+provider. No root, prime, CRT width, or duplicate-point fact is accepted as an
+untrusted Boolean without a sound checker theorem. `native_decide` remains
+banned.
+
+## Conformance
+
+The new driver is `conformance/HexPolyFast/Conformance.lean`, with fixtures in
+`conformance-fixtures/HexPolyFast/`. The JSONL surface contains:
+
+- `mul`, `square`, and `slice`, including the selected kernel name;
+- `divmod`, `gcd`, `xgcd`, and `xgcd_left`;
+- `cyclic` and `negacyclic`;
+- `eval_many` and `interpolate`;
+- `pade` with the homogeneous relation and normalized success/failure;
+- NTT plan, round-trip, direct convolution, and CRT convolution cases;
+- KS1/KS2/KS3/KS4 forced-kernel cases.
+
+Small cases are checked independently against schoolbook operations and a
+simple Python/SymPy oracle. Integer and prime-field whole results are also
+checked against FLINT through the existing persistent oracle infrastructure.
+The oracle never reports which kernel Hex should choose; dispatch is tested by
+agreement plus benchmark evidence.
+
+Mandatory edge families:
+
+- both operands empty, one empty, constants, and normalized trailing zeros;
+- odd split sizes and every Karatsuba cutoff boundary;
+- operand ratios from balanced through at least 64:1;
+- empty, one-coefficient, last-coefficient, and wholly out-of-range slices;
+- positive and negative coefficients at every Kronecker digit bound;
+- NTT lengths `1`, `2`, the largest catalogue length, and one beyond it;
+- raw butterfly values at `0`, `p-1`, `p`, `2p-1`, and `4p-1` where valid;
+- CRT modulus products immediately below and above `2*B`;
+- zero divisor, constant divisor, larger divisor, and exact division;
+- gcd inputs `(0,0)`, `(f,0)`, `(0,f)`, associates, and reversed degrees;
+- empty point sets, duplicate interpolation points, and value-count mismatch;
+- Padé cases with a unit denominator, only a nonunit homogeneous denominator,
+  and no normalized result.
+
+## Benchmarking and production dispatch
+
+Per [benchmarking](../benchmarking.md), the bench driver is
+`bench/HexPolyFast/Bench.lean`. It imports no Mathlib. Every dispatch family
+records both time and allocation counts and includes cells immediately below,
+at, and above the proposed crossover.
+
+Required families:
+
+- schoolbook, Karatsuba, square, and clipped products over `Int`, `Rat`, and
+  small `ZMod64` fields, with degrees from 4 through at least 16384;
+- balanced and unbalanced shapes, with ratios 1, 2, 4, 16, and 64;
+- KS1/KS2/KS3/KS4 over the current degree/coefficient-width grid, extended
+  into the GMP Karatsuba, Toom, and FFT regimes;
+- direct NTT, CRT-NTT, packed Fp multiplication, and generic Karatsuba across
+  modulus and transform-length ladders;
+- cold plan construction, warm plan reuse, and repeated fixed-modulus calls;
+- Newton division against long division, with and without a cached divisor;
+- Euclidean gcd/xgcd against half-gcd;
+- Horner against product/remainder-tree evaluation for one and repeated
+  polynomials;
+- direct Lagrange interpolation against the reusable interpolation plan;
+- linear-algebra reference Padé against half-gcd Padé on small shared cases.
+
+FLINT `fmpz_poly` and `nmod_poly` are informational external comparators. The
+gating comparisons are within Lean: no production cell selected by a committed
+dispatch table may lose to the retained implementation outside the uncertainty
+band defined by the benchmark protocol. Each table records the host, toolchain,
+sample count, and script that regenerates it.
+
+The downstream audit covers at least:
+
+- `HexHensel.QuadraticMultifactor` product trees and lift products;
+- Fp square-free decomposition and the Berlekamp irreducibility gcd chain;
+- `FpPoly.composeModMonic`, Frobenius, and GFq reduction/power paths;
+- Berlekamp-Zassenhaus trial products and integer reassembly;
+- repeated modulus division in finite-field and quotient-ring consumers.
+
+A call site changes only when its representative end-to-end benchmark wins.
+A measured loss keeps the old path and is a completed audit result, not a
+reason to move the global crossover until unrelated cells regress.
+
+## The Mathlib layer
+
+There is no `hex-poly-fast-mathlib`. Each optimized multiplication and
+division theorem lands on an existing `DensePoly` operation, and
+hex-poly-mathlib already transports those operations to `Polynomial`.
+Likewise, evaluation and interpolation soundness are stated directly with
+`DensePoly.eval`; a later Mathlib-facing consumer can rewrite through the
+existing equivalence.
+
+If a future theorem needs Mathlib's asymptotic framework, it belongs in that
+consumer or in a documentation proof, not in the computational dependency
+graph. The executable complexity contracts here are enforced by body shape
+and benchmarks.
+
+## Milestones
+
+1. **Prerequisites.** Finish hex-truncated-series through Newton inversion and
+   hex-modular through scalar/vector and balanced batch CRT. Add measured
+   Karatsuba `mulUpTo` to hex-truncated-series without changing its dependency.
+2. **Generic multiplication.** `MulPlan`, schoolbook, Karatsuba, specialized
+   square, unbalanced blocking, arbitrary slices, cyclic/negacyclic references,
+   and all agreement theorems.
+3. **Newton division.** Reversal/series bridges, `reciprocalWith`, `DivPlan`,
+   monic and field division, cached remainders, and exact agreement.
+4. **Half-gcd.** The transformation invariant, fast gcd, full and one-sided
+   extended gcd, exact agreement, and the degree/complexity benchmarks.
+5. **Multipoint Kronecker.** KS2, KS3, KS4, signed bounds and recovery,
+   compatibility with current APIs, and the measured integer dispatcher.
+6. **NTT.** Plan validation, redundant forward/inverse butterflies, transform
+   correctness, direct Fp convolution, and cyclic/negacyclic adapters.
+7. **CRT-NTT.** Balanced batch CRT, the fixed prime catalogue, strict recovery
+   bounds, arbitrary-Fp and integer paths, and total fallback dispatchers.
+8. **Trees and Padé.** Product/remainder trees, reusable evaluation and
+   interpolation plans, homogeneous and normalized Padé, and their complete
+   conformance/benchmark families.
+9. **Adoption.** Audit the named consumers, switch only winning cells, update
+   their owning SPECs and benchmarks, and keep the single-job CI topology.
+
+No later milestone may be used to excuse a quadratic placeholder in an earlier
+one. In particular, milestone 3 implements Newton division with clipped
+products, and milestone 4 implements an actual half-gcd recursion rather than
+renaming the Euclidean loop.
+
+## File organisation
+
+```text
+HexPolyFast/
+  Plan.lean          -- MulPlan, schoolbookPlan, agreement projections
+  Karatsuba.lean     -- full, square, unbalanced, and clipped recursion
+  Cyclic.lean        -- cyclic and negacyclic reference operations
+  Reverse.lean       -- DensePoly/TSeries bridges
+  Reciprocal.lean    -- plan-driven Newton inverse
+  Division.lean      -- DivPlan and one-shot division
+  HalfGcd.lean       -- GcdStep, gcd, xgcd, xgcdLeft
+  ProductTree.lean   -- balanced product/remainder trees
+  Multipoint.lean    -- EvalPlan and InterpPlan
+  Pade.lean          -- homogeneous and normalized approximants
+HexPolyFast.lean
+```
+
+The coefficient-owner file layouts gain:
+
+```text
+HexModArith/Ntt/{Plan,Butterfly,Transform,Catalogue}.lean
+HexModular/BatchCrt.lean
+HexPolyFp/NttMul.lean
+HexPolyZ/KroneckerMulti.lean
+HexPolyZ/NttMul.lean
+```
+
+`libraries.yml` eventually gains, after its dependencies are active:
+
+```yaml
+  HexPolyFast:
+    deps: [HexPoly, HexTruncatedSeries]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_poly and nmod_poly via python-flint
+          class: informational
+          rationale: "FLINT has independently tuned coefficient-specific dispatch; within-Lean agreement and crossover cells gate production selection."
+      input_families:
+        - name: full-and-clipped-multiplication
+          description: Balanced and unbalanced full, square, low, and middle products across crossover sizes.
+        - name: newton-division
+          description: One-shot and cached-divisor division against long division.
+        - name: half-gcd
+          description: Gcd, full xgcd, and one-sided xgcd across balanced and skewed degree pairs.
+        - name: multipoint
+          description: Cold and reused product/remainder trees for evaluation and interpolation.
+        - name: pade
+          description: Homogeneous and normalized Padé cases, including normalized failure.
+        - name: coefficient-kernels
+          description: Forced Kronecker and direct/CRT-NTT paths across degree, width, and modulus ladders.
+```
+
+hex-poly-fp and hex-poly-z then add `HexPolyFast` and `HexModular`; hex-poly-z
+also adds `HexModArith`. The release manifest is updated only when those
+implementation changes actually land, never by this SPEC-only change.
+
+## References
+
+- David Harvey, [*Faster polynomial multiplication via multipoint Kronecker
+  substitution*](https://arxiv.org/abs/0712.4046), Journal of Symbolic
+  Computation 44 (2009), 1502-1510. This is the basis for KS2, KS3, and KS4.
+- David Harvey, [*Faster arithmetic for number-theoretic
+  transforms*](https://arxiv.org/abs/1205.2926), Journal of Symbolic
+  Computation 60 (2014), 113-119. This is the basis for the redundant Shoup
+  butterflies.
+- David Harvey, [*The Karatsuba integer middle
+  product*](https://doi.org/10.1016/j.jsc.2012.02.001), Journal of Symbolic
+  Computation 47 (2012), 954-967. This SPEC uses the polynomial
+  middle-product construction that the integer algorithm adapts; it does not
+  add a limb-level integer primitive.

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -77,27 +77,6 @@ and normalization behaviour differ, and gcd or division of sparse inputs
 usually becomes dense. Keep explicit conversions until several real consumers
 show which operations a common interface must support.
 
-### Fast polynomial arithmetic
-
-Proposed library: `hex-poly-fast`, depending on `hex-poly` and
-`hex-truncated-series`.
-
-Add algorithms behind the existing dense-polynomial semantics in measured
-stages:
-
-- Karatsuba multiplication with a benchmarked crossover.
-- Newton inversion of reversed polynomials, then fast division.
-- Half-gcd for gcd and extended gcd after fast division is useful.
-- Toom-Cook or NTT multiplication only when a consumer justifies the added
-  machinery. An NTT implementation may also depend on `hex-mod-arith` and use
-  CRT reconstruction for integer coefficients.
-
-Each fast routine needs an executable agreement theorem with the existing
-operation and benchmarks that include crossover-sized inputs rather than only
-asymptotic winners. The SPEC must keep the dependency direction from
-`hex-poly-fast` to both input libraries; `hex-truncated-series` should not
-acquire a dependency on `hex-poly` merely to support this consumer.
-
 ### Extended subresultant chain for gcd consumers
 
 Amend `hex-resultant` with the transformation that produces each Brown entry,

--- a/SPEC/prior-art.md
+++ b/SPEC/prior-art.md
@@ -31,3 +31,11 @@ Refinement-based approach.
 
 **FLINT (C)**: The performance target. Dense `nmod_poly` and `fmpz_poly`
 with Barrett reduction, Karatsuba, NTT. Not verified.
+
+**Harvey's practical multiplication kernels**: The fast-polynomial SPEC uses
+only three pieces of this line of work: multipoint Kronecker substitution
+(KS2/KS3/KS4), redundant-residue Shoup butterflies for word-sized NTTs, and
+the Karatsuba polynomial middle product underlying the integer middle-product
+paper. The exact algorithms, bounds, and references are recorded in
+[hex-poly-fast](Libraries/hex-poly-fast.md); the rest of Harvey's publication
+list is not part of that roadmap.

--- a/progress/20260824T053157Z_fast-polynomial-arithmetic-research.md
+++ b/progress/20260824T053157Z_fast-polynomial-arithmetic-research.md
@@ -1,0 +1,46 @@
+# Fast polynomial arithmetic research
+
+## Accomplished
+
+- Read `SPEC/future-work.md` from freshly fetched `origin/main` at
+  `4a74b7a6ed84fe2ef0a0ad4e386f65a72fee03b4`, specifically the fast
+  polynomial arithmetic sketch and its dependency placement.
+- Audited the related default-branch implementation and design state:
+  generic schoolbook `DensePoly.mul`, schoolbook Euclidean division/gcd,
+  the specified but unimplemented `hex-truncated-series`, optional packed
+  `FpPoly.mulPacked`, and the proved, measured `ZPoly.mulKronecker` kernel.
+- Reviewed the evidence from issues #9142/#9147 and #9320: Karatsuba lost
+  to Kronecker on the measured bignum Hensel shapes; single-point Kronecker
+  has degree/bit-width cutoffs; truncated series currently has a SPEC only.
+- Surveyed David Harvey's primary publication pages and papers on
+  multipoint Kronecker substitution, redundant-representation NTT
+  butterflies, middle products, truncated/cache-friendly/in-place Fourier
+  transforms, fast power-series operations, characteristic-two transforms,
+  and asymptotically fast finite-field multiplication.
+
+## Current frontier
+
+- The most actionable Harvey-derived experiments are a two-/four-point
+  extension of `ZPoly.mulKronecker` and a raw-word NTT plan using redundant
+  residues under the existing `ZMod64` bound.
+- The architectural prerequisite for fast division remains implementing
+  `hex-truncated-series`, then adding the `DensePoly` reversal/conversion
+  bridge in `hex-poly-fast`.
+- Low, high, middle, cyclic, and negacyclic products should be treated as
+  first-class kernels rather than deriving every consumer from a full
+  product.
+
+## Next step
+
+- If this direction is promoted from research to implementation, write a
+  `hex-poly-fast` SPEC that separates generic ring Karatsuba, finite-field
+  NTT, and integer Kronecker/CRT dispatch, and begin with benchmark-only
+  prototypes for multipoint Kronecker and the redundant-residue NTT
+  butterfly.
+
+## Blockers
+
+- `hex-truncated-series` is specified but not implemented or registered in
+  `libraries.yml`; fast reciprocal/division cannot yet consume it.
+- No current large-degree workload establishes a need for the much more
+  elaborate Harvey--van der Hoeven asymptotic finite-field algorithms.

--- a/progress/20260824T080011Z_fast-polynomial-spec.md
+++ b/progress/20260824T080011Z_fast-polynomial-spec.md
@@ -1,0 +1,39 @@
+# Fast polynomial arithmetic SPEC
+
+## Accomplished
+
+- Added `SPEC/Libraries/hex-poly-fast.md`, specifying explicit lawful
+  multiplication plans, Karatsuba/clipped products, Newton division,
+  half-gcd, product/remainder trees, multipoint evaluation/interpolation,
+  Padé approximation, multipoint Kronecker, redundant-residue NTTs, and both
+  finite-field and integer CRT-NTT multiplication.
+- Assigned coefficient-specific work to hex-mod-arith, hex-modular,
+  hex-poly-fp, and hex-poly-z and amended each owning SPEC.
+- Added benchmark-gated adoption requirements to the Hensel, Berlekamp,
+  Berlekamp-Zassenhaus, and GFq-ring consumer SPECs.
+- Indexed the new planned library, removed its sketch from future work, and
+  limited the Harvey prior-art discussion to the three selected papers.
+- Left `libraries.yml`, `scripts/release/released.yml`, and Lake configuration
+  unchanged; this session specifies future implementation rather than
+  registering it.
+- Passed `scripts/check_dag.py`, `scripts/check_phase4.py`, `git diff --check`,
+  and relative-link/code-fence validation over every changed Markdown file.
+
+## Current frontier
+
+The specification family is decision-complete. The first executable work is
+blocked by the planned hex-truncated-series and hex-modular prerequisites;
+their SPECs now include the required Karatsuba `mulUpToImpl` and balanced
+batch CRT work.
+
+## Next step
+
+Implement and activate the prerequisite milestones, then scaffold
+`HexPolyFast` with `MulPlan`, schoolbook agreement, and the measured Karatsuba
+full/square/slice kernels before starting Newton division.
+
+## Blockers
+
+No documentation blocker. Implementation ordering must preserve the DAG:
+hex-truncated-series and hex-modular precede hex-poly-fast, and coefficient
+library dependency changes land only after hex-poly-fast is active.

--- a/progress/20260825T004258Z_fast-polynomial-spec-pr.md
+++ b/progress/20260825T004258Z_fast-polynomial-spec-pr.md
@@ -1,0 +1,28 @@
+# Fast polynomial SPEC PR
+
+## Accomplished
+
+- Rebased the fast polynomial arithmetic specification package onto the current
+  `origin/main` and reconciled the source-local SPEC moves for `HexModular` and
+  `HexTruncatedSeries`.
+- Corrected all relative links affected by those moves and re-ran the DAG,
+  Phase 4, Markdown-link, code-fence, and whitespace checks successfully.
+- Opened upstream PR #9580 from `docs/fast-polynomial-spec`; its initial CI run
+  cleared the repository metadata, dependency, trust-surface, and documentation
+  registration gates.
+
+## Current frontier
+
+The design is complete and ready to guide implementation. The planned library
+remains intentionally absent from `libraries.yml`, `lakefile.toml`, and the
+release manifest until its prerequisite APIs and first source module exist.
+
+## Next step
+
+Implement the prerequisite clipped-product/Newton interfaces in
+`HexTruncatedSeries` and balanced batch CRT in `HexModular`, then scaffold
+`HexPolyFast` around the schoolbook agreement theorem and explicit `MulPlan`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- specify a proof-carrying `hex-poly-fast` layer covering multiplication plans, clipped products, Newton division, half-gcd, product/remainder trees, multipoint evaluation/interpolation, and Padé approximation
- incorporate the three high-priority Harvey directions: multipoint Kronecker substitution, redundant-representation NTTs, and cache-friendly truncated transforms
- assign coefficient-specific NTT/CRT machinery and consumer contracts to the existing owning libraries, while keeping dependency directions explicit
- replace the future-work sketch with the detailed SPEC and update the library index and prior-art map

## Validation

- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- relative-link and Markdown-fence validation across all changed Markdown files
- `git diff --check`