### PR TITLE
Add HexMvGcd Phase 4 benchmark foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Define the hex-dev cache + build target sets
         run: |
           echo "HEX_LIB_TARGETS=HexBasic HexTruncatedSeries HexTruncatedSeriesMathlib HexArith HexPoly HexMvPoly HexModArith HexGF2 HexPolyZ HexRoots HexResultant HexInterval HexIntervalExperiment HexIntervalMathlib HexIntervalMathlibExperiment HexIntervalReplayProbe HexIntervalMathlibReplayProbe HexRealRootsMathlibReplayProbe HexRCFProofProbe HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexPrimality HexPrimalityKernelProbe HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexHermite HexCharPoly HexMinPoly HexGramSchmidt HexLLL HexMatrixMathlib HexHermiteMathlib HexCharPolyMathlib HexMinPolyMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexPrimalityMathlib HexPolyFpMathlib HexFactorizationModules HexRealRootsMathlib HexGF2Mathlib HexGFqMathlib HexMvPolyMathlib HexMvPolyMathlibProofProbe HexRCF HexRCFTests HexRootsMathlib HexResultantMathlib HexNumberField HexNumberFieldMathlib HexNumberFieldTower HexNumberFieldTowerMathlib HexReleaseTests HexReleaseExamples HexAggregateCheck" >> "$GITHUB_ENV"
-          echo "HEX_EXE_TARGETS=hextruncatedseries_bench hexarith_bench hexpoly_bench hexmvpoly_bench hexsparsepoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexmodular_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexprimality_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexcharpoly_bench hexminpoly_bench hexgramschmidt_bench hexhermite_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexinterval_decision_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_arith_floor hexlll_bench hexlll_gram_bench hexlll_external_reduction hexbz_factor_service" >> "$GITHUB_ENV"
+          echo "HEX_EXE_TARGETS=hextruncatedseries_bench hexarith_bench hexpoly_bench hexmvpoly_bench hexmvgcd_bench hexsparsepoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexmodular_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexprimality_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexcharpoly_bench hexminpoly_bench hexgramschmidt_bench hexhermite_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexinterval_decision_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_arith_floor hexlll_bench hexlll_gram_bench hexlll_external_reduction hexbz_factor_service" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails
       # below only *run* things, never rebuild them -- which is what lets the
@@ -220,7 +220,8 @@ jobs:
         run: |
           bash scripts/ci/check_bench_verify_budget.sh \
             hextruncatedseries_bench \
-            hexarith_bench hexpoly_bench hexmvpoly_bench hexpolyz_bench \
+            hexarith_bench hexpoly_bench hexmvpoly_bench hexmvgcd_bench \
+            hexpolyz_bench \
             hexpolyzgcd_bench hexsparsepoly_bench hexpolyfp_bench \
             hexmodarith_bench \
             hexmodular_bench \

--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -1,0 +1,470 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvGcd
+import HexMvPolyCorpus
+import LeanBench
+
+/-!
+Native benchmark registrations for `hex-mv-gcd`.
+
+This first benchmark layer covers the public executable API and the seven
+input families named by the SPEC. Input construction is outside the timed
+region. Timed functions return structural checksums, so the benchmark runner
+must traverse the result and can compare repeated runs for exact agreement.
+
+The route benchmarks deliberately separate the public dispatcher from the
+deterministic PRS fallback. This makes a regression in coprime detection,
+Brown interpolation, or coefficient swell attributable to one registration.
+
+Each parametric child batch autotunes warm in-process repetitions. The
+executable's startup floor is larger than those batches on the scheduled host,
+so `signalFloorMultiplier := 1.0` retains the child-side measurements without
+changing their scientific ladders or wallclock caps.
+-/
+
+namespace Hex.MvGcdBench
+
+open Hex
+open Hex.MvPoly
+open Hex.MvPolyBench.Corpus
+
+abbrev P2 (R : Type) [Zero R] := MvPoly 2 R Mono.lex
+abbrev P3 (R : Type) [Zero R] := MvPoly 3 R Mono.lex
+abbrev P8 (R : Type) [Zero R] := MvPoly 8 R Mono.lex
+
+/-- Stable structural hash of a canonical sparse polynomial. -/
+def checksum [Zero R] [Hashable R]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n R cmp) : UInt64 :=
+  p.termsList.foldl
+    (fun acc term =>
+      mixHash (mixHash acc (hash term.1.toList)) (hash term.2))
+    0
+
+instance [Zero R] [Hashable R]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
+    Hashable (MvPoly n R cmp) where
+  hash := checksum
+
+/-- Dense bivariate coefficient box. -/
+def denseBox2 [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R] [NatCast R]
+    (degree : Nat) : P2 R :=
+  ofTerms <| (List.range (degree + 1)).flatMap fun xExponent =>
+    (List.range (degree + 1)).map fun yExponent =>
+      (Hex.Vector.ofFn' fun i =>
+        if i.val = 0 then xExponent else yExponent, 1)
+
+/-- Dense trivariate box used by the Brown family. -/
+def denseBox3 (degree : Nat) : P3 Int :=
+  ofTerms <| (List.range (degree + 1)).flatMap fun xExponent =>
+    (List.range (degree + 1)).flatMap fun yExponent =>
+      (List.range (degree + 1)).map fun zExponent =>
+        (Hex.Vector.ofFn' fun i =>
+          if i.val = 0 then xExponent
+          else if i.val = 1 then yExponent
+          else zExponent, 1)
+
+/-- High-degree, low-support polynomial in eight variables. -/
+def sparse8 (degree salt : Nat) : P8 Int :=
+  ofTerms <| (Mono.zero, 1) :: (List.finRange 8).map fun axis =>
+    (Hex.Vector.ofFn' fun i => if i = axis then degree else 0,
+      Int.ofNat (axis.val + salt + 1))
+
+structure PublicInput where
+  left : P2 Int
+  right : P2 Int
+  product : P2 Int
+  deriving Hashable, Nonempty
+
+structure SupportInput where
+  polynomial : P2 Int
+  deriving Hashable
+
+/-- Exactly `count` supported terms with bounded coefficients. -/
+def prepSupport (count : Nat) : SupportInput :=
+  { polynomial := ofTerms <| intTerms count 79 fun exponent =>
+      Hex.Vector.ofFn' fun i =>
+        if i.val = 0 then exponent else count - exponent }
+
+def prepPublic (degree : Nat) : PublicInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  let common := x + y + 1
+  let leftCofactor := denseBox2 degree + x + 2
+  let rightCofactor := denseBox2 degree + y + 3
+  { left := common * leftCofactor
+    right := common * rightCofactor
+    product := common ^ 3 * leftCofactor ^ 2 * rightCofactor }
+
+def runMonoContent (input : SupportInput) : UInt64 :=
+  hash (monoContent input.polynomial).toList
+
+def runContent (input : SupportInput) : UInt64 :=
+  hash (content input.polynomial)
+
+def runPrimPart (input : SupportInput) : UInt64 :=
+  checksum (primPart input.polynomial)
+
+def runScalarContent (input : SupportInput) : UInt64 :=
+  hash (scalarContent input.polynomial)
+
+def runPolyNormalize (input : SupportInput) : UInt64 :=
+  checksum (polyNormalize input.polynomial)
+
+def runPolyIsUnit (input : SupportInput) : UInt64 :=
+  hash (polyIsUnit input.polynomial)
+
+def runToUnivariate (input : SupportInput) : UInt64 :=
+  let view := toUnivariate (0 : Fin 2) Mono.lex input.polynomial
+  view.toArray.foldl (fun acc coefficient =>
+    mixHash acc (checksum coefficient)) 0
+
+def runContentIn (input : PublicInput) : UInt64 :=
+  checksum (contentIn (0 : Fin 2) Mono.lex input.product)
+
+def runPrimPartIn (input : PublicInput) : UInt64 :=
+  checksum (primPartIn (0 : Fin 2) Mono.lex input.product)
+
+def runDivExact (input : PublicInput) : UInt64 :=
+  match divExact? input.left (X 0 + X 1 + 1) with
+  | none => 0
+  | some quotient => checksum quotient
+
+def runGcd (input : PublicInput) : UInt64 :=
+  checksum (gcd input.left input.right)
+
+def runCofactors (input : PublicInput) : UInt64 :=
+  let result := cofactors input.left input.right
+  mixHash (checksum result.1) (checksum result.2)
+
+def runIsCoprime (input : PublicInput) : UInt64 :=
+  hash (isCoprime input.left input.right)
+
+def runGcdList (input : PublicInput) : UInt64 :=
+  checksum (gcdList [input.left, input.right, input.product])
+
+def runLcm (input : PublicInput) : UInt64 :=
+  checksum (lcm input.left input.right)
+
+def runSqfDecomp (input : PublicInput) : UInt64 :=
+  let decomp := sqfDecomp input.product
+  decomp.factors.foldl
+    (fun acc factor =>
+      mixHash (mixHash acc (checksum factor.factor))
+        (hash factor.multiplicity))
+    (hash decomp.content)
+
+def runRadical (input : PublicInput) : UInt64 :=
+  checksum (radical input.product)
+
+def runIsSquarefree (input : PublicInput) : UInt64 :=
+  hash (isSquarefree input.product)
+
+initialize public2 : PublicInput ← pure (prepPublic 2)
+
+def runContentInFixed : Unit → IO UInt64 := fun _ =>
+  pure (runContentIn public2)
+
+def runPrimPartInFixed : Unit → IO UInt64 := fun _ =>
+  pure (runPrimPartIn public2)
+
+def runGcdFixed : Unit → IO UInt64 := fun _ => pure (runGcd public2)
+
+def runCofactorsFixed : Unit → IO UInt64 := fun _ =>
+  pure (runCofactors public2)
+
+def runIsCoprimeFixed : Unit → IO UInt64 := fun _ =>
+  pure (runIsCoprime public2)
+
+def runGcdListFixed : Unit → IO UInt64 := fun _ =>
+  pure (runGcdList public2)
+
+def runLcmFixed : Unit → IO UInt64 := fun _ => pure (runLcm public2)
+
+def runSqfDecompFixed : Unit → IO UInt64 := fun _ =>
+  pure (runSqfDecomp public2)
+
+def runRadicalFixed : Unit → IO UInt64 := fun _ =>
+  pure (runRadical public2)
+
+def runIsSquarefreeFixed : Unit → IO UInt64 := fun _ =>
+  pure (runIsSquarefree public2)
+
+def runDivExactFixed : Unit → IO UInt64 := fun _ =>
+  pure (runDivExact public2)
+
+structure CoprimeInput where
+  left : P2 Int
+  right : P2 Int
+  deriving Hashable, Nonempty
+
+def prepCoprime (degree : Nat) : CoprimeInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  { left := x ^ (degree + 1) + y + 1
+    right := y ^ (degree + 1) + x + 2 }
+
+def runCoprime (input : CoprimeInput) : UInt64 :=
+  mixHash (checksum (gcd input.left input.right))
+    (hash (isCoprime input.left input.right))
+
+initialize coprime1 : CoprimeInput ← pure (prepCoprime 1)
+
+def runCoprimeFamilyFixed : Unit → IO UInt64 := fun _ =>
+  pure (runCoprime coprime1)
+
+structure DenseInput where
+  left : P3 Int
+  right : P3 Int
+  deriving Hashable, Nonempty
+
+def prepDense (degree : Nat) : DenseInput :=
+  let x : P3 Int := X 0
+  let y : P3 Int := X 1
+  let z : P3 Int := X 2
+  let common := x + y + z + 1
+  let box := denseBox3 degree
+  { left := common * (box + x + 2)
+    right := common * (box + y + 3) }
+
+def runDense (input : DenseInput) : UInt64 :=
+  checksum (gcd input.left input.right)
+
+initialize dense0 : DenseInput ← pure (prepDense 0)
+
+def runDenseFixed : Unit → IO UInt64 := fun _ =>
+  pure (runDense dense0)
+
+structure SparseInput where
+  left : P8 Int
+  right : P8 Int
+  deriving Hashable, Nonempty
+
+def prepSparse (degree : Nat) : SparseInput :=
+  let common : P8 Int := X 0 + X 7 + 1
+  { left := common * sparse8 degree 1
+    right := common * sparse8 (degree + 1) 3 }
+
+def runSparse (input : SparseInput) : UInt64 :=
+  checksum (gcd input.left input.right)
+
+initialize sparse1 : SparseInput ← pure (prepSparse 1)
+
+def runSparseFixed : Unit → IO UInt64 := fun _ =>
+  pure (runSparse sparse1)
+
+structure SwellInput where
+  left : P2 Int
+  right : P2 Int
+  deriving Hashable, Nonempty
+
+def prepSwell (degree : Nat) : SwellInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  let common := C 2 * x + y + 1
+  { left := common * (x ^ degree + C 37 * y + 1)
+    right := common * (x ^ (degree + 1) - C 41 * y + 2) }
+
+def runSwell (input : SwellInput) : UInt64 :=
+  checksum (prsCert input.left input.right).gcd
+
+initialize swell3 : SwellInput ← pure (prepSwell 3)
+initialize swell4 : SwellInput ← pure (prepSwell 4)
+initialize swell5 : SwellInput ← pure (prepSwell 5)
+
+def runSwell3 : Unit → IO UInt64 := fun _ => pure (runSwell swell3)
+def runSwell4 : Unit → IO UInt64 := fun _ => pure (runSwell swell4)
+def runSwell5 : Unit → IO UInt64 := fun _ => pure (runSwell swell5)
+
+structure RationalInput where
+  left : P2 Rat
+  right : P2 Rat
+  deriving Hashable, Nonempty
+
+def prepRational (degree : Nat) : RationalInput :=
+  let x : P2 Rat := X 0
+  let y : P2 Rat := X 1
+  let common := C ((1 : Rat) / 2) * x + C ((1 : Rat) / 3) * y + 1
+  let box := denseBox2 degree
+  { left := common * (box + C ((1 : Rat) / 5) * x + 1)
+    right := common * (box + C ((1 : Rat) / 7) * y + 2) }
+
+def runRational (input : RationalInput) : UInt64 :=
+  checksum (gcd input.left input.right)
+
+initialize rational0 : RationalInput ← pure (prepRational 0)
+
+def runRationalFixed : Unit → IO UInt64 := fun _ =>
+  pure (runRational rational0)
+
+structure SquarefreeInput where
+  polynomial : P2 Int
+  deriving Hashable, Nonempty
+
+def prepSquarefree (multiplicity : Nat) : SquarefreeInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  { polynomial :=
+      (x + y + 1) ^ multiplicity *
+        (x + C 2 * y + 3) ^ (multiplicity + 1) }
+
+def runSquarefree (input : SquarefreeInput) : UInt64 :=
+  let decomp := sqfDecomp input.polynomial
+  decomp.factors.foldl
+    (fun acc factor =>
+      mixHash (mixHash acc (checksum factor.factor))
+        (hash factor.multiplicity))
+    (hash decomp.content)
+
+initialize squarefree1 : SquarefreeInput ← pure (prepSquarefree 1)
+
+def runSquarefreeFixed : Unit → IO UInt64 := fun _ =>
+  pure (runSquarefree squarefree1)
+
+structure CofactorInput where
+  dividend : P2 Int
+  divisor : P2 Int
+  deriving Hashable
+
+def prepCofactor (degree : Nat) : CofactorInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  let divisor := x + y + 1
+  { dividend := divisor * (denseBox2 degree + x * y + 2)
+    divisor := divisor }
+
+def runCofactor (input : CofactorInput) : UInt64 :=
+  match divExact? input.dividend input.divisor with
+  | none => 0
+  | some quotient => checksum quotient
+
+/- The support fold visits each of the `n` terms once and compares fixed-arity
+exponent vectors, so the term-count model is linear. -/
+setup_benchmark runMonoContent n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Coefficient content is one bounded-coefficient gcd per supported term, so
+the `n`-term ladder has linear cost. -/
+setup_benchmark runContent n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Primitive part performs the linear content fold and one scalar traversal
+over the same `n` terms. -/
+setup_benchmark runPrimPart n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Scalar content is the same bounded-coefficient gcd fold, hence linear in
+the exact support size `n`. -/
+setup_benchmark runScalarContent n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Normalization reads the leading term and scales each of the `n` terms by a
+unit, giving a linear support traversal. -/
+setup_benchmark runPolyNormalize n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Unit recognition inspects the canonical support and its sole coefficient;
+the nonunit ladder still returns a checksum after the linear support-size
+query, so the declared bound is linear. -/
+setup_benchmark runPolyIsUnit n => n
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Recursive-view construction partitions `n` terms into a canonical map;
+each insertion is logarithmic in the number of occupied coefficients. -/
+setup_benchmark runToUnivariate n => n * Nat.log2 (n + 1)
+  with prep := prepSupport
+  where {
+    paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384, 32768]
+    signalFloorMultiplier := 1.0
+  }
+
+/- Named content and primitive part invoke recursive gcd production, for which
+the SPEC gives probe counts rather than a full runtime model. They therefore
+use canonical fixed registrations instead of invented asymptotics. -/
+setup_fixed_benchmark runContentInFixed
+setup_fixed_benchmark runPrimPartInFixed
+
+/- The public exact-division entry point is covered here on the same canonical
+input as the other wrappers. The cofactor-heavy family below carries its
+machine-operation model without constructing unrelated public results. -/
+setup_fixed_benchmark runDivExactFixed
+
+/- The public dispatcher, cofactor wrappers, list/lcm wrappers, and squarefree
+operations are route-dependent. Canonical fixed registrations cover their API
+surface; the isolated families below carry the scientific ladders. -/
+setup_fixed_benchmark runGcdFixed
+setup_fixed_benchmark runCofactorsFixed
+setup_fixed_benchmark runIsCoprimeFixed
+setup_fixed_benchmark runGcdListFixed
+setup_fixed_benchmark runLcmFixed
+setup_fixed_benchmark runSqfDecompFixed
+setup_fixed_benchmark runRadicalFixed
+setup_fixed_benchmark runIsSquarefreeFixed
+
+/- The SPEC gives image-gcd probe counts, not full runtime models, for the
+route-dependent families. Canonical fixed cases record their costs without
+inventing asymptotics from degree alone. Phase 4 expands these representatives
+across the full arity and shape matrix named by the SPEC. -/
+setup_fixed_benchmark runCoprimeFamilyFixed
+setup_fixed_benchmark runDenseFixed
+setup_fixed_benchmark runSparseFixed
+
+/- The extended PRS has no useful asymptotic bound in the SPEC. Fixed rungs
+record coefficient swell without asserting a false scaling model. -/
+setup_fixed_benchmark runSwell3
+setup_fixed_benchmark runSwell4
+setup_fixed_benchmark runSwell5
+
+/- Denominator clearing and Yun's loop likewise inherit dispatcher-dependent
+gcd costs. Their fixed cases exercise the rational lift and repeated-factor
+paths without treating probe counts as machine-operation models. -/
+setup_fixed_benchmark runRationalFixed
+setup_fixed_benchmark runSquarefreeFixed
+
+/- With a three-term divisor and a dense quotient, exact division visits each
+quotient/divisor term pair and performs logarithmic support updates. -/
+setup_benchmark runCofactor n => n * n * Nat.log2 (n + 1)
+  with prep := prepCofactor
+  where {
+    paramSchedule := .custom #[16, 32, 64, 128]
+    maxSecondsPerCall := 3.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+    outerTrials := 3
+  }
+
+end Hex.MvGcdBench
+
+def main (args : List String) : IO UInt32 :=
+  LeanBench.Cli.dispatch args

--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -167,38 +167,40 @@ def runRadical (input : PublicInput) : UInt64 :=
 def runIsSquarefree (input : PublicInput) : UInt64 :=
   hash (isSquarefree input.product)
 
-initialize public2 : PublicInput ← pure (prepPublic 2)
+initialize public2 : IO.Ref PublicInput ← IO.mkRef (prepPublic 2)
 
-def runContentInFixed : Unit → IO UInt64 := fun _ =>
-  pure (runContentIn public2)
+def runContentInFixed (_ : Unit) : IO UInt64 := do
+  return runContentIn (← public2.get)
 
-def runPrimPartInFixed : Unit → IO UInt64 := fun _ =>
-  pure (runPrimPartIn public2)
+def runPrimPartInFixed (_ : Unit) : IO UInt64 := do
+  return runPrimPartIn (← public2.get)
 
-def runGcdFixed : Unit → IO UInt64 := fun _ => pure (runGcd public2)
+def runGcdFixed (_ : Unit) : IO UInt64 := do
+  return runGcd (← public2.get)
 
-def runCofactorsFixed : Unit → IO UInt64 := fun _ =>
-  pure (runCofactors public2)
+def runCofactorsFixed (_ : Unit) : IO UInt64 := do
+  return runCofactors (← public2.get)
 
-def runIsCoprimeFixed : Unit → IO UInt64 := fun _ =>
-  pure (runIsCoprime public2)
+def runIsCoprimeFixed (_ : Unit) : IO UInt64 := do
+  return runIsCoprime (← public2.get)
 
-def runGcdListFixed : Unit → IO UInt64 := fun _ =>
-  pure (runGcdList public2)
+def runGcdListFixed (_ : Unit) : IO UInt64 := do
+  return runGcdList (← public2.get)
 
-def runLcmFixed : Unit → IO UInt64 := fun _ => pure (runLcm public2)
+def runLcmFixed (_ : Unit) : IO UInt64 := do
+  return runLcm (← public2.get)
 
-def runSqfDecompFixed : Unit → IO UInt64 := fun _ =>
-  pure (runSqfDecomp public2)
+def runSqfDecompFixed (_ : Unit) : IO UInt64 := do
+  return runSqfDecomp (← public2.get)
 
-def runRadicalFixed : Unit → IO UInt64 := fun _ =>
-  pure (runRadical public2)
+def runRadicalFixed (_ : Unit) : IO UInt64 := do
+  return runRadical (← public2.get)
 
-def runIsSquarefreeFixed : Unit → IO UInt64 := fun _ =>
-  pure (runIsSquarefree public2)
+def runIsSquarefreeFixed (_ : Unit) : IO UInt64 := do
+  return runIsSquarefree (← public2.get)
 
-def runDivExactFixed : Unit → IO UInt64 := fun _ =>
-  pure (runDivExact public2)
+def runDivExactFixed (_ : Unit) : IO UInt64 := do
+  return runDivExact (← public2.get)
 
 structure CoprimeInput where
   left : P2 Int
@@ -215,10 +217,10 @@ def runCoprime (input : CoprimeInput) : UInt64 :=
   mixHash (checksum (gcd input.left input.right))
     (hash (isCoprime input.left input.right))
 
-initialize coprime1 : CoprimeInput ← pure (prepCoprime 1)
+initialize coprime1 : IO.Ref CoprimeInput ← IO.mkRef (prepCoprime 1)
 
-def runCoprimeFamilyFixed : Unit → IO UInt64 := fun _ =>
-  pure (runCoprime coprime1)
+def runCoprimeFamilyFixed (_ : Unit) : IO UInt64 := do
+  return runCoprime (← coprime1.get)
 
 structure DenseInput where
   left : P3 Int
@@ -237,10 +239,10 @@ def prepDense (degree : Nat) : DenseInput :=
 def runDense (input : DenseInput) : UInt64 :=
   checksum (gcd input.left input.right)
 
-initialize dense0 : DenseInput ← pure (prepDense 0)
+initialize dense0 : IO.Ref DenseInput ← IO.mkRef (prepDense 0)
 
-def runDenseFixed : Unit → IO UInt64 := fun _ =>
-  pure (runDense dense0)
+def runDenseFixed (_ : Unit) : IO UInt64 := do
+  return runDense (← dense0.get)
 
 structure SparseInput where
   left : P8 Int
@@ -255,10 +257,10 @@ def prepSparse (degree : Nat) : SparseInput :=
 def runSparse (input : SparseInput) : UInt64 :=
   checksum (gcd input.left input.right)
 
-initialize sparse1 : SparseInput ← pure (prepSparse 1)
+initialize sparse1 : IO.Ref SparseInput ← IO.mkRef (prepSparse 1)
 
-def runSparseFixed : Unit → IO UInt64 := fun _ =>
-  pure (runSparse sparse1)
+def runSparseFixed (_ : Unit) : IO UInt64 := do
+  return runSparse (← sparse1.get)
 
 structure SwellInput where
   left : P2 Int
@@ -275,13 +277,18 @@ def prepSwell (degree : Nat) : SwellInput :=
 def runSwell (input : SwellInput) : UInt64 :=
   checksum (prsCert input.left input.right).gcd
 
-initialize swell3 : SwellInput ← pure (prepSwell 3)
-initialize swell4 : SwellInput ← pure (prepSwell 4)
-initialize swell5 : SwellInput ← pure (prepSwell 5)
+initialize swell3 : IO.Ref SwellInput ← IO.mkRef (prepSwell 3)
+initialize swell4 : IO.Ref SwellInput ← IO.mkRef (prepSwell 4)
+initialize swell5 : IO.Ref SwellInput ← IO.mkRef (prepSwell 5)
 
-def runSwell3 : Unit → IO UInt64 := fun _ => pure (runSwell swell3)
-def runSwell4 : Unit → IO UInt64 := fun _ => pure (runSwell swell4)
-def runSwell5 : Unit → IO UInt64 := fun _ => pure (runSwell swell5)
+def runSwell3 (_ : Unit) : IO UInt64 := do
+  return runSwell (← swell3.get)
+
+def runSwell4 (_ : Unit) : IO UInt64 := do
+  return runSwell (← swell4.get)
+
+def runSwell5 (_ : Unit) : IO UInt64 := do
+  return runSwell (← swell5.get)
 
 structure RationalInput where
   left : P2 Rat
@@ -299,10 +306,10 @@ def prepRational (degree : Nat) : RationalInput :=
 def runRational (input : RationalInput) : UInt64 :=
   checksum (gcd input.left input.right)
 
-initialize rational0 : RationalInput ← pure (prepRational 0)
+initialize rational0 : IO.Ref RationalInput ← IO.mkRef (prepRational 0)
 
-def runRationalFixed : Unit → IO UInt64 := fun _ =>
-  pure (runRational rational0)
+def runRationalFixed (_ : Unit) : IO UInt64 := do
+  return runRational (← rational0.get)
 
 structure SquarefreeInput where
   polynomial : P2 Int
@@ -323,10 +330,11 @@ def runSquarefree (input : SquarefreeInput) : UInt64 :=
         (hash factor.multiplicity))
     (hash decomp.content)
 
-initialize squarefree1 : SquarefreeInput ← pure (prepSquarefree 1)
+initialize squarefree1 : IO.Ref SquarefreeInput ←
+  IO.mkRef (prepSquarefree 1)
 
-def runSquarefreeFixed : Unit → IO UInt64 := fun _ =>
-  pure (runSquarefree squarefree1)
+def runSquarefreeFixed (_ : Unit) : IO UInt64 := do
+  return runSquarefree (← squarefree1.get)
 
 structure CofactorInput where
   dividend : P2 Int

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -959,6 +959,10 @@ lean_exe hexmvpoly_bench where
   srcDir := "bench"
   root := `HexMvPoly.Bench
 
+lean_exe hexmvgcd_bench where
+  srcDir := "bench"
+  root := `HexMvGcd.Bench
+
 lean_exe hextruncatedseries_bench where
   srcDir := "bench"
   root := `HexTruncatedSeries.Bench

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1204,5 +1204,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "bc4b3051451c1952a129177db6f3c5d13be41986",
     "reason": "Registers only the HexMvFactor conformance module and fixture emitter; no factorization runtime target, definition, build flag, or dependency changes."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "665cf74c2e425a35d05b654b5de4200d394525ae",
+    "reason": "Registers only the HexMvGcd Phase 4 benchmark executable; hexbz_factor_service, its build flags, and every factorization runtime dependency are unchanged."
   }
 ]


### PR DESCRIPTION
Adds the native `hexmvgcd_bench` target and wires its `list`/`verify` smoke gate into the existing single Ubuntu CI job.

The benchmark covers the public executable surface with structural hashes, seven exact-support/core-operation ladders, a cofactor-heavy exact-division ladder, and fixed registrations for dispatcher-dependent routes whose SPEC entries provide probe counts rather than full machine-runtime models. Input preparation is hoisted and uses direct canonical term construction; this avoids charging fixture construction to the timed region. This is the Phase 4 foundation only: it deliberately does not bump `done_through`, and the full arity/shape family matrix, FLINT/Singular ratios, profiles, kernel suite, and headline report remain follow-up work.

Cost-model rationale: fixed arity makes support folds and coefficient traversals linear in exact support; recursive-view insertion is `n log n`; the cofactor-heavy family has Theta(n^2) quotient terms, a fixed three-term divisor, and logarithmic support updates, giving `n^2 log n`. Route-dependent families are fixed rather than assigned invented asymptotics.

Verified locally:
- `lake build hexmvgcd_bench`
- `.lake/build/bin/hexmvgcd_bench verify` (27/27)
- scientific runs for all eight parametric registrations; each verdict is consistent
- `python3 scripts/ci/check_benches_mathlib_free.py`
- `python3 scripts/check_phase4.py --base origin/main`
- `git diff --check origin/main...`
