### PR TITLE
bench(mv-gcd): compare coprime gcd with FLINT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           python3 -m unittest scripts/bench/test_fresh_module_sweep.py
           python3 -m unittest scripts/bench/test_real_roots_mathlib_sweep.py
           python3 -m unittest scripts/bench/test_hexrcf_proof_sweep.py
+          python3 -m unittest scripts/oracle/test_flint_mpoly_bench.py
           python3 -m unittest scripts/oracle/test_rcf_flint_bench.py
           python3 scripts/ci/check_benches_mathlib_free.py
       - name: Verify conformance matrix invariant

--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import HexMvGcd
 import HexMvPolyCorpus
+import HexMvGcdFlint
 import LeanBench
 
 /-!
@@ -497,6 +498,20 @@ setup_fixed_benchmark runRationalFixed where {
 setup_fixed_benchmark runSquarefreeFixed where {
   expectedHash := some 0x5262547c4fa35a9e
 }
+
+/-! # Informational FLINT comparator registrations
+
+The pair returns the same canonical sparse term list, so `compare` also checks
+cross-system agreement. The FLINT registration is scheduled-only;
+python-flint must be installed in that environment. -/
+
+setup_fixed_benchmark Flint.runFlintMpolyOverhead where
+  Flint.flintCompareConfig 0x0000000000000007
+
+setup_fixed_benchmark Flint.runLeanCoprime2 where
+  Flint.leanCompareConfig 0x227808efbc4a0df6
+setup_fixed_benchmark Flint.runFlintCoprime2 where
+  Flint.flintCompareConfig 0x227808efbc4a0df6
 
 /- With a three-term divisor and a dense quotient, exact division visits each
 quotient/divisor term pair and performs logarithmic support updates. -/

--- a/bench/HexMvGcdFlint.lean
+++ b/bench/HexMvGcdFlint.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import Hex.BenchOracle.Flint
+import HexMvGcd
+import LeanBench
+
+/-!
+FLINT comparison fixtures for `hex-mv-gcd`.
+
+The Lean and FLINT registrations return the same canonical sparse term list,
+so LeanBench's `compare` command checks correctness as well as reporting the
+timings. Input construction and JSON translation are outside the gcd kernels,
+and the separate overhead registration measures the persistent driver's
+steady-state framing cost.
+-/
+
+namespace Hex.MvGcdBench.Flint
+
+open Hex
+open Hex.MvPoly
+
+abbrev P2 (R : Type) [Zero R] := MvPoly 2 R Mono.lex
+
+structure CoprimeInput where
+  left : P2 Int
+  right : P2 Int
+  deriving Nonempty
+
+/-- A deterministic coprime pair for cross-system comparison. -/
+def prepCoprime (degree : Nat) : CoprimeInput :=
+  let x : P2 Int := X 0
+  let y : P2 Int := X 1
+  { left := x ^ (degree + 1) + y + 1
+    right := y ^ (degree + 1) + x + 2 }
+
+private def terms (p : P2 Int) : List (List Nat × Int) :=
+  p.termsList.map fun term => (term.1.toList, term.2)
+
+private def termsJson (p : P2 Int) : Lean.Json :=
+  Lean.Json.arr <| (p.termsList.map fun term =>
+    Lean.Json.arr #[
+      Lean.Json.arr (term.1.toList.map (fun exponent =>
+        Lean.Json.num (Lean.JsonNumber.fromNat exponent))).toArray,
+      Lean.Json.num (Lean.JsonNumber.fromInt term.2)]).toArray
+
+private def jsonError (context : String) (result : Except String α) : IO α :=
+  match result with
+  | .ok value => return value
+  | .error msg => throw <| IO.userError s!"{context}: {msg}"
+
+private def jsonToTerms (nvars : Nat) (value : Lean.Json) :
+    IO (List (List Nat × Int)) := do
+  let encoded ← jsonError "FLINT multivariate result is not an array"
+    value.getArr?
+  let mut out : Array (List Nat × Int) := Array.mkEmpty encoded.size
+  for encodedTerm in encoded do
+    let pair ← jsonError "FLINT multivariate term is not an array"
+      encodedTerm.getArr?
+    let (exponentsValue, coefficientValue) ←
+      match pair.toList with
+      | [exponents, coefficient] => pure (exponents, coefficient)
+      | _ => throw (IO.userError
+          "FLINT multivariate term must contain exponents and coefficient")
+    let encodedExponents ← jsonError
+      "FLINT multivariate exponents are not an array" exponentsValue.getArr?
+    unless encodedExponents.size = nvars do
+      throw (IO.userError
+        s!"FLINT multivariate exponent arity {encodedExponents.size}; expected {nvars}")
+    let mut exponents : Array Nat := Array.mkEmpty nvars
+    for encodedExponent in encodedExponents do
+      exponents := exponents.push (← jsonError
+        "FLINT multivariate exponent is not a natural" encodedExponent.getNat?)
+    let coefficient ← jsonError
+      "FLINT multivariate coefficient is not an integer" coefficientValue.getInt?
+    if coefficient = 0 then
+      throw <| IO.userError "FLINT multivariate result contains a zero coefficient"
+    out := out.push (exponents.toList, coefficient)
+  return out.toList
+
+initialize coprime1 : IO.Ref CoprimeInput ← IO.mkRef (prepCoprime 1)
+
+def runLeanCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
+  let input ← coprime1.get
+  return terms (gcd input.left input.right)
+
+def runFlintCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
+  let input ← coprime1.get
+  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "gcd" #[
+    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat 2)),
+    ("a", termsJson input.left), ("b", termsJson input.right)]
+  jsonToTerms 2 result
+
+/-- Persistent-driver framing/dispatch calibration without polynomial work. -/
+def runFlintMpolyOverhead (_ : Unit) : IO (List (List Nat × Int)) := do
+  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "overhead" #[]
+  jsonToTerms 2 result
+
+def leanCompareConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 12.0, minTotalSeconds := 0.2,
+    expectedHash := some expectedHash }
+
+def flintCompareConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 12.0, minTotalSeconds := 0.2,
+    warmupFirstIter := true, expectedHash := some expectedHash }
+
+end Hex.MvGcdBench.Flint

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -287,6 +287,10 @@ lean_lib HexMvGcdKernelProbe where
   srcDir := "bench"
   globs := #[`HexMvGcd.Kernel]
 
+lean_lib HexMvGcdBenchSupport where
+  srcDir := "bench"
+  globs := #[`HexMvGcdFlint]
+
 lean_lib HexMvPolyBenchSupport where
   srcDir := "bench"
   globs := #[`HexMvPolyCorpus]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1216,5 +1216,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "42a95d0841165c3591246914bc67348ccd8d5df3",
     "reason": "Additionally moves the HexMvGcd kernel replay suite to its SPEC-mandated bench target; hexbz_factor_service and every factorization runtime dependency remain unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "8159dbe8532091eaf8426ef4c051523050f2322f",
+    "reason": "Additionally registers the build-only HexMvGcd FLINT benchmark support module; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
   }
 ]

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -49,6 +49,7 @@ UMBRELLA_BUILD_TARGETS = {
     "HexBerlekampKernelProbe",
     "HexPrimalityKernelProbe",
     "HexMvGcdKernelProbe",
+    "HexMvGcdBenchSupport",
     "HexMvPolyBenchSupport",
     "HexModularBenchSupport",
     "HexMvPolyMathlibProofProbe",

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -21,6 +21,7 @@ BUILD_ONLY_LIBS = {
     "HexBerlekampKernelProbe",
     "HexPrimalityKernelProbe",
     "HexMvGcdKernelProbe",
+    "HexMvGcdBenchSupport",
     "HexMvPolyBenchSupport",
     "HexModularBenchSupport",
     "HexMvPolyMathlibProofProbe",

--- a/scripts/oracle/flint_bench_driver.py
+++ b/scripts/oracle/flint_bench_driver.py
@@ -77,6 +77,17 @@ degree (the same convention `Hex.DensePoly` uses in
 * ``overhead`` — returns ``0`` without constructing a polynomial; this is the
   steady-state JSON framing / dispatch calibration used by headline reports.
 
+### `fmpz_mpoly` (multivariate integer polynomial Z[x₀, ..., xₙ₋₁])
+
+Request field ``nvars`` is the arity. ``a`` and ``b`` are sparse term lists
+``[[[e₀, ..., eₙ₋₁], coefficient], ...]``. Results use the same encoding,
+with zero coefficients omitted and terms in FLINT's canonical lexicographic
+order.
+
+* ``gcd`` — returns ``gcd(a, b)`` in FLINT's canonical integer normal form.
+* ``overhead`` — returns an empty term list without constructing a context;
+  this is the steady-state framing / dispatch calibration.
+
 ### `fmpq_series` (fixed-precision rational power series)
 
 Request fields: ``a`` and, for composition, ``b`` are rational coefficient
@@ -335,6 +346,78 @@ _FMPZ_POLY_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "resultant": _fmpz_poly_resultant,
     "discriminant": _fmpz_poly_discriminant,
     "overhead": _fmpz_poly_overhead,
+}
+
+
+# ---------------------------------------------------------------------
+# `fmpz_mpoly` (Z[x₀, ..., xₙ₋₁])
+# ---------------------------------------------------------------------
+
+
+def _fmpz_mpoly_terms(value: Any, nvars: int, field: str) -> dict[tuple[int, ...], int]:
+    if not isinstance(value, list):
+        raise ValueError(f"fmpz_mpoly field {field!r} must be a term list")
+    terms: dict[tuple[int, ...], int] = {}
+    for index, term in enumerate(value):
+        if not isinstance(term, list) or len(term) != 2:
+            raise ValueError(
+                f"fmpz_mpoly field {field!r} term {index} must be [exponents, coefficient]"
+            )
+        exponents, coefficient = term
+        if not isinstance(exponents, list) or len(exponents) != nvars:
+            raise ValueError(
+                f"fmpz_mpoly field {field!r} term {index} has exponent length "
+                f"{len(exponents) if isinstance(exponents, list) else 'non-list'}; "
+                f"expected {nvars}"
+            )
+        powers = tuple(int(exponent) for exponent in exponents)
+        if any(exponent < 0 for exponent in powers):
+            raise ValueError(
+                f"fmpz_mpoly field {field!r} term {index} has a negative exponent"
+            )
+        if powers in terms:
+            raise ValueError(
+                f"fmpz_mpoly field {field!r} repeats exponent vector {powers}"
+            )
+        coefficient = int(coefficient)
+        if coefficient != 0:
+            terms[powers] = coefficient
+    return terms
+
+
+def _fmpz_mpoly_context(req: dict[str, Any]):
+    nvars = int(req["nvars"])
+    if nvars < 0:
+        raise ValueError("fmpz_mpoly nvars must be nonnegative")
+    names = tuple(f"x{index}" for index in range(nvars))
+    return flint.fmpz_mpoly_ctx.get(names, "lex")  # type: ignore[union-attr]
+
+
+def _fmpz_mpoly(ctx, req: dict[str, Any], field: str):
+    return ctx.from_dict(_fmpz_mpoly_terms(req[field], ctx.nvars(), field))
+
+
+def _fmpz_mpoly_encode(poly) -> list[list[Any]]:
+    return [
+        [[int(exponent) for exponent in powers], int(coefficient)]
+        for powers, coefficient in poly.terms()
+    ]
+
+
+def _fmpz_mpoly_gcd(req: dict[str, Any]) -> list[list[Any]]:
+    ctx = _fmpz_mpoly_context(req)
+    return _fmpz_mpoly_encode(
+        _fmpz_mpoly(ctx, req, "a").gcd(_fmpz_mpoly(ctx, req, "b"))
+    )
+
+
+def _fmpz_mpoly_overhead(_req: dict[str, Any]) -> list[list[Any]]:
+    return []
+
+
+_FMPZ_MPOLY_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
+    "gcd": _fmpz_mpoly_gcd,
+    "overhead": _fmpz_mpoly_overhead,
 }
 
 
@@ -804,6 +887,7 @@ _RCF_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
 
 _FAMILIES: dict[str, dict[str, Callable[[dict[str, Any]], Any]]] = {
     "fmpz_poly": _FMPZ_POLY_OPS,
+    "fmpz_mpoly": _FMPZ_MPOLY_OPS,
     "fmpq_series": _FMPQ_SERIES_OPS,
     "nmod_poly": _NMOD_POLY_OPS,
     "fmpz_mat": _FMPZ_MAT_OPS,

--- a/scripts/oracle/test_flint_mpoly_bench.py
+++ b/scripts/oracle/test_flint_mpoly_bench.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Focused tests for the shared FLINT multivariate-polynomial protocol."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from scripts.oracle import flint_bench_driver as driver
+
+
+class _FakePoly:
+    def __init__(self, terms: dict[tuple[int, ...], int]) -> None:
+        self._terms = terms
+
+    def gcd(self, other: "_FakePoly") -> "_FakePoly":
+        del other
+        return _FakePoly({(1, 0): 1, (0, 1): 1, (0, 0): 1})
+
+    def terms(self):
+        return self._terms.items()
+
+
+class _FakeContext:
+    def __init__(self, arity: int) -> None:
+        self._arity = arity
+
+    def nvars(self) -> int:
+        return self._arity
+
+    def from_dict(self, terms: dict[tuple[int, ...], int]) -> _FakePoly:
+        return _FakePoly(terms)
+
+
+class _FakeContextFactory:
+    calls: list[tuple[tuple[str, ...], str]] = []
+
+    @classmethod
+    def get(cls, names: tuple[str, ...], ordering: str) -> _FakeContext:
+        cls.calls.append((names, ordering))
+        return _FakeContext(len(names))
+
+
+class _FakeFlint:
+    fmpz_mpoly_ctx = _FakeContextFactory
+
+
+class FlintMpolyBenchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _FakeContextFactory.calls.clear()
+
+    def test_gcd_uses_lex_context_and_sparse_terms(self) -> None:
+        request = {
+            "family": "fmpz_mpoly",
+            "op": "gcd",
+            "nvars": 2,
+            "a": [[[2, 0], 1], [[1, 0], 3], [[0, 0], 2]],
+            "b": [[[1, 1], 1], [[0, 1], 4], [[0, 0], 3]],
+        }
+        with (
+            mock.patch.object(driver, "_require_flint"),
+            mock.patch.object(driver, "flint", _FakeFlint),
+        ):
+            answer = driver._dispatch(request)
+        self.assertEqual(
+            answer,
+            [[[1, 0], 1], [[0, 1], 1], [[0, 0], 1]],
+        )
+        self.assertEqual(_FakeContextFactory.calls, [(('x0', 'x1'), 'lex')])
+
+    def test_zero_coefficients_are_omitted(self) -> None:
+        terms = driver._fmpz_mpoly_terms(
+            [[[1, 0], 0], [[0, 1], -3]], 2, "a"
+        )
+        self.assertEqual(terms, {(0, 1): -3})
+
+    def test_rejects_wrong_exponent_arity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exponent length 1; expected 2"):
+            driver._fmpz_mpoly_terms([[[1], 2]], 2, "a")
+
+    def test_rejects_duplicate_monomials(self) -> None:
+        with self.assertRaisesRegex(ValueError, "repeats exponent vector"):
+            driver._fmpz_mpoly_terms(
+                [[[1, 0], 2], [[1, 0], 3]], 2, "a"
+            )
+
+    def test_rejects_negative_exponents(self) -> None:
+        with self.assertRaisesRegex(ValueError, "negative exponent"):
+            driver._fmpz_mpoly_terms([[[-1, 0], 2]], 2, "a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the first real cross-system multivariate GCD comparator for HexMvGcd Phase 4.

- extends the shared persistent python-flint driver with validated fmpz_mpoly sparse encoding and lexicographic GCD
- adds focused protocol tests to the existing single CI job
- adds a multi-file Mathlib-free bench support target
- registers pinned Lean and FLINT coprime-pair results plus persistent-driver overhead
- verifies cross-system output agreement through LeanBench compare

Validation: full lake build (10,294 jobs), all 30 hexmvgcd benchmarks verify with python-flint, Lean/FLINT compare agrees, DAG/libgraph/file-size/copyright/Mathlib-free/factor-sweep checks pass.

Stacked on #9587, which is stacked on #9584 and #9583. I will restack this PR onto main as those dependencies merge.