### PR TITLE
perf(mv-gcd): make Brown shape matrix practical

### DIFF
--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -285,7 +285,9 @@ def brownStepOps {n : Nat} {R : Type u}
             if brownPointBad point gamma fPrimitive hPrimitive then
               loop rest (fuel - 1) state samples
             else
-              match lower.candidate? Mono.lex (fuel - 1) rest fImage hImage with
+              -- Each recursive variable has an independent interpolation
+              -- axis; consuming an outer point must not shorten its supply.
+              match lower.candidate? Mono.lex pointFuel points fImage hImage with
               | none => loop rest (fuel - 1) state samples
               | some rawImage =>
                   let imageLeading := brownMainLeadingCoeff rawImage

--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -251,7 +251,7 @@ def brownStepOps {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Inv R]
     [Dvd R] [BezoutOps R]
     (lower : BrownOpsAt R (n + 1)) : BrownOpsAt R (n + 2) where
-  candidate? := fun cmp _ pointFuel points f h =>
+  candidate? := fun cmp _ pointFuel points f h => do
     if f == 0 || h == 0 || polyIsUnit f || polyIsUnit h then
       some (prsCert f h).gcd
     else
@@ -259,21 +259,37 @@ def brownStepOps {n : Nat} {R : Type u}
       let outer : Fin (n + 2) := Fin.last (n + 1)
       let fView := toUnivariate main Mono.lex f
       let hView := toUnivariate main Mono.lex h
-      let fContent := contentCertWith (fun a b => prsCert a b)
-        fView.toArray.toList
-      let hContent := contentCertWith (fun a b => prsCert a b)
-        hView.toArray.toList
-      let common := prsCert fContent.value hContent.value
-      let fPrimitive := quotient f (constIn main Mono.lex fContent.value)
-      let hPrimitive := quotient h (constIn main Mono.lex hContent.value)
-      let gamma :=
-        (prsCert (brownMainLeadingCoeff fPrimitive)
-          (brownMainLeadingCoeff hPrimitive)).gcd
+      let lowerGcd? := fun a b => do
+        let candidate ← lower.candidate? Mono.lex pointFuel points a b
+        some (polyNormalize candidate)
+      -- A recursive Brown decline must abort this speculative image.  Falling
+      -- back to multivariate PRS here can turn one unlucky small-prime image
+      -- into the dominant cost of the whole modular route; the outer prime
+      -- loop can instead try the next bundled modulus immediately.
+      let fContent ← fView.toArray.toList.foldlM lowerGcd? 0
+      let hContent ← hView.toArray.toList.foldlM lowerGcd? 0
+      let common ← lowerGcd? fContent hContent
+      let fPrimitive := quotient f (constIn main Mono.lex fContent)
+      let hPrimitive := quotient h (constIn main Mono.lex hContent)
+      let gamma ← lowerGcd? (brownMainLeadingCoeff fPrimitive)
+        (brownMainLeadingCoeff hPrimitive)
       let sampleTarget :=
         max (degreeOf outer fPrimitive) (degreeOf outer hPrimitive) + 1
+      let reconstruct := fun
+          (samples : List (R × MvPoly (n + 1) R Mono.lex)) => do
+        let interpolation ← brownInterpolate? samples
+        let reconstructed :=
+          ofUnivariate (cmp := cmp) outer Mono.lex interpolation
+        let reconstructedView := toUnivariate main Mono.lex reconstructed
+        let reconstructedContent ←
+          reconstructedView.toArray.toList.foldlM lowerGcd? 0
+        let primitive := quotient reconstructed
+          (constIn main Mono.lex reconstructedContent)
+        some (constIn main Mono.lex common * primitive)
       let rec loop (remaining : List R) (fuel : Nat)
           (state : BrownPointState)
-          (samples : List (R × MvPoly (n + 1) R Mono.lex)) :
+          (samples : List (R × MvPoly (n + 1) R Mono.lex))
+          (previous? : Option (MvPoly (n + 2) R cmp)) :
           Option (MvPoly (n + 2) R cmp) := do
         if fuel = 0 then none else pure PUnit.unit
         match remaining with
@@ -283,56 +299,46 @@ def brownStepOps {n : Nat} {R : Type u}
             let hImage := brownEvalLast point hPrimitive
             let gammaAt := brownEvalLast point gamma
             if brownPointBad point gamma fPrimitive hPrimitive then
-              loop rest (fuel - 1) state samples
+              loop rest (fuel - 1) state samples previous?
             else
               -- Each recursive variable has an independent interpolation
               -- axis; consuming an outer point must not shorten its supply.
               match lower.candidate? Mono.lex pointFuel points fImage hImage with
-              | none => loop rest (fuel - 1) state samples
+              | none => loop rest (fuel - 1) state samples previous?
               | some rawImage =>
                   let imageLeading := brownMainLeadingCoeff rawImage
                   match divExact? gammaAt imageLeading with
-                  | none => loop rest (fuel - 1) state samples
+                  | none => loop rest (fuel - 1) state samples previous?
                   | some scale =>
                       let corrected := constIn (0 : Fin (n + 1)) Mono.lex scale * rawImage
                       if brownMainLeadingCoeff corrected != gammaAt then
-                        loop rest (fuel - 1) state samples
+                        loop rest (fuel - 1) state samples previous?
                       else
                         let imageDegree := degreeOf (0 : Fin (n + 1)) corrected
                         let offered := state.offer true true imageDegree
                         match offered.1 with
                         | .bad | .unlucky =>
-                            loop rest (fuel - 1) offered.2 samples
+                            loop rest (fuel - 1) offered.2 samples previous?
                         | .restart =>
-                            if sampleTarget ≤ 1 then
-                              let interpolation ← brownInterpolate? [(point, corrected)]
-                              let reconstructed :=
-                                ofUnivariate (cmp := cmp) outer Mono.lex interpolation
-                              let reconstructedView := toUnivariate main Mono.lex reconstructed
-                              let reconstructedContent := contentCertWith
-                                (fun a b => prsCert a b)
-                                reconstructedView.toArray.toList
-                              let primitive := quotient reconstructed
-                                (constIn main Mono.lex reconstructedContent.value)
-                              some (constIn main Mono.lex common.gcd * primitive)
-                            else
-                              loop rest (fuel - 1) offered.2 [(point, corrected)]
+                            let nextSamples := [(point, corrected)]
+                            let next ← reconstruct nextSamples
+                            if sampleTarget ≤ 1 then some next
+                            else loop rest (fuel - 1) offered.2 nextSamples (some next)
                         | .accept =>
                             let nextSamples := (point, corrected) :: samples
-                            if sampleTarget ≤ offered.2.accepted then
-                              let interpolation ← brownInterpolate? nextSamples
-                              let reconstructed :=
-                                ofUnivariate (cmp := cmp) outer Mono.lex interpolation
-                              let reconstructedView := toUnivariate main Mono.lex reconstructed
-                              let reconstructedContent := contentCertWith
-                                (fun a b => prsCert a b)
-                                reconstructedView.toArray.toList
-                              let primitive := quotient reconstructed
-                                (constIn main Mono.lex reconstructedContent.value)
-                              some (constIn main Mono.lex common.gcd * primitive)
-                            else
-                              loop rest (fuel - 1) offered.2 nextSamples
-      loop points pointFuel {} []
+                            match previous? with
+                            | some previous =>
+                                if brownEvalLast point previous == corrected then
+                                  some previous
+                                else
+                                  let next ← reconstruct nextSamples
+                                  if sampleTarget ≤ offered.2.accepted then some next
+                                  else loop rest (fuel - 1) offered.2 nextSamples (some next)
+                            | none =>
+                                let next ← reconstruct nextSamples
+                                if sampleTarget ≤ offered.2.accepted then some next
+                                else loop rest (fuel - 1) offered.2 nextSamples (some next)
+      loop points pointFuel {} [] none
 
 /-- Construct all recursive point layers by arity. -/
 def brownOps {R : Type u}

--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -617,13 +617,16 @@ delegated arity-one case. -/
 def intConcreteProposalGeneric {n : Nat}
     (cmp : Mono n → Mono n → Ordering) [IsMonomialOrder cmp]
     (cfg : GcdConfig) (f h : MvPoly n Int cmp) : GcdProposal n Int cmp :=
-  let fast := intFastProposal cfg f h
-  match fast.cert? with
-  | some _ => fast
+  match remainderCert? f h with
+  | some cert => ⟨some cert, cfg.rand⟩
   | none =>
-      match intHeuristicCert? cfg f h with
-      | some cert => ⟨some cert, fast.rand⟩
-      | none => ⟨intBrownCert? cmp cfg f h, fast.rand⟩
+      let fast := intFastProposal cfg f h
+      match fast.cert? with
+      | some _ => fast
+      | none =>
+          match intHeuristicCert? cfg f h with
+          | some cert => ⟨some cert, fast.rand⟩
+          | none => ⟨intBrownCert? cmp cfg f h, fast.rand⟩
 
 /-- Concrete integer producer.  Arity one delegates immediately to the
 released dense integer kernel; other arities use the multivariate routes. -/

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -86,6 +86,14 @@ mutual
         {cmp : Mono 0 → Mono 0 → Ordering}
         [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
         (u v : R) : CoprimeCert 0 R cmp
+    /-- A direct Bézout identity at any arity.  The checker replays the
+    polynomial identity instead of descending through a subresultant chain. -/
+    | bezout {n : Nat} {R : Type u}
+        [zeroR : Zero R]
+        {cmp : Mono n → Mono n → Ordering}
+        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
+        (u v : @MvPoly n R zeroR cmp outerTrans outerEq) :
+        @CoprimeCert n R zeroR cmp outerTrans outerEq
     /-- Internal universe-polymorphic form of rational lifting.  The public
     `CoprimeCert.ratLift` smart constructor fixes the embedded coefficient
     type to `Int` and the target type to `Rat`. -/
@@ -352,6 +360,7 @@ recursive. -/
   match cert with
   | .unit => polyIsUnit f || polyIsUnit h
   | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
+  | .bezout u v => u * f + v * h == 1
   | _ => false
 
 @[reducible] def succCheckNoLift {n : Nat} {S : Type u}
@@ -364,6 +373,7 @@ recursive. -/
     (cert : CoprimeCert (n + 1) S cmp) : Bool := by
   cases cert with
   | unit => exact polyIsUnit f || polyIsUnit h
+  | bezout u v => exact u * f + v * h == 1
   | ratLiftCore => exact false
   | split i cmp' P φ a α β left right rest =>
       letI : ZMod64.Bounds P.m := P.bounds
@@ -432,6 +442,7 @@ recursive. -/
   match cert with
   | .unit => polyIsUnit f || polyIsUnit h
   | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
+  | .bezout u v => u * f + v * h == 1
   | @CoprimeCert.ratLiftCore _ _ S _ _ _ _ _ringModel _decModel
       _beqModel _lawfulModel _dvdModel _gcdModel _ _ _ embed _ _ _ _ _
       scaleL scaleR invL invR left right cert =>
@@ -448,6 +459,7 @@ recursive. -/
     (cert : CoprimeCert (n + 1) R cmp) : Bool := by
   cases cert with
   | unit => exact polyIsUnit f || polyIsUnit h
+  | bezout u v => exact u * f + v * h == 1
   | @ratLiftCore _ _ S _ _ _ _ ringModel decModel beqModel
       lawfulModel dvdModel gcdModel _ _ _ embed _ _ _ _ _
       scaleL scaleR invL invR left right cert =>

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -17,6 +17,7 @@ private abbrev P0 := MvPoly 0 Int Mono.lex
 private abbrev P1 := MvPoly 1 Int Mono.lex
 private abbrev P2 := MvPoly 2 Int Mono.lex
 private abbrev Q2 := MvPoly 2 Rat Mono.lex
+private abbrev Q3 := MvPoly 3 Rat Mono.lex
 private def brownPrimeAt? (p : Nat) : Option ZMod64.Prime :=
   (ZMod64.primesBelow p 1)[0]?
 #guard (smallPrimeSupply 47 5).map (fun P => P.m) == [2, 3, 5, 7, 11]
@@ -226,6 +227,16 @@ private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
   let f := common * (x + 2)
   let h := common * (y + 3)
   match brownFieldCert? 12 [0, 1, 2, 3] f h with
+  | some cert => checkGcd f h cert && cert.gcd == common
+  | none => false
+#guard
+  let x : Q3 := X 0
+  let y : Q3 := X 1
+  let z : Q3 := X 2
+  let common := x + y + z + 1
+  let f := common * (x + 2)
+  let h := common * (x + 3)
+  match brownFieldCert? 12 [0, 1, 2] f h with
   | some cert => checkGcd f h cert && cert.gcd == common
   | none => false
 #guard

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -126,6 +126,14 @@ private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
   (checkedCandidate? f h (intHeuristicCandidateAt f h 101)).isSome
 #guard
   let x : P1 := X 0
+  let common := x + 1
+  let f := common * x
+  let h := common * (x ^ 2 + 1)
+  match remainderCert? f h with
+  | some cert => checkGcd f h cert && cert.gcd == common
+  | none => false
+#guard
+  let x : P1 := X 0
   let f := x
   let h := x ^ 2 + 1
   match unitRemainderCert? f h with

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -127,6 +127,13 @@ private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
 #guard
   let x : P1 := X 0
   let f := x
+  let h := x ^ 2 + 1
+  match unitRemainderCert? f h with
+  | some cert => checkCoprime f h cert
+  | none => false
+#guard
+  let x : P1 := X 0
+  let f := x
   let h := x + 5
   (checkedCandidate? f h (intHeuristicCandidateAt f h 5)).isNone
 #guard

--- a/HexMvGcd/Eval.lean
+++ b/HexMvGcd/Eval.lean
@@ -295,6 +295,15 @@ private def observedRand {n : Nat} {cmp : Mono n → Mono n → Ordering}
   | some cert => checkGcd f h cert && cert.gcd == common
   | none => false
 #guard
+  let lower : BrownOpsAt Rat 1 :=
+    { candidate? := fun _ _ _ _ _ _ => none }
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let common := x + y + 1
+  let f := common * (x + 2)
+  let h := common * (y + 3)
+  ((brownStepOps lower).candidate? Mono.lex 8 [0, 1, 2] f h).isNone
+#guard
   let x : P2 := X 0
   let f := C 2 * x + 1
   let h := C 2 * x + 3

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -188,10 +188,28 @@ def unitDiffCert? {n : Nat} {R : Type u}
   else if h - f == 1 then some (.bezout (-1) 1)
   else none
 
+/-- Detect a one-step polynomial remainder equal to `±1` and replay the
+resulting direct Bézout identity.  This keeps candidate checking cheap when a
+large cofactor is an affine polynomial multiple of the other. -/
+def unitRemainderCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R]
+    (f h : MvPoly n R cmp) : Option (CoprimeCert n R cmp) :=
+  let right := divMod h f
+  if right.2 == 1 then some (.bezout (-right.1) 1)
+  else if right.2 == -1 then some (.bezout right.1 (-1))
+  else
+    let left := divMod f h
+    if left.2 == 1 then some (.bezout 1 (-left.1))
+    else if left.2 == -1 then some (.bezout (-1) left.1)
+    else none
+
 /-- Offer an arbitrary nonzero polynomial candidate to the full multivariate
-checker.  Exact division builds cofactors; a unit difference gives a direct
-Bézout witness, and all other pairs use route 4.  No producer may bypass this
-function's final replay. -/
+checker.  Exact division builds cofactors; a unit difference or unit remainder
+gives a direct Bézout witness, and all other pairs use route 4.  No producer
+may bypass this function's final replay. -/
 def checkedCandidate? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
@@ -205,7 +223,9 @@ def checkedCandidate? {n : Nat} {R : Type u}
     let cofR := quotient h normalized
     let coprime := match unitDiffCert? cofL cofR with
       | some cert => cert
-      | none => (prsCert cofL cofR).coprime
+      | none => match unitRemainderCert? cofL cofR with
+        | some cert => cert
+        | none => (prsCert cofL cofR).coprime
     let cert := GcdCert.mk normalized cofL cofR coprime
     if checkGcd f h cert then some cert else none
 

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -229,6 +229,27 @@ def checkedCandidate? {n : Nat} {R : Type u}
     let cert := GcdCert.mk normalized cofL cofR coprime
     if checkGcd f h cert then some cert else none
 
+/-- Offer a strict one-step polynomial remainder as a gcd candidate.  Exact
+division and coprimality replay remain the acceptance gate; a division which
+makes no progress is skipped, and exact divisibility offers the divisor. -/
+def remainderCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [BezoutOps R]
+    (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+  let right := (divMod h f).2
+  if right != h then
+    match checkedCandidate? f h (if right == 0 then f else right) with
+    | some cert => some cert
+    | none => tryLeft f h
+  else tryLeft f h
+where
+  tryLeft (f h : MvPoly n R cmp) : Option (GcdCert n R cmp) :=
+    let left := (divMod f h).2
+    if left == f then none
+    else checkedCandidate? f h (if left == 0 then h else left)
+
 /-! # Integer modular coprimality -/
 
 /-- Canonical reduction homomorphism carried in an image certificate. -/

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -178,9 +178,20 @@ def gcdCertWith (cfg : GcdConfig)
                 fallback proposal.rand
           | none => fallback proposal.rand
 
+/-- Direct coprimality witness when two cofactors differ by one. -/
+def unitDiffCert? {n : Nat} {R : Type u}
+    {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    (f h : MvPoly n R cmp) : Option (CoprimeCert n R cmp) :=
+  if f - h == 1 then some (.bezout 1 (-1))
+  else if h - f == 1 then some (.bezout (-1) 1)
+  else none
+
 /-- Offer an arbitrary nonzero polynomial candidate to the full multivariate
-checker.  Exact division builds cofactors and route 4 supplies their
-coprimality witness; no producer may bypass this function's final replay. -/
+checker.  Exact division builds cofactors; a unit difference gives a direct
+Bézout witness, and all other pairs use route 4.  No producer may bypass this
+function's final replay. -/
 def checkedCandidate? {n : Nat} {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp]
@@ -192,8 +203,10 @@ def checkedCandidate? {n : Nat} {R : Type u}
     let normalized := polyNormalize candidate
     let cofL := quotient f normalized
     let cofR := quotient h normalized
-    let cofactorCert := prsCert cofL cofR
-    let cert := GcdCert.mk normalized cofL cofR cofactorCert.coprime
+    let coprime := match unitDiffCert? cofL cofR with
+      | some cert => cert
+      | none => (prsCert cofL cofR).coprime
+    let cert := GcdCert.mk normalized cofL cofR coprime
     if checkGcd f h cert then some cert else none
 
 /-! # Integer modular coprimality -/

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -578,7 +578,11 @@ and `u · x + v · 2 = 1` has no solution in `ℤ[x]`. The same holds in
 `R[x₁, …, xₙ]` over any base that is not a field, and over a field as
 soon as `n ≥ 2` (`x₁` and `x₂` are coprime with no Bézout identity).
 
-Two things do work, and both are supported.
+Three things do work, and all are supported. A direct polynomial Bézout
+identity, when one happens to exist, is the cheapest: replay
+`u · f' + v · h' = 1` without claiming that every coprime pair admits such
+an identity. The modular and recursive witnesses below cover pairs for which
+no direct identity exists.
 
 ### The modular witness, which is primary when available
 
@@ -634,6 +638,7 @@ mutual
       [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type u
     | unit : CoprimeCert n R cmp
     | base (u v : R) : CoprimeCert 0 R cmp
+    | bezout (u v : MvPoly n R cmp) : CoprimeCert n R cmp
     | split (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering)
         [IsMonomialOrder cmp'] [One R] [Add R] [Mul R]
         (P : ZMod64.Prime)
@@ -698,8 +703,9 @@ typeclass search. Producers try the smallest usable prime because kernel
 replay checks its primality proof and the project-local trial proof becomes
 expensive near the 31-bit limit.
 `splitBezout` checks `r ≠ 0`, `u · f + v · h = constIn i cmp' r`, the two
-content certificates, and the same recursive check. `base` checks the
-Bézout identity in `R`, and `unit` checks that one side is a unit.
+content certificates, and the same recursive check. `bezout` checks the
+direct identity `u · f + v · h = 1`; `base` checks its scalar analogue in
+`R`, and `unit` checks that one side is a unit.
 `ratLift` checks `scaleL ≠ 0`, `scaleR ≠ 0`, that the two rational inputs
 are the stated scalar multiples of the coefficientwise `Int → Rat` images,
 that both integer models have `scalarContent = 1`, and that `cert` checks
@@ -1544,7 +1550,7 @@ oracle's normalisation conventions.
 Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at
 `bench/HexMvGcd/Bench.lean`. Native only for throughput. A separate
 `bench/HexMvGcd/Kernel.lean` suite replays valid and one-field-corrupted
-certificates through `by decide +kernel`: base, modular split,
+certificates through `by decide +kernel`: base, direct Bézout, modular split,
 `splitBezout`, `ratLift`, nested content folds, zero, and unit cases. Hex-mv-poly's
 kernel suite cannot substitute for this recursive checker coverage.
 

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1010,6 +1010,14 @@ linear in the term count and strictly shrinks the problem without changing
 the certificate's arity. Restricting to `vars f ∩ vars h` is deferred until
 there is a specified certificate re-embedding operation.
 
+Before modular evaluation, integer dispatch performs polynomial division in
+both directions and offers any strict nonzero remainder as a gcd candidate;
+an exact division offers the divisor. A no-progress remainder is ignored.
+This inexpensive prepass captures affine-multiple shapes such as
+`h = q · f + g`, but proves nothing from that equation alone: exact division
+by `g` and a checked coprimality certificate for the two cofactors remain the
+acceptance condition.
+
 ### 1. Coprime detection, the case that dominates
 
 `tryCoprimeCert?` runs, per variable, one evaluation and one univariate

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1081,7 +1081,17 @@ Fix the main variable `i`. Recursion on the remaining variables:
   points, keep the images of minimal degree, and restart the
   interpolation whenever a smaller degree appears.
 - Interpolate in the outermost remaining variable, take the primitive
-  part in `xᵢ`, and multiply back the content gcd.
+  part in `xᵢ`, and multiply back the content gcd. The content and
+  leading-coefficient gcds use the same recursive Brown operation. If one
+  of those speculative recursive calls declines, the current image declines
+  too: it must not start the complete multivariate PRS fallback inside a
+  modular image, because the surrounding point or prime loop can cheaply try
+  its next value.
+- Reconstruction may stop before the dense degree bound when the current
+  interpolant predicts the next accepted image exactly. This is only an
+  untrusted early-termination heuristic. The completed field image is checked
+  by exact division and a cofactor certificate before the prime layer uses it,
+  and the eventual integer candidate passes the same public checker.
 
 The prime layer needs the same machinery, one level up: primes must
 preserve the input degrees, primes giving a larger modular gcd degree

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -582,7 +582,10 @@ Three things do work, and all are supported. A direct polynomial Bézout
 identity, when one happens to exist, is the cheapest: replay
 `u · f' + v · h' = 1` without claiming that every coprime pair admits such
 an identity. The modular and recursive witnesses below cover pairs for which
-no direct identity exists.
+no direct identity exists. Candidate checking recognises two common direct
+forms before invoking recursive PRS: a unit difference, and a one-step
+polynomial division whose remainder is `1` or `-1`. In the latter case the
+quotient and sign give the two Bézout coefficients immediately.
 
 ### The modular witness, which is primary when available
 

--- a/bench/HexMvGcd/Kernel.lean
+++ b/bench/HexMvGcd/Kernel.lean
@@ -162,6 +162,24 @@ theorem bezoutSplitCorrupt :
     checkCoprime x (x + 1) badBezoutSplit = false := by
   decide +kernel
 
+private def directBezout : CoprimeCert 1 Int Mono.lex :=
+  .bezout (-1) 1
+
+private def badDirectBezout : CoprimeCert 1 Int Mono.lex :=
+  .bezout 0 1
+
+theorem directBezoutValid :
+    checkCoprime x (x + 1) directBezout = true := by
+  unfold checkCoprime checkOps succCheckCoprime directBezout
+  unfold x
+  decide +kernel
+
+theorem directBezoutCorrupt :
+    checkCoprime x (x + 1) badDirectBezout = false := by
+  unfold checkCoprime checkOps succCheckCoprime badDirectBezout
+  unfold x
+  decide +kernel
+
 private def baseCert : GcdCert 0 Int Mono.lex :=
   .mk (C 6) (C 2) (C 3) (.base (-1) 1)
 


### PR DESCRIPTION
## Summary

- replay cheap checked Bezout witnesses for unit differences and unit remainders before modular search
- try strict multivariate remainders as checked gcd candidates, with exact-division fallback
- keep Brown modular images on the recursive Brown path and reuse specialization points independently across axes
- document the dispatch paths and add executable kernel probes for the new fast paths

Every shortcut still returns a certificate through the existing checker; failure remains an explicit decline to the next checked path.

## Validation

- `lake build` from a fresh dependency checkout (10,301/10,301 jobs)
- `lake build HexMvGcd.Eval HexMvGcdKernelProbe hexmvgcd_bench`
- `PATH=/tmp/hex-polyzgcd-flint-20260824/bin:$PATH ./.lake/build/bin/hexmvgcd_bench verify` (30/30)
- copyright, source-line, dependency-DAG, Phase 4, and Mathlib-free bench gates