### PR TITLE
bench(mv-gcd): pin fixed benchmark hashes

### DIFF
--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -420,45 +420,83 @@ setup_benchmark runToUnivariate n => n * Nat.log2 (n + 1)
 /- Named content and primitive part invoke recursive gcd production, for which
 the SPEC gives probe counts rather than a full runtime model. They therefore
 use canonical fixed registrations instead of invented asymptotics. -/
-setup_fixed_benchmark runContentInFixed
-setup_fixed_benchmark runPrimPartInFixed
+setup_fixed_benchmark runContentInFixed where {
+  expectedHash := some 0xd1f9ea943ea7ea73
+}
+setup_fixed_benchmark runPrimPartInFixed where {
+  expectedHash := some 0x358b5704b57e7de5
+}
 
 /- The public exact-division entry point is covered here on the same canonical
 input as the other wrappers. The cofactor-heavy family below carries its
 machine-operation model without constructing unrelated public results. -/
-setup_fixed_benchmark runDivExactFixed
+setup_fixed_benchmark runDivExactFixed where {
+  expectedHash := some 0xeeadb45fd4afbeef
+}
 
 /- The public dispatcher, cofactor wrappers, list/lcm wrappers, and squarefree
 operations are route-dependent. Canonical fixed registrations cover their API
 surface; the isolated families below carry the scientific ladders. -/
-setup_fixed_benchmark runGcdFixed
-setup_fixed_benchmark runCofactorsFixed
-setup_fixed_benchmark runIsCoprimeFixed
-setup_fixed_benchmark runGcdListFixed
-setup_fixed_benchmark runLcmFixed
-setup_fixed_benchmark runSqfDecompFixed
-setup_fixed_benchmark runRadicalFixed
-setup_fixed_benchmark runIsSquarefreeFixed
+setup_fixed_benchmark runGcdFixed where {
+  expectedHash := some 0x01a55d7eea73bbb3
+}
+setup_fixed_benchmark runCofactorsFixed where {
+  expectedHash := some 0x0cc3e4fb6781af05
+}
+setup_fixed_benchmark runIsCoprimeFixed where {
+  expectedHash := some 0x000000000000000d
+}
+setup_fixed_benchmark runGcdListFixed where {
+  expectedHash := some 0x01a55d7eea73bbb3
+}
+setup_fixed_benchmark runLcmFixed where {
+  expectedHash := some 0x45d39921edcf59e0
+}
+setup_fixed_benchmark runSqfDecompFixed where {
+  expectedHash := some 0xc2c56dd345ace7ce
+}
+setup_fixed_benchmark runRadicalFixed where {
+  expectedHash := some 0x45d39921edcf59e0
+}
+setup_fixed_benchmark runIsSquarefreeFixed where {
+  expectedHash := some 0x000000000000000d
+}
 
 /- The SPEC gives image-gcd probe counts, not full runtime models, for the
 route-dependent families. Canonical fixed cases record their costs without
 inventing asymptotics from degree alone. Phase 4 expands these representatives
 across the full arity and shape matrix named by the SPEC. -/
-setup_fixed_benchmark runCoprimeFamilyFixed
-setup_fixed_benchmark runDenseFixed
-setup_fixed_benchmark runSparseFixed
+setup_fixed_benchmark runCoprimeFamilyFixed where {
+  expectedHash := some 0x42905229134041e6
+}
+setup_fixed_benchmark runDenseFixed where {
+  expectedHash := some 0x78ec2b32b48ac34
+}
+setup_fixed_benchmark runSparseFixed where {
+  expectedHash := some 0xb45fffc66bacdc5f
+}
 
 /- The extended PRS has no useful asymptotic bound in the SPEC. Fixed rungs
 record coefficient swell without asserting a false scaling model. -/
-setup_fixed_benchmark runSwell3
-setup_fixed_benchmark runSwell4
-setup_fixed_benchmark runSwell5
+setup_fixed_benchmark runSwell3 where {
+  expectedHash := some 0x9fac850485b60c86
+}
+setup_fixed_benchmark runSwell4 where {
+  expectedHash := some 0x9fac850485b60c86
+}
+setup_fixed_benchmark runSwell5 where {
+  expectedHash := some 0x9fac850485b60c86
+}
 
 /- Denominator clearing and Yun's loop likewise inherit dispatcher-dependent
 gcd costs. Their fixed cases exercise the rational lift and repeated-factor
 paths without treating probe counts as machine-operation models. -/
-setup_fixed_benchmark runRationalFixed
-setup_fixed_benchmark runSquarefreeFixed
+setup_fixed_benchmark runRationalFixed where {
+  expectedHash := some 0xf6040a6b74bc3ff1
+}
+setup_fixed_benchmark runSquarefreeFixed where {
+  expectedHash := some 0x5262547c4fa35a9e
+}
 
 /- With a three-term divisor and a dense quotient, exact division visits each
 quotient/divisor term pair and performs logarithmic support updates. -/


### PR DESCRIPTION
Pins the structural result hash for every fixed `HexMvGcd` benchmark registration, as required by `SPEC/benchmarking.md`. This makes fixed cases detect stable wrong answers rather than merely checking that repeated runs agree. All 27 registrations pass `verify` with the pinned values.\n\nStacked dependency: #9584 (which itself depends on #9583). This PR should be reviewed and merged after that stack; it will be restacked onto `main` as dependencies land.\n\nLocal validation:\n- `lake build hexmvgcd_bench`\n- `.lake/build/bin/hexmvgcd_bench verify`\n- `python3 scripts/check_phase4.py --base origin/main`\n- copyright, line-count, Mathlib-free bench, freshness, and diff checks