### PR TITLE
Advance HexTruncatedSeriesMathlib through Phase 4

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -735,7 +735,7 @@ libraries:
   HexTruncatedSeriesMathlib:
     deps: [HexTruncatedSeries]
     mathlib: true
-    done_through: 3
+    done_through: 4
     status: active
 
   # ---------- Planned (status: planned; SPEC ready, implementation deferred) ----------


### PR DESCRIPTION
## Summary
- advance HexTruncatedSeriesMathlib from Phase 3 to Phase 4
- rely on the documented `correspondence-only-layer` exemption
- keep all compiled performance evidence in HexTruncatedSeries

## Dependencies
- depends on #9589
- depends on #9590
- depends on #9594

## Validation
- `lake build HexTruncatedSeriesMathlib`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/ci/check_benches_mathlib_free.py`
- `scripts/release/released.yml` unchanged