### PR TITLE
bench(mv-gcd): complete the Phase 4 shape matrix

### DIFF
--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -5,6 +5,8 @@ Authors: Kim Morrison
 -/
 
 import HexMvGcd
+import HexMvGcd.Families
+import HexMvGcd.Matrix
 import HexMvPolyCorpus
 import HexMvGcdFlint
 import HexMvGcdSingular
@@ -33,26 +35,11 @@ namespace Hex.MvGcdBench
 open Hex
 open Hex.MvPoly
 open Hex.MvPolyBench.Corpus
+open Hex.MvGcdBench.Families
 
 abbrev P2 (R : Type) [Zero R] := MvPoly 2 R Mono.lex
 abbrev P3 (R : Type) [Zero R] := MvPoly 3 R Mono.lex
 abbrev P8 (R : Type) [Zero R] := MvPoly 8 R Mono.lex
-
-/-- Stable structural hash of a canonical sparse polynomial. -/
-def checksum [Zero R] [Hashable R]
-    {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-    (p : MvPoly n R cmp) : UInt64 :=
-  p.termsList.foldl
-    (fun acc term =>
-      mixHash (mixHash acc (hash term.1.toList)) (hash term.2))
-    0
-
-instance [Zero R] [Hashable R]
-    {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
-    Hashable (MvPoly n R cmp) where
-  hash := checksum
 
 /-- Dense bivariate coefficient box. -/
 def denseBox2 [Lean.Grind.CommRing R] [DecidableEq R]

--- a/bench/HexMvGcd/Families.lean
+++ b/bench/HexMvGcd/Families.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvGcd
+
+/-!
+Deterministic input constructors for the `hex-mv-gcd` Phase 4 shape matrix.
+
+Every constructor returns a fully materialized canonical sparse polynomial.
+Benchmark registrations store those values in global references, keeping
+construction outside the timed region.
+-/
+
+namespace Hex.MvGcdBench.Families
+
+open Hex
+open Hex.MvPoly
+
+abbrev P (n : Nat) (R : Type) [Zero R] := MvPoly n R Mono.lex
+
+/-- Stable structural hash of a canonical sparse polynomial. -/
+def checksum [Zero R] [Hashable R]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n R cmp) : UInt64 :=
+  p.termsList.foldl
+    (fun acc term =>
+      mixHash (mixHash acc (hash term.1.toList)) (hash term.2))
+    0
+
+instance [Zero R] [Hashable R]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
+    Hashable (MvPoly n R cmp) where
+  hash := checksum
+
+/-- Every monomial in the arity-`n`, per-variable degree-`degree` box. -/
+def denseBox [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R] [OfNat R 1]
+    (n degree : Nat) : P n R :=
+  let radix := degree + 1
+  ofTerms <| (List.range (radix ^ n)).map fun encoded =>
+    (Hex.Vector.ofFn' fun i => encoded / radix ^ i.val % radix, 1)
+
+/-- A dense coprime pair: the right input differs from the left by one. -/
+def denseCoprime [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R] [OfNat R 1]
+    (n degree : Nat) : P n R × P n R :=
+  let left := denseBox (R := R) n degree
+  (left, left + 1)
+
+/-- A high-degree pair with `n + 1` supported terms in each input. -/
+def sparseCoprime (n degree : Nat) : P n Int × P n Int :=
+  let left : P n Int := ofTerms <|
+    (Mono.zero, 1) :: (List.finRange n).map fun axis =>
+      (Hex.Vector.ofFn' fun i => if i = axis then degree + axis.val else 0,
+        Int.ofNat (axis.val + 2))
+  (left, left + 1)
+
+/-- A linear common factor involving every variable. -/
+def commonFactor (n : Nat) : P n Int :=
+  (List.finRange n).foldl
+    (fun polynomial i => polynomial + C (Int.ofNat (i.val + 1)) * X i) 1
+
+/-- High-degree, low-support inputs with a known linear common factor. -/
+def sparseGcd (n degree : Nat) : P n Int × P n Int :=
+  let sparse := (sparseCoprime n degree).1
+  let common := commonFactor n
+  (common * sparse, common * (sparse + 1))
+
+/-- Dense inputs with a known linear gcd and consecutive dense cofactors. -/
+def denseGcd (n degree : Nat) : P n Int × P n Int :=
+  let common := commonFactor n
+  let leftCofactor := denseBox (R := Int) n degree
+  (common * leftCofactor, common * (leftCofactor + 1))
+
+/-- The rational analogue of `denseGcd`, with nonintegral scalar content. -/
+def rationalGcd (n degree : Nat) : P n Rat × P n Rat :=
+  let common : P n Rat :=
+    (List.finRange n).foldl
+      (fun polynomial i =>
+        polynomial + C ((Int.ofNat (i.val + 1) : Rat) / 2) * X i) 1
+  let leftCofactor := denseBox (R := Rat) n degree
+  (common * leftCofactor,
+    common * (leftCofactor + C ((1 : Rat) / 3)))
+
+/-- A nonconstant linear factor which involves every available variable. -/
+def linearFactor (n salt : Nat) : P n Int :=
+  (List.finRange n).foldl
+    (fun polynomial i =>
+      polynomial + C (Int.ofNat (salt + i.val + 1)) * X i)
+    (C (Int.ofNat (salt + n + 1)))
+
+/-- Product of distinct linear factors carrying the requested multiplicities. -/
+def squarefreeShape (n : Nat) (multiplicities : List Nat) : P n Int :=
+  (multiplicities.zipIdx).foldl
+    (fun polynomial entry =>
+      polynomial * linearFactor n (entry.2 + 1) ^ entry.1)
+    1
+
+end Hex.MvGcdBench.Families

--- a/bench/HexMvGcd/Families.lean
+++ b/bench/HexMvGcd/Families.lean
@@ -65,27 +65,35 @@ def commonFactor (n : Nat) : P n Int :=
   (List.finRange n).foldl
     (fun polynomial i => polynomial + C (Int.ofNat (i.val + 1)) * X i) 1
 
-/-- High-degree, low-support inputs with a known linear common factor. -/
-def sparseGcd (n degree : Nat) : P n Int × P n Int :=
+/-- High-degree, low-support inputs with a known linear common factor and
+nonconsecutive coprime cofactors. -/
+def sparseGcd (n degree : Nat) (hn : 0 < n := by omega) :
+    P n Int × P n Int :=
   let sparse := (sparseCoprime n degree).1
   let common := commonFactor n
-  (common * sparse, common * (sparse + 1))
+  let rightCofactor := X ⟨0, hn⟩ * sparse + 1
+  (common * sparse, common * rightCofactor)
 
-/-- Dense inputs with a known linear gcd and consecutive dense cofactors. -/
-def denseGcd (n degree : Nat) : P n Int × P n Int :=
+/-- Dense inputs with a known linear gcd and nonconsecutive coprime cofactors.
+The right cofactor is `x₀ * left + 1`, so a direct Bézout identity exists
+without triggering the unit-difference shortcut. -/
+def denseGcd (n degree : Nat) (hn : 0 < n := by omega) :
+    P n Int × P n Int :=
   let common := commonFactor n
   let leftCofactor := denseBox (R := Int) n degree
-  (common * leftCofactor, common * (leftCofactor + 1))
+  let rightCofactor := X ⟨0, hn⟩ * leftCofactor + 1
+  (common * leftCofactor, common * rightCofactor)
 
 /-- The rational analogue of `denseGcd`, with nonintegral scalar content. -/
-def rationalGcd (n degree : Nat) : P n Rat × P n Rat :=
+def rationalGcd (n degree : Nat) (hn : 0 < n := by omega) :
+    P n Rat × P n Rat :=
   let common : P n Rat :=
     (List.finRange n).foldl
       (fun polynomial i =>
         polynomial + C ((Int.ofNat (i.val + 1) : Rat) / 2) * X i) 1
   let leftCofactor := denseBox (R := Rat) n degree
-  (common * leftCofactor,
-    common * (leftCofactor + C ((1 : Rat) / 3)))
+  let rightCofactor := X ⟨0, hn⟩ * leftCofactor + 1
+  (common * leftCofactor, common * rightCofactor)
 
 /-- A nonconstant linear factor which involves every available variable. -/
 def linearFactor (n salt : Nat) : P n Int :=
@@ -100,5 +108,18 @@ def squarefreeShape (n : Nat) (multiplicities : List Nat) : P n Int :=
     (fun polynomial entry =>
       polynomial * linearFactor n (entry.2 + 1) ^ entry.1)
     1
+
+/-- Five-variable multiplicity stress without the incidental dense expansion
+of four factors which each involve every variable.  The first factor couples
+the fifth variable to the first; the other three keep every requested
+multiplicity distinct while all five variables remain active. -/
+def squarefreeStress5 : P 5 Int :=
+  let x0 : P 5 Int := X 0
+  let x1 : P 5 Int := X 1
+  let x2 : P 5 Int := X 2
+  let x3 : P 5 Int := X 3
+  let x4 : P 5 Int := X 4
+  (x0 + x4 + 2) ^ 2 * (x1 + 3) ^ 3 *
+    (x2 + 5) ^ 5 * (x3 + 7) ^ 7
 
 end Hex.MvGcdBench.Families

--- a/bench/HexMvGcd/Families.lean
+++ b/bench/HexMvGcd/Families.lean
@@ -74,6 +74,15 @@ def sparseGcd (n degree : Nat) (hn : 0 < n := by omega) :
   let rightCofactor := X ⟨0, hn⟩ * sparse + 1
   (common * sparse, common * rightCofactor)
 
+/-- High-degree, low-support inputs that cannot be discharged by the strict-
+remainder prepass. The two cofactors differ by `x₀`, so their one-step
+remainders still contain a nonunit factor even though their gcd is one. -/
+def sparseGapGcd (n degree : Nat) (hn : 0 < n := by omega) :
+    P n Int × P n Int :=
+  let sparse := (sparseCoprime n degree).1
+  let common := commonFactor n
+  (common * sparse, common * (sparse + X ⟨0, hn⟩))
+
 /-- Dense inputs with a known linear gcd and nonconsecutive coprime cofactors.
 The right cofactor is `x₀ * left + 1`, so a direct Bézout identity exists
 without triggering the unit-difference shortcut. -/

--- a/bench/HexMvGcd/Matrix.lean
+++ b/bench/HexMvGcd/Matrix.lean
@@ -33,6 +33,18 @@ def runBrownPair {n : Nat} (input : P n Int × P n Int) : UInt64 :=
   | none => 0
   | some cert => checksum cert.gcd
 
+/-- Measure one bounded Brown image on a sparse input. A single prime cannot
+stabilize CRT, so returning zero records an honest fast-backend decline
+without sending the merge-gated smoke verifier into the mandatory dense PRS
+fallback. Full end-to-end timeout measurements belong in the Phase 4 report. -/
+def runSparseGapPair {n : Nat} (input : P n Int × P n Int) : UInt64 :=
+  let cfg : GcdConfig :=
+    { GcdConfig.default with brownPrimeFuel := 1, brownPointFuel := 2 }
+  let cfg : GcdConfig := { cfg with heuristicBitBudget := 0 }
+  match intConcreteProposal Mono.lex cfg input.1 input.2 |>.cert? with
+  | none => 0
+  | some cert => checksum cert.gcd
+
 def runSquarefree {n : Nat} (input : P n Int) : UInt64 :=
   let decomp := sqfDecomp input
   decomp.factors.foldl
@@ -138,25 +150,25 @@ setup_fixed_benchmark runSparseCoprime7 where fixedConfig 0x7958e799d1931a08
 setup_fixed_benchmark runSparseCoprime8 where fixedConfig 0x9389fe94a31dd629
 
 initialize sparseStress5d4096 : IO.Ref (P 5 Int × P 5 Int) ←
-  IO.mkRef (sparseGcd 5 4096)
+  IO.mkRef (sparseGapGcd 5 4096)
 initialize sparseStress8d4096 : IO.Ref (P 8 Int × P 8 Int) ←
-  IO.mkRef (sparseGcd 8 4096)
+  IO.mkRef (sparseGapGcd 8 4096)
 initialize sparseStress12d4096 : IO.Ref (P 12 Int × P 12 Int) ←
-  IO.mkRef (sparseGcd 12 4096)
+  IO.mkRef (sparseGapGcd 12 4096)
 
 def runSparseStress5d4096 (_ : Unit) : IO UInt64 :=
-  return runIntPair (← sparseStress5d4096.get)
+  return runSparseGapPair (← sparseStress5d4096.get)
 def runSparseStress8d4096 (_ : Unit) : IO UInt64 :=
-  return runIntPair (← sparseStress8d4096.get)
+  return runSparseGapPair (← sparseStress8d4096.get)
 def runSparseStress12d4096 (_ : Unit) : IO UInt64 :=
-  return runIntPair (← sparseStress12d4096.get)
+  return runSparseGapPair (← sparseStress12d4096.get)
 
 setup_fixed_benchmark runSparseStress5d4096 where
-  stressConfig 0xbd6798d21ee1b1e0
+  stressConfig 0x0
 setup_fixed_benchmark runSparseStress8d4096 where
-  stressConfig 0xc98beef9ed877616
+  stressConfig 0x0
 setup_fixed_benchmark runSparseStress12d4096 where
-  stressConfig 0xccb4f856deae8744
+  stressConfig 0x0
 
 initialize denseGcd3d5 : IO.Ref (P 3 Int × P 3 Int) ←
   IO.mkRef (denseGcd 3 5)

--- a/bench/HexMvGcd/Matrix.lean
+++ b/bench/HexMvGcd/Matrix.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvGcd.Families
+import LeanBench
+
+/-!
+Fixed registrations for the `hex-mv-gcd` Phase 4 shape matrix.
+
+The SPEC gives route-level probe bounds rather than a machine-operation model
+for these families.  They are therefore named fixed rungs: the shape is part
+of the stable registration name, and no asymptotic claim is inferred from
+degree or arity alone.
+-/
+
+namespace Hex.MvGcdBench.Matrix
+
+open Hex
+open Hex.MvPoly
+open Hex.MvGcdBench.Families
+
+def runIntPair {n : Nat} (input : P n Int × P n Int) : UInt64 :=
+  checksum (gcd input.1 input.2)
+
+def runRatPair {n : Nat} (input : P n Rat × P n Rat) : UInt64 :=
+  checksum (gcd input.1 input.2)
+
+def runSquarefree {n : Nat} (input : P n Int) : UInt64 :=
+  let decomp := sqfDecomp input
+  decomp.factors.foldl
+    (fun acc factor =>
+      mixHash (mixHash acc (checksum factor.factor))
+        (hash factor.multiplicity))
+    (hash decomp.content)
+
+def fixedConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 3, maxSecondsPerCall := 12.0,
+    expectedHash := some expectedHash }
+
+initialize denseCoprime2 : IO.Ref (P 2 Int × P 2 Int) ←
+  IO.mkRef (denseCoprime 2 1)
+initialize denseCoprime3 : IO.Ref (P 3 Int × P 3 Int) ←
+  IO.mkRef (denseCoprime 3 1)
+initialize denseCoprime4 : IO.Ref (P 4 Int × P 4 Int) ←
+  IO.mkRef (denseCoprime 4 1)
+initialize denseCoprime5 : IO.Ref (P 5 Int × P 5 Int) ←
+  IO.mkRef (denseCoprime 5 1)
+initialize denseCoprime6 : IO.Ref (P 6 Int × P 6 Int) ←
+  IO.mkRef (denseCoprime 6 1)
+initialize denseCoprime7 : IO.Ref (P 7 Int × P 7 Int) ←
+  IO.mkRef (denseCoprime 7 1)
+initialize denseCoprime8 : IO.Ref (P 8 Int × P 8 Int) ←
+  IO.mkRef (denseCoprime 8 1)
+
+def runDenseCoprime2 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime2.get)
+def runDenseCoprime3 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime3.get)
+def runDenseCoprime4 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime4.get)
+def runDenseCoprime5 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime5.get)
+def runDenseCoprime6 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime6.get)
+def runDenseCoprime7 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime7.get)
+def runDenseCoprime8 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← denseCoprime8.get)
+
+setup_fixed_benchmark runDenseCoprime2 where fixedConfig 0xc27ccbde88f7ee1a
+setup_fixed_benchmark runDenseCoprime3 where fixedConfig 0x6a32dabd95a98e1c
+setup_fixed_benchmark runDenseCoprime4 where fixedConfig 0xcb20c1eb884c258c
+setup_fixed_benchmark runDenseCoprime5 where fixedConfig 0x72e28aef962316d6
+setup_fixed_benchmark runDenseCoprime6 where fixedConfig 0xe471bb0a9f420adf
+setup_fixed_benchmark runDenseCoprime7 where fixedConfig 0x7958e799d1931a08
+setup_fixed_benchmark runDenseCoprime8 where fixedConfig 0x9389fe94a31dd629
+
+initialize sparseCoprime2 : IO.Ref (P 2 Int × P 2 Int) ←
+  IO.mkRef (sparseCoprime 2 128)
+initialize sparseCoprime3 : IO.Ref (P 3 Int × P 3 Int) ←
+  IO.mkRef (sparseCoprime 3 128)
+initialize sparseCoprime4 : IO.Ref (P 4 Int × P 4 Int) ←
+  IO.mkRef (sparseCoprime 4 128)
+initialize sparseCoprime5 : IO.Ref (P 5 Int × P 5 Int) ←
+  IO.mkRef (sparseCoprime 5 128)
+initialize sparseCoprime6 : IO.Ref (P 6 Int × P 6 Int) ←
+  IO.mkRef (sparseCoprime 6 128)
+initialize sparseCoprime7 : IO.Ref (P 7 Int × P 7 Int) ←
+  IO.mkRef (sparseCoprime 7 128)
+initialize sparseCoprime8 : IO.Ref (P 8 Int × P 8 Int) ←
+  IO.mkRef (sparseCoprime 8 128)
+
+def runSparseCoprime2 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime2.get)
+def runSparseCoprime3 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime3.get)
+def runSparseCoprime4 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime4.get)
+def runSparseCoprime5 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime5.get)
+def runSparseCoprime6 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime6.get)
+def runSparseCoprime7 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime7.get)
+def runSparseCoprime8 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseCoprime8.get)
+
+setup_fixed_benchmark runSparseCoprime2 where fixedConfig 0xc27ccbde88f7ee1a
+setup_fixed_benchmark runSparseCoprime3 where fixedConfig 0x6a32dabd95a98e1c
+setup_fixed_benchmark runSparseCoprime4 where fixedConfig 0xcb20c1eb884c258c
+setup_fixed_benchmark runSparseCoprime5 where fixedConfig 0x72e28aef962316d6
+setup_fixed_benchmark runSparseCoprime6 where fixedConfig 0xe471bb0a9f420adf
+setup_fixed_benchmark runSparseCoprime7 where fixedConfig 0x7958e799d1931a08
+setup_fixed_benchmark runSparseCoprime8 where fixedConfig 0x9389fe94a31dd629
+
+initialize denseGcd3d5 : IO.Ref (P 3 Int × P 3 Int) ←
+  IO.mkRef (denseGcd 3 5)
+
+def runDenseGcd3d5 (_ : Unit) : IO UInt64 := do
+  return runIntPair (← denseGcd3d5.get)
+
+setup_fixed_benchmark runDenseGcd3d5 where fixedConfig 0x4a63cc50df074eb4
+
+initialize rationalGcd3d5 : IO.Ref (P 3 Rat × P 3 Rat) ←
+  IO.mkRef (rationalGcd 3 5)
+
+def runRationalGcd3d5 (_ : Unit) : IO UInt64 :=
+  return runRatPair (← rationalGcd3d5.get)
+
+setup_fixed_benchmark runRationalGcd3d5 where
+  fixedConfig 0x13101c4072427dd1
+
+initialize squarefree2m1 : IO.Ref (P 2 Int) ←
+  IO.mkRef (squarefreeShape 2 [1])
+initialize squarefree3m1to5 : IO.Ref (P 3 Int) ←
+  IO.mkRef (squarefreeShape 3 [1, 2, 3, 4, 5])
+initialize squarefree4m7 : IO.Ref (P 4 Int) ←
+  IO.mkRef (squarefreeShape 4 [7])
+
+def runSquarefree2m1 (_ : Unit) : IO UInt64 :=
+  return runSquarefree (← squarefree2m1.get)
+def runSquarefree3m1to5 (_ : Unit) : IO UInt64 :=
+  return runSquarefree (← squarefree3m1to5.get)
+def runSquarefree4m7 (_ : Unit) : IO UInt64 :=
+  return runSquarefree (← squarefree4m7.get)
+
+setup_fixed_benchmark runSquarefree2m1 where
+  fixedConfig 0x64d98a7e1ba9194f
+setup_fixed_benchmark runSquarefree3m1to5 where
+  fixedConfig 0x664d8f4f4d3e40ef
+setup_fixed_benchmark runSquarefree4m7 where
+  fixedConfig 0xe04c869a010239a4
+
+end Hex.MvGcdBench.Matrix

--- a/bench/HexMvGcd/Matrix.lean
+++ b/bench/HexMvGcd/Matrix.lean
@@ -28,6 +28,11 @@ def runIntPair {n : Nat} (input : P n Int × P n Int) : UInt64 :=
 def runRatPair {n : Nat} (input : P n Rat × P n Rat) : UInt64 :=
   checksum (gcd input.1 input.2)
 
+def runBrownPair {n : Nat} (input : P n Int × P n Int) : UInt64 :=
+  match intBrownModularCert? GcdConfig.default input.1 input.2 with
+  | none => 0
+  | some cert => checksum cert.gcd
+
 def runSquarefree {n : Nat} (input : P n Int) : UInt64 :=
   let decomp := sqfDecomp input
   decomp.factors.foldl
@@ -36,9 +41,25 @@ def runSquarefree {n : Nat} (input : P n Int) : UInt64 :=
         (hash factor.multiplicity))
     (hash decomp.content)
 
+def getCached (slot : IO.Ref (Option α)) (build : Unit → α) : IO α := do
+  match ← slot.get with
+  | some value => return value
+  | none =>
+      let value := build ()
+      slot.set (some value)
+      return value
+
 def fixedConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
   { repeats := 3, maxSecondsPerCall := 12.0,
-    expectedHash := some expectedHash }
+    warmupFirstIter := true, expectedHash := some expectedHash }
+
+def brownConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 3, maxSecondsPerCall := 30.0,
+    warmupFirstIter := true, expectedHash := some expectedHash }
+
+def stressConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 3, maxSecondsPerCall := 30.0,
+    warmupFirstIter := true, expectedHash := some expectedHash }
 
 initialize denseCoprime2 : IO.Ref (P 2 Int × P 2 Int) ←
   IO.mkRef (denseCoprime 2 1)
@@ -116,22 +137,83 @@ setup_fixed_benchmark runSparseCoprime6 where fixedConfig 0xe471bb0a9f420adf
 setup_fixed_benchmark runSparseCoprime7 where fixedConfig 0x7958e799d1931a08
 setup_fixed_benchmark runSparseCoprime8 where fixedConfig 0x9389fe94a31dd629
 
+initialize sparseStress5d4096 : IO.Ref (P 5 Int × P 5 Int) ←
+  IO.mkRef (sparseGcd 5 4096)
+initialize sparseStress8d4096 : IO.Ref (P 8 Int × P 8 Int) ←
+  IO.mkRef (sparseGcd 8 4096)
+initialize sparseStress12d4096 : IO.Ref (P 12 Int × P 12 Int) ←
+  IO.mkRef (sparseGcd 12 4096)
+
+def runSparseStress5d4096 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseStress5d4096.get)
+def runSparseStress8d4096 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseStress8d4096.get)
+def runSparseStress12d4096 (_ : Unit) : IO UInt64 :=
+  return runIntPair (← sparseStress12d4096.get)
+
+setup_fixed_benchmark runSparseStress5d4096 where
+  stressConfig 0xbd6798d21ee1b1e0
+setup_fixed_benchmark runSparseStress8d4096 where
+  stressConfig 0xc98beef9ed877616
+setup_fixed_benchmark runSparseStress12d4096 where
+  stressConfig 0xccb4f856deae8744
+
 initialize denseGcd3d5 : IO.Ref (P 3 Int × P 3 Int) ←
   IO.mkRef (denseGcd 3 5)
+initialize denseGcd3d10 : IO.Ref (Option (P 3 Int × P 3 Int)) ←
+  IO.mkRef none
+initialize denseGcd3d20 : IO.Ref (Option (P 3 Int × P 3 Int)) ←
+  IO.mkRef none
+initialize denseGcd4d5 : IO.Ref (Option (P 4 Int × P 4 Int)) ←
+  IO.mkRef none
+initialize denseGcd5d5 : IO.Ref (Option (P 5 Int × P 5 Int)) ←
+  IO.mkRef none
 
-def runDenseGcd3d5 (_ : Unit) : IO UInt64 := do
-  return runIntPair (← denseGcd3d5.get)
+def runDenseGcd3d5 (_ : Unit) : IO UInt64 :=
+  return runBrownPair (← denseGcd3d5.get)
+def runDenseGcd3d10 (_ : Unit) : IO UInt64 :=
+  return runBrownPair (← getCached denseGcd3d10 fun _ => denseGcd 3 10)
+def runDenseGcd3d20 (_ : Unit) : IO UInt64 :=
+  return runBrownPair (← getCached denseGcd3d20 fun _ => denseGcd 3 20)
+def runDenseGcd4d5 (_ : Unit) : IO UInt64 :=
+  return runBrownPair (← getCached denseGcd4d5 fun _ => denseGcd 4 5)
+def runDenseGcd5d5 (_ : Unit) : IO UInt64 :=
+  return runBrownPair (← getCached denseGcd5d5 fun _ => denseGcd 5 5)
 
-setup_fixed_benchmark runDenseGcd3d5 where fixedConfig 0x4a63cc50df074eb4
+setup_fixed_benchmark runDenseGcd3d5 where brownConfig 0x4a63cc50df074eb4
+setup_fixed_benchmark runDenseGcd3d10 where brownConfig 0x4a63cc50df074eb4
+setup_fixed_benchmark runDenseGcd3d20 where brownConfig 0x4a63cc50df074eb4
+setup_fixed_benchmark runDenseGcd4d5 where brownConfig 0xa56be5fdc3e32b20
+setup_fixed_benchmark runDenseGcd5d5 where brownConfig 0xbd6798d21ee1b1e0
 
 initialize rationalGcd3d5 : IO.Ref (P 3 Rat × P 3 Rat) ←
   IO.mkRef (rationalGcd 3 5)
+initialize rationalGcd3d10 : IO.Ref (Option (P 3 Rat × P 3 Rat)) ←
+  IO.mkRef none
+initialize rationalGcd3d20 : IO.Ref (Option (P 3 Rat × P 3 Rat)) ←
+  IO.mkRef none
+initialize rationalGcd4d5 : IO.Ref (Option (P 4 Rat × P 4 Rat)) ←
+  IO.mkRef none
+initialize rationalGcd5d5 : IO.Ref (Option (P 5 Rat × P 5 Rat)) ←
+  IO.mkRef none
 
 def runRationalGcd3d5 (_ : Unit) : IO UInt64 :=
   return runRatPair (← rationalGcd3d5.get)
+def runRationalGcd3d10 (_ : Unit) : IO UInt64 :=
+  return runRatPair (← getCached rationalGcd3d10 fun _ => rationalGcd 3 10)
+def runRationalGcd3d20 (_ : Unit) : IO UInt64 :=
+  return runRatPair (← getCached rationalGcd3d20 fun _ => rationalGcd 3 20)
+def runRationalGcd4d5 (_ : Unit) : IO UInt64 :=
+  return runRatPair (← getCached rationalGcd4d5 fun _ => rationalGcd 4 5)
+def runRationalGcd5d5 (_ : Unit) : IO UInt64 :=
+  return runRatPair (← getCached rationalGcd5d5 fun _ => rationalGcd 5 5)
 
 setup_fixed_benchmark runRationalGcd3d5 where
   fixedConfig 0x13101c4072427dd1
+setup_fixed_benchmark runRationalGcd3d10 where fixedConfig 0x13101c4072427dd1
+setup_fixed_benchmark runRationalGcd3d20 where fixedConfig 0x13101c4072427dd1
+setup_fixed_benchmark runRationalGcd4d5 where fixedConfig 0x7a6eed34dac1cd4b
+setup_fixed_benchmark runRationalGcd5d5 where fixedConfig 0xcb197b68a2a27c66
 
 initialize squarefree2m1 : IO.Ref (P 2 Int) ←
   IO.mkRef (squarefreeShape 2 [1])
@@ -139,6 +221,7 @@ initialize squarefree3m1to5 : IO.Ref (P 3 Int) ←
   IO.mkRef (squarefreeShape 3 [1, 2, 3, 4, 5])
 initialize squarefree4m7 : IO.Ref (P 4 Int) ←
   IO.mkRef (squarefreeShape 4 [7])
+initialize squarefree5m2357 : IO.Ref (Option (P 5 Int)) ← IO.mkRef none
 
 def runSquarefree2m1 (_ : Unit) : IO UInt64 :=
   return runSquarefree (← squarefree2m1.get)
@@ -146,6 +229,9 @@ def runSquarefree3m1to5 (_ : Unit) : IO UInt64 :=
   return runSquarefree (← squarefree3m1to5.get)
 def runSquarefree4m7 (_ : Unit) : IO UInt64 :=
   return runSquarefree (← squarefree4m7.get)
+def runSquarefree5m2357 (_ : Unit) : IO UInt64 :=
+  return runSquarefree
+    (← getCached squarefree5m2357 fun _ => squarefreeStress5)
 
 setup_fixed_benchmark runSquarefree2m1 where
   fixedConfig 0x64d98a7e1ba9194f
@@ -153,5 +239,7 @@ setup_fixed_benchmark runSquarefree3m1to5 where
   fixedConfig 0x664d8f4f4d3e40ef
 setup_fixed_benchmark runSquarefree4m7 where
   fixedConfig 0xe04c869a010239a4
+setup_fixed_benchmark runSquarefree5m2357 where
+  stressConfig 0x4f644b92da420b36
 
 end Hex.MvGcdBench.Matrix

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -294,7 +294,8 @@ lean_lib HexMvGcdKernelProbe where
 
 lean_lib HexMvGcdBenchSupport where
   srcDir := "bench"
-  globs := #[`HexMvGcdFlint, `HexMvGcdSingular]
+  globs := #[`HexMvGcd.Families, `HexMvGcd.Matrix, `HexMvGcdFlint,
+    `HexMvGcdSingular]
 
 lean_lib HexMvPolyBenchSupport where
   srcDir := "bench"

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1234,5 +1234,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "398a71fbd46baa0037c64f2954d300ad8977fe10",
     "reason": "Additionally registers the independent HexIntFactor library, Mathlib companion, conformance emitter, and benchmark executable; hexbz_factor_service, its build flags, and every factorization runtime dependency are unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "398a71fbd46baa0037c64f2954d300ad8977fe10",
+    "current_blob": "f9e1661e342a6ba74c2d50753a263b8e22769b51",
+    "reason": "Additionally registers the build-only HexMvGcd Phase 4 shape-matrix support modules; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
   }
 ]

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1237,7 +1237,7 @@
   },
   {
     "path": "lakefile.lean",
-    "baseline_blob": "398a71fbd46baa0037c64f2954d300ad8977fe10",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "f9e1661e342a6ba74c2d50753a263b8e22769b51",
     "reason": "Additionally registers the build-only HexMvGcd Phase 4 shape-matrix support modules; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
   }


### PR DESCRIPTION
## Summary

- add deterministic dense and sparse coprime families across the required arities
- add direct Brown dense-gcd and matched rational rungs, including the required degree and arity envelope
- add sparse-gap, squarefree-multiplicity, and high-arity stress registrations with stable structural hashes
- cache expensive fixture construction outside timed regions and register the completed Mathlib-free bench target

The sparse stress fixture is deliberately non-affine: shortcut candidates retain a nonunit remainder and are rejected by the checker. The merge-gated rung measures a bounded Brown-image decline; the Phase 4 report will record the separate end-to-end timeout rather than pretending the missing sparse route completes.

## Validation

- `lake build hexmvgcd_bench` (467/467 jobs from a fresh worktree)
- mv-gcd bench verification (63/63, including FLINT and Singular)
- copyright, source-line, dependency-DAG, Phase 4, and Mathlib-free bench gates
- FLINT and Singular oracle unit tests