### PR TITLE
Advance HexTruncatedSeriesMathlib through Phase 5

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -735,7 +735,7 @@ libraries:
   HexTruncatedSeriesMathlib:
     deps: [HexTruncatedSeries]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
 
   # ---------- Planned (status: planned; SPEC ready, implementation deferred) ----------


### PR DESCRIPTION
## Summary
- confirm the Mathlib correspondence layer has no `sorry`, `axiom`, or `native_decide`
- rebuild the complete companion library
- advance HexTruncatedSeriesMathlib through Phase 5

## Dependencies
- depends on #9589, #9590, #9594, #9595, and #9596

## Validation
- `lake build HexTruncatedSeriesMathlib`
- `python3 scripts/check_dag.py`
- `scripts/release/released.yml` unchanged