### PR TITLE
Document HexTruncatedSeries for Phase 7

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -33,6 +33,7 @@ import HexManual.Chapters.HexLLL
 import HexManual.Chapters.HexBerlekampZassenhaus
 import HexManual.Chapters.FactorTactics
 -- Unreleased libraries (dependency order).
+import HexManual.Chapters.HexTruncatedSeries
 import HexManual.Chapters.HexPrimality
 import HexManual.Chapters.HexModular
 import HexManual.Chapters.HexResultant
@@ -157,6 +158,8 @@ These libraries are still incubating in the
 [`hex-dev`](https://github.com/kim-em/hex-dev) monorepo and have not been
 split out for release yet, so their APIs may still change. They are grouped
 here to keep the reference chapters above focused on the released libraries.
+
+{include 2 HexManual.Chapters.HexTruncatedSeries}
 
 {include 2 HexManual.Chapters.HexPrimality}
 

--- a/HexManual/Chapters/HexTruncatedSeries.lean
+++ b/HexManual/Chapters/HexTruncatedSeries.lean
@@ -1,0 +1,248 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexTruncatedSeriesMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexTruncatedSeries: fixed-precision series" =>
+%%%
+tag := "hex-truncated-series"
+%%%
+
+# Introduction
+%%%
+tag := "hex-truncated-series-intro"
+%%%
+
+`HexTruncatedSeries` provides executable power series whose precision is
+fixed in the type. A value of precision `n` stores exactly the coefficients
+below degree `n`; every operation discards higher terms. This makes the
+precision contract explicit while keeping the representation suitable for
+bounded multiplication and Newton iteration.
+
+The computational library is Mathlib-free and depends only on
+{ref "hex-basic"}[`HexBasic`]. It supplies arithmetic, precision changes,
+inverse, square root, exponential, logarithm, composition, and reversion.
+`HexTruncatedSeriesMathlib`, described in
+{ref "hex-truncated-series-mathlib"}[the correspondence section], identifies
+the representation with Mathlib power series modulo `X ^ n`.
+
+# Representation and arithmetic
+%%%
+tag := "hex-truncated-series-representation"
+%%%
+
+{docstring Hex.TSeries}
+
+{docstring Hex.TSeries.coeff}
+
+Coefficient access is total: an index outside the represented precision
+reads as zero. Tabulation and extensionality are the main constructor and
+equality principle.
+
+{docstring Hex.TSeries.ofFn}
+
+{docstring Hex.TSeries.ext}
+
+The usual notation is available for addition, subtraction, multiplication,
+and powers. Constants and the indeterminate have explicit constructors, and
+`mulUpTo` computes only the requested prefix.
+
+{docstring Hex.TSeries.C}
+
+{docstring Hex.TSeries.X}
+
+{docstring Hex.TSeries.mulUpTo}
+
+This finite geometric series demonstrates that multiplication is always
+interpreted modulo the precision.
+
+```lean
+open Hex Hex.TSeries
+
+def geometric : TSeries Int 6 :=
+  ofFn fun _ => 1
+
+#guard (geometric * (1 - X)).coeff 0 == 1
+#guard (geometric * (1 - X)).coeff 4 == 0
+```
+
+# Precision-changing operations
+%%%
+tag := "hex-truncated-series-precision"
+%%%
+
+Truncation and zero extension change the precision in the type. Multiplying
+or dividing by a power of `X` shifts coefficients; division is partial
+because discarded low coefficients must be zero. `valuation?` reports the
+first represented nonzero coefficient and returns `none` for the zero
+truncated series.
+
+{docstring Hex.TSeries.truncate}
+
+{docstring Hex.TSeries.extend}
+
+{docstring Hex.TSeries.divXPow?}
+
+{docstring Hex.TSeries.valuation?}
+
+```lean
+open Hex Hex.TSeries
+
+def shifted : TSeries Int 6 :=
+  ofFn fun i => if i = 2 then 7 else 0
+
+#guard shifted.valuation? == some 2
+#guard
+  (shifted.divXPow? 2).map (fun q => q.coeff 0) ==
+    some 7
+```
+
+Differentiation loses one coefficient of precision. Integration adds a
+zero constant coefficient and requires only the finitely many natural
+inverses needed at the chosen precision.
+
+{docstring Hex.TSeries.deriv}
+
+{docstring Hex.TSeries.integrate}
+
+{docstring Hex.TSeries.NatInverses}
+
+# Newton operations
+%%%
+tag := "hex-truncated-series-newton"
+%%%
+
+The main algorithms accept algebraic witnesses rather than searching the
+coefficient ring. Optional wrappers use `UnitOps` when executable unit
+detection is available. Bounded variants expose the prefixes used by Newton
+doubling, and their agreement theorems connect those implementations to the
+full operations.
+
+{docstring Hex.TSeries.UnitOps}
+
+{docstring Hex.TSeries.invOfUnit}
+
+{docstring Hex.TSeries.inv?}
+
+{docstring Hex.TSeries.invOfUnit_mul}
+
+Square-root lifting takes a chosen constant root `r` and an inverse of
+`2 * r`; it proves both the square equation and uniqueness above that root.
+
+{docstring Hex.TSeries.sqrtOfRoot}
+
+{docstring Hex.TSeries.sqrtOfRoot_sq}
+
+{docstring Hex.TSeries.sqrt_unique}
+
+Formal exponential and logarithm use `NatInverses R (n - 1)`, so the core
+API states exactly which scalar divisions are required rather than assuming
+characteristic zero.
+
+{docstring Hex.TSeries.exp}
+
+{docstring Hex.TSeries.log}
+
+{docstring Hex.TSeries.log_exp}
+
+{docstring Hex.TSeries.exp_log}
+
+# Composition and reversion
+%%%
+tag := "hex-truncated-series-composition"
+%%%
+
+Composition uses a Brent--Kung implementation and requires a zero constant
+coefficient for its algebraic laws. Reversion lifts an inverse of the linear
+coefficient by Newton iteration. A direct Lagrange implementation provides
+an independent route when the required natural inverses exist.
+
+{docstring Hex.TSeries.comp}
+
+{docstring Hex.TSeries.comp_spec}
+
+{docstring Hex.TSeries.revOfUnit}
+
+{docstring Hex.TSeries.revOfUnit_comp}
+
+{docstring Hex.TSeries.revLagrange}
+
+{docstring Hex.TSeries.revLagrange_eq}
+
+Here `x - x²` has invertible linear coefficient. Both reversion algorithms
+produce the same series, and substitution recovers `x` at precision six.
+
+```lean
+open Hex Hex.TSeries
+
+def reversible : TSeries Rat 6 :=
+  X - X ^ 2
+
+#guard
+  comp reversible (revOfUnit reversible 1) == X
+#guard
+  revLagrange reversible 1 ==
+    revOfUnit reversible 1
+```
+
+# The Mathlib correspondence
+%%%
+tag := "hex-truncated-series-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. The companion installs
+Mathlib's `CommRing` API using those same operations and defines coefficient
+truncation from `PowerSeries R` as a surjective ring homomorphism.
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeriesHom}
+
+Its kernel is the ideal generated by `X ^ n`, giving the headline quotient
+equivalence.
+
+{docstring HexTruncatedSeriesMathlib.ker_ofPowerSeriesHom}
+
+{docstring HexTruncatedSeriesMathlib.quotEquiv}
+
+The correspondence covers powers, precision changes, differentiation,
+inverse, substitution, reversion, exponential, and logarithm. Square roots
+have a direct existence-and-uniqueness theorem because Mathlib has no
+matching power-series square-root operation with a supplied root.
+
+{docstring HexTruncatedSeriesMathlib.deriv_ofPowerSeries}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries_invOfUnit}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries_subst}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries_substInvOfIsUnit}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries_exp}
+
+{docstring HexTruncatedSeriesMathlib.ofPowerSeries_logOf}
+
+{docstring HexTruncatedSeriesMathlib.exists_unique_sq}
+
+# Cross-references
+%%%
+tag := "hex-truncated-series-cross-references"
+%%%
+
+* {ref "hex-basic"}[`HexBasic`] supplies the kernel-reducible vector and
+  fold helpers used by the fixed-length representation and convolution.
+* `HexTruncatedSeriesMathlib` is the proof boundary: it imports Mathlib,
+  while `HexTruncatedSeries` and executable consumers do not.
+* Polynomial reversal and fast polynomial division belong above this
+  library in the dependency graph; the truncated-series API deliberately
+  names no polynomial representation.

--- a/HexTruncatedSeries/README.md
+++ b/HexTruncatedSeries/README.md
@@ -1,0 +1,79 @@
+# hex-truncated-series
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-truncated-series` provides fixed-precision power series, arithmetic,
+precision changes, Newton operations, composition, and reversion. It depends
+on [`hex-basic`](https://github.com/leanprover/hex-basic). See
+[`hex-truncated-series-mathlib`](https://github.com/leanprover/hex-truncated-series-mathlib)
+for the correspondence with Mathlib's `PowerSeries`.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-truncated-series"
+git = "https://github.com/leanprover/hex-truncated-series.git"
+rev = "main"
+```
+
+```lean
+import HexTruncatedSeries
+
+open Hex Hex.TSeries
+
+def geometric : TSeries Int 6 :=
+  ofFn fun _ => 1
+
+#guard (geometric * (1 - X)).coeff 0 == 1
+#guard (geometric * (1 - X)).coeff 4 == 0
+
+def reversible : TSeries Rat 6 := X - X ^ 2
+
+#guard comp reversible (revOfUnit reversible 1) == X
+#guard revLagrange reversible 1 == revOfUnit reversible 1
+```
+
+# Functionality
+
+- Fixed-length `TSeries R n` values with total coefficient access,
+  coefficient extensionality, constants, `X`, arithmetic, and powers.
+- Precision changes with `truncate` and `extend`; coefficient shifts with
+  `mulXPow` and exact `divXPow?`; represented valuation with `valuation?`.
+- Formal derivative and integral with an explicit, precision-indexed
+  `NatInverses` capability.
+- Witness-taking and optional forms of inverse and square root, plus formal
+  `exp` and `log`, all using bounded Newton iteration.
+- Brent--Kung composition and Newton reversion, with direct Horner and
+  Lagrange implementations as verified reference routes.
+
+# Verification
+
+The representation has a proved lightweight commutative-ring structure.
+Every precision-changing operation has coefficient laws, each Newton
+operation satisfies its defining equation and uniqueness contract, and the
+bounded implementations agree with their full forms. The two independent
+reversion routes agree under their shared hypotheses:
+
+```lean
+theorem revLagrange_eq [Lean.Grind.CommRing R]
+    [NatInverses R (n - 1)] (b : TSeries R n) (v : R)
+    (h0 : b.coeff 0 = 0) (hv : b.coeff 1 * v = 1) :
+    revLagrange b v = revOfUnit b v
+```
+
+The quotient interpretation and correspondence with Mathlib power series
+live in
+[`hex-truncated-series-mathlib`](https://github.com/leanprover/hex-truncated-series-mathlib).
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this
+published mirror. Contributions are welcome as pull requests to the
+`SPEC/` directory there: describe the behaviour you want and leave the
+implementation to the maintainer.

--- a/HexTruncatedSeriesMathlib/README.md
+++ b/HexTruncatedSeriesMathlib/README.md
@@ -1,0 +1,74 @@
+# hex-truncated-series-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+`hex-truncated-series-mathlib` is the Mathlib correspondence layer for
+[`hex-truncated-series`](https://github.com/leanprover/hex-truncated-series).
+It identifies fixed-precision series with `PowerSeries R` modulo `X ^ n` and
+transports the executable operations. It depends on Mathlib and
+`hex-truncated-series`.
+
+# Quickstart
+
+Add to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "hex-truncated-series-mathlib"
+git = "https://github.com/leanprover/hex-truncated-series-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexTruncatedSeriesMathlib
+
+open Hex HexTruncatedSeriesMathlib
+
+#check (quotEquiv (R := Rat) (n := 6))
+
+example (f : PowerSeries Rat) :
+    ofPowerSeries (n := 6) (f ^ 2) =
+      Hex.TSeries.pow (ofPowerSeries f) 2 :=
+  ofPowerSeries_pow f 2
+```
+
+# Functionality
+
+- A Mathlib `CommRing (TSeries R n)` instance pinned to the executable
+  operations from `hex-truncated-series`.
+- Coefficient truncation `ofPowerSeries`, the ring homomorphism
+  `ofPowerSeriesHom`, its surjectivity and kernel, and the quotient ring
+  equivalence `quotEquiv`.
+- Correspondence for constants, `X`, powers, truncation, multiplication by a
+  power of `X`, and differentiation.
+- Transfer theorems for inverse, substitution, compositional inverse,
+  exponential, and logarithm, plus power-series square-root existence and
+  uniqueness above a supplied constant root.
+- A low-priority `NatInverses` instance for rational algebras.
+
+# Verification
+
+The headline equivalence identifies fixed-precision series exactly with the
+quotient by the discarded tail:
+
+```lean
+noncomputable def quotEquiv [CommRing R] :
+    (PowerSeries R ⧸
+      Ideal.span {(PowerSeries.X : PowerSeries R) ^ n}) ≃+*
+        TSeries R n
+```
+
+Its action on representatives and every listed operation correspondence are
+proved. There is no executable algorithm in this companion; those operations
+and their Mathlib-free correctness proofs live in
+[`hex-truncated-series`](https://github.com/leanprover/hex-truncated-series).
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this
+published mirror. Contributions are welcome as pull requests to the
+`SPEC/` directory there: describe the behaviour you want and leave the
+implementation to the maintainer.

--- a/libraries.yml
+++ b/libraries.yml
@@ -74,7 +74,7 @@ libraries:
   HexTruncatedSeries:
     deps: [HexBasic]
     mathlib: false
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -813,7 +813,7 @@ libraries:
   HexTruncatedSeriesMathlib:
     deps: [HexTruncatedSeries]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
 
   # ---------- Planned (status: planned; SPEC ready, implementation deferred) ----------


### PR DESCRIPTION
## Summary

- add the live Verso reference chapter for the computational and Mathlib APIs
- add checked landing-page READMEs for both future split repositories
- keep the chapter in the unreleased draft section and advance both libraries through Phase 7

## Validation

- `lake build HexManual` (10,205 jobs)
- `python3 scripts/check_phase7.py`
- `python3 scripts/release/check_manual_split.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_copyright_headers.py`
- both README quickstarts build-checked against their package umbrellas

## Dependencies

This PR contains the full truncated-series maturity stack and should merge after #9601. It deliberately does not modify `scripts/release/released.yml`.