### PR TITLE
Advance HexTruncatedSeries through Phase 5

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -74,7 +74,7 @@ libraries:
   HexTruncatedSeries:
     deps: [HexBasic]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:


### PR DESCRIPTION
## Summary
- confirm HexTruncatedSeries has no `sorry`, `axiom`, or `native_decide`
- rebuild the library and its Phase 3 conformance module
- advance the computational library through Phase 5

## Dependencies
- depends on #9589
- depends on #9590
- depends on #9594
- depends on #9595

## Validation
- `lake build HexTruncatedSeries HexTruncatedSeries.Conformance`
- `python3 scripts/check_dag.py`
- `scripts/release/released.yml` unchanged