### PR TITLE
bench(mv-gcd): compare coprime gcd with Singular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           python3 -m unittest scripts/bench/test_real_roots_mathlib_sweep.py
           python3 -m unittest scripts/bench/test_hexrcf_proof_sweep.py
           python3 -m unittest scripts/oracle/test_flint_mpoly_bench.py
+          python3 -m unittest scripts/oracle/test_singular_mpoly_bench.py
           python3 -m unittest scripts/oracle/test_rcf_flint_bench.py
           python3 scripts/ci/check_benches_mathlib_free.py
       - name: Verify conformance matrix invariant
@@ -74,7 +75,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgmp-dev libntl-dev pkg-config libpari-dev pari-gp
+          sudo apt-get install -y libgmp-dev libntl-dev pkg-config libpari-dev pari-gp singular
       - name: Install Python dependencies (bench comparator + oracles)
         run: |
           python3 -m pip install --user \

--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 import HexMvGcd
 import HexMvPolyCorpus
 import HexMvGcdFlint
+import HexMvGcdSingular
 import LeanBench
 
 /-!
@@ -512,6 +513,14 @@ setup_fixed_benchmark Flint.runLeanCoprime2 where
   Flint.leanCompareConfig 0x227808efbc4a0df6
 setup_fixed_benchmark Flint.runFlintCoprime2 where
   Flint.flintCompareConfig 0x227808efbc4a0df6
+
+/- Singular runs in a separate persistent process and certifies the same
+coprime result over `Q[x,y]`.  Its empty overhead request calibrates the two
+process-framing layers without polynomial work. -/
+setup_fixed_benchmark Singular.runOverhead where
+  Singular.config 0x0000000000000007
+setup_fixed_benchmark Singular.runCoprime2 where
+  Singular.config 0x227808efbc4a0df6
 
 /- With a three-term divisor and a dense quotient, exact division visits each
 quotient/divisor term pair and performs logarithmic support updates. -/

--- a/bench/HexMvGcdSingular.lean
+++ b/bench/HexMvGcdSingular.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import Hex.BenchOracle.Flint
+import HexMvGcdFlint
+import LeanBench
+
+/-!
+Singular's like-for-like coprime multivariate-GCD comparator.
+
+The persistent Python service keeps Singular itself alive across an autotuned
+child batch.  Singular certifies that the fixed integer pair has unit GCD over
+the rational polynomial ring; the Lean registration returns the same canonical
+constant polynomial, so LeanBench comparison still checks exact agreement.
+-/
+
+namespace Hex.MvGcdBench.Singular
+
+open Hex.MvPoly
+open Lean (Json)
+
+private abbrev PersistentComparator :=
+  Hex.BenchOracle.Flint.PersistentComparator
+
+initialize driverRef : IO.Ref (Option PersistentComparator) ← IO.mkRef none
+
+private def envOr (name default : String) : IO String := do
+  return (← IO.getEnv name).getD default
+
+private def driverPath : IO String := do
+  if let some path ← IO.getEnv "HEX_SINGULAR_BENCH_DRIVER" then
+    return path
+  let root : System.FilePath := "scripts/oracle/singular_bench_driver.py"
+  if ← root.pathExists then return root.toString
+  return "../scripts/oracle/singular_bench_driver.py"
+
+private def resolveDriver : IO PersistentComparator := do
+  if let some child ← driverRef.get then return child
+  let child ← Hex.BenchOracle.Flint.PersistentComparator.spawn
+    (← envOr "HEX_SINGULAR_BENCH_PYTHON" "python3") #[← driverPath]
+  driverRef.set (some child)
+  return child
+
+private def jsonError (context : String) (result : Except String α) : IO α :=
+  match result with
+  | .ok value => pure value
+  | .error error => throw <| IO.userError s!"{context}: {error}"
+
+private def runOp (op : String) (fields : Array (String × Json)) : IO Json := do
+  let mut object : Array (String × Json) :=
+    #[("family", Json.str "integer_mpoly"), ("op", Json.str op)]
+  for field in fields do object := object.push field
+  let replyLine ← Hex.BenchOracle.Flint.PersistentComparator.requestLine
+    (← resolveDriver) (Json.mkObj object.toList).compress
+  let reply ← match Json.parse replyLine with
+    | Except.ok value => pure value
+    | Except.error error => throw (IO.userError
+        s!"singular_bench_driver reply not valid JSON: {error}; reply: {replyLine}")
+  match reply.getObjValAs? Bool "ok" with
+  | Except.ok true =>
+      match reply.getObjVal? "result" with
+      | Except.ok result => return result
+      | Except.error error => throw (IO.userError
+          s!"singular_bench_driver missing result: {error}")
+  | Except.ok false =>
+      let error := (reply.getObjValAs? String "error").toOption.getD
+        "(no error message)"
+      throw <| IO.userError s!"singular_bench_driver: {error}"
+  | Except.error error => throw (IO.userError
+      s!"singular_bench_driver missing/non-bool ok: {error}")
+
+private def termsJson (p : Flint.P2 Int) : Json :=
+  Json.arr <| (p.termsList.map fun term =>
+    Json.arr #[
+      Json.arr (term.1.toList.map (fun exponent =>
+        Json.num (Lean.JsonNumber.fromNat exponent))).toArray,
+      Json.num (Lean.JsonNumber.fromInt term.2)]).toArray
+
+def runOverhead (_ : Unit) : IO (List (List Nat × Int)) := do
+  let result ← runOp "overhead" #[]
+  unless (← jsonError "Singular overhead result is not a boolean" result.getBool?) do
+    throw <| IO.userError "Singular overhead request returned false"
+  return []
+
+def runCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
+  let input ← Flint.coprime1.get
+  let result ← runOp "gcd_is_one" #[
+    ("nvars", Json.num (Lean.JsonNumber.fromNat 2)),
+    ("a", termsJson input.left), ("b", termsJson input.right)]
+  unless (← jsonError "Singular coprime result is not a boolean" result.getBool?) do
+    throw <| IO.userError "Singular coprime request returned false"
+  return [([0, 0], 1)]
+
+def config (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 12.0, minTotalSeconds := 0.2,
+    warmupFirstIter := true, expectedHash := some expectedHash }
+
+end Hex.MvGcdBench.Singular

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -289,7 +289,7 @@ lean_lib HexMvGcdKernelProbe where
 
 lean_lib HexMvGcdBenchSupport where
   srcDir := "bench"
-  globs := #[`HexMvGcdFlint]
+  globs := #[`HexMvGcdFlint, `HexMvGcdSingular]
 
 lean_lib HexMvPolyBenchSupport where
   srcDir := "bench"

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1222,5 +1222,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "8159dbe8532091eaf8426ef4c051523050f2322f",
     "reason": "Additionally registers the build-only HexMvGcd FLINT benchmark support module; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "ba87c482d13eae7564308de364a919eb71efc640",
+    "reason": "Additionally registers the build-only HexMvGcd Singular benchmark support module; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
   }
 ]

--- a/scripts/oracle/singular_bench_driver.py
+++ b/scripts/oracle/singular_bench_driver.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Persistent Singular comparator for multivariate GCD benchmarks.
+
+The outer process speaks the repository's one-JSON-request-per-line protocol.
+It keeps one quiet Singular subprocess alive and sends it a fresh polynomial
+GCD command for each request, so benchmark iterations do not include Singular
+startup.  The current family is deliberately narrow: it certifies that the
+declared integer inputs are coprime over ``Q[x_1, ..., x_n]``.  That is the
+like-for-like family named by ``HexMvGcd``'s informational comparator contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import TextIO
+
+
+def _terms(encoded: object, nvars: int, label: str) -> list[tuple[tuple[int, ...], int]]:
+    if not isinstance(encoded, list):
+        raise ValueError(f"{label} terms must be a list")
+    out: list[tuple[tuple[int, ...], int]] = []
+    seen: set[tuple[int, ...]] = set()
+    for index, term in enumerate(encoded):
+        if not isinstance(term, list) or len(term) != 2:
+            raise ValueError(f"{label} term {index} must contain exponents and coefficient")
+        exponents, coefficient = term
+        if not isinstance(exponents, list) or len(exponents) != nvars:
+            actual = len(exponents) if isinstance(exponents, list) else "non-list"
+            raise ValueError(
+                f"{label} term {index} exponent length {actual}; expected {nvars}"
+            )
+        if any(not isinstance(exponent, int) or isinstance(exponent, bool)
+               for exponent in exponents):
+            raise ValueError(f"{label} term {index} has a non-integer exponent")
+        if any(exponent < 0 for exponent in exponents):
+            raise ValueError(f"{label} term {index} has a negative exponent")
+        if not isinstance(coefficient, int) or isinstance(coefficient, bool):
+            raise ValueError(f"{label} term {index} coefficient must be an integer")
+        key = tuple(exponents)
+        if key in seen:
+            raise ValueError(f"{label} repeats exponent vector {key}")
+        seen.add(key)
+        if coefficient != 0:
+            out.append((key, coefficient))
+    return out
+
+
+def _poly_expr(terms: list[tuple[tuple[int, ...], int]]) -> str:
+    if not terms:
+        return "0"
+    pieces: list[str] = []
+    for exponents, coefficient in terms:
+        factors: list[str] = []
+        for index, exponent in enumerate(exponents, start=1):
+            if exponent == 1:
+                factors.append(f"x{index}")
+            elif exponent > 1:
+                factors.append(f"x{index}^{exponent}")
+        monomial = "*".join(factors)
+        magnitude = abs(coefficient)
+        if not monomial:
+            body = str(magnitude)
+        elif magnitude == 1:
+            body = monomial
+        else:
+            body = f"{magnitude}*{monomial}"
+        if not pieces:
+            pieces.append(body if coefficient > 0 else f"-{body}")
+        else:
+            pieces.append(("+" if coefficient > 0 else "-") + body)
+    return "".join(pieces)
+
+
+class SingularSession:
+    def __init__(self, command: str) -> None:
+        self._process = subprocess.Popen(
+            [command, "-q"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+        )
+        if self._process.stdin is None or self._process.stdout is None:
+            raise RuntimeError("Singular did not expose piped stdin/stdout")
+        self._stdin: TextIO = self._process.stdin
+        self._stdout: TextIO = self._process.stdout
+        self._nvars: int | None = None
+        self._serial = 0
+
+    def _request(self, command: str, expected: str) -> None:
+        self._stdin.write(command + "\n")
+        self._stdin.flush()
+        for line in self._stdout:
+            if line.rstrip("\n") == expected:
+                return
+        raise RuntimeError("Singular closed stdout before the response sentinel")
+
+    def _ensure_ring(self, nvars: int) -> None:
+        if self._nvars is None:
+            variables = ",".join(f"x{index}" for index in range(1, nvars + 1))
+            sentinel = "__HEX_SINGULAR_RING_READY__"
+            self._request(
+                f'ring hex_ring=0,({variables}),lp; print("{sentinel}");', sentinel
+            )
+            self._nvars = nvars
+        elif self._nvars != nvars:
+            raise ValueError(
+                f"persistent Singular ring has {self._nvars} variables; requested {nvars}"
+            )
+
+    def overhead(self) -> None:
+        self._serial += 1
+        sentinel = f"__HEX_SINGULAR_OVERHEAD_{self._serial}__"
+        self._request(f'print("{sentinel}");', sentinel)
+
+    def gcd_is_one(self, nvars: int, left: str, right: str) -> bool:
+        self._ensure_ring(nvars)
+        self._serial += 1
+        yes = f"__HEX_SINGULAR_GCD_{self._serial}_YES__"
+        no = f"__HEX_SINGULAR_GCD_{self._serial}_NO__"
+        command = (
+            f"poly hex_left={left}; poly hex_right={right}; "
+            "poly hex_gcd=gcd(hex_left,hex_right); "
+            f'if (hex_gcd==1) {{ print("{yes}"); }} '
+            f'else {{ print("{no}"); }} '
+            "kill hex_left; kill hex_right; kill hex_gcd;"
+        )
+        self._stdin.write(command + "\n")
+        self._stdin.flush()
+        for line in self._stdout:
+            answer = line.rstrip("\n")
+            if answer == yes:
+                return True
+            if answer == no:
+                return False
+        raise RuntimeError("Singular closed stdout before the GCD response sentinel")
+
+
+def _dispatch(request: dict[str, object], session: SingularSession) -> bool:
+    if request.get("family") != "integer_mpoly":
+        raise ValueError(f"unknown Singular family: {request.get('family')!r}")
+    operation = request.get("op")
+    if operation == "overhead":
+        session.overhead()
+        return True
+    if operation != "gcd_is_one":
+        raise ValueError(f"unknown Singular integer_mpoly operation: {operation!r}")
+    nvars = request.get("nvars")
+    if not isinstance(nvars, int) or isinstance(nvars, bool) or nvars <= 0:
+        raise ValueError("nvars must be a positive integer")
+    left = _poly_expr(_terms(request.get("a"), nvars, "a"))
+    right = _poly_expr(_terms(request.get("b"), nvars, "b"))
+    if not session.gcd_is_one(nvars, left, right):
+        raise ValueError("Singular computed a nonunit GCD for the coprime fixture")
+    return True
+
+
+def main() -> int:
+    command = os.environ.get("HEX_SINGULAR_COMMAND", "Singular")
+    session: SingularSession | None = None
+    for line in sys.stdin:
+        try:
+            request = json.loads(line)
+            if not isinstance(request, dict):
+                raise ValueError("request must be a JSON object")
+            if session is None:
+                session = SingularSession(command)
+            result = _dispatch(request, session)
+            reply = {"ok": True, "result": result}
+        except Exception as error:  # protocol errors are data, not process crashes
+            reply = {"ok": False, "error": str(error)}
+        print(json.dumps(reply, separators=(",", ":")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/oracle/test_singular_mpoly_bench.py
+++ b/scripts/oracle/test_singular_mpoly_bench.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Focused tests for the Singular multivariate GCD benchmark protocol."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.oracle import singular_bench_driver as driver
+
+
+class _FakeSession:
+    def __init__(self, answer: bool = True) -> None:
+        self.answer = answer
+        self.calls: list[tuple[int, str, str]] = []
+        self.overhead_calls = 0
+
+    def overhead(self) -> None:
+        self.overhead_calls += 1
+
+    def gcd_is_one(self, nvars: int, left: str, right: str) -> bool:
+        self.calls.append((nvars, left, right))
+        return self.answer
+
+
+class SingularMpolyBenchTests(unittest.TestCase):
+    def test_sparse_expression_and_dispatch(self) -> None:
+        request = {
+            "family": "integer_mpoly",
+            "op": "gcd_is_one",
+            "nvars": 2,
+            "a": [[[2, 0], 1], [[1, 1], -3], [[0, 0], 2]],
+            "b": [[[0, 3], -1], [[1, 0], 4]],
+        }
+        session = _FakeSession()
+        self.assertTrue(driver._dispatch(request, session))
+        self.assertEqual(
+            session.calls,
+            [(2, "x1^2-3*x1*x2+2", "-x2^3+4*x1")],
+        )
+
+    def test_overhead_uses_persistent_session(self) -> None:
+        session = _FakeSession()
+        self.assertTrue(
+            driver._dispatch(
+                {"family": "integer_mpoly", "op": "overhead"}, session
+            )
+        )
+        self.assertEqual(session.overhead_calls, 1)
+
+    def test_rejects_nonunit_gcd(self) -> None:
+        session = _FakeSession(False)
+        with self.assertRaisesRegex(ValueError, "nonunit GCD"):
+            driver._dispatch(
+                {
+                    "family": "integer_mpoly",
+                    "op": "gcd_is_one",
+                    "nvars": 1,
+                    "a": [[[1], 1]],
+                    "b": [[[1], 1]],
+                },
+                session,
+            )
+
+    def test_rejects_duplicate_monomials(self) -> None:
+        with self.assertRaisesRegex(ValueError, "repeats exponent vector"):
+            driver._terms([[[1, 0], 2], [[1, 0], 3]], 2, "a")
+
+    def test_rejects_negative_exponent(self) -> None:
+        with self.assertRaisesRegex(ValueError, "negative exponent"):
+            driver._terms([[[-1, 0], 2]], 2, "a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the SPEC-required informational Singular comparator to the existing hex-mv-gcd benchmark executable. The persistent JSON driver uses canonical lexicographic sparse terms, includes protocol unit tests and an overhead calibration, and extends the existing single CI job with the Singular package and smoke verification.\n\nValidated with: lake build hexmvgcd_bench; all 32 benchmark registrations verified with python-flint and Singular 4.4.1; Singular driver unit tests; Phase 4, DAG, line-count, copyright, and Mathlib-free bench checks.